### PR TITLE
Added quotes around %JAVA% usages to handle spaces in path

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -8,16 +8,16 @@ IF DEFINED JAVA_HOME (
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )
-IF NOT EXIST %JAVA% (
+IF NOT EXIST "%JAVA%" (
   ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
   EXIT /B 1
 )
 IF DEFINED JAVA_HOME GOTO :cont
 
-IF NOT %JAVA:~-13% == "\bin\java.exe" (
-  FOR /f "tokens=2 delims=[]" %%I IN ('dir %JAVA%') DO @set JAVA=%%I
+IF NOT "%JAVA:~-13%" == "\bin\java.exe" (
+  FOR /f "tokens=2 delims=[]" %%I IN ('dir "%JAVA%"') DO @set JAVA=%%I
 )
-IF %JAVA:~-13% == "\bin\java.exe" (
+IF "%JAVA:~-13%" == "\bin\java.exe" (
   SET JAVA_HOME=%JAVA:~0,-13%
 )
 
@@ -27,14 +27,14 @@ if not "%CONF_FILE%" == "" goto conffileset
 set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
-%JAVA% -Xmx50M -version > nul 2>&1
+"%JAVA%" -Xmx50M -version > nul 2>&1
 
 if errorlevel 1 (
 	echo Warning: Could not start JVM to detect version, defaulting to x86:
 	goto x86
 )
 
-%JAVA% -Xmx50M -version 2>&1 | "%windir%\System32\find" "64-Bit" >nul:
+"%JAVA%" -Xmx50M -version 2>&1 | "%windir%\System32\find" "64-Bit" >nul:
 
 if errorlevel 1 goto x86
 set EXECUTABLE=%ES_HOME%\bin\elasticsearch-service-x64.exe

--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -54,6 +54,6 @@ IF ERRORLEVEL 1 (
 	EXIT /B %ERRORLEVEL%
 )
 
-%JAVA% %ES_JAVA_OPTS% %ES_PARAMS% -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch" !newparams!
+"%JAVA%" %ES_JAVA_OPTS% %ES_PARAMS% -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch" !newparams!
 
 ENDLOCAL

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -5,7 +5,7 @@ IF DEFINED JAVA_HOME (
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )
-IF NOT EXIST %JAVA% (
+IF NOT EXIST "%JAVA%" (
   ECHO Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME 1>&2
   EXIT /B 1
 )
@@ -23,7 +23,7 @@ ECHO added to the main classpath, add jars to lib\, unsupported 1>&2
 EXIT /B 1
 )
 
-%JAVA% -cp "%ES_CLASSPATH%" "org.elasticsearch.tools.JavaVersionChecker"
+"%JAVA%" -cp "%ES_CLASSPATH%" "org.elasticsearch.tools.JavaVersionChecker"
 
 IF ERRORLEVEL 1 (
     ECHO Elasticsearch requires at least Java 8 but your Java version from %JAVA% does not meet this requirement

--- a/distribution/src/main/resources/bin/elasticsearch.in.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.in.bat
@@ -1,7 +1,7 @@
 @echo off
 
 IF DEFINED JAVA_HOME (
-  set JAVA="%JAVA_HOME%\bin\java.exe"
+  set JAVA=%JAVA_HOME%\bin\java.exe
 ) ELSE (
   FOR %%I IN (java.exe) DO set JAVA=%%~$PATH:I
 )


### PR DESCRIPTION
If the java installation path on windows contains spaces (e.g. `c:\Program Files`) and `%JAVA_HOME%` isn't set the batch scripts for startup will fail, because file tests and starting java use only the part before the first space instead of the whole path. I added double quotes around all occurrences of `%JAVA%` where quotes are necessary to handle spaces.