### PR TITLE
Only re-parse operation if a mapping update was needed

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/MappingUpdatePerformer.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/MappingUpdatePerformer.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.bulk;
 
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -29,13 +30,9 @@ import java.util.Objects;
 public interface MappingUpdatePerformer {
 
     /**
-     * Determine if any mappings need to be updated, and update them on the master node if
-     * necessary. Returnes a failure Exception in the event updating the mappings fails or null if
-     * successful.
+     * Update the mappings on the master.
      */
-    void updateMappingsIfNeeded(Engine.Index operation,
-                                ShardId shardId,
-                                String type) throws Exception;
+    void updateMappings(Mapping update, ShardId shardId, String type) throws Exception;
 
     /**
      *  Throws a {@code ReplicationOperation.RetryOnPrimaryException} if the operation needs to be

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperTests.java
@@ -49,7 +49,7 @@ public class MapperTests extends ESTestCase {
         XContentBuilder mapping = createMappingWithIncludeInAll();
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
 
-        final MapperService currentMapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), settings);
+        final MapperService currentMapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), settings, "test");
         Exception e = expectThrows(MapperParsingException.class, () ->
                 currentMapperService.parse("type", new CompressedXContent(mapping.string()), true));
         assertEquals("[include_in_all] is not allowed for indices created on or after version 6.0.0 as [_all] is deprecated. " +
@@ -59,7 +59,7 @@ public class MapperTests extends ESTestCase {
         settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_5_3_0_UNRELEASED).build();
 
         // Create the mapping service with an older index creation version
-        final MapperService oldMapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), settings);
+        final MapperService oldMapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), settings, "test");
         // Should not throw an exception now
         oldMapperService.parse("type", new CompressedXContent(mapping.string()), true);
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldCopyToMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldCopyToMapperTests.java
@@ -37,7 +37,7 @@ public class MultiFieldCopyToMapperTests extends ESTestCase {
         XContentBuilder mapping = createMappinmgWithCopyToInMultiField();
 
         // first check that for newer versions we throw exception if copy_to is found withing multi field
-        MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), Settings.EMPTY);
+        MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), Settings.EMPTY, "test");
         try {
             mapperService.parse("type", new CompressedXContent(mapping.string()), true);
             fail("Parsing should throw an exception because the mapping contains a copy_to in a multi field");

--- a/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldIncludeInAllMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldIncludeInAllMapperTests.java
@@ -34,7 +34,7 @@ public class MultiFieldIncludeInAllMapperTests extends ESTestCase {
         XContentBuilder mapping = createMappingWithIncludeInAllInMultiField();
 
         // first check that for newer versions we throw exception if include_in_all is found withing multi field
-        MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), Settings.EMPTY);
+        MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), Settings.EMPTY, "test");
         Exception e = expectThrows(MapperParsingException.class, () ->
             mapperService.parse("type", new CompressedXContent(mapping.string()), true));
         assertEquals("include_in_all in multi fields is not allowed. Found the include_in_all in field [c] which is within a multi field.",

--- a/test/framework/src/main/java/org/elasticsearch/index/MapperTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/MapperTestUtils.java
@@ -40,14 +40,16 @@ import static org.elasticsearch.test.ESTestCase.createTestAnalysis;
 
 public class MapperTestUtils {
 
-    public static MapperService newMapperService(NamedXContentRegistry xContentRegistry, Path tempDir, Settings indexSettings)
-            throws IOException {
+    public static MapperService newMapperService(NamedXContentRegistry xContentRegistry,
+                                                 Path tempDir,
+                                                 Settings indexSettings,
+                                                 String indexName) throws IOException {
         IndicesModule indicesModule = new IndicesModule(Collections.emptyList());
-        return newMapperService(xContentRegistry, tempDir, indexSettings, indicesModule);
+        return newMapperService(xContentRegistry, tempDir, indexSettings, indicesModule, indexName);
     }
 
     public static MapperService newMapperService(NamedXContentRegistry xContentRegistry, Path tempDir, Settings settings,
-            IndicesModule indicesModule) throws IOException {
+                                                 IndicesModule indicesModule, String indexName) throws IOException {
         Settings.Builder settingsBuilder = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
             .put(settings);
@@ -56,7 +58,7 @@ public class MapperTestUtils {
         }
         Settings finalSettings = settingsBuilder.build();
         MapperRegistry mapperRegistry = indicesModule.getMapperRegistry();
-        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("test", finalSettings);
+        IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(indexName, finalSettings);
         IndexAnalyzers indexAnalyzers = createTestAnalysis(indexSettings, finalSettings).indexAnalyzers;
         SimilarityService similarityService = new SimilarityService(indexSettings, Collections.emptyMap());
         return new MapperService(indexSettings,

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -268,7 +268,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
         try {
             IndexCache indexCache = new IndexCache(indexSettings, new DisabledQueryCache(indexSettings), null);
             MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(),
-                    indexSettings.getSettings());
+                    indexSettings.getSettings(), "index");
             mapperService.merge(indexMetaData, MapperService.MergeReason.MAPPING_RECOVERY, true);
             SimilarityService similarityService = new SimilarityService(indexSettings, Collections.emptyMap());
             final IndexEventListener indexEventListener = new IndexEventListener() {


### PR DESCRIPTION
When executing an index operation on the primary shard,
`TransportShardBulkAction` first parses the document, sees if there are any
mapping updates that needs to be applied, and then updates the mapping on the
master node. It then re-parses the document to make sure that the mappings have
been applied and propagated.

This adds a check that skips the second parsing of the document in the event
there was not a mapping update applied in the first case.

Fixes a performance regression introduced in #23665