### PR TITLE
Match- and MultiMatchQueryBuilder should only allow setting analyzer on string values

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -210,9 +210,14 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     /**
      * Explicitly set the analyzer to use. Defaults to use explicit mapping config for the field, or, if not
      * set, the default search analyzer.
+     * @throws IllegalArgumentException when analyzer is used with a non-String value
      */
     public MatchQueryBuilder analyzer(String analyzer) {
         this.analyzer = analyzer;
+        if (analyzer != null && value instanceof String == false) {
+            throw new IllegalArgumentException("Setting analyzers is only allowed for string "
+                    + "values but was [" + value.getClass() + "]");
+        }
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -331,6 +331,10 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
      */
     public MultiMatchQueryBuilder analyzer(String analyzer) {
         this.analyzer = analyzer;
+        if (analyzer != null && value instanceof String == false) {
+            throw new IllegalArgumentException("Setting analyzers is only allowed for string "
+                    + "values but was [" + value.getClass() + "]");
+        }
         return this;
     }
 


### PR DESCRIPTION
Currently the user can set an analyzer on e.g. a numeric query, but explicitely
setting an analyzer only make sense for input text. Otherwise we might
analyze e.g. floats in scientific notation like `1.34e-6` to just an `e` which
leads to NumberFormatExceptions on each shard later (if targeting a numeric
field).

Closes #21665
