### PR TITLE
Javadoc: ThreadPool doesn't reject while shutdown

### DIFF
--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -295,16 +295,24 @@ public class ThreadPool extends AbstractComponent implements Closeable {
     }
 
     /**
-     * Get the generic executor service. This executor service {@link Executor#execute(Runnable)} method will run the {@link Runnable} it
-     * is given in the {@link ThreadContext} of the thread that queues it.
+     * Get the generic {@link ExecutorService}. This executor service
+     * {@link Executor#execute(Runnable)} method will run the {@link Runnable} it is given in the
+     * {@link ThreadContext} of the thread that queues it.
+     * <p>
+     * Warning: this {@linkplain ExecutorService} will not throw {@link RejectedExecutionException}
+     * if you submit a task while it shutdown. It will instead silently queue it and not run it.
      */
     public ExecutorService generic() {
         return executor(Names.GENERIC);
     }
 
     /**
-     * Get the executor service with the given name. This executor service's {@link Executor#execute(Runnable)} method will run the
-     * {@link Runnable} it is given in the {@link ThreadContext} of the thread that queues it.
+     * Get the {@link ExecutorService} with the given name. This executor service's
+     * {@link Executor#execute(Runnable)} method will run the {@link Runnable} it is given in the
+     * {@link ThreadContext} of the thread that queues it.
+     * <p>
+     * Warning: this {@linkplain ExecutorService} might not throw {@link RejectedExecutionException}
+     * if you submit a task while it shutdown. It will instead silently queue it and not run it.
      *
      * @param name the name of the executor service to obtain
      * @throws IllegalArgumentException if no executor service with the specified name exists


### PR DESCRIPTION
It caught me offguard yesterday that our executors won't always
reject when the ThreadPool is shutdown.

