### PR TITLE
Build: Versioning for guava and jimfs

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/StandaloneTestPlugin.groovy
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle.test
 
 import com.carrotsearch.gradle.junit4.RandomizedTestingTask
 import org.elasticsearch.gradle.BuildPlugin
+import org.elasticsearch.gradle.VersionProperties
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaBasePlugin
@@ -48,6 +49,7 @@ public class StandaloneTestPlugin implements Plugin<Project> {
         test.classpath = project.sourceSets.test.runtimeClasspath
         test.testClassesDir project.sourceSets.test.output.classesDir
         test.mustRunAfter(project.precommit)
+        project.ext.versions = VersionProperties.versions
         project.check.dependsOn(test)
     }
 }

--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -3,29 +3,31 @@ elasticsearch     = 6.0.0-alpha1
 lucene            = 6.5.0-snapshot-f919485
 
 # optional dependencies
-spatial4j         = 0.6
-jts               = 1.13
+guava             = 18.0
 jackson           = 2.8.6
-snakeyaml         = 1.15
+jimfs             = 1.1
+jna               = 4.2.2
+jts               = 1.13
 # When updating log4j, please update also docs/java-api/index.asciidoc
 log4j             = 2.7
 slf4j             = 1.6.2
-jna               = 4.2.2
+snakeyaml         = 1.15
+spatial4j         = 0.6
 
 # test dependencies
-randomizedrunner  = 2.4.0
-junit             = 4.11
+commonscodec      = 1.10
+commonslogging    = 1.1.3
+hamcrest          = 1.3
+# When updating httpasyncclient, please also update core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+httpasyncclient   = 4.1.2
 httpclient        = 4.5.2
 # When updating httpcore, please also update core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
 httpcore          = 4.4.5
-# When updating httpasyncclient, please also update core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
-httpasyncclient   = 4.1.2
-commonslogging    = 1.1.3
-commonscodec      = 1.10
-hamcrest          = 1.3
-securemock        = 1.2
+junit             = 4.11
 # When updating mocksocket, please also update core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
 mocksocket        = 1.1
+randomizedrunner  = 2.4.0
+securemock        = 1.2
 
 # benchmark dependencies
 jmh               = 1.17.3

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -94,8 +94,8 @@ dependencies {
       exclude group: 'org.elasticsearch', module: 'elasticsearch'
     }
   }
-  testCompile 'com.google.jimfs:jimfs:1.1'
-  testCompile 'com.google.guava:guava:18.0'
+  testCompile "com.google.jimfs:jimfs:${versions.jimfs}"
+  testCompile "com.google.guava:guava:${versions.guava}"
 }
 
 if (isEclipse) {

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -42,7 +42,7 @@ dependencies {
   compile "org.apache.hadoop:hadoop-auth:${versions.hadoop2}"
   compile "org.apache.hadoop:hadoop-hdfs:${versions.hadoop2}"
   compile 'org.apache.htrace:htrace-core:3.1.0-incubating'
-  compile 'com.google.guava:guava:16.0.1'
+  compile "com.google.guava:guava:${versions.guava}"
   compile 'com.google.protobuf:protobuf-java:2.5.0'
   compile 'commons-logging:commons-logging:1.1.3'
   compile 'commons-cli:commons-cli:1.2'

--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -26,7 +26,7 @@
 apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
-  testCompile 'com.google.jimfs:jimfs:1.1'
+  testCompile "com.google.jimfs:jimfs:${versions.jimfs}"
 }
 
 // TODO: give each evil test its own fresh JVM for more isolation.


### PR DESCRIPTION
This change puts guava and jimfs into versioning to fix a guava version conflict leading to jar-hell in a dependent project. For ease of use I also sorted the version file (keeping the original sections, just order by alphabet inside a section) as it gets harder to read now with more and more entries.