### PR TITLE
Improve missing ingest processor error

### DIFF
--- a/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -244,13 +244,22 @@ public final class ConfigurationUtils {
 
     public static List<Processor> readProcessorConfigs(List<Map<String, Map<String, Object>>> processorConfigs,
                                                        Map<String, Processor.Factory> processorFactories) throws Exception {
+        Exception exception = null;
         List<Processor> processors = new ArrayList<>();
         if (processorConfigs != null) {
             for (Map<String, Map<String, Object>> processorConfigWithKey : processorConfigs) {
                 for (Map.Entry<String, Map<String, Object>> entry : processorConfigWithKey.entrySet()) {
-                    processors.add(readProcessor(processorFactories, entry.getKey(), entry.getValue()));
+                    try {
+                        processors.add(readProcessor(processorFactories, entry.getKey(), entry.getValue()));
+                    } catch (Exception e) {
+                        exception = ExceptionsHelper.useOrSuppress(exception, e);
+                    }
                 }
             }
+        }
+
+        if (exception != null) {
+            throw exception;
         }
 
         return processors;

--- a/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
+++ b/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
@@ -164,12 +164,12 @@ public class PipelineStore extends AbstractComponent implements ClusterStateAppl
 
         Map<String, Object> pipelineConfig = XContentHelper.convertToMap(request.getSource(), false, request.getXContentType()).v2();
         Pipeline pipeline = factory.create(request.getId(), pipelineConfig, processorFactories);
-        List<IllegalArgumentException> exceptions = new ArrayList<>();
+        List<Exception> exceptions = new ArrayList<>();
         for (Processor processor : pipeline.flattenAllProcessors()) {
             for (Map.Entry<DiscoveryNode, IngestInfo> entry : ingestInfos.entrySet()) {
                 if (entry.getValue().containsProcessor(processor.getType()) == false) {
                     String message = "Processor type [" + processor.getType() + "] is not installed on node [" + entry.getKey() + "]";
-                    exceptions.add(new IllegalArgumentException(message));
+                    exceptions.add(ConfigurationUtils.newConfigurationException(processor.getType(), processor.getTag(), null, message));
                 }
             }
         }

--- a/core/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
@@ -19,6 +19,10 @@
 
 package org.elasticsearch.ingest;
 
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,11 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.test.ESTestCase;
-import org.junit.Before;
-
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -110,15 +111,33 @@ public class ConfigurationUtilsTests extends ESTestCase {
         Map<String, Object> unknownTaggedConfig = new HashMap<>();
         unknownTaggedConfig.put("tag", "my_unknown");
         config.add(Collections.singletonMap("unknown_processor", unknownTaggedConfig));
-        try {
-            ConfigurationUtils.readProcessorConfigs(config, registry);
-            fail("exception expected");
-        } catch (ElasticsearchParseException e) {
-            assertThat(e.getMessage(), equalTo("No processor type exists with name [unknown_processor]"));
-            assertThat(e.getHeader("processor_tag"), equalTo(Collections.singletonList("my_unknown")));
-            assertThat(e.getHeader("processor_type"), equalTo(Collections.singletonList("unknown_processor")));
-            assertThat(e.getHeader("property_name"), is(nullValue()));
-        }
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class,
+            () -> ConfigurationUtils.readProcessorConfigs(config, registry));
+        assertThat(e.getMessage(), equalTo("No processor type exists with name [unknown_processor]"));
+        assertThat(e.getHeader("processor_tag"), equalTo(Collections.singletonList("my_unknown")));
+        assertThat(e.getHeader("processor_type"), equalTo(Collections.singletonList("unknown_processor")));
+        assertThat(e.getHeader("property_name"), is(nullValue()));
+
+        List<Map<String, Map<String, Object>>> config2 = new ArrayList<>();
+        unknownTaggedConfig = new HashMap<>();
+        unknownTaggedConfig.put("tag", "my_unknown");
+        config2.add(Collections.singletonMap("unknown_processor", unknownTaggedConfig));
+        Map<String, Object> secondUnknonwTaggedConfig = new HashMap<>();
+        secondUnknonwTaggedConfig.put("tag", "my_second_unknown");
+        config2.add(Collections.singletonMap("second_unknown_processor", secondUnknonwTaggedConfig));
+        e = expectThrows(ElasticsearchParseException.class, () -> ConfigurationUtils.readProcessorConfigs(config2, registry));
+        assertThat(e.getMessage(), equalTo("No processor type exists with name [unknown_processor]"));
+        assertThat(e.getHeader("processor_tag"), equalTo(Collections.singletonList("my_unknown")));
+        assertThat(e.getHeader("processor_type"), equalTo(Collections.singletonList("unknown_processor")));
+        assertThat(e.getHeader("property_name"), is(nullValue()));
+
+        assertThat(e.getSuppressed().length, equalTo(1));
+        assertThat(e.getSuppressed()[0], instanceOf(ElasticsearchParseException.class));
+        ElasticsearchParseException e2 = (ElasticsearchParseException) e.getSuppressed()[0];
+        assertThat(e2.getMessage(), equalTo("No processor type exists with name [second_unknown_processor]"));
+        assertThat(e2.getHeader("processor_tag"), equalTo(Collections.singletonList("my_second_unknown")));
+        assertThat(e2.getHeader("processor_type"), equalTo(Collections.singletonList("second_unknown_processor")));
+        assertThat(e2.getHeader("property_name"), is(nullValue()));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/ingest/IngestProcessorNotInstalledOnAllNodesIT.java
+++ b/core/src/test/java/org/elasticsearch/ingest/IngestProcessorNotInstalledOnAllNodesIT.java
@@ -22,8 +22,8 @@ package org.elasticsearch.ingest;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ingest.WritePipelineResponse;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.node.NodeService;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.node.NodeService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 
@@ -72,7 +72,7 @@ public class IngestProcessorNotInstalledOnAllNodesIT extends ESIntegTestCase {
         try {
             client().admin().cluster().preparePutPipeline("_id", pipelineSource, XContentType.JSON).get();
             fail("exception expected");
-        } catch (IllegalArgumentException e) {
+        } catch (ElasticsearchParseException e) {
             assertThat(e.getMessage(), containsString("Processor type [test] is not installed on node"));
         }
     }


### PR DESCRIPTION
This pr fixes two issues:
* Accumulate any potential other processor parse errors before failing instead of failing upon first processor parsing error. This is useful if more than one processor type is unknown, so that the client creating the pipeline knows about all missing processors. Note that suppressed exceptions are not rendered yet on the [rest layer](https://github.com/elastic/elasticsearch/issues/23392). However suppressed exceptions are being serialized in the internal node-to-node layer.
* Attach type and tag header to the error that is thrown when ingest processor isn't available on other ingest nodes.