### PR TITLE
Fixes snapshot status on failed snapshots

### DIFF
--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -60,7 +60,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.snapshots.IndexShardRestoreFailedException;
 import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -71,7 +70,6 @@ import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
-import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -581,7 +579,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         shardSnapshotStatus.failure(shardFailure.reason());
                         shardStatus.put(shardId, shardSnapshotStatus);
                     } else {
-                        IndexShardSnapshotStatus shardSnapshotStatus;
+                        final IndexShardSnapshotStatus shardSnapshotStatus;
                         if (snapshotInfo.state() == SnapshotState.FAILED) {
                             // If the snapshot failed, but the shard's snapshot does
                             // not have an exception, it means that partial snapshots
@@ -592,10 +590,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                             // could not be taken due to partial being set to false.
                             shardSnapshotStatus = new IndexShardSnapshotStatus();
                             shardSnapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.FAILURE);
-                            String msg = "snapshot not taken because partial snapshots are not " +
-                                         "configured for this snapshot and another shard caused " +
-                                         "the snapshot to fail";
-                            shardSnapshotStatus.failure(msg);
+                            shardSnapshotStatus.failure("skipped");
                         } else {
                             shardSnapshotStatus = repository.getShardSnapshotStatus(
                                 snapshotInfo.snapshotId(),

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -2802,10 +2802,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         for (SnapshotIndexShardStatus shardStatus : snapshotStatus.getShards()) {
             assertEquals(SnapshotIndexShardStage.FAILURE, shardStatus.getStage());
             if (shardStatus.getIndex().equals("test-idx-good")) {
-                String msg = "snapshot not taken because partial snapshots are not " +
-                             "configured for this snapshot and another shard caused the " +
-                             "snapshot to fail";
-                assertEquals(msg, shardStatus.getFailure());
+                assertEquals("skipped", shardStatus.getFailure());
             } else {
                 assertEquals("primary shard is not allocated", shardStatus.getFailure());
             }


### PR DESCRIPTION
If a snapshot is taken on multiple indices, and some of them are "good"
indices that don't contain any corruption or failures, and some of them
are "bad" indices that contain missing shards or corrupted shards, and
if the snapshot request is set to partial=false (meaning don't take a
snapshot if there are any failures), then the good indices will not be
snapshotted either.  Previously, when getting the status of such a
snapshot, a 500 error would be thrown, because the snap-*.dat blob for
the shards in the good index could not be found.

This commit fixes the problem by reporting shards of good indices as
failed due to a failed snapshot, instead of throwing the
NoSuchFileException.

Closes #23716