### PR TITLE
Enforce validation for PathHierarchy tokenizer

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/analysis/PathHierarchyTokenizerFactory.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PathHierarchyTokenizerFactory.java
@@ -41,8 +41,8 @@ public class PathHierarchyTokenizerFactory extends AbstractTokenizerFactory {
         String delimiter = settings.get("delimiter");
         if (delimiter == null) {
             this.delimiter = PathHierarchyTokenizer.DEFAULT_DELIMITER;
-        } else if (delimiter.length() > 1) {
-            throw new IllegalArgumentException("delimiter can only be a one char value");
+        } else if (delimiter.length() != 1) {
+            throw new IllegalArgumentException("delimiter must be a one char value");
         } else {
             this.delimiter = delimiter.charAt(0);
         }
@@ -50,8 +50,8 @@ public class PathHierarchyTokenizerFactory extends AbstractTokenizerFactory {
         String replacement = settings.get("replacement");
         if (replacement == null) {
             this.replacement = this.delimiter;
-        } else if (replacement.length() > 1) {
-            throw new IllegalArgumentException("replacement can only be a one char value");
+        } else if (replacement.length() != 1) {
+            throw new IllegalArgumentException("replacement must be a one char value");
         } else {
             this.replacement = replacement.charAt(0);
         }


### PR DESCRIPTION
If delimiter or replacement parameter are an empty string, the error is not clear enough to indicate how to fix it:

```
{
   "error": {
      "root_cause": [
         {
            "type": "index_creation_exception",
            "reason": "failed to create index"
         }
      ],
      "type": "string_index_out_of_bounds_exception",
      "reason": "String index out of range: 0"
   },
   "status": 500
}
```

With this change, the user knows these parameter must be a non empty string.
