### PR TITLE
Fix reindex with a remote source on a version before 2.0.0

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
@@ -184,4 +184,18 @@ final class RemoteRequestBuilders {
             throw new ElasticsearchException("failed to build scroll entity", e);
         }
     }
+
+    static HttpEntity clearScrollEntity(String scroll, Version remoteVersion) {
+        if (remoteVersion.before(Version.V_2_0_0)) {
+            // Versions before 2.0.0 extract the plain scroll_id from the body
+            return new StringEntity(scroll, ContentType.TEXT_PLAIN);
+        }
+        try (XContentBuilder entity = JsonXContent.contentBuilder()) {
+            return new StringEntity(entity.startObject()
+                .array("scroll_id", scroll)
+                .endObject().string(), ContentType.APPLICATION_JSON);
+        } catch (IOException e) {
+            throw new ElasticsearchException("failed to build clear scroll entity", e);
+        }
+    }
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
@@ -171,23 +171,17 @@ final class RemoteRequestBuilders {
         return singletonMap("scroll", keepAlive.toString());
     }
 
-    static HttpEntity scrollEntity(String scroll) {
+    static HttpEntity scrollEntity(String scroll, Version remoteVersion) {
+        if (remoteVersion.before(Version.V_2_0_0)) {
+            // Versions before 2.0.0 extract the plain scroll_id from the body
+            return new StringEntity(scroll, ContentType.TEXT_PLAIN);
+        }
         try (XContentBuilder entity = JsonXContent.contentBuilder()) {
             return new StringEntity(entity.startObject()
                 .field("scroll_id", scroll)
                 .endObject().string(), ContentType.APPLICATION_JSON);
         } catch (IOException e) {
             throw new ElasticsearchException("failed to build scroll entity", e);
-        }
-    }
-
-    static HttpEntity clearScrollEntity(String scroll) {
-        try (XContentBuilder entity = JsonXContent.contentBuilder()) {
-            return new StringEntity(entity.startObject()
-                .array("scroll_id", scroll)
-                .endObject().string(), ContentType.APPLICATION_JSON);
-        } catch (IOException e) {
-            throw new ElasticsearchException("failed to build clear scroll entity", e);
         }
     }
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -58,6 +58,7 @@ import java.util.function.Consumer;
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.elasticsearch.common.unit.TimeValue.timeValueNanos;
+import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.clearScrollEntity;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initialSearchEntity;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initialSearchParams;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initialSearchPath;
@@ -111,7 +112,7 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
 
     @Override
     protected void clearScroll(String scrollId, Runnable onCompletion) {
-        client.performRequestAsync("DELETE", scrollPath(), emptyMap(), scrollEntity(scrollId, remoteVersion), new ResponseListener() {
+        client.performRequestAsync("DELETE", scrollPath(), emptyMap(), clearScrollEntity(scrollId, remoteVersion), new ResponseListener() {
             @Override
             public void onSuccess(org.elasticsearch.client.Response response) {
                 logger.debug("Successfully cleared [{}]", scrollId);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -58,7 +58,6 @@ import java.util.function.Consumer;
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.elasticsearch.common.unit.TimeValue.timeValueNanos;
-import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.clearScrollEntity;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initialSearchEntity;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initialSearchParams;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initialSearchPath;
@@ -107,12 +106,12 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
     @Override
     protected void doStartNextScroll(String scrollId, TimeValue extraKeepAlive, Consumer<? super Response> onResponse) {
         execute("POST", scrollPath(), scrollParams(timeValueNanos(searchRequest.scroll().keepAlive().nanos() + extraKeepAlive.nanos())),
-                scrollEntity(scrollId), RESPONSE_PARSER, onResponse);
+                scrollEntity(scrollId, remoteVersion), RESPONSE_PARSER, onResponse);
     }
 
     @Override
     protected void clearScroll(String scrollId, Runnable onCompletion) {
-        client.performRequestAsync("DELETE", scrollPath(), emptyMap(), clearScrollEntity(scrollId), new ResponseListener() {
+        client.performRequestAsync("DELETE", scrollPath(), emptyMap(), scrollEntity(scrollId, remoteVersion), new ResponseListener() {
             @Override
             public void onSuccess(org.elasticsearch.client.Response response) {
                 logger.debug("Successfully cleared [{}]", scrollId);

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
@@ -39,6 +39,7 @@ import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initi
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initialSearchParams;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.initialSearchPath;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.scrollEntity;
+import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.clearScrollEntity;
 import static org.elasticsearch.index.reindex.remote.RemoteRequestBuilders.scrollParams;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
@@ -192,6 +193,20 @@ public class RemoteRequestBuildersTests extends ESTestCase {
 
         // Test with version < 2.0.0
         entity = scrollEntity(scroll, Version.fromId(1070499));
+        assertEquals(ContentType.TEXT_PLAIN.toString(), entity.getContentType().getValue());
+        assertEquals(scroll, Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)));
+    }
+
+
+    public void testClearScrollEntity() throws IOException {
+        String scroll = randomAsciiOfLength(30);
+        HttpEntity entity = clearScrollEntity(scroll, Version.V_5_0_0);
+        assertEquals(ContentType.APPLICATION_JSON.toString(), entity.getContentType().getValue());
+        assertThat(Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)),
+            containsString("\"" + scroll + "\""));
+
+        // Test with version < 2.0.0
+        entity = clearScrollEntity(scroll, Version.fromId(1070499));
         assertEquals(ContentType.TEXT_PLAIN.toString(), entity.getContentType().getValue());
         assertEquals(scroll, Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)));
     }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
@@ -197,7 +197,6 @@ public class RemoteRequestBuildersTests extends ESTestCase {
         assertEquals(scroll, Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)));
     }
 
-
     public void testClearScrollEntity() throws IOException {
         String scroll = randomAsciiOfLength(30);
         HttpEntity entity = clearScrollEntity(scroll, Version.V_5_0_0);

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
@@ -185,9 +185,14 @@ public class RemoteRequestBuildersTests extends ESTestCase {
 
     public void testScrollEntity() throws IOException {
         String scroll = randomAsciiOfLength(30);
-        HttpEntity entity = scrollEntity(scroll);
+        HttpEntity entity = scrollEntity(scroll, Version.V_5_0_0);
         assertEquals(ContentType.APPLICATION_JSON.toString(), entity.getContentType().getValue());
         assertThat(Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)),
             containsString("\"" + scroll + "\""));
+
+        // Test with version < 2.0.0
+        entity = scrollEntity(scroll, Version.fromId(1070499));
+        assertEquals(ContentType.TEXT_PLAIN.toString(), entity.getContentType().getValue());
+        assertEquals(scroll, Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)));
     }
 }


### PR DESCRIPTION
Discussed in https://discuss.elastic.co/t/5-3-0-breaks--reindex/80388 and https://github.com/elastic/elasticsearch/pull/22931#issuecomment-290093349

This commit https://github.com/elastic/elasticsearch/commit/7520a107bee67099338813728147d2aee25ed240#diff-0c925d1f41390dd5d7dd09b6ff5d51d1 in master and v5.3 breaks `reindex from remote` when the source is on a version before 2.0.0. The `scroll_id` is always extracted from a plain text body in ES 1.7 (and before) and does not accept the JSON version that appears in 2.0.0.
This change checks the version of the remote cluster and builds the scroll_id in the body depending on the remote version.