### PR TITLE
Enable explicitly enforcing bootstrap checks

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -56,7 +56,7 @@ final class BootstrapChecks {
     private BootstrapChecks() {
     }
 
-    final static String ES_ENFORCE_BOOTSTRAP_CHECKS = "es.enforce.bootstrap.checks";
+    static final String ES_ENFORCE_BOOTSTRAP_CHECKS = "es.enforce.bootstrap.checks";
 
     /**
      * Executes the bootstrap checks if the node has the transport protocol bound to a non-loopback interface. If the system property

--- a/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -48,8 +48,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * We enforce bootstrap checks once a node has the transport protocol bound to a non-loopback interface. In this case we assume the node is
- * running in production and all bootstrap checks must pass.
+ * We enforce bootstrap checks once a node has the transport protocol bound to a non-loopback interface or if the system property {@code
+ * es.enforce.bootstrap.checks} is set to {@true}. In this case we assume the node is running in production and all bootstrap checks must
+ * pass.
  */
 final class BootstrapChecks {
 
@@ -60,8 +61,8 @@ final class BootstrapChecks {
 
     /**
      * Executes the bootstrap checks if the node has the transport protocol bound to a non-loopback interface. If the system property
-     * "es.enforce.bootstrap.checks" is set to {@code true} then the bootstrap checks will be enforced regardless of whether or not the
-     * transport protocol is bound to a non-loopback interface.
+     * {@code es.enforce.bootstrap.checks} is set to {@code true} then the bootstrap checks will be enforced regardless of whether or not
+     * the transport protocol is bound to a non-loopback interface.
      *
      * @param settings              the current node settings
      * @param boundTransportAddress the node network bindings
@@ -78,7 +79,9 @@ final class BootstrapChecks {
     }
 
     /**
-     * Executes the provided checks and fails the node if {@code enforceLimits} is {@code true}, otherwise logs warnings.
+     * Executes the provided checks and fails the node if {@code enforceLimits} is {@code true}, otherwise logs warnings. If the system
+     * property {@code es.enforce.bootstrap.checks} is set to {@code true} then the bootstrap checks will be enforced regardless of whether
+     * or not the transport protocol is bound to a non-loopback interface.
      *
      * @param enforceLimits {@code true} if the checks should be enforced or otherwise warned
      * @param checks        the checks to execute
@@ -92,7 +95,9 @@ final class BootstrapChecks {
     }
 
     /**
-     * Executes the provided checks and fails the node if {@code enforceLimits} is {@code true}, otherwise logs warnings.
+     * Executes the provided checks and fails the node if {@code enforceLimits} is {@code true}, otherwise logs warnings. If the system
+     * property {@code es.enforce.bootstrap.checks }is set to {@code true} then the bootstrap checks will be enforced regardless of whether
+     * or not the transport protocol is bound to a non-loopback interface.
      *
      * @param enforceLimits {@code true} if the checks should be enforced or otherwise warned
      * @param checks        the checks to execute

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class BootstrapCheckTests extends ESTestCase {
+public class BootstrapChecksTests extends ESTestCase {
 
     public void testNonProductionMode() throws NodeValidationException {
         // nothing should happen since we are in non-production mode

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -35,7 +35,12 @@ production mode if it does bind transport to an external interface. Note
 that HTTP can be configured independently of transport via
 <<modules-http,`http.host`>> and <<modules-transport,`transport.host`>>;
 this can be useful for configuring a single instance to be reachable via
-HTTP for testing purposes without triggering production mode.
+HTTP for testing purposes without triggering production mode. If you do
+want to force enforcement of the bootstrap checks independent of the
+binding of the transport protocal, you can set the system property
+`es.enforce.bootstrap.checks` to `true` (this can be useful on a
+single-node production system that does not bind transport to an external
+interface).
 
 === Heap size check
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -21,6 +21,7 @@
 package org.elasticsearch.bootstrap;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matcher;
@@ -49,6 +50,7 @@ public class EvilBootstrapChecksTests extends ESTestCase {
         super.setUp();
     }
 
+    @SuppressForbidden(reason = "set or clear system property es.enforce.bootstrap.checks")
     @Override
     @After
     public void tearDown() throws Exception {
@@ -60,6 +62,7 @@ public class EvilBootstrapChecksTests extends ESTestCase {
         super.tearDown();
     }
 
+    @SuppressForbidden(reason = "set system property es.enforce.bootstrap.checks")
     public void testEnforceBootstrapChecks() throws NodeValidationException {
         System.setProperty(ES_ENFORCE_BOOTSTRAP_CHECKS, "true");
         final List<BootstrapCheck> checks = Collections.singletonList(
@@ -87,6 +90,7 @@ public class EvilBootstrapChecksTests extends ESTestCase {
         verifyNoMoreInteractions(logger);
     }
 
+    @SuppressForbidden(reason = "clear system property es.enforce.bootstrap.checks")
     public void testNonEnforcedBootstrapChecks() throws NodeValidationException {
         System.clearProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);
         final Logger logger = mock(Logger.class);
@@ -95,6 +99,7 @@ public class EvilBootstrapChecksTests extends ESTestCase {
         verifyNoMoreInteractions(logger);
     }
 
+    @SuppressForbidden(reason = "set system property es.enforce.bootstrap.checks")
     public void testInvalidValue() {
         final String value = randomAsciiOfLength(8);
         System.setProperty(ES_ENFORCE_BOOTSTRAP_CHECKS, value);

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.node.NodeValidationException;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matcher;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.elasticsearch.bootstrap.BootstrapChecks.ES_ENFORCE_BOOTSTRAP_CHECKS;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasToString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class EvilBootstrapChecksTests extends ESTestCase {
+
+    private String esEnforceBootstrapChecks = System.getProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        if (esEnforceBootstrapChecks == null) {
+            System.clearProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);
+        } else {
+            System.setProperty(ES_ENFORCE_BOOTSTRAP_CHECKS, esEnforceBootstrapChecks);
+        }
+        super.tearDown();
+    }
+
+    public void testEnforceBootstrapChecks() throws NodeValidationException {
+        System.setProperty(ES_ENFORCE_BOOTSTRAP_CHECKS, "true");
+        final List<BootstrapCheck> checks = Collections.singletonList(
+                new BootstrapCheck() {
+                    @Override
+                    public boolean check() {
+                        return true;
+                    }
+
+                    @Override
+                    public String errorMessage() {
+                        return "error";
+                    }
+                }
+        );
+        final Logger logger = mock(Logger.class);
+
+        final NodeValidationException e = expectThrows(
+                NodeValidationException.class,
+                () -> BootstrapChecks.check(false, checks, logger));
+        final Matcher<String> allOf =
+                allOf(containsString("bootstrap checks failed"), containsString("error"));
+        assertThat(e, hasToString(allOf));
+        verify(logger).info("explicitly enforcing bootstrap checks");
+        verifyNoMoreInteractions(logger);
+    }
+
+    public void testNonEnforcedBootstrapChecks() throws NodeValidationException {
+        System.clearProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);
+        final Logger logger = mock(Logger.class);
+        // nothing should happen
+        BootstrapChecks.check(false, emptyList(), logger);
+        verifyNoMoreInteractions(logger);
+    }
+
+    public void testInvalidValue() {
+        final String value = randomAsciiOfLength(8);
+        System.setProperty(ES_ENFORCE_BOOTSTRAP_CHECKS, value);
+        final boolean enforceLimits = randomBoolean();
+        final IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> BootstrapChecks.check(enforceLimits, emptyList(), "testInvalidValue"));
+        final Matcher<String> matcher = containsString(
+                "[es.enforce.bootstrap.checks] must be [true] but was [" + value + "]");
+        assertThat(e, hasToString(matcher));
+    }
+
+}

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -50,21 +50,15 @@ public class EvilBootstrapChecksTests extends ESTestCase {
         super.setUp();
     }
 
-    @SuppressForbidden(reason = "set or clear system property es.enforce.bootstrap.checks")
     @Override
     @After
     public void tearDown() throws Exception {
-        if (esEnforceBootstrapChecks == null) {
-            System.clearProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);
-        } else {
-            System.setProperty(ES_ENFORCE_BOOTSTRAP_CHECKS, esEnforceBootstrapChecks);
-        }
+        setEsEnforceBootstrapChecks(esEnforceBootstrapChecks);
         super.tearDown();
     }
 
-    @SuppressForbidden(reason = "set system property es.enforce.bootstrap.checks")
     public void testEnforceBootstrapChecks() throws NodeValidationException {
-        System.setProperty(ES_ENFORCE_BOOTSTRAP_CHECKS, "true");
+        setEsEnforceBootstrapChecks("true");
         final List<BootstrapCheck> checks = Collections.singletonList(
                 new BootstrapCheck() {
                     @Override
@@ -90,19 +84,17 @@ public class EvilBootstrapChecksTests extends ESTestCase {
         verifyNoMoreInteractions(logger);
     }
 
-    @SuppressForbidden(reason = "clear system property es.enforce.bootstrap.checks")
     public void testNonEnforcedBootstrapChecks() throws NodeValidationException {
-        System.clearProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);
+        setEsEnforceBootstrapChecks(null);
         final Logger logger = mock(Logger.class);
         // nothing should happen
         BootstrapChecks.check(false, emptyList(), logger);
         verifyNoMoreInteractions(logger);
     }
 
-    @SuppressForbidden(reason = "set system property es.enforce.bootstrap.checks")
     public void testInvalidValue() {
         final String value = randomAsciiOfLength(8);
-        System.setProperty(ES_ENFORCE_BOOTSTRAP_CHECKS, value);
+        setEsEnforceBootstrapChecks(value);
         final boolean enforceLimits = randomBoolean();
         final IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
@@ -110,6 +102,15 @@ public class EvilBootstrapChecksTests extends ESTestCase {
         final Matcher<String> matcher = containsString(
                 "[es.enforce.bootstrap.checks] must be [true] but was [" + value + "]");
         assertThat(e, hasToString(matcher));
+    }
+
+    @SuppressForbidden(reason = "set or clear system property es.enforce.bootstrap.checks")
+    public void setEsEnforceBootstrapChecks(final String value) {
+        if (value == null) {
+            System.clearProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);
+        } else {
+            System.setProperty(ES_ENFORCE_BOOTSTRAP_CHECKS, value);
+        }
     }
 
 }


### PR DESCRIPTION
This commit adds a system property that enables end-users to explicitly enforce the bootstrap checks, indepdently of the binding of the transport protocol. This can be useful for single-node production systems that do not bind the transport protocol (and thus the bootstrap checks would not be enforced).

Closes #21864
