### PR TITLE
Remove BWC layer for number of reduce phases

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
@@ -342,9 +341,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         types = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         requestCache = in.readOptionalBoolean();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
-            batchedReduceSize = in.readVInt();
-        }
+        batchedReduceSize = in.readVInt();
     }
 
     @Override
@@ -362,9 +359,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         out.writeStringArray(types);
         indicesOptions.writeIndicesOptions(out);
         out.writeOptionalBoolean(requestCache);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
-            out.writeVInt(batchedReduceSize);
-        }
+        out.writeVInt(batchedReduceSize);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/InternalSearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalSearchResponse.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.internal;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -144,11 +143,7 @@ public class InternalSearchResponse implements Streamable, ToXContent {
         timedOut = in.readBoolean();
         terminatedEarly = in.readOptionalBoolean();
         profileResults = in.readOptionalWriteable(SearchProfileShardResults::new);
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
-            numReducePhases = in.readVInt();
-        } else {
-            numReducePhases = 1;
-        }
+        numReducePhases = in.readVInt();
     }
 
     @Override
@@ -169,8 +164,6 @@ public class InternalSearchResponse implements Streamable, ToXContent {
         out.writeBoolean(timedOut);
         out.writeOptionalBoolean(terminatedEarly);
         out.writeOptionalWriteable(profileResults);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
-            out.writeVInt(numReducePhases);
-        }
+        out.writeVInt(numReducePhases);
     }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/120_batch_reduce_size.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/120_batch_reduce_size.yaml
@@ -15,8 +15,8 @@ setup:
 ---
 "batched_reduce_size lower limit":
   - skip:
-      version: " - 5.99.99"
-      reason:  this was added in 6.0.0
+      version: " - 5.3.99"
+      reason:  this was added in 5.4.0
   - do:
       catch:      /batchedReduceSize must be >= 2/
       search:
@@ -27,8 +27,8 @@ setup:
 ---
 "batched_reduce_size 2 with 5 shards":
   - skip:
-      version: " - 5.99.99"
-      reason:  this was added in 6.0.0
+      version: " - 5.3.99"
+      reason:  this was added in 5.4.0
   - do:
       index:
         index: test_1


### PR DESCRIPTION
Both PRs below have been backported to 5.4 such that we can enable
BWC tests of this feature as well as remove version dependend serialization
for search request / responses.

Relates to #23288
Relates to #23253