### PR TITLE
Clarify task cancellation command

### DIFF
--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -168,6 +168,7 @@ If a long-running task supports cancellation, it can be cancelled by the followi
 POST _tasks/node_id:task_id/_cancel
 --------------------------------------------------
 // CONSOLE
+// TEST[s/task_id/1/]
 
 The task cancellation command supports the same task selection parameters as the list tasks command, so multiple tasks
 can be cancelled at the same time. For example, the following command will cancel all reindex tasks running on the

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -165,7 +165,7 @@ If a long-running task supports cancellation, it can be cancelled by the followi
 
 [source,js]
 --------------------------------------------------
-POST _tasks/task_id:1/_cancel
+POST _tasks/node_id:task_id/_cancel
 --------------------------------------------------
 // CONSOLE
 


### PR DESCRIPTION
Makes it explicit that the `node_id` has to be included when canceling a task. I had to look into the code to figure this out.

There might be a different and maybe better way of making this clear - though this change seems intuitive to me.