### PR TITLE
Synchronized CollapseTopFieldDocs with lucenes relatives

### DIFF
--- a/core/src/main/java/org/apache/lucene/search/grouping/CollapseTopFieldDocs.java
+++ b/core/src/main/java/org/apache/lucene/search/grouping/CollapseTopFieldDocs.java
@@ -90,7 +90,7 @@ public final class CollapseTopFieldDocs extends TopFieldDocs {
         final int firstShardIndex = first.getShardIndex(firstDoc);
         final int secondShardIndex = second.getShardIndex(secondDoc);
         // Tie break: earlier shard wins
-        if (firstShardIndex< secondShardIndex) {
+        if (firstShardIndex < secondShardIndex) {
             return true;
         } else if (firstShardIndex > secondShardIndex) {
             return false;

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -234,7 +234,7 @@ public final class SearchPhaseController extends AbstractComponent {
             final CollapseTopFieldDocs[] shardTopDocs = new CollapseTopFieldDocs[numShards];
             fillTopDocs(shardTopDocs, results, new CollapseTopFieldDocs(firstTopDocs.field, 0, new FieldDoc[0],
                 sort.getSort(), new Object[0], Float.NaN));
-            mergedTopDocs = CollapseTopFieldDocs.merge(sort, from, topN, shardTopDocs);
+            mergedTopDocs = CollapseTopFieldDocs.merge(sort, from, topN, shardTopDocs, true);
         } else if (result.queryResult().topDocs() instanceof TopFieldDocs) {
             TopFieldDocs firstTopDocs = (TopFieldDocs) result.queryResult().topDocs();
             final Sort sort = new Sort(firstTopDocs.fields);

--- a/core/src/test/java/org/apache/lucene/grouping/CollapsingTopDocsCollectorTests.java
+++ b/core/src/test/java/org/apache/lucene/grouping/CollapsingTopDocsCollectorTests.java
@@ -198,7 +198,7 @@ public class CollapsingTopDocsCollectorTests extends ESTestCase {
             subSearcher.search(weight, c);
             shardHits[shardIDX] = c.getTopDocs();
         }
-        CollapseTopFieldDocs mergedFieldDocs = CollapseTopFieldDocs.merge(sort, 0, expectedNumGroups, shardHits);
+        CollapseTopFieldDocs mergedFieldDocs = CollapseTopFieldDocs.merge(sort, 0, expectedNumGroups, shardHits, true);
         assertTopDocsEquals(mergedFieldDocs, collapseTopFieldDocs);
         w.close();
         reader.close();


### PR DESCRIPTION
TopDocs et.al. got additional parameters to incrementally reduce
top docs. In order to add incremental reduction `CollapseTopFieldDocs`
needs to have the same properties.
