### PR TITLE
Test that buildCredentials returns correct clazz

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -214,7 +214,7 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent implements 
     static class PrivilegedInstanceProfileCredentialsProvider implements AWSCredentialsProvider {
         private final InstanceProfileCredentialsProvider credentials;
 
-        public PrivilegedInstanceProfileCredentialsProvider(InstanceProfileCredentialsProvider credentials) {
+        private PrivilegedInstanceProfileCredentialsProvider(InstanceProfileCredentialsProvider credentials) {
             this.credentials = credentials;
         }
 

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -150,7 +150,7 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent implements 
 
             if (key.length() == 0 && secret.length() == 0) {
                 logger.debug("Using instance profile credentials");
-                return new PrivilegedInstanceProfileCredentialsProvider(new InstanceProfileCredentialsProvider());
+                return new PrivilegedInstanceProfileCredentialsProvider();
             } else {
                 logger.debug("Using basic key/secret credentials");
                 return new StaticCredentialsProvider(new BasicAWSCredentials(key.toString(), secret.toString()));
@@ -214,8 +214,8 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent implements 
     static class PrivilegedInstanceProfileCredentialsProvider implements AWSCredentialsProvider {
         private final InstanceProfileCredentialsProvider credentials;
 
-        private PrivilegedInstanceProfileCredentialsProvider(InstanceProfileCredentialsProvider credentials) {
-            this.credentials = credentials;
+        private PrivilegedInstanceProfileCredentialsProvider() {
+            this.credentials = new InstanceProfileCredentialsProvider();
         }
 
         @Override

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/cloud/aws/InternalAwsS3Service.java
@@ -150,18 +150,7 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent implements 
 
             if (key.length() == 0 && secret.length() == 0) {
                 logger.debug("Using instance profile credentials");
-                AWSCredentialsProvider credentials = new InstanceProfileCredentialsProvider();
-                return new AWSCredentialsProvider() {
-                    @Override
-                    public AWSCredentials getCredentials() {
-                        return SocketAccess.doPrivileged(credentials::getCredentials);
-                    }
-
-                    @Override
-                    public void refresh() {
-                        SocketAccess.doPrivilegedVoid(credentials::refresh);
-                    }
-                };
+                return new PrivilegedInstanceProfileCredentialsProvider(new InstanceProfileCredentialsProvider());
             } else {
                 logger.debug("Using basic key/secret credentials");
                 return new StaticCredentialsProvider(new BasicAWSCredentials(key.toString(), secret.toString()));
@@ -220,5 +209,23 @@ public class InternalAwsS3Service extends AbstractLifecycleComponent implements 
 
         // Ensure that IdleConnectionReaper is shutdown
         IdleConnectionReaper.shutdown();
+    }
+
+    static class PrivilegedInstanceProfileCredentialsProvider implements AWSCredentialsProvider {
+        private final InstanceProfileCredentialsProvider credentials;
+
+        public PrivilegedInstanceProfileCredentialsProvider(InstanceProfileCredentialsProvider credentials) {
+            this.credentials = credentials;
+        }
+
+        @Override
+        public AWSCredentials getCredentials() {
+            return SocketAccess.doPrivileged(credentials::getCredentials);
+        }
+
+        @Override
+        public void refresh() {
+            SocketAccess.doPrivilegedVoid(credentials::refresh);
+        }
     }
 }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/AwsS3ServiceImplTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/AwsS3ServiceImplTests.java
@@ -37,7 +37,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     public void testAWSCredentialsWithSystemProviders() {
         AWSCredentialsProvider credentialsProvider =
             InternalAwsS3Service.buildCredentials(logger, deprecationLogger, Settings.EMPTY, Settings.EMPTY, "default");
-        assertThat(credentialsProvider, instanceOf(AWSCredentialsProvider.class));
+        assertThat(credentialsProvider, instanceOf(InternalAwsS3Service.PrivilegedInstanceProfileCredentialsProvider.class));
     }
 
     public void testAwsCredsDefaultSettings() {


### PR DESCRIPTION
This is fallout from #23297. That commit wrapped
`InstanceProfileCredentialsProvider` to ensure that the `getCredentials`
and `refresh` methods had privileged access. However, it looks like
there was a test ensuring that `buildCredentials` returned the correct
clazz type. This commit adjusts that test to check that the correct
wrapper is returned.