### PR TITLE
Build: Find bwc version during build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,6 @@ allprojects {
     bwcVersion = "${prevMajor}.${prevMinor}.0${prevSnapshot}"
   }
 }
-println bwcVersion
 
 subprojects {
   project.afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -18,15 +18,17 @@
  */
 
 import java.nio.file.Path
+import java.util.regex.Matcher
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.lib.RepositoryBuilder
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.elasticsearch.gradle.VersionProperties
 
 // common maven publishing configuration
 subprojects {
   group = 'org.elasticsearch'
-  version = org.elasticsearch.gradle.VersionProperties.elasticsearch
+  version = VersionProperties.elasticsearch
   description = "Elasticsearch subproject ${project.path}"
 }
 
@@ -59,14 +61,29 @@ configure(subprojects.findAll { it.projectDir.toPath().startsWith(rootPath) }) {
   }
 }
 
+int prevMajor = Integer.parseInt(VersionProperties.elasticsearch.split('\\.')[0]) - 1
+String prevSnapshot = VersionProperties.elasticsearch.contains('alpha') ? '-SNAPSHOT' : ''
+File versionFile = file('core/src/main/java/org/elasticsearch/Version.java')
+List<String> versionLines = versionFile.readLines('UTF-8')
+int prevMinor = 0
+for (String line : versionLines) {
+  Matcher match = line =~ /\W+public static final Version V_${prevMajor}_(\d+)_.*/
+  if (match.matches()) {
+    prevMinor = Math.max(Integer.parseInt(match.group(1)), prevMinor)
+  }
+}
+
+// injecting groovy property variables into all projects
 allprojects {
-  // injecting groovy property variables into all projects
   project.ext {
     // for ide hacks...
     isEclipse = System.getProperty("eclipse.launcher") != null || gradle.startParameter.taskNames.contains('eclipse') || gradle.startParameter.taskNames.contains('cleanEclipse')
     isIdea = System.getProperty("idea.active") != null || gradle.startParameter.taskNames.contains('idea') || gradle.startParameter.taskNames.contains('cleanIdea')
+    // for backcompat testing
+    bwcVersion = "${prevMajor}.${prevMinor}.0${prevSnapshot}"
   }
 }
+println bwcVersion
 
 subprojects {
   project.afterEvaluate {
@@ -113,7 +130,7 @@ subprojects {
     "org.elasticsearch.test:framework:${version}": ':test:framework',
     "org.elasticsearch.distribution.integ-test-zip:elasticsearch:${version}": ':distribution:integ-test-zip',
     // TODO: don't use a hardcoded version here, introspect it from Version.java
-    "org.elasticsearch.distribution.zip:elasticsearch:5.4.0-SNAPSHOT": ':distribution:bwc-zip',
+    "org.elasticsearch.distribution.zip:elasticsearch:${bwcVersion}": ':distribution:bwc-zip',
     "org.elasticsearch.distribution.zip:elasticsearch:${version}": ':distribution:zip',
     "org.elasticsearch.distribution.tar:elasticsearch:${version}": ':distribution:tar',
     "org.elasticsearch.distribution.rpm:elasticsearch:${version}": ':distribution:rpm',

--- a/distribution/bwc-zip/build.gradle
+++ b/distribution/bwc-zip/build.gradle
@@ -29,9 +29,6 @@ import org.elasticsearch.gradle.LoggedExec
 
 apply plugin: 'distribution'
 
-// TODO: generate this, by introspecting Version.java for last previous minor
-String BWC_VERSION = "5.4.0-SNAPSHOT"
-
 String checkoutDir = "${buildDir}/bwc/checkout-5.x"
 task createClone(type: LoggedExec) {
   onlyIf { new File(checkoutDir).exists() == false }
@@ -71,7 +68,7 @@ task checkoutBwcBranch(type: LoggedExec) {
   commandLine = ['git', 'checkout', 'upstream/5.x']
 }
 
-File bwcZip = file("${checkoutDir}/distribution/zip/build/distributions/elasticsearch-${BWC_VERSION}.zip")
+File bwcZip = file("${checkoutDir}/distribution/zip/build/distributions/elasticsearch-${bwcVersion}.zip")
 task buildBwcVersion(type: GradleBuild) {
   dependsOn checkoutBwcBranch
   dir = checkoutDir

--- a/qa/backwards-5.0/build.gradle
+++ b/qa/backwards-5.0/build.gradle
@@ -28,7 +28,7 @@ integTest {
 integTestCluster {
   numNodes = 4
   numBwcNodes = 2
-  bwcVersion = "5.4.0-SNAPSHOT"
+  bwcVersion = project.bwcVersion
   setting 'logger.org.elasticsearch', 'DEBUG'
 }
 

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -27,7 +27,7 @@ task oldClusterTest(type: RestIntegTestTask) {
 
 oldClusterTestCluster {
   distribution = 'zip'
-  bwcVersion = '5.4.0-SNAPSHOT' // TODO: either randomize, or make this settable with sysprop
+  bwcVersion = project.bwcVersion // TODO: either randomize, or make this settable with sysprop
   numBwcNodes = 2
   numNodes = 2
   clusterName = 'rolling-upgrade'


### PR DESCRIPTION
We currently have the last minor version of the previous major hardcoded
in tests like rolling upgrade. This change programmatically finds this
during gradle initialization by parsing versions from Version.java.