### PR TITLE
Unmark reindex as experimental

### DIFF
--- a/docs/java-api/docs/update-by-query.asciidoc
+++ b/docs/java-api/docs/update-by-query.asciidoc
@@ -1,8 +1,6 @@
 [[docs-update-by-query]]
 == Update By Query API
 
-experimental[The update-by-query API is new and should still be considered experimental.  The API may change in ways that are not backwards compatible]
-
 The simplest usage of `updateByQuery` updates each
 document in an index without changing the source. This usage enables
 <<picking-up-a-new-property,picking up a new property>> or another online

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -1,8 +1,6 @@
 [[docs-delete-by-query]]
 == Delete By Query API
 
-experimental[The delete-by-query API is new and should still be considered experimental.  The API may change in ways that are not backwards compatible]
-
 The simplest usage of `_delete_by_query` just performs a deletion on every
 document that match a query. Here is the API:
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -1,8 +1,6 @@
 [[docs-reindex]]
 == Reindex API
 
-experimental[The reindex API is new and should still be considered experimental.  The API may change in ways that are not backwards compatible]
-
 IMPORTANT: Reindex does not attempt to set up the destination index.  It does
 not copy the settings of the source index.  You should set up the destination
 index prior to running a `_reindex` action, including setting up mappings, shard


### PR DESCRIPTION
The reindex API is mature now, and we will work to maintain backwards compatibility in accordance with our backwards compatibility policy. This commit unmarks the reindex API as experimental.
