### PR TITLE
Fix FieldCapabilities compilation in Eclipse

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -227,7 +227,7 @@ public class FieldCapabilities implements Writeable, ToXContent {
 
         FieldCapabilities build(boolean withIndices) {
             final String[] indices;
-            Collections.sort(indiceList, Comparator.comparing(o -> o.name));
+            Collections.sort(indiceList, Comparator.comparing((IndexCaps o) -> o.name));
             if (withIndices) {
                 indices = indiceList.stream()
                     .map(caps -> caps.name)

--- a/core/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -227,6 +227,8 @@ public class FieldCapabilities implements Writeable, ToXContent {
 
         FieldCapabilities build(boolean withIndices) {
             final String[] indices;
+            /* Eclipse can't deal with o -> o.name, maybe because of
+             * https://bugs.eclipse.org/bugs/show_bug.cgi?id=511750 */
             Collections.sort(indiceList, Comparator.comparing((IndexCaps o) -> o.name));
             if (withIndices) {
                 indices = indiceList.stream()


### PR DESCRIPTION
Eclipse can't deal with the generics, maybe the fixed but
unreleased https://bugs.eclipse.org/bugs/show_bug.cgi?id=511750
