### PR TITLE
Adding equals/hashCode to MainResponse

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class MainResponse extends ActionResponse implements ToXContentObject {
 
@@ -136,5 +137,27 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
 
     public static MainResponse fromXContent(XContentParser parser) {
         return PARSER.apply(parser, null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MainResponse other = (MainResponse) o;
+        return Objects.equals(nodeName, other.nodeName) &&
+                Objects.equals(version, other.version) &&
+                Objects.equals(clusterUuid, other.clusterUuid) &&
+                Objects.equals(build, other.build) &&
+                Objects.equals(available, other.available) &&
+                Objects.equals(clusterName, other.clusterName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodeName, version, clusterUuid, build, clusterName, available);
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.Date;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 
 public class MainResponseTests extends ESTestCase {
@@ -87,6 +88,46 @@ public class MainResponseTests extends ESTestCase {
                     + "\"lucene_version\":\"5.5.2\"},"
                 + "\"tagline\":\"You Know, for Search\""
           + "}", builder.string());
+    }
+
+    public void testEqualsAndHashcode() {
+        MainResponse original = createTestItem();
+        checkEqualsAndHashCode(original, MainResponseTests::copy, MainResponseTests::mutate);
+    }
+
+    private static MainResponse copy(MainResponse o) {
+        return new MainResponse(o.getNodeName(), o.getVersion(), o.getClusterName(), o.getClusterUuid(), o.getBuild(), o.isAvailable());
+    }
+
+    private static MainResponse mutate(MainResponse o) {
+        String clusterUuid = o.getClusterUuid();
+        boolean available = o.isAvailable();
+        Build build = o.getBuild();
+        Version version = o.getVersion();
+        String nodeName = o.getNodeName();
+        ClusterName clusterName = o.getClusterName();
+        switch (randomIntBetween(0, 5)) {
+        case 0:
+            clusterUuid = clusterUuid + randomAsciiOfLength(5);
+            break;
+        case 1:
+            nodeName = nodeName + randomAsciiOfLength(5);
+            break;
+        case 2:
+            available = !available;
+            break;
+        case 3:
+            // toggle the snapshot flag of the original Build parameter
+            build = new Build(build.shortHash(), build.date(), !build.isSnapshot());
+            break;
+        case 4:
+            version = randomValueOtherThan(version, () -> VersionUtils.randomVersion(random()));
+            break;
+        case 5:
+            clusterName = new ClusterName(clusterName + randomAsciiOfLength(5));
+            break;
+        }
+        return new MainResponse(nodeName, version, clusterName, clusterUuid, build, available);
     }
 
 }


### PR DESCRIPTION
Make it easier to check two MainResponse instances for equality. 

Relates to #23350
