### PR TITLE
Deprecate Netty 3

### DIFF
--- a/docs/reference/migration/migrate_5_3.asciidoc
+++ b/docs/reference/migration/migrate_5_3.asciidoc
@@ -22,6 +22,13 @@ three properties:
 
 The property `es.logs` is deprecated and will be removed in Elasticsearch 6.0.0.
 
+[float]
+==== Use of Netty 3 is deprecated
+
+Usage of Netty 3 for transport (`transport.type=netty3`) or HTTP
+(`http.type=netty3`) is deprecated and will be removed in Elasticsearch
+6.0.0.
+
 [[breaking_53_settings_changes]]
 [float]
 === Settings changes
@@ -52,4 +59,3 @@ is deprecated.
 
 Usage of any value other than `false`, `"false", `true` and `"true"` for
 boolean values in mappings is deprecated.
-

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
@@ -224,6 +224,7 @@ public class Netty3HttpServerTransport extends AbstractLifecycleComponent implem
     public Netty3HttpServerTransport(Settings settings, NetworkService networkService, BigArrays bigArrays, ThreadPool threadPool,
             NamedXContentRegistry xContentRegistry, HttpServerTransport.Dispatcher dispatcher) {
         super(settings);
+        deprecationLogger.deprecated("http type [netty3] is deprecated");
         this.networkService = networkService;
         this.bigArrays = bigArrays;
         this.threadPool = threadPool;

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Transport.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Transport.java
@@ -38,7 +38,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -144,6 +143,7 @@ public class Netty3Transport extends TcpTransport<Channel> {
     public Netty3Transport(Settings settings, ThreadPool threadPool, NetworkService networkService, BigArrays bigArrays,
                            NamedWriteableRegistry namedWriteableRegistry, CircuitBreakerService circuitBreakerService) {
         super("netty3", settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService);
+        deprecationLogger.deprecated("transport type [netty3] is deprecated");
         this.workerCount = WORKER_COUNT.get(settings);
         this.maxCumulationBufferCapacity = NETTY_MAX_CUMULATION_BUFFER_CAPACITY.get(settings);
         this.maxCompositeBufferComponents = NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS.get(settings);


### PR DESCRIPTION
This commit adds deprecation warnings for the use of Netty 3 for transport or HTTP requests.

