### PR TITLE
Fix auto-unboxing in painless

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -162,8 +162,10 @@ public final class MethodWriter extends GeneratorAdapter {
                         else throw new IllegalStateException("Illegal tree structure.");
                     }
                 } else {
-                    unbox(from.type);
-                    writeCast(from, to);
+                    // TODO it'd be nice not to have to look this up here but it'd create a static initialization loop. I think.
+                    Definition.Type unboxed = Definition.getType(from.sort.unboxed.getName());
+                    unbox(unboxed.type);
+                    writeCast(unboxed, to);
                 }
             } else if (cast.unboxTo) {
                 writeCast(from, to);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/CastTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/CastTests.java
@@ -261,7 +261,21 @@ public class CastTests extends ScriptTestCase {
         assertEquals(10L, exec("def x = 5L; return (long) (x <<= 1);"));
         assertEquals(10D, exec("def x = 5L; return (double) (x <<= 1);"));
     }
-    
+
+    public void testUnboxMethodParameters() {
+        assertEquals('a', exec("'a'.charAt(Integer.valueOf(0))"));
+    }
+
+    public void testIllegalCastInMethodArgument() {
+        assertEquals('a', exec("'a'.charAt(0)"));
+        Exception e = expectScriptThrows(ClassCastException.class, () -> exec("'a'.charAt(0L)"));
+        assertEquals("Cannot cast from [long] to [int].", e.getMessage());
+        e = expectScriptThrows(ClassCastException.class, () -> exec("'a'.charAt(0.0f)"));
+        assertEquals("Cannot cast from [float] to [int].", e.getMessage());
+        e = expectScriptThrows(ClassCastException.class, () -> exec("'a'.charAt(0.0d)"));
+        assertEquals("Cannot cast from [double] to [int].", e.getMessage());
+    }
+
     /**
      * Test that without a cast, we fail when conversions would narrow.
      */

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionTests.java
@@ -54,11 +54,32 @@ public class FunctionTests extends ScriptTestCase {
         assertThat(expected.getMessage(), containsString("Cannot generate an empty function"));
     }
 
+    public void testReturnsAreUnboxedIfNeeded() {
+        assertEquals((byte) 5, exec("byte get() {Byte.valueOf(5)} get()"));
+        assertEquals((short) 5, exec("short get() {Byte.valueOf(5)} get()"));
+        assertEquals(5, exec("int get() {Byte.valueOf(5)} get()"));
+        assertEquals((short) 5, exec("short get() {Short.valueOf(5)} get()"));
+        assertEquals(5, exec("int get() {Integer.valueOf(5)} get()"));
+        assertEquals(5.0f, exec("float get() {Float.valueOf(5)} get()"));
+        assertEquals(5.0d, exec("double get() {Float.valueOf(5)} get()"));
+        assertEquals(5.0d, exec("double get() {Double.valueOf(5)} get()"));
+        assertEquals(true, exec("boolean get() {Boolean.TRUE} get()"));
+    }
+
     public void testDuplicates() {
         Exception expected = expectScriptThrows(IllegalArgumentException.class, () -> {
             exec("void test(int x) {x = 2;} void test(def y) {y = 3;} test()");
         });
         assertThat(expected.getMessage(), containsString("Duplicate functions"));
+    }
+
+    public void testBadCastFromMethod() {
+        Exception e = expectScriptThrows(ClassCastException.class, () -> exec("int get() {5L} get()"));
+        assertEquals("Cannot cast from [long] to [int].", e.getMessage());
+        e = expectScriptThrows(ClassCastException.class, () -> exec("int get() {5.1f} get()"));
+        assertEquals("Cannot cast from [float] to [int].", e.getMessage());
+        e = expectScriptThrows(ClassCastException.class, () -> exec("int get() {5.1d} get()"));
+        assertEquals("Cannot cast from [double] to [int].", e.getMessage());
     }
 
     public void testInfiniteLoop() {


### PR DESCRIPTION
Painless in general isn't a big fan of autoboxing and auto-unboxing
but it *does* support it in a few instances:
```
int get() {Integer.valueOf(5)} get()
```
and
```
'a'.charAt(Integer.valueOf(0))
```

In these cases we unbox (and maybe cast) the parameters. Before this
patch they would blow up with a null pointer exception inside of
asm. That was bad. So I fixed it. Now we actually unbox and cast
properly.
