### PR TITLE
UnicastZenPing shouldn't ping the address of the local node

### DIFF
--- a/core/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
@@ -488,7 +488,7 @@ public class UnicastZenPingTests extends ESTestCase {
         final List<DiscoveryNode> discoveryNodes = TestUnicastZenPing.resolveHostsLists(
             executorService,
             logger,
-            Collections.singletonList(loopbackAddress.getHostAddress()),
+            Collections.singletonList(NetworkAddress.format(loopbackAddress)),
             10,
             transportService,
             "test_",

--- a/plugins/discovery-file/src/test/java/org/elasticsearch/discovery/file/FileBasedUnicastHostsProviderTests.java
+++ b/plugins/discovery-file/src/test/java/org/elasticsearch/discovery/file/FileBasedUnicastHostsProviderTests.java
@@ -23,6 +23,9 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -37,6 +40,7 @@ import org.junit.Before;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -85,7 +89,15 @@ public class FileBasedUnicastHostsProviderTests extends ESTestCase {
                                     BigArrays.NON_RECYCLING_INSTANCE,
                                     new NoneCircuitBreakerService(),
                                     new NamedWriteableRegistry(Collections.emptyList()),
-                                    new NetworkService(Settings.EMPTY, Collections.emptyList()));
+                                    new NetworkService(Settings.EMPTY, Collections.emptyList())) {
+                @Override
+                public BoundTransportAddress boundAddress() {
+                    return new BoundTransportAddress(
+                        new TransportAddress[]{new InetSocketTransportAddress(InetAddress.getLoopbackAddress(), 9300)},
+                        new InetSocketTransportAddress(InetAddress.getLoopbackAddress(), 9300)
+                    );
+                }
+            };
         transportService = new MockTransportService(Settings.EMPTY, transport, threadPool, TransportService.NOOP_TRANSPORT_INTERCEPTOR,
                 null);
     }


### PR DESCRIPTION
Pinging the local node address doesn't really add to discovering other nodes. It just pollutes the logs with unneeded information.