### PR TITLE
Tests InternalSingleBucketAggregation subclasses

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -437,18 +437,14 @@
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]InternalMultiBucketAggregation.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]ValuesSourceAggregationBuilder.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]BucketsAggregator.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]InternalSingleBucketAggregation.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]children[/\\]ChildrenParser.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]children[/\\]ParentToChildrenAggregator.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]filter[/\\]InternalFilter.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]filters[/\\]FiltersAggregator.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]filters[/\\]FiltersParser.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]filters[/\\]InternalFilters.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]geogrid[/\\]GeoHashGridAggregator.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]histogram[/\\]HistogramAggregator.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]missing[/\\]InternalMissing.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]missing[/\\]MissingAggregator.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]nested[/\\]InternalReverseNested.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]nested[/\\]ReverseNestedAggregator.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]range[/\\]RangeAggregator.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]significant[/\\]GlobalOrdinalsSignificantTermsAggregator.java" checks="LineLength" />

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -47,7 +47,8 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
      * @param docCount      The document count in the single bucket.
      * @param aggregations  The already built sub-aggregations that are associated with the bucket.
      */
-    protected InternalSingleBucketAggregation(String name, long docCount, InternalAggregations aggregations, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+    protected InternalSingleBucketAggregation(String name, long docCount, InternalAggregations aggregations,
+            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.docCount = docCount;
         this.aggregations = aggregations;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilter.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilter.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.search.aggregations.bucket.filter;
 
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,7 +29,8 @@ import java.util.List;
 import java.util.Map;
 
 public class InternalFilter extends InternalSingleBucketAggregation implements Filter {
-    InternalFilter(String name, long docCount, InternalAggregations subAggregations, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+    InternalFilter(String name, long docCount, InternalAggregations subAggregations, List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData) {
         super(name, docCount, subAggregations, pipelineAggregators, metaData);
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissing.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissing.java
@@ -28,7 +28,8 @@ import java.util.List;
 import java.util.Map;
 
 public class InternalMissing extends InternalSingleBucketAggregation implements Missing {
-    InternalMissing(String name, long docCount, InternalAggregations aggregations, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+    InternalMissing(String name, long docCount, InternalAggregations aggregations, List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData) {
         super(name, docCount, aggregations, pipelineAggregators, metaData);
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
@@ -49,11 +49,12 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
     }
 
     public final void testReduceRandom() {
+        String name = randomAsciiOfLength(5);
         List<T> inputs = new ArrayList<>();
         List<InternalAggregation> toReduce = new ArrayList<>();
         int toReduceSize = between(1, 200);
         for (int i = 0; i < toReduceSize; i++) {
-            T t = randomBoolean() ? createUnmappedInstance() : createTestInstance();
+            T t = randomBoolean() ? createUnmappedInstance(name) : createTestInstance(name);
             inputs.add(t);
             toReduce.add(t);
         }
@@ -76,7 +77,10 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
 
     @Override
     protected final T createTestInstance() {
-        String name = randomAsciiOfLength(5);
+        return createTestInstance(randomAsciiOfLength(5));
+    }
+
+    private T createTestInstance(String name) {
         List<PipelineAggregator> pipelineAggregators = new ArrayList<>();
         // TODO populate pipelineAggregators
         Map<String, Object> metaData = new HashMap<>();
@@ -88,8 +92,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
     }
 
     /** Return an instance on an unmapped field. */
-    protected final T createUnmappedInstance() {
-        String name = randomAsciiOfLength(5);
+    protected final T createUnmappedInstance(String name) {
         List<PipelineAggregator> pipelineAggregators = new ArrayList<>();
         // TODO populate pipelineAggregators
         Map<String, Object> metaData = new HashMap<>();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregationTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket;
+
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.metrics.max.InternalMax;
+import org.elasticsearch.search.aggregations.metrics.min.InternalMin;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+
+public abstract class InternalSingleBucketAggregationTestCase<T extends InternalSingleBucketAggregation>
+        extends InternalAggregationTestCase<T> {
+    private final boolean hasInternalMax = randomBoolean();
+    private final boolean hasInternalMin = randomBoolean();
+
+    protected abstract T createTestInstance(String name, long docCount, InternalAggregations aggregations,
+            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData);
+    protected abstract void extraAssertReduced(T reduced, List<T> inputs);
+
+    @Override
+    protected final T createTestInstance(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        List<InternalAggregation> internal = new ArrayList<>();
+        if (hasInternalMax) {
+            internal.add(new InternalMax("max", randomDouble(),
+                    randomFrom(DocValueFormat.BOOLEAN, DocValueFormat.GEOHASH, DocValueFormat.IP, DocValueFormat.RAW), emptyList(),
+                    emptyMap()));
+        }
+        if (hasInternalMin) {
+            internal.add(new InternalMin("min", randomDouble(),
+                    randomFrom(DocValueFormat.BOOLEAN, DocValueFormat.GEOHASH, DocValueFormat.IP, DocValueFormat.RAW), emptyList(),
+                    emptyMap()));
+        }
+        // we shouldn't use the full long range here since we sum doc count on reduce, and don't want to overflow the long range there
+        long docCount = between(0, Integer.MAX_VALUE);
+        return createTestInstance(name, docCount, new InternalAggregations(internal), pipelineAggregators, metaData);
+    }
+
+    @Override
+    protected final void assertReduced(T reduced, List<T> inputs) {
+        assertEquals(inputs.stream().mapToLong(InternalSingleBucketAggregation::getDocCount).sum(), reduced.getDocCount());
+        if (hasInternalMax) {
+            double expected = inputs.stream().mapToDouble(i -> {
+                        InternalMax max = i.getAggregations().get("max");
+                        return max.getValue();
+                    }).max().getAsDouble();
+            InternalMax reducedMax = reduced.getAggregations().get("max");
+            assertEquals(expected, reducedMax.getValue(), 0);
+        }
+        if (hasInternalMin) {
+            double expected = inputs.stream().mapToDouble(i -> {
+                        InternalMin min = i.getAggregations().get("min");
+                        return min.getValue();
+                    }).min().getAsDouble();
+            InternalMin reducedMin = reduced.getAggregations().get("min");
+            assertEquals(expected, reducedMin.getValue(), 0);
+        }
+        extraAssertReduced(reduced, inputs);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/children/InternalChildrenTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/children/InternalChildrenTests.java
@@ -20,42 +20,23 @@
 package org.elasticsearch.search.aggregations.bucket.children;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
-import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.metrics.max.InternalMax;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class InternalChildrenTests extends InternalAggregationTestCase<InternalChildren> {
-
+public class InternalChildrenTests extends InternalSingleBucketAggregationTestCase<InternalChildren> {
     @Override
-    protected InternalChildren createTestInstance(String name, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metaData) {
-        // we shouldn't use the full long range here since we sum doc count on reduce, and don't want to overflow the long range there
-        long docCount = randomIntBetween(0, Integer.MAX_VALUE);
-        int numAggregations = randomIntBetween(0, 20);
-        List<InternalAggregation> aggs = new ArrayList<>(numAggregations);
-        for (int i = 0; i < numAggregations; i++) {
-            aggs.add(new InternalMax(randomAsciiOfLength(5), randomDouble(),
-                    randomFrom(DocValueFormat.BOOLEAN, DocValueFormat.GEOHASH, DocValueFormat.IP, DocValueFormat.RAW), pipelineAggregators,
-                    metaData));
-        }
-        // don't randomize the name parameter, since InternalSingleBucketAggregation#doReduce asserts its the same for all reduced aggs
-        return new InternalChildren("childAgg", docCount, new InternalAggregations(aggs), pipelineAggregators, metaData);
+    protected InternalChildren createTestInstance(String name, long docCount, InternalAggregations aggregations,
+            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        return new InternalChildren(name, docCount, aggregations, pipelineAggregators, metaData);
     }
 
     @Override
-    protected void assertReduced(InternalChildren reduced, List<InternalChildren> inputs) {
-        long expectedDocCount = 0;
-        for (Children input : inputs) {
-            expectedDocCount += input.getDocCount();
-        }
-        assertEquals(expectedDocCount, reduced.getDocCount());
+    protected void extraAssertReduced(InternalChildren reduced, List<InternalChildren> inputs) {
+        // Nothing extra to assert
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilterTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilterTests.java
@@ -16,40 +16,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket.nested;
 
-import org.elasticsearch.common.io.stream.StreamInput;
+package org.elasticsearch.search.aggregations.bucket.filter;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Result of the {@link ReverseNestedAggregator}.
- */
-public class InternalReverseNested extends InternalSingleBucketAggregation implements ReverseNested {
-    public InternalReverseNested(String name, long docCount, InternalAggregations aggregations,
+public class InternalFilterTests extends InternalSingleBucketAggregationTestCase<InternalFilter> {
+    @Override
+    protected InternalFilter createTestInstance(String name, long docCount, InternalAggregations aggregations,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        super(name, docCount, aggregations, pipelineAggregators, metaData);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public InternalReverseNested(StreamInput in) throws IOException {
-        super(in);
+        return new InternalFilter(name, docCount, aggregations, pipelineAggregators, metaData);
     }
 
     @Override
-    public String getWriteableName() {
-        return ReverseNestedAggregationBuilder.NAME;
+    protected void extraAssertReduced(InternalFilter reduced, List<InternalFilter> inputs) {
+        // Nothing extra to assert
     }
 
     @Override
-    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalReverseNested(name, docCount, subAggregations, pipelineAggregators(), getMetaData());
+    protected Reader<InternalFilter> instanceReader() {
+        return InternalFilter::new;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlogbalTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlogbalTests.java
@@ -16,40 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket.nested;
 
-import org.elasticsearch.common.io.stream.StreamInput;
+package org.elasticsearch.search.aggregations.bucket.global;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Result of the {@link ReverseNestedAggregator}.
- */
-public class InternalReverseNested extends InternalSingleBucketAggregation implements ReverseNested {
-    public InternalReverseNested(String name, long docCount, InternalAggregations aggregations,
+public class InternalGlogbalTests extends InternalSingleBucketAggregationTestCase<InternalGlobal> {
+    @Override
+    protected InternalGlobal createTestInstance(String name, long docCount, InternalAggregations aggregations,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        super(name, docCount, aggregations, pipelineAggregators, metaData);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public InternalReverseNested(StreamInput in) throws IOException {
-        super(in);
+        return new InternalGlobal(name, docCount, aggregations, pipelineAggregators, metaData);
     }
 
     @Override
-    public String getWriteableName() {
-        return ReverseNestedAggregationBuilder.NAME;
+    protected void extraAssertReduced(InternalGlobal reduced, List<InternalGlobal> inputs) {
+        // Nothing extra to assert
     }
 
     @Override
-    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalReverseNested(name, docCount, subAggregations, pipelineAggregators(), getMetaData());
+    protected Reader<InternalGlobal> instanceReader() {
+        return InternalGlobal::new;
     }
+
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissingTests.java
@@ -16,40 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket.nested;
 
-import org.elasticsearch.common.io.stream.StreamInput;
+package org.elasticsearch.search.aggregations.bucket.missing;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Result of the {@link ReverseNestedAggregator}.
- */
-public class InternalReverseNested extends InternalSingleBucketAggregation implements ReverseNested {
-    public InternalReverseNested(String name, long docCount, InternalAggregations aggregations,
+public class InternalMissingTests extends InternalSingleBucketAggregationTestCase<InternalMissing> {
+    @Override
+    protected InternalMissing createTestInstance(String name, long docCount, InternalAggregations aggregations,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        super(name, docCount, aggregations, pipelineAggregators, metaData);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public InternalReverseNested(StreamInput in) throws IOException {
-        super(in);
+        return new InternalMissing(name, docCount, aggregations, pipelineAggregators, metaData);
     }
 
     @Override
-    public String getWriteableName() {
-        return ReverseNestedAggregationBuilder.NAME;
+    protected void extraAssertReduced(InternalMissing reduced, List<InternalMissing> inputs) {
+        // Nothing extra to assert
     }
 
     @Override
-    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalReverseNested(name, docCount, subAggregations, pipelineAggregators(), getMetaData());
+    protected Reader<InternalMissing> instanceReader() {
+        return InternalMissing::new;
     }
+
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNestedTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNestedTests.java
@@ -16,40 +16,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.search.aggregations.bucket.nested;
 
-import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Result of the {@link ReverseNestedAggregator}.
- */
-public class InternalReverseNested extends InternalSingleBucketAggregation implements ReverseNested {
-    public InternalReverseNested(String name, long docCount, InternalAggregations aggregations,
+public class InternalNestedTests extends InternalSingleBucketAggregationTestCase<InternalNested> {
+    @Override
+    protected InternalNested createTestInstance(String name, long docCount, InternalAggregations aggregations,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        super(name, docCount, aggregations, pipelineAggregators, metaData);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public InternalReverseNested(StreamInput in) throws IOException {
-        super(in);
+        return new InternalNested(name, docCount, aggregations, pipelineAggregators, metaData);
     }
 
     @Override
-    public String getWriteableName() {
-        return ReverseNestedAggregationBuilder.NAME;
+    protected void extraAssertReduced(InternalNested reduced, List<InternalNested> inputs) {
+        // Nothing extra to assert
     }
 
     @Override
-    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalReverseNested(name, docCount, subAggregations, pipelineAggregators(), getMetaData());
+    protected Reader<InternalNested> instanceReader() {
+        return InternalNested::new;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNestedTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNestedTests.java
@@ -16,40 +16,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.search.aggregations.bucket.nested;
 
-import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Result of the {@link ReverseNestedAggregator}.
- */
-public class InternalReverseNested extends InternalSingleBucketAggregation implements ReverseNested {
-    public InternalReverseNested(String name, long docCount, InternalAggregations aggregations,
+public class InternalReverseNestedTests extends InternalSingleBucketAggregationTestCase<InternalReverseNested> {
+    @Override
+    protected InternalReverseNested createTestInstance(String name, long docCount, InternalAggregations aggregations,
             List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        super(name, docCount, aggregations, pipelineAggregators, metaData);
-    }
-
-    /**
-     * Read from a stream.
-     */
-    public InternalReverseNested(StreamInput in) throws IOException {
-        super(in);
+        return new InternalReverseNested(name, docCount, aggregations, pipelineAggregators, metaData);
     }
 
     @Override
-    public String getWriteableName() {
-        return ReverseNestedAggregationBuilder.NAME;
+    protected void extraAssertReduced(InternalReverseNested reduced, List<InternalReverseNested> inputs) {
+        // Nothing extra to assert
     }
 
     @Override
-    protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
-        return new InternalReverseNested(name, docCount, subAggregations, pipelineAggregators(), getMetaData());
+    protected Reader<InternalReverseNested> instanceReader() {
+        return InternalReverseNested::new;
     }
 }


### PR DESCRIPTION
Adds a common base class for testing subclasses of
`InternalSingleBucketAggregation`. They are so similar they
call into question the utility of having all of these classes.
We maybe could just use `InternalSingleBucketAggregation` in
all those cases.... But for now, let's test the classes!

Relates to #22278
