### PR TITLE
Validate top-level keys for create index request 5.x deprecation (#23755)

### DIFF
--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilderTests.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class CreateIndexRequestBuilderTests extends ESTestCase {
@@ -60,17 +61,27 @@ public class CreateIndexRequestBuilderTests extends ESTestCase {
         CreateIndexRequestBuilder builder = new CreateIndexRequestBuilder(this.testClient, CreateIndexAction.INSTANCE);
         builder.setSource("{\""+KEY+"\" : \""+VALUE+"\"}", XContentType.JSON);
         assertEquals(VALUE, builder.request().settings().get(KEY));
+        assertWarnings(String.format(Locale.ROOT,
+                "Implicit parsing of [%s] as [settings] is deprecated: "
+                + "instead use \"settings\": { \"%s\": ... }", KEY, KEY));
 
         XContentBuilder xContent = XContentFactory.jsonBuilder().startObject().field(KEY, VALUE).endObject();
         xContent.close();
         builder.setSource(xContent);
         assertEquals(VALUE, builder.request().settings().get(KEY));
+        assertWarnings(String.format(Locale.ROOT,
+                "Implicit parsing of [%s] as [settings] is deprecated: "
+                + "instead use \"settings\": { \"%s\": ... }", KEY, KEY));
 
         ByteArrayOutputStream docOut = new ByteArrayOutputStream();
         XContentBuilder doc = XContentFactory.jsonBuilder(docOut).startObject().field(KEY, VALUE).endObject();
         doc.close();
         builder.setSource(docOut.toByteArray(), XContentType.JSON);
         assertEquals(VALUE, builder.request().settings().get(KEY));
+        assertWarnings(String.format(Locale.ROOT, 
+                "Implicit parsing of [%s] as [settings] is deprecated: "
+                + "instead use \"settings\": { \"%s\": ... }", KEY, KEY));
+
 
         Map<String, String> settingsMap = new HashMap<>();
         settingsMap.put(KEY, VALUE);

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.create;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -29,6 +30,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.Base64;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class CreateIndexRequestTests extends ESTestCase {
 
@@ -68,5 +71,30 @@ public class CreateIndexRequestTests extends ESTestCase {
                 assertArrayEquals(data, out.bytes().toBytesRef().bytes);
             }
         }
+    }
+    
+    public void testTopLevelKeys() throws IOException {
+        String createIndexString =
+                "{\n"
+                + "  \"FOO_SHOULD_BE_ILLEGAL_HERE\": {\n"
+                + "    \"BAR_IS_THE_SAME\": 42\n"
+                + "  },\n"
+                + "  \"mappings\": {\n"
+                + "    \"test\": {\n"
+                + "      \"properties\": {\n"
+                + "        \"field1\": {\n"
+                + "          \"type\": \"text\"\n"
+                + "       }\n"
+                + "     }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+        CreateIndexRequest request = new CreateIndexRequest();
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, 
+                () -> {request.source(createIndexString, XContentType.JSON);});
+        assertThat(e.toString(), containsString(
+                "unknown key [FOO_SHOULD_BE_ILLEGAL_HERE] for a [START_OBJECT], "
+                + "expected [settings], [mappings] or [aliases]"));
     }
 }

--- a/docs/reference/analysis/tokenfilters/compound-word-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/compound-word-tokenfilter.asciidoc
@@ -86,25 +86,27 @@ Here is an example:
 --------------------------------------------------
 PUT /compound_word_example
 {
-    "index": {
-        "analysis": {
-            "analyzer": {
-                "my_analyzer": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": ["dictionary_decompounder", "hyphenation_decompounder"]
-                }
-            },
-            "filter": {
-                "dictionary_decompounder": {
-                    "type": "dictionary_decompounder",
-                    "word_list": ["one", "two", "three"]
+    "settings" : {
+        "index": {
+            "analysis": {
+                "analyzer": {
+                    "my_analyzer": {
+                        "type": "custom",
+                        "tokenizer": "standard",
+                        "filter": ["dictionary_decompounder", "hyphenation_decompounder"]
+                    }
                 },
-                "hyphenation_decompounder": {
-                    "type" : "hyphenation_decompounder",
-                    "word_list_path": "analysis/example_word_list.txt",
-                    "hyphenation_patterns_path": "analysis/hyphenation_patterns.xml",
-                    "max_subword_size": 22
+                "filter": {
+                    "dictionary_decompounder": {
+                        "type": "dictionary_decompounder",
+                        "word_list": ["one", "two", "three"]
+                    },
+                    "hyphenation_decompounder": {
+                        "type" : "hyphenation_decompounder",
+                        "word_list_path": "analysis/example_word_list.txt",
+                        "hyphenation_patterns_path": "analysis/hyphenation_patterns.xml",
+                        "max_subword_size": 22
+                    }
                 }
             }
         }

--- a/plugins/store-smb/src/test/resources/rest-api-spec/test/store_smb/15_index_creation.yaml
+++ b/plugins/store-smb/src/test/resources/rest-api-spec/test/store_smb/15_index_creation.yaml
@@ -3,8 +3,9 @@
       indices.create:
         index: smb-test
         body:
-          index:
-            store.type: smb_mmap_fs
+          settings:
+            index:
+              store.type: smb_mmap_fs
 
   - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.allocation_explain/10_basic.yaml
@@ -42,7 +42,8 @@
   - do:
       indices.create:
         index: test
-        body: { "index.number_of_shards": 1, "index.number_of_replicas": 9 }
+        body:
+          settings : { "index.number_of_shards": 1, "index.number_of_replicas": 9 }
 
   - do:
       cluster.state:


### PR DESCRIPTION
Create index accepts only `settings`, `mappings` or `aliases` as top-level keys.

The behavior of the create index request is that iff none of the supported keys are found (`settings`, `mappings`, `aliases`) then the top level elements are treated as settings.

In other words
```
PUT test 
{ 
  "index.number_of_shards" : 3 
}
```
would actually create the index `test` with 3 shards. This behavior is preserved with this PR.

The implicit parsing of any keys other than the supported ones as `settings` is deprecated for 5.x and should be removed in the next major version (please refer to https://github.com/elastic/elasticsearch/pull/23846#discussion_r109138114)

However now 
```
PUT test
{
	"FOO_SHOULD_BE_ILLEGAL_HERE": {
		"BAR_IS_THE_SAME": 42
	},
	"mappings": {
		"test": {
			"properties": {
				"field1": {
					"type": "text"
				}
			}
		}
	}
} 
```
will throw an exception as there is a `mapping` defined.

Addresses #23755 
