### PR TITLE
Settings: Fix keystore cli prompting for yes/no to handle console returning null

### DIFF
--- a/core/src/main/java/org/elasticsearch/cli/Terminal.java
+++ b/core/src/main/java/org/elasticsearch/cli/Terminal.java
@@ -100,10 +100,11 @@ public abstract class Terminal {
     public final boolean promptYesNo(String prompt, boolean defaultYes) {
         String answerPrompt = defaultYes ? " [Y/n]" : " [y/N]";
         while (true) {
-            String answer = readText(prompt + answerPrompt).toLowerCase(Locale.ROOT);
-            if (answer.isEmpty()) {
+            String answer = readText(prompt + answerPrompt);
+            if (answer == null || answer.isEmpty()) {
                 return defaultYes;
             }
+            answer = answer.toLowerCase(Locale.ROOT);
             boolean answerYes = answer.equals("y");
             if (answerYes == false && answer.equals("n") == false) {
                 println("Did not understand answer '" + answer + "'");

--- a/core/src/test/java/org/elasticsearch/cli/TerminalTests.java
+++ b/core/src/test/java/org/elasticsearch/cli/TerminalTests.java
@@ -52,6 +52,8 @@ public class TerminalTests extends ESTestCase {
         assertTrue(terminal.promptYesNo("Answer?", true));
         terminal.addTextInput("");
         assertFalse(terminal.promptYesNo("Answer?", false));
+        terminal.addTextInput(null);
+        assertFalse(terminal.promptYesNo("Answer?", false));
     }
 
     public void testPromptYesNoReprompt() throws Exception {


### PR DESCRIPTION
Console.readText may return null in certain cases. This commit fixes a
bug in Terminal.promptYesNo which assumed a non-null return value.  It
also adds a test for this, and modifies mock terminal to be able to
handle null input values.