### PR TITLE
Tests: Re-enable debian-8 and fedora-24 packaging tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -40,9 +40,11 @@ class PluginPropertiesTask extends Copy {
                 templateFile.setText(resourceTemplate.getText('UTF-8'), 'UTF-8')
             }
         }
+        doFirst {
+            project.delete(generatedResourcesDir)
+        }
         dependsOn(copyPluginPropertiesTemplate)
         extension = project.extensions.create('esplugin', PluginPropertiesExtension, project)
-        project.clean.delete(generatedResourcesDir)
         project.afterEvaluate {
             // check require properties are set
             if (extension.name == null) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -16,10 +16,8 @@ class VagrantTestPlugin implements Plugin<Project> {
     static List<String> BOXES = [
             'centos-6',
             'centos-7',
-            // TODO: re-enable debian once it does not have broken openjdk packages
-            //'debian-8',
-            // TODO: re-enable fedora once it does not have broken openjdk packages
-            //'fedora-24',
+            'debian-8',
+            'fedora-24',
             'oel-6',
             'oel-7',
             'opensuse-13',

--- a/qa/vagrant/src/test/resources/packaging/tests/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/40_rpm_package.bats
@@ -126,20 +126,14 @@ setup() {
     # see postrm file
     assert_file_not_exist "/var/log/elasticsearch"
     assert_file_not_exist "/usr/share/elasticsearch/plugins"
-    assert_file_not_exist "/usr/share/elasticsearch/modules"
     assert_file_not_exist "/var/run/elasticsearch"
 
     # Those directories are removed by the package manager
     assert_file_not_exist "/usr/share/elasticsearch/bin"
     assert_file_not_exist "/usr/share/elasticsearch/lib"
     assert_file_not_exist "/usr/share/elasticsearch/modules"
-    assert_file_not_exist "/usr/share/elasticsearch/modules/lang-painless"
 
     assert_file_not_exist "/etc/elasticsearch"
-    assert_file_not_exist "/etc/elasticsearch/scripts"
-    assert_file_not_exist "/etc/elasticsearch/elasticsearch.yml"
-    assert_file_not_exist "/etc/elasticsearch/jvm.options"
-    assert_file_not_exist "/etc/elasticsearch/log4j2.properties"
 
     assert_file_not_exist "/etc/init.d/elasticsearch"
     assert_file_not_exist "/usr/lib/systemd/system/elasticsearch.service"


### PR DESCRIPTION
These images have been rebuilt to be preloaded with java 8 installed.
This change re-enables the systems. It also removes some redundancy in
the rpm checks I found while testing the new images, and fixes a
potential issue with generated resources in plugins where a stale dir
can cause junk to get into the distribution.
