### PR TITLE
Build: Use GradleBuild task for invoking 5.x checkout build

### DIFF
--- a/distribution/bwc-zip/build.gradle
+++ b/distribution/bwc-zip/build.gradle
@@ -72,10 +72,10 @@ task checkoutBwcBranch(type: LoggedExec) {
 }
 
 File bwcZip = file("${checkoutDir}/distribution/zip/build/distributions/elasticsearch-${BWC_VERSION}.zip")
-task buildBwcVersion(type: LoggedExec) {
+task buildBwcVersion(type: GradleBuild) {
   dependsOn checkoutBwcBranch
-  workingDir = checkoutDir
-  commandLine = ['gradle', ':distribution:zip:assemble']
+  dir = checkoutDir
+  tasks = [':distribution:zip:assemble']
 }
 
 artifacts {


### PR DESCRIPTION
This commit switches from executing gradle when building the bwc testing
zip through Exec, to using GradleBuild. In addition to not depending on
gradle being in the PATH, it also has the added benefit of much better
logging while the bwc build is going on (the actual tasks show up as
tasks of a subproject within the current build).
