### PR TITLE
[TEST] skip yaml tests that expect warnings with nodes pre 5.3.0

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yaml
@@ -168,8 +168,8 @@
 ---
 "Test cat shards with shadow replicas":
   - skip:
-      version: " - 5.1.99"
-      reason: deprecation was added in 5.2.0
+      version: " - 5.2.99"
+      reason: deprecation was added in 5.2.0 and its format changed in 5.3.0
       features: "warnings"
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/27_force_version.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/27_force_version.yaml
@@ -3,8 +3,8 @@
 
  - skip:
     features: "warnings"
-    version: " - 5.0.0"
-    reason:  headers were introduced in 5.0.1
+    version: " - 5.2.99"
+    reason: warning headers were introduced in 5.0.1 and their format changed in 5.3.0
 
  - do:
       warnings:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/get/95_force_versions.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/get/95_force_versions.yaml
@@ -2,8 +2,8 @@
 "Force Versions":
  - skip:
     features: "warnings"
-    version: " - 5.0.0"
-    reason:  headers were introduced in 5.0.1
+    version: " - 5.2.99"
+    reason: warning headers were introduced in 5.0.1 and their format changed in 5.3.0
  - do:
       index:
           index:  test_1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/37_force_version.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/37_force_version.yaml
@@ -3,8 +3,8 @@
 
  - skip:
     features: "warnings"
-    version: " - 5.0.0"
-    reason:  headers were introduced in 5.0.1
+    version: " - 5.2.99"
+    reason:  warning headers were introduced in 5.0.1 and their format changed in 5.3.0
 
  - do:
       warnings:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yaml
@@ -8,8 +8,8 @@ setup:
 "Basic test":
     - skip:
         features: "warnings"
-        version: " - 5.0.99"
-        reason:  text was deprecated in 5.1.0
+        version: " - 5.2.99"
+        reason:  text was deprecated in 5.1.0 and the deprecation format changed in 5.3.0
     - do:
         warnings:
           - text request parameter is deprecated and will be removed in the next major release. Please use the JSON in the request body instead request param
@@ -23,8 +23,8 @@ setup:
 "Tokenizer and filter":
     - skip:
         features: "warnings"
-        version: " - 5.0.99"
-        reason:  text, filter and tokenizer were deprecated in 5.1.0
+        version: " - 5.2.99"
+        reason:  text was deprecated in 5.1.0 and the deprecation format changed in 5.3.0
     - do:
         warnings:
           - filter request parameter is deprecated and will be removed in the next major release. Please use the JSON in the request body instead request param
@@ -41,8 +41,8 @@ setup:
 "Index and field":
     - skip:
         features: "warnings"
-        version: " - 5.0.99"
-        reason:  text was deprecated in 5.1.0
+        version: " - 5.2.99"
+        reason:  text was deprecated in 5.1.0 and the deprecation format changed in 5.3.0
     - do:
         indices.create:
           index: test
@@ -76,8 +76,8 @@ setup:
 "Body params override query string":
     - skip:
         features: "warnings"
-        version: " - 5.0.99"
-        reason:  text was deprecated in 5.1.0
+        version: " - 5.2.99"
+        reason:  text was deprecated in 5.1.0 and the deprecation format changed in 5.3.0
     - do:
         warnings:
           - text request parameter is deprecated and will be removed in the next major release. Please use the JSON in the request body instead request param

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/10_index.yaml
@@ -118,8 +118,8 @@ setup:
 "Indices stats warns on percolate":
   - skip:
       features: "warnings"
-      version: " - 5.0.99"
-      reason:  The warning was introduced in 5.1
+      version: " - 5.2.99"
+      reason:  The warning was introduced in 5.1 and its format changed in 5.3.0
   - do:
       warnings:
           - 'percolate stats are no longer available and requests for percolate stats will fail starting in 6.0.0'

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/10_basic.yaml
@@ -39,8 +39,8 @@
 "Node stats warns on percolate":
   - skip:
       features: "warnings"
-      version: " - 5.0.99"
-      reason:  The warning was introduced in 5.1
+      version: " - 5.2.99"
+      reason:  The warning was introduced in 5.1 and its format changed in 5.3.0
   - do:
       warnings:
           - 'percolate stats are no longer available and requests for percolate stats will fail starting in 6.0.0'

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/40_indices_boost.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/40_indices_boost.yaml
@@ -37,8 +37,8 @@ setup:
 ---
 "Indices boost using object":
   - skip:
