### PR TITLE
Update reference docs for Highlighter fragmenter

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -374,6 +374,42 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
+==== Fragmenter
+
+Fragmenter can control how text should be broken up in highlight snippets.
+However, this option is applicable only for the Plain Highlighter.
+There are two options:
+
+[horizontal]
+`simple`:: Breaks up text into same sized fragments.
+`span`:: Same as the simple fragmenter, but tries not to break up text between highlighted terms (this is applicable when using phrase like queries). This is the default.
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "query" : {
+        "match" : {
+            "body" : {
+                "some text"
+            }
+        }
+    },
+    "highlight": {
+        "fields": {
+            "body": {
+                "fragment_size": 200,
+                "fragmenter" : "simple"
+            }
+        }
+   }
+}
+--------------------------------------------------
+// CONSOLE
+
+If the `number_of_fragments` option is set to `0`,
+`NullFragmenter` is used which does not fragment the text at all.
+This is useful for highlighting the entire content of a document or field.
 
 ==== Highlight query
 

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -386,26 +386,112 @@ There are two options:
 
 [source,js]
 --------------------------------------------------
-GET /_search
+GET twitter/tweet/_search
 {
     "query" : {
-        "match" : {
-            "body" : {
-                "some text"
-            }
-        }
+        "match_phrase": { "message": "number 1" }
     },
-    "highlight": {
-        "fields": {
-            "body": {
-                "fragment_size": 200,
-                "fragmenter" : "simple"
+    "highlight" : {
+        "fields" : {
+            "message" : {
+                "fragment_size" : 15,
+                "number_of_fragments" : 3,
+                "fragmenter": "simple"
             }
         }
-   }
+    }
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[setup:twitter]
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+    ...
+    "hits": {
+        "total": 1,
+        "max_score": 1.4818809,
+        "hits": [
+            {
+                "_index": "twitter",
+                "_type": "tweet",
+                "_id": "1",
+                "_score": 1.4818809,
+                "_source": {
+                    "user": "test",
+                    "message": "some message with the number 1",
+                    "date": "2009-11-15T14:12:12",
+                    "likes": 1
+                },
+                "highlight": {
+                    "message": [
+                        " with the <em>number</em>",
+                        " <em>1</em>"
+                    ]
+                }
+            }
+        ]
+    }
+}
+--------------------------------------------------
+// TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,/]
+
+[source,js]
+--------------------------------------------------
+GET twitter/tweet/_search
+{
+    "query" : {
+        "match_phrase": { "message": "number 1" }
+    },
+    "highlight" : {
+        "fields" : {
+            "message" : {
+                "fragment_size" : 15,
+                "number_of_fragments" : 3,
+                "fragmenter": "span"
+            }
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
+
+Response:
+
+[source,js]
+--------------------------------------------------
+{
+    ...
+    "hits": {
+        "total": 1,
+        "max_score": 1.4818809,
+        "hits": [
+            {
+                "_index": "twitter",
+                "_type": "tweet",
+                "_id": "1",
+                "_score": 1.4818809,
+                "_source": {
+                    "user": "test",
+                    "message": "some message with the number 1",
+                    "date": "2009-11-15T14:12:12",
+                    "likes": 1
+                },
+                "highlight": {
+                    "message": [
+                        "some message with the <em>number</em> <em>1</em>"
+                    ]
+                }
+            }
+        ]
+    }
+}
+--------------------------------------------------
+// TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,/]
 
 If the `number_of_fragments` option is set to `0`,
 `NullFragmenter` is used which does not fragment the text at all.


### PR DESCRIPTION
Highlighting supports an option `fragmenter` which is supported by the Plain fragmenter but the reference documentation does not mention it.

Reference documentation for the same was added by collating information from the following sources:
- Expose fragmenter option for plain highlighter #2465
- Lucene docs for [Fragmenter](https://lucene.apache.org/core/3_0_3/api/contrib-highlighter/org/apache/lucene/search/highlight/Fragmenter.html), [NullFragmenter](https://lucene.apache.org/core/6_4_0/highlighter/org/apache/lucene/search/highlight/NullFragmenter.html), [SimpleFragmenter](https://lucene.apache.org/core/6_4_0/highlighter/org/apache/lucene/search/highlight/SimpleFragmenter.html) and [SpansHighlighter](https://lucene.apache.org/core/6_4_0/core/org/apache/lucene/search/spans/Spans.html)
- Elasticsearch source code for [PlainHighlighter](/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java#L77-L89)
- Discussion in the issue #23736

Closes #23736