### PR TITLE
ThreadedActionListener always wraps listener to preserve context

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/AbstractListenableActionFuture.java
+++ b/core/src/main/java/org/elasticsearch/action/support/AbstractListenableActionFuture.java
@@ -50,7 +50,8 @@ public abstract class AbstractListenableActionFuture<T, L> extends AdapterAction
     }
 
     public void internalAddListener(ActionListener<T> listener) {
-        listener = new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.LISTENER, listener, false);
+        listener = new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.LISTENER,
+            ContextPreservingActionListener.wrap(listener, threadPool.getThreadContext(), false), false);
         boolean executeImmediate = false;
         synchronized (this) {
             if (executedListeners) {

--- a/core/src/main/java/org/elasticsearch/action/support/ContextPreservingActionListener.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ContextPreservingActionListener.java
@@ -50,4 +50,12 @@ public final class ContextPreservingActionListener<R> implements ActionListener<
             delegate.onFailure(e);
         }
     }
+
+    /**
+     * Wraps the given action listener so that it restores the current context.
+     */
+    public static <R> ContextPreservingActionListener<R> wrap(ActionListener<R> listener, ThreadContext context,
+                                                              boolean restoreResponseHeader) {
+        return new ContextPreservingActionListener<>(context.newRestorableContext(restoreResponseHeader), listener);
+    }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/ThreadedActionListener.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ThreadedActionListener.java
@@ -81,7 +81,7 @@ public final class ThreadedActionListener<Response> implements ActionListener<Re
         this.logger = logger;
         this.threadPool = threadPool;
         this.executor = executor;
-        this.listener = listener;
+        this.listener = ContextPreservingActionListener.wrap(listener, threadPool.getThreadContext(), false);
         this.forceExecution = forceExecution;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/ThreadedActionListener.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ThreadedActionListener.java
@@ -66,22 +66,23 @@ public final class ThreadedActionListener<Response> implements ActionListener<Re
             if (listener instanceof ThreadedActionListener) {
                 return listener;
             }
-            return new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.LISTENER, listener, false);
+            return new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.LISTENER,
+                ContextPreservingActionListener.wrap(listener, threadPool.getThreadContext(), false), false);
         }
     }
 
     private final Logger logger;
     private final ThreadPool threadPool;
     private final String executor;
-    private final ActionListener<Response> listener;
+    private final ContextPreservingActionListener<Response> listener;
     private final boolean forceExecution;
 
