### PR TITLE
fix #22814 resource.reload.interval not configurable

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -396,6 +396,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING,
                     IndexingMemoryController.SHARD_MEMORY_INTERVAL_TIME_SETTING,
                     ResourceWatcherService.ENABLED,
+                    ResourceWatcherService.RELOAD_INTERVAL,
                     ResourceWatcherService.RELOAD_INTERVAL_HIGH,
                     ResourceWatcherService.RELOAD_INTERVAL_MEDIUM,
                     ResourceWatcherService.RELOAD_INTERVAL_LOW,

--- a/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
+++ b/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
@@ -69,8 +69,10 @@ public class ResourceWatcherService extends AbstractLifecycleComponent {
     public static final Setting<Boolean> ENABLED = Setting.boolSetting("resource.reload.enabled", true, Property.NodeScope);
     public static final Setting<TimeValue> RELOAD_INTERVAL_HIGH =
         Setting.timeSetting("resource.reload.interval.high", Frequency.HIGH.interval, Property.NodeScope);
-    public static final Setting<TimeValue> RELOAD_INTERVAL_MEDIUM = Setting.timeSetting("resource.reload.interval.medium",
-        Setting.timeSetting("resource.reload.interval", Frequency.MEDIUM.interval), Property.NodeScope);
+    public static final Setting<TimeValue> RELOAD_INTERVAL =
+        Setting.timeSetting("resource.reload.interval", Frequency.MEDIUM.interval, Property.NodeScope);
+    public static final Setting<TimeValue> RELOAD_INTERVAL_MEDIUM =
+        Setting.timeSetting("resource.reload.interval.medium", RELOAD_INTERVAL, Property.NodeScope);
     public static final Setting<TimeValue> RELOAD_INTERVAL_LOW =
         Setting.timeSetting("resource.reload.interval.low", Frequency.LOW.interval, Property.NodeScope);
 


### PR DESCRIPTION
I test the issue mentioned in #22814  with ES-5.2.2, and verify the parameter "resource.reload.interval" is still not configurable. This commit expected to fix the problem, Thanks.
--Fanfan 