### PR TITLE
Fix control group pattern

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -188,7 +188,7 @@ public class OsProbe {
     }
 
     // pattern for lines in /proc/self/cgroup
-    private static final Pattern CONTROL_GROUP_PATTERN = Pattern.compile("\\d+:([^:,]+(?:,[^:,]+)?):(/.*)");
+    private static final Pattern CONTROL_GROUP_PATTERN = Pattern.compile("\\d+:([^:,]+(?:,[^:,]+)*):(/.*)");
 
     // this property is to support a hack to workaround an issue with Docker containers mounting the cgroups hierarchy inconsistently with
     // respect to /proc/self/cgroup; for Docker containers this should be set to "/"

--- a/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -188,7 +188,7 @@ public class OsProbe {
     }
 
     // pattern for lines in /proc/self/cgroup
-    private static final Pattern CONTROL_GROUP_PATTERN = Pattern.compile("\\d+:([^:,]+(?:,[^:,]+)*):(/.*)");
+    private static final Pattern CONTROL_GROUP_PATTERN = Pattern.compile("\\d+:([^:]+):(/.*)");
 
     // this property is to support a hack to workaround an issue with Docker containers mounting the cgroups hierarchy inconsistently with
     // respect to /proc/self/cgroup; for Docker containers this should be set to "/"

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -155,16 +155,15 @@ public class OsProbeTests extends ESTestCase {
             @Override
             List<String> readProcSelfCgroup() {
                 return Arrays.asList(
-                    "11:freezer:/",
-                    "10:net_cls,net_prio:/",
-                    "9:pids:/",
-                    "8:cpuset:/",
+                    "10:freezer:/",
+                    "9:net_cls,net_prio:/",
+                    "8:pids:/",
                     "7:blkio:/",
                     "6:memory:/",
                     "5:devices:/user.slice",
                     "4:hugetlb:/",
                     "3:perf_event:/",
-                    "2:cpu,cpuacct:/" + hierarchy,
+                    "2:cpu,cpuacct,cpuset:/" + hierarchy,
                     "1:name=systemd:/user.slice/user-1000.slice/session-2359.scope");
             }
 


### PR DESCRIPTION
The file /proc/self/cgroup lists the control groups to which the process
belongs. This file is a colon separated list of three fields:
 1. a hierarchy ID number
 2. a comma-separated list of hierarchies
 3. the pathname of the control group in the hierarchy

The regex pattern for this contains a bug for the second field. It
allows one or two entries in the comma-separated list, but not
more. This commit fixes the pattern to allow one or more entires in the
comma-separated list.

Closes #23218