### PR TITLE
Fix bulk queue_size and size in thread pool document

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -32,7 +32,7 @@ There are several thread pools, but the important ones include:
 `bulk`::
     For bulk operations. Thread pool type is `fixed`
     with a size of `# of available processors`,
-    queue_size of `50`.  The maximum size for this pool
+    queue_size of `200`.  The maximum size for this pool
     is `1 + # of available processors`.
 
 `snapshot`::
@@ -75,7 +75,7 @@ requests with a queue (optionally bounded) for pending requests that
 have no threads to service them.
 
 The `size` parameter controls the number of threads, and defaults to the
-number of cores times 5.
+number of cores.
 
 The `queue_size` allows to control the size of the queue of pending
 requests that have no threads to execute them. By default, it is set to

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -75,7 +75,7 @@ requests with a queue (optionally bounded) for pending requests that
 have no threads to service them.
 
 The `size` parameter controls the number of threads, and defaults to the
-number of cores.
+number of cores times 5.
 
 The `queue_size` allows to control the size of the queue of pending
 requests that have no threads to execute them. By default, it is set to


### PR DESCRIPTION
I check source code https://github.com/elastic/elasticsearch/blob/v5.3.0/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java#L172

I conclude current document contains bugs.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
