### PR TITLE
[DOCS] Fixed various typos in the 'cat APIs' section

### DIFF
--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -106,7 +106,7 @@ by all the shards, not number of documents).  The `/_cat/indices` API
 is ideal.  We only need to tweak two things.  First, we want to turn
 off human mode.  We'll use a byte-level resolution.  Then we'll pipe
 our output into `sort` using the appropriate column, which in this
-case is the eight one.
+case is the eighth one.
 
 [source,sh]
 --------------------------------------------------

--- a/docs/reference/cat/alias.asciidoc
+++ b/docs/reference/cat/alias.asciidoc
@@ -51,7 +51,7 @@ alias4 test1 -      2            1,2
 --------------------------------------------------
 // TESTRESPONSE[s/[*]/[*]/ _cat]
 
-The output shows that `alias` has configured a filter, and specific routing
+The output shows that `alias2` has configured a filter, and specific routing
 configurations in `alias3` and `alias4`.
 
 If you only want to get information about a single alias, you can specify

--- a/docs/reference/cat/fielddata.asciidoc
+++ b/docs/reference/cat/fielddata.asciidoc
@@ -95,4 +95,4 @@ Nqk-6inXQq-OxUfOUI8jNQ 127.0.0.1 127.0.0.1 Nqk-6in soul    480b
 // TESTRESPONSE[s/544b|480b/\\d+(\\.\\d+)?[tgmk]?b/]
 // TESTRESPONSE[s/Nqk-6in[^ ]*/.+/ s/soul|body/\\w+/ _cat]
 
-The output shows the individual fielddata for the`body` and `text` fields, one row per field per node.
+The output shows the individual fielddata for the `body` and `soul` fields, one row per field per node.

--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -20,7 +20,7 @@ ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role master
 // TESTRESPONSE[s/65          99  42/\\d+ \\d+ \\d+/]
 // TESTRESPONSE[s/[*]/[*]/ s/mJw06l1/.+/ _cat]
 
-The first few columns (`ip, `heap.percent`, `ram.percent`, `cpu, `load_*`) tell
+The first few columns (`ip`, `heap.percent`, `ram.percent`, `cpu`, `load_*`) tell
 you where your nodes live and give a quick picture of performance stats.
 
 The last (`node.role`, `master`, and `name`) columns provide ancillary
@@ -67,7 +67,7 @@ veJR 127.0.0.1 59938 {version} *
 |`pid` |`p` |No |Process ID |13061
 |`ip` |`i` |Yes |IP address |127.0.1.1
 |`port` |`po` |No |Bound transport port |9300
-|`http_address` |`http`| No | bound http address | 127.0.0.1:9200
+|`http_address` |`http`| No |Bound http address | 127.0.0.1:9200
 |`version` |`v` |No |Elasticsearch version |{version}
 |`build` |`b` |No |Elasticsearch Build hash |5c03844
 |`jdk` |`j` |No |Running Java version |1.8.0

--- a/docs/reference/cat/segments.asciidoc
+++ b/docs/reference/cat/segments.asciidoc
@@ -34,7 +34,7 @@ The following columns provide additional monitoring information:
 
 prirep::        Whether this segment belongs to a primary or replica shard.
 
-ip::            The ip address of the segments shard.
+ip::            The ip address of the segment's shard.
 
 segment::       A segment name, derived from the segment generation. The name
                 is internally used to generate the file names in the directory

--- a/docs/reference/cat/shards.asciidoc
+++ b/docs/reference/cat/shards.asciidoc
@@ -96,7 +96,7 @@ wiki1 2 r UNASSIGNED ALLOCATION_FAILED
 [[reason-unassigned]]
 === Reasons for unassigned shard
 
-These are the possible reasons for a shard be in a unassigned state:
+These are the possible reasons for a shard to be in a unassigned state:
 
 [horizontal]
 `INDEX_CREATED`::           Unassigned as a result of an API creation of an index.

--- a/docs/reference/cat/templates.asciidoc
+++ b/docs/reference/cat/templates.asciidoc
@@ -6,14 +6,14 @@ The `templates` command provides information about existing templates.
 [source, sh]
 --------------------------------------------------
 % curl 'localhost:9200/_cat/templates?v=true'
-name       template order version
+name      template order version
 template0 te*      0
 template1 tea*     1
 template2 teak*    2     7
 --------------------------------------------------
 
 The output shows that there are three existing templates,
-with template_2 having a version value.
+with template2 having a version value.
 
 The endpoint also supports giving a template name or pattern in the url
 to filter the results, for example `/_cat/templates/template*` or

--- a/docs/reference/cat/thread_pool.asciidoc
+++ b/docs/reference/cat/thread_pool.asciidoc
@@ -83,7 +83,7 @@ id                     name    active rejected completed
 0EWUhXeBQtaVGlexUeVwMg generic      0        0        70
 --------------------------------------------------
 
-Here the host columns and the active, rejected and completed suggest thread pool statistic are displayed.
+Here the host columns and the active, rejected and completed suggest thread pool statistics are displayed.
 
 All <<modules-threadpool,built-in thread pools>> and custom thread pools are available.
 [float]


### PR DESCRIPTION
Here's my second attempt at a PR for documentation fixes :smile:
As per the suggestion in #23127 (thanks @clintongormley!) I'm now using Elasticsearch 5.2 and my proposed changes are based on master. Hopefully that will make them easier to integrate.