### PR TITLE
Keep the pipeline handler queue small initially

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/pipelining/HttpPipeliningHandler.java
@@ -33,7 +33,8 @@ import java.util.PriorityQueue;
  */
 public class HttpPipeliningHandler extends ChannelDuplexHandler {
 
-    private static final int INITIAL_EVENTS_HELD = 8;
+    // we use a priority queue so that responses are ordered by their sequence number
+    private final PriorityQueue<HttpPipelinedResponse> holdingQueue;
 
     private final int maxEventsHeld;
 
@@ -45,9 +46,6 @@ public class HttpPipeliningHandler extends ChannelDuplexHandler {
     private int readSequence;
     private int writeSequence;
 
-    // we use a priority queue so that responses are ordered by their sequence number
-    private final PriorityQueue<HttpPipelinedResponse> holdingQueue;
-
     /**
      * Construct a new pipelining handler; this handler should be used downstream of HTTP decoding/aggregation.
      *
@@ -56,7 +54,7 @@ public class HttpPipeliningHandler extends ChannelDuplexHandler {
      */
     public HttpPipeliningHandler(final int maxEventsHeld) {
         this.maxEventsHeld = maxEventsHeld;
-        this.holdingQueue = new PriorityQueue<>(INITIAL_EVENTS_HELD);
+        this.holdingQueue = new PriorityQueue<>(1);
     }
 
     @Override


### PR DESCRIPTION
This commit sets the intial size of the pipeline handler queue small to prevent waste if pipelined requests are never sent. Since the queue will grow quickly if pipeline requests are indeed set, this should not be problematic.
