### PR TITLE
Don't set local node on cluster state used for node join validation

### DIFF
--- a/core/src/main/java/org/elasticsearch/discovery/zen/MembershipAction.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/MembershipAction.java
@@ -39,7 +39,6 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 public class MembershipAction extends AbstractComponent {
 
@@ -63,8 +62,7 @@ public class MembershipAction extends AbstractComponent {
 
     private final MembershipListener listener;
 
-    public MembershipAction(Settings settings, TransportService transportService,
-                            Supplier<DiscoveryNode> localNodeSupplier, MembershipListener listener) {
+    public MembershipAction(Settings settings, TransportService transportService, MembershipListener listener) {
         super(settings);
         this.transportService = transportService;
         this.listener = listener;
@@ -73,7 +71,7 @@ public class MembershipAction extends AbstractComponent {
         transportService.registerRequestHandler(DISCOVERY_JOIN_ACTION_NAME, JoinRequest::new,
             ThreadPool.Names.GENERIC, new JoinRequestRequestHandler());
         transportService.registerRequestHandler(DISCOVERY_JOIN_VALIDATE_ACTION_NAME,
-            () -> new ValidateJoinRequest(localNodeSupplier), ThreadPool.Names.GENERIC,
+            () -> new ValidateJoinRequest(), ThreadPool.Names.GENERIC,
             new ValidateJoinRequestRequestHandler());
         transportService.registerRequestHandler(DISCOVERY_LEAVE_ACTION_NAME, LeaveRequest::new,
             ThreadPool.Names.GENERIC, new LeaveRequestRequestHandler());
@@ -155,22 +153,18 @@ public class MembershipAction extends AbstractComponent {
     }
 
     static class ValidateJoinRequest extends TransportRequest {
-        private final Supplier<DiscoveryNode> localNode;
         private ClusterState state;
 
-        ValidateJoinRequest(Supplier<DiscoveryNode> localNode) {
-            this.localNode = localNode;
-        }
+        ValidateJoinRequest() {}
 
         ValidateJoinRequest(ClusterState state) {
             this.state = state;
-            this.localNode = state.nodes()::getLocalNode;
         }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
             super.readFrom(in);
-            this.state = ClusterState.readFrom(in, localNode.get());
+            this.state = ClusterState.readFrom(in, null);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -191,7 +191,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
                         new NewPendingClusterStateListener(),
                         discoverySettings,
                         clusterService.getClusterName());
-        this.membership = new MembershipAction(settings, transportService, this::localNode, new MembershipListener());
+        this.membership = new MembershipAction(settings, transportService, new MembershipListener());
         this.joinThreadControl = new JoinThreadControl();
 
         transportService.registerRequestHandler(


### PR DESCRIPTION
When a node wants to join a cluster, it sends a join request to the master. The master then sends a join validation request to the node. This checks that the node can deserialize the current cluster state that exists on the master and that it can thus handle all the indices that are currently in the cluster (see #21830).

The current code can trip an assertion as it does not take the cluster state as is but sets itself as the local node on the cluster state. This can result in an inconsistent DiscoveryNodes object as the local node is not yet part of the cluster state and a node with same id but different address can still exist in the cluster state. Also another node with the same address but different id can exist in the cluster state if multiple nodes are run on the same machine and ports have been swapped after node crashes/restarts.

Build failure:

https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-unix-compatibility/os=ubuntu/643/consoleFull

From the logs:

```
at java.lang.Thread.run(Thread.java:745)Throwable #3: com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=7061, name=elasticsearch[node_t4][__mock_network_thread][T#6], state=RUNNABLE, group=TGRP-MinimumMasterNodesIT]
   > Caused by: java.lang.AssertionError: building disco nodes from network doesn't pass preflight: can't add node {node_t4}{YTZdF3xkQQmT-vN8PRNOvA}{K8X3Bf9fRb26y3FQWWmgkg}{127.0.0.1}{127.0.0.1:9783}, found existing node {node_t3}{cP9AQejSTBWvJmopV5y4Mw}{pT5FBfktS5-3OX1PiNEVvg}{127.0.0.1}{127.0.0.1:9783} with same address
   > 	at __randomizedtesting.SeedInfo.seed([840C6FA44DFAF8D3]:0)
   > 	at org.elasticsearch.cluster.node.DiscoveryNodes.readFrom(DiscoveryNodes.java:543)
   > 	at org.elasticsearch.cluster.ClusterState.readFrom(ClusterState.java:662)
   > 	at org.elasticsearch.discovery.zen.MembershipAction$ValidateJoinRequest.readFrom(MembershipAction.java:173)
   > 	at org.elasticsearch.transport.TcpTransport.handleRequest(TcpTransport.java:1441)
   > 	at org.elasticsearch.transport.TcpTransport.messageReceived(TcpTransport.java:1328)
   > 	at org.elasticsearch.transport.MockTcpTransport.readMessage(MockTcpTransport.java:175)
   > 	at org.elasticsearch.transport.MockTcpTransport.access$1000(MockTcpTransport.java:72)
   > 	at org.elasticsearch.transport.MockTcpTransport$MockChannel$1.lambda$doRun$0(MockTcpTransport.java:359)
   > 	at org.elasticsearch.common.util.CancellableThreads.executeIO(CancellableThreads.java:105)
   > 	at org.elasticsearch.transport.MockTcpTransport$MockChannel$1.doRun(MockTcpTransport.java:359)
   > 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
   > 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
   > 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
   > 	at java.lang.Thread.run(Thread.java:745)Throwable #4: com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=7057, name=elasticsearch[node_t5][__mock_network_thread][T#9], state=RUNNABLE, group=TGRP-MinimumMasterNodesIT]
```