### PR TITLE
Tests: Add base tests for InternalSimpleValue and InternalDerivative

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValue.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValue.java
@@ -25,11 +25,11 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
-import org.elasticsearch.search.aggregations.metrics.max.InternalMax;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class InternalSimpleValue extends InternalNumericMetricsAggregation.SingleValue implements SimpleValue {
     public static final String NAME = "simple_value";
@@ -72,7 +72,7 @@ public class InternalSimpleValue extends InternalNumericMetricsAggregation.Singl
     }
 
     @Override
-    public InternalMax doReduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+    public InternalSimpleValue doReduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         throw new UnsupportedOperationException("Not supported");
     }
 
@@ -84,5 +84,17 @@ public class InternalSimpleValue extends InternalNumericMetricsAggregation.Singl
             builder.field(CommonFields.VALUE_AS_STRING.getPreferredName(), format.format(value));
         }
         return builder;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(value, format.getWriteableName());
+    }
+
+    @Override
+    protected boolean doEquals(Object obj) {
+        InternalSimpleValue other = (InternalSimpleValue) obj;
+        return Objects.equals(value, other.value)
+                && Objects.equals(format.getWriteableName(), other.format.getWriteableName());
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValue.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValue.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 
 public class InternalSimpleValue extends InternalNumericMetricsAggregation.SingleValue implements SimpleValue {
     public static final String NAME = "simple_value";
-    private final double value;
+    protected final double value;
 
     public InternalSimpleValue(String name, double value, DocValueFormat formatter, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
@@ -88,13 +88,12 @@ public class InternalSimpleValue extends InternalNumericMetricsAggregation.Singl
 
     @Override
     protected int doHashCode() {
-        return Objects.hash(value, format.getWriteableName());
+        return Objects.hash(value);
     }
 
     @Override
     protected boolean doEquals(Object obj) {
         InternalSimpleValue other = (InternalSimpleValue) obj;
-        return Objects.equals(value, other.value)
-                && Objects.equals(format.getWriteableName(), other.format.getWriteableName());
+        return Objects.equals(value, other.value);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivative.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivative.java
@@ -93,14 +93,13 @@ public class InternalDerivative extends InternalSimpleValue implements Derivativ
 
     @Override
     protected int doHashCode() {
-        return Objects.hash(normalizationFactor, super.doHashCode());
+        return Objects.hash(normalizationFactor, value);
     }
 
     @Override
     protected boolean doEquals(Object obj) {
         InternalDerivative other = (InternalDerivative) obj;
-        return Objects.equals(getValue(), other.getValue())
-                && Objects.equals(normalizationFactor, other.normalizationFactor)
-                && Objects.equals(format.getWriteableName(), other.format.getWriteableName());
+        return Objects.equals(value, other.value)
+                && Objects.equals(normalizationFactor, other.normalizationFactor);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivative.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivative.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class InternalDerivative extends InternalSimpleValue implements Derivative {
     private final double normalizationFactor;
@@ -88,5 +89,18 @@ public class InternalDerivative extends InternalSimpleValue implements Derivativ
             }
         }
         return builder;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(normalizationFactor, super.doHashCode());
+    }
+
+    @Override
+    protected boolean doEquals(Object obj) {
+        InternalDerivative other = (InternalDerivative) obj;
+        return Objects.equals(getValue(), other.getValue())
+                && Objects.equals(normalizationFactor, other.normalizationFactor)
+                && Objects.equals(format.getWriteableName(), other.format.getWriteableName());
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
@@ -50,7 +50,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         return createTestInstance(name, pipelineAggregators, metaData);
     }
 
-    public final void testReduceRandom() {
+    public void testReduceRandom() {
         String name = randomAsciiOfLength(5);
         List<T> inputs = new ArrayList<>();
         List<InternalAggregation> toReduce = new ArrayList<>();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -39,7 +40,9 @@ public class InternalSimpleValueTests extends InternalAggregationTestCase<Intern
 
     @Override
     public void testReduceRandom() {
-        // no test since reduce operation is unsupported
+        expectThrows(UnsupportedOperationException.class,
+                () -> createTestInstance("name", Collections.emptyList(), null).reduce(null,
+                        null));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+public class InternalSimpleValueTests extends InternalAggregationTestCase<InternalSimpleValue>{
+
+    @Override
+    protected InternalSimpleValue createTestInstance(String name,
+            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        DocValueFormat formatter = randomFrom(DocValueFormat.BOOLEAN, DocValueFormat.GEOHASH,
+                DocValueFormat.IP, DocValueFormat.RAW);
+        double value = randomDoubleBetween(0, 100000, true);
+        return new InternalSimpleValue(name, value, formatter, pipelineAggregators, metaData);
+    }
+
+    @Override
+    public void testReduceRandom() {
+        // no test since reduce operation is unsupported
+    }
+
+    @Override
+    protected void assertReduced(InternalSimpleValue reduced, List<InternalSimpleValue> inputs) {
+        // no test since reduce operation is unsupported
+    }
+
+    @Override
+    protected Reader<InternalSimpleValue> instanceReader() {
+        return InternalSimpleValue::new;
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivativeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivativeTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -42,7 +43,9 @@ public class InternalDerivativeTests extends InternalAggregationTestCase<Interna
 
     @Override
     public void testReduceRandom() {
-        // no test since reduce operation is unsupported
+        expectThrows(UnsupportedOperationException.class,
+                () -> createTestInstance("name", Collections.emptyList(), null).reduce(null,
+                        null));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivativeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivativeTests.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline.derivative;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+
+import java.util.List;
+import java.util.Map;
+
+public class InternalDerivativeTests extends InternalAggregationTestCase<InternalDerivative> {
+
+    @Override
+    protected InternalDerivative createTestInstance(String name,
+            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        DocValueFormat formatter = randomFrom(DocValueFormat.BOOLEAN, DocValueFormat.GEOHASH,
+                DocValueFormat.IP, DocValueFormat.RAW);
+        double value = randomDoubleBetween(0, 100000, true);
+        double normalizationFactor = randomDoubleBetween(0, 100000, true);
+        return new InternalDerivative(name, value, normalizationFactor, formatter,
+                pipelineAggregators, metaData);
+    }
+
+    @Override
+    public void testReduceRandom() {
+        // no test since reduce operation is unsupported
+    }
+
+    @Override
+    protected void assertReduced(InternalDerivative reduced, List<InternalDerivative> inputs) {
+        // no test since reduce operation is unsupported
+    }
+
+    @Override
+    protected Reader<InternalDerivative> instanceReader() {
+        return InternalDerivative::new;
+    }
+
+}


### PR DESCRIPTION
As an addition to https://github.com/elastic/elasticsearch/issues/22278 we should probably also have base tests for InternalSimpleValue and InternalDerivative, although it seems to me they don't have a corresponding Aggregator implementation. We will need to extend this test when writing the aggregation parsing as well.