### PR TITLE
The `filter` and `significant_terms` aggregations should parse the `filter` as a filter, not a query.

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -3089,7 +3089,7 @@
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]DiversifiedSamplerIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]DoubleTermsIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]FilterIT.java" checks="LineLength" />
-  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]FiltersAggregatorTests.java" checks="LineLength" />
+  <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]filters[/\\]FiltersAggregatorTests.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]FiltersIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]GeoDistanceIT.java" checks="LineLength" />
   <suppress files="core[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]search[/\\]aggregations[/\\]bucket[/\\]GeoHashGridIT.java" checks="LineLength" />

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorFactory.java
@@ -35,13 +35,13 @@ import java.util.Map;
 
 public class FilterAggregatorFactory extends AggregatorFactory<FilterAggregatorFactory> {
 
-    private final Weight weight;
+    final Weight weight;
 
     public FilterAggregatorFactory(String name, QueryBuilder filterBuilder, SearchContext context,
             AggregatorFactory<?> parent, AggregatorFactories.Builder subFactoriesBuilder, Map<String, Object> metaData) throws IOException {
         super(name, context, parent, subFactoriesBuilder, metaData);
         IndexSearcher contextSearcher = context.searcher();
-        Query filter = filterBuilder.toQuery(context.getQueryShardContext());
+        Query filter = filterBuilder.toFilter(context.getQueryShardContext());
         weight = contextSearcher.createNormalizedWeight(filter, false);
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregatorFactory.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class FiltersAggregatorFactory extends AggregatorFactory<FiltersAggregatorFactory> {
 
     private final String[] keys;
-    private final Weight[] weights;
+    final Weight[] weights;
     private final boolean keyed;
     private final boolean otherBucket;
     private final String otherBucketKey;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorFactory.java
@@ -65,7 +65,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
     private MappedFieldType fieldType;
     private FilterableTermsEnum termsEnum;
     private int numberOfAggregatorsCreated;
-    private final Query filter;
+    final Query filter;
     private final int supersetNumDocs;
     private final TermsAggregator.BucketCountThresholds bucketCountThresholds;
     private final SignificanceHeuristic significanceHeuristic;
@@ -79,7 +79,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
         this.executionHint = executionHint;
         this.filter = filterBuilder == null
                 ? null
-                : filterBuilder.toQuery(context.getQueryShardContext());
+                : filterBuilder.toFilter(context.getQueryShardContext());
         IndexSearcher searcher = context.searcher();
         this.supersetNumDocs = filter == null
                 // Important - need to use the doc count that includes deleted docs

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorTests.java
@@ -16,25 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket;
+package org.elasticsearch.search.aggregations.bucket.filter;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilter;
+import org.hamcrest.Matchers;
 import org.junit.Before;
+
+import java.io.IOException;
 
 public class FilterAggregatorTests extends AggregatorTestCase {
     private MappedFieldType fieldType;
@@ -101,5 +109,23 @@ public class FilterAggregatorTests extends AggregatorTestCase {
         }
         indexReader.close();
         directory.close();
+    }
+
+    public void testParsedAsFilter() throws IOException {
+        IndexReader indexReader = new MultiReader();
+        IndexSearcher indexSearcher = newSearcher(indexReader);
+        QueryBuilder filter = QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("field", "foo"))
+                .should(QueryBuilders.termQuery("field", "bar"));
+        FilterAggregationBuilder builder = new FilterAggregationBuilder("test", filter);
+        AggregatorFactory<?> factory = createAggregatorFactory(builder, indexSearcher, fieldType);
+        assertThat(factory, Matchers.instanceOf(FilterAggregatorFactory.class));
+        FilterAggregatorFactory filterFactory = (FilterAggregatorFactory) factory;
+        Query parsedQuery = filterFactory.weight.getQuery();
+        assertThat(parsedQuery, Matchers.instanceOf(BooleanQuery.class));
+        assertEquals(2, ((BooleanQuery) parsedQuery).clauses().size());
+        // means the bool query has been parsed as a filter, if it was a query minShouldMatch would
+        // be 0
+        assertEquals(1, ((BooleanQuery) parsedQuery).getMinimumNumberShouldMatch());
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filters/FiltersAggregatorTests.java
@@ -16,27 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket;
+package org.elasticsearch.search.aggregations.bucket.filters;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregator;
+import org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.filters.InternalFilters;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -199,5 +206,23 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
         }
         indexReader.close();
         directory.close();
+    }
+
+    public void testParsedAsFilter() throws IOException {
+        IndexReader indexReader = new MultiReader();
+        IndexSearcher indexSearcher = newSearcher(indexReader);
+        QueryBuilder filter = QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("field", "foo"))
+                .should(QueryBuilders.termQuery("field", "bar"));
+        FiltersAggregationBuilder builder = new FiltersAggregationBuilder("test", filter);
+        AggregatorFactory<?> factory = createAggregatorFactory(builder, indexSearcher, fieldType);
+        assertThat(factory, Matchers.instanceOf(FiltersAggregatorFactory.class));
+        FiltersAggregatorFactory filtersFactory = (FiltersAggregatorFactory) factory;
+        Query parsedQuery = filtersFactory.weights[0].getQuery();
+        assertThat(parsedQuery, Matchers.instanceOf(BooleanQuery.class));
+        assertEquals(2, ((BooleanQuery) parsedQuery).clauses().size());
+        // means the bool query has been parsed as a filter, if it was a query minShouldMatch would
+        // be 0
+        assertEquals(1, ((BooleanQuery) parsedQuery).getMinimumNumberShouldMatch());
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorTests.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.significant;
+
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiReader;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.support.ValueType;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+
+import java.io.IOException;
+
+public class SignificantTermsAggregatorTests extends AggregatorTestCase {
+
+    private MappedFieldType fieldType;
+
+    @Before
+    public void setUpTest() throws Exception {
+        super.setUp();
+        fieldType = new KeywordFieldMapper.KeywordFieldType();
+        fieldType.setHasDocValues(true);
+        fieldType.setIndexOptions(IndexOptions.DOCS);
+        fieldType.setName("field");
+    }
+
+    public void testParsedAsFilter() throws IOException {
+        IndexReader indexReader = new MultiReader();
+        IndexSearcher indexSearcher = newSearcher(indexReader);
+        QueryBuilder filter = QueryBuilders.boolQuery()
+                .must(QueryBuilders.termQuery("field", "foo"))
+                .should(QueryBuilders.termQuery("field", "bar"));
+        SignificantTermsAggregationBuilder builder = new SignificantTermsAggregationBuilder(
+                "test", ValueType.STRING)
+                .field("field")
+                .backgroundFilter(filter);
+        AggregatorFactory<?> factory = createAggregatorFactory(builder, indexSearcher, fieldType);
+        assertThat(factory, Matchers.instanceOf(SignificantTermsAggregatorFactory.class));
+        SignificantTermsAggregatorFactory sigTermsFactory =
+                (SignificantTermsAggregatorFactory) factory;
+        Query parsedQuery = sigTermsFactory.filter;
+        assertThat(parsedQuery, Matchers.instanceOf(BooleanQuery.class));
+        assertEquals(2, ((BooleanQuery) parsedQuery).clauses().size());
+        // means the bool query has been parsed as a filter, if it was a query minShouldMatch would
+        // be 0
+        assertEquals(1, ((BooleanQuery) parsedQuery).getMinimumNumberShouldMatch());
+    }
+
+}


### PR DESCRIPTION
This is important for some queries like `terms`, which are parsed differently
depending on whether we want to get a query or a filter.