### PR TITLE
Fix NPE with scaled floats stats when field is not indexed

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -265,12 +265,16 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             if (stats == null) {
                 return null;
             }
-            return new FieldStats.Double(stats.getMaxDoc(), stats.getDocCount(),
+            if (stats.hasMinMax()) {
+                return new FieldStats.Double(stats.getMaxDoc(), stats.getDocCount(),
                     stats.getSumDocFreq(), stats.getSumTotalTermFreq(),
                     stats.isSearchable(), stats.isAggregatable(),
-                    stats.getMinValue() == null ? 0.0 : stats.getMinValue() / scalingFactor,
-                    stats.getMaxValue() == null ? 0.0  : stats.getMaxValue() / scalingFactor);
-
+                    stats.getMinValue() / scalingFactor,
+                    stats.getMaxValue() / scalingFactor);
+            }
+            return new FieldStats.Double(stats.getMaxDoc(), stats.getDocCount(),
+                stats.getSumDocFreq(), stats.getSumTotalTermFreq(),
+                stats.isSearchable(), stats.isAggregatable());
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -268,8 +268,9 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             return new FieldStats.Double(stats.getMaxDoc(), stats.getDocCount(),
                     stats.getSumDocFreq(), stats.getSumTotalTermFreq(),
                     stats.isSearchable(), stats.isAggregatable(),
-                    stats.getMinValue() == null ? null : stats.getMinValue() / scalingFactor,
-                    stats.getMaxValue() == null ? null : stats.getMaxValue() / scalingFactor);
+                    stats.getMinValue() == null ? 0.0 : stats.getMinValue() / scalingFactor,
+                    stats.getMaxValue() == null ? 0.0  : stats.getMaxValue() / scalingFactor);
+
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -149,8 +149,9 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
         try (DirectoryReader reader = DirectoryReader.open(w)) {
             // field exists, but has no point values
             FieldStats<?> stats = ft.stats(reader);
-            assertEquals(0.0, stats.getMinValue());
-            assertEquals(0.0, stats.getMaxValue());
+            assertFalse(stats.hasMinMax());
+            assertNull(stats.getMinValue());
+            assertNull(stats.getMaxValue());
         }
         LongPoint point = new LongPoint("scaled_float", -1);
         doc.add(point);

--- a/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
@@ -143,6 +144,14 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
             assertNull(ft.stats(reader));
         }
         Document doc = new Document();
+        doc.add(new StoredField("scaled_float", -1));
+        w.addDocument(doc);
+        try (DirectoryReader reader = DirectoryReader.open(w)) {
+            // field exists, but has no point values
+            FieldStats<?> stats = ft.stats(reader);
+            assertEquals(0.0, stats.getMinValue());
+            assertEquals(0.0, stats.getMaxValue());
+        }
         LongPoint point = new LongPoint("scaled_float", -1);
         doc.add(point);
         w.addDocument(doc);
@@ -152,7 +161,7 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
             FieldStats<?> stats = ft.stats(reader);
             assertEquals(-1/ft.getScalingFactor(), stats.getMinValue());
             assertEquals(10/ft.getScalingFactor(), stats.getMaxValue());
-            assertEquals(2, stats.getMaxDoc());
+            assertEquals(3, stats.getMaxDoc());
         }
         w.deleteAll();
         try (DirectoryReader reader = DirectoryReader.open(w)) {


### PR DESCRIPTION
This fixes an NPE in finding scaled float stats. The type of min/max
methods on the wrapped long stats returns a boxed type, but in the case
this is null, the unbox done for the FieldStats.Double ctor primitive
types will cause the NPE. These methods would have null for min/max when
the field exists, but does not actually have points values.

fixes #23487

