### PR TITLE
Fix Painless's implementation of interfaces returning primitives

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
@@ -97,7 +97,7 @@ public final class Locals {
         locals.defineVariable(null, Definition.getType("Object"), THIS, true);
 
         // Method arguments
-        for (MethodArgument arg : scriptInterface.getArguments()) {
+        for (MethodArgument arg : scriptInterface.getExecuteArguments()) {
             locals.defineVariable(null, arg.getType(), arg.getName(), true);
         }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
@@ -92,7 +92,7 @@ public final class Locals {
 
     /** Creates a new main method scope */
     public static Locals newMainMethodScope(ScriptInterface scriptInterface, Locals programScope, int maxLoopCounter) {
-        Locals locals = new Locals(programScope, Definition.OBJECT_TYPE, KEYWORDS);
+        Locals locals = new Locals(programScope, scriptInterface.getExecuteMethodReturnType(), KEYWORDS);
         // This reference. Internal use only.
         locals.defineVariable(null, Definition.getType("Object"), THIS, true);
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -34,13 +34,6 @@ import java.util.BitSet;
 import java.util.Deque;
 import java.util.List;
 
-import static org.elasticsearch.painless.Definition.BOOLEAN_TYPE;
-import static org.elasticsearch.painless.Definition.BYTE_TYPE;
-import static org.elasticsearch.painless.Definition.DOUBLE_TYPE;
-import static org.elasticsearch.painless.Definition.FLOAT_TYPE;
-import static org.elasticsearch.painless.Definition.INT_TYPE;
-import static org.elasticsearch.painless.Definition.LONG_TYPE;
-import static org.elasticsearch.painless.Definition.SHORT_TYPE;
 import static org.elasticsearch.painless.WriterConstants.CHAR_TO_STRING;
 import static org.elasticsearch.painless.WriterConstants.DEF_BOOTSTRAP_HANDLE;
 import static org.elasticsearch.painless.WriterConstants.DEF_TO_BOOLEAN;
@@ -377,17 +370,6 @@ public final class MethodWriter extends GeneratorAdapter {
         } else if (size == 2) {
             pop2();
         }
-    }
-
-    public void writeDefaultValue(org.objectweb.asm.Type type) {
-        if (type.equals(BOOLEAN_TYPE.type))     push(false);
-        else if (type.equals(BYTE_TYPE.type))   push(0);
-        else if (type.equals(SHORT_TYPE.type))  push(0);
-        else if (type.equals(INT_TYPE.type))    push(0);
-        else if (type.equals(LONG_TYPE.type))   push(0L);
-        else if (type.equals(FLOAT_TYPE.type))  push(0f);
-        else if (type.equals(DOUBLE_TYPE.type)) push(0d);
-        else                                    visitInsn(Opcodes.ACONST_NULL);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -34,6 +34,7 @@ import java.util.BitSet;
 import java.util.Deque;
 import java.util.List;
 
+import static org.elasticsearch.painless.Definition.*;
 import static org.elasticsearch.painless.WriterConstants.CHAR_TO_STRING;
 import static org.elasticsearch.painless.WriterConstants.DEF_BOOTSTRAP_HANDLE;
 import static org.elasticsearch.painless.WriterConstants.DEF_TO_BOOLEAN;
@@ -370,6 +371,17 @@ public final class MethodWriter extends GeneratorAdapter {
         } else if (size == 2) {
             pop2();
         }
+    }
+
+    public void writeDefaultValue(org.objectweb.asm.Type type) {
+        if (type.equals(BOOLEAN_TYPE.type))     push(false);
+        else if (type.equals(BYTE_TYPE.type))   push(0);
+        else if (type.equals(SHORT_TYPE.type))  push(0);
+        else if (type.equals(INT_TYPE.type))    push(0);
+        else if (type.equals(LONG_TYPE.type))   push(0L);
+        else if (type.equals(FLOAT_TYPE.type))  push(0f);
+        else if (type.equals(DOUBLE_TYPE.type)) push(0d);
+        else                                    visitInsn(Opcodes.ACONST_NULL);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -34,7 +34,13 @@ import java.util.BitSet;
 import java.util.Deque;
 import java.util.List;
 
-import static org.elasticsearch.painless.Definition.*;
+import static org.elasticsearch.painless.Definition.BOOLEAN_TYPE;
+import static org.elasticsearch.painless.Definition.BYTE_TYPE;
+import static org.elasticsearch.painless.Definition.DOUBLE_TYPE;
+import static org.elasticsearch.painless.Definition.FLOAT_TYPE;
+import static org.elasticsearch.painless.Definition.INT_TYPE;
+import static org.elasticsearch.painless.Definition.LONG_TYPE;
+import static org.elasticsearch.painless.Definition.SHORT_TYPE;
 import static org.elasticsearch.painless.WriterConstants.CHAR_TO_STRING;
 import static org.elasticsearch.painless.WriterConstants.DEF_BOOTSTRAP_HANDLE;
 import static org.elasticsearch.painless.WriterConstants.DEF_TO_BOOLEAN;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptInterface.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptInterface.java
@@ -149,7 +149,7 @@ public class ScriptInterface {
                 + componentType.getName() + ". Painless interfaces can only accept arguments that are of whitelisted types.");
         return new MethodArgument(defType, argName);
     }
-    
+
     private static Definition.Type definitionTypeForClass(Class<?> type, Function<Class<?>, String> unknownErrorMessageSource) {
         int dimensions = 0;
         Class<?> componentType = type;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptInterface.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptInterface.java
@@ -37,7 +37,7 @@ public class ScriptInterface {
     private final Class<?> iface;
     private final org.objectweb.asm.commons.Method executeMethod;
     private final Definition.Type executeMethodReturnType;
-    private final List<MethodArgument> arguments;
+    private final List<MethodArgument> executeArguments;
     private final List<org.objectweb.asm.commons.Method> usesMethods;
 
     public ScriptInterface(Class<?> iface) {
@@ -94,7 +94,7 @@ public class ScriptInterface {
             arguments.add(methodArgument(types[arg], argumentNamesConstant[arg]));
             argumentNames.add(argumentNamesConstant[arg]);
         }
-        this.arguments = unmodifiableList(arguments);
+        this.executeArguments = unmodifiableList(arguments);
 
         // Validate that the uses$argName methods reference argument names
         for (org.objectweb.asm.commons.Method usesMethod : usesMethods) {
@@ -132,8 +132,8 @@ public class ScriptInterface {
      * Painless {@link Definition.Type}s and names of the arguments to the {@code execute} method. The names are exposed to the Painless
      * script.
      */
-    public List<MethodArgument> getArguments() {
-        return arguments;
+    public List<MethodArgument> getExecuteArguments() {
+        return executeArguments;
     }
 
     /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptInterface.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptInterface.java
@@ -106,26 +106,46 @@ public class ScriptInterface {
         this.usesMethods = unmodifiableList(usesMethods);
     }
 
+    /**
+     * The interface that the Painless script should implement.
+     */
     public Class<?> getInterface() {
         return iface;
     }
 
+    /**
+     * An asm method descriptor for the {@code execute} method.
+     */
     public org.objectweb.asm.commons.Method getExecuteMethod() {
         return executeMethod;
     }
 
+    /**
+     * The Painless {@link Definition.Type} or the return type of the {@code execute} method. This is used to generate the appropriate
+     * return bytecode.
+     */
     public Definition.Type getExecuteMethodReturnType() {
         return executeMethodReturnType;
     }
 
+    /**
+     * Painless {@link Definition.Type}s and names of the arguments to the {@code execute} method. The names are exposed to the Painless
+     * script.
+     */
     public List<MethodArgument> getArguments() {
         return arguments;
     }
 
+    /**
+     * The {@code uses$varName} methods that must be implemented by Painless to complete implementing the interface.
+     */
     public List<org.objectweb.asm.commons.Method> getUsesMethods() {
         return usesMethods;
     }
 
+    /**
+     * Painless {@link Definition.Type}s and name of the argument to the {@code execute} method.
+     */
     public static class MethodArgument {
         private final Definition.Type type;
         private final String name;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
@@ -317,7 +317,8 @@ public final class SSource extends AStatement {
                 // TODO this should fail too but it can't to keep compatibility with Elasticsearch scripts
                 writer.visitInsn(Opcodes.ACONST_NULL);
             } else if (false == scriptInterface.getExecuteMethodReturnType().equals(Definition.VOID_TYPE)) {
-                throw new IllegalArgumentException("Expected all paths to [return] but not all did."); // TODO better error message
+                throw new IllegalArgumentException("Expected all paths to [return] but not all did or end in an expression to return but "
+                        + "some path ends is missing a return and ends in a statement.");
             }
             writer.returnValue();
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
@@ -192,6 +192,15 @@ public final class SSource extends AStatement {
             methodEscape = statement.methodEscape;
             allEscape = statement.allEscape;
         }
+
+        if (!methodEscape) {
+            if (scriptInterface.getExecuteMethodReturnType().equals(Definition.DEF_TYPE)) {
+                // TODO this should fail too but it can't to keep compatibility with Elasticsearch scripts
+            } else if (false == scriptInterface.getExecuteMethodReturnType().equals(Definition.VOID_TYPE)) {
+                throw new IllegalArgumentException("Expected all paths to [return] but not all did or end in an expression to return but "
+                        + "some path ends is missing a return and ends in a statement.");
+            }
+        }
     }
 
     public void write() {
@@ -317,6 +326,7 @@ public final class SSource extends AStatement {
                 // TODO this should fail too but it can't to keep compatibility with Elasticsearch scripts
                 writer.visitInsn(Opcodes.ACONST_NULL);
             } else if (false == scriptInterface.getExecuteMethodReturnType().equals(Definition.VOID_TYPE)) {
+                assert false : "this should have failed during the analyze phase";
                 throw new IllegalArgumentException("Expected all paths to [return] but not all did or end in an expression to return but "
                         + "some path ends is missing a return and ends in a statement.");
             }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
@@ -192,15 +192,6 @@ public final class SSource extends AStatement {
             methodEscape = statement.methodEscape;
             allEscape = statement.allEscape;
         }
-
-        if (!methodEscape) {
-            if (scriptInterface.getExecuteMethodReturnType().equals(Definition.DEF_TYPE)) {
-                // TODO this should fail too but it can't to keep compatibility with Elasticsearch scripts
-            } else if (false == scriptInterface.getExecuteMethodReturnType().equals(Definition.VOID_TYPE)) {
-                throw new IllegalArgumentException("Expected all paths to [return] but not all did or end in an expression to return but "
-                        + "some path ends is missing a return and ends in a statement.");
-            }
-        }
     }
 
     public void write() {
@@ -322,13 +313,8 @@ public final class SSource extends AStatement {
         }
 
         if (!methodEscape) {
-            if (scriptInterface.getExecuteMethodReturnType().equals(Definition.DEF_TYPE)) {
-                // TODO this should fail too but it can't to keep compatibility with Elasticsearch scripts
-                writer.visitInsn(Opcodes.ACONST_NULL);
-            } else if (false == scriptInterface.getExecuteMethodReturnType().equals(Definition.VOID_TYPE)) {
-                assert false : "this should have failed during the analyze phase";
-                throw new IllegalArgumentException("Expected all paths to [return] but not all did or end in an expression to return but "
-                        + "some path ends is missing a return and ends in a statement.");
+            if (false == scriptInterface.getExecuteMethod().getReturnType().equals(Definition.VOID_TYPE.type)) {
+                writer.writeDefaultValue(scriptInterface.getExecuteMethod().getReturnType());
             }
             writer.returnValue();
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Constant;
-import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Method;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Globals;
@@ -313,8 +312,16 @@ public final class SSource extends AStatement {
         }
 
         if (!methodEscape) {
-            if (false == scriptInterface.getExecuteMethod().getReturnType().equals(Definition.VOID_TYPE.type)) {
-                writer.writeDefaultValue(scriptInterface.getExecuteMethod().getReturnType());
+            switch (scriptInterface.getExecuteMethod().getReturnType().getSort()) {
+            case org.objectweb.asm.Type.VOID:    break;
+            case org.objectweb.asm.Type.BOOLEAN: writer.push(false); break;
+            case org.objectweb.asm.Type.BYTE:    writer.push(0); break;
+            case org.objectweb.asm.Type.SHORT:   writer.push(0); break;
+            case org.objectweb.asm.Type.INT:     writer.push(0); break;
+            case org.objectweb.asm.Type.LONG:    writer.push(0L); break;
+            case org.objectweb.asm.Type.FLOAT:   writer.push(0f); break;
+            case org.objectweb.asm.Type.DOUBLE:  writer.push(0d); break;
+            default:                             writer.visitInsn(Opcodes.ACONST_NULL);
             }
             writer.returnValue();
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
@@ -21,6 +21,7 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Constant;
+import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Method;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Globals;
@@ -312,7 +313,12 @@ public final class SSource extends AStatement {
         }
 
         if (!methodEscape) {
-            writer.visitInsn(Opcodes.ACONST_NULL);
+            if (scriptInterface.getExecuteMethodReturnType().equals(Definition.DEF_TYPE)) {
+                // TODO this should fail too but it can't to keep compatibility with Elasticsearch scripts
+                writer.visitInsn(Opcodes.ACONST_NULL);
+            } else if (false == scriptInterface.getExecuteMethodReturnType().equals(Definition.VOID_TYPE)) {
+                throw new IllegalArgumentException("Expected all paths to [return] but not all did."); // TODO better error message
+            }
             writer.returnValue();
         }
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
@@ -184,9 +184,6 @@ public class ImplementInterfacesTests extends ScriptTestCase {
         assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "Integer.valueOf(1)", emptyMap()).execute());
 
         assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = 1; i", emptyMap()).execute());
-        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = (int) 1L; i", emptyMap()).execute());
-        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = (int) 1.1d; i", emptyMap()).execute());
-        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = (int) 1.1f; i", emptyMap()).execute());
         assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = Integer.valueOf(1); i", emptyMap()).execute());
 
         assertEquals(2, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "1 + 1", emptyMap()).execute());
@@ -214,6 +211,41 @@ public class ImplementInterfacesTests extends ScriptTestCase {
 
         e = expectScriptThrows(IllegalArgumentException.class, () ->
             scriptEngine.compile(ReturnsPrimitiveInt.class, null, "int i = 0", emptyMap()));
+        assertEquals("Expected all paths to [return] but not all did or end in an expression to return but "
+                + "some path ends is missing a return and ends in a statement.", e.getMessage());
+    }
+
+    public interface ReturnsPrimitiveDouble {
+        String[] ARGUMENTS = new String[] {};
+        double execute();
+    }
+    public void testReturnsPrimitiveDouble() {
+        assertEquals(1.0, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "1", emptyMap()).execute(), 0);
+        assertEquals(1.0, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "1L", emptyMap()).execute(), 0);
+        assertEquals(1.1, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "1.1d", emptyMap()).execute(), 0);
+        assertEquals((double) 1.1f, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "1.1f", emptyMap()).execute(), 0);
+        assertEquals(1.1, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "Double.valueOf(1.1)", emptyMap()).execute(), 0);
+        assertEquals((double) 1.1f,
+                    scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "Float.valueOf(1.1f)", emptyMap()).execute(), 0);
+
+        assertEquals(1.0, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "def d = 1; d", emptyMap()).execute(), 0);
+        assertEquals(1.0, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "def d = 1L; d", emptyMap()).execute(), 0);
+        assertEquals(1.1, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "def d = 1.1d; d", emptyMap()).execute(), 0);
+        assertEquals((double) 1.1f, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "def d = 1.1f; d", emptyMap()).execute(), 0);
+        assertEquals(1.1,
+                scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "def d = Double.valueOf(1.1); d", emptyMap()).execute(), 0);
+        assertEquals((double) 1.1f,
+                scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "def d = Float.valueOf(1.1f); d", emptyMap()).execute(), 0);
+
+        assertEquals(1.1 + 6.7, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "1.1 + 6.7", emptyMap()).execute(), 0);
+
+        String debug = Debugger.toString(ReturnsPrimitiveDouble.class, "1", new CompilerSettings());
+        assertThat(debug, containsString("DCONST_1"));
+        // The important thing here is that we have the bytecode for returning a double instead of an object
+        assertThat(debug, containsString("DRETURN"));
+
+        Exception e = expectScriptThrows(IllegalArgumentException.class, () ->
+            scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "int i = 0", emptyMap()));
         assertEquals("Expected all paths to [return] but not all did or end in an expression to return but "
                 + "some path ends is missing a return and ends in a statement.", e.getMessage());
     }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
