### PR TITLE
Install Gradle quietly

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -266,8 +266,8 @@ def provision(config,
     }
 
     installed gradle || {
-      echo "==> Installing gradle"
-      curl -o /tmp/gradle.zip -L https://services.gradle.org/distributions/gradle-3.3-bin.zip
+      echo "==> Installing Gradle"
+      curl -sS -o /tmp/gradle.zip -L https://services.gradle.org/distributions/gradle-3.3-bin.zip
       unzip /tmp/gradle.zip -d /opt
       rm -rf /tmp/gradle.zip 
       ln -s /opt/gradle-3.3/bin/gradle /usr/bin/gradle


### PR DESCRIPTION
When downloading Gradle to install inside the VMs used for testing, the
download progress logs do not play well with the Gradle progress logger
so we see garbage like:

```
==> centos-6: ==> Installing gradle
==> centos-6:
==> centos-6:
==> centos-6: %
==> centos-6:
==> centos-6: T
==> centos-6: o
==> centos-6: t
==> centos-6: a
==> centos-6: l
==> centos-6:
==> centos-6:
==> centos-6:
==> centos-6:
==> centos-6: %
==> centos-6:
==> centos-6: R
==> centos-6: e
==> centos-6: c
==> centos-6: e
==> centos-6: i
==> centos-6: v
==> centos-6: e
==> centos-6: d
==> centos-6:
==> centos-6: %
==> centos-6:
==> centos-6: X
==> centos-6: f
==> centos-6: e
==> centos-6: r
==> centos-6: d
==> centos-6:
==> centos-6:
==> centos-6: A
==> centos-6: v
==> centos-6: e
==> centos-6: r
==> centos-6: a
==> centos-6: g
==> centos-6: e
==> centos-6:
==> centos-6: S
==> centos-6: p
==> centos-6: e
==> centos-6: e
==> centos-6: d
==> centos-6:
==> centos-6:
```

This commit addresses this by setting curl to be silent and only show
errors. This instead gives:

```
==> centos-6: ==> Installing gradle
==> centos-6: Archive:  /tmp/gradle.zip
```

