### PR TITLE
Add equals/hashcode method to ReplicationResponse

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -72,9 +72,25 @@ public class ReplicationResponse extends ActionResponse {
         this.shardInfo = shardInfo;
     }
 
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+        if (that == null || getClass() != that.getClass()) {
+            return false;
+        }
+        ReplicationResponse other = (ReplicationResponse) that;
+        return Objects.equals(shardInfo, other.shardInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shardInfo);
+    }
+
     public static class ShardInfo implements Streamable, ToXContentObject {
 
-        private static final String _SHARDS = "_shards";
         private static final String TOTAL = "total";
         private static final String SUCCESSFUL = "successful";
         private static final String FAILED = "failed";
@@ -150,7 +166,7 @@ public class ReplicationResponse extends ActionResponse {
 
         @Override
         public int hashCode() {
-            return Objects.hash(total, successful, failures);
+            return Objects.hash(total, successful, Arrays.hashCode(failures));
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/EqualsHashCodeTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/EqualsHashCodeTestUtils.java
@@ -67,8 +67,7 @@ public class EqualsHashCodeTestUtils {
      * from the input in one aspect. The output of this call is used to check that it is not equal()
      * to the input object
      */
-    public static <T> void checkEqualsAndHashCode(T original, CopyFunction<T> copyFunction,
-            MutateFunction<T> mutationFunction) {
+    public static <T> void checkEqualsAndHashCode(T original, CopyFunction<T> copyFunction, MutateFunction<T> mutationFunction) {
         try {
             String objectName = original.getClass().getSimpleName();
             assertFalse(objectName + " is equal to null", original.equals(null));


### PR DESCRIPTION
This commit adds equals() & hashcode() methods to ReplicationResponse. This will later help for testing IndexResponse, DeleteResponse etc.