@@ -181,6 +181,45 @@ public class ImplementInterfacesTests extends ScriptTestCase {
         assertThat(debug, not(containsString("ACONST_NULL")));
     }
 
+    public interface ReturnsPrimitiveBoolean {
+        String[] ARGUMENTS = new String[] {};
+        boolean execute();
+    }
+    public void testReturnsPrimitiveBoolean() {
+        assertEquals(true, scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "true", emptyMap()).execute());
+        assertEquals(false, scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "false", emptyMap()).execute());
+        assertEquals(true, scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "Boolean.TRUE", emptyMap()).execute());
+        assertEquals(false, scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "Boolean.FALSE", emptyMap()).execute());
+
+        assertEquals(true, scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "def i = true; i", emptyMap()).execute());
+        assertEquals(true, scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "def i = Boolean.TRUE; i", emptyMap()).execute());
+
+        assertEquals(true, scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "true || false", emptyMap()).execute());
+
+        String debug = Debugger.toString(ReturnsPrimitiveBoolean.class, "false", new CompilerSettings());
+        assertThat(debug, containsString("ICONST_0"));
+        // The important thing here is that we have the bytecode for returning an integer instead of an object. booleans are integers.
+        assertThat(debug, containsString("IRETURN"));
+
+        Exception e = expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "1L", emptyMap()).execute());
+        assertEquals("Cannot cast from [long] to [boolean].", e.getMessage());
+        e = expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "1.1f", emptyMap()).execute());
+        assertEquals("Cannot cast from [float] to [boolean].", e.getMessage());
+        e = expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "1.1d", emptyMap()).execute());
+        assertEquals("Cannot cast from [double] to [boolean].", e.getMessage());
+        expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "def i = 1L; i", emptyMap()).execute());
+        expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "def i = 1.1f; i", emptyMap()).execute());
+        expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "def i = 1.1d; i", emptyMap()).execute());
+
+        assertEquals(false, scriptEngine.compile(ReturnsPrimitiveBoolean.class, null, "int i = 0", emptyMap()).execute());
+    }
+
     public interface ReturnsPrimitiveInt {
         String[] ARGUMENTS = new String[] {};
         int execute();

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
@@ -173,36 +173,40 @@ public class ImplementInterfacesTests extends ScriptTestCase {
         assertThat(debug, containsString("RETURN"));
     }
 
-    public interface ReturnsPrimitive {
+    public interface ReturnsPrimitiveInt {
         String[] ARGUMENTS = new String[] {};
         int execute();
     }
     public void testReturnsPrimitive() {
-//        assertEquals(1, scriptEngine.compile(ReturnsPrimitive.class, null, "1", emptyMap()).execute());
-//        assertEquals(1, scriptEngine.compile(ReturnsPrimitive.class, null, "def i = 1; i", emptyMap()).execute());
-//        assertEquals(1, scriptEngine.compile(ReturnsPrimitive.class, null, "(int) 1L", emptyMap()).execute());
-//        assertEquals(1, scriptEngine.compile(ReturnsPrimitive.class, null, "(int) 1.1d", emptyMap()).execute());
-//        assertEquals(1, scriptEngine.compile(ReturnsPrimitive.class, null, "(int) 1.1f", emptyMap()).execute());
-//        NOCOMMIT def or all of the funny types
-//
-//        assertEquals(2, scriptEngine.compile(ReturnsPrimitive.class, null, "1 + 1", emptyMap()).execute());
-//
-//        expectScriptThrows(ClassCastException.class, () ->
-//                scriptEngine.compile(ReturnsPrimitive.class, null, "1L", emptyMap()).execute());
-//        expectScriptThrows(ClassCastException.class, () ->
-//                scriptEngine.compile(ReturnsPrimitive.class, null, "1.1f", emptyMap()).execute());
-//        expectScriptThrows(ClassCastException.class, () ->
-//                scriptEngine.compile(ReturnsPrimitive.class, null, "1.1d", emptyMap()).execute());
-        expectScriptThrows(ClassCastException.class, () ->
-                scriptEngine.compile(ReturnsPrimitive.class, null, "Integer.valueOf(1)", emptyMap()).execute());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "1", emptyMap()).execute());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "(int) 1L", emptyMap()).execute());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "(int) 1.1d", emptyMap()).execute());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "(int) 1.1f", emptyMap()).execute());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "Integer.valueOf(1)", emptyMap()).execute());
 