-    public ThreadedActionListener(Logger logger, ThreadPool threadPool, String executor, ActionListener<Response> listener,
+    public ThreadedActionListener(Logger logger, ThreadPool threadPool, String executor, ContextPreservingActionListener<Response> listener,
                                   boolean forceExecution) {
         this.logger = logger;
         this.threadPool = threadPool;
         this.executor = executor;
-        this.listener = ContextPreservingActionListener.wrap(listener, threadPool.getThreadContext(), false);
+        this.listener = listener;
         this.forceExecution = forceExecution;
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -477,7 +477,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
     }
 
     private ContextPreservingActionListener<ClusterStateUpdateResponse> wrapPreservingContext(ActionListener<ClusterStateUpdateResponse> listener) {
-        return new ContextPreservingActionListener<>(threadPool.getThreadContext().newRestorableContext(false), listener);
+        return ContextPreservingActionListener.wrap(listener, threadPool.getThreadContext(), false);
     }
 
     private List<IndexTemplateMetaData> findTemplates(CreateIndexClusterStateUpdateRequest request, ClusterState state) throws IOException {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -289,7 +289,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
     }
 
     private ContextPreservingActionListener<ClusterStateUpdateResponse> wrapPreservingContext(ActionListener<ClusterStateUpdateResponse> listener) {
-        return new ContextPreservingActionListener<>(threadPool.getThreadContext().newRestorableContext(false), listener);
+        return ContextPreservingActionListener.wrap(listener, threadPool.getThreadContext(), false);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShardOperationsLock.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShardOperationsLock.java
@@ -127,11 +127,13 @@ public class IndexShardOperationsLock implements Closeable {
                     if (delayedOperations == null) {
                         delayedOperations = new ArrayList<>();
                     }
+                    final ContextPreservingActionListener<Releasable> wrappedListener =
+                        ContextPreservingActionListener.wrap(onAcquired, threadPool.getThreadContext(), false);
                     if (executorOnDelay != null) {
                         delayedOperations.add(
-                            new ThreadedActionListener<>(logger, threadPool, executorOnDelay, onAcquired, forceExecution));
+                            new ThreadedActionListener<>(logger, threadPool, executorOnDelay, wrappedListener, forceExecution));
                     } else {
-                        delayedOperations.add(ContextPreservingActionListener.wrap(onAcquired, threadPool.getThreadContext(), false));
+                        delayedOperations.add(wrappedListener);
                     }
                     return;
                 }

--- a/core/src/test/java/org/elasticsearch/action/support/ThreadedActionListenerTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/ThreadedActionListenerTests.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPool.Names;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class ThreadedActionListenerTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void createThreadPool() {
+        threadPool = new TestThreadPool(ThreadedActionListenerTests.class.getName());
+    }
+
+    @After
+    public void terminateThreadPool() throws InterruptedException {
+        terminate(threadPool);
+    }
+
+    public void testThreadedActionListenerPreservesContext() throws InterruptedException {
+        final ThreadedActionListener<Void> listener;
+        final ThreadContext context = threadPool.getThreadContext();
+        final CountDownLatch responseLatch = new CountDownLatch(1);
+        final CountDownLatch exceptionLatch = new CountDownLatch(1);
+        try (ThreadContext.StoredContext ignore = context.newStoredContext(false)) {
+            context.putHeader("foo", "bar");
+            context.putTransient("bar", "baz");
+            listener = new ThreadedActionListener<>(logger, threadPool, Names.GENERIC, ActionListener.wrap(r -> {
+                    assertEquals("bar", context.getHeader("foo"));
+                    assertEquals("baz", context.getTransient("bar"));
+                    responseLatch.countDown();
+                },
+                e -> {
+                    assertEquals("bar", context.getHeader("foo"));
+                    assertEquals("baz", context.getTransient("bar"));
+                    exceptionLatch.countDown();
+                }), randomBoolean());
+        }
+
+        assertNull(context.getHeader("foo"));
+        assertNull(context.getTransient("bar"));
+        assertEquals(1, responseLatch.getCount());
+
+        listener.onResponse(null);
+        responseLatch.await(1L, TimeUnit.HOURS);
+        assertEquals(0, responseLatch.getCount());
+
+        assertNull(context.getHeader("foo"));
+        assertNull(context.getTransient("bar"));
+        assertEquals(1, exceptionLatch.getCount());
+
+        listener.onFailure(null);
+        exceptionLatch.await(1L, TimeUnit.HOURS);
+        assertEquals(0, exceptionLatch.getCount());
+        assertNull(context.getHeader("foo"));
+        assertNull(context.getTransient("bar"));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
@@ -137,7 +138,8 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         @Override
         protected void doExecute(Task task, final Request request, ActionListener<Response> listener) {
             // remove unneeded threading by wrapping listener with SAME to prevent super.doExecute from wrapping it with LISTENER
-            super.doExecute(task, request, new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.SAME, listener, false));
+            super.doExecute(task, request, new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.SAME,
+                ContextPreservingActionListener.wrap(listener, threadPool.getThreadContext(), false), false));
         }
 
         @Override


### PR DESCRIPTION
The ThreadedActionListener may not be invoked by the same thread that creates it. When this happens, the ThreadContext from the thread that created the ThreadedActionListener should be used. This change makes the ThreadedActionListener always wrap the ActionListener in a ContextPreservingActionListener to prevent accidental loss of the ThreadContext.

Relates #23349