### PR TITLE
Build: Set vagrant group for gradle install in vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -270,8 +270,7 @@ def provision(config,
       rm -rf /tmp/gradle.zip 
       ln -s /opt/gradle-3.3/bin/gradle /usr/bin/gradle
       # make nfs mounted gradle home dir writeable
-      # TODO: also chgrp to vagrant once sles and opensuse have vagrant group...
-      chown vagrant /home/vagrant/.gradle
+      chown vagrant:vagrant /home/vagrant/.gradle
     }
 
 


### PR DESCRIPTION
We previously removed setting the vagrant group because sles-12 and
opensuse-13 did not have this group. Now that those images have the
group, we can go back to setting both user and group to vagrant.
