### PR TITLE
[TEST] Removes timeout based wait_for_active_shards REST test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/10_basic.yaml
@@ -31,25 +31,6 @@
   - match: { test_index.settings.index.number_of_replicas: "0"}
 
 ---
-"Create index with too large wait_for_active_shards":
-
-  - do:
-      indices.create:
-        index: test_index
-        timeout: 300ms
-        master_timeout: 300ms
-        wait_for_active_shards: 6
-        body:
-          settings:
-            number_of_replicas: 5
-
-  - match: { shards_acknowledged: false }
-
-  - do:
-      cluster.health:
-          wait_for_events: urgent      
-
----
 "Create index with wait_for_active_shards set to all":
 
   - do:


### PR DESCRIPTION
This commit removes a broken test that attempts to ensure, when 
there are not enough nodes to allocate the `wait_for_active_shards`
number of shards, that shardsAcknowledged returns false.  We already
test for this in WaitForActiveShardsIT, and this test introduces a timeout
so we do not wait the full 30s before timing out and returning 
shardsAcknowledged=false.  A very small timeout, however, can cause the test
to fail for other reasons, namely that the master has not even gotten the chance
to update the cluster state with the newly created index.  Increasing the timeout
here to allow index creation in the cluster state to complete adds more duration
to a test that is not really necessary.  Hence, this test is being removed.