### PR TITLE
Fix ArrayIndexOutOfBoundsException when no ranges are specified in the query

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.range;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -51,7 +52,11 @@ public class RangeAggregationBuilder extends AbstractRangeBuilder<RangeAggregati
     }
 
     public static AggregationBuilder parse(String aggregationName, QueryParseContext context) throws IOException {
-        return PARSER.parse(context.parser(), new RangeAggregationBuilder(aggregationName), context);
+        RangeAggregationBuilder builder = PARSER.parse(context.parser(), new RangeAggregationBuilder(aggregationName), context);
+        if(builder.ranges().size() == 0){
+            throw new ElasticsearchParseException("No [ranges] specified for the [" + builder.getName() + "] aggregation");
+        }
+        return builder;
     }
 
     private static Range parseRange(XContentParser parser, QueryParseContext context) throws IOException {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.bucket.range;
 
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -52,11 +51,7 @@ public class RangeAggregationBuilder extends AbstractRangeBuilder<RangeAggregati
     }
 
     public static AggregationBuilder parse(String aggregationName, QueryParseContext context) throws IOException {
-        RangeAggregationBuilder builder = PARSER.parse(context.parser(), new RangeAggregationBuilder(aggregationName), context);
-        if(builder.ranges().size() == 0){
-            throw new ElasticsearchParseException("No [ranges] specified for the [" + builder.getName() + "] aggregation");
-        }
-        return builder;
+        return PARSER.parse(context.parser(), new RangeAggregationBuilder(aggregationName), context);
     }
 
     private static Range parseRange(XContentParser parser, QueryParseContext context) throws IOException {
@@ -145,6 +140,9 @@ public class RangeAggregationBuilder extends AbstractRangeBuilder<RangeAggregati
             AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {
         // We need to call processRanges here so they are parsed before we make the decision of whether to cache the request
         Range[] ranges = processRanges(context, config);
+        if (ranges.length == 0) {
+            throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");
+        }
         return new RangeAggregatorFactory(name, config, ranges, keyed, rangeFactory, context, parent, subFactoriesBuilder,
                 metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -217,9 +217,11 @@ public class RangeAggregator extends BucketsAggregator {
         this.ranges = ranges;
 
         maxTo = new double[this.ranges.length];
-        maxTo[0] = this.ranges[0].to;
-        for (int i = 1; i < this.ranges.length; ++i) {
-            maxTo[i] = Math.max(this.ranges[i].to,maxTo[i-1]);
+        if(ranges.length > 0){
+            maxTo[0] = this.ranges[0].to;
+            for (int i = 1; i < this.ranges.length; ++i) {
+                maxTo[i] = Math.max(this.ranges[i].to,maxTo[i-1]);
+            }
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -217,11 +217,9 @@ public class RangeAggregator extends BucketsAggregator {
         this.ranges = ranges;
 
         maxTo = new double[this.ranges.length];
-        if(ranges.length > 0){
-            maxTo[0] = this.ranges[0].to;
-            for (int i = 1; i < this.ranges.length; ++i) {
-                maxTo[i] = Math.max(this.ranges[i].to,maxTo[i-1]);
-            }
+        maxTo[0] = this.ranges[0].to;
+        for (int i = 1; i < this.ranges.length; ++i) {
+            maxTo[i] = Math.max(this.ranges[i].to,maxTo[i-1]);
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeAggregationBuilder.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.range.date;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -54,7 +55,11 @@ public class DateRangeAggregationBuilder extends AbstractRangeBuilder<DateRangeA
     }
 
     public static AggregationBuilder parse(String aggregationName, QueryParseContext context) throws IOException {
-        return PARSER.parse(context.parser(), new DateRangeAggregationBuilder(aggregationName), context);
+        DateRangeAggregationBuilder builder = PARSER.parse(context.parser(), new DateRangeAggregationBuilder(aggregationName), context);
+        if(builder.ranges().size() == 0){
+            throw new ElasticsearchParseException("No [ranges] specified for the [" + builder.getName() + "] aggregation");
+        }
+        return builder;
     }
 
     private static Range parseRange(XContentParser parser, QueryParseContext context) throws IOException {
@@ -283,7 +288,7 @@ public class DateRangeAggregationBuilder extends AbstractRangeBuilder<DateRangeA
     @Override
     protected DateRangeAggregatorFactory innerBuild(SearchContext context, ValuesSourceConfig<Numeric> config,
             AggregatorFactory<?> parent, Builder subFactoriesBuilder) throws IOException {
-        // We need to call processRanges here so they are parsed and we know whether `now` has been used before we make 
+        // We need to call processRanges here so they are parsed and we know whether `now` has been used before we make
         // the decision of whether to cache the request
         Range[] ranges = processRanges(context, config);
         return new DateRangeAggregatorFactory(name, config, ranges, keyed, rangeFactory, context, parent, subFactoriesBuilder,

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/date/DateRangeAggregationBuilder.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.bucket.range.date;
 
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -55,11 +54,7 @@ public class DateRangeAggregationBuilder extends AbstractRangeBuilder<DateRangeA
     }
 
     public static AggregationBuilder parse(String aggregationName, QueryParseContext context) throws IOException {
-        DateRangeAggregationBuilder builder = PARSER.parse(context.parser(), new DateRangeAggregationBuilder(aggregationName), context);
-        if(builder.ranges().size() == 0){
-            throw new ElasticsearchParseException("No [ranges] specified for the [" + builder.getName() + "] aggregation");
-        }
-        return builder;
+        return PARSER.parse(context.parser(), new DateRangeAggregationBuilder(aggregationName), context);
     }
 
     private static Range parseRange(XContentParser parser, QueryParseContext context) throws IOException {
@@ -291,6 +286,9 @@ public class DateRangeAggregationBuilder extends AbstractRangeBuilder<DateRangeA
         // We need to call processRanges here so they are parsed and we know whether `now` has been used before we make
         // the decision of whether to cache the request
         Range[] ranges = processRanges(context, config);
+        if (ranges.length == 0) {
+            throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");
+        }
         return new DateRangeAggregatorFactory(name, config, ranges, keyed, rangeFactory, context, parent, subFactoriesBuilder,
                 metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/GeoDistanceAggregationBuilder.java
@@ -384,6 +384,9 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
             ValuesSourceConfig<ValuesSource.GeoPoint> config, AggregatorFactory<?> parent, Builder subFactoriesBuilder)
                     throws IOException {
         Range[] ranges = this.ranges.toArray(new Range[this.range().size()]);
+        if (ranges.length == 0) {
+            throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");
+        }
         return new GeoDistanceRangeAggregatorFactory(name, config, origin, ranges, unit, distanceType, keyed, context, parent,
                 subFactoriesBuilder, metaData);
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ip/IpRangeAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ip/IpRangeAggregationBuilder.java
@@ -369,6 +369,9 @@ public final class IpRangeAggregationBuilder
             AggregatorFactory<?> parent, Builder subFactoriesBuilder)
                     throws IOException {
         List<BinaryRangeAggregator.Range> ranges = new ArrayList<>();
+        if(this.ranges.size() == 0){
+            throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");
+        }
         for (Range range : this.ranges) {
             ranges.add(new BinaryRangeAggregator.Range(range.key, toBytesRef(range.from), toBytesRef(range.to)));
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
@@ -50,6 +51,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -863,6 +865,19 @@ public class DateRangeIT extends ESIntegTestCase {
         assertThat(((DateTime) buckets.get(0).getTo()).getMillis(), equalTo(1L));
         assertThat(buckets.get(0).getDocCount(), equalTo(0L));
         assertThat(buckets.get(0).getAggregations().asList().isEmpty(), is(true));
+    }
+
+    public void testNoRangesInQuery()  {
+        try {
+            client().prepareSearch("idx")
+                .addAggregation(dateRange("my_date_range_agg").field("value"))
+                .execute().actionGet();
+            fail();
+        } catch (SearchPhaseExecutionException spee){
+            Throwable rootCause = spee.getCause().getCause();
+            assertThat(rootCause, instanceOf(IllegalArgumentException.class));
+            assertEquals(rootCause.getMessage(), "No [ranges] specified for the [my_date_range_agg] aggregation");
+        }
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -51,6 +52,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -437,6 +439,19 @@ public class GeoDistanceIT extends ESIntegTestCase {
         assertThat(buckets.get(0).getFromAsString(), equalTo("0.0"));
         assertThat(buckets.get(0).getToAsString(), equalTo("100.0"));
         assertThat(buckets.get(0).getDocCount(), equalTo(0L));
+    }
+
+    public void testNoRangesInQuery()  {
+        try {
+            client().prepareSearch("idx")
+                .addAggregation(geoDistance("geo_dist", new GeoPoint(52.3760, 4.894)))
+                .execute().actionGet();
+            fail();
+        } catch (SearchPhaseExecutionException spee){
+            Throwable rootCause = spee.getCause().getCause();
+            assertThat(rootCause, instanceOf(IllegalArgumentException.class));
+            assertEquals(rootCause.getMessage(), "No [ranges] specified for the [geo_dist] aggregation");
+        }
     }
 
     public void testMultiValues() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
@@ -660,6 +660,21 @@ public class RangeIT extends ESIntegTestCase {
         assertThat(bucket.getDocCount(), equalTo(0L));
     }
 
+    public void testNoRanges() throws Exception {
+        SearchResponse response = client().prepareSearch("idx")
+            .addAggregation(range("range")
+                .field(SINGLE_VALUED_FIELD_NAME))
+            .execute().actionGet();
+
+        assertSearchResponse(response);
+
+        Range range = response.getAggregations().get("range");
+        assertThat(range, notNullValue());
+        assertThat(range.getName(), equalTo("range"));
+        List<? extends Bucket> buckets = range.getBuckets();
+        assertThat(buckets.size(), equalTo(0));
+    }
+
     public void testScriptMultiValued() throws Exception {
         Script script =
             new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['" + MULTI_VALUED_FIELD_NAME + "'].values", Collections.emptyMap());

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
@@ -660,21 +660,6 @@ public class RangeIT extends ESIntegTestCase {
         assertThat(bucket.getDocCount(), equalTo(0L));
     }
 
-    public void testNoRanges() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-            .addAggregation(range("range")
-                .field(SINGLE_VALUED_FIELD_NAME))
-            .execute().actionGet();
-
-        assertSearchResponse(response);
-
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(0));
-    }
-
     public void testScriptMultiValued() throws Exception {
         Script script =
             new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['" + MULTI_VALUED_FIELD_NAME + "'].values", Collections.emptyMap());

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
@@ -52,6 +53,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -658,6 +660,20 @@ public class RangeIT extends ESIntegTestCase {
         assertThat(bucket.getFromAsString(), equalTo("1000.0"));
         assertThat(bucket.getToAsString(), nullValue());
         assertThat(bucket.getDocCount(), equalTo(0L));
+    }
+
+    public void testNoRangesInQuery()  {
+        try {
+            client().prepareSearch("idx")
+                .addAggregation(range("foobar")
+                    .field(SINGLE_VALUED_FIELD_NAME))
+                .execute().actionGet();
+            fail();
+        } catch (SearchPhaseExecutionException spee){
+            Throwable rootCause = spee.getCause().getCause();
+            assertThat(rootCause, instanceOf(IllegalArgumentException.class));
+            assertEquals(rootCause.getMessage(), "No [ranges] specified for the [foobar] aggregation");
+        }
     }
 
     public void testScriptMultiValued() throws Exception {


### PR DESCRIPTION
The issue is reproduced in 5.1, 5.2, 5.3, 5.x and master branch. My fix is on master.

This commit just checks the ranges array size at the spot where the exception is raised. I am not sure if this should be fixed at a higher level in the code.

Closes #22881 
