### PR TITLE
Set RuntimeDirectory in systemd service

### DIFF
--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+RuntimeDirectory=elasticsearch
 Environment=ES_HOME=/usr/share/elasticsearch
 Environment=CONF_DIR=${path.conf}
 Environment=DATA_DIR=/var/lib/elasticsearch


### PR DESCRIPTION
This instruction tells systemd to create a directory /var/run/elasticsearch before starting Elasticsearch.

Without this change, the default PID_DIR (/var/run/elasticsearch) may not exist, and without it, Elasticsearch will fail to start.