### PR TITLE
doc: highlight that doc counts come from lucene

### DIFF
--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -24,9 +24,16 @@ green  open   twitter2 nYFWZEO7TUiOjLQXBaYJpA   5   0          0            0   
 // TESTRESPONSE[s/u8FNjxh8Rfy_awN11oDKYQ|nYFWZEO7TUiOjLQXBaYJpA/.+/ _cat]
 
 We can tell quickly how many shards make up an index, the number of
-docs at the Lucene level, including hidden docs (e.g., from nested types),
-deleted docs, primary store size, and total store size (all shards including replicas).
+docs, deleted docs, primary store size, and total store size (all shards including replicas).
 All these exposed metrics come directly from Lucene APIs.
+
+*Notes:*
+
+1. As the number of documents and deleted documents shown in this are at the lucene level,
+it includes all the hidden documents (e.g. from nested documents) as well.
+
+2. To get actual count of documents at the elasticsearch level, the recommended way
+is to use either the <<cat-count>> or the <<search-count>>
 
 [float]
 [[pri-flag]]


### PR DESCRIPTION
The docs don't clearly explain that the deleted doc count also comes from lucene.
IMHO, it is worth highlighting this information separately, as a Note.
Apart from that, there should be an official recommended alternative as well.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
