### PR TITLE
Add a property to mark setting as final

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -183,7 +183,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContent {
             throw new IllegalArgumentException("es.index.max_number_of_shards must be > 0");
         }
         return Setting.intSetting(SETTING_NUMBER_OF_SHARDS, Math.min(5, maxNumShards), 1, maxNumShards,
-            Property.IndexScope);
+            Property.IndexScope, Property.Final);
     }
 
     public static final String INDEX_SETTING_PREFIX = "index.";

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -165,10 +165,6 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
         indexScopedSettings.validate(normalizedSettings);
         // never allow to change the number of shards
         for (Map.Entry<String, String> entry : normalizedSettings.getAsMap().entrySet()) {
-            if (entry.getKey().equals(IndexMetaData.SETTING_NUMBER_OF_SHARDS)) {
-                listener.onFailure(new IllegalArgumentException("can't change the number of shards for an index"));
-                return;
-            }
             Setting setting = indexScopedSettings.get(entry.getKey());
             assert setting != null; // we already validated the normalized settings
             settingsForClosedIndices.put(entry.getKey(), entry.getValue());

--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -35,8 +35,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -382,7 +380,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
     /**
      * Returns <code>true</code> if the setting for the given key is dynamically updateable. Otherwise <code>false</code>.
      */
-    public boolean hasDynamicSetting(String key) {
+    public boolean isDynamicSetting(String key) {
         final Setting<?> setting = get(key);
         return setting != null && setting.isDynamic();
     }
@@ -390,7 +388,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
     /**
      * Returns <code>true</code> if the setting for the given key is final. Otherwise <code>false</code>.
      */
-    public boolean hasFinalSetting(String key) {
+    public boolean isFinalSetting(String key) {
         final Setting<?> setting = get(key);
         return setting != null && setting.isFinal();
     }
@@ -474,11 +472,11 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
         final Set<String> toRemove = new HashSet<>();
         Settings.Builder settingsBuilder = Settings.builder();
         final Predicate<String> canUpdate = (key) -> (
-            hasFinalSetting(key) == false && // it's not a final setting
-                ((onlyDynamic == false && get(key) != null) || hasDynamicSetting(key)));
+            isFinalSetting(key) == false && // it's not a final setting
+                ((onlyDynamic == false && get(key) != null) || isDynamicSetting(key)));
         final Predicate<String> canRemove = (key) ->(// we can delete if
-            hasFinalSetting(key) == false && // it's not a final setting
-                (onlyDynamic && hasDynamicSetting(key)  // it's a dynamicSetting and we only do dynamic settings
+            isFinalSetting(key) == false && // it's not a final setting
+                (onlyDynamic && isDynamicSetting(key)  // it's a dynamicSetting and we only do dynamic settings
                 || get(key) == null && key.startsWith(ARCHIVED_SETTINGS_PREFIX) // the setting is not registered AND it's been archived
                 || (onlyDynamic == false && get(key) != null))); // if it's not dynamic AND we have a key
         for (Map.Entry<String, String> entry : toApply.getAsMap().entrySet()) {
@@ -493,7 +491,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
                 updates.put(entry.getKey(), entry.getValue());
                 changed = true;
             } else {
-                if (hasFinalSetting(entry.getKey())) {
+                if (isFinalSetting(entry.getKey())) {
                     throw new IllegalArgumentException("final " + type + " setting [" + entry.getKey() + "], not updateable");
                 } else {
                     throw new IllegalArgumentException(type + " setting [" + entry.getKey() + "], not dynamically updateable");

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -96,7 +96,8 @@ public class Setting<T> extends ToXContentToBytes {
         Dynamic,
 
         /**
-         * mark this setting as final (the value cannot be updated)
+         * mark this setting as final, not updateable even when the context is not dynamic
+         * ie. Setting this property on an index scoped setting will fail update when the index is closed
          */
         Final,
 

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -96,6 +96,11 @@ public class Setting<T> extends ToXContentToBytes {
         Dynamic,
 
         /**
+         * mark this setting as final (the value cannot be updated)
+         */
+        Final,
+
+        /**
          * mark this setting as deprecated
          */
         Deprecated,
@@ -135,6 +140,9 @@ public class Setting<T> extends ToXContentToBytes {
             this.properties = EMPTY_PROPERTIES;
         } else {
             this.properties = EnumSet.copyOf(Arrays.asList(properties));
+            if (isDynamic() && isFinal()) {
+                throw new IllegalArgumentException("final setting [" + key + "] cannot be dynamic");
+            }
         }
     }
 
@@ -216,6 +224,13 @@ public class Setting<T> extends ToXContentToBytes {
      */
     public final boolean isDynamic() {
         return properties.contains(Property.Dynamic);
+    }
+
+    /**
+     * Returns <code>true</code> if this setting is final, otherwise <code>false</code>
+     */
+    public final boolean isFinal() {
+        return properties.contains(Property.Final);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
@@ -92,7 +92,7 @@ public class ClusterModuleTests extends ModuleTestCase {
     public void testRegisterClusterDynamicSetting() {
         SettingsModule module = new SettingsModule(Settings.EMPTY,
             Setting.boolSetting("foo.bar", false, Property.Dynamic, Property.NodeScope));
-        assertInstanceBinding(module, ClusterSettings.class, service -> service.hasDynamicSetting("foo.bar"));
+        assertInstanceBinding(module, ClusterSettings.class, service -> service.isDynamicSetting("foo.bar"));
     }
 
     public void testRegisterIndexDynamicSettingDuplicate() {
@@ -107,7 +107,7 @@ public class ClusterModuleTests extends ModuleTestCase {
     public void testRegisterIndexDynamicSetting() {
         SettingsModule module = new SettingsModule(Settings.EMPTY,
             Setting.boolSetting("index.foo.bar", false, Property.Dynamic, Property.IndexScope));
-        assertInstanceBinding(module, IndexScopedSettings.class, service -> service.hasDynamicSetting("index.foo.bar"));
+        assertInstanceBinding(module, IndexScopedSettings.class, service -> service.isDynamicSetting("index.foo.bar"));
     }
 
     public void testRegisterAllocationDeciderDuplicate() {

--- a/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -252,13 +252,13 @@ public class ScopedSettingsTests extends ESTestCase {
             new ClusterSettings(Settings.EMPTY,
                 new HashSet<>(Arrays.asList(Setting.intSetting("foo.bar", 1, Property.Dynamic, Property.NodeScope),
                     Setting.intSetting("foo.bar.baz", 1, Property.NodeScope))));
-        assertFalse(settings.hasDynamicSetting("foo.bar.baz"));
-        assertTrue(settings.hasDynamicSetting("foo.bar"));
+        assertFalse(settings.isDynamicSetting("foo.bar.baz"));
+        assertTrue(settings.isDynamicSetting("foo.bar"));
         assertNotNull(settings.get("foo.bar.baz"));
         settings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        assertTrue(settings.hasDynamicSetting("transport.tracer.include." + randomIntBetween(1, 100)));
-        assertFalse(settings.hasDynamicSetting("transport.tracer.include.BOOM"));
-        assertTrue(settings.hasDynamicSetting("cluster.routing.allocation.require.value"));
+        assertTrue(settings.isDynamicSetting("transport.tracer.include." + randomIntBetween(1, 100)));
+        assertFalse(settings.isDynamicSetting("transport.tracer.include.BOOM"));
+        assertTrue(settings.isDynamicSetting("cluster.routing.allocation.require.value"));
     }
 
     public void testIsFinal() {
@@ -269,15 +269,15 @@ public class ScopedSettingsTests extends ESTestCase {
                     Setting.groupSetting("foo.list.",  Property.Final, Property.NodeScope),
                     Setting.intSetting("foo.int.baz", 1, Property.NodeScope))));
 
-        assertFalse(settings.hasFinalSetting("foo.int.baz"));
-        assertTrue(settings.hasFinalSetting("foo.int"));
+        assertFalse(settings.isFinalSetting("foo.int.baz"));
+        assertTrue(settings.isFinalSetting("foo.int"));
 
-        assertFalse(settings.hasFinalSetting("foo.list"));
-        assertTrue(settings.hasFinalSetting("foo.list.0.key"));
-        assertTrue(settings.hasFinalSetting("foo.list.key"));
+        assertFalse(settings.isFinalSetting("foo.list"));
+        assertTrue(settings.isFinalSetting("foo.list.0.key"));
+        assertTrue(settings.isFinalSetting("foo.list.key"));
 
-        assertFalse(settings.hasFinalSetting("foo.group"));
-        assertTrue(settings.hasFinalSetting("foo.group.key"));
+        assertFalse(settings.isFinalSetting("foo.group"));
+        assertTrue(settings.isFinalSetting("foo.group.key"));
     }
 
     public void testDiff() throws IOException {

--- a/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IllegalFormatCodePointException;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -600,6 +599,16 @@ public class ScopedSettingsTests extends ESTestCase {
                 assertEquals("complex setting key: [foo.] overlaps existing setting key: [foo.bar]", e.getMessage());
             }
         }
+    }
+
+    public void testUpdateNumberOfShardsFail() {
+        IndexScopedSettings settings = new IndexScopedSettings(Settings.EMPTY,
+            IndexScopedSettings.BUILT_IN_INDEX_SETTINGS);
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
+            () -> settings.updateSettings(Settings.builder().put("index.number_of_shards", 8).build(),
+                Settings.builder(), Settings.builder(), "index"));
+        assertThat(ex.getMessage(),
+            containsString("final index setting [index.number_of_shards], not updateable"));
     }
 
     public void testFinalSettingUpdateFail() {

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -552,12 +552,15 @@ public class SettingTests extends ESTestCase {
      * We can't have Null properties
      */
     public void testRejectNullProperties() {
-        try {
-            Setting.simpleString("foo.bar", (Property[]) null);
-            fail();
-        } catch (IllegalArgumentException ex) {
-            assertThat(ex.getMessage(), containsString("properties cannot be null for setting"));
-        }
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
+            () -> Setting.simpleString("foo.bar", (Property[]) null));
+        assertThat(ex.getMessage(), containsString("properties cannot be null for setting"));
+    }
+
+    public void testRejectConflictProperties() {
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
+            () -> Setting.simpleString("foo.bar", Property.Final, Property.Dynamic));
+        assertThat(ex.getMessage(), containsString("final setting [foo.bar] cannot be dynamic"));
     }
 
     public void testTimeValue() {

--- a/core/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -44,6 +44,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_READ_ONLY
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBlocked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThrows;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -66,7 +67,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(DummySettingPlugin.class);
+        return Arrays.asList(DummySettingPlugin.class, FinalSettingPlugin.class);
     }
 
     public static class DummySettingPlugin extends Plugin {
@@ -83,6 +84,19 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         @Override
         public List<Setting<?>> getSettings() {
             return Collections.singletonList(DUMMY_SETTING);
+        }
+    }
+
+    public static class FinalSettingPlugin extends Plugin {
+        public static final Setting<String> FINAL_SETTING = Setting.simpleString("index.final",
+            Setting.Property.IndexScope, Setting.Property.Final);
+        @Override
+        public void onIndexModule(IndexModule indexModule) {
+        }
+
+        @Override
+        public List<Setting<?>> getSettings() {
+            return Collections.singletonList(FINAL_SETTING);
         }
     }
 
@@ -130,7 +144,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
     }
     public void testOpenCloseUpdateSettings() throws Exception {
         createIndex("test");
-        try {
+        expectThrows(IllegalArgumentException.class, () ->
             client()
                 .admin()
                 .indices()
@@ -139,20 +153,29 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                     .put("index.refresh_interval", -1) // this one can change
                     .put("index.fielddata.cache", "none")) // this one can't
                 .execute()
-                .actionGet();
-            fail();
-        } catch (IllegalArgumentException e) {
-            // all is well
-        }
-
+                .actionGet()
+        );
+        expectThrows(IllegalArgumentException.class, () ->
+            client()
+                .admin()
+                .indices()
+                .prepareUpdateSettings("test")
+                .setSettings(Settings.builder()
+                    .put("index.refresh_interval", -1) // this one can change
+                    .put("index.final", "no")) // this one can't
+                .execute()
+                .actionGet()
+        );
         IndexMetaData indexMetaData = client().admin().cluster().prepareState().execute().actionGet().getState().metaData().index("test");
         assertThat(indexMetaData.getSettings().get("index.refresh_interval"), nullValue());
         assertThat(indexMetaData.getSettings().get("index.fielddata.cache"), nullValue());
+        assertThat(indexMetaData.getSettings().get("index.final"), nullValue());
 
         // Now verify via dedicated get settings api:
         GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
         assertThat(getSettingsResponse.getSetting("test", "index.refresh_interval"), nullValue());
         assertThat(getSettingsResponse.getSetting("test", "index.fielddata.cache"), nullValue());
+        assertThat(getSettingsResponse.getSetting("test", "index.final"), nullValue());
 
         client()
             .admin()
@@ -210,10 +233,27 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         assertThat(indexMetaData.getSettings().get("index.refresh_interval"), equalTo("1s"));
         assertThat(indexMetaData.getSettings().get("index.fielddata.cache"), equalTo("none"));
 
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () ->
+            client()
+                .admin()
+                .indices()
+                .prepareUpdateSettings("test")
+                .setSettings(Settings.builder()
+                    .put("index.refresh_interval", -1) // this one can change
+                    .put("index.final", "no")) // this one really can't
+                .execute()
+                .actionGet()
+        );
+        assertThat(ex.getMessage(), containsString("final test setting [index.final], not updateable"));
+        indexMetaData = client().admin().cluster().prepareState().execute().actionGet().getState().metaData().index("test");
+        assertThat(indexMetaData.getSettings().get("index.refresh_interval"), equalTo("1s"));
+        assertThat(indexMetaData.getSettings().get("index.final"), nullValue());
+
+
         // Now verify via dedicated get settings api:
         getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
         assertThat(getSettingsResponse.getSetting("test", "index.refresh_interval"), equalTo("1s"));
-        assertThat(getSettingsResponse.getSetting("test", "index.fielddata.cache"), equalTo("none"));
+        assertThat(getSettingsResponse.getSetting("test", "index.final"), nullValue());
     }
 
     public void testEngineGCDeletesSetting() throws InterruptedException {


### PR DESCRIPTION
This change adds a setting property `Final` that sets the value of a setting as final.
Updating a `Final` setting is prohibited in any context, for instance an index setting
marked as final must be set at index creation and will refuse any update even if the index is closed.