### PR TITLE
Build: Change location in zip of license and notice inclusion for plugins

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -253,19 +253,15 @@ public class PluginBuildPlugin extends BuildPlugin {
     protected void addNoticeGeneration(Project project) {
         File licenseFile = project.pluginProperties.extension.licenseFile
         if (licenseFile != null) {
-            project.bundlePlugin.into('/') {
-                from(licenseFile.parentFile) {
-                    include(licenseFile.name)
-                }
+            project.bundlePlugin.from(licenseFile.parentFile) {
+                include(licenseFile.name)
             }
         }
         File noticeFile = project.pluginProperties.extension.licenseFile
         if (noticeFile != null) {
             NoticeTask generateNotice = project.tasks.create('generateNotice', NoticeTask.class)
             generateNotice.dependencies(project)
-            project.bundlePlugin.into('/') {
-                from(generateNotice)
-            }
+            project.bundlePlugin.from(generateNotice)
         }
     }
 }


### PR DESCRIPTION
This commit moves the LICENSE.txt and NOTICE.txt files for each plugin
to be alongside the other plugin files, inside the elasticsearch subdir.
This ensures those files are installed alongside the plugin.
