### PR TITLE
Build: Make plugin list for smoke tester dynamic

### DIFF
--- a/dev-tools/smoke_test_rc.py
+++ b/dev-tools/smoke_test_rc.py
@@ -44,6 +44,7 @@
 import argparse
 import tempfile
 import os
+from os.path import basename, dirname, isdir, join
 import signal
 import shutil
 import urllib
@@ -57,26 +58,14 @@ from urllib.parse import urlparse
 
 from http.client import HTTPConnection
 
-DEFAULT_PLUGINS = ["analysis-icu",
-                   "analysis-kuromoji",
-                   "analysis-phonetic",
-                   "analysis-smartcn",
-                   "analysis-stempel",
-                   "discovery-azure-classic",
-                   "discovery-ec2",
-                   "discovery-file",
-                   "discovery-gce",
-                   "ingest-attachment",
-                   "ingest-geoip",
-                   "ingest-user-agent",
-                   "mapper-attachments",
-                   "mapper-murmur3",
-                   "mapper-size",
-                   "repository-azure",
-                   "repository-gcs",
-                   "repository-hdfs",
-                   "repository-s3",
-                   "store-smb"]
+def find_official_plugins():
+    plugins_dir = join(dirname(dirname(__file__)), 'plugins')
+    plugins = []
+    for plugin in os.listdir(plugins_dir):
+        if isdir(join(plugins_dir, plugin)):
+            plugins.append(plugin)
+    return plugins
+DEFAULT_PLUGINS = find_official_plugins()
 
 try:
   JAVA_HOME = os.environ['JAVA_HOME']


### PR DESCRIPTION
This commit removes the hardcoded list of plugins used by the smoke
tester and instead loads this list the same way the build does: by
looking for directories under the `plugins` dir.

closes #13096