-        String debug = Debugger.toString(ReturnsPrimitive.class, "1", new CompilerSettings());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = 1; i", emptyMap()).execute());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = (int) 1L; i", emptyMap()).execute());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = (int) 1.1d; i", emptyMap()).execute());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = (int) 1.1f; i", emptyMap()).execute());
+        assertEquals(1, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = Integer.valueOf(1); i", emptyMap()).execute());
+
+        assertEquals(2, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "1 + 1", emptyMap()).execute());
+
+        expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveInt.class, null, "1L", emptyMap()).execute());
+        expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveInt.class, null, "1.1f", emptyMap()).execute());
+        expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveInt.class, null, "1.1d", emptyMap()).execute());
+
+        String debug = Debugger.toString(ReturnsPrimitiveInt.class, "1", new CompilerSettings());
         assertThat(debug, containsString("ICONST_1"));
         assertThat(debug, containsString("IRETURN"));
 
         Exception e = expectScriptThrows(IllegalArgumentException.class, () ->
-            scriptEngine.compile(ReturnsPrimitive.class, null, "int i = 0", emptyMap()));
-        assertEquals("Expected all paths to [return] but not all did.", e.getMessage());
+            scriptEngine.compile(ReturnsPrimitiveInt.class, null, "int i = 0", emptyMap()));
+        assertEquals("Expected all paths to [return] but not all did or end in an expression to return but "
+                + "some path ends is missing a return and ends in a statement.", e.getMessage());
     }
 
     public interface NoArgumentsConstant {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
@@ -218,10 +218,36 @@ public class ImplementInterfacesTests extends ScriptTestCase {
         expectScriptThrows(ClassCastException.class, () ->
                 scriptEngine.compile(ReturnsPrimitiveInt.class, null, "def i = 1.1d; i", emptyMap()).execute());
 
-        e = expectScriptThrows(IllegalArgumentException.class, () ->
-            scriptEngine.compile(ReturnsPrimitiveInt.class, null, "int i = 0", emptyMap()));
-        assertEquals("Expected all paths to [return] but not all did or end in an expression to return but "
-                + "some path ends is missing a return and ends in a statement.", e.getMessage());
+        assertEquals(0, scriptEngine.compile(ReturnsPrimitiveInt.class, null, "int i = 0", emptyMap()).execute());
+    }
+
+    public interface ReturnsPrimitiveFloat {
+        String[] ARGUMENTS = new String[] {};
+        float execute();
+    }
+    public void testReturnsPrimitiveFloat() {
+        assertEquals(1.1f, scriptEngine.compile(ReturnsPrimitiveFloat.class, null, "1.1f", emptyMap()).execute(), 0);
+        assertEquals(1.1f, scriptEngine.compile(ReturnsPrimitiveFloat.class, null, "(float) 1.1d", emptyMap()).execute(), 0);
+        assertEquals(1.1f, scriptEngine.compile(ReturnsPrimitiveFloat.class, null, "def d = 1.1f; d", emptyMap()).execute(), 0);
+        assertEquals(1.1f,
+                scriptEngine.compile(ReturnsPrimitiveFloat.class, null, "def d = Float.valueOf(1.1f); d", emptyMap()).execute(), 0);
+
+        assertEquals(1.1f + 6.7f, scriptEngine.compile(ReturnsPrimitiveFloat.class, null, "1.1f + 6.7f", emptyMap()).execute(), 0);
+
+        Exception e = expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveFloat.class, null, "1.1d", emptyMap()).execute());
+        assertEquals("Cannot cast from [double] to [float].", e.getMessage());
+        e = expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveFloat.class, null, "def d = 1.1d; d", emptyMap()).execute());
+        e = expectScriptThrows(ClassCastException.class, () ->
+                scriptEngine.compile(ReturnsPrimitiveFloat.class, null, "def d = Double.valueOf(1.1); d", emptyMap()).execute());
+
+        String debug = Debugger.toString(ReturnsPrimitiveFloat.class, "1f", new CompilerSettings());
+        assertThat(debug, containsString("FCONST_1"));
+        // The important thing here is that we have the bytecode for returning a float instead of an object
+        assertThat(debug, containsString("FRETURN"));
+
+        assertEquals(0.0f, scriptEngine.compile(ReturnsPrimitiveFloat.class, null, "int i = 0", emptyMap()).execute(), 0);
     }
 
     public interface ReturnsPrimitiveDouble {
@@ -253,10 +279,7 @@ public class ImplementInterfacesTests extends ScriptTestCase {
         // The important thing here is that we have the bytecode for returning a double instead of an object
         assertThat(debug, containsString("DRETURN"));
 
-        Exception e = expectScriptThrows(IllegalArgumentException.class, () ->
-            scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "int i = 0", emptyMap()));
-        assertEquals("Expected all paths to [return] but not all did or end in an expression to return but "
-                + "some path ends is missing a return and ends in a statement.", e.getMessage());
+        assertEquals(0.0, scriptEngine.compile(ReturnsPrimitiveDouble.class, null, "int i = 0", emptyMap()).execute(), 0);
     }
 
     public interface NoArgumentsConstant {


### PR DESCRIPTION
Fixes Painless to properly implement scripts that return primitives and void. Adds some simple tests that we emit sane opcodes and some other tests that we implement primitives as expected.

Mostly this is just a fix following up from #22983 but there is one thing I did really worth talking about, I think. So, before this script Painless scripts could only ever return `Object` and they did would always return `null` for paths that didn't return any values. Now that they can return primitives the question is "what should Painless return from paths that don't return any values?" In those cases Painless will now return `0` or `false`.

Edit: The last sentence in the last paragraph used to be: And I answered that with "Painless should refuse to compile scripts like this".