### PR TITLE
Adapter action future should restore interrupts

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
+++ b/core/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
@@ -38,6 +38,7 @@ public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements
         try {
             return get();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IllegalStateException("Future got interrupted", e);
         } catch (ExecutionException e) {
             throw rethrowExecutionException(e);
@@ -66,6 +67,7 @@ public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements
         } catch (TimeoutException e) {
             throw new ElasticsearchTimeoutException(e);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IllegalStateException("Future got interrupted", e);
         } catch (ExecutionException e) {
             throw rethrowExecutionException(e);
@@ -100,4 +102,5 @@ public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements
     }
 
     protected abstract T convert(L listenerResponse);
+
 }

--- a/core/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
@@ -81,7 +81,6 @@ public class AdapterActionFutureTests extends ESTestCase {
         } catch (final IllegalStateException e) {
             assertTrue(Thread.currentThread().isInterrupted());
         }
-
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
@@ -81,6 +81,8 @@ public class AdapterActionFutureTests extends ESTestCase {
         } catch (final IllegalStateException e) {
             assertTrue(Thread.currentThread().isInterrupted());
         }
+
+        thread.join();
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Objects;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+
+public class AdapterActionFutureTests extends ESTestCase {
+
+    public void testInterruption() throws Exception {
+        final AdapterActionFuture<String, Integer> adapter =
+                new AdapterActionFuture<String, Integer>() {
+                    @Override
+                    protected String convert(final Integer listenerResponse) {
+                        return Objects.toString(listenerResponse);
+                    }
+                };
+
+        // test all possible methods that can be interrupted
+        final Runnable runnable = () -> {
+            final int method = randomIntBetween(0, 4);
+            switch (method) {
+                case 0:
+                    adapter.actionGet();
+                    break;
+                case 1:
+                    adapter.actionGet("30s");
+                    break;
+                case 2:
+                    adapter.actionGet(30000);
+                    break;
+                case 3:
+                    adapter.actionGet(TimeValue.timeValueSeconds(30));
+                    break;
+                case 4:
+                    adapter.actionGet(30, TimeUnit.SECONDS);
+                    break;
+                default:
+                    throw new AssertionError(method);
+            }
+        };
+
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        final Thread main = Thread.currentThread();
+        final Thread thread = new Thread(() -> {
+            try {
+                barrier.await();
+            } catch (final BrokenBarrierException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            main.interrupt();
+        });
+        thread.start();
+
+        barrier.await();
+
+        try {
+            runnable.run();
+        } catch (final IllegalStateException e) {
+            assertTrue(Thread.currentThread().isInterrupted());
+        }
+
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AdapterActionFutureTests extends ESTestCase {
 
@@ -76,11 +77,14 @@ public class AdapterActionFutureTests extends ESTestCase {
 
         barrier.await();
 
+        final AtomicBoolean interrupted = new AtomicBoolean();
         try {
             runnable.run();
         } catch (final IllegalStateException e) {
-            assertTrue(Thread.currentThread().isInterrupted());
+            interrupted.set(Thread.currentThread().isInterrupted());
         }
+        // we check this here instead of in the catch block to ensure that the catch block executed
+        assertTrue(interrupted.get());
 
         thread.join();
     }


### PR DESCRIPTION
When a thread blocking on an adapter action future is interrupted, we throw an illegal state exception. This is documented, but it is rude to not restore the interrupt flag. This commit restores the interrupt flag in this situation, and adds a test.

Closes #23617