### PR TITLE
Deprecate Netty 3

### DIFF
--- a/docs/reference/migration/migrate_5_3.asciidoc
+++ b/docs/reference/migration/migrate_5_3.asciidoc
@@ -22,6 +22,13 @@ three properties:
 
 The property `es.logs` is deprecated and will be removed in Elasticsearch 6.0.0.
 
+[float]
+==== Use of Netty 3 is deprecated
+
+Usage of Netty 3 for transport (`transport.type=netty3`) or HTTP
+(`http.type=netty3`) is deprecated and will be removed in Elasticsearch
+6.0.0.
+
 [[breaking_53_settings_changes]]
 [float]
 === Settings changes
@@ -52,4 +59,3 @@ is deprecated.
 
 Usage of any value other than `false`, `"false", `true` and `"true"` for
 boolean values in mappings is deprecated.
-

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/http/netty3/Netty3HttpServerTransport.java
@@ -224,6 +224,7 @@ public class Netty3HttpServerTransport extends AbstractLifecycleComponent implem
     public Netty3HttpServerTransport(Settings settings, NetworkService networkService, BigArrays bigArrays, ThreadPool threadPool,
             NamedXContentRegistry xContentRegistry, HttpServerTransport.Dispatcher dispatcher) {
         super(settings);
+        deprecationLogger.deprecated(deprecationMessage());
         this.networkService = networkService;
         this.bigArrays = bigArrays;
         this.threadPool = threadPool;
@@ -276,6 +277,10 @@ public class Netty3HttpServerTransport extends AbstractLifecycleComponent implem
         logger.debug("using max_chunk_size[{}], max_header_size[{}], max_initial_line_length[{}], max_content_length[{}], " +
             "receive_predictor[{}->{}], pipelining[{}], pipelining_max_events[{}]", maxChunkSize, maxHeaderSize, maxInitialLineLength,
             this.maxContentLength, receivePredictorMin, receivePredictorMax, pipelining, pipeliningMaxEvents);
+    }
+
+    protected String deprecationMessage() {
+        return "http type [netty3] is deprecated";
     }
 
     public Settings settings() {

--- a/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Transport.java
+++ b/modules/transport-netty3/src/main/java/org/elasticsearch/transport/netty3/Netty3Transport.java
@@ -38,7 +38,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -144,6 +143,7 @@ public class Netty3Transport extends TcpTransport<Channel> {
     public Netty3Transport(Settings settings, ThreadPool threadPool, NetworkService networkService, BigArrays bigArrays,
                            NamedWriteableRegistry namedWriteableRegistry, CircuitBreakerService circuitBreakerService) {
         super("netty3", settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService);
+        deprecationLogger.deprecated(deprecationMessage());
         this.workerCount = WORKER_COUNT.get(settings);
         this.maxCumulationBufferCapacity = NETTY_MAX_CUMULATION_BUFFER_CAPACITY.get(settings);
         this.maxCompositeBufferComponents = NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS.get(settings);
@@ -157,6 +157,10 @@ public class Netty3Transport extends TcpTransport<Channel> {
             receiveBufferSizePredictorFactory = new AdaptiveReceiveBufferSizePredictorFactory((int) receivePredictorMin.getBytes(),
                 (int) receivePredictorMin.getBytes(), (int) receivePredictorMax.getBytes());
         }
+    }
+
+    protected String deprecationMessage() {
+        return "transport type [netty3] is deprecated";
     }
 
     TransportServiceAdapter transportServiceAdapter() {

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpChannelTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpChannelTests.java
@@ -79,6 +79,7 @@ public class Netty3HttpChannelTests extends ESTestCase {
 
     @After
     public void shutdown() throws Exception {
+        assertWarnings("http type [netty3] is deprecated");
         if (threadPool != null) {
             threadPool.shutdownNow();
         }

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpServerPipeliningTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpServerPipeliningTests.java
@@ -82,6 +82,7 @@ public class Netty3HttpServerPipeliningTests extends ESTestCase {
 
     @After
     public void shutdown() throws Exception {
+        assertWarnings("http type [netty3] is deprecated");
         if (threadPool != null) {
             threadPool.shutdownNow();
         }

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpServerTransportTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/http/netty3/Netty3HttpServerTransportTests.java
@@ -67,6 +67,7 @@ public class Netty3HttpServerTransportTests extends ESTestCase {
 
     @After
     public void shutdown() throws Exception {
+        assertWarnings("http type [netty3] is deprecated");
         if (threadPool != null) {
             threadPool.shutdownNow();
         }

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/transport/Netty3SizeHeaderFrameDecoderTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/transport/Netty3SizeHeaderFrameDecoderTests.java
@@ -60,8 +60,10 @@ public class Netty3SizeHeaderFrameDecoderTests extends ESTestCase {
     private int port;
     private InetAddress host;
 
+    @Override
     @Before
-    public void startThreadPool() {
+    public void setUp() throws Exception {
+        super.setUp();
         threadPool = new ThreadPool(settings);
         NetworkService networkService = new NetworkService(settings, Collections.emptyList());
         BigArrays bigArrays = new MockBigArrays(Settings.EMPTY, new NoneCircuitBreakerService());
@@ -80,11 +82,14 @@ public class Netty3SizeHeaderFrameDecoderTests extends ESTestCase {
 
     }
 
+    @Override
     @After
-    public void terminateThreadPool() throws InterruptedException {
+    public void tearDown() throws Exception {
+        assertWarnings("transport type [netty3] is deprecated");
         nettyTransport.stop();
         terminate(threadPool);
         threadPool = null;
+        super.tearDown();
     }
 
     public void testThatTextMessageIsReturnedOnHTTPLikeRequest() throws Exception {

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3ScheduledPingTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3ScheduledPingTests.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.transport.netty3;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lease.Releasables;
@@ -33,7 +32,6 @@ import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectionProfile;
-import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
@@ -41,19 +39,27 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportResponseOptions;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.TransportSettings;
+import org.junit.After;
 
 import java.io.IOException;
 import java.util.Collections;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class Netty3ScheduledPingTests extends ESTestCase {
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        assertWarnings("transport type [netty3] is deprecated");
+        super.tearDown();
+    }
+
     public void testScheduledPing() throws Exception {
         ThreadPool threadPool = new TestThreadPool(getClass().getName());
 

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3TransportMultiPortTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/Netty3TransportMultiPortTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.TransportSettings;
+import org.junit.After;
 import org.junit.Before;
 
 import java.util.Collections;
@@ -49,6 +50,13 @@ public class Netty3TransportMultiPortTests extends ESTestCase {
         } else {
             host = "127.0.0.1";
         }
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        assertWarnings("transport type [netty3] is deprecated");
+        super.tearDown();
     }
 
     public void testThatNettyCanBindToMultiplePorts() throws Exception {

--- a/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/SimpleNetty3TransportTests.java
+++ b/modules/transport-netty3/src/test/java/org/elasticsearch/transport/netty3/SimpleNetty3TransportTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.TransportSettings;
 import org.jboss.netty.channel.Channel;
+import org.junit.After;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -50,6 +51,13 @@ import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.containsString;
 
 public class SimpleNetty3TransportTests extends AbstractSimpleTransportTestCase {
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        assertWarnings("transport type [netty3] is deprecated");
+        super.tearDown();
+    }
 
     public static MockTransportService nettyFromThreadPool(Settings settings, ThreadPool threadPool, final Version version,
                                                            ClusterSettings clusterSettings, boolean doHandshake) {


### PR DESCRIPTION
This commit adds deprecation warnings for the use of Netty 3 for transport or HTTP requests.

Supersedes #23411