### PR TITLE
Deprecate request_cache for clear-cache

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
@@ -81,7 +81,7 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
             if (Fields.QUERY.match(entry.getKey())) {
                 clearIndicesCacheRequest.queryCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.queryCache()));
             }
-            if (Fields.REQUEST_CACHE.match(entry.getKey())) {
+            if (Fields.REQUEST.match(entry.getKey())) {
                 clearIndicesCacheRequest.requestCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.requestCache()));
             }
             if (Fields.FIELD_DATA.match(entry.getKey())) {
@@ -100,7 +100,7 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
 
     public static class Fields {
         public static final ParseField QUERY = new ParseField("query", "filter", "filter_cache");
-        public static final ParseField REQUEST_CACHE = new ParseField("request_cache");
+        public static final ParseField REQUEST = new ParseField("request", "request_cache");
         public static final ParseField FIELD_DATA = new ParseField("field_data", "fielddata");
         public static final ParseField RECYCLER = new ParseField("recycler");
         public static final ParseField FIELDS = new ParseField("fields");

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheActionTests.java
@@ -34,7 +34,7 @@ public class RestClearIndicesCacheActionTests extends ESTestCase {
         final HashMap<String, String> params = new HashMap<>();
         params.put("request", "true");
         final RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
-                                            .withPath("_cache").withParams(params).build();
+                                                           .withParams(params).build();
         ClearIndicesCacheRequest cacheRequest = new ClearIndicesCacheRequest();
         cacheRequest = RestClearIndicesCacheAction.fromRequest(restRequest, cacheRequest);
         assertThat(cacheRequest.requestCache(), equalTo(true));

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheActionTests.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices;
+
+import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheRequest;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class RestClearIndicesCacheActionTests extends ESTestCase {
+
+    public void testRequestCacheSet() throws Exception {
+        final HashMap<String, String> params = new HashMap<>();
+        params.put("request", "true");
+        final RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
+                                            .withPath("_cache").withParams(params).build();
+        ClearIndicesCacheRequest cacheRequest = new ClearIndicesCacheRequest();
+        cacheRequest = RestClearIndicesCacheAction.fromRequest(restRequest, cacheRequest);
+        assertThat(cacheRequest.requestCache(), equalTo(true));
+    }
+}

--- a/docs/reference/modules/indices/request_cache.asciidoc
+++ b/docs/reference/modules/indices/request_cache.asciidoc
@@ -42,7 +42,7 @@ The cache can be expired manually with the <<indices-clearcache,`clear-cache` AP
 
 [source,js]
 ------------------------
-POST /kimchy,elasticsearch/_cache/clear?request_cache=true
+POST /kimchy,elasticsearch/_cache/clear?request=true
 ------------------------
 // CONSOLE
 // TEST[s/^/PUT kimchy\nPUT elasticsearch\n/]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
@@ -50,6 +50,10 @@
           "type" : "boolean",
           "description" : "Clear the recycler cache"
         },
+        "request_cache": {
+          "type" : "boolean",
+          "description" : "Clear request cache"
+        },
         "request": {
           "type" : "boolean",
           "description" : "Clear request cache"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yaml
@@ -2,3 +2,22 @@
 "clear_cache test":
   - do:
       indices.clear_cache: {}
+
+---
+"clear_cache with request set to false":
+  - do:
+      indices.clear_cache:
+        request: false
+
+---
+"clear_cache with request_cache set to false":
+  - skip:
+      version: " - 5.2.2"
+      reason: deprecation was added in 5.2.3
+      features: "warnings"
+
+  - do:
+      warnings:
+        - 'Deprecated field [request_cache] used, expected [request] instead'
+      indices.clear_cache:
+        request_cache: false

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yaml
@@ -12,8 +12,8 @@
 ---
 "clear_cache with request_cache set to false":
   - skip:
-      version: " - 5.2.2"
-      reason: deprecation was added in 5.2.3
+      version: " - 5.3.99"
+      reason: deprecation was added in 5.4.0
       features: "warnings"
 
   - do:


### PR DESCRIPTION
Fixes issue #22748.
This commit deprecates the use of 'request_cache' to clear the cache. Instead, 'request' should be used.
This is my first contribution, so any feedback is appreciated, particularly around code conventions and the versioning I specified in the test case.
