### PR TITLE
Respect promises on pipelined responses

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpChannel.java
@@ -135,7 +135,7 @@ final class Netty4HttpChannel extends AbstractRestChannel {
 
             final Object msg;
             if (pipelinedRequest != null) {
-                msg = pipelinedRequest.createHttpResponse(resp);
+                msg = pipelinedRequest.createHttpResponse(resp, promise);
             } else {
                 msg = resp;
             }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipelinedRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipelinedRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.http.netty4.pipelining;
 
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCounted;
@@ -32,7 +33,6 @@ public class HttpPipelinedRequest implements ReferenceCounted {
     private final LastHttpContent last;
     private final int sequence;
 
-
     public HttpPipelinedRequest(final LastHttpContent last, final int sequence) {
         this.last = last;
         this.sequence = sequence;
@@ -42,8 +42,8 @@ public class HttpPipelinedRequest implements ReferenceCounted {
         return last;
     }
 
-    public HttpPipelinedResponse createHttpResponse(final FullHttpResponse response) {
-        return new HttpPipelinedResponse(response, sequence);
+    public HttpPipelinedResponse createHttpResponse(final FullHttpResponse response, final ChannelPromise promise) {
+        return new HttpPipelinedResponse(response, promise, sequence);
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipelinedResponse.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipelinedResponse.java
@@ -19,21 +19,28 @@ package org.elasticsearch.http.netty4.pipelining;
  * under the License.
  */
 
+import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.util.ReferenceCounted;
 
 class HttpPipelinedResponse implements Comparable<HttpPipelinedResponse>, ReferenceCounted {
 
     private final FullHttpResponse response;
+    private final ChannelPromise promise;
     private final int sequence;
 
-    HttpPipelinedResponse(FullHttpResponse response, int sequence) {
+    HttpPipelinedResponse(FullHttpResponse response, ChannelPromise promise, int sequence) {
         this.response = response;
+        this.promise = promise;
         this.sequence = sequence;
     }
 
     public FullHttpResponse response() {
         return response;
+    }
+
+    public ChannelPromise promise() {
+        return promise;
     }
 
     public int sequence() {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
@@ -87,7 +87,12 @@ public class HttpPipeliningHandler extends ChannelDuplexHandler {
                             break;
                         }
                         holdingQueue.remove();
-                        ctx.write(response.response(), promise);
+                        /*
+                         * We must use the promise attached to the response; this is necessary since are going to hold a response until all
+                         * responses that precede it in the pipeline are written first. Note that the promise from the method invocation is
+                         * not ignored, it will already be attached to an existing response and consumed when that response is drained.
+                         */
+                        ctx.write(response.response(), response.promise());
                         writeSequence++;
                     }
                 } else {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
@@ -80,7 +80,7 @@ public class HttpPipeliningHandler extends ChannelDuplexHandler {
                     while (!holdingQueue.isEmpty()) {
                         /*
                          * Since the response with the lowest sequence number is the top of the priority queue, we know if its sequence
-                         * number does not match the current write sequence then we have not processed all preceding responses yet.
+                         * number does not match the current write sequence number then we have not processed all preceding responses yet.
                          */
                         final HttpPipelinedResponse response = holdingQueue.peek();
                         if (response.sequence() != writeSequence) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
@@ -33,8 +33,7 @@ import java.util.PriorityQueue;
  */
 public class HttpPipeliningHandler extends ChannelDuplexHandler {
 
-    // we use a priority queue so that responses are ordered by their sequence number
-    private final PriorityQueue<HttpPipelinedResponse> holdingQueue;
+    private static final int INITIAL_EVENTS_HELD = 8;
 
     private final int maxEventsHeld;
 
@@ -46,6 +45,9 @@ public class HttpPipeliningHandler extends ChannelDuplexHandler {
     private int readSequence;
     private int writeSequence;
 
+    // we use a priority queue so that responses are ordered by their sequence number
+    private final PriorityQueue<HttpPipelinedResponse> holdingQueue;
+
     /**
      * Construct a new pipelining handler; this handler should be used downstream of HTTP decoding/aggregation.
      *
@@ -54,7 +56,7 @@ public class HttpPipeliningHandler extends ChannelDuplexHandler {
      */
     public HttpPipeliningHandler(final int maxEventsHeld) {
         this.maxEventsHeld = maxEventsHeld;
-        this.holdingQueue = new PriorityQueue<>(1);
+        this.holdingQueue = new PriorityQueue<>(INITIAL_EVENTS_HELD);
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
@@ -33,7 +33,8 @@ import java.util.PriorityQueue;
  */
 public class HttpPipeliningHandler extends ChannelDuplexHandler {
 
-    private static final int INITIAL_EVENTS_HELD = 8;
+    // we use a priority queue so that responses are ordered by their sequence number
+    private final PriorityQueue<HttpPipelinedResponse> holdingQueue;
 
     private final int maxEventsHeld;
 
@@ -45,9 +46,6 @@ public class HttpPipeliningHandler extends ChannelDuplexHandler {
     private int readSequence;
     private int writeSequence;
 
-    // we use a priority queue so that responses are ordered by their sequence number
-    private final PriorityQueue<HttpPipelinedResponse> holdingQueue;
-
     /**
      * Construct a new pipelining handler; this handler should be used downstream of HTTP decoding/aggregation.
      *
@@ -56,7 +54,7 @@ public class HttpPipeliningHandler extends ChannelDuplexHandler {
      */
     public HttpPipeliningHandler(final int maxEventsHeld) {
         this.maxEventsHeld = maxEventsHeld;
-        this.holdingQueue = new PriorityQueue<>(INITIAL_EVENTS_HELD);
+        this.holdingQueue = new PriorityQueue<>(1);
     }
 
     @Override

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
@@ -24,6 +24,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -255,11 +256,14 @@ public class Netty4HttpServerPipeliningTests extends ESTestCase {
                 assert uri.matches("/\\d+");
             }
 
+            final ChannelPromise promise = ctx.newPromise();
+            final Object msg;
             if (pipelinedRequest != null) {
-                ctx.writeAndFlush(pipelinedRequest.createHttpResponse(httpResponse, ctx.newPromise()));
+                msg = pipelinedRequest.createHttpResponse(httpResponse, promise);
             } else {
-                ctx.writeAndFlush(httpResponse);
+                msg = httpResponse;
             }
+            ctx.writeAndFlush(msg, promise);
         }
 
     }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerPipeliningTests.java
@@ -256,7 +256,7 @@ public class Netty4HttpServerPipeliningTests extends ESTestCase {
             }
 
             if (pipelinedRequest != null) {
-                ctx.writeAndFlush(pipelinedRequest.createHttpResponse(httpResponse));
+                ctx.writeAndFlush(pipelinedRequest.createHttpResponse(httpResponse, ctx.newPromise()));
             } else {
                 ctx.writeAndFlush(httpResponse);
             }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/pipelining/Netty4HttpPipeliningHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/pipelining/Netty4HttpPipeliningHandlerTests.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -246,7 +247,8 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
             executorService.submit(() -> {
                 try {
                     waitingLatch.await(1000, TimeUnit.SECONDS);
-                    ctx.write(pipelinedRequest.createHttpResponse(httpResponse), ctx.newPromise());
+                    final ChannelPromise promise = ctx.newPromise();
+                    ctx.write(pipelinedRequest.createHttpResponse(httpResponse, promise), promise);
                     finishingLatch.countDown();
                 } catch (InterruptedException e) {
                     fail(e.toString());


### PR DESCRIPTION
When pipelined responses are sent to the pipeline handler for writing, they are not necessarily written immediately. They must be held in a priority queue until all responses preceding the given response are written. This means that when write is invoked on the handler, the promise that is attached to the write invocation will not necessarily be the promise associated with the responses that are written while the queue is drained. To address this, the promise associated with a pipelined response must be held with the response and then used when the channel context is actually written to. This was introduced when ensuring that the releasing promise is always chained through on write calls lest the releasing promise never be invoked. This leads to many failing test cases, so no new test cases are needed here.

Relates #23310, closes #23322
