### PR TITLE
Fall back to non-atomic move when removing plugins

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.plugins;
 
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -83,7 +84,12 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
 
         terminal.println(VERBOSE, "Removing: " + pluginDir);
         final Path tmpPluginDir = env.pluginsFile().resolve(".removing-" + pluginName);
-        Files.move(pluginDir, tmpPluginDir, StandardCopyOption.ATOMIC_MOVE);
+        try {
+            Files.move(pluginDir, tmpPluginDir, StandardCopyOption.ATOMIC_MOVE);
+        } catch (final AtomicMoveNotSupportedException e) {
+            // this can happen on a union filesystem when a plugin is not installed on the top layer; we fall back to a non-atomic move
+            Files.move(pluginDir, tmpPluginDir);
+        }
         pluginPaths.add(tmpPluginDir);
 
         IOUtils.rm(pluginPaths.toArray(new Path[pluginPaths.size()]));


### PR DESCRIPTION
When plugins are installed on a union filesystem (for example, inside a Docker container), removing them can fail because we attempt an atomic move which will not work if the plugin is not installed in the top layer. This commit modifies removing a plugin to fall back to a non-atomic move in cases when the underlying filesystem does not support atomic moves.

Closes elastic/elasticsearch-docker#35