### PR TITLE
Refactor TransportShardBulkAction and add unit tests

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResultHolder.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkItemResultHolder.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.engine.Engine;
+
+/**
+ * A struct-like holder for a bulk items reponse, result, and the resulting
+ * replica operation to be executed.
+ */
+class BulkItemResultHolder {
+    public final @Nullable DocWriteResponse response;
+    public final @Nullable Engine.Result operationResult;
+    public final BulkItemRequest replicaRequest;
+
+    BulkItemResultHolder(@Nullable DocWriteResponse response,
+                         @Nullable Engine.Result operationResult,
+                         BulkItemRequest replicaRequest) {
+        this.response = response;
+        this.operationResult = operationResult;
+        this.replicaRequest = replicaRequest;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/action/bulk/MappingUpdatePerformer.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/MappingUpdatePerformer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.shard.IndexShard;
+
+import java.util.Objects;
+
+public interface MappingUpdatePerformer {
+    /**
+     * Determine if any mappings need to be updated, and update them on the
+     * master node if necessary. Returnes a failed {@code Engine.IndexResult}
+     * in the event updating the mappings fails or null if successful.
+     * Throws a {@code ReplicationOperation.RetryOnPrimaryException} if the
+     * operation needs to be retried on the primary due to the mappings not
+     * being present yet, or a different exception if updating the mappings
+     * on the master failed.
+     */
+    @Nullable
+    MappingUpdateResult updateMappingsIfNeeded(IndexShard primary, IndexRequest request) throws Exception;
+
+    /**
+     * Class encapsulating the resulting of potentially updating the mapping
+     */
+    class MappingUpdateResult {
+        @Nullable
+        public final Engine.Index operation;
+        @Nullable
+        public final Exception failure;
+
+        MappingUpdateResult(Exception failure) {
+            Objects.requireNonNull(failure, "failure cannot be null");
+            this.failure = failure;
+            this.operation = null;
+        }
+
+        MappingUpdateResult(Engine.Index operation) {
+            Objects.requireNonNull(operation, "operation cannot be null");
+            this.operation = operation;
+            this.failure = null;
+        }
+
+        public boolean isFailed() {
+            return failure != null;
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -668,7 +668,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         public final long translogLocation;
         public final int size;
 
-        Location(long generation, long translogLocation, int size) {
+        public Location(long generation, long translogLocation, int size) {
             this.generation = generation;
             this.translogLocation = translogLocation;
             this.size = size;

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -1,0 +1,493 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequestBuilder;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.action.support.replication.ReplicationOperation;
+import org.elasticsearch.action.update.UpdateHelper;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.mapper.Mapping;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.action.bulk.TransportShardBulkAction;
+
+import java.io.IOException;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.containsString;
+
+public class TransportShardBulkActionTests extends IndexShardTestCase {
+
+    private final ShardId shardId = new ShardId("index", "_na_", 0);
+    private final Settings idxSettings = Settings.builder()
+            .put("index.number_of_shards", 1)
+            .put("index.number_of_replicas", 0)
+            .put("index.version.created", Version.CURRENT.id)
+            .build();
+
+    private IndexMetaData indexMetaData() throws IOException {
+        return IndexMetaData.builder("index")
+                .putMapping("type", "{\"properties\": {\"foo\": {\"type\": \"text\"}}}")
+                .settings(idxSettings)
+                .primaryTerm(0, 1).build();
+    }
+
+    public void testShouldExecuteReplicaItem() throws Exception {
+        // Successful index request should be replicated
+        DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
+        DocWriteResponse response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean());
+        BulkItemRequest request = new BulkItemRequest(0, writeRequest);
+        request.setPrimaryResponse(new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, response));
+        assertTrue(TransportShardBulkAction.shouldExecuteReplicaItem(request, 0));
+
+        // Failed index requests should not be replicated (for now!)
+        writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
+        response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean());
+        request = new BulkItemRequest(0, writeRequest);
+        request.setPrimaryResponse(
+                new BulkItemResponse(0, DocWriteRequest.OpType.INDEX,
+                        new BulkItemResponse.Failure("test", "type", "id", new IllegalArgumentException("i died"))));
+        assertFalse(TransportShardBulkAction.shouldExecuteReplicaItem(request, 0));
+
+        // NOOP requests should not be replicated
+        writeRequest = new UpdateRequest("index", "type", "id");
+        response = new UpdateResponse(shardId, "type", "id", 1, DocWriteResponse.Result.NOOP);
+        request = new BulkItemRequest(0, writeRequest);
+        request.setPrimaryResponse(new BulkItemResponse(0, DocWriteRequest.OpType.UPDATE, response));
+        assertFalse(TransportShardBulkAction.shouldExecuteReplicaItem(request, 0));
+    }
+
+
+    public void testExecuteBulkIndexRequest() throws Exception {
+        IndexMetaData metaData = indexMetaData();
+        IndexShard shard = newStartedShard(true);
+
+        BulkItemRequest[] items = new BulkItemRequest[1];
+        boolean create = randomBoolean();
+        DocWriteRequest writeRequest = new IndexRequest("index", "type", "id")
+                .source(Requests.INDEX_CONTENT_TYPE, "foo", "bar")
+                .create(create);
+        BulkItemRequest primaryRequest = new BulkItemRequest(0, writeRequest);
+        items[0] = primaryRequest;
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+
+        Translog.Location location = new Translog.Location(0, 0, 0);
+        UpdateHelper updateHelper = null;
+
+        Translog.Location newLocation = TransportShardBulkAction.executeBulkItemRequest(metaData, shard, bulkShardRequest,
+                location, 0, updateHelper, threadPool::absoluteTimeInMillis, new NoopMappingUpdatePerformer());
+
+        // Translog should change, since there were no problems
+        assertThat(newLocation, not(location));
+
+        BulkItemResponse primaryResponse = bulkShardRequest.items()[0].getPrimaryResponse();
+
+        assertThat(primaryResponse.getItemId(), equalTo(0));
+        assertThat(primaryResponse.getId(), equalTo("id"));
+        assertThat(primaryResponse.getOpType(), equalTo(create ? DocWriteRequest.OpType.CREATE : DocWriteRequest.OpType.INDEX));
+        assertFalse(primaryResponse.isFailed());
+
+        // Assert that the document actually made it there
+        assertDocCount(shard, 1);
+
+        writeRequest = new IndexRequest("index", "type", "id")
+                .source(Requests.INDEX_CONTENT_TYPE, "foo", "bar")
+                .create(true);
+        primaryRequest = new BulkItemRequest(0, writeRequest);
+        items[0] = primaryRequest;
+        bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+
+        Translog.Location secondLocation = TransportShardBulkAction.executeBulkItemRequest(metaData, shard, bulkShardRequest,
+                newLocation, 0, updateHelper, threadPool::absoluteTimeInMillis, new NoopMappingUpdatePerformer());
+
+        // Translog should not change, since the document was not indexed due to a version conflict
+        assertThat(secondLocation, equalTo(newLocation));
+
+        BulkItemRequest replicaRequest = bulkShardRequest.items()[0];
+
+        primaryResponse = bulkShardRequest.items()[0].getPrimaryResponse();
+
+        assertThat(primaryResponse.getItemId(), equalTo(0));
+        assertThat(primaryResponse.getId(), equalTo("id"));
+        assertThat(primaryResponse.getOpType(), equalTo(DocWriteRequest.OpType.CREATE));
+        // Should be failed since the document already exists
+        assertTrue(primaryResponse.isFailed());
+
+        BulkItemResponse.Failure failure = primaryResponse.getFailure();
+        assertThat(failure.getIndex(), equalTo("index"));
+        assertThat(failure.getType(), equalTo("type"));
+        assertThat(failure.getId(), equalTo("id"));
+        assertThat(failure.getCause().getClass(), equalTo(VersionConflictEngineException.class));
+        assertThat(failure.getCause().getMessage(),
+                containsString("version conflict, document already exists (current version [1])"));
+        assertThat(failure.getStatus(), equalTo(RestStatus.CONFLICT));
+
+        assertThat(replicaRequest, equalTo(primaryRequest));
+
+        // Assert that the document count is still 1
+        assertDocCount(shard, 1);
+        closeShards(shard);
+    }
+
+    public void testExecuteBulkIndexRequestWithRejection() throws Exception {
+        IndexMetaData metaData = indexMetaData();
+        IndexShard shard = newStartedShard(true);
+
+        BulkItemRequest[] items = new BulkItemRequest[1];
+        DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
+        items[0] = new BulkItemRequest(0, writeRequest);
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+
+        Translog.Location location = new Translog.Location(0, 0, 0);
+        UpdateHelper updateHelper = null;
+
+        // Pretend the mappings haven't made it to the node yet, and throw  a rejection
+        Exception err = new ReplicationOperation.RetryOnPrimaryException(shardId, "rejection");
+
+        try {
+            TransportShardBulkAction.executeBulkItemRequest(metaData, shard, bulkShardRequest, location,
+                    0, updateHelper, threadPool::absoluteTimeInMillis, new ThrowingMappingUpdatePerformer(err));
+            fail("should have thrown a retry exception");
+        } catch (ReplicationOperation.RetryOnPrimaryException e) {
+            assertThat(e, equalTo(err));
+        }
+
+        closeShards(shard);
+    }
+
+    public void testExecuteBulkIndexRequestWithConflictingMappings() throws Exception {
+        IndexMetaData metaData = indexMetaData();
+        IndexShard shard = newStartedShard(true);
+
+        BulkItemRequest[] items = new BulkItemRequest[1];
+        DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
+        items[0] = new BulkItemRequest(0, writeRequest);
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+
+        Translog.Location location = new Translog.Location(0, 0, 0);
+        UpdateHelper updateHelper = null;
+
+        // Return a mapping conflict (IAE) when trying to update the mapping
+        Exception err = new IllegalArgumentException("mapping conflict");
+
+        Translog.Location newLocation = TransportShardBulkAction.executeBulkItemRequest(metaData, shard, bulkShardRequest,
+                location, 0, updateHelper, threadPool::absoluteTimeInMillis, new FailingMappingUpdatePerformer(err));
+
+        // Translog shouldn't change, as there were conflicting mappings
+        assertThat(newLocation, equalTo(location));
+
+        BulkItemResponse primaryResponse = bulkShardRequest.items()[0].getPrimaryResponse();
+
+        // Since this was not a conflict failure, the primary response
+        // should be filled out with the failure information
+        assertThat(primaryResponse.getItemId(), equalTo(0));
+        assertThat(primaryResponse.getId(), equalTo("id"));
+        assertThat(primaryResponse.getOpType(), equalTo(DocWriteRequest.OpType.INDEX));
+        assertTrue(primaryResponse.isFailed());
+        assertThat(primaryResponse.getFailureMessage(), containsString("mapping conflict"));
+        BulkItemResponse.Failure failure = primaryResponse.getFailure();
+        assertThat(failure.getIndex(), equalTo("index"));
+        assertThat(failure.getType(), equalTo("type"));
+        assertThat(failure.getId(), equalTo("id"));
+        assertThat(failure.getCause(), equalTo(err));
+        assertThat(failure.getStatus(), equalTo(RestStatus.BAD_REQUEST));
+
+        closeShards(shard);
+    }
+
+    public void testExecuteBulkDeleteRequest() throws Exception {
+        IndexMetaData metaData = indexMetaData();
+        IndexShard shard = newStartedShard(true);
+
+        BulkItemRequest[] items = new BulkItemRequest[1];
+        DocWriteRequest writeRequest = new DeleteRequest("index", "type", "id");
+        items[0] = new BulkItemRequest(0, writeRequest);
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+
+        Translog.Location location = new Translog.Location(0, 0, 0);
+        UpdateHelper updateHelper = null;
+
+        Translog.Location newLocation = TransportShardBulkAction.executeBulkItemRequest(metaData, shard, bulkShardRequest,
+                location, 0, updateHelper, threadPool::absoluteTimeInMillis, new NoopMappingUpdatePerformer());
+
+        // Translog changes, even though the document didn't exist
+        assertThat(newLocation, not(location));
+
+        BulkItemRequest replicaRequest = bulkShardRequest.items()[0];
+        DocWriteRequest replicaDeleteRequest = replicaRequest.request();
+        BulkItemResponse primaryResponse = replicaRequest.getPrimaryResponse();
+        DeleteResponse response = primaryResponse.getResponse();
+
+        // Any version can be matched on replica
+        assertThat(replicaDeleteRequest.version(), equalTo(Versions.MATCH_ANY));
+        assertThat(replicaDeleteRequest.versionType(), equalTo(VersionType.INTERNAL));
+
+        assertThat(primaryResponse.getItemId(), equalTo(0));
+        assertThat(primaryResponse.getId(), equalTo("id"));
+        assertThat(primaryResponse.getOpType(), equalTo(DocWriteRequest.OpType.DELETE));
+        assertFalse(primaryResponse.isFailed());
+
+        assertThat(response.getResult(), equalTo(DocWriteResponse.Result.NOT_FOUND));
+        assertThat(response.getShardId(), equalTo(shard.shardId()));
+        assertThat(response.getIndex(), equalTo("index"));
+        assertThat(response.getType(), equalTo("type"));
+        assertThat(response.getId(), equalTo("id"));
+        assertThat(response.getVersion(), equalTo(1L));
+        assertThat(response.getSeqNo(), equalTo(0L));
+        assertThat(response.forcedRefresh(), equalTo(false));
+
+        // Now do the same after indexing the document, it should now find and delete the document
+        indexDoc(shard, "type", "id", "{\"foo\": \"bar\"}");
+
+        writeRequest = new DeleteRequest("index", "type", "id");
+        items[0] = new BulkItemRequest(0, writeRequest);
+        bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+
+        location = newLocation;
+
+        newLocation = TransportShardBulkAction.executeBulkItemRequest(metaData, shard, bulkShardRequest,
+                location, 0, updateHelper, threadPool::absoluteTimeInMillis, new NoopMappingUpdatePerformer());
+
+        // Translog changes, because the document was deleted
+        assertThat(newLocation, not(location));
+
+        replicaRequest = bulkShardRequest.items()[0];
+        replicaDeleteRequest = replicaRequest.request();
+        primaryResponse = replicaRequest.getPrimaryResponse();
+        response = primaryResponse.getResponse();
+
+        // Any version can be matched on replica
+        assertThat(replicaDeleteRequest.version(), equalTo(Versions.MATCH_ANY));
+        assertThat(replicaDeleteRequest.versionType(), equalTo(VersionType.INTERNAL));
+
+        assertThat(primaryResponse.getItemId(), equalTo(0));
+        assertThat(primaryResponse.getId(), equalTo("id"));
+        assertThat(primaryResponse.getOpType(), equalTo(DocWriteRequest.OpType.DELETE));
+        assertFalse(primaryResponse.isFailed());
+
+        assertThat(response.getResult(), equalTo(DocWriteResponse.Result.DELETED));
+        assertThat(response.getShardId(), equalTo(shard.shardId()));
+        assertThat(response.getIndex(), equalTo("index"));
+        assertThat(response.getType(), equalTo("type"));
+        assertThat(response.getId(), equalTo("id"));
+        assertThat(response.getVersion(), equalTo(3L));
+        assertThat(response.getSeqNo(), equalTo(2L));
+        assertThat(response.forcedRefresh(), equalTo(false));
+
+        assertDocCount(shard, 0);
+        closeShards(shard);
+    }
+
+    public void testNoopUpdateReplicaRequest() throws Exception {
+        DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "field", "value");
+        BulkItemRequest replicaRequest = new BulkItemRequest(0, writeRequest);
+
+        DocWriteResponse noopUpdateResponse = new UpdateResponse(shardId, "index", "id", 0, DocWriteResponse.Result.NOOP);
+        BulkItemResultHolder noopResults = new BulkItemResultHolder(noopUpdateResponse, null, replicaRequest);
+
+        Translog.Location location = new Translog.Location(0, 0, 0);
+        BulkItemRequest[] items = new BulkItemRequest[0];
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+        Translog.Location newLocation = TransportShardBulkAction.updateReplicaRequest(noopResults,
+                DocWriteRequest.OpType.UPDATE, location, bulkShardRequest);
+
+        BulkItemResponse primaryResponse = replicaRequest.getPrimaryResponse();
+
+        // Basically nothing changes in the request since it's a noop
+        assertThat(newLocation, equalTo(location));
+        assertThat(primaryResponse.getItemId(), equalTo(0));
+        assertThat(primaryResponse.getId(), equalTo("id"));
+        assertThat(primaryResponse.getOpType(), equalTo(DocWriteRequest.OpType.UPDATE));
+        assertThat(primaryResponse.getResponse(), equalTo(noopUpdateResponse));
+        assertThat(primaryResponse.getResponse().getResult(), equalTo(DocWriteResponse.Result.NOOP));
+    }
+
+    public void testUpdateReplicaRequestWithFailure() throws Exception {
+        DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "field", "value");
+        BulkItemRequest replicaRequest = new BulkItemRequest(0, writeRequest);
+
+        Exception err = new ElasticsearchException("I'm dead <(x.x)>");
+        Engine.IndexResult indexResult = new Engine.IndexResult(err, 0, 0);
+        BulkItemResultHolder failedResults = new BulkItemResultHolder(null, indexResult, replicaRequest);
+
+        Translog.Location location = new Translog.Location(0, 0, 0);
+        BulkItemRequest[] items = new BulkItemRequest[0];
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+        Translog.Location newLocation = TransportShardBulkAction.updateReplicaRequest(failedResults,
+                DocWriteRequest.OpType.UPDATE, location, bulkShardRequest);
+
+        BulkItemResponse primaryResponse = replicaRequest.getPrimaryResponse();
+
+        // Since this was not a conflict failure, the primary response
+        // should be filled out with the failure information
+        assertThat(newLocation, equalTo(location));
+        assertThat(primaryResponse.getItemId(), equalTo(0));
+        assertThat(primaryResponse.getId(), equalTo("id"));
+        assertThat(primaryResponse.getOpType(), equalTo(DocWriteRequest.OpType.INDEX));
+        assertTrue(primaryResponse.isFailed());
+        assertThat(primaryResponse.getFailureMessage(), containsString("I'm dead <(x.x)>"));
+        BulkItemResponse.Failure failure = primaryResponse.getFailure();
+        assertThat(failure.getIndex(), equalTo("index"));
+        assertThat(failure.getType(), equalTo("type"));
+        assertThat(failure.getId(), equalTo("id"));
+        assertThat(failure.getCause(), equalTo(err));
+        assertThat(failure.getStatus(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    public void testUpdateReplicaRequestWithConflictFailure() throws Exception {
+        DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "field", "value");
+        BulkItemRequest replicaRequest = new BulkItemRequest(0, writeRequest);
+
+        Exception err = new VersionConflictEngineException(shardId, "type", "id", "I'm conflicted <(;_;)>");
+        Engine.IndexResult indexResult = new Engine.IndexResult(err, 0, 0);
+        BulkItemResultHolder failedResults = new BulkItemResultHolder(null, indexResult, replicaRequest);
+
+        Translog.Location location = new Translog.Location(0, 0, 0);
+        BulkItemRequest[] items = new BulkItemRequest[0];
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+        Translog.Location newLocation = TransportShardBulkAction.updateReplicaRequest(failedResults,
+                DocWriteRequest.OpType.UPDATE, location, bulkShardRequest);
+
+        BulkItemResponse primaryResponse = replicaRequest.getPrimaryResponse();
+
+        // Since this was not a conflict failure, the primary response
+        // should be filled out with the failure information
+        assertThat(newLocation, equalTo(location));
+        assertThat(primaryResponse.getItemId(), equalTo(0));
+        assertThat(primaryResponse.getId(), equalTo("id"));
+        assertThat(primaryResponse.getOpType(), equalTo(DocWriteRequest.OpType.INDEX));
+        assertTrue(primaryResponse.isFailed());
+        assertThat(primaryResponse.getFailureMessage(), containsString("I'm conflicted <(;_;)>"));
+        BulkItemResponse.Failure failure = primaryResponse.getFailure();
+        assertThat(failure.getIndex(), equalTo("index"));
+        assertThat(failure.getType(), equalTo("type"));
+        assertThat(failure.getId(), equalTo("id"));
+        assertThat(failure.getCause(), equalTo(err));
+        assertThat(failure.getStatus(), equalTo(RestStatus.CONFLICT));
+    }
+
+    public void testUpdateReplicaRequestWithSuccess() throws Exception {
+        DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "field", "value");
+        BulkItemRequest replicaRequest = new BulkItemRequest(0, writeRequest);
+
+        boolean created = randomBoolean();
+        Translog.Location resultLocation = new Translog.Location(42, 42, 42);
+        Engine.IndexResult indexResult = new FakeResult(1, 1, created, resultLocation);
+        DocWriteResponse indexResponse = new IndexResponse(shardId, "index", "id", 1, 1, created);
+        BulkItemResultHolder goodResults = new BulkItemResultHolder(indexResponse, indexResult, replicaRequest);
+
+        Translog.Location originalLocation = new Translog.Location(21, 21, 21);
+        BulkItemRequest[] items = new BulkItemRequest[0];
+        BulkShardRequest bulkShardRequest = new BulkShardRequest(shardId, RefreshPolicy.NONE, items);
+        Translog.Location newLocation = TransportShardBulkAction.updateReplicaRequest(goodResults,
+                DocWriteRequest.OpType.INDEX, originalLocation, bulkShardRequest);
+
+        BulkItemResponse primaryResponse = replicaRequest.getPrimaryResponse();
+
+        // Check that the translog is successfully advanced
+        assertThat(newLocation, equalTo(resultLocation));
+        // Since this was not a conflict failure, the primary response
+        // should be filled out with the failure information
+        assertThat(primaryResponse.getItemId(), equalTo(0));
+        assertThat(primaryResponse.getId(), equalTo("id"));
+        assertThat(primaryResponse.getOpType(), equalTo(DocWriteRequest.OpType.INDEX));
+        DocWriteResponse response = primaryResponse.getResponse();
+        assertThat(response.status(), equalTo(created ? RestStatus.CREATED : RestStatus.OK));
+    }
+
+    /**
+     * Fake IndexResult that has a settable translog location
+     */
+    private static class FakeResult extends Engine.IndexResult {
+
+        private final Translog.Location location;
+
+        protected FakeResult(long version, long seqNo, boolean created, Translog.Location location) {
+            super(version, seqNo, created);
+            this.location = location;
+        }
+
+        @Override
+        public Translog.Location getTranslogLocation() {
+            return this.location;
+        }
+    }
+
+    /** Doesn't perform any mapping updates */
+    public static class NoopMappingUpdatePerformer implements MappingUpdatePerformer {
+        public MappingUpdatePerformer.MappingUpdateResult updateMappingsIfNeeded(IndexShard primary,
+                                                                                 IndexRequest request) throws Exception {
+            Engine.Index operation = TransportShardBulkAction.prepareIndexOperationOnPrimary(request, primary);
+            return new MappingUpdatePerformer.MappingUpdateResult(operation);
+        }
+    }
+
+    /** Always returns the given failure */
+    private class FailingMappingUpdatePerformer implements MappingUpdatePerformer {
+        private final Exception e;
+        FailingMappingUpdatePerformer(Exception e) {
+            this.e = e;
+        }
+
+        public MappingUpdatePerformer.MappingUpdateResult updateMappingsIfNeeded(IndexShard primary,
+                                                                                 IndexRequest request) throws Exception {
+            return new MappingUpdatePerformer.MappingUpdateResult(e);
+        }
+    }
+
+    /** Always throw the given exception */
+    private class ThrowingMappingUpdatePerformer implements MappingUpdatePerformer {
+        private final Exception e;
+        ThrowingMappingUpdatePerformer(Exception e) {
+            this.e = e;
+        }
+
+        public MappingUpdatePerformer.MappingUpdateResult updateMappingsIfNeeded(IndexShard primary,
+                                                                                 IndexRequest request) throws Exception {
+            throw e;
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -31,6 +31,7 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.bulk.BulkShardRequest;
 import org.elasticsearch.action.bulk.BulkShardResponse;
+import org.elasticsearch.action.bulk.TransportShardBulkActionTests;
 import org.elasticsearch.action.bulk.TransportSingleItemBulkWriteAction;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -549,7 +550,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
      */
     protected IndexResponse indexOnPrimary(IndexRequest request, IndexShard primary) throws Exception {
         final Engine.IndexResult indexResult = executeIndexRequestOnPrimary(request, primary,
-                null);
+                new TransportShardBulkActionTests.NoopMappingUpdatePerformer());
         request.primaryTerm(primary.getPrimaryTerm());
         TransportWriteActionTestHelper.performPostWriteActions(primary, request, indexResult.getTranslogLocation(), logger);
         return new IndexResponse(
@@ -591,5 +592,4 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             replica.getTranslog().sync();
         }
     }
-
 }


### PR DESCRIPTION
This refactors the `TransportShardBulkAction` to split it appart and make it
unit-testable, and then it also adds unit tests that use these methods.

In particular, this makes `executeBulkItemRequest` shorter and more readable

I'd like to add more tests for the update execution, however, I think a follow-up
 after the refactoring would be better than having this PR get too large.