### PR TITLE
Validate top-level keys when parsing mget requests

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -320,6 +320,14 @@ public class MultiGetRequest extends ActionRequest implements Iterable<MultiGetR
             boolean allowExplicitIndex) throws IOException {
         XContentParser.Token token;
         String currentFieldName = null;
+        if ((token = parser.nextToken()) != XContentParser.Token.START_OBJECT) {
+            final String message = String.format(
+                    Locale.ROOT,
+                    "unexpected token [%s], expected [%s]",
+                    token,
+                    XContentParser.Token.START_OBJECT);
+            throw new ParsingException(parser.getTokenLocation(), message);
+        }
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
@@ -331,11 +339,19 @@ public class MultiGetRequest extends ActionRequest implements Iterable<MultiGetR
                 } else {
                     final String message = String.format(
                             Locale.ROOT,
-                            "Unknown key [%s] for a %s, expected [docs] or [ids]",
+                            "unknown key [%s] for a %s, expected [docs] or [ids]",
                             currentFieldName,
                             token);
                     throw new ParsingException(parser.getTokenLocation(), message);
                 }
+            } else {
+                final String message = String.format(
+                        Locale.ROOT,
+                        "unexpected token [%s], expected [%s] or [%s]",
+                        token,
+                        XContentParser.Token.FIELD_NAME,
+                        XContentParser.Token.START_ARRAY);
+                throw new ParsingException(parser.getTokenLocation(), message);
             }
         }
         return this;

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 
 public class MultiGetRequest extends ActionRequest implements Iterable<MultiGetRequest.Item>, CompositeIndicesRequest, RealtimeRequest {
 
@@ -327,6 +328,13 @@ public class MultiGetRequest extends ActionRequest implements Iterable<MultiGetR
                     parseDocuments(parser, this.items, defaultIndex, defaultType, defaultFields, defaultFetchSource, defaultRouting, allowExplicitIndex);
                 } else if ("ids".equals(currentFieldName)) {
                     parseIds(parser, this.items, defaultIndex, defaultType, defaultFields, defaultFetchSource, defaultRouting);
+                } else {
+                    final String message = String.format(
+                            Locale.ROOT,
+                            "Unknown key [%s] for a %s, expected [docs] or [ids]",
+                            currentFieldName,
+                            token);
+                    throw new ParsingException(parser.getTokenLocation(), message);
                 }
             }
         }

--- a/core/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.get;
 
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -30,7 +29,6 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasToString;
 
 public class MultiGetRequestTests extends ESTestCase {
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/12_non_existent_index.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/12_non_existent_index.yaml
@@ -21,7 +21,6 @@
   - do:
       mget:
         body:
-          index:  test_2
           docs:
             - { _index: test_1, _type: test, _id: 1}
 


### PR DESCRIPTION
Today, when parsing mget requests, we silently ignore keys in the top level that do not match "docs" or "ids". This commit addresses this situation by throwing an exception if any other key occurs here, and providing the names of valid keys.

Closes #23720