-      version: " - 5.1.99"
-      reason: deprecation was added in 5.2.0
+      version: " - 5.2.99"
+      reason: deprecation was added in 5.2.0 and its format changed in 5.3.0
       features: "warnings"
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search_shards/10_basic.yaml
@@ -15,8 +15,8 @@
 "Search shards with type":
   - skip:
       features: "warnings"
-      version: " - 5.0.99"
-      reason: type was deprecated in 5.1.0
+      version: " - 5.2.99"
+      reason: type was deprecated in 5.1.0 and the deprecation format changed in 5.3.0
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/10_basic.yaml
@@ -28,8 +28,8 @@ setup:
 "Suggest API should have deprecation warning":
   - skip:
       features: 'warnings'
-      version: ' - 5.2.0'
-      reason: 'no deprecation logging prior to 5.2'
+      version: ' - 5.2.99'
+      reason: no deprecation logging prior to 5.2, log format changed in 5.3.0
   - do:
       warnings:
         - "[POST /_suggest] is deprecated! Use [POST /_search] instead."

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/110_completion.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/110_completion.yaml
@@ -31,8 +31,8 @@ setup:
 "Simple suggestion should work":
   - skip:
       features: 'warnings'
-      version: ' - 5.2.0'
-      reason: 'no deprecation logging prior to 5.2'
+      version: ' - 5.2.99'
+      reason: no deprecation logging prior to 5.2 and log format changed in 5.3.0
 
   - do:
       index:
@@ -70,8 +70,8 @@ setup:
 "Simple suggestion array should work":
   - skip:
       features: 'warnings'
-      version: ' - 5.2.0'
-      reason: 'no deprecation logging prior to 5.2'
+      version: ' - 5.2.99'
+      reason: no deprecation logging prior to 5.2, log format changed in 5.3.0
 
   - do:
       index:
@@ -116,8 +116,8 @@ setup:
 "Suggestion entry should work":
   - skip:
       features: 'warnings'
-      version: ' - 5.2.0'
-      reason: 'no deprecation logging prior to 5.2'
+      version: ' - 5.2.99'
+      reason: no deprecation logging prior to 5.2, log format changed in 5.3.0
 
   - do:
       index:
@@ -161,8 +161,8 @@ setup:
 "Suggestion entry array should work":
   - skip:
       features: 'warnings'
-      version: ' - 5.2.0'
-      reason: 'no deprecation logging prior to 5.2'
+      version: ' - 5.2.99'
+      reason: no deprecation logging prior to 5.2, log format changed in 5.3.0
 
   - do:
       index:
@@ -225,8 +225,8 @@ setup:
 "Multiple Completion fields should work":
   - skip:
       features: 'warnings'
-      version: ' - 5.2.0'
-      reason: 'no deprecation logging prior to 5.2'
+      version: ' - 5.2.99'
+      reason: no deprecation logging prior to 5.2, log format changed in 5.3.0
 
   - do:
       index:
@@ -272,8 +272,8 @@ setup:
 "Suggestions with source should work":
   - skip:
       features: 'warnings'
-      version: ' - 5.2.0'
-      reason: 'no deprecation logging prior to 5.2'
+      version: ' - 5.2.99'
+      reason: no deprecation logging prior to 5.2, log format changed in 5.3.0
   - do:
       index:
         index: test

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/45_force_versions.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/termvectors/45_force_versions.yaml
@@ -2,8 +2,8 @@
 "Force Version":
  - skip:
     features: "warnings"
-    version: " - 5.0.0"
-    reason:  headers were introduced in 5.0.1
+    version: " - 5.2.99"
+    reason: warning headers were introduced in 5.0.1 and their format changed in 5.3.0
 
  - do:
       index:

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
@@ -85,7 +85,7 @@ public class ClientYamlTestResponse {
             if (header.getName().equals("Warning")) {
                 if (nodeVersion.onOrAfter(Version.V_5_3_0_UNRELEASED) && response.getRequestLine().getMethod().equals("GET")
                     && response.getRequestLine().getUri().contains("source")
-                    && response.getRequestLine().getUri().contains("source_content_type") == false && header.getValue().startsWith(
+                    && response.getRequestLine().getUri().contains("source_content_type") == false && header.getValue().contains(
                         "Deprecated use of the [source] parameter without the [source_content_type] parameter.")) {
                     // this is because we do not send the source content type header when the node is 5.3.0 or below and the request
                     // might have been sent to a node with a version > 5.3.0 when running backwards 5.0 tests. The Java RestClient


### PR DESCRIPTION
The skip will come into play when we run backwards tests. We changed the deprecation headers format with 5.3.0 and we can't properly test that pre 5.3.0 nodes return the previous format warnings, so we just skip these tests whenever a pre 5.3.0 node is in the cluster.