### PR TITLE
Remove unnecessary Groovy deprecation logging

### DIFF
--- a/modules/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
+++ b/modules/lang-groovy/src/main/java/org/elasticsearch/script/groovy/GroovyScriptEngineService.java
@@ -98,8 +98,6 @@ public class GroovyScriptEngineService extends AbstractComponent implements Scri
     public GroovyScriptEngineService(Settings settings) {
         super(settings);
 
-        deprecationLogger.deprecated("[groovy] scripts are deprecated, use [painless] scripts instead");
-
         // Creates the classloader here in order to isolate Groovy-land code
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {


### PR DESCRIPTION
This commit removes a deprecation log message that is printed any time
the Groovy script engine is loaded. This is unnecessary because we print
deprecation messages any time a Groovy script is used, so this message
appears independently of whether or not a user is actually using Groovy
scripts.

Closes #23401
