### PR TITLE
Validate top-level keys for create index request 

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -383,6 +383,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     @SuppressWarnings("unchecked")
     public CreateIndexRequest source(Map<String, ?> source) {
         boolean found = false;
+        String unsupportedKey = null;
         for (Map.Entry<String, ?> entry : source.entrySet()) {
             String name = entry.getKey();
             if (name.equals("settings")) {
@@ -407,12 +408,22 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
                     } catch (IOException e) {
                         throw new ElasticsearchParseException("failed to parse custom metadata for [{}]", name);
                     }
+                } else {
+                    // found a key which is neither custom defined nor one of the supported ones
+                    if (unsupportedKey == null) {
+                        unsupportedKey = name;
+                    }
                 }
             }
-        }
+        }   
         if (!found) {
             // the top level are settings, use them
             settings(source);
+        }
+        if (found && unsupportedKey != null) {
+            throw new ElasticsearchParseException(
+                    "unknown key [{}] for a [{}], expected [settings], [mappings] or [aliases]",
+                    unsupportedKey, XContentParser.Token.START_OBJECT);
         }
         return this;
     }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.create;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -29,6 +30,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Base64;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class CreateIndexRequestTests extends ESTestCase {
 
@@ -68,5 +71,30 @@ public class CreateIndexRequestTests extends ESTestCase {
                 assertArrayEquals(data, out.bytes().toBytesRef().bytes);
             }
         }
+    }
+    
+    public void testTopLevelKeys() throws IOException {
+        String createIndexString =
+                "{\n"
+                + "  \"FOO_SHOULD_BE_ILLEGAL_HERE\": {\n"
+                + "    \"BAR_IS_THE_SAME\": 42\n"
+                + "  },\n"
+                + "  \"mappings\": {\n"
+                + "    \"test\": {\n"
+                + "      \"properties\": {\n"
+                + "        \"field1\": {\n"
+                + "          \"type\": \"text\"\n"
+                + "       }\n"
+                + "     }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+        CreateIndexRequest request = new CreateIndexRequest();
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, 
+                () -> {request.source(createIndexString.getBytes(), XContentType.JSON);});
+        assertThat(e.toString(), containsString(
+                "unknown key [FOO_SHOULD_BE_ILLEGAL_HERE] for a [START_OBJECT], "
+                + "expected [settings], [mappings] or [aliases]"));
     }
 }


### PR DESCRIPTION
Create index accepts only `settings`, `mappings` or `aliases` as top-level keys.

Closes #23755