### PR TITLE
Ensure we try to autodetect content type for handlers that support plain text

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestController.java
@@ -272,10 +272,19 @@ public class RestController extends AbstractComponent implements HttpServerTrans
     private boolean hasContentTypeOrCanAutoDetect(final RestRequest restRequest, final RestHandler restHandler) {
         if (restRequest.getXContentType() == null) {
             if (restHandler != null && restHandler.supportsPlainText()) {
-                // content type of null with a handler that supports plain text gets through for now. Once we remove plain text this can
-                // be removed!
-                deprecationLogger.deprecated("Plain text request bodies are deprecated. Use request parameters or body " +
-                    "in a supported format.");
+                if (isContentTypeRequired) {
+                    // content type of null with a handler that supports plain text gets through for now. Once we remove plain text this can
+                    // be removed!
+                    deprecationLogger.deprecated("Plain text request bodies are deprecated. Use request parameters or body " +
+                        "in a supported format.");
+                } else {
+                    // attempt to autodetect since we do not know that it is truly plain-text
+                    final boolean detected = autoDetectXContentType(restRequest);
+                    if (detected == false) {
+                        deprecationLogger.deprecated("Plain text request bodies are deprecated. Use request parameters or body " +
+                            "in a supported format.");
+                    }
+                }
             } else if (restHandler != null && restHandler.supportsContentStream() && restRequest.header("Content-Type") != null) {
                 final String lowercaseMediaType = restRequest.header("Content-Type").toLowerCase(Locale.ROOT);
                 // we also support newline delimited JSON: http://specs.okfnlabs.org/ndjson/

--- a/core/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -300,7 +300,31 @@ public class RestControllerTests extends ESTestCase {
         assertFalse(channel.getSendResponseCalled());
         restController.dispatchRequest(fakeRestRequest, channel, new ThreadContext(Settings.EMPTY));
         assertTrue(channel.getSendResponseCalled());
-        assertWarnings("Plain text request bodies are deprecated. Use request parameters or body in a supported format.");
+        assertWarnings("Plain text request bodies are deprecated. Use request parameters or body in a supported format.",
+            "Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header.");
+    }
+
+    public void testDispatchWorksWithAutodetectOnPlainTextHandler() {
+        String content = "{}";
+        FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withContent(new BytesArray(content), null).withPath("/foo").build();
+        AssertingChannel channel = new AssertingChannel(fakeRestRequest, true, RestStatus.OK);
+        restController.registerHandler(RestRequest.Method.GET, "/foo", new RestHandler() {
+            @Override
+            public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY));
+            }
+
+            @Override
+            public boolean supportsPlainText() {
+                return true;
+            }
+        });
+
+        assertFalse(channel.getSendResponseCalled());
+        restController.dispatchRequest(fakeRestRequest, channel, new ThreadContext(Settings.EMPTY));
+        assertTrue(channel.getSendResponseCalled());
+        assertWarnings("Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header.");
     }
 
     public void testDispatchWorksWithAutoDetection() {


### PR DESCRIPTION
For rest handlers that support plain text, we did not always try to auto detect the content type and instead just sent the request along. This breaks sending of JSON or other XContent requests without a content type header as the body will be parsed as plain text. This commit ensures we auto detect for these requests if auto detection is enabled.
