### PR TITLE
Always restore the ThreadContext for operations delayed due to a block

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShardOperationsLock.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShardOperationsLock.java
@@ -129,13 +129,13 @@ public class IndexShardOperationsLock implements Closeable {
                     if (delayedOperations == null) {
                         delayedOperations = new ArrayList<>();
                     }
+                    final Supplier<StoredContext> contextSupplier = threadPool.getThreadContext().newRestorableContext(false);
                     if (executorOnDelay != null) {
-                        final Supplier<StoredContext> contextSupplier = threadPool.getThreadContext().newRestorableContext(false);
                         delayedOperations.add(
                             new ThreadedActionListener<>(logger, threadPool, executorOnDelay,
                                 new ContextPreservingActionListener<>(contextSupplier, onAcquired), forceExecution));
                     } else {
-                        delayedOperations.add(onAcquired);
+                        delayedOperations.add(new ContextPreservingActionListener<>(contextSupplier, onAcquired));
                     }
                     return;
                 }


### PR DESCRIPTION
The IndexShardOperationsLock has a mechanism to delay operations if there is currently a block on the lock. These delayed operations are executed when the block is released and are executed by a different thread. When the different thread executes the operations, the ThreadContext is that of the thread that was blocking operations. In order to preserve the ThreadContext, we need to store it and wrap the listener when the operation is delayed.