### PR TITLE
Switch include_in_all in multifield to warning

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -253,8 +253,9 @@ public class TypeParsers {
                 iterator.remove();
             } else if (propName.equals("include_in_all")) {
                 if (parserContext.isWithinMultiField()) {
-                    throw new MapperParsingException("include_in_all in multi fields is not allowed. Found the include_in_all in field ["
-                        + name + "] which is within a multi field.");
+                    deprecationLogger.deprecated("include_in_all in multi fields is deprecated "
+                            + "because it doesn't do anything. Found the include_in_all in field "
+                            + "[{}] which is within a multi field.", name);
                 } else {
                     deprecationLogger.deprecated("field [include_in_all] is deprecated, as [_all] is deprecated, " +
                                     "and will be disallowed in 6.0, use [copy_to] instead.");

--- a/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldIncludeInAllMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldIncludeInAllMapperTests.java
@@ -33,12 +33,11 @@ public class MultiFieldIncludeInAllMapperTests extends ESTestCase {
     public void testExceptionForIncludeInAllInMultiFields() throws IOException {
         XContentBuilder mapping = createMappingWithIncludeInAllInMultiField();
 
-        // first check that for newer versions we throw exception if include_in_all is found withing multi field
+        // first check that for newer versions we throw exception if include_in_all is found within multi field
         MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), Settings.EMPTY);
-        Exception e = expectThrows(MapperParsingException.class, () ->
-            mapperService.parse("type", new CompressedXContent(mapping.string()), true));
-        assertEquals("include_in_all in multi fields is not allowed. Found the include_in_all in field [c] which is within a multi field.",
-                e.getMessage());
+        mapperService.parse("type", new CompressedXContent(mapping.string()), true);
+        assertWarnings("include_in_all in multi fields is deprecated because it doesn't do "
+                + "anything. Found the include_in_all in field [c] which is within a multi field.");
     }
 
     private static XContentBuilder createMappingWithIncludeInAllInMultiField() throws IOException {


### PR DESCRIPTION
This reverts #21971 which should only have been applied in master
to preserve backwards compatibility. Instead of throwing an error
when you specify `include_in_all` inside a multifield we instead
return a deprecation warning. `include_in_all` in a multifield
still doesn't do anything. But at least people who use it erroneously
won't break.

Closes #23654

