### PR TITLE
	Improve handle of spaces on Windows by using shorten paths

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-keystore.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-keystore.bat
@@ -12,8 +12,8 @@ IF NOT EXIST "%JAVA%" (
   EXIT /B 1
 )
 
-set SCRIPT_DIR=%~dp0
-for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
+set SCRIPT_DIR=%~dps0
+for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpsfI
 
 TITLE Elasticsearch Plugin Manager ${project.version}
 

--- a/distribution/src/main/resources/bin/elasticsearch-plugin.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin.bat
@@ -12,8 +12,8 @@ IF NOT EXIST "%JAVA%" (
   EXIT /B 1
 )
 
-set SCRIPT_DIR=%~dp0
-for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
+set SCRIPT_DIR=%~dps0
+for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpsfI
 
 TITLE Elasticsearch Plugin Manager ${project.version}
 

--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -24,8 +24,8 @@ IF %JAVA:~-13% == "\bin\java.exe" (
 :cont
 if not "%CONF_FILE%" == "" goto conffileset
 
-set SCRIPT_DIR=%~dp0
-for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
+set SCRIPT_DIR=%~dps0
+for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpsfI
 
 %JAVA% -Xmx50M -version > nul 2>&1
 

--- a/distribution/src/main/resources/bin/elasticsearch-translog.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-translog.bat
@@ -12,8 +12,8 @@ IF NOT EXIST "%JAVA%" (
   EXIT /B 1
 )
 
-set SCRIPT_DIR=%~dp0
-for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
+set SCRIPT_DIR=%~dps0
+for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpsfI
 
 TITLE Elasticsearch Plugin Manager ${project.version}
 

--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -37,7 +37,7 @@ SET HOSTNAME=%COMPUTERNAME%
 
 if "%ES_JVM_OPTIONS%" == "" (
 rem '0' is the batch file, '~dp' appends the drive and path
-set ES_JVM_OPTIONS=%~dp0\..\config\jvm.options
+set ES_JVM_OPTIONS=%~dps0\..\config\jvm.options
 )
 
 @setlocal
@@ -46,7 +46,7 @@ rem such options are the lines beginning with '-', thus "findstr /b"
 for /F "usebackq delims=" %%a in (`findstr /b \- "%ES_JVM_OPTIONS%"`) do set JVM_OPTIONS=!JVM_OPTIONS! %%a
 @endlocal & set ES_JAVA_OPTS=%JVM_OPTIONS% %ES_JAVA_OPTS%
 
-CALL "%~dp0elasticsearch.in.bat"
+CALL "%~dps0elasticsearch.in.bat"
 IF ERRORLEVEL 1 (
 	IF NOT DEFINED nopauseonerror (
 		PAUSE

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -10,8 +10,8 @@ IF NOT EXIST %JAVA% (
   EXIT /B 1
 )
 
-set SCRIPT_DIR=%~dp0
-for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
+set SCRIPT_DIR=%~dps0
+for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpsfI
 
 REM check in case a user was using this mechanism
 if "%ES_CLASSPATH%" == "" (


### PR DESCRIPTION
Adding S in the %~d something to use shorter names (
https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/percent.mspx?mfr=true
)