### PR TITLE
Avoid overflow when computing total FS stats

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -138,8 +138,8 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContent {
 
         public void add(Path path) {
             total = FsProbe.adjustForHugeFilesystems(addLong(total, path.total));
-            free = addLong(free, path.free);
-            available = addLong(available, path.available);
+            free = FsProbe.adjustForHugeFilesystems(addLong(free, path.free));
+            available = FsProbe.adjustForHugeFilesystems(addLong(available, path.available));
             if (path.spins != null && path.spins.booleanValue()) {
                 // Spinning is contagious!
                 spins = Boolean.TRUE;

--- a/core/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
@@ -121,7 +121,7 @@ public class FsProbeTests extends ESTestCase {
                 "available",
                 () -> new FsInfo.Path("/foo/baz", null, 0, 0, randomNonNegativeLong()));
 
-        // even after overflowing, it should not be negative
+        // even after overflowing these should not be negative
         assertThat(pathStats.total, greaterThan(0L));
         assertThat(pathStats.free, greaterThan(0L));
         assertThat(pathStats.available, greaterThan(0L));

--- a/core/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
@@ -150,7 +150,7 @@ public class FsProbeTests extends ESTestCase {
                 getter.apply(pathToAdd),
                 getter.apply(pathStats),
                 field,
-                getter.apply(pathToAdd) + getter.apply(pathStats));
+                getter.apply(pathStats) + getter.apply(pathToAdd));
         assertThat(getter.apply(pathStats) + getter.apply(pathToAdd), lessThan(0L));
         pathStats.add(pathToAdd);
     }


### PR DESCRIPTION
When adding filesystem stats from individual filesystems, free and available can overflow. This commit guards against this by adjusting these situations to Long.MAX_VALUE.

