### PR TITLE
Properly clean up thread context after tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -286,7 +286,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         // initialized
         if (threadContext != null) {
             ensureNoWarnings();
-            threadContext = null;
+            assert threadContext == null;
         }
         ensureAllSearchContextsReleased();
         ensureCheckIndexPassed();
@@ -300,7 +300,7 @@ public abstract class ESTestCase extends LuceneTestCase {
             final List<String> warnings = threadContext.getResponseHeaders().get("Warning");
             assertNull("unexpected warning headers", warnings);
         } finally {
-            resetDeprecationLogger();
+            resetDeprecationLogger(false);
         }
     }
 
@@ -337,11 +337,17 @@ public abstract class ESTestCase extends LuceneTestCase {
                     + Arrays.asList(expectedWarnings) + "\nActual: " + actualWarnings,
                 expectedWarnings.length, actualWarnings.size());
         } finally {
-            resetDeprecationLogger();
+            resetDeprecationLogger(true);
         }
     }
 
-    private void resetDeprecationLogger() {
+    /**
+     * Reset the deprecation logger by removing the current thread context, and setting a new thread context if {@code setNewThreadContext}
+     * is set to {@code true} and otherwise clearing the current thread context.
+     *
+     * @param setNewThreadContext whether or not to attach a new thread context to the deprecation logger
+     */
+    private void resetDeprecationLogger(final boolean setNewThreadContext) {
         // "clear" current warning headers by setting a new ThreadContext
         DeprecationLogger.removeThreadContext(this.threadContext);
         try {
@@ -351,8 +357,12 @@ public abstract class ESTestCase extends LuceneTestCase {
         } catch (IOException ex) {
             throw new AssertionError("IOException thrown while closing deprecation logger's thread context", ex);
         }
-        this.threadContext = new ThreadContext(Settings.EMPTY);
-        DeprecationLogger.setThreadContext(this.threadContext);
+        if (setNewThreadContext) {
+            this.threadContext = new ThreadContext(Settings.EMPTY);
+            DeprecationLogger.setThreadContext(this.threadContext);
+        } else {
+            this.threadContext = null;
+        }
     }
 
     private static final List<StatusData> statusData = new ArrayList<>();


### PR DESCRIPTION
Today when resetting the deprecation logger after a test is torn down, we attach a new thread context to the deprecation logger. This thread context is never cleared and we are left with a thread context attached to the deprecation logger for every test method that ran in the same JVM. This commit adds a flag when resetting the deprecation logger to not attach a new thread context when the test is being torn down.
