### PR TITLE
Align REST specs for HEAD requests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -1,0 +1,71 @@
+{
+  "exists_source": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
+    "methods": ["HEAD"],
+    "url": {
+      "path": "/{index}/{type}/{id}/_source",
+      "paths": ["/{index}/{type}/{id}/_source"],
+      "parts": {
+        "id": {
+          "type" : "string",
+          "required" : true,
+          "description" : "The document ID"
+        },
+        "index": {
+          "type" : "string",
+          "required" : true,
+          "description" : "The name of the index"
+        },
+        "type": {
+          "type" : "string",
+          "required" : true,
+          "description" : "The type of the document; use `_all` to fetch the first document matching the ID across all types"
+        }
+      },
+      "params": {
+        "parent": {
+          "type" : "string",
+          "description" : "The ID of the parent document"
+        },
+        "preference": {
+          "type" : "string",
+          "description" : "Specify the node or shard the operation should be performed on (default: random)"
+        },
+        "realtime": {
+          "type" : "boolean",
+          "description" : "Specify whether to perform the operation in realtime or search mode"
+        },
+        "refresh": {
+          "type" : "boolean",
+          "description" : "Refresh the shard containing the document before performing the operation"
+        },
+        "routing": {
+          "type" : "string",
+          "description" : "Specific routing value"
+        },
+        "_source": {
+          "type" : "list",
+          "description" : "True or false to return the _source field or not, or a list of fields to return"
+        },
+        "_source_exclude": {
+          "type" : "list",
+          "description" : "A list of fields to exclude from the returned _source field"
+        },
+        "_source_include": {
+          "type" : "list",
+          "description" : "A list of fields to extract and return from the _source field"
+        },
+        "version" : {
+          "type" : "number",
+          "description" : "Explicit version number for concurrency control"
+        },
+        "version_type": {
+          "type" : "enum",
+          "options" : ["internal", "external", "external_gte", "force"],
+          "description" : "Specific version type"
+        }
+      }
+    },
+    "body": null
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -1,27 +1,44 @@
 {
   "indices.exists": {
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html",
-    "methods": ["HEAD"],
+    "methods": [ "HEAD" ],
     "url": {
       "path": "/{index}",
-      "paths": ["/{index}"],
+      "paths": [ "/{index}" ],
       "parts": {
         "index": {
-          "type" : "list",
-          "required" : true,
-          "description" : "A comma-separated list of indices to check"
+          "type": "list",
+          "required": true,
+          "description": "A comma-separated list of index names"
         }
       },
       "params": {
-        "expand_wildcards": {
-            "type" : "enum",
-            "options" : ["open","closed","none","all"],
-            "default" : "open",
-            "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
-        },
         "local": {
-            "type": "boolean",
-            "description": "Return local information, do not retrieve the state from master node (default: false)"
+          "type": "boolean",
+          "description": "Return local information, do not retrieve the state from master node (default: false)"
+        },
+        "ignore_unavailable": {
+          "type": "boolean",
+          "description": "Ignore unavailable indexes (default: false)"
+        },
+        "allow_no_indices": {
+          "type": "boolean",
+          "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
+        },
+        "expand_wildcards": {
+          "type": "enum",
+          "options": [ "open", "closed", "none", "all" ],
+          "default": "open",
+          "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+        },
+        "flat_settings": {
+          "type": "boolean",
+          "description": "Return settings in flat format (default: false)"
+        },
+        "include_defaults": {
+          "type": "boolean",
+          "description": "Whether to return all default setting for each of the indices.",
+          "default": false
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -4,7 +4,7 @@
     "methods": ["HEAD"],
     "url": {
       "path": "/_alias/{name}",
-      "paths": ["/_alias/{name}", "/{index}/_alias/{name}", "/{index}/_alias"],
+      "paths": ["/_alias/{name}", "/{index}/_alias/{name}"],
       "parts": {
         "index": {
           "type" : "list",
@@ -17,22 +17,22 @@
       },
       "params": {
         "ignore_unavailable": {
-            "type" : "boolean",
-            "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+          "type" : "boolean",
+          "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
         },
         "allow_no_indices": {
-           "type" : "boolean",
-           "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+          "type" : "boolean",
+          "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
         },
         "expand_wildcards": {
-           "type" : "enum",
-           "options" : ["open","closed","none","all"],
-           "default" : ["open", "closed"],
-           "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+          "type" : "enum",
+          "options" : ["open","closed","none","all"],
+          "default" : "all",
+          "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
         },
         "local": {
-           "type": "boolean",
-           "description": "Return local information, do not retrieve the state from master node (default: false)"
+          "type": "boolean",
+          "description": "Return local information, do not retrieve the state from master node (default: false)"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -4,15 +4,19 @@
     "methods": ["HEAD"],
     "url": {
       "path": "/_template/{name}",
-      "paths": ["/_template/{name}"],
+      "paths": [ "/_template/{name}" ],
       "parts": {
         "name": {
-          "type": "string",
-          "required": true,
-          "description": "The name of the template"
+          "type": "list",
+          "required": false,
+          "description": "The comma separated names of the index templates"
         }
       },
       "params": {
+        "flat_settings": {
+          "type": "boolean",
+          "description": "Return settings in flat format (default: false)"
+        },
         "master_timeout": {
           "type": "time",
           "description": "Explicit operation timeout for connection to master node"


### PR DESCRIPTION
Previous changes aligned HEAD requests to be consistent with GET
requests to the same endpoint. This commit aligns the REST spec for the
impacted endpoints.

Relates #21125
