### PR TITLE
Typo: VersionConflictException -> VersionConflictEngineException

### DIFF
--- a/docs/reference/migration/migrate_5_0/java.asciidoc
+++ b/docs/reference/migration/migrate_5_0/java.asciidoc
@@ -88,7 +88,7 @@ language `org.codehaus.groovy:groovy` artifact.
 
 ==== DocumentAlreadyExistsException removed
 
-`DocumentAlreadyExistsException` is removed and a `VersionConflictException` is thrown instead (with a better
+`DocumentAlreadyExistsException` is removed and a `VersionConflictEngineException` is thrown instead (with a better
 error description). This will influence code that use the `IndexRequest.opType()` or `IndexRequest.create()`
 to index a document only if it doesn't already exist.
 


### PR DESCRIPTION
Wrong type mentioned - DocumentAlreadyExistsException was superseded by VersionConflictEngineException, not VersionConflictException (which doesn't exist).

I figured this out by searching the code here: https://github.com/elastic/elasticsearch/search?utf8=✓&q=DocumentAlreadyExistsException

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
