### PR TITLE
Improve error handling for epoch format parser with time zone (#22621)

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -336,8 +336,7 @@ public class Joda {
             if (bucket.getZone() != DateTimeZone.UTC) {
                 String format = hasMilliSecondPrecision ? "epoch_millis" : "epoch_second";
                 throw new IllegalArgumentException("time_zone must be UTC for format [" + format + "]");
-            }
-            else if (isPositive && isTooLong) {
+            } else if (isPositive && isTooLong) {
                 return -1;
             }
 

--- a/core/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -333,9 +333,11 @@ public class Joda {
             boolean isPositive = text.startsWith("-") == false;
             boolean isTooLong = text.length() > estimateParsedLength();
 
-            if ((isPositive && isTooLong) ||
-                // timestamps have to have UTC timezone
-                bucket.getZone() != DateTimeZone.UTC) {
+            if (bucket.getZone() != DateTimeZone.UTC) {
+                String format = hasMilliSecondPrecision ? "epoch_millis" : "epoch_second";
+                throw new IllegalArgumentException("time_zone must be UTC for format [" + format + "]");
+            }
+            else if (isPositive && isTooLong) {
                 return -1;
             }
 

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -455,6 +455,8 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
         if (fieldType == null) {
             // no field means we have no values
             return MappedFieldType.Relation.DISJOINT;
+        } else if(timeZone != null && timeZone != DateTimeZone.UTC && format != null && (format.format().equals("epoch_millis") || format.format().equals("epoch_second"))) {
+            throw new IllegalArgumentException("time_zone must be UTC when using format [" + format.format() + "]");
         } else {
             DateMathParser dateMathParser = format == null ? null : new DateMathParser(format);
             return fieldType.isFieldWithinQuery(queryRewriteContext.getIndexReader(), from, to, includeLower,

--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -455,8 +455,6 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
         if (fieldType == null) {
             // no field means we have no values
             return MappedFieldType.Relation.DISJOINT;
-        } else if(timeZone != null && timeZone != DateTimeZone.UTC && format != null && (format.format().equals("epoch_millis") || format.format().equals("epoch_second"))) {
-            throw new IllegalArgumentException("time_zone must be UTC when using format [" + format.format() + "]");
         } else {
             DateMathParser dateMathParser = format == null ? null : new DateMathParser(format);
             return fieldType.isFieldWithinQuery(queryRewriteContext.getIndexReader(), from, to, includeLower,

--- a/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
+++ b/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
@@ -315,8 +315,12 @@ public class SimpleJodaTests extends ESTestCase {
     }
 
     public void testForInvalidTimeZoneWithEpochSeconds() {
-        DateTimeZone zone = DateTimeZone.forOffsetHours(1);
-        FormatDateTimeFormatter formatter = new FormatDateTimeFormatter("epoch_seconds", new DateTimeFormatterBuilder().append(new Joda.EpochTimeParser(false)).toFormatter().withZone(zone), Locale.ROOT);
+        DateTimeFormatter dateTimeFormatter = new DateTimeFormatterBuilder()
+            .append(new Joda.EpochTimeParser(false))
+            .toFormatter()
+            .withZone(DateTimeZone.forOffsetHours(1));
+        FormatDateTimeFormatter formatter =
+            new FormatDateTimeFormatter("epoch_seconds", dateTimeFormatter, Locale.ROOT);
         try {
             formatter.parser().parseDateTime("1433144433655");
             fail("Expected IllegalArgumentException");
@@ -326,8 +330,12 @@ public class SimpleJodaTests extends ESTestCase {
     }
 
     public void testForInvalidTimeZoneWithEpochMillis() {
-        DateTimeZone zone = DateTimeZone.forOffsetHours(1);
-        FormatDateTimeFormatter formatter = new FormatDateTimeFormatter("epoch_millis", new DateTimeFormatterBuilder().append(new Joda.EpochTimeParser(true)).toFormatter().withZone(zone), Locale.ROOT);
+        DateTimeFormatter dateTimeFormatter = new DateTimeFormatterBuilder()
+            .append(new Joda.EpochTimeParser(true))
+            .toFormatter()
+            .withZone(DateTimeZone.forOffsetHours(1));
+        FormatDateTimeFormatter formatter =
+            new FormatDateTimeFormatter("epoch_millis", dateTimeFormatter, Locale.ROOT);
         try {
             formatter.parser().parseDateTime("1433144433");
             fail("Expected IllegalArgumentException");

--- a/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
+++ b/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
@@ -314,6 +314,28 @@ public class SimpleJodaTests extends ESTestCase {
         }
     }
 
+    public void testForInvalidTimeZoneWithEpochSeconds() {
+        DateTimeZone zone = DateTimeZone.forOffsetHours(1);
+        FormatDateTimeFormatter formatter = new FormatDateTimeFormatter("epoch_seconds", new DateTimeFormatterBuilder().append(new Joda.EpochTimeParser(false)).toFormatter().withZone(zone), Locale.ROOT);
+        try {
+            formatter.parser().parseDateTime("1433144433655");
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("time_zone must be UTC"));
+        }
+    }
+
+    public void testForInvalidTimeZoneWithEpochMillis() {
+        DateTimeZone zone = DateTimeZone.forOffsetHours(1);
+        FormatDateTimeFormatter formatter = new FormatDateTimeFormatter("epoch_millis", new DateTimeFormatterBuilder().append(new Joda.EpochTimeParser(true)).toFormatter().withZone(zone), Locale.ROOT);
+        try {
+            formatter.parser().parseDateTime("1433144433");
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("time_zone must be UTC"));
+        }
+    }
+
     public void testThatEpochParserIsPrinter() {
         FormatDateTimeFormatter formatter = Joda.forPattern("epoch_millis");
         assertThat(formatter.parser().isPrinter(), is(true));


### PR DESCRIPTION
Change the error response when using a non UTC timezone for range queries with epoch_millis or epoch_second formats to an illegal argument exception. The goal is to provide a better explanation of why the query has failed. The current behavior is to respond with a parse exception.