### PR TITLE
[DOCS] Multi-cluster snapshots connected to the same repository

### DIFF
--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -16,6 +16,16 @@ a 2.x cluster and use <<reindex-from-remote,reindex-from-remote>> to rebuild
 the index in a 5.x cluster. This is as time consuming as restoring from
 archival copies of the original data.
 
+Note: If a repository is connected to a 2.x cluster, and you want to connect
+a 5.x cluster to the same repository, you will first have to set the 2.x repository
+to `readonly` mode (see below for details on `readonly` mode).  A 5.x cluster will
+update the repository to conform to 5.x specific formats, which will mean that any
+new snapshots written via the 2.x cluster will not be visible to the 5.x cluster.
+In fact, as a general rule, only one cluster should connect to the same repository
+location with write access; all other clusters connected to the same repository
+should be set to `readonly` mode.
+
+
 [float]
 === Repositories
 

--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -17,13 +17,16 @@ the index in a 5.x cluster. This is as time consuming as restoring from
 archival copies of the original data.
 
 Note: If a repository is connected to a 2.x cluster, and you want to connect
-a 5.x cluster to the same repository, you will first have to set the 2.x repository
-to `readonly` mode (see below for details on `readonly` mode).  A 5.x cluster will
-update the repository to conform to 5.x specific formats, which will mean that any
-new snapshots written via the 2.x cluster will not be visible to the 5.x cluster.
+a 5.x cluster to the same repository, you will have to either first set the 2.x 
+repository to `readonly` mode (see below for details on `readonly` mode) or create
+the 5.x repository in `readonly` mode.  A 5.x cluster will update the repository 
+to conform to 5.x specific formats, which will mean that any new snapshots written 
+via the 2.x cluster will not be visible to the 5.x cluster, and vice versa.  
 In fact, as a general rule, only one cluster should connect to the same repository
 location with write access; all other clusters connected to the same repository
-should be set to `readonly` mode.
+should be set to `readonly` mode.  While setting all but one repositories to 
+`readonly` should work with multiple clusters differing by one major version, 
+it is not a supported configuration.
 
 
 [float]


### PR DESCRIPTION
This commit adds information about connecting the same repository to clusters of different versions, namely 2.x and 5.x clusters, which is only supported if the 2.x clusters create the repository in `readonly` mode.