### PR TITLE
Allow different data types for category in Context suggester

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -528,14 +528,10 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
                                 if (currentToken == XContentParser.Token.FIELD_NAME) {
                                     fieldName = parser.currentName();
                                     contextMapping = contextMappings.get(fieldName);
-                                } else if (currentToken == XContentParser.Token.VALUE_STRING
-                                        || currentToken == XContentParser.Token.START_ARRAY
-                                        || currentToken == XContentParser.Token.START_OBJECT) {
+                                } else {
                                     assert fieldName != null;
                                     assert !contextsMap.containsKey(fieldName);
                                     contextsMap.put(fieldName, contextMapping.parseContext(parseContext, parser));
-                                } else {
-                                    throw new IllegalArgumentException("contexts must be an object or an array , but was [" + currentToken + "]");
                                 }
                             }
                         } else {

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
@@ -107,21 +107,28 @@ public class CategoryContextMapping extends ContextMapping<CategoryQueryContext>
      *  </ul>
      */
     @Override
-    public Set<CharSequence> parseContext(ParseContext parseContext, XContentParser parser) throws IOException, ElasticsearchParseException {
+    public Set<CharSequence> parseContext(ParseContext parseContext, XContentParser parser)
+            throws IOException, ElasticsearchParseException {
         final Set<CharSequence> contexts = new HashSet<>();
         Token token = parser.currentToken();
-        if (token == Token.VALUE_STRING) {
+        if (token == Token.VALUE_NULL) {
+            return contexts;
+        } else if (token == Token.VALUE_STRING || token == Token.VALUE_NUMBER || token == Token.VALUE_BOOLEAN) {
             contexts.add(parser.text());
         } else if (token == Token.START_ARRAY) {
             while ((token = parser.nextToken()) != Token.END_ARRAY) {
-                if (token == Token.VALUE_STRING) {
+                if (token == Token.VALUE_STRING || token == Token.VALUE_NUMBER || token == Token.VALUE_BOOLEAN) {
                     contexts.add(parser.text());
+                } else if (token == Token.VALUE_NULL) {
+                    continue;
                 } else {
-                    throw new ElasticsearchParseException("context array must have string values");
+                    throw new ElasticsearchParseException(
+                            "context array must have string, number or boolean values, but was [" + token + "]");
                 }
             }
         } else {
-            throw new ElasticsearchParseException("contexts must be a string or a list of strings");
+            throw new ElasticsearchParseException(
+                    "contexts must be a string, number or boolean or a list of string, number or boolean, but was [" + token + "]");
         }
         return contexts;
     }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
@@ -111,16 +111,12 @@ public class CategoryContextMapping extends ContextMapping<CategoryQueryContext>
             throws IOException, ElasticsearchParseException {
         final Set<CharSequence> contexts = new HashSet<>();
         Token token = parser.currentToken();
-        if (token == Token.VALUE_NULL) {
-            return contexts;
-        } else if (token == Token.VALUE_STRING || token == Token.VALUE_NUMBER || token == Token.VALUE_BOOLEAN) {
+        if (token == Token.VALUE_STRING || token == Token.VALUE_NUMBER || token == Token.VALUE_BOOLEAN) {
             contexts.add(parser.text());
         } else if (token == Token.START_ARRAY) {
             while ((token = parser.nextToken()) != Token.END_ARRAY) {
                 if (token == Token.VALUE_STRING || token == Token.VALUE_NUMBER || token == Token.VALUE_BOOLEAN) {
                     contexts.add(parser.text());
-                } else if (token == Token.VALUE_NULL) {
-                    continue;
                 } else {
                     throw new ElasticsearchParseException(
                             "context array must have string, number or boolean values, but was [" + token + "]");

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
@@ -98,7 +98,8 @@ public final class CategoryQueryContext implements ToXContent {
 
     private static ObjectParser<Builder, Void> CATEGORY_PARSER = new ObjectParser<>(NAME, null);
     static {
-        CATEGORY_PARSER.declareString(Builder::setCategory, new ParseField(CONTEXT_VALUE));
+        CATEGORY_PARSER.declareField(Builder::setCategory, XContentParser::text, new ParseField(CONTEXT_VALUE),
+                ObjectParser.ValueType.VALUE);
         CATEGORY_PARSER.declareInt(Builder::setBoost, new ParseField(CONTEXT_BOOST));
         CATEGORY_PARSER.declareBoolean(Builder::setPrefix, new ParseField(CONTEXT_PREFIX));
     }
@@ -109,7 +110,8 @@ public final class CategoryQueryContext implements ToXContent {
         Builder builder = builder();
         if (token == XContentParser.Token.START_OBJECT) {
             CATEGORY_PARSER.parse(parser, builder, null);
-        } else if (token == XContentParser.Token.VALUE_STRING) {
+        } else if (token == XContentParser.Token.VALUE_STRING || token == XContentParser.Token.VALUE_BOOLEAN
+                || token == XContentParser.Token.VALUE_NUMBER) {
             builder.setCategory(parser.text());
         } else {
             throw new ElasticsearchParseException("category context must be an object or string");

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.suggest.completion.context;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -109,12 +110,16 @@ public final class CategoryQueryContext implements ToXContent {
         XContentParser.Token token = parser.currentToken();
         Builder builder = builder();
         if (token == XContentParser.Token.START_OBJECT) {
-            CATEGORY_PARSER.parse(parser, builder, null);
+            try {
+                CATEGORY_PARSER.parse(parser, builder, null);
+            } catch(ParsingException e) {
+                throw new ElasticsearchParseException("category context must be a string, number or boolean");
+            } 
         } else if (token == XContentParser.Token.VALUE_STRING || token == XContentParser.Token.VALUE_BOOLEAN
                 || token == XContentParser.Token.VALUE_NUMBER) {
             builder.setCategory(parser.text());
         } else {
-            throw new ElasticsearchParseException("category context must be an object or string");
+            throw new ElasticsearchParseException("category context must be an object, string, number or boolean");
         }
         return builder.build();
     }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMapping.java
@@ -109,13 +109,14 @@ public abstract class ContextMapping<T extends ToXContent> implements ToXContent
         List<T> queryContexts = new ArrayList<>();
         XContentParser parser = context.parser();
         Token token = parser.nextToken();
-        if (token == Token.START_OBJECT || token == Token.VALUE_STRING) {
-            queryContexts.add(fromXContent(context));
-        } else if (token == Token.START_ARRAY) {
+        if (token == Token.START_ARRAY) {
             while (parser.nextToken() != Token.END_ARRAY) {
                 queryContexts.add(fromXContent(context));
             }
+        } else if (token != Token.VALUE_NULL) {
+            queryContexts.add(fromXContent(context));
         }
+        
         return toInternalQueryContexts(queryContexts);
     }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMapping.java
@@ -113,7 +113,7 @@ public abstract class ContextMapping<T extends ToXContent> implements ToXContent
             while (parser.nextToken() != Token.END_ARRAY) {
                 queryContexts.add(fromXContent(context));
             }
-        } else if (token != Token.VALUE_NULL) {
+        } else {
             queryContexts.add(fromXContent(context));
         }
         

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -199,8 +199,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        try {
-            defaultMapper.parse("test", "type1", "1", jsonBuilder()
+        XContentBuilder builder = jsonBuilder()
                 .startObject()
                 .startArray("completion")
                 .startObject()
@@ -211,11 +210,10 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .field("weight", 5)
                 .endObject()
                 .endArray()
-                .endObject()
-                .bytes());
-        } catch(MapperParsingException e) {
-            assertEquals(e.getCause().getMessage(), "contexts must be a string, number or boolean or a list of string, number or boolean, but was [VALUE_NULL]");
-        }
+                .endObject();
+        
+        Exception e = expectThrows(MapperParsingException.class, () -> defaultMapper.parse("test", "type1", "1", builder.bytes()));
+        assertEquals("contexts must be a string, number or boolean or a list of string, number or boolean, but was [VALUE_NULL]", e.getCause().getMessage());
     }
 
     public void testIndexingWithContextList() throws Exception {
@@ -294,8 +292,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        try {
-            defaultMapper.parse("test", "type1", "1", jsonBuilder()
+        XContentBuilder builder = jsonBuilder()
                 .startObject()
                 .startObject("completion")
                 .array("input", "suggestion5", "suggestion6", "suggestion7")
@@ -304,11 +301,10 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject()
                 .field("weight", 5)
                 .endObject()
-                .endObject()
-                .bytes());
-        } catch(MapperParsingException e) {
-            assertEquals(e.getCause().getMessage(), "context array must have string, number or boolean values, but was [VALUE_NULL]");
-        }
+                .endObject();
+        
+        Exception e = expectThrows(MapperParsingException.class, () -> defaultMapper.parse("test", "type1", "1", builder.bytes()));
+        assertEquals("context array must have string, number or boolean values, but was [VALUE_NULL]", e.getCause().getMessage());
     }
 
     public void testIndexingWithMultipleContexts() throws Exception {
@@ -386,11 +382,9 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         XContentBuilder builder = jsonBuilder().nullValue();
         XContentParser parser = createParser(JsonXContent.jsonXContent, builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        try {
-            mapping.parseQueryContext(createParseContext(parser));
-        } catch(ElasticsearchParseException e) {
-            assertEquals(e.getMessage(), "category context must be an object, string, number or boolean");
-        }
+        
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(createParseContext(parser)));
+        assertEquals("category context must be an object, string, number or boolean", e.getMessage());
     }
 
     public void testQueryContextParsingArray() throws Exception {
@@ -445,11 +439,9 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endArray();
         XContentParser parser = createParser(JsonXContent.jsonXContent, builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        try {
-            mapping.parseQueryContext(createParseContext(parser));
-        } catch(ElasticsearchParseException e) {
-            assertEquals(e.getMessage(), "category context must be an object, string, number or boolean");
-        }
+        
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(createParseContext(parser)));
+        assertEquals("category context must be an object, string, number or boolean", e.getMessage());
     }
 
     public void testQueryContextParsingObject() throws Exception {
@@ -505,11 +497,9 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject();
         XContentParser parser = createParser(JsonXContent.jsonXContent, builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        try {
-            mapping.parseQueryContext(createParseContext(parser));
-        } catch(ElasticsearchParseException e) {
-            assertEquals(e.getMessage(), "category context must be a string, number or boolean");
-        }
+        
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(createParseContext(parser)));
+        assertEquals("category context must be a string, number or boolean", e.getMessage());
     }
     
     public void testQueryContextParsingObjectArray() throws Exception {
@@ -608,11 +598,9 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endArray();
         XContentParser parser = createParser(JsonXContent.jsonXContent, builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        try {
-            mapping.parseQueryContext(createParseContext(parser));
-        } catch(ElasticsearchParseException e) {
-            assertEquals(e.getMessage(), "category context must be a string, number or boolean");
-        }
+        
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(createParseContext(parser)));
+        assertEquals("category context must be a string, number or boolean", e.getMessage());
     }
 
     private static QueryParseContext createParseContext(XContentParser parser) {
@@ -670,11 +658,9 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endArray();
         XContentParser parser = createParser(JsonXContent.jsonXContent, builder.bytes());
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        try {
-            mapping.parseQueryContext(createParseContext(parser));
-        } catch(ElasticsearchParseException e) {
-            assertEquals(e.getMessage(), "category context must be an object, string, number or boolean");
-        }
+        
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(createParseContext(parser)));
+        assertEquals("category context must be an object, string, number or boolean", e.getMessage());
     }
 
     public void testParsingContextFromDocument() throws Exception {


### PR DESCRIPTION
The "category" in context suggester could be String, Number or Boolean. However with the changes in version 5 this is failing and only accepting String. This will have problem for existing users of Elasticsearch if they choose to migrate to higher version; as their existing Mapping and query will fail as mentioned in a bug #22358

This PR fixes the above mentioned issue and allows user to migrate seamlessly.

Note: Providing the NULL value for a category at index and query time will throw an exception.

Closes #22358
