### PR TITLE
Fix REST spec for exists

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -44,7 +44,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 
 public class CrudIT extends ESRestHighLevelClientTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/23196")
     public void testExists() throws IOException {
         {
             GetRequest getRequest = new GetRequest("index", "type", "id");
@@ -64,10 +63,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         }
         {
             GetRequest getRequest = new GetRequest("index", "type", "does_not_exist").version(1);
-            ElasticsearchException exception = expectThrows(ElasticsearchException.class,
-                    () -> execute(getRequest, highLevelClient()::exists, highLevelClient()::existsAsync));
-            assertEquals(RestStatus.BAD_REQUEST, exception.status());
-            assertThat(exception.getMessage(), containsString("/index/type/does_not_exist?version=1: HTTP/1.1 400 Bad Request"));
+            assertFalse(execute(getRequest, highLevelClient()::exists, highLevelClient()::existsAsync));
         }
     }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -23,6 +23,10 @@
         }
       },
       "params": {
+        "stored_fields": {
+          "type": "list",
+          "description" : "A comma-separated list of stored fields to return in the response"
+        },
         "parent": {
           "type" : "string",
           "description" : "The ID of the parent document"
@@ -42,6 +46,27 @@
         "routing": {
           "type" : "string",
           "description" : "Specific routing value"
+        },
+        "_source": {
+          "type" : "list",
+          "description" : "True or false to return the _source field or not, or a list of fields to return"
+        },
+        "_source_exclude": {
+          "type" : "list",
+          "description" : "A list of fields to exclude from the returned _source field"
+        },
+        "_source_include": {
+          "type" : "list",
+          "description" : "A list of fields to extract and return from the _source field"
+        },
+        "version" : {
+          "type" : "number",
+          "description" : "Explicit version number for concurrency control"
+        },
+        "version_type": {
+          "type" : "enum",
+          "options" : ["internal", "external", "external_gte", "force"],
+          "description" : "Specific version type"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/exists/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/exists/10_basic.yaml
@@ -25,3 +25,12 @@
         id:    1
 
   - is_true: ''
+
+  - do:
+      exists:
+        index: test_1
+        type: test
+        id: 1
+        version: 1
+
+  - is_true: ''


### PR DESCRIPTION
A previous change aligned the handling of the GET document and HEAD document APIs. This commit aligns the specification for these two APIs as well, and fixes a failing test.

Relates #23186

