### PR TITLE
Increase chunk_size max to 256 Mb instead of 64 Mb

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
@@ -44,7 +44,7 @@ import java.util.function.Function;
 public interface AzureStorageService {
 
     ByteSizeValue MIN_CHUNK_SIZE = new ByteSizeValue(1, ByteSizeUnit.BYTES);
-    ByteSizeValue MAX_CHUNK_SIZE = new ByteSizeValue(64, ByteSizeUnit.MB);
+    ByteSizeValue MAX_CHUNK_SIZE = new ByteSizeValue(256, ByteSizeUnit.MB);
 
     final class Storage {
         public static final String PREFIX = "cloud.azure.storage.";


### PR DESCRIPTION
Increasing the max size of the chunk from 64mb to 256mb.

Closes #23446.