### PR TITLE
[Tests] Cleans up DocWriteResponse parsing tests

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
@@ -74,7 +73,6 @@ public class ReplicationResponse extends ActionResponse {
 
     public static class ShardInfo implements Streamable, ToXContentObject {
 
-        private static final String _SHARDS = "_shards";
         private static final String TOTAL = "total";
         private static final String SUCCESSFUL = "successful";
         private static final String FAILED = "failed";
@@ -132,25 +130,6 @@ public class ReplicationResponse extends ActionResponse {
                 }
             }
             return status;
-        }
-
-        @Override
-        public boolean equals(Object that) {
-            if (this == that) {
-                return true;
-            }
-            if (that == null || getClass() != that.getClass()) {
-                return false;
-            }
-            ShardInfo other = (ShardInfo) that;
-            return Objects.equals(total, other.total) &&
-                    Objects.equals(successful, other.successful) &&
-                    Arrays.equals(failures, other.failures);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(total, successful, failures);
         }
 
         @Override
@@ -325,27 +304,6 @@ public class ReplicationResponse extends ActionResponse {
              */
             public boolean primary() {
                 return primary;
-            }
-
-            @Override
-            public boolean equals(Object that) {
-                if (this == that) {
-                    return true;
-                }
-                if (that == null || getClass() != that.getClass()) {
-                    return false;
-                }
-                Failure failure = (Failure) that;
-                return Objects.equals(primary, failure.primary) &&
-                        Objects.equals(shardId, failure.shardId) &&
-                        Objects.equals(nodeId, failure.nodeId) &&
-                        Objects.equals(cause, failure.cause) &&
-                        Objects.equals(status, failure.status);
-            }
-
-            @Override
-            public int hashCode() {
-                return Objects.hash(shardId, nodeId, cause, status, primary);
             }
 
             @Override

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
@@ -99,8 +99,8 @@ public class BulkItemResponseTests extends ESTestCase {
 
         final Tuple<Throwable, ElasticsearchException> exceptions = randomExceptions();
 
-        BulkItemResponse bulkItemResponse = new BulkItemResponse(itemId, opType, new Failure(index, type, id, (Exception)  exceptions.v1()));
-        BulkItemResponse expectedBulkItemResponse = new BulkItemResponse(itemId, opType, new Failure(index, type, id,  exceptions.v2()));
+        BulkItemResponse bulkItemResponse = new BulkItemResponse(itemId, opType, new Failure(index, type, id, (Exception) exceptions.v1()));
+        BulkItemResponse expectedBulkItemResponse = new BulkItemResponse(itemId, opType, new Failure(index, type, id, exceptions.v2()));
         BytesReference originalBytes = toXContent(bulkItemResponse, xContentType, randomBoolean());
 
         // Shuffle the XContent fields
@@ -143,6 +143,7 @@ public class BulkItemResponseTests extends ESTestCase {
             if (expected.getOpType() == DocWriteRequest.OpType.UPDATE) {
                 UpdateResponseTests.assertUpdateResponse(expected.getResponse(), actual.getResponse());
             } else {
+                // assertDocWriteResponse check the result for INDEX/CREATE and DELETE operations
                 IndexResponseTests.assertDocWriteResponse(expected.getResponse(), actual.getResponse());
             }
         }

--- a/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
@@ -19,24 +19,22 @@
 
 package org.elasticsearch.action.index;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.RandomObjects;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 
+import static org.elasticsearch.action.support.replication.ReplicationResponseTests.assertShardInfo;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_UUID_NA_VALUE;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 
 public class IndexResponseTests extends ESTestCase {
@@ -59,11 +57,12 @@ public class IndexResponseTests extends ESTestCase {
     }
 
     public void testToAndFromXContent() throws IOException {
-        final XContentType xContentType = XContentType.JSON;//randomFrom(XContentType.values());
+        final Tuple<IndexResponse, IndexResponse> tuple = randomIndexResponse();
+        IndexResponse indexResponse = tuple.v1();
+        IndexResponse expectedIndexResponse = tuple.v2();
 
-        // Create a random IndexResponse and converts it to XContent in bytes
-        IndexResponse indexResponse = randomIndexResponse();
         boolean humanReadable = randomBoolean();
+        XContentType xContentType = randomFrom(XContentType.values());
         BytesReference indexResponseBytes = toXContent(indexResponse, xContentType, humanReadable);
 
         // Shuffle the XContent fields
@@ -83,106 +82,48 @@ public class IndexResponseTests extends ESTestCase {
         // We can't use equals() to compare the original and the parsed index response
         // because the random index response can contain shard failures with exceptions,
         // and those exceptions are not parsed back with the same types.
-
-        // Print the parsed object out and test that the output is the same as the original output
-        BytesReference parsedIndexResponseBytes = toXContent(parsedIndexResponse, xContentType, humanReadable);
-        try (XContentParser parser = createParser(xContentType.xContent(), parsedIndexResponseBytes)) {
-            assertIndexResponse(indexResponse, parser.map());
-        }
+        assertDocWriteResponse(expectedIndexResponse, parsedIndexResponse);
     }
 
-    @SuppressWarnings("unchecked")
-    public static void assertDocWriteResponse(DocWriteResponse expected, Map<String, Object> actual) {
-        assertEquals(expected.getIndex(), actual.get("_index"));
-        assertEquals(expected.getType(), actual.get("_type"));
-        assertEquals(expected.getId(), actual.get("_id"));
-        assertEquals(expected.getVersion(), ((Number) actual.get("_version")).longValue());
-        assertEquals(expected.getResult().getLowercase(), actual.get("result"));
-        if (expected.forcedRefresh()) {
-            assertTrue((Boolean) actual.get("forced_refresh"));
-        } else {
-            assertFalse(actual.containsKey("forced_refresh"));
-        }
-        if (expected.getSeqNo() >= 0) {
-            assertEquals(expected.getSeqNo(), ((Number) actual.get("_seq_no")).longValue());
-        } else {
-            assertFalse(actual.containsKey("_seq_no"));
-        }
-
-        Map<String, Object> actualShards = (Map<String, Object>) actual.get("_shards");
-        assertNotNull(actualShards);
-        assertEquals(expected.getShardInfo().getTotal(), actualShards.get("total"));
-        assertEquals(expected.getShardInfo().getSuccessful(), actualShards.get("successful"));
-        assertEquals(expected.getShardInfo().getFailed(), actualShards.get("failed"));
-
-        List<Map<String, Object>> actualFailures = (List<Map<String, Object>>) actualShards.get("failures");
-        if (CollectionUtils.isEmpty(expected.getShardInfo().getFailures())) {
-            assertNull(actualFailures);
-        } else {
-            assertEquals(expected.getShardInfo().getFailures().length, actualFailures.size());
-            for (int i = 0; i < expected.getShardInfo().getFailures().length; i++) {
-                ReplicationResponse.ShardInfo.Failure failure = expected.getShardInfo().getFailures()[i];
-                Map<String, Object> actualFailure = actualFailures.get(i);
-
-                assertEquals(failure.index(), actualFailure.get("_index"));
-                assertEquals(failure.shardId(), actualFailure.get("_shard"));
-                assertEquals(failure.nodeId(), actualFailure.get("_node"));
-                assertEquals(failure.status(), RestStatus.valueOf((String) actualFailure.get("status")));
-                assertEquals(failure.primary(), actualFailure.get("primary"));
-
-                Throwable cause = failure.getCause();
-                Map<String, Object> actualClause = (Map<String, Object>) actualFailure.get("reason");
-                assertNotNull(actualClause);
-                while (cause != null) {
-                    // The expected IndexResponse has been converted in XContent, then the resulting bytes have been
-                    // parsed to create a new parsed IndexResponse. During this process, the type of the exceptions
-                    // have been lost.
-                    assertEquals("exception", actualClause.get("type"));
-                    String expectedMessage = "Elasticsearch exception [type=" + ElasticsearchException.getExceptionName(cause)
-                            + ", reason=" + cause.getMessage() + "]";
-                    assertEquals(expectedMessage, actualClause.get("reason"));
-
-                    if (cause instanceof ElasticsearchException) {
-                        ElasticsearchException ex = (ElasticsearchException) cause;
-                        Map<String, Object> actualHeaders = (Map<String, Object>) actualClause.get("header");
-
-                        // When a IndexResponse is converted to XContent, the exception headers that start with "es."
-                        // are added to the XContent as fields with the prefix removed. Other headers are added under
-                        // a "header" root object.
-                        // In the test, the "es." prefix is lost when the XContent is generating, so when the parsed
-                        // IndexResponse is converted back to XContent all exception headers are under the "header" object.
-                        for (String name : ex.getHeaderKeys()) {
-                            assertEquals(ex.getHeader(name).get(0), actualHeaders.get(name.replaceFirst("es.", "")));
-                        }
-                    }
-                    actualClause = (Map<String, Object>) actualClause.get("caused_by");
-                    cause = cause.getCause();
-                }
-            }
-        }
+    public static void assertDocWriteResponse(DocWriteResponse expected, DocWriteResponse actual) {
+        assertEquals(expected.getIndex(), actual.getIndex());
+        assertEquals(expected.getType(), actual.getType());
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getSeqNo(), actual.getSeqNo());
+        assertEquals(expected.getResult(), actual.getResult());
+        assertEquals(expected.getShardId(), actual.getShardId());
+        assertEquals(expected.forcedRefresh(), actual.forcedRefresh());
+        assertEquals(expected.status(), actual.status());
+        assertShardInfo(expected.getShardInfo(), actual.getShardInfo());
     }
 
-    public static void assertIndexResponse(IndexResponse expected, Map<String, Object> actual) {
-        assertDocWriteResponse(expected, actual);
-        if (expected.getResult() == DocWriteResponse.Result.CREATED) {
-            assertTrue((boolean) actual.get("created"));
-        } else {
-            assertFalse((boolean) actual.get("created"));
-        }
-    }
-
-    public static IndexResponse randomIndexResponse() {
-        ShardId shardId = new ShardId(randomAsciiOfLength(5), randomAsciiOfLength(5), randomIntBetween(0, 5));
+    /**
+     * Returns a tuple of {@link IndexResponse}s.
+     * <p>
+     * The left element is the actual {@link IndexResponse} to serialize while the right element is the
+     * expected {@link IndexResponse} after parsing.
+     */
+    public static Tuple<IndexResponse, IndexResponse> randomIndexResponse() {
+        String index = randomAsciiOfLength(5);
+        String indexUUid = randomAsciiOfLength(5);
+        int shardId = randomIntBetween(0, 5);
         String type = randomAsciiOfLength(5);
         String id = randomAsciiOfLength(5);
         long seqNo = randomFrom(SequenceNumbersService.UNASSIGNED_SEQ_NO, randomNonNegativeLong(), (long) randomIntBetween(0, 10000));
         long version = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
         boolean created = randomBoolean();
+        boolean forcedRefresh = randomBoolean();
 
-        IndexResponse indexResponse = new IndexResponse(shardId, type, id, seqNo, version, created);
-        indexResponse.setForcedRefresh(randomBoolean());
-        indexResponse.setShardInfo(RandomObjects.randomShardInfo(random(), randomBoolean()));
-        return indexResponse;
+        Tuple<ReplicationResponse.ShardInfo, ReplicationResponse.ShardInfo> shardInfos = RandomObjects.randomShardInfo(random());
+
+        IndexResponse actual = new IndexResponse(new ShardId(index, indexUUid, shardId), type, id, seqNo, version, created);
+        actual.setForcedRefresh(forcedRefresh);
+        actual.setShardInfo(shardInfos.v1());
+
+        IndexResponse expected = new IndexResponse(new ShardId(index, INDEX_UUID_NA_VALUE, -1), type, id, seqNo, version, created);
+        expected.setForcedRefresh(forcedRefresh);
+        expected.setShardInfo(shardInfos.v2());
+
+        return Tuple.tuple(actual, expected);
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationResponseTests.java
@@ -20,342 +20,110 @@
 package org.elasticsearch.action.support.replication;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.replication.ReplicationResponse.ShardInfo;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.EqualsHashCodeTestUtils;
 import org.elasticsearch.test.RandomObjects;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
-import java.util.Set;
-import java.util.function.Supplier;
 
-import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.elasticsearch.ElasticsearchExceptionTests.assertDeepEquals;
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 
 public class ReplicationResponseTests extends ESTestCase {
 
     public void testShardInfoToString() {
         final int total = 5;
         final int successful = randomIntBetween(1, total);
-        final ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(total, successful);
+        final ShardInfo shardInfo = new ShardInfo(total, successful);
         assertEquals(String.format(Locale.ROOT, "ShardInfo{total=5, successful=%d, failures=[]}", successful), shardInfo.toString());
     }
 
-    public void testShardInfoEqualsAndHashcode() {
-        EqualsHashCodeTestUtils.CopyFunction<ReplicationResponse.ShardInfo> copy = shardInfo ->
-                new ReplicationResponse.ShardInfo(shardInfo.getTotal(), shardInfo.getSuccessful(), shardInfo.getFailures());
-
-        EqualsHashCodeTestUtils.MutateFunction<ReplicationResponse.ShardInfo> mutate = shardInfo -> {
-            List<Supplier<ReplicationResponse.ShardInfo>> mutations = new ArrayList<>();
-            mutations.add(() ->
-                    new ReplicationResponse.ShardInfo(shardInfo.getTotal() + 1, shardInfo.getSuccessful(), shardInfo.getFailures()));
-            mutations.add(() ->
-                    new ReplicationResponse.ShardInfo(shardInfo.getTotal(), shardInfo.getSuccessful() + 1, shardInfo.getFailures()));
-            mutations.add(() -> {
-                int nbFailures = randomIntBetween(1, 5);
-                ReplicationResponse.ShardInfo.Failure[] randomFailures = RandomObjects.randomShardInfoFailures(random(), nbFailures);
-                return new ReplicationResponse.ShardInfo(shardInfo.getTotal(), shardInfo.getSuccessful(), randomFailures);
-            });
-            return randomFrom(mutations).get();
-        };
-
-        checkEqualsAndHashCode(RandomObjects.randomShardInfo(random(), randomBoolean()), copy, mutate);
-    }
-
-    public void testFailureEqualsAndHashcode() {
-        EqualsHashCodeTestUtils.CopyFunction<ReplicationResponse.ShardInfo.Failure> copy = failure -> {
-            Index index = failure.fullShardId().getIndex();
-            ShardId shardId = new ShardId(index.getName(), index.getUUID(), failure.shardId());
-            Exception cause = (Exception) failure.getCause();
-            return new ReplicationResponse.ShardInfo.Failure(shardId, failure.nodeId(), cause, failure.status(), failure.primary());
-        };
-
-        EqualsHashCodeTestUtils.MutateFunction<ReplicationResponse.ShardInfo.Failure> mutate = failure -> {
-            List<Supplier<ReplicationResponse.ShardInfo.Failure>> mutations = new ArrayList<>();
-
-            final Index index = failure.fullShardId().getIndex();
-            final Set<String> indexNamePool = new HashSet<>(Arrays.asList(
-                    randomUnicodeOfCodepointLength(5), randomUnicodeOfCodepointLength(6)));
-            indexNamePool.remove(index.getName());
-            final ShardId randomIndex = new ShardId(randomFrom(indexNamePool), index.getUUID(), failure.shardId());
-            mutations.add(() -> new ReplicationResponse.ShardInfo.Failure(randomIndex, failure.nodeId(), (Exception) failure.getCause(),
-                    failure.status(), failure.primary()));
-
-            final Set<String> uuidPool = new HashSet<>(Arrays.asList(randomUnicodeOfCodepointLength(5), randomUnicodeOfCodepointLength(6)));
-            uuidPool.remove(index.getUUID());
-            final ShardId randomUUID = new ShardId(index.getName(), randomFrom(uuidPool), failure.shardId());
-            mutations.add(() -> new ReplicationResponse.ShardInfo.Failure(randomUUID, failure.nodeId(), (Exception) failure.getCause(),
-                    failure.status(), failure.primary()));
-
-            final ShardId randomShardId = new ShardId(index.getName(),index.getUUID(), failure.shardId() + randomIntBetween(1, 3));
-            mutations.add(() -> new ReplicationResponse.ShardInfo.Failure(randomShardId, failure.nodeId(), (Exception) failure.getCause(),
-                    failure.status(), failure.primary()));
-
-            final Set<String> nodeIdPool = new HashSet<>(Arrays.asList(randomUnicodeOfLength(3), randomUnicodeOfLength(4)));
-            nodeIdPool.remove(failure.nodeId());
-            final String randomNode = randomFrom(nodeIdPool);
-            mutations.add(() -> new ReplicationResponse.ShardInfo.Failure(failure.fullShardId(), randomNode, (Exception) failure.getCause(),
-                    failure.status(), failure.primary()));
-
-            final Set<Exception> exceptionPool = new HashSet<>(Arrays.asList(
-                    new IllegalStateException("a"), new IllegalArgumentException("b")));
-            exceptionPool.remove(failure.getCause());
-            final Exception randomException = randomFrom(exceptionPool);
-            mutations.add(() -> new ReplicationResponse.ShardInfo.Failure(failure.fullShardId(), failure.nodeId(), randomException,
-                    failure.status(), failure.primary()));
-
-            final Set<RestStatus> otherStatuses = new HashSet<>(Arrays.asList(RestStatus.values()));
-            otherStatuses.remove(failure.status());
-            final RestStatus randomStatus = randomFrom(otherStatuses);
-            mutations.add(() -> new ReplicationResponse.ShardInfo.Failure(failure.fullShardId(), failure.nodeId(),
-                    (Exception) failure.getCause(), randomStatus, failure.primary()));
-
-            final boolean randomPrimary = !failure.primary();
-            mutations.add(() -> new ReplicationResponse.ShardInfo.Failure(failure.fullShardId(), failure.nodeId(),
-                    (Exception) failure.getCause(), failure.status(), randomPrimary));
-
-            return randomFrom(mutations).get();
-        };
-
-        checkEqualsAndHashCode(RandomObjects.randomShardInfoFailure(random()), copy, mutate);
-    }
-
     public void testShardInfoToXContent() throws IOException {
-        final XContentType xContentType = randomFrom(XContentType.values());
-
-        final ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(5, 3);
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType, randomBoolean());
-
-        // Expected JSON is {"total":5,"successful":3,"failed":0}
-        assertThat(shardInfo, instanceOf(ToXContentObject.class));
-        try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("total", parser.currentName());
-            assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
-            assertEquals(shardInfo.getTotal(), parser.intValue());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("successful", parser.currentName());
-            assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
-            assertEquals(shardInfo.getSuccessful(), parser.intValue());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("failed", parser.currentName());
-            assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
-            assertEquals(shardInfo.getFailed(), parser.intValue());
-            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
-            assertNull(parser.nextToken());
+        {
+            ShardInfo shardInfo = new ShardInfo(5, 3);
+            String output = Strings.toString(shardInfo);
+            assertEquals("{\"total\":5,\"successful\":3,\"failed\":0}", output);
+        }
+        {
+            ShardInfo shardInfo = new ShardInfo(6, 4,
+                    new ShardInfo.Failure(new ShardId("index", "_uuid", 3),
+                            "_node_id", new IllegalArgumentException("Wrong"), RestStatus.BAD_REQUEST, false),
+                    new ShardInfo.Failure(new ShardId("index", "_uuid", 1),
+                            "_node_id", new CircuitBreakingException("Wrong", 12, 21), RestStatus.NOT_ACCEPTABLE, true));
+            String output = Strings.toString(shardInfo);
+            assertEquals("{\"total\":6,\"successful\":4,\"failed\":2,\"failures\":[{\"_index\":\"index\",\"_shard\":3," +
+                    "\"_node\":\"_node_id\",\"reason\":{\"type\":\"illegal_argument_exception\",\"reason\":\"Wrong\"}," +
+                    "\"status\":\"BAD_REQUEST\",\"primary\":false},{\"_index\":\"index\",\"_shard\":1,\"_node\":\"_node_id\"," +
+                    "\"reason\":{\"type\":\"circuit_breaking_exception\",\"reason\":\"Wrong\",\"bytes_wanted\":12,\"bytes_limit\":21}," +
+                    "\"status\":\"NOT_ACCEPTABLE\",\"primary\":true}]}", output);
         }
     }
 
     public void testShardInfoToAndFromXContent() throws IOException {
-        final XContentType xContentType = randomFrom(XContentType.values());
+        final Tuple<ShardInfo, ShardInfo> tuple = RandomObjects.randomShardInfo(random());
+        ShardInfo shardInfo = tuple.v1();
+        ShardInfo expectedShardInfo = tuple.v2();
 
-        final ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(randomIntBetween(1, 5), randomIntBetween(1, 5));
+        final XContentType xContentType = randomFrom(XContentType.values());
         boolean humanReadable = randomBoolean();
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType, humanReadable);
+        BytesReference originalBytes = toXContent(shardInfo, xContentType, humanReadable);
 
-        ReplicationResponse.ShardInfo parsedShardInfo;
-        try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
+        // Shuffle the XContent fields
+        if (randomBoolean()) {
+            try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+                originalBytes = shuffleXContent(parser, randomBoolean()).bytes();
+            }
+        }
+
+        ShardInfo parsedShardInfo;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
             // Move to the first start object
             assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            parsedShardInfo = ReplicationResponse.ShardInfo.fromXContent(parser);
+            parsedShardInfo = ShardInfo.fromXContent(parser);
             assertNull(parser.nextToken());
         }
-        // We can use assertEquals because the shardInfo doesn't have a failure (and exceptions)
-        assertEquals(shardInfo, parsedShardInfo);
+        assertShardInfo(expectedShardInfo, parsedShardInfo);
 
-        BytesReference parsedShardInfoBytes = XContentHelper.toXContent(parsedShardInfo, xContentType, humanReadable);
-        assertEquals(shardInfoBytes, parsedShardInfoBytes);
+        BytesReference expectedFinalBytes = toXContent(expectedShardInfo, xContentType, humanReadable);
+        BytesReference finalBytes = toXContent(parsedShardInfo, xContentType, humanReadable);
+        assertToXContentEquivalent(expectedFinalBytes, finalBytes, xContentType);
     }
 
-    public void testShardInfoWithFailureToXContent() throws IOException {
-        final XContentType xContentType = randomFrom(XContentType.values());
+    public static void assertShardInfo(ShardInfo expected, ShardInfo actual) {
+        if (expected == null) {
+            assertNull(actual);
+        } else {
+            assertEquals(expected.getTotal(), actual.getTotal());
+            assertEquals(expected.getSuccessful(), actual.getSuccessful());
+            assertEquals(expected.getFailed(), actual.getFailed());
 
-        final ReplicationResponse.ShardInfo shardInfo = RandomObjects.randomShardInfo(random(), true);
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType, randomBoolean());
+            ReplicationResponse.ShardInfo.Failure[] expectedFailures = expected.getFailures();
+            ReplicationResponse.ShardInfo.Failure[] actualFailures = actual.getFailures();
+            assertEquals(expectedFailures.length, actualFailures.length);
 
-        try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("total", parser.currentName());
-            assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
-            assertEquals(shardInfo.getTotal(), parser.intValue());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("successful", parser.currentName());
-            assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
-            assertEquals(shardInfo.getSuccessful(), parser.intValue());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("failed", parser.currentName());
-            assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
-            assertEquals(shardInfo.getFailed(), parser.intValue());
+            for (int i = 0; i < expectedFailures.length; i++) {
+                ReplicationResponse.ShardInfo.Failure expectedFailure = expectedFailures[i];
+                ReplicationResponse.ShardInfo.Failure actualFailure = actualFailures[i];
 
-            if (shardInfo.getFailures() != null && shardInfo.getFailures().length > 0) {
-                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-                assertEquals("failures", parser.currentName());
-                assertEquals(XContentParser.Token.START_ARRAY, parser.nextToken());
+                assertEquals(expectedFailure.fullShardId(), actualFailure.fullShardId());
+                assertEquals(expectedFailure.status(), actualFailure.status());
+                assertEquals(expectedFailure.nodeId(), actualFailure.nodeId());
+                assertEquals(expectedFailure.primary(), actualFailure.primary());
 
-                for (int i = 0; i < shardInfo.getFailures().length; i++) {
-                    assertFailure(parser, shardInfo.getFailures()[i]);
-                }
-                assertEquals(XContentParser.Token.END_ARRAY, parser.nextToken());
-            }
-
-            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
-            assertNull(parser.nextToken());
-        }
-    }
-
-    public void testRandomShardInfoFromXContent() throws IOException {
-        final XContentType xContentType = randomFrom(XContentType.values());
-
-        final ReplicationResponse.ShardInfo shardInfo = RandomObjects.randomShardInfo(random(), randomBoolean());
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfo, xContentType, randomBoolean());
-
-        ReplicationResponse.ShardInfo parsedShardInfo;
-        try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
-            // Move to the first start object
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            parsedShardInfo = ReplicationResponse.ShardInfo.fromXContent(parser);
-            assertNull(parser.nextToken());
-        }
-
-        // We can't use assertEquals to compare the original ShardInfo with the parsed ShardInfo
-        // because it may include random failures with exceptions, and exception types are not
-        // preserved during ToXContent->FromXContent process.
-        assertNotNull(parsedShardInfo);
-        assertEquals(shardInfo.getTotal(), parsedShardInfo.getTotal());
-        assertEquals(shardInfo.getSuccessful(), parsedShardInfo.getSuccessful());
-        assertEquals(shardInfo.getFailed(), parsedShardInfo.getFailed());
-        assertEquals(shardInfo.getFailures().length, parsedShardInfo.getFailures().length);
-
-        for (int i = 0; i < shardInfo.getFailures().length; i++) {
-            ReplicationResponse.ShardInfo.Failure parsedFailure = parsedShardInfo.getFailures()[i];
-            ReplicationResponse.ShardInfo.Failure failure = shardInfo.getFailures()[i];
-
-            assertEquals(failure.index(), parsedFailure.index());
-            assertEquals(failure.shardId(), parsedFailure.shardId());
-            assertEquals(failure.nodeId(), parsedFailure.nodeId());
-            assertEquals(failure.status(), parsedFailure.status());
-            assertEquals(failure.primary(), parsedFailure.primary());
-
-            Throwable cause = failure.getCause();
-            String expectedMessage = "Elasticsearch exception [type=" + ElasticsearchException.getExceptionName(cause)
-                    + ", reason=" + cause.getMessage() + "]";
-            assertEquals(expectedMessage, parsedFailure.getCause().getMessage());
-        }
-    }
-
-    public void testRandomFailureToXContent() throws IOException {
-        final XContentType xContentType = randomFrom(XContentType.values());
-
-        final ReplicationResponse.ShardInfo.Failure shardInfoFailure = RandomObjects.randomShardInfoFailure(random());
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfoFailure, xContentType, randomBoolean());
-
-        try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
-            assertFailure(parser, shardInfoFailure);
-        }
-    }
-
-    public void testRandomFailureToAndFromXContent() throws IOException {
-        final XContentType xContentType = randomFrom(XContentType.values());
-
-        final ReplicationResponse.ShardInfo.Failure shardInfoFailure = RandomObjects.randomShardInfoFailure(random());;
-        final BytesReference shardInfoBytes = XContentHelper.toXContent(shardInfoFailure, xContentType, randomBoolean());
-
-        ReplicationResponse.ShardInfo.Failure parsedFailure;
-        try (XContentParser parser = createParser(xContentType.xContent(), shardInfoBytes)) {
-            // Move to the first start object
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            parsedFailure = ReplicationResponse.ShardInfo.Failure.fromXContent(parser);
-            assertNull(parser.nextToken());
-        }
-
-        assertEquals(shardInfoFailure.index(), parsedFailure.index());
-        assertEquals(shardInfoFailure.shardId(), parsedFailure.shardId());
-        assertEquals(shardInfoFailure.nodeId(), parsedFailure.nodeId());
-        assertEquals(shardInfoFailure.status(), parsedFailure.status());
-        assertEquals(shardInfoFailure.primary(), parsedFailure.primary());
-
-        Throwable cause = shardInfoFailure.getCause();
-        String expectedMessage = "Elasticsearch exception [type=" + ElasticsearchException.getExceptionName(cause)
-                + ", reason=" + cause.getMessage() + "]";
-        assertEquals(expectedMessage, parsedFailure.getCause().getMessage());
-    }
-
-    private static void assertFailure(XContentParser parser, ReplicationResponse.ShardInfo.Failure failure) throws IOException {
-        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-        assertEquals("_index", parser.currentName());
-        assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
-        assertEquals(failure.index(), parser.text());
-        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-        assertEquals("_shard", parser.currentName());
-        assertEquals(XContentParser.Token.VALUE_NUMBER, parser.nextToken());
-        assertEquals(failure.shardId(), parser.intValue());
-        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-        assertEquals("_node", parser.currentName());
-        assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
-        assertEquals(failure.nodeId(), parser.text());
-
-        Throwable cause = failure.getCause();
-        if (cause != null) {
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("reason", parser.currentName());
-            assertThrowable(parser, cause);
-        }
-        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-        assertEquals("status", parser.currentName());
-        assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
-        assertEquals(failure.status(), RestStatus.valueOf(parser.text()));
-        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-        assertEquals("primary", parser.currentName());
-        assertEquals(XContentParser.Token.VALUE_BOOLEAN, parser.nextToken());
-        assertEquals(failure.primary(), parser.booleanValue());
-        assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
-    }
-
-    private static void assertThrowable(XContentParser parser, Throwable cause) throws IOException {
-        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-        assertEquals("type", parser.currentName());
-        assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
-        assertEquals(ElasticsearchException.getExceptionName(cause), parser.text());
-        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-        assertEquals("reason", parser.currentName());
-        assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
-        assertEquals(cause.getMessage(), parser.text());
-        if (cause instanceof ElasticsearchException) {
-            ElasticsearchException ex = (ElasticsearchException) cause;
-            for (String name : ex.getHeaderKeys()) {
-                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-                assertEquals(name, parser.currentName());
-                assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
-                assertEquals(ex.getHeader(name).get(0), parser.text());
-            }
-            for (String name : ex.getMetadataKeys()) {
-                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-                assertEquals(name.replaceFirst("es.", ""), parser.currentName());
-                assertEquals(XContentParser.Token.VALUE_STRING, parser.nextToken());
-                assertEquals(ex.getMetadata(name).get(0), parser.text());
-            }
-            if (ex.getCause() != null) {
-                assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-                assertEquals("caused_by", parser.currentName());
-                assertThrowable(parser, ex.getCause());
+                ElasticsearchException expectedCause = (ElasticsearchException) expectedFailure.getCause();
+                ElasticsearchException actualCause = (ElasticsearchException) actualFailure.getCause();
+                assertDeepEquals(expectedCause, actualCause);
             }
         }
-        assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import static org.elasticsearch.action.DocWriteResponse.Result.DELETED;
 import static org.elasticsearch.action.DocWriteResponse.Result.NOT_FOUND;
 import static org.elasticsearch.action.DocWriteResponse.Result.UPDATED;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_UUID_NA_VALUE;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 
 public class UpdateResponseTests extends ESTestCase {
@@ -82,9 +83,11 @@ public class UpdateResponseTests extends ESTestCase {
     public void testToAndFromXContent() throws IOException {
         final XContentType xContentType = randomFrom(XContentType.values());
         final Tuple<UpdateResponse, UpdateResponse> tuple = randomUpdateResponse(xContentType);
-        boolean humanReadable = randomBoolean();
+        UpdateResponse updateResponse = tuple.v1();
+        UpdateResponse expectedUpdateResponse = tuple.v2();
 
-        BytesReference updateResponseBytes = toXContent(tuple.v1(), xContentType, humanReadable);
+        boolean humanReadable = randomBoolean();
+        BytesReference updateResponseBytes = toXContent(updateResponse, xContentType, humanReadable);
 
         // Shuffle the XContent fields
         if (randomBoolean()) {
@@ -100,41 +103,52 @@ public class UpdateResponseTests extends ESTestCase {
             assertNull(parser.nextToken());
         }
 
-        final UpdateResponse expectedUpdateResponse = tuple.v2();
-        try (XContentParser parser = createParser(xContentType.xContent(), toXContent(parsedUpdateResponse, xContentType, humanReadable))) {
-            assertUpdateResponse(expectedUpdateResponse, parsedUpdateResponse, parser.map());
-        }
+        // We can't use equals() to compare the original and the parsed delete response
+        // because the random delete response can contain shard failures with exceptions,
+        // and those exceptions are not parsed back with the same types.
+        assertUpdateResponse(expectedUpdateResponse, parsedUpdateResponse);
     }
 
-    public static void assertUpdateResponse(UpdateResponse expected, UpdateResponse parsed, Map<String, Object> actual) throws IOException {
+    public static void assertUpdateResponse(UpdateResponse expected, UpdateResponse actual) {
         IndexResponseTests.assertDocWriteResponse(expected, actual);
-        assertEquals(expected.getGetResult(), parsed.getGetResult());
+        assertEquals(expected.getGetResult(), actual.getGetResult());
     }
 
+    /**
+     * Returns a tuple of {@link UpdateResponse}s.
+     * <p>
+     * The left element is the actual {@link UpdateResponse} to serialize while the right element is the
+     * expected {@link UpdateResponse} after parsing.
+     */
     public static Tuple<UpdateResponse, UpdateResponse> randomUpdateResponse(XContentType xContentType) {
         Tuple<GetResult, GetResult> getResults = GetResultTests.randomGetResult(xContentType);
         GetResult actualGetResult = getResults.v1();
         GetResult expectedGetResult = getResults.v2();
 
-        ShardId shardId = new ShardId(actualGetResult.getIndex(), randomAsciiOfLength(5), randomIntBetween(0, 5));
+        String index = actualGetResult.getIndex();
         String type = actualGetResult.getType();
         String id = actualGetResult.getId();
         long version = actualGetResult.getVersion();
         DocWriteResponse.Result result = actualGetResult.isExists() ? DocWriteResponse.Result.UPDATED : DocWriteResponse.Result.NOT_FOUND;
+        String indexUUid = randomAsciiOfLength(5);
+        int shardId = randomIntBetween(0, 5);
 
         // We also want small number values (randomNonNegativeLong() tend to generate high numbers)
         // in order to catch some conversion error that happen between int/long after parsing.
         Long seqNo = randomFrom(randomNonNegativeLong(), (long) randomIntBetween(0, 10_000), null);
 
+        ShardId actualShardId = new ShardId(index, indexUUid, shardId);
+        ShardId expectedShardId = new ShardId(index, INDEX_UUID_NA_VALUE, -1);
+
         UpdateResponse actual, expected;
         if (seqNo != null) {
-            ReplicationResponse.ShardInfo shardInfo = RandomObjects.randomShardInfo(random(), true);
-            actual = new UpdateResponse(shardInfo, shardId, type, id, seqNo, version, result);
-            expected = new UpdateResponse(shardInfo, shardId, type, id, seqNo, version, result);
+            Tuple<ReplicationResponse.ShardInfo, ReplicationResponse.ShardInfo> shardInfos = RandomObjects.randomShardInfo(random());
 
+            actual = new UpdateResponse(shardInfos.v1(), actualShardId, type, id, seqNo, version, result);
+            expected = new UpdateResponse(shardInfos.v2(), expectedShardId, type, id, seqNo, version, result);
         } else {
-            actual = new UpdateResponse(shardId, type, id, version, result);
-            expected = new UpdateResponse(shardId, type, id, version, result);
+            actual = new UpdateResponse(actualShardId, type, id, version, result);
+            expected = new UpdateResponse(expectedShardId, type, id, version, result);
         }
 
         if (actualGetResult.isExists()) {
@@ -142,8 +156,7 @@ public class UpdateResponseTests extends ESTestCase {
         }
 
         if (expectedGetResult.isExists()) {
-            expected.setGetResult(new GetResult(shardId.getIndexName(), type, id, version,
-                    expectedGetResult.isExists(), expectedGetResult.internalSourceRef(), expectedGetResult.getFields()));
+            expected.setGetResult(expectedGetResult);
         }
 
         boolean forcedRefresh = randomBoolean();

--- a/test/framework/src/main/java/org/elasticsearch/test/RandomObjects.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/RandomObjects.java
@@ -271,7 +271,7 @@ public final class RandomObjects {
         String indexUuid = randomAsciiOfLength(random, 5);
         int shardId = randomIntBetween(random, 1, 10);
         String nodeId = randomAsciiOfLength(random, 5);
-        RestStatus status = randomFrom(random, RestStatus.values());
+        RestStatus status = randomFrom(random, RestStatus.INTERNAL_SERVER_ERROR, RestStatus.FORBIDDEN, RestStatus.NOT_FOUND);
         boolean primary = random.nextBoolean();
         ShardId shard = new ShardId(index, indexUuid, shardId);
 


### PR DESCRIPTION
This pull requests cleans up some parsing tests added from the High Level Rest Client: IndexResponseTests, DeleteResponseTests, UpdateResponseTests, BulkItemResponseTests.

These tests are now more uniform with the others _test-from-to-XContent_ tests we have, they now shuffle the XContent fields before parsing, the asserting method for parsed objects does not used a Map<String, Object> anymore, and buggy equals/hasCode methods in ShardInfo and ShardInfo.Failure have been removed.