### PR TITLE
Accept ingest simulate params as ints or strings

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -174,16 +174,24 @@ public class SimulatePipelineRequest extends ActionRequest {
     }
 
     private static List<IngestDocument> parseDocs(Map<String, Object> config) {
-        List<Map<String, Object>> docs = ConfigurationUtils.readList(null, null, config, Fields.DOCS);
+        List<Map<String, Object>> docs =
+            ConfigurationUtils.readList(null, null, config, Fields.DOCS);
         List<IngestDocument> ingestDocumentList = new ArrayList<>();
         for (Map<String, Object> dataMap : docs) {
-            Map<String, Object> document = ConfigurationUtils.readMap(null, null, dataMap, Fields.SOURCE);
-            IngestDocument ingestDocument = new IngestDocument(ConfigurationUtils.readStringProperty(null, null, dataMap, MetaData.INDEX.getFieldName(), "_index"),
-                    ConfigurationUtils.readStringProperty(null, null, dataMap, MetaData.TYPE.getFieldName(), "_type"),
-                    ConfigurationUtils.readStringProperty(null, null, dataMap, MetaData.ID.getFieldName(), "_id"),
-                    ConfigurationUtils.readOptionalStringProperty(null, null, dataMap, MetaData.ROUTING.getFieldName()),
-                    ConfigurationUtils.readOptionalStringProperty(null, null, dataMap, MetaData.PARENT.getFieldName()),
-                    document);
+            Map<String, Object> document = ConfigurationUtils.readMap(null, null,
+                dataMap, Fields.SOURCE);
+            String index = ConfigurationUtils.readStringOrIntProperty(null, null,
+                dataMap, MetaData.INDEX.getFieldName(), "_index");
+            String type = ConfigurationUtils.readStringOrIntProperty(null, null,
+                dataMap, MetaData.TYPE.getFieldName(), "_type");
+            String id = ConfigurationUtils.readStringOrIntProperty(null, null,
+                dataMap, MetaData.ID.getFieldName(), "_id");
+            String routing = ConfigurationUtils.readOptionalStringOrIntProperty(null, null,
+                dataMap, MetaData.ROUTING.getFieldName());
+            String parent = ConfigurationUtils.readOptionalStringOrIntProperty(null, null,
+                dataMap, MetaData.PARENT.getFieldName());
+            IngestDocument ingestDocument =
+                new IngestDocument(index, type, id, routing, parent, document);
             ingestDocumentList.add(ingestDocument);
         }
         return ingestDocumentList;

--- a/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -92,6 +92,52 @@ public final class ConfigurationUtils {
             value.getClass().getName() + "]");
     }
 
+    /**
+     * Returns and removes the specified property from the specified configuration map.
+     *
+     * If the property value isn't of type string or int a {@link ElasticsearchParseException} is thrown.
+     * If the property is missing and no default value has been specified a {@link ElasticsearchParseException} is thrown
+     */
+     public static String readStringOrIntProperty(String processorType, String processorTag,
+            Map<String, Object> configuration, String propertyName, String defaultValue) {
+        Object value = configuration.remove(propertyName);
+        if (value == null && defaultValue != null) {
+            return defaultValue;
+        } else if (value == null) {
+            throw newConfigurationException(processorType, processorTag, propertyName,
+                "required property is missing");
+        }
+        return readStringOrInt(processorType, processorTag, propertyName, value);
+    }
+
+    private static String readStringOrInt(String processorType, String processorTag,
+            String propertyName, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String) {
+            return (String) value;
+        } else if (value instanceof Integer) {
+            return String.valueOf(value);
+        }
+        throw newConfigurationException(processorType, processorTag, propertyName,
+            "property isn't a string or int, but of type [" + value.getClass().getName() + "]");
+    }
+
+    /**
+     * Returns and removes the specified property from the specified configuration map.
+     *
+     * If the property value isn't of type string or int a {@link ElasticsearchParseException} is thrown.
+     */
+    public static String readOptionalStringOrIntProperty(String processorType, String processorTag,
+            Map<String, Object> configuration, String propertyName) {
+        Object value = configuration.remove(propertyName);
+        if (value == null) {
+            return null;
+        }
+        return readStringOrInt(processorType, processorTag, propertyName, value);
+    }
+
     public static Boolean readBooleanProperty(String processorType, String processorTag, Map<String, Object> configuration,
                                              String propertyName, boolean defaultValue) {
         Object value = configuration.remove(propertyName);

--- a/core/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/ConfigurationUtilsTests.java
@@ -54,6 +54,7 @@ public class ConfigurationUtilsTests extends ESTestCase {
         Map<String, Object> fizz = new HashMap<>();
         fizz.put("buzz", "hello world");
         config.put("fizz", fizz);
+        config.put("num", 1);
     }
 
     public void testReadStringProperty() {
@@ -91,6 +92,22 @@ public class ConfigurationUtilsTests extends ESTestCase {
     public void testOptional_InvalidType() {
         List<String> val = ConfigurationUtils.readList(null, null, config, "int");
         assertThat(val, equalTo(Collections.singletonList(2)));
+    }
+
+    public void testReadStringOrIntProperty() {
+        String val1 = ConfigurationUtils.readStringOrIntProperty(null, null, config, "foo", null);
+        String val2 = ConfigurationUtils.readStringOrIntProperty(null, null, config, "num", null);
+        assertThat(val1, equalTo("bar"));
+        assertThat(val2, equalTo("1"));
+    }
+
+    public void testReadStringOrIntPropertyInvalidType() {
+        try {
+            ConfigurationUtils.readStringOrIntProperty(null, null, config, "arr", null);
+        } catch (ElasticsearchParseException e) {
+            assertThat(e.getMessage(), equalTo(
+                "[arr] property isn't a string or int, but of type [java.util.Arrays$ArrayList]"));
+        }
     }
 
     public void testReadProcessors() throws Exception {


### PR DESCRIPTION
Update Ingest simulate to accept _id, _index, _type, _routing and _parent as either strings or ints.

Issue #23823.