### PR TITLE
Test: Check that parsing SearchHit without _type/_id works

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -493,7 +493,7 @@ public final class SearchHit implements Streamable, ToXContentObject, Iterable<S
 
     public static void declareInnerHitsParseFields(ObjectParser<Map<String, Object>, Void> parser) {
         declareMetaDataFields(parser);
-        parser.declareString((map, value) -> map.put(Fields._TYPE, value), new ParseField(Fields._TYPE));
+        parser.declareString((map, value) -> map.put(Fields._TYPE, new Text(value)), new ParseField(Fields._TYPE));
         parser.declareString((map, value) -> map.put(Fields._INDEX, value), new ParseField(Fields._INDEX));
         parser.declareString((map, value) -> map.put(Fields._ID, value), new ParseField(Fields._ID));
         parser.declareString((map, value) -> map.put(Fields._NODE, value), new ParseField(Fields._NODE));
@@ -524,11 +524,11 @@ public final class SearchHit implements Streamable, ToXContentObject, Iterable<S
 
     public static SearchHit createFromMap(Map<String, Object> values) {
         String id = get(Fields._ID, values, null);
-        String type = get(Fields._TYPE, values, null);
+        Text type = get(Fields._TYPE, values, null);
         NestedIdentity nestedIdentity = get(NestedIdentity._NESTED, values, null);
         Map<String, SearchHitField> fields = get(Fields.FIELDS, values, null);
 
-        SearchHit searchHit = new SearchHit(-1, id, new Text(type), nestedIdentity, fields);
+        SearchHit searchHit = new SearchHit(-1, id, type, nestedIdentity, fields);
         searchHit.index = get(Fields._INDEX, values, null);
         searchHit.score(get(Fields._SCORE, values, DEFAULT_SCORE));
         searchHit.version(get(Fields._VERSION, values, -1L));

--- a/core/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -149,6 +149,22 @@ public class SearchHitTests extends ESTestCase {
         assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, humanReadable), xContentType);
     }
 
+    /**
+     * When e.g. with "stored_fields": "_none_", only "_index" and "_score" are returned.
+     */
+    public void testFromXContentWithoutTypeAndId() throws IOException {
+        String hit = "{\"_index\": \"my_index\", \"_score\": 1}";
+        SearchHit parsed;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, hit)) {
+            parser.nextToken(); // jump to first START_OBJECT
+            parsed = SearchHit.fromXContent(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+            assertNull(parser.nextToken());
+        }
+        assertEquals("my_index", parsed.getIndex());
+        assertEquals(1, parsed.getScore(), Float.MIN_VALUE);
+    }
+
     public void testToXContent() throws IOException {
         SearchHit searchHit = new SearchHit(1, "id1", new Text("type"), Collections.emptyMap());
         searchHit.score(1.5f);

--- a/core/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -163,6 +163,8 @@ public class SearchHitTests extends ESTestCase {
         }
         assertEquals("my_index", parsed.getIndex());
         assertEquals(1, parsed.getScore(), Float.MIN_VALUE);
+        assertNull(parsed.getType());
+        assertNull(parsed.getId());
     }
 
     public void testToXContent() throws IOException {


### PR DESCRIPTION
Each search hit object can be very small e.g. when using "stored_fields": ["_none_"]
we only get back "_index" and "_score" fields. This adds a test that checks that we 
can still parse back the object.

