### PR TITLE
[TEST] Fixed the "Msearch" typed keys YAML test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yaml
@@ -1,3 +1,4 @@
+---
 setup:
   - skip:
       version: " - 5.3.99"
@@ -66,7 +67,7 @@ setup:
         body:
           # Testing aggegrations
           - index: test-*
-          - {query: {match: {bool: true} }, size: 0, aggs: {test_filter: {filter: {range:{integer: {gte: 20} } } } } }
+          - {query: {match: {bool: true} }, size: 0, aggs: {test_filter: {filter: {range: {integer: {gte: 20} } } } } }
           - index: test-1
           - {query: {match_all: {} }, size: 0, aggs: {test_range: {range: {field: float, ranges: [ {to: 19.2499999}, {from: 19.25} ] } } } }
           - index: test-*


### PR DESCRIPTION
The YAML test has been failing for the Ruby runner, because of the incorrect syntax in the query definition and the missing document separator.

* Added the YAML document separator to the beginning of the file
* Fixed the incorrect JSON syntax in the query
