### PR TITLE
Add lower bound for translog generation threshold

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -119,6 +119,15 @@ public final class IndexSettings {
             Setting.byteSizeSetting(
                     "index.translog.generation_threshold_size",
                     new ByteSizeValue(64, ByteSizeUnit.MB),
+                    /*
+                     * An empty translog occupies 43 bytes on disk. If the generation threshold is
+                     * below this, the flush thread can get stuck in an infinite loop repeatedly
+                     * rolling the generation as every new generation will already exceed the
+                     * generation threshold. However, small thresholds are useful for testing so we
+                     * do not add a large lower bound here.
+                     */
+                    new ByteSizeValue(64, ByteSizeUnit.BYTES),
+                    new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
                     new Property[]{Property.Dynamic, Property.IndexScope});
 
     public static final Setting<TimeValue> INDEX_SEQ_NO_CHECKPOINT_SYNC_INTERVAL =

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -364,7 +364,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
     }
 
     public void testMaybeRollTranslogGeneration() throws Exception {
-        final int generationThreshold = randomIntBetween(1, 512);
+        final int generationThreshold = randomIntBetween(64, 512);
         final Settings settings =
                 Settings
                         .builder()
@@ -380,7 +380,8 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         int rolls = 0;
         final Translog translog = shard.getEngine().getTranslog();
         final long generation = translog.currentFileGeneration();
-        for (int i = 0; i < randomIntBetween(32, 128); i++) {
+        final int numberOfDocuments = randomIntBetween(32, 128);
+        for (int i = 0; i < numberOfDocuments; i++) {
             assertThat(translog.currentFileGeneration(), equalTo(generation + rolls));
             final ParsedDocument doc = testParsedDocument(
                     "1",


### PR DESCRIPTION
The translog already occupies 43 bytes on disk when empty. If the translog generation threshold is below this, the flush thread can get stuck in an infinite loop repeatedly rolling the generation. This commit adds a lower bound on the translog generation to avoid this problem, however we keep the lower bound small for convenience in testing.

Relates #23606

