### PR TITLE
Build: Use filesystem agnostic printing of bwc dir path

### DIFF
--- a/distribution/bwc-zip/build.gradle
+++ b/distribution/bwc-zip/build.gradle
@@ -29,9 +29,9 @@ import org.elasticsearch.gradle.LoggedExec
 
 apply plugin: 'distribution'
 
-String checkoutDir = "${buildDir}/bwc/checkout-5.x"
+File checkoutDir = file("${buildDir}/bwc/checkout-5.x")
 task createClone(type: LoggedExec) {
-  onlyIf { new File(checkoutDir).exists() == false }
+  onlyIf { checkoutDir.exists() == false }
   commandLine = ['git', 'clone', rootDir, checkoutDir]
 }
 


### PR DESCRIPTION
This will use File.toString() for the `git clone` command, which will
automatically be correct for whatever system the build is running on.

closes #23784