### PR TITLE
Fixes snapshot deletion handling on in-progress snapshot failure

### DIFF
--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1150,11 +1150,22 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         @Override
                         public void onSnapshotFailure(Snapshot failedSnapshot, Exception e) {
                             if (failedSnapshot.equals(snapshot)) {
-                                logger.trace("deleted snapshot failed - deleting files", e);
+                                logger.warn("deleted snapshot failed - deleting files", e);
                                 removeListener(this);
-                                threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(() ->
-                                    deleteSnapshot(failedSnapshot.getRepository(), failedSnapshot.getSnapshotId().getName(), listener, true)
-                                );
+                                threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(() -> {
+                                    try {
+                                        deleteSnapshot(failedSnapshot.getRepository(),
+                                                       failedSnapshot.getSnapshotId().getName(),
+                                                       listener,
+                                                       true);
+                                    } catch (SnapshotMissingException smex) {
+                                        logger.info((Supplier<?>) () -> new ParameterizedMessage(
+                                            "Tried deleting in-progress snapshot [{}], but it " +
+                                            "could not be found after failed snapshot abort",
+                                            smex.getSnapshotName()), e);
+                                        listener.onFailure(smex);
+                                    }
+                                });
                             }
                         }
                     });

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1161,9 +1161,11 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                     } catch (SnapshotMissingException smex) {
                                         logger.info((Supplier<?>) () -> new ParameterizedMessage(
                                             "Tried deleting in-progress snapshot [{}], but it " +
-                                            "could not be found after failed snapshot abort",
+                                            "could not be found after failing to abort.",
                                             smex.getSnapshotName()), e);
-                                        listener.onFailure(smex);
+                                        listener.onFailure(new SnapshotException(snapshot,
+                                            "Tried deleting in-progress snapshot [{}], but it " +
+                                            "could not be found after failing to abort."));
                                     }
                                 });
                             }

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1165,7 +1165,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                                             smex.getSnapshotName()), e);
                                         listener.onFailure(new SnapshotException(snapshot,
                                             "Tried deleting in-progress snapshot [{}], but it " +
-                                            "could not be found after failing to abort."));
+                                            "could not be found after failing to abort.", smex));
                                     }
                                 });
                             }


### PR DESCRIPTION
This commit fixes an issue manifested in the
SharedClusterSnapshotRestoreIT#testGetSnapshotsRequest where a delete
request on a snapshot encounters an in-progress snapshot, so it first
tries to abort the snapshot.  During the aborting process, an exception
is thrown which is handled by the snapshot listener's onSnapshotFailure
method.  This method retries the delete snapshot request, only to
encounter that the snapshot is missing, throwing an exception.  It is
possible that the snapshot failure resulted in the snapshot never having
been written to the repository, and hence, there is nothing to delete.
This commit handles the SnapshotMissingException by logging it and
notifying the listener of the missing snapshot.

Closes #23663