### PR TITLE
Replace `#!/bin/bash` with `#!/usr/bin/env bash`

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # CONTROLLING STARTUP:
 #

--- a/distribution/src/main/resources/bin/elasticsearch-keystore
+++ b/distribution/src/main/resources/bin/elasticsearch-keystore
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CDPATH=""
 SCRIPT="$0"

--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CDPATH=""
 SCRIPT="$0"

--- a/distribution/src/main/resources/bin/elasticsearch-systemd-pre-exec
+++ b/distribution/src/main/resources/bin/elasticsearch-systemd-pre-exec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # CONF_FILE setting was removed
 if [ ! -z "$CONF_FILE" ]; then

--- a/distribution/src/main/resources/bin/elasticsearch-translog
+++ b/distribution/src/main/resources/bin/elasticsearch-translog
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CDPATH=""
 SCRIPT="$0"


### PR DESCRIPTION
This fixes #23443 by changing the shebang line of shell scripts to make
them work on operating systems that don't have bash installed in `/bin`.
