### PR TITLE
Set build hash to Unknown when unavailable

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -464,7 +464,7 @@ class BuildPlugin implements Plugin<Project> {
                         'Build-Java-Version': project.javaVersion)
                 if (jarTask.manifest.attributes.containsKey('Change') == false) {
                     logger.warn('Building without git revision id.')
-                    jarTask.manifest.attributes('Change': 'N/A')
+                    jarTask.manifest.attributes('Change': 'Unknown')
                 }
             }
         }


### PR DESCRIPTION
This commit changes the build hash to be the string "Unknown" when forsome reason this build hash is not available. This aligns the value with the value we use when the hash is not available from the jar
manifest. This situation can occur when running tests from a worktree which is not currently handled correctly by JGit, the upstream dependency that is used to acquire the hash. This causes problems when running tests locally because the warning header pattern expects a hash or the string "Unknown". While the warning header pattern be changed to allow "N/A" as well, it seemed more sensible to align the value here with the value when the hash is not available from the jar manifest.

