### PR TITLE
Rename random ASCII helper methods

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -79,9 +79,9 @@ public class RequestTests extends ESTestCase {
     }
 
     public void testDelete() throws IOException {
-        String index = randomAsciiOfLengthBetween(3, 10);
-        String type = randomAsciiOfLengthBetween(3, 10);
-        String id = randomAsciiOfLengthBetween(3, 10);
+        String index = randomAlphaOfLengthBetween(3, 10);
+        String type = randomAlphaOfLengthBetween(3, 10);
+        String id = randomAlphaOfLengthBetween(3, 10);
         DeleteRequest deleteRequest = new DeleteRequest(index, type, id);
 
         Map<String, String> expectedParams = new HashMap<>();
@@ -93,12 +93,12 @@ public class RequestTests extends ESTestCase {
 
         if (frequently()) {
             if (randomBoolean()) {
-                String routing = randomAsciiOfLengthBetween(3, 10);
+                String routing = randomAlphaOfLengthBetween(3, 10);
                 deleteRequest.routing(routing);
                 expectedParams.put("routing", routing);
             }
             if (randomBoolean()) {
-                String parent = randomAsciiOfLengthBetween(3, 10);
+                String parent = randomAlphaOfLengthBetween(3, 10);
                 deleteRequest.parent(parent);
                 expectedParams.put("parent", parent);
             }
@@ -116,20 +116,20 @@ public class RequestTests extends ESTestCase {
     }
 
     private static void getAndExistsTest(Function<GetRequest, Request> requestConverter, String method) {
-        String index = randomAsciiOfLengthBetween(3, 10);
-        String type = randomAsciiOfLengthBetween(3, 10);
-        String id = randomAsciiOfLengthBetween(3, 10);
+        String index = randomAlphaOfLengthBetween(3, 10);
+        String type = randomAlphaOfLengthBetween(3, 10);
+        String id = randomAlphaOfLengthBetween(3, 10);
         GetRequest getRequest = new GetRequest(index, type, id);
 
         Map<String, String> expectedParams = new HashMap<>();
         if (randomBoolean()) {
             if (randomBoolean()) {
-                String preference = randomAsciiOfLengthBetween(3, 10);
+                String preference = randomAlphaOfLengthBetween(3, 10);
                 getRequest.preference(preference);
                 expectedParams.put("preference", preference);
             }
             if (randomBoolean()) {
-                String routing = randomAsciiOfLengthBetween(3, 10);
+                String routing = randomAlphaOfLengthBetween(3, 10);
                 getRequest.routing(routing);
                 expectedParams.put("routing", routing);
             }
@@ -166,7 +166,7 @@ public class RequestTests extends ESTestCase {
                 String[] storedFields = new String[numStoredFields];
                 StringBuilder storedFieldsParam = new StringBuilder();
                 for (int i = 0; i < numStoredFields; i++) {
-                    String storedField = randomAsciiOfLengthBetween(3, 10);
+                    String storedField = randomAlphaOfLengthBetween(3, 10);
                     storedFields[i] = storedField;
                     storedFieldsParam.append(storedField);
                     if (i < numStoredFields - 1) {
@@ -188,11 +188,11 @@ public class RequestTests extends ESTestCase {
     }
 
     public void testIndex() throws IOException {
-        String index = randomAsciiOfLengthBetween(3, 10);
-        String type = randomAsciiOfLengthBetween(3, 10);
+        String index = randomAlphaOfLengthBetween(3, 10);
+        String type = randomAlphaOfLengthBetween(3, 10);
         IndexRequest indexRequest = new IndexRequest(index, type);
 
-        String id = randomBoolean() ? randomAsciiOfLengthBetween(3, 10) : null;
+        String id = randomBoolean() ? randomAlphaOfLengthBetween(3, 10) : null;
         indexRequest.id(id);
 
         Map<String, String> expectedParams = new HashMap<>();
@@ -219,17 +219,17 @@ public class RequestTests extends ESTestCase {
 
         if (frequently()) {
             if (randomBoolean()) {
-                String routing = randomAsciiOfLengthBetween(3, 10);
+                String routing = randomAlphaOfLengthBetween(3, 10);
                 indexRequest.routing(routing);
                 expectedParams.put("routing", routing);
             }
             if (randomBoolean()) {
-                String parent = randomAsciiOfLengthBetween(3, 10);
+                String parent = randomAlphaOfLengthBetween(3, 10);
                 indexRequest.parent(parent);
                 expectedParams.put("parent", parent);
             }
             if (randomBoolean()) {
-                String pipeline = randomAsciiOfLengthBetween(3, 10);
+                String pipeline = randomAlphaOfLengthBetween(3, 10);
                 indexRequest.setPipeline(pipeline);
                 expectedParams.put("pipeline", pipeline);
             }
@@ -270,9 +270,9 @@ public class RequestTests extends ESTestCase {
         XContentType xContentType = randomFrom(XContentType.values());
 
         Map<String, String> expectedParams = new HashMap<>();
-        String index = randomAsciiOfLengthBetween(3, 10);
-        String type = randomAsciiOfLengthBetween(3, 10);
-        String id = randomAsciiOfLengthBetween(3, 10);
+        String index = randomAlphaOfLengthBetween(3, 10);
+        String type = randomAlphaOfLengthBetween(3, 10);
+        String id = randomAlphaOfLengthBetween(3, 10);
 
         UpdateRequest updateRequest = new UpdateRequest(index, type, id);
         updateRequest.detectNoop(randomBoolean());
@@ -295,12 +295,12 @@ public class RequestTests extends ESTestCase {
             updateRequest.upsert(new IndexRequest().source(source, xContentType));
         }
         if (randomBoolean()) {
-            String routing = randomAsciiOfLengthBetween(3, 10);
+            String routing = randomAlphaOfLengthBetween(3, 10);
             updateRequest.routing(routing);
             expectedParams.put("routing", routing);
         }
         if (randomBoolean()) {
-            String parent = randomAsciiOfLengthBetween(3, 10);
+            String parent = randomAlphaOfLengthBetween(3, 10);
             updateRequest.parent(parent);
             expectedParams.put("parent", parent);
         }
@@ -416,9 +416,9 @@ public class RequestTests extends ESTestCase {
 
         int nbItems = randomIntBetween(10, 100);
         for (int i = 0; i < nbItems; i++) {
-            String index = randomAsciiOfLength(5);
-            String type = randomAsciiOfLength(5);
-            String id = randomAsciiOfLength(5);
+            String index = randomAlphaOfLength(5);
+            String type = randomAlphaOfLength(5);
+            String id = randomAlphaOfLength(5);
 
             BytesReference source = RandomObjects.randomSource(random(), xContentType);
             DocWriteRequest.OpType opType = randomFrom(DocWriteRequest.OpType.values());
@@ -428,16 +428,16 @@ public class RequestTests extends ESTestCase {
                 IndexRequest indexRequest = new IndexRequest(index, type, id).source(source, xContentType);
                 docWriteRequest = indexRequest;
                 if (randomBoolean()) {
-                    indexRequest.setPipeline(randomAsciiOfLength(5));
+                    indexRequest.setPipeline(randomAlphaOfLength(5));
                 }
                 if (randomBoolean()) {
-                    indexRequest.parent(randomAsciiOfLength(5));
+                    indexRequest.parent(randomAlphaOfLength(5));
                 }
             } else if (opType == DocWriteRequest.OpType.CREATE) {
                 IndexRequest createRequest = new IndexRequest(index, type, id).source(source, xContentType).create(true);
                 docWriteRequest = createRequest;
                 if (randomBoolean()) {
-                    createRequest.parent(randomAsciiOfLength(5));
+                    createRequest.parent(randomAlphaOfLength(5));
                 }
             } else if (opType == DocWriteRequest.OpType.UPDATE) {
                 final UpdateRequest updateRequest = new UpdateRequest(index, type, id).doc(new IndexRequest().source(source, xContentType));
@@ -449,14 +449,14 @@ public class RequestTests extends ESTestCase {
                     randomizeFetchSourceContextParams(updateRequest::fetchSource, new HashMap<>());
                 }
                 if (randomBoolean()) {
-                    updateRequest.parent(randomAsciiOfLength(5));
+                    updateRequest.parent(randomAlphaOfLength(5));
                 }
             } else if (opType == DocWriteRequest.OpType.DELETE) {
                 docWriteRequest = new DeleteRequest(index, type, id);
             }
 
             if (randomBoolean()) {
-                docWriteRequest.routing(randomAsciiOfLength(10));
+                docWriteRequest.routing(randomAlphaOfLength(10));
             }
             if (randomBoolean()) {
                 docWriteRequest.version(randomNonNegativeLong());
@@ -591,7 +591,7 @@ public class RequestTests extends ESTestCase {
         Map<String, String> expectedParams = new HashMap<>();
         for (int i = 0; i < nbParams; i++) {
             String paramName = "p_" + i;
-            String paramValue = randomAsciiOfLength(5);
+            String paramValue = randomAlphaOfLength(5);
             params.putParam(paramName, paramValue);
             expectedParams.put(paramName, paramValue);
         }
@@ -665,7 +665,7 @@ public class RequestTests extends ESTestCase {
                 String[] includes = new String[numIncludes];
                 StringBuilder includesParam = new StringBuilder();
                 for (int i = 0; i < numIncludes; i++) {
-                    String include = randomAsciiOfLengthBetween(3, 10);
+                    String include = randomAlphaOfLengthBetween(3, 10);
                     includes[i] = include;
                     includesParam.append(include);
                     if (i < numIncludes - 1) {
@@ -679,7 +679,7 @@ public class RequestTests extends ESTestCase {
                 String[] excludes = new String[numExcludes];
                 StringBuilder excludesParam = new StringBuilder();
                 for (int i = 0; i < numExcludes; i++) {
-                    String exclude = randomAsciiOfLengthBetween(3, 10);
+                    String exclude = randomAlphaOfLengthBetween(3, 10);
                     excludes[i] = exclude;
                     excludesParam.append(exclude);
                     if (i < numExcludes - 1) {

--- a/core/src/test/java/org/apache/lucene/search/uhighlight/BoundedBreakIteratorScannerTests.java
+++ b/core/src/test/java/org/apache/lucene/search/uhighlight/BoundedBreakIteratorScannerTests.java
@@ -43,9 +43,9 @@ public class BoundedBreakIteratorScannerTests extends ESTestCase {
         String[] vocabulary = new String[maxSize];
         for (int i = 0; i < maxSize; i++) {
             if (rarely()) {
-                vocabulary[i] = randomAsciiOfLengthBetween(50, 200);
+                vocabulary[i] = randomAlphaOfLengthBetween(50, 200);
             } else {
-                vocabulary[i] = randomAsciiOfLengthBetween(1, 30);
+                vocabulary[i] = randomAlphaOfLengthBetween(1, 30);
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/BuildTests.java
+++ b/core/src/test/java/org/elasticsearch/BuildTests.java
@@ -44,7 +44,7 @@ public class BuildTests extends ESTestCase {
         assertEquals(build, another);
         assertEquals(build.hashCode(), another.hashCode());
 
-        Build differentHash = new Build(randomAsciiOfLengthBetween(3, 10), build.date(), build.isSnapshot());
+        Build differentHash = new Build(randomAlphaOfLengthBetween(3, 10), build.date(), build.isSnapshot());
         assertNotEquals(build, differentHash);
 
         Build differentDate = new Build(build.shortHash(), "1970-01-01", build.isSnapshot());

--- a/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -918,7 +918,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
                     int nbValues = randomIntBetween(1, 3);
                     for (int j = 0; j < nbValues; j++) {
-                        values.add(frequently() ? randomAsciiOfLength(5) : "");
+                        values.add(frequently() ? randomAlphaOfLength(5) : "");
                     }
                     randomHeaders.put("header_" + i, values);
                 }
@@ -943,7 +943,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
                     int nbValues = randomIntBetween(1, 3);
                     for (int j = 0; j < nbValues; j++) {
-                        values.add(frequently() ? randomAsciiOfLength(5) : "");
+                        values.add(frequently() ? randomAlphaOfLength(5) : "");
                     }
                     randomMetadata.put("es.metadata_" + i, values);
                 }
@@ -965,7 +965,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
                     String resourceType = "type_" + i;
                     String[] resourceIds = new String[randomIntBetween(1, 3)];
                     for (int j = 0; j < resourceIds.length; j++) {
-                        resourceIds[j] = frequently() ? randomAsciiOfLength(5) : "";
+                        resourceIds[j] = frequently() ? randomAlphaOfLength(5) : "";
                     }
                     actualException.setResources(resourceType, resourceIds);
                     expected.setResources(resourceType, resourceIds);

--- a/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -646,8 +646,8 @@ public class ExceptionSerializationTests extends ESTestCase {
     }
 
     public void testNoLongerPrimaryShardException() throws IOException {
-        ShardId shardId = new ShardId(new Index(randomAsciiOfLength(4), randomAsciiOfLength(4)), randomIntBetween(0, Integer.MAX_VALUE));
-        String msg = randomAsciiOfLength(4);
+        ShardId shardId = new ShardId(new Index(randomAlphaOfLength(4), randomAlphaOfLength(4)), randomIntBetween(0, Integer.MAX_VALUE));
+        String msg = randomAlphaOfLength(4);
         ShardStateAction.NoLongerPrimaryShardException ex = serialize(new ShardStateAction.NoLongerPrimaryShardException(shardId, msg));
         assertEquals(shardId, ex.getShardId());
         assertEquals(msg, ex.getMessage());

--- a/core/src/test/java/org/elasticsearch/action/OriginalIndicesTests.java
+++ b/core/src/test/java/org/elasticsearch/action/OriginalIndicesTests.java
@@ -57,7 +57,7 @@ public class OriginalIndicesTests extends ESTestCase {
         int numIndices = randomInt(10);
         String[] indices = new String[numIndices];
         for (int j = 0; j < indices.length; j++) {
-            indices[j] = randomAsciiOfLength(randomIntBetween(1, 10));
+            indices[j] = randomAlphaOfLength(randomIntBetween(1, 10));
         }
         IndicesOptions indicesOptions = randomFrom(indicesOptionsValues);
         return new OriginalIndices(indices, indicesOptions);

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainRequestTests.java
@@ -26,8 +26,8 @@ public class ClusterAllocationExplainRequestTests extends ESTestCase {
 
     public void testSerialization() throws Exception {
         ClusterAllocationExplainRequest request =
-                new ClusterAllocationExplainRequest(randomAsciiOfLength(4), randomIntBetween(0, Integer.MAX_VALUE), randomBoolean(),
-                                                       randomBoolean() ? randomAsciiOfLength(5) : null);
+                new ClusterAllocationExplainRequest(randomAlphaOfLength(4), randomIntBetween(0, Integer.MAX_VALUE), randomBoolean(),
+                                                       randomBoolean() ? randomAlphaOfLength(5) : null);
         request.includeYesDecisions(randomBoolean());
         request.includeDiskInfo(randomBoolean());
         BytesStreamOutput output = new BytesStreamOutput();

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -290,9 +290,9 @@ public class NodeStatsTests extends ESTestCase {
                     new OsStats.Mem(randomLong(), randomLong()),
                     new OsStats.Swap(randomLong(), randomLong()),
                     new OsStats.Cgroup(
-                        randomAsciiOfLength(8),
+                        randomAlphaOfLength(8),
                         randomNonNegativeLong(),
-                        randomAsciiOfLength(8),
+                        randomAlphaOfLength(8),
                         randomNonNegativeLong(),
                         randomNonNegativeLong(),
                         new OsStats.Cgroup.CpuStat(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong())));
@@ -310,14 +310,14 @@ public class NodeStatsTests extends ESTestCase {
             int numMemoryPools = randomIntBetween(0, 10);
             List<JvmStats.MemoryPool> memoryPools = new ArrayList<>(numMemoryPools);
             for (int i = 0; i < numMemoryPools; i++) {
-                memoryPools.add(new JvmStats.MemoryPool(randomAsciiOfLengthBetween(3, 10), randomNonNegativeLong(),
+                memoryPools.add(new JvmStats.MemoryPool(randomAlphaOfLengthBetween(3, 10), randomNonNegativeLong(),
                         randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()));
             }
             JvmStats.Threads threads = new JvmStats.Threads(randomIntBetween(1, 1000), randomIntBetween(1, 1000));
             int numGarbageCollectors = randomIntBetween(0, 10);
             JvmStats.GarbageCollector[] garbageCollectorsArray = new JvmStats.GarbageCollector[numGarbageCollectors];
             for (int i = 0; i < numGarbageCollectors; i++) {
-                garbageCollectorsArray[i] = new JvmStats.GarbageCollector(randomAsciiOfLengthBetween(3, 10),
+                garbageCollectorsArray[i] = new JvmStats.GarbageCollector(randomAlphaOfLengthBetween(3, 10),
                         randomNonNegativeLong(), randomNonNegativeLong());
             }
             JvmStats.GarbageCollectors garbageCollectors = new JvmStats.GarbageCollectors(garbageCollectorsArray);
@@ -326,7 +326,7 @@ public class NodeStatsTests extends ESTestCase {
             for (int i = 0; i < numBufferPools; i++) {
                 bufferPoolList.add(
                     new JvmStats.BufferPool(
-                        randomAsciiOfLengthBetween(3, 10),
+                        randomAlphaOfLengthBetween(3, 10),
                         randomNonNegativeLong(),
                         randomNonNegativeLong(),
                         randomNonNegativeLong()));
@@ -342,7 +342,7 @@ public class NodeStatsTests extends ESTestCase {
             int numThreadPoolStats = randomIntBetween(0, 10);
             List<ThreadPoolStats.Stats> threadPoolStatsList = new ArrayList<>();
             for (int i = 0; i < numThreadPoolStats; i++) {
-                threadPoolStatsList.add(new ThreadPoolStats.Stats(randomAsciiOfLengthBetween(3, 10), randomIntBetween(1, 1000),
+                threadPoolStatsList.add(new ThreadPoolStats.Stats(randomAlphaOfLengthBetween(3, 10), randomIntBetween(1, 1000),
                         randomIntBetween(1, 1000), randomIntBetween(1, 1000), randomNonNegativeLong(),
                         randomIntBetween(1, 1000), randomIntBetween(1, 1000)));
             }
@@ -354,17 +354,17 @@ public class NodeStatsTests extends ESTestCase {
             FsInfo.DeviceStats[] deviceStatsArray = new FsInfo.DeviceStats[numDeviceStats];
             for (int i = 0; i < numDeviceStats; i++) {
                 FsInfo.DeviceStats previousDeviceStats = randomBoolean() ? null :
-                        new FsInfo.DeviceStats(randomInt(), randomInt(), randomAsciiOfLengthBetween(3, 10),
+                        new FsInfo.DeviceStats(randomInt(), randomInt(), randomAlphaOfLengthBetween(3, 10),
                                 randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), null);
                 deviceStatsArray[i] =
-                    new FsInfo.DeviceStats(randomInt(), randomInt(), randomAsciiOfLengthBetween(3, 10), randomNonNegativeLong(),
+                    new FsInfo.DeviceStats(randomInt(), randomInt(), randomAlphaOfLengthBetween(3, 10), randomNonNegativeLong(),
                         randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), previousDeviceStats);
             }
             FsInfo.IoStats ioStats = new FsInfo.IoStats(deviceStatsArray);
             int numPaths = randomIntBetween(0, 10);
             FsInfo.Path[] paths = new FsInfo.Path[numPaths];
             for (int i = 0; i < numPaths; i++) {
-                paths[i] = new FsInfo.Path(randomAsciiOfLengthBetween(3, 10), randomBoolean() ? randomAsciiOfLengthBetween(3, 10) : null,
+                paths[i] = new FsInfo.Path(randomAlphaOfLengthBetween(3, 10), randomBoolean() ? randomAlphaOfLengthBetween(3, 10) : null,
                         randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());
             }
             fsInfo = new FsInfo(randomNonNegativeLong(), ioStats, paths);
@@ -377,7 +377,7 @@ public class NodeStatsTests extends ESTestCase {
             int numCircuitBreakerStats = randomIntBetween(0, 10);
             CircuitBreakerStats[] circuitBreakerStatsArray = new CircuitBreakerStats[numCircuitBreakerStats];
             for (int i = 0; i < numCircuitBreakerStats; i++) {
-                circuitBreakerStatsArray[i] = new CircuitBreakerStats(randomAsciiOfLengthBetween(3, 10), randomNonNegativeLong(),
+                circuitBreakerStatsArray[i] = new CircuitBreakerStats(randomAlphaOfLengthBetween(3, 10), randomNonNegativeLong(),
                         randomNonNegativeLong(), randomDouble(), randomNonNegativeLong());
             }
             allCircuitBreakerStats = new AllCircuitBreakerStats(circuitBreakerStatsArray);
@@ -393,7 +393,7 @@ public class NodeStatsTests extends ESTestCase {
             int numStatsPerPipeline = randomIntBetween(0, 10);
             Map<String, IngestStats.Stats> statsPerPipeline = new HashMap<>();
             for (int i = 0; i < numStatsPerPipeline; i++) {
-                statsPerPipeline.put(randomAsciiOfLengthBetween(3, 10), new IngestStats.Stats(randomNonNegativeLong(),
+                statsPerPipeline.put(randomAlphaOfLengthBetween(3, 10), new IngestStats.Stats(randomNonNegativeLong(),
                         randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()));
             }
             ingestStats = new IngestStats(totalStats, statsPerPipeline);

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskTests.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class TaskTests extends ESTestCase {
 
     public void testTaskInfoToString() {
-        String nodeId = randomAsciiOfLength(10);
+        String nodeId = randomAlphaOfLength(10);
         long taskId = randomIntBetween(0, 100000);
         long startTime = randomNonNegativeLong();
         long runningTime = randomNonNegativeLong();

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestTests.java
@@ -59,16 +59,16 @@ public class ClusterRerouteRequestTests extends ESTestCase {
     private static final int ROUNDS = 30;
     private final List<Supplier<AllocationCommand>> RANDOM_COMMAND_GENERATORS = unmodifiableList(
             Arrays.<Supplier<AllocationCommand>> asList(
-            () -> new AllocateReplicaAllocationCommand(randomAsciiOfLengthBetween(2, 10), between(0, 1000),
-                    randomAsciiOfLengthBetween(2, 10)),
-            () -> new AllocateEmptyPrimaryAllocationCommand(randomAsciiOfLengthBetween(2, 10), between(0, 1000),
-                    randomAsciiOfLengthBetween(2, 10), randomBoolean()),
-            () -> new AllocateStalePrimaryAllocationCommand(randomAsciiOfLengthBetween(2, 10), between(0, 1000),
-                    randomAsciiOfLengthBetween(2, 10), randomBoolean()),
-            () -> new CancelAllocationCommand(randomAsciiOfLengthBetween(2, 10), between(0, 1000),
-                    randomAsciiOfLengthBetween(2, 10), randomBoolean()),
-            () -> new MoveAllocationCommand(randomAsciiOfLengthBetween(2, 10), between(0, 1000),
-                    randomAsciiOfLengthBetween(2, 10), randomAsciiOfLengthBetween(2, 10))));
+            () -> new AllocateReplicaAllocationCommand(randomAlphaOfLengthBetween(2, 10), between(0, 1000),
+                    randomAlphaOfLengthBetween(2, 10)),
+            () -> new AllocateEmptyPrimaryAllocationCommand(randomAlphaOfLengthBetween(2, 10), between(0, 1000),
+                    randomAlphaOfLengthBetween(2, 10), randomBoolean()),
+            () -> new AllocateStalePrimaryAllocationCommand(randomAlphaOfLengthBetween(2, 10), between(0, 1000),
+                    randomAlphaOfLengthBetween(2, 10), randomBoolean()),
+            () -> new CancelAllocationCommand(randomAlphaOfLengthBetween(2, 10), between(0, 1000),
+                    randomAlphaOfLengthBetween(2, 10), randomBoolean()),
+            () -> new MoveAllocationCommand(randomAlphaOfLengthBetween(2, 10), between(0, 1000),
+                    randomAlphaOfLengthBetween(2, 10), randomAlphaOfLengthBetween(2, 10))));
     private final NamedWriteableRegistry namedWriteableRegistry;
 
     public ClusterRerouteRequestTests() {

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestTests.java
@@ -34,7 +34,7 @@ public class ClusterSearchShardsRequestTests extends ESTestCase {
             int numIndices = randomIntBetween(1, 5);
             String[] indices = new String[numIndices];
             for (int i = 0; i < numIndices; i++) {
-                indices[i] = randomAsciiOfLengthBetween(3, 10);
+                indices[i] = randomAlphaOfLengthBetween(3, 10);
             }
             request.indices(indices);
         }
@@ -43,13 +43,13 @@ public class ClusterSearchShardsRequestTests extends ESTestCase {
                     IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()));
         }
         if (randomBoolean()) {
-            request.preference(randomAsciiOfLengthBetween(3, 10));
+            request.preference(randomAlphaOfLengthBetween(3, 10));
         }
         if (randomBoolean()) {
             int numRoutings = randomIntBetween(1, 3);
             String[] routings = new String[numRoutings];
             for (int i = 0; i < numRoutings; i++) {
-                routings[i] = randomAsciiOfLengthBetween(3, 10);
+                routings[i] = randomAlphaOfLengthBetween(3, 10);
             }
             request.routing(routings);
         }

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
@@ -54,9 +54,9 @@ public class ClusterSearchShardsResponseTests extends ESTestCase {
         int numShards = randomIntBetween(1, 10);
         ClusterSearchShardsGroup[] clusterSearchShardsGroups = new ClusterSearchShardsGroup[numShards];
         for (int i = 0; i < numShards; i++) {
-            String index = randomAsciiOfLengthBetween(3, 10);
-            ShardId shardId = new ShardId(index, randomAsciiOfLength(12), i);
-            String nodeId = randomAsciiOfLength(10);
+            String index = randomAlphaOfLengthBetween(3, 10);
+            ShardId shardId = new ShardId(index, randomAlphaOfLength(12), i);
+            String nodeId = randomAlphaOfLength(10);
             ShardRouting shardRouting = TestShardRouting.newShardRouting(shardId, nodeId, randomBoolean(), ShardRoutingState.STARTED);
             clusterSearchShardsGroups[i] = new ClusterSearchShardsGroup(shardId, new ShardRouting[]{shardRouting});
             DiscoveryNode node = new DiscoveryNode(shardRouting.currentNodeId(),

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/alias/AliasActionsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/alias/AliasActionsTests.java
@@ -47,9 +47,9 @@ public class AliasActionsTests extends ESTestCase {
             assertEquals("One of [index] or [indices] is required", e.getMessage());
         } else {
             Exception e = expectThrows(IllegalArgumentException.class,
-                    () -> new AliasActions(type).alias(randomAsciiOfLength(5)).validate());
+                    () -> new AliasActions(type).alias(randomAlphaOfLength(5)).validate());
             assertEquals("One of [index] or [indices] is required", e.getMessage());
-            e = expectThrows(IllegalArgumentException.class, () -> new AliasActions(type).index(randomAsciiOfLength(5)).validate());
+            e = expectThrows(IllegalArgumentException.class, () -> new AliasActions(type).index(randomAlphaOfLength(5)).validate());
             assertEquals("One of [alias] or [aliases] is required", e.getMessage());
         }
     }
@@ -156,8 +156,8 @@ public class AliasActionsTests extends ESTestCase {
     }
 
     public void testParseAddDefaultRouting() throws IOException {
-        String index = randomAsciiOfLength(5);
-        String alias = randomAsciiOfLength(5);
+        String index = randomAlphaOfLength(5);
+        String alias = randomAlphaOfLength(5);
         Object searchRouting = randomRouting();
         Object indexRouting = randomRouting();
         XContentBuilder b = XContentBuilder.builder(randomFrom(XContentType.values()).xContent());
@@ -217,7 +217,7 @@ public class AliasActionsTests extends ESTestCase {
     }
 
     public void testParseRemoveIndex() throws IOException {
-        String[] indices = randomBoolean() ? new String[] {randomAsciiOfLength(5)} : generateRandomStringArray(10, 5, false, false);
+        String[] indices = randomBoolean() ? new String[] {randomAlphaOfLength(5)} : generateRandomStringArray(10, 5, false, false);
         XContentBuilder b = XContentBuilder.builder(randomFrom(XContentType.values()).xContent());
         b.startObject(); {
             b.startObject("remove_index"); {
@@ -243,9 +243,9 @@ public class AliasActionsTests extends ESTestCase {
         XContentBuilder b = XContentBuilder.builder(randomFrom(XContentType.values()).xContent());
         b.startObject(); {
             b.startObject(randomFrom("add", "remove")); {
-                b.field("index", randomAsciiOfLength(5));
+                b.field("index", randomAlphaOfLength(5));
                 b.array("indices", generateRandomStringArray(10, 5, false, false));
-                b.field("alias", randomAsciiOfLength(5));
+                b.field("alias", randomAlphaOfLength(5));
             }
             b.endObject();
         }
@@ -261,8 +261,8 @@ public class AliasActionsTests extends ESTestCase {
         XContentBuilder b = XContentBuilder.builder(randomFrom(XContentType.values()).xContent());
         b.startObject(); {
             b.startObject(randomFrom("add", "remove")); {
-                b.field("index", randomAsciiOfLength(5));
-                b.field("alias", randomAsciiOfLength(5));
+                b.field("index", randomAlphaOfLength(5));
+                b.field("alias", randomAlphaOfLength(5));
                 b.array("aliases", generateRandomStringArray(10, 5, false, false));
             }
             b.endObject();
@@ -278,27 +278,27 @@ public class AliasActionsTests extends ESTestCase {
     public void testRoundTrip() throws IOException {
         AliasActions action = new AliasActions(randomFrom(AliasActions.Type.values()));
         if (randomBoolean()) {
-            action.index(randomAsciiOfLength(5));
+            action.index(randomAlphaOfLength(5));
         } else {
             action.indices(generateRandomStringArray(5, 5, false, false));
         }
         if (action.actionType() != AliasActions.Type.REMOVE_INDEX) {
             if (randomBoolean()) {
-                action.alias(randomAsciiOfLength(5));
+                action.alias(randomAlphaOfLength(5));
             } else {
                 action.aliases(generateRandomStringArray(5, 5, false, false));
             }
         }
         if (action.actionType() == AliasActions.Type.ADD) {
             if (randomBoolean()) {
-                action.filter(randomAsciiOfLength(10));
+                action.filter(randomAlphaOfLength(10));
             }
             if (randomBoolean()) {
                 if (randomBoolean()) {
-                    action.routing(randomAsciiOfLength(5));
+                    action.routing(randomAlphaOfLength(5));
                 } else {
-                    action.searchRouting(randomAsciiOfLength(5));
-                    action.indexRouting(randomAsciiOfLength(5));
+                    action.searchRouting(randomAlphaOfLength(5));
+                    action.indexRouting(randomAlphaOfLength(5));
                 }
             }
         }
@@ -322,11 +322,11 @@ public class AliasActionsTests extends ESTestCase {
                 if (maxDepth > 0) {
                     value = randomMap(maxDepth - 1);
                 } else {
-                    value = randomAsciiOfLength(5);
+                    value = randomAlphaOfLength(5);
                 }
                 break;
             case 1:
-                value = randomAsciiOfLength(5);
+                value = randomAlphaOfLength(5);
                 break;
             case 2:
                 value = randomBoolean();
@@ -337,12 +337,12 @@ public class AliasActionsTests extends ESTestCase {
             default:
                 throw new UnsupportedOperationException();
             }
-            result.put(randomAsciiOfLength(5), value);
+            result.put(randomAlphaOfLength(5), value);
         }
         return result;
     }
 
     private Object randomRouting() {
-        return randomBoolean() ? randomAsciiOfLength(5) : randomInt();
+        return randomBoolean() ? randomAlphaOfLength(5) : randomInt();
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class RolloverRequestTests extends ESTestCase {
 
     public void testConditionsParsing() throws Exception {
-        final RolloverRequest request = new RolloverRequest(randomAsciiOfLength(10), randomAsciiOfLength(10));
+        final RolloverRequest request = new RolloverRequest(randomAlphaOfLength(10), randomAlphaOfLength(10));
         final XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
                 .startObject("conditions")
@@ -56,7 +56,7 @@ public class RolloverRequestTests extends ESTestCase {
     }
 
     public void testParsingWithIndexSettings() throws Exception {
-        final RolloverRequest request = new RolloverRequest(randomAsciiOfLength(10), randomAsciiOfLength(10));
+        final RolloverRequest request = new RolloverRequest(randomAlphaOfLength(10), randomAlphaOfLength(10));
         final XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
                 .startObject("conditions")

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -34,9 +34,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.test.ESTestCase;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
 
 import java.util.HashSet;
 import java.util.List;
@@ -60,7 +57,7 @@ public class TransportRolloverActionTests extends ESTestCase {
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .build();
-        final IndexMetaData metaData = IndexMetaData.builder(randomAsciiOfLength(10))
+        final IndexMetaData metaData = IndexMetaData.builder(randomAlphaOfLength(10))
             .creationDate(System.currentTimeMillis() - TimeValue.timeValueHours(3).getMillis())
             .settings(settings)
             .build();
@@ -95,9 +92,9 @@ public class TransportRolloverActionTests extends ESTestCase {
     }
 
     public void testCreateUpdateAliasRequest() throws Exception {
-        String sourceAlias = randomAsciiOfLength(10);
-        String sourceIndex = randomAsciiOfLength(10);
-        String targetIndex = randomAsciiOfLength(10);
+        String sourceAlias = randomAlphaOfLength(10);
+        String sourceIndex = randomAlphaOfLength(10);
+        String targetIndex = randomAlphaOfLength(10);
         final RolloverRequest rolloverRequest = new RolloverRequest(sourceAlias, targetIndex);
         final IndicesAliasesClusterStateUpdateRequest updateRequest =
             TransportRolloverAction.prepareRolloverAliasesUpdateRequest(sourceIndex, targetIndex, rolloverRequest);
@@ -122,10 +119,10 @@ public class TransportRolloverActionTests extends ESTestCase {
     }
 
     public void testValidation() throws Exception {
-        String index1 = randomAsciiOfLength(10);
-        String alias = randomAsciiOfLength(10);
-        String index2 = randomAsciiOfLength(10);
-        String aliasWithMultipleIndices = randomAsciiOfLength(10);
+        String index1 = randomAlphaOfLength(10);
+        String alias = randomAlphaOfLength(10);
+        String index2 = randomAlphaOfLength(10);
+        String aliasWithMultipleIndices = randomAlphaOfLength(10);
         final Settings settings = Settings.builder()
             .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
             .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
@@ -145,24 +142,24 @@ public class TransportRolloverActionTests extends ESTestCase {
 
         expectThrows(IllegalArgumentException.class, () ->
             TransportRolloverAction.validate(metaData, new RolloverRequest(aliasWithMultipleIndices,
-                randomAsciiOfLength(10))));
+                randomAlphaOfLength(10))));
         expectThrows(IllegalArgumentException.class, () ->
             TransportRolloverAction.validate(metaData, new RolloverRequest(randomFrom(index1, index2),
-                randomAsciiOfLength(10))));
+                randomAlphaOfLength(10))));
         expectThrows(IllegalArgumentException.class, () ->
-            TransportRolloverAction.validate(metaData, new RolloverRequest(randomAsciiOfLength(5),
-                randomAsciiOfLength(10)))
+            TransportRolloverAction.validate(metaData, new RolloverRequest(randomAlphaOfLength(5),
+                randomAlphaOfLength(10)))
         );
-        TransportRolloverAction.validate(metaData, new RolloverRequest(alias, randomAsciiOfLength(10)));
+        TransportRolloverAction.validate(metaData, new RolloverRequest(alias, randomAlphaOfLength(10)));
     }
 
     public void testGenerateRolloverIndexName() throws Exception {
-        String invalidIndexName = randomAsciiOfLength(10) + "A";
+        String invalidIndexName = randomAlphaOfLength(10) + "A";
         IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(Settings.EMPTY);
         expectThrows(IllegalArgumentException.class, () ->
             TransportRolloverAction.generateRolloverIndexName(invalidIndexName, indexNameExpressionResolver));
         int num = randomIntBetween(0, 100);
-        final String indexPrefix = randomAsciiOfLength(10);
+        final String indexPrefix = randomAlphaOfLength(10);
         String indexEndingInNumbers = indexPrefix + "-" + num;
         assertThat(TransportRolloverAction.generateRolloverIndexName(indexEndingInNumbers, indexNameExpressionResolver),
             equalTo(indexPrefix + "-" + String.format(Locale.ROOT, "%06d", num + 1)));
@@ -175,9 +172,9 @@ public class TransportRolloverActionTests extends ESTestCase {
     }
 
     public void testCreateIndexRequest() throws Exception {
-        String alias = randomAsciiOfLength(10);
-        String rolloverIndex = randomAsciiOfLength(10);
-        final RolloverRequest rolloverRequest = new RolloverRequest(alias, randomAsciiOfLength(10));
+        String alias = randomAlphaOfLength(10);
+        String rolloverIndex = randomAlphaOfLength(10);
+        final RolloverRequest rolloverRequest = new RolloverRequest(alias, randomAlphaOfLength(10));
         final ActiveShardCount activeShardCount = randomBoolean() ? ActiveShardCount.ALL : ActiveShardCount.ONE;
         rolloverRequest.setWaitForActiveShards(activeShardCount);
         final Settings settings = Settings.builder()

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportShrinkActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportShrinkActionTests.java
@@ -110,7 +110,7 @@ public class TransportShrinkActionTests extends ESTestCase {
     }
 
     public void testShrinkIndexSettings() {
-        String indexName = randomAsciiOfLength(10);
+        String indexName = randomAlphaOfLength(10);
         // create one that won't fail
         ClusterState clusterState = ClusterState.builder(createClusterState(indexName, randomIntBetween(2, 10), 0,
             Settings.builder()

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponseTests.java
@@ -32,7 +32,7 @@ public class IndicesStatsResponseTests extends ESTestCase {
 
     public void testInvalidLevel() {
         final IndicesStatsResponse response = new IndicesStatsResponse();
-        final String level = randomAsciiOfLength(16);
+        final String level = randomAlphaOfLength(16);
         final ToXContent.Params params = new ToXContent.MapParams(Collections.singletonMap("level", level));
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> response.toXContent(null, params));
         assertThat(

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
@@ -93,9 +93,9 @@ public class BulkItemResponseTests extends ESTestCase {
         final XContentType xContentType = randomFrom(XContentType.values());
 
         int itemId = randomIntBetween(0, 100);
-        String index = randomAsciiOfLength(5);
-        String type = randomAsciiOfLength(5);
-        String id = randomAsciiOfLength(5);
+        String index = randomAlphaOfLength(5);
+        String type = randomAlphaOfLength(5);
+        String id = randomAlphaOfLength(5);
         DocWriteRequest.OpType opType = randomFrom(DocWriteRequest.OpType.values());
 
         final Tuple<Throwable, ElasticsearchException> exceptions = randomExceptions();

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkResponseTests.java
@@ -71,9 +71,9 @@ public class BulkResponseTests extends ESTestCase {
                 bulkItems[i] = new BulkItemResponse(i, opType, randomDocWriteResponses.v1());
                 expectedBulkItems[i] = new BulkItemResponse(i, opType, randomDocWriteResponses.v2());
             } else {
-                String index = randomAsciiOfLength(5);
-                String type = randomAsciiOfLength(5);
-                String id = randomAsciiOfLength(5);
+                String index = randomAlphaOfLength(5);
+                String type = randomAlphaOfLength(5);
+                String id = randomAlphaOfLength(5);
 
                 Tuple<Throwable, ElasticsearchException> failures = randomExceptions();
 

--- a/core/src/test/java/org/elasticsearch/action/bulk/RetryTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/RetryTests.java
@@ -59,7 +59,7 @@ public class RetryTests extends ESTestCase {
         // Stash some random headers so we can assert that we preserve them
         bulkClient.threadPool().getThreadContext().stashContext();
         expectedHeaders.clear();
-        expectedHeaders.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+        expectedHeaders.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
         bulkClient.threadPool().getThreadContext().putHeader(expectedHeaders);
     }
 

--- a/core/src/test/java/org/elasticsearch/action/bulk/byscroll/BulkByScrollParallelizationHelperTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/byscroll/BulkByScrollParallelizationHelperTests.java
@@ -44,7 +44,7 @@ public class BulkByScrollParallelizationHelperTests extends ESTestCase {
             searchRequest.source().slice(null);
         }
         int times = between(2, 100);
-        String field = randomBoolean() ? UidFieldMapper.NAME : randomAsciiOfLength(5);
+        String field = randomBoolean() ? UidFieldMapper.NAME : randomAlphaOfLength(5);
         int currentSliceId = 0;
         for (SearchRequest slice : sliceIntoSubRequests(searchRequest, field, times)) {
             assertEquals(field, slice.source().slice().getField());

--- a/core/src/test/java/org/elasticsearch/action/bulk/byscroll/BulkByScrollResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/byscroll/BulkByScrollResponseTests.java
@@ -64,9 +64,9 @@ public class BulkByScrollResponseTests extends ESTestCase {
         Integer shardId = null;
         String nodeId = null;
         if (randomBoolean()) {
-            index = randomAsciiOfLength(5);
+            index = randomAlphaOfLength(5);
             shardId = randomInt();
-            nodeId = usually() ? randomAsciiOfLength(5) : null;
+            nodeId = usually() ? randomAlphaOfLength(5) : null;
         }
         return singletonList(new SearchFailure(new ElasticsearchException("foo"), index, shardId, nodeId));
     }

--- a/core/src/test/java/org/elasticsearch/action/bulk/byscroll/BulkByScrollTaskStatusTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/byscroll/BulkByScrollTaskStatusTests.java
@@ -105,7 +105,7 @@ public class BulkByScrollTaskStatusTests extends ESTestCase {
                         return null;
                     }
                     if (randomBoolean()) {
-                        return new BulkByScrollTask.StatusOrException(new ElasticsearchException(randomAsciiOfLength(5)));
+                        return new BulkByScrollTask.StatusOrException(new ElasticsearchException(randomAlphaOfLength(5)));
                     }
                     return new BulkByScrollTask.StatusOrException(randomWorkingStatus(i));
                 })

--- a/core/src/test/java/org/elasticsearch/action/bulk/byscroll/BulkByScrollTaskTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/byscroll/BulkByScrollTaskTests.java
@@ -19,13 +19,11 @@
 
 package org.elasticsearch.action.bulk.byscroll;
 
-import org.elasticsearch.action.bulk.byscroll.BulkByScrollTask;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -139,7 +137,7 @@ public class BulkByScrollTaskTests extends ESTestCase {
             mergedRequestsPerSecond += requestsPerSecond;
             mergedThrottledUntil = timeValueNanos(min(mergedThrottledUntil.nanos(), throttledUntil.nanos()));
         }
-        String reasonCancelled = randomBoolean() ? randomAsciiOfLength(10) : null;
+        String reasonCancelled = randomBoolean() ? randomAlphaOfLength(10) : null;
         BulkByScrollTask.Status merged = new BulkByScrollTask.Status(Arrays.asList(statuses), reasonCancelled);
         assertEquals(mergedTotal, merged.getTotal());
         assertEquals(mergedUpdated, merged.getUpdated());

--- a/core/src/test/java/org/elasticsearch/action/bulk/byscroll/DeleteByQueryRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/byscroll/DeleteByQueryRequestTests.java
@@ -66,7 +66,7 @@ public class DeleteByQueryRequestTests extends AbstractBulkByScrollRequestTestCa
 
     @Override
     protected DeleteByQueryRequest newRequest() {
-        return new DeleteByQueryRequest(new SearchRequest(randomAsciiOfLength(5)));
+        return new DeleteByQueryRequest(new SearchRequest(randomAlphaOfLength(5)));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
@@ -91,11 +91,11 @@ public class DeleteResponseTests extends ESTestCase {
      * expected {@link DeleteResponse} after parsing.
      */
     public static Tuple<DeleteResponse, DeleteResponse> randomDeleteResponse() {
-        String index = randomAsciiOfLength(5);
-        String indexUUid = randomAsciiOfLength(5);
+        String index = randomAlphaOfLength(5);
+        String indexUUid = randomAlphaOfLength(5);
         int shardId = randomIntBetween(0, 5);
-        String type = randomAsciiOfLength(5);
-        String id = randomAsciiOfLength(5);
+        String type = randomAlphaOfLength(5);
+        String id = randomAlphaOfLength(5);
         long seqNo = randomFrom(SequenceNumbersService.UNASSIGNED_SEQ_NO, randomNonNegativeLong(), (long) randomIntBetween(0, 10000));
         long version = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
         boolean found = randomBoolean();

--- a/core/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
@@ -31,7 +31,7 @@ public class FieldCapabilitiesRequestTests extends ESTestCase {
         int size = randomIntBetween(1, 20);
         String[] randomFields = new String[size];
         for (int i = 0; i < size; i++) {
-            randomFields[i] = randomAsciiOfLengthBetween(5, 10);
+            randomFields[i] = randomAlphaOfLengthBetween(5, 10);
         }
         request.fields(randomFields);
         return request;

--- a/core/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -32,11 +32,11 @@ public class FieldCapabilitiesResponseTests extends ESTestCase {
         Map<String, Map<String, FieldCapabilities> > fieldMap = new HashMap<> ();
         int numFields = randomInt(10);
         for (int i = 0; i < numFields; i++) {
-            String fieldName = randomAsciiOfLengthBetween(5, 10);
+            String fieldName = randomAlphaOfLengthBetween(5, 10);
             int numIndices = randomIntBetween(1, 5);
             Map<String, FieldCapabilities> indexFieldMap = new HashMap<> ();
             for (int j = 0; j < numIndices; j++) {
-                String index = randomAsciiOfLengthBetween(10, 20);
+                String index = randomAlphaOfLengthBetween(10, 20);
                 indexFieldMap.put(index, FieldCapabilitiesTests.randomFieldCaps());
             }
             fieldMap.put(fieldName, indexFieldMap);

--- a/core/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesTests.java
+++ b/core/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesTests.java
@@ -85,25 +85,25 @@ public class FieldCapabilitiesTests extends AbstractWireSerializingTestCase<Fiel
         if (randomBoolean()) {
             indices = new String[randomIntBetween(1, 5)];
             for (int i = 0; i < indices.length; i++) {
-                indices[i] = randomAsciiOfLengthBetween(5, 20);
+                indices[i] = randomAlphaOfLengthBetween(5, 20);
             }
         }
         String[] nonSearchableIndices = null;
         if (randomBoolean()) {
             nonSearchableIndices = new String[randomIntBetween(0, 5)];
             for (int i = 0; i < nonSearchableIndices.length; i++) {
-                nonSearchableIndices[i] = randomAsciiOfLengthBetween(5, 20);
+                nonSearchableIndices[i] = randomAlphaOfLengthBetween(5, 20);
             }
         }
         String[] nonAggregatableIndices = null;
         if (randomBoolean()) {
             nonAggregatableIndices = new String[randomIntBetween(0, 5)];
             for (int i = 0; i < nonAggregatableIndices.length; i++) {
-                nonAggregatableIndices[i] = randomAsciiOfLengthBetween(5, 20);
+                nonAggregatableIndices[i] = randomAlphaOfLengthBetween(5, 20);
             }
         }
-        return new FieldCapabilities(randomAsciiOfLengthBetween(5, 20),
-            randomAsciiOfLengthBetween(5, 20), randomBoolean(), randomBoolean(),
+        return new FieldCapabilities(randomAlphaOfLengthBetween(5, 20),
+            randomAlphaOfLengthBetween(5, 20), randomBoolean(), randomBoolean(),
             indices, nonSearchableIndices, nonAggregatableIndices);
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
@@ -53,8 +53,8 @@ public class MultiGetRequestTests extends ESTestCase {
         final ParsingException e = expectThrows(
                 ParsingException.class,
                 () -> {
-                    final String defaultIndex = randomAsciiOfLength(5);
-                    final String defaultType = randomAsciiOfLength(3);
+                    final String defaultIndex = randomAlphaOfLength(5);
+                    final String defaultType = randomAlphaOfLength(3);
                     final FetchSourceContext fetchSource = FetchSourceContext.FETCH_SOURCE;
                     mgr.add(defaultIndex, defaultType, null, fetchSource, null, parser, true);
                 });
@@ -80,8 +80,8 @@ public class MultiGetRequestTests extends ESTestCase {
         final ParsingException e = expectThrows(
                 ParsingException.class,
                 () -> {
-                    final String defaultIndex = randomAsciiOfLength(5);
-                    final String defaultType = randomAsciiOfLength(3);
+                    final String defaultIndex = randomAlphaOfLength(5);
+                    final String defaultType = randomAlphaOfLength(3);
                     final FetchSourceContext fetchSource = FetchSourceContext.FETCH_SOURCE;
                     mgr.add(defaultIndex, defaultType, null, fetchSource, null, parser, true);
                 });
@@ -105,7 +105,7 @@ public class MultiGetRequestTests extends ESTestCase {
 
         MultiGetRequest multiGetRequest = new MultiGetRequest();
         IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> multiGetRequest.add
-            (randomAsciiOfLength(5), randomAsciiOfLength(3), null, FetchSourceContext.FETCH_SOURCE, null, parser, true));
+            (randomAlphaOfLength(5), randomAlphaOfLength(3), null, FetchSourceContext.FETCH_SOURCE, null, parser, true));
         assertEquals("Failed to parse value [" + sourceValue + "] as only [true] or [false] are allowed.", ex.getMessage());
     }
 
@@ -125,7 +125,7 @@ public class MultiGetRequestTests extends ESTestCase {
 
         MultiGetRequest multiGetRequest = new MultiGetRequest();
         multiGetRequest.add(
-            randomAsciiOfLength(5), randomAsciiOfLength(3), null, FetchSourceContext.FETCH_SOURCE, null, parser, true);
+            randomAlphaOfLength(5), randomAlphaOfLength(3), null, FetchSourceContext.FETCH_SOURCE, null, parser, true);
 
         assertEquals(2, multiGetRequest.getItems().size());
     }

--- a/core/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
@@ -34,7 +34,7 @@ public class MultiGetShardRequestTests extends ESTestCase {
     public void testSerialization() throws IOException {
         MultiGetRequest multiGetRequest = new MultiGetRequest();
         if (randomBoolean()) {
-            multiGetRequest.preference(randomAsciiOfLength(randomIntBetween(1, 10)));
+            multiGetRequest.preference(randomAlphaOfLength(randomIntBetween(1, 10)));
         }
         if (randomBoolean()) {
             multiGetRequest.realtime(false);
@@ -45,12 +45,12 @@ public class MultiGetShardRequestTests extends ESTestCase {
         MultiGetShardRequest multiGetShardRequest = new MultiGetShardRequest(multiGetRequest, "index", 0);
         int numItems = iterations(10, 30);
         for (int i = 0; i < numItems; i++) {
-            MultiGetRequest.Item item = new MultiGetRequest.Item("alias-" + randomAsciiOfLength(randomIntBetween(1, 10)), "type", "id-" + i);
+            MultiGetRequest.Item item = new MultiGetRequest.Item("alias-" + randomAlphaOfLength(randomIntBetween(1, 10)), "type", "id-" + i);
             if (randomBoolean()) {
                 int numFields = randomIntBetween(1, 5);
                 String[] fields = new String[numFields];
                 for (int j = 0; j < fields.length; j++) {
-                    fields[j] = randomAsciiOfLength(randomIntBetween(1, 10));
+                    fields[j] = randomAlphaOfLength(randomIntBetween(1, 10));
                 }
                 item.storedFields(fields);
             }

--- a/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -90,19 +90,19 @@ public class IndexRequestTests extends ESTestCase {
     }
 
     public void testIndexingRejectsLongIds() {
-        String id = randomAsciiOfLength(511);
+        String id = randomAlphaOfLength(511);
         IndexRequest request = new IndexRequest("index", "type", id);
         request.source("{}", XContentType.JSON);
         ActionRequestValidationException validate = request.validate();
         assertNull(validate);
 
-        id = randomAsciiOfLength(512);
+        id = randomAlphaOfLength(512);
         request = new IndexRequest("index", "type", id);
         request.source("{}", XContentType.JSON);
         validate = request.validate();
         assertNull(validate);
 
-        id = randomAsciiOfLength(513);
+        id = randomAlphaOfLength(513);
         request = new IndexRequest("index", "type", id);
         request.source("{}", XContentType.JSON);
         validate = request.validate();
@@ -130,9 +130,9 @@ public class IndexRequestTests extends ESTestCase {
     }
 
     public void testIndexResponse() {
-        ShardId shardId = new ShardId(randomAsciiOfLengthBetween(3, 10), randomAsciiOfLengthBetween(3, 10), randomIntBetween(0, 1000));
-        String type = randomAsciiOfLengthBetween(3, 10);
-        String id = randomAsciiOfLengthBetween(3, 10);
+        ShardId shardId = new ShardId(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10), randomIntBetween(0, 1000));
+        String type = randomAlphaOfLengthBetween(3, 10);
+        String id = randomAlphaOfLengthBetween(3, 10);
         long version = randomLong();
         boolean created = randomBoolean();
         IndexResponse indexResponse = new IndexResponse(shardId, type, id, SequenceNumbersService.UNASSIGNED_SEQ_NO, version, created);

--- a/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
@@ -104,11 +104,11 @@ public class IndexResponseTests extends ESTestCase {
      * expected {@link IndexResponse} after parsing.
      */
     public static Tuple<IndexResponse, IndexResponse> randomIndexResponse() {
-        String index = randomAsciiOfLength(5);
-        String indexUUid = randomAsciiOfLength(5);
+        String index = randomAlphaOfLength(5);
+        String indexUUid = randomAlphaOfLength(5);
         int shardId = randomIntBetween(0, 5);
-        String type = randomAsciiOfLength(5);
-        String id = randomAsciiOfLength(5);
+        String type = randomAlphaOfLength(5);
+        String id = randomAlphaOfLength(5);
         long seqNo = randomFrom(SequenceNumbersService.UNASSIGNED_SEQ_NO, randomNonNegativeLong(), (long) randomIntBetween(0, 10000));
         long version = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
         boolean created = randomBoolean();

--- a/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
@@ -71,14 +71,14 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
         requestContent.put(Fields.DOCS, docs);
         for (int i = 0; i < numDocs; i++) {
             Map<String, Object> doc = new HashMap<>();
-            String index = randomAsciiOfLengthBetween(1, 10);
-            String type = randomAsciiOfLengthBetween(1, 10);
-            String id = randomAsciiOfLengthBetween(1, 10);
+            String index = randomAlphaOfLengthBetween(1, 10);
+            String type = randomAlphaOfLengthBetween(1, 10);
+            String id = randomAlphaOfLengthBetween(1, 10);
             doc.put(INDEX.getFieldName(), index);
             doc.put(TYPE.getFieldName(), type);
             doc.put(ID.getFieldName(), id);
-            String fieldName = randomAsciiOfLengthBetween(1, 10);
-            String fieldValue = randomAsciiOfLengthBetween(1, 10);
+            String fieldName = randomAlphaOfLengthBetween(1, 10);
+            String fieldValue = randomAlphaOfLengthBetween(1, 10);
             doc.put(Fields.SOURCE, Collections.singletonMap(fieldName, fieldValue));
             docs.add(doc);
             Map<String, Object> expectedDoc = new HashMap<>();
@@ -116,14 +116,14 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
         requestContent.put(Fields.DOCS, docs);
         for (int i = 0; i < numDocs; i++) {
             Map<String, Object> doc = new HashMap<>();
-            String index = randomAsciiOfLengthBetween(1, 10);
-            String type = randomAsciiOfLengthBetween(1, 10);
-            String id = randomAsciiOfLengthBetween(1, 10);
+            String index = randomAlphaOfLengthBetween(1, 10);
+            String type = randomAlphaOfLengthBetween(1, 10);
+            String id = randomAlphaOfLengthBetween(1, 10);
             doc.put(INDEX.getFieldName(), index);
             doc.put(TYPE.getFieldName(), type);
             doc.put(ID.getFieldName(), id);
-            String fieldName = randomAsciiOfLengthBetween(1, 10);
-            String fieldValue = randomAsciiOfLengthBetween(1, 10);
+            String fieldName = randomAlphaOfLengthBetween(1, 10);
+            String fieldValue = randomAlphaOfLengthBetween(1, 10);
             doc.put(Fields.SOURCE, Collections.singletonMap(fieldName, fieldValue));
             docs.add(doc);
             Map<String, Object> expectedDoc = new HashMap<>();
@@ -190,7 +190,7 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
     }
 
     public void testNonExistentPipelineId() {
-        String pipelineId = randomAsciiOfLengthBetween(1, 10);
+        String pipelineId = randomAlphaOfLengthBetween(1, 10);
         Map<String, Object> requestContent = new HashMap<>();
         List<Map<String, Object>> docs = new ArrayList<>();
         requestContent.put(Fields.DOCS, docs);

--- a/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestTests.java
@@ -38,7 +38,7 @@ public class SimulatePipelineRequestTests extends ESTestCase {
         SimulatePipelineRequest request = new SimulatePipelineRequest(new BytesArray(""), XContentType.JSON);
         // Sometimes we set an id
         if (randomBoolean()) {
-            request.setId(randomAsciiOfLengthBetween(1, 10));
+            request.setId(randomAlphaOfLengthBetween(1, 10));
         }
 
         // Sometimes we explicitly set a boolean (with whatever value)

--- a/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineResponseTests.java
@@ -39,7 +39,7 @@ public class SimulatePipelineResponseTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
         boolean isVerbose = randomBoolean();
-        String id = randomBoolean() ? randomAsciiOfLengthBetween(1, 10) : null;
+        String id = randomBoolean() ? randomAlphaOfLengthBetween(1, 10) : null;
         int numResults = randomIntBetween(1, 10);
         List<SimulateDocumentResult> results = new ArrayList<>(numResults);
         for (int i = 0; i < numResults; i++) {
@@ -49,7 +49,7 @@ public class SimulatePipelineResponseTests extends ESTestCase {
                 int numProcessors = randomIntBetween(1, 10);
                 List<SimulateProcessorResult> processorResults = new ArrayList<>(numProcessors);
                 for (int j = 0; j < numProcessors; j++) {
-                    String processorTag = randomAsciiOfLengthBetween(1, 10);
+                    String processorTag = randomAlphaOfLengthBetween(1, 10);
                     SimulateProcessorResult processorResult;
                     if (isFailure) {
                         processorResult = new SimulateProcessorResult(processorTag, new IllegalArgumentException("test"));

--- a/core/src/test/java/org/elasticsearch/action/ingest/SimulateProcessorResultTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/SimulateProcessorResultTests.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class SimulateProcessorResultTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
-        String processorTag = randomAsciiOfLengthBetween(1, 10);
+        String processorTag = randomAlphaOfLengthBetween(1, 10);
         boolean isSuccessful = randomBoolean();
         boolean isIgnoredException = randomBoolean();
         SimulateProcessorResult simulateProcessorResult;

--- a/core/src/test/java/org/elasticsearch/action/ingest/WriteableIngestDocumentTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ingest/WriteableIngestDocumentTests.java
@@ -45,12 +45,12 @@ public class WriteableIngestDocumentTests extends ESTestCase {
         Map<String, Object> sourceAndMetadata = RandomDocumentPicks.randomSource(random());
         int numFields = randomIntBetween(1, IngestDocument.MetaData.values().length);
         for (int i = 0; i < numFields; i++) {
-            sourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAsciiOfLengthBetween(5, 10));
+            sourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAlphaOfLengthBetween(5, 10));
         }
         Map<String, Object> ingestMetadata = new HashMap<>();
         numFields = randomIntBetween(1, 5);
         for (int i = 0; i < numFields; i++) {
-            ingestMetadata.put(randomAsciiOfLengthBetween(5, 10), randomAsciiOfLengthBetween(5, 10));
+            ingestMetadata.put(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10));
         }
         WriteableIngestDocument ingestDocument = new WriteableIngestDocument(new IngestDocument(sourceAndMetadata, ingestMetadata));
 
@@ -65,7 +65,7 @@ public class WriteableIngestDocumentTests extends ESTestCase {
         if (randomBoolean()) {
             numFields = randomIntBetween(1, IngestDocument.MetaData.values().length);
             for (int i = 0; i < numFields; i++) {
-                otherSourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAsciiOfLengthBetween(5, 10));
+                otherSourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAlphaOfLengthBetween(5, 10));
             }
             changed = true;
         }
@@ -75,7 +75,7 @@ public class WriteableIngestDocumentTests extends ESTestCase {
             otherIngestMetadata = new HashMap<>();
             numFields = randomIntBetween(1, 5);
             for (int i = 0; i < numFields; i++) {
-                otherIngestMetadata.put(randomAsciiOfLengthBetween(5, 10), randomAsciiOfLengthBetween(5, 10));
+                otherIngestMetadata.put(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10));
             }
             changed = true;
         } else {
@@ -101,12 +101,12 @@ public class WriteableIngestDocumentTests extends ESTestCase {
         Map<String, Object> sourceAndMetadata = RandomDocumentPicks.randomSource(random());
         int numFields = randomIntBetween(1, IngestDocument.MetaData.values().length);
         for (int i = 0; i < numFields; i++) {
-            sourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAsciiOfLengthBetween(5, 10));
+            sourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAlphaOfLengthBetween(5, 10));
         }
         Map<String, Object> ingestMetadata = new HashMap<>();
         numFields = randomIntBetween(1, 5);
         for (int i = 0; i < numFields; i++) {
-            ingestMetadata.put(randomAsciiOfLengthBetween(5, 10), randomAsciiOfLengthBetween(5, 10));
+            ingestMetadata.put(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10));
         }
         WriteableIngestDocument writeableIngestDocument = new WriteableIngestDocument(new IngestDocument(sourceAndMetadata, ingestMetadata));
 

--- a/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
@@ -54,7 +54,7 @@ public class MainActionTests extends ESTestCase {
     public void testMainResponseSerialization() throws IOException {
         final String nodeName = "node1";
         final ClusterName clusterName = new ClusterName("cluster1");
-        final String clusterUUID = randomAsciiOfLengthBetween(10, 20);
+        final String clusterUUID = randomAlphaOfLengthBetween(10, 20);
         final boolean available = randomBoolean();
         final Version version = Version.CURRENT;
         final Build build = Build.CURRENT;
@@ -73,7 +73,7 @@ public class MainActionTests extends ESTestCase {
     }
 
     public void testMainResponseXContent() throws IOException {
-        String clusterUUID = randomAsciiOfLengthBetween(10, 20);
+        String clusterUUID = randomAlphaOfLengthBetween(10, 20);
         final MainResponse mainResponse = new MainResponse("node1", Version.CURRENT, new ClusterName("cluster1"), clusterUUID,
                 Build.CURRENT, false);
         final String expected = "{" +

--- a/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -41,10 +41,10 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 public class MainResponseTests extends ESTestCase {
 
     public static MainResponse createTestItem() {
-        String clusterUuid = randomAsciiOfLength(10);
-        ClusterName clusterName = new ClusterName(randomAsciiOfLength(10));
-        String nodeName = randomAsciiOfLength(10);
-        Build build = new Build(randomAsciiOfLength(8), new Date(randomNonNegativeLong()).toString(), randomBoolean());
+        String clusterUuid = randomAlphaOfLength(10);
+        ClusterName clusterName = new ClusterName(randomAlphaOfLength(10));
+        String nodeName = randomAlphaOfLength(10);
+        Build build = new Build(randomAlphaOfLength(8), new Date(randomNonNegativeLong()).toString(), randomBoolean());
         Version version = VersionUtils.randomVersion(random());
         boolean available = randomBoolean();
         return new MainResponse(nodeName, version, clusterName, clusterUuid , build, available);
@@ -108,10 +108,10 @@ public class MainResponseTests extends ESTestCase {
         ClusterName clusterName = o.getClusterName();
         switch (randomIntBetween(0, 5)) {
         case 0:
-            clusterUuid = clusterUuid + randomAsciiOfLength(5);
+            clusterUuid = clusterUuid + randomAlphaOfLength(5);
             break;
         case 1:
-            nodeName = nodeName + randomAsciiOfLength(5);
+            nodeName = nodeName + randomAlphaOfLength(5);
             break;
         case 2:
             available = !available;
@@ -124,7 +124,7 @@ public class MainResponseTests extends ESTestCase {
             version = randomValueOtherThan(version, () -> VersionUtils.randomVersion(random()));
             break;
         case 5:
-            clusterName = new ClusterName(clusterName + randomAsciiOfLength(5));
+            clusterName = new ClusterName(clusterName + randomAlphaOfLength(5));
             break;
         }
         return new MainResponse(nodeName, version, clusterName, clusterUuid, build, available);

--- a/core/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
@@ -70,7 +70,7 @@ public class SearchPhaseControllerTests extends ESTestCase {
     public void testSort() throws Exception {
         List<CompletionSuggestion> suggestions = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
-            suggestions.add(new CompletionSuggestion(randomAsciiOfLength(randomIntBetween(1, 5)), randomIntBetween(1, 20)));
+            suggestions.add(new CompletionSuggestion(randomAlphaOfLength(randomIntBetween(1, 5)), randomIntBetween(1, 20)));
         }
         int nShards = randomIntBetween(1, 20);
         int queryResultSize = randomBoolean() ? 0 : randomIntBetween(1, nShards * 2);
@@ -99,7 +99,7 @@ public class SearchPhaseControllerTests extends ESTestCase {
     public void testMerge() throws IOException {
         List<CompletionSuggestion> suggestions = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
-            suggestions.add(new CompletionSuggestion(randomAsciiOfLength(randomIntBetween(1, 5)), randomIntBetween(1, 20)));
+            suggestions.add(new CompletionSuggestion(randomAlphaOfLength(randomIntBetween(1, 5)), randomIntBetween(1, 20)));
         }
         int nShards = randomIntBetween(1, 20);
         int queryResultSize = randomBoolean() ? 0 : randomIntBetween(1, nShards * 2);

--- a/core/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
@@ -65,7 +65,7 @@ public class SearchScrollRequestTests extends ESTestCase {
     }
 
     public static SearchScrollRequest createSearchScrollRequest() {
-        SearchScrollRequest searchScrollRequest = new SearchScrollRequest(randomAsciiOfLengthBetween(3, 10));
+        SearchScrollRequest searchScrollRequest = new SearchScrollRequest(randomAlphaOfLengthBetween(3, 10));
         searchScrollRequest.scroll(randomPositiveTimeValue());
         return searchScrollRequest;
     }

--- a/core/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
@@ -35,11 +35,11 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 public class ShardSearchFailureTests extends ESTestCase {
 
     public static ShardSearchFailure createTestItem() {
-        String randomMessage = randomAsciiOfLengthBetween(3, 20);
+        String randomMessage = randomAlphaOfLengthBetween(3, 20);
         Exception ex = new ParsingException(0, 0, randomMessage , new IllegalArgumentException("some bad argument"));
-        String nodeId = randomAsciiOfLengthBetween(5, 10);
-        String indexName = randomAsciiOfLengthBetween(5, 10);
-        String indexUuid = randomAsciiOfLengthBetween(5, 10);
+        String nodeId = randomAlphaOfLengthBetween(5, 10);
+        String indexName = randomAlphaOfLengthBetween(5, 10);
+        String indexUuid = randomAlphaOfLengthBetween(5, 10);
         int shardId = randomInt();
         return new ShardSearchFailure(ex,
                 new SearchShardTarget(nodeId, new ShardId(new Index(indexName, indexUuid), shardId)));

--- a/core/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/ActiveShardCountTests.java
@@ -62,7 +62,7 @@ public class ActiveShardCountTests extends ESTestCase {
         assertSame(ActiveShardCount.parseString("0"), ActiveShardCount.NONE);
         int value = randomIntBetween(1, 50);
         assertEquals(ActiveShardCount.parseString(value + ""), ActiveShardCount.from(value));
-        expectThrows(IllegalArgumentException.class, () -> ActiveShardCount.parseString(randomAsciiOfLengthBetween(4, 8)));
+        expectThrows(IllegalArgumentException.class, () -> ActiveShardCount.parseString(randomAlphaOfLengthBetween(4, 8)));
         expectThrows(IllegalArgumentException.class, () -> ActiveShardCount.parseString("-1")); // magic numbers not exposed through API
         expectThrows(IllegalArgumentException.class, () -> ActiveShardCount.parseString("-2"));
         expectThrows(IllegalArgumentException.class, () -> ActiveShardCount.parseString(randomIntBetween(-10, -3) + ""));
@@ -200,7 +200,7 @@ public class ActiveShardCountTests extends ESTestCase {
             final IndexShardRoutingTable shardRoutingTable = shardEntry.value;
             for (ShardRouting shardRouting : shardRoutingTable.getShards()) {
                 if (shardRouting.primary()) {
-                    shardRouting = shardRouting.initialize(randomAsciiOfLength(8), null, shardRouting.getExpectedShardSize())
+                    shardRouting = shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize())
                                        .moveToStarted();
                 }
                 newIndexRoutingTable.addShard(shardRouting);
@@ -224,7 +224,7 @@ public class ActiveShardCountTests extends ESTestCase {
                     assertTrue(shardRouting.active());
                 } else {
                     if (numToStart > 0) {
-                        shardRouting = shardRouting.initialize(randomAsciiOfLength(8), null, shardRouting.getExpectedShardSize())
+                        shardRouting = shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize())
                                            .moveToStarted();
                         numToStart--;
                     }
@@ -250,7 +250,7 @@ public class ActiveShardCountTests extends ESTestCase {
                 } else {
                     if (shardRouting.active() == false) {
                         if (numToStart > 0) {
-                            shardRouting = shardRouting.initialize(randomAsciiOfLength(8), null, shardRouting.getExpectedShardSize())
+                            shardRouting = shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize())
                                                .moveToStarted();
                             numToStart--;
                         }
@@ -276,7 +276,7 @@ public class ActiveShardCountTests extends ESTestCase {
                     assertTrue(shardRouting.active());
                 } else {
                     if (shardRouting.active() == false) {
-                        shardRouting = shardRouting.initialize(randomAsciiOfLength(8), null, shardRouting.getExpectedShardSize())
+                        shardRouting = shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize())
                                            .moveToStarted();
                     }
                 }

--- a/core/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
@@ -85,24 +85,24 @@ public class AutoCreateIndexTests extends ESTestCase {
         Settings settings = Settings.builder().put(AutoCreateIndex.AUTO_CREATE_INDEX_SETTING.getKey(), false).build();
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () ->
-            autoCreateIndex.shouldAutoCreate(randomAsciiOfLengthBetween(1, 10), buildClusterState()));
+            autoCreateIndex.shouldAutoCreate(randomAlphaOfLengthBetween(1, 10), buildClusterState()));
         assertEquals("no such index and [action.auto_create_index] is [false]", e.getMessage());
     }
 
     public void testAutoCreationEnabled() {
         Settings settings = Settings.builder().put(AutoCreateIndex.AUTO_CREATE_INDEX_SETTING.getKey(), true).build();
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
-        assertThat(autoCreateIndex.shouldAutoCreate(randomAsciiOfLengthBetween(1, 10), buildClusterState()), equalTo(true));
+        assertThat(autoCreateIndex.shouldAutoCreate(randomAlphaOfLengthBetween(1, 10), buildClusterState()), equalTo(true));
     }
 
     public void testDefaultAutoCreation() {
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(Settings.EMPTY);
-        assertThat(autoCreateIndex.shouldAutoCreate(randomAsciiOfLengthBetween(1, 10), buildClusterState()), equalTo(true));
+        assertThat(autoCreateIndex.shouldAutoCreate(randomAlphaOfLengthBetween(1, 10), buildClusterState()), equalTo(true));
     }
 
     public void testExistingIndex() {
         Settings settings = Settings.builder().put(AutoCreateIndex.AUTO_CREATE_INDEX_SETTING.getKey(), randomFrom(true, false,
-                randomAsciiOfLengthBetween(7, 10))).build();
+                randomAlphaOfLengthBetween(7, 10))).build();
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
         assertThat(autoCreateIndex.shouldAutoCreate(randomFrom("index1", "index2", "index3"),
                 buildClusterState("index1", "index2", "index3")), equalTo(false));
@@ -110,11 +110,11 @@ public class AutoCreateIndexTests extends ESTestCase {
 
     public void testDynamicMappingDisabled() {
         Settings settings = Settings.builder().put(AutoCreateIndex.AUTO_CREATE_INDEX_SETTING.getKey(), randomFrom(true,
-                randomAsciiOfLengthBetween(1, 10)))
+                randomAlphaOfLengthBetween(1, 10)))
             .put(MapperService.INDEX_MAPPER_DYNAMIC_SETTING.getKey(), false).build();
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
         IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () ->
-            autoCreateIndex.shouldAutoCreate(randomAsciiOfLengthBetween(1, 10), buildClusterState()));
+            autoCreateIndex.shouldAutoCreate(randomAlphaOfLengthBetween(1, 10), buildClusterState()));
         assertEquals("no such index and [index.mapper.dynamic] is [false]", e.getMessage());
     }
 
@@ -123,18 +123,18 @@ public class AutoCreateIndexTests extends ESTestCase {
                 .build();
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
         ClusterState clusterState = ClusterState.builder(new ClusterName("test")).metaData(MetaData.builder()).build();
-        assertThat(autoCreateIndex.shouldAutoCreate("index" + randomAsciiOfLengthBetween(1, 5), clusterState), equalTo(true));
-        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAsciiOfLengthBetween(1, 5));
+        assertThat(autoCreateIndex.shouldAutoCreate("index" + randomAlphaOfLengthBetween(1, 5), clusterState), equalTo(true));
+        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAlphaOfLengthBetween(1, 5));
     }
 
     public void testAutoCreationPatternDisabled() {
         Settings settings = Settings.builder().put(AutoCreateIndex.AUTO_CREATE_INDEX_SETTING.getKey(), "-index*").build();
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
         ClusterState clusterState = ClusterState.builder(new ClusterName("test")).metaData(MetaData.builder()).build();
-        expectForbidden(clusterState, autoCreateIndex, "index" + randomAsciiOfLengthBetween(1, 5), "-index*");
+        expectForbidden(clusterState, autoCreateIndex, "index" + randomAlphaOfLengthBetween(1, 5), "-index*");
         /* When patterns are specified, even if the are all negative, the default is can't create. So a pure negative pattern is the same
          * as false, really. */
-        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAsciiOfLengthBetween(1, 5));
+        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAlphaOfLengthBetween(1, 5));
     }
 
     public void testAutoCreationMultiplePatternsWithWildcards() {
@@ -142,9 +142,9 @@ public class AutoCreateIndexTests extends ESTestCase {
                 randomFrom("+test*,-index*", "test*,-index*")).build();
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
         ClusterState clusterState = ClusterState.builder(new ClusterName("test")).metaData(MetaData.builder()).build();
-        expectForbidden(clusterState, autoCreateIndex, "index" + randomAsciiOfLengthBetween(1, 5), "-index*");
-        assertThat(autoCreateIndex.shouldAutoCreate("test" + randomAsciiOfLengthBetween(1, 5), clusterState), equalTo(true));
-        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAsciiOfLengthBetween(1, 5));
+        expectForbidden(clusterState, autoCreateIndex, "index" + randomAlphaOfLengthBetween(1, 5), "-index*");
+        assertThat(autoCreateIndex.shouldAutoCreate("test" + randomAlphaOfLengthBetween(1, 5), clusterState), equalTo(true));
+        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAlphaOfLengthBetween(1, 5));
     }
 
     public void testAutoCreationMultiplePatternsNoWildcards() {
@@ -152,9 +152,9 @@ public class AutoCreateIndexTests extends ESTestCase {
         AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
         ClusterState clusterState = ClusterState.builder(new ClusterName("test")).metaData(MetaData.builder()).build();
         assertThat(autoCreateIndex.shouldAutoCreate("test1", clusterState), equalTo(true));
-        expectNotMatch(clusterState, autoCreateIndex, "index" + randomAsciiOfLengthBetween(1, 5));
-        expectNotMatch(clusterState, autoCreateIndex, "test" + randomAsciiOfLengthBetween(2, 5));
-        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAsciiOfLengthBetween(1, 5));
+        expectNotMatch(clusterState, autoCreateIndex, "index" + randomAlphaOfLengthBetween(1, 5));
+        expectNotMatch(clusterState, autoCreateIndex, "test" + randomAlphaOfLengthBetween(2, 5));
+        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAlphaOfLengthBetween(1, 5));
     }
 
     public void testAutoCreationMultipleIndexNames() {
@@ -163,7 +163,7 @@ public class AutoCreateIndexTests extends ESTestCase {
         ClusterState clusterState = ClusterState.builder(new ClusterName("test")).metaData(MetaData.builder()).build();
         assertThat(autoCreateIndex.shouldAutoCreate("test1", clusterState), equalTo(true));
         assertThat(autoCreateIndex.shouldAutoCreate("test2", clusterState), equalTo(true));
-        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAsciiOfLengthBetween(1, 5));
+        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAlphaOfLengthBetween(1, 5));
     }
 
     public void testAutoCreationConflictingPatternsFirstWins() {
@@ -173,7 +173,7 @@ public class AutoCreateIndexTests extends ESTestCase {
         ClusterState clusterState = ClusterState.builder(new ClusterName("test")).metaData(MetaData.builder()).build();
         assertThat(autoCreateIndex.shouldAutoCreate("test1", clusterState), equalTo(true));
         expectForbidden(clusterState, autoCreateIndex, "test2", "-test2");
-        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAsciiOfLengthBetween(1, 5));
+        expectNotMatch(clusterState, autoCreateIndex, "does_not_match" + randomAlphaOfLengthBetween(1, 5));
     }
 
     public void testUpdate() {

--- a/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/TransportActionFilterChainTests.java
@@ -41,8 +41,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
-import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -69,7 +67,7 @@ public class TransportActionFilterChainTests extends ESTestCase {
             filters.add(new RequestTestFilter(order, randomFrom(RequestOperation.values())));
         }
 
-        String actionName = randomAsciiOfLength(randomInt(30));
+        String actionName = randomAlphaOfLength(randomInt(30));
         ActionFilters actionFilters = new ActionFilters(filters);
         TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters, null, new TaskManager(Settings.EMPTY)) {
             @Override
@@ -153,7 +151,7 @@ public class TransportActionFilterChainTests extends ESTestCase {
         Set<ActionFilter> filters = new HashSet<>();
         filters.add(testFilter);
 
-        String actionName = randomAsciiOfLength(randomInt(30));
+        String actionName = randomAlphaOfLength(randomInt(30));
         ActionFilters actionFilters = new ActionFilters(filters);
         TransportAction<TestRequest, TestResponse> transportAction = new TransportAction<TestRequest, TestResponse>(Settings.EMPTY, actionName, null, actionFilters, null, new TaskManager(Settings.EMPTY)) {
             @Override

--- a/core/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -113,9 +113,9 @@ public class TransportNodesActionTests extends ESTestCase {
         nodeResponses.add(new OtherNodeResponse());
         List<FailedNodeException> failures = mockList(
             () -> new FailedNodeException(
-                randomAsciiOfLength(8),
-                randomAsciiOfLength(8),
-                new IllegalStateException(randomAsciiOfLength(8))),
+                randomAlphaOfLength(8),
+                randomAlphaOfLength(8),
+                new IllegalStateException(randomAlphaOfLength(8))),
             randomIntBetween(0, 2));
 
         List<Object> allResponses = new ArrayList<>(expectedNodeResponses);
@@ -192,7 +192,7 @@ public class TransportNodesActionTests extends ESTestCase {
             Map<String, String> attributes = new HashMap<>();
             Set<DiscoveryNode.Role> roles = new HashSet<>(randomSubsetOf(Arrays.asList(DiscoveryNode.Role.values())));
             if (frequently()) {
-                attributes.put("custom", randomBoolean() ? "match" : randomAsciiOfLengthBetween(3, 5));
+                attributes.put("custom", randomBoolean() ? "match" : randomAlphaOfLengthBetween(3, 5));
             }
             final DiscoveryNode node = newNode(i, attributes, roles);
             discoBuilder = discoBuilder.add(node);

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -175,7 +175,7 @@ public class ReplicationOperationTests extends ESTestCase {
         }
         // add in-sync allocation id that doesn't have a corresponding routing entry
         state = ClusterState.builder(state).metaData(MetaData.builder(state.metaData()).put(IndexMetaData.builder(indexMetaData)
-            .putInSyncAllocationIds(0, Sets.union(indexMetaData.inSyncAllocationIds(0), Sets.newHashSet(randomAsciiOfLength(10))))))
+            .putInSyncAllocationIds(0, Sets.union(indexMetaData.inSyncAllocationIds(0), Sets.newHashSet(randomAlphaOfLength(10))))))
             .build();
 
         final Set<ShardRouting> expectedReplicas = getExpectedReplicas(shardId, state);

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -64,7 +64,6 @@ import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.cluster.ClusterStateChanges;
-import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.CapturingTransport;
@@ -626,7 +625,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         assertThat(captures, arrayWithSize(1));
         if (randomBoolean()) {
             final TransportReplicationAction.ReplicaResponse response =
-                new TransportReplicationAction.ReplicaResponse(randomAsciiOfLength(10), randomLong());
+                new TransportReplicationAction.ReplicaResponse(randomAlphaOfLength(10), randomLong());
             transport.handleResponse(captures[0].requestId, response);
             assertTrue(listener.isDone());
             assertThat(listener.get(), equalTo(response));

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
@@ -20,14 +20,11 @@
 package org.elasticsearch.action.support.replication;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.support.WriteResponse;
-import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
-import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.ReplicationOperation.ReplicaResponse;
 import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.elasticsearch.cluster.ClusterState;
@@ -56,7 +53,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
@@ -290,7 +286,7 @@ public class TransportWriteActionTests extends ESTestCase {
         assertThat(captures, arrayWithSize(1));
         if (randomBoolean()) {
             final TransportReplicationAction.ReplicaResponse response =
-                new TransportReplicationAction.ReplicaResponse(randomAsciiOfLength(10), randomLong());
+                new TransportReplicationAction.ReplicaResponse(randomAlphaOfLength(10), randomLong());
             transport.handleResponse(captures[0].requestId, response);
             assertTrue(listener.isDone());
             assertThat(listener.get(), equalTo(response));

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -417,12 +417,12 @@ public class UpdateRequestTests extends ESTestCase {
             updateRequest.docAsUpsert(randomBoolean());
         } else {
             ScriptType scriptType = randomFrom(ScriptType.values());
-            String scriptLang = (scriptType != ScriptType.STORED) ? randomAsciiOfLength(10) : null;
-            String scriptIdOrCode = randomAsciiOfLength(10);
+            String scriptLang = (scriptType != ScriptType.STORED) ? randomAlphaOfLength(10) : null;
+            String scriptIdOrCode = randomAlphaOfLength(10);
             int nbScriptParams = randomIntBetween(0, 5);
             Map<String, Object> scriptParams = new HashMap<>(nbScriptParams);
             for (int i = 0; i < nbScriptParams; i++) {
-                scriptParams.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+                scriptParams.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
             }
             updateRequest.script(new Script(scriptType, scriptLang, scriptIdOrCode, scriptParams));
             updateRequest.scriptedUpsert(randomBoolean());
@@ -435,7 +435,7 @@ public class UpdateRequestTests extends ESTestCase {
         if (randomBoolean()) {
             String[] fields = new String[randomIntBetween(0, 5)];
             for (int i = 0; i < fields.length; i++) {
-                fields[i] = randomAsciiOfLength(5);
+                fields[i] = randomAlphaOfLength(5);
             }
             updateRequest.fields(fields);
         }
@@ -445,11 +445,11 @@ public class UpdateRequestTests extends ESTestCase {
             } else {
                 String[] includes = new String[randomIntBetween(0, 5)];
                 for (int i = 0; i < includes.length; i++) {
-                    includes[i] = randomAsciiOfLength(5);
+                    includes[i] = randomAlphaOfLength(5);
                 }
                 String[] excludes = new String[randomIntBetween(0, 5)];
                 for (int i = 0; i < excludes.length; i++) {
-                    excludes[i] = randomAsciiOfLength(5);
+                    excludes[i] = randomAlphaOfLength(5);
                 }
                 if (randomBoolean()) {
                     updateRequest.fetchSource(includes, excludes);

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
@@ -130,7 +130,7 @@ public class UpdateResponseTests extends ESTestCase {
         String id = actualGetResult.getId();
         long version = actualGetResult.getVersion();
         DocWriteResponse.Result result = actualGetResult.isExists() ? DocWriteResponse.Result.UPDATED : DocWriteResponse.Result.NOT_FOUND;
-        String indexUUid = randomAsciiOfLength(5);
+        String indexUUid = randomAlphaOfLength(5);
         int shardId = randomIntBetween(0, 5);
 
         // We also want small number values (randomNonNegativeLong() tend to generate high numbers)

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
@@ -483,7 +483,7 @@ public class BootstrapChecksTests extends ESTestCase {
             }
         };
 
-        final String command = randomAsciiOfLength(16);
+        final String command = randomAlphaOfLength(16);
         runMightForkTest(
             check,
             isSystemCallFilterInstalled,
@@ -511,7 +511,7 @@ public class BootstrapChecksTests extends ESTestCase {
             }
         };
 
-        final String command = randomAsciiOfLength(16);
+        final String command = randomAlphaOfLength(16);
         runMightForkTest(
             check,
             isSystemCallFilterInstalled,
@@ -647,7 +647,7 @@ public class BootstrapChecksTests extends ESTestCase {
 
             @Override
             String jvmVendor() {
-                return randomAsciiOfLength(8);
+                return randomAlphaOfLength(8);
             }
 
         };

--- a/core/src/test/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandlerTests.java
@@ -60,7 +60,7 @@ public class ElasticsearchUncaughtExceptionHandlerTests extends ESTestCase {
             new IOError(new IOException("fatal")),
             new Error() {});
         final Thread thread = new Thread(() -> { throw error; });
-        final String name = randomAsciiOfLength(10);
+        final String name = randomAlphaOfLength(10);
         thread.setName(name);
         final AtomicBoolean halt = new AtomicBoolean();
         final AtomicInteger observedStatus = new AtomicInteger();
@@ -103,7 +103,7 @@ public class ElasticsearchUncaughtExceptionHandlerTests extends ESTestCase {
     public void testUncaughtException() throws InterruptedException {
         final RuntimeException e = new RuntimeException("boom");
         final Thread thread = new Thread(() -> { throw e; });
-        final String name = randomAsciiOfLength(10);
+        final String name = randomAlphaOfLength(10);
         thread.setName(name);
         final AtomicReference<String> threadNameReference = new AtomicReference<>();
         final AtomicReference<Throwable> throwableReference = new AtomicReference<>();

--- a/core/src/test/java/org/elasticsearch/client/AbstractClientHeadersTestCase.java
+++ b/core/src/test/java/org/elasticsearch/client/AbstractClientHeadersTestCase.java
@@ -40,8 +40,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.After;
-import org.junit.Before;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -122,7 +120,7 @@ public abstract class AbstractClientHeadersTestCase extends ESTestCase {
     }
 
     public void testOverrideHeader() throws Exception {
-        String key1Val = randomAsciiOfLength(5);
+        String key1Val = randomAlphaOfLength(5);
         Map<String, String> expected = new HashMap<>();
         expected.put("key1", key1Val);
         expected.put("key2", "val 2");

--- a/core/src/test/java/org/elasticsearch/client/ParentTaskAssigningClientTests.java
+++ b/core/src/test/java/org/elasticsearch/client/ParentTaskAssigningClientTests.java
@@ -33,7 +33,7 @@ import org.elasticsearch.test.client.NoOpClient;
 
 public class ParentTaskAssigningClientTests extends ESTestCase {
     public void testSetsParentId() {
-        TaskId[] parentTaskId = new TaskId[] {new TaskId(randomAsciiOfLength(3), randomLong())};
+        TaskId[] parentTaskId = new TaskId[] {new TaskId(randomAlphaOfLength(3), randomLong())};
 
         // This mock will do nothing but verify that parentTaskId is set on all requests sent to it.
         NoOpClient mock = new NoOpClient(getTestName()) {

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterChangedEventTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterChangedEventTests.java
@@ -529,7 +529,7 @@ public class ClusterChangedEventTests extends ESTestCase {
             default: throw new AssertionError("Unhandled mode [" + deletionQuantity + "]");
         }
         final boolean changeClusterUUID = randomBoolean();
-        final List<Index> addedIndices = addIndices(numAdd, randomAsciiOfLengthBetween(5, 10));
+        final List<Index> addedIndices = addIndices(numAdd, randomAlphaOfLengthBetween(5, 10));
         List<Index> delIndices;
         if (changeClusterUUID) {
             delIndices = new ArrayList<>();

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
@@ -46,9 +46,9 @@ public class ClusterInfoTests extends ESTestCase {
         int numEntries = randomIntBetween(0, 128);
         ImmutableOpenMap.Builder<String, DiskUsage> builder = ImmutableOpenMap.builder(numEntries);
         for (int i = 0; i < numEntries; i++) {
-            String key = randomAsciiOfLength(32);
+            String key = randomAlphaOfLength(32);
             DiskUsage diskUsage = new DiskUsage(
-                    randomAsciiOfLength(4), randomAsciiOfLength(4), randomAsciiOfLength(4),
+                    randomAlphaOfLength(4), randomAlphaOfLength(4), randomAlphaOfLength(4),
                     randomIntBetween(0, Integer.MAX_VALUE), randomIntBetween(0, Integer.MAX_VALUE)
             );
             builder.put(key, diskUsage);
@@ -60,7 +60,7 @@ public class ClusterInfoTests extends ESTestCase {
         int numEntries = randomIntBetween(0, 128);
         ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.builder(numEntries);
         for (int i = 0; i < numEntries; i++) {
-            String key = randomAsciiOfLength(32);
+            String key = randomAlphaOfLength(32);
             long shardSize = randomIntBetween(0, Integer.MAX_VALUE);
             builder.put(key, shardSize);
         }
@@ -71,9 +71,9 @@ public class ClusterInfoTests extends ESTestCase {
         int numEntries = randomIntBetween(0, 128);
         ImmutableOpenMap.Builder<ShardRouting, String> builder = ImmutableOpenMap.builder(numEntries);
         for (int i = 0; i < numEntries; i++) {
-            ShardId shardId = new ShardId(randomAsciiOfLength(32), randomAsciiOfLength(32), randomIntBetween(0, Integer.MAX_VALUE));
+            ShardId shardId = new ShardId(randomAlphaOfLength(32), randomAlphaOfLength(32), randomIntBetween(0, Integer.MAX_VALUE));
             ShardRouting shardRouting = TestShardRouting.newShardRouting(shardId, null, randomBoolean(), ShardRoutingState.UNASSIGNED);
-            builder.put(shardRouting, randomAsciiOfLength(32));
+            builder.put(shardRouting, randomAlphaOfLength(32));
         }
         return builder.build();
     }

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -207,7 +207,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
         }
         int additionalNodeCount = randomIntBetween(1, 20);
         for (int i = 0; i < additionalNodeCount; i++) {
-            nodes.add(new DiscoveryNode("node-" + randomAsciiOfLength(10), buildNewFakeTransportAddress(),
+            nodes.add(new DiscoveryNode("node-" + randomAlphaOfLength(10), buildNewFakeTransportAddress(),
                     emptyMap(), emptySet(), randomVersion(random())));
         }
         return ClusterState.builder(clusterState).nodes(nodes);
@@ -250,7 +250,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
             for (int j = 0; j < replicaCount; j++) {
                 UnassignedInfo unassignedInfo = null;
                 if (randomInt(5) == 1) {
-                    unassignedInfo = new UnassignedInfo(randomReason(), randomAsciiOfLength(10));
+                    unassignedInfo = new UnassignedInfo(randomReason(), randomAlphaOfLength(10));
                 }
                 if (availableNodeIds.isEmpty()) {
                     break;
@@ -420,7 +420,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
         }
         int settingsCount = randomInt(10);
         for (int i = 0; i < settingsCount; i++) {
-            builder.put(randomAsciiOfLength(10), randomAsciiOfLength(10));
+            builder.put(randomAlphaOfLength(10), randomAlphaOfLength(10));
         }
         return builder.build();
 
@@ -541,7 +541,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
                         if (randomBoolean() && part.getAliases().isEmpty() == false) {
                             builder.removeAlias(randomFrom(part.getAliases().keys().toArray(String.class)));
                         } else {
-                            builder.putAlias(AliasMetaData.builder(randomAsciiOfLength(10)));
+                            builder.putAlias(AliasMetaData.builder(randomAlphaOfLength(10)));
                         }
                         break;
                     case 2:
@@ -606,7 +606,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
             builder.filter(QueryBuilders.termQuery("test", randomRealisticUnicodeOfCodepointLength(10)).toString());
         }
         if (randomBoolean()) {
-            builder.routing(randomAsciiOfLength(10));
+            builder.routing(randomAlphaOfLength(10));
         }
         return builder.build();
     }

--- a/core/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.LocalClusterUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -366,7 +365,7 @@ public class ClusterStateHealthTests extends ESTestCase {
         final Set<String> nodeIds = new HashSet<>();
         final int numNodes = randomIntBetween(numberOfReplicas + 1, 10);
         for (int i = 0; i < numNodes; i++) {
-            nodeIds.add(randomAsciiOfLength(8));
+            nodeIds.add(randomAlphaOfLength(8));
         }
 
         final List<ClusterState> clusterStates = new ArrayList<>();

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/DateMathExpressionResolverTests.java
@@ -51,7 +51,7 @@ public class DateMathExpressionResolverTests extends ESTestCase {
         int numIndexExpressions = randomIntBetween(1, 9);
         List<String> indexExpressions = new ArrayList<>(numIndexExpressions);
         for (int i = 0; i < numIndexExpressions; i++) {
-            indexExpressions.add(randomAsciiOfLength(10));
+            indexExpressions.add(randomAlphaOfLength(10));
         }
         List<String> result = expressionResolver.resolve(context, indexExpressions);
         assertThat(result.size(), equalTo(indexExpressions.size()));

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
@@ -49,7 +49,7 @@ public class IndexGraveyardTests extends ESTestCase {
         final IndexGraveyard graveyard = createRandom();
         assertThat(graveyard, equalTo(IndexGraveyard.builder(graveyard).build()));
         final IndexGraveyard.Builder newGraveyard = IndexGraveyard.builder(graveyard);
-        newGraveyard.addTombstone(new Index(randomAsciiOfLengthBetween(4, 15), UUIDs.randomBase64UUID()));
+        newGraveyard.addTombstone(new Index(randomAlphaOfLengthBetween(4, 15), UUIDs.randomBase64UUID()));
         assertThat(newGraveyard.build(), not(graveyard));
     }
 
@@ -140,7 +140,7 @@ public class IndexGraveyardTests extends ESTestCase {
         for (final Index index : indices) {
             assertTrue(indexGraveyard.containsIndex(index));
         }
-        assertFalse(indexGraveyard.containsIndex(new Index(randomAsciiOfLength(6), UUIDs.randomBase64UUID())));
+        assertFalse(indexGraveyard.containsIndex(new Index(randomAlphaOfLength(6), UUIDs.randomBase64UUID())));
     }
 
     public static IndexGraveyard createRandom() {

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
@@ -152,7 +152,7 @@ public class MetaDataCreateIndexServiceTests extends ESTestCase {
     }
 
     public void testShrinkIndexSettings() {
-        String indexName = randomAsciiOfLength(10);
+        String indexName = randomAlphaOfLength(10);
         List<Version> versions = Arrays.asList(VersionUtils.randomVersion(random()), VersionUtils.randomVersion(random()),
             VersionUtils.randomVersion(random()));
         versions.sort((l, r) -> Long.compare(l.id, r.id));

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataDeleteIndexServiceTests.java
@@ -55,7 +55,7 @@ public class MetaDataDeleteIndexServiceTests extends ESTestCase {
     }
 
     public void testDeleteSnapshotting() {
-        String index = randomAsciiOfLength(5);
+        String index = randomAlphaOfLength(5);
         Snapshot snapshot = new Snapshot("doesn't matter", new SnapshotId("snapshot name", "snapshot uuid"));
         SnapshotsInProgress snaps = new SnapshotsInProgress(new SnapshotsInProgress.Entry(snapshot, true, false,
                 SnapshotsInProgress.State.INIT, singletonList(new IndexId(index, "doesn't matter")),
@@ -71,7 +71,7 @@ public class MetaDataDeleteIndexServiceTests extends ESTestCase {
 
     public void testDeleteUnassigned() {
         // Create an unassigned index
-        String index = randomAsciiOfLength(5);
+        String index = randomAlphaOfLength(5);
         ClusterState before = clusterState(index);
 
         // Mock the built reroute

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesServiceTests.java
@@ -60,7 +60,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
 
     public void testAddAndRemove() {
         // Create a state with a single index
-        String index = randomAsciiOfLength(5);
+        String index = randomAlphaOfLength(5);
         ClusterState before = createIndex(ClusterState.builder(ClusterName.DEFAULT).build(), index);
 
         // Add an alias to it

--- a/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.cluster.node;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.elasticsearch.Version;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.VersionUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -172,7 +171,7 @@ public class DiscoveryNodesTests extends ESTestCase {
         for (int i = 0; i < numNodes; i++) {
             Map<String, String> attributes = new HashMap<>();
             if (frequently()) {
-                attributes.put("custom", randomBoolean() ? "match" : randomAsciiOfLengthBetween(3, 5));
+                attributes.put("custom", randomBoolean() ? "match" : randomAlphaOfLengthBetween(3, 5));
             }
             final DiscoveryNode node = newNode(idGenerator.getAndIncrement(), attributes,
                 new HashSet<>(randomSubsetOf(Arrays.asList(DiscoveryNode.Role.values()))));

--- a/core/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
@@ -58,7 +58,7 @@ public class OperationRoutingTests extends ESTestCase{
             assertEquals(shardSplits[1], (shardSplits[1] / shardSplits[2]) * shardSplits[2]);
             IndexMetaData metaData = IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(shardSplits[0])
                 .numberOfReplicas(1).build();
-            String term = randomAsciiOfLength(10);
+            String term = randomAlphaOfLength(10);
             final int shard = OperationRouting.generateShardId(metaData, term, null);
             IndexMetaData shrunk = IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(shardSplits[1])
                 .numberOfReplicas(1)

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RandomShardRoutingMutator.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RandomShardRoutingMutator.java
@@ -21,7 +21,7 @@ package org.elasticsearch.cluster.routing;
 
 import java.util.Set;
 
-import static org.elasticsearch.test.ESTestCase.randomAsciiOfLength;
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.ESTestCase.randomInt;
 
@@ -37,9 +37,9 @@ public final class RandomShardRoutingMutator {
         switch (randomInt(2)) {
             case 0:
                 if (shardRouting.unassigned() == false && shardRouting.primary() == false) {
-                    shardRouting = shardRouting.moveToUnassigned(new UnassignedInfo(randomReason(), randomAsciiOfLength(10)));
+                    shardRouting = shardRouting.moveToUnassigned(new UnassignedInfo(randomReason(), randomAlphaOfLength(10)));
                 } else if (shardRouting.unassignedInfo() != null) {
-                    shardRouting = shardRouting.updateUnassigned(new UnassignedInfo(randomReason(), randomAsciiOfLength(10)),
+                    shardRouting = shardRouting.updateUnassigned(new UnassignedInfo(randomReason(), randomAlphaOfLength(10)),
                         shardRouting.recoverySource());
                 }
                 break;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -118,7 +118,7 @@ public class ShardRoutingTests extends ESTestCase {
             switch (changeId) {
                 case 0:
                     // change index
-                    ShardId shardId = new ShardId(new Index("blubb", randomAsciiOfLength(10)), otherRouting.id());
+                    ShardId shardId = new ShardId(new Index("blubb", randomAlphaOfLength(10)), otherRouting.id());
                     otherRouting = new ShardRouting(shardId, otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                             otherRouting.primary(), otherRouting.state(), otherRouting.recoverySource(), otherRouting.unassignedInfo(),
                             otherRouting.allocationId(), otherRouting.getExpectedShardSize());

--- a/core/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
@@ -79,9 +79,9 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
     public void testSerialization() throws Exception {
         UnassignedInfo.Reason reason = RandomPicks.randomFrom(random(), UnassignedInfo.Reason.values());
         UnassignedInfo meta = reason == UnassignedInfo.Reason.ALLOCATION_FAILED ?
-            new UnassignedInfo(reason, randomBoolean() ? randomAsciiOfLength(4) : null, null, randomIntBetween(1, 100), System.nanoTime(),
+            new UnassignedInfo(reason, randomBoolean() ? randomAlphaOfLength(4) : null, null, randomIntBetween(1, 100), System.nanoTime(),
                                System.currentTimeMillis(), false, AllocationStatus.NO_ATTEMPT):
-            new UnassignedInfo(reason, randomBoolean() ? randomAsciiOfLength(4) : null);
+            new UnassignedInfo(reason, randomBoolean() ? randomAlphaOfLength(4) : null);
         BytesStreamOutput out = new BytesStreamOutput();
         meta.writeTo(out);
         out.close();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecisionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocateUnassignedDecisionTests.java
@@ -174,7 +174,7 @@ public class AllocateUnassignedDecisionTests extends ESTestCase {
                                                               randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES), 1));
         AllocateUnassignedDecision decision;
         if (finalDecision == Decision.Type.YES) {
-            decision = AllocateUnassignedDecision.yes(assignedNode, randomBoolean() ? randomAsciiOfLength(5) : null,
+            decision = AllocateUnassignedDecision.yes(assignedNode, randomBoolean() ? randomAlphaOfLength(5) : null,
                 nodeDecisions, randomBoolean());
         } else {
             decision = AllocateUnassignedDecision.no(randomFrom(

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -191,7 +191,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
         int excludeNodesSize = randomIntBetween(0, numAddedNodes - 1);
         final Set<String> excludeNodes = new HashSet<>();
         for (int i = 0; i < numAddedNodes; i++) {
-            DiscoveryNode discoveryNode = newNode(randomAsciiOfLength(7));
+            DiscoveryNode discoveryNode = newNode(randomAlphaOfLength(7));
             nodesBuilder.add(discoveryNode);
             if (i < excludeNodesSize) {
                 excludeNodes.add(discoveryNode.getId());
@@ -331,7 +331,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
     private ClusterState addNodesToClusterState(ClusterState clusterState, int numNodesToAdd) {
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(clusterState.nodes());
         for (int i = 0; i < numNodesToAdd; i++) {
-            DiscoveryNode discoveryNode = newNode(randomAsciiOfLength(7));
+            DiscoveryNode discoveryNode = newNode(randomAlphaOfLength(7));
             nodesBuilder.add(discoveryNode);
         }
         return ClusterState.builder(clusterState).nodes(nodesBuilder).build();
@@ -352,7 +352,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
         ClusterState clusterState = ClusterStateCreationUtils.state("idx", 2, numShards);
         // add a new node so shards can be rebalanced there
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(clusterState.nodes());
-        nodesBuilder.add(newNode(randomAsciiOfLength(7)));
+        nodesBuilder.add(newNode(randomAlphaOfLength(7)));
         clusterState = ClusterState.builder(clusterState).nodes(nodesBuilder).build();
         ShardRouting shard = clusterState.routingTable().index("idx").shard(0).primaryShard();
         RoutingAllocation routingAllocation = newRoutingAllocation(

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResultTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResultTests.java
@@ -61,7 +61,7 @@ public class NodeAllocationResultTests extends ESTestCase {
         assertFalse(explanation.getShardStoreInfo().isInSync());
         assertFalse(explanation.getShardStoreInfo().hasMatchingSyncId());
 
-        String allocId = randomAsciiOfLength(5);
+        String allocId = randomAlphaOfLength(5);
         boolean inSync = randomBoolean();
         shardStoreInfo = new ShardStoreInfo(allocId, inSync, randomBoolean() ? new Exception("bad stuff") : null);
         explanation = new NodeAllocationResult(node, shardStoreInfo, decision);

--- a/core/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/core/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -712,7 +712,7 @@ public class CacheTests extends ESTestCase {
 
         CyclicBarrier barrier = new CyclicBarrier(1 + numberOfThreads);
 
-        final String key = randomAsciiOfLengthBetween(2, 32);
+        final String key = randomAlphaOfLengthBetween(2, 32);
         for (int i = 0; i < numberOfThreads; i++) {
             Thread thread = new Thread(() -> {
                 try {

--- a/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -339,8 +339,8 @@ public class BytesStreamsTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.singletonList(
                     new NamedWriteableRegistry.Entry(BaseNamedWriteable.class, TestNamedWriteable.NAME, TestNamedWriteable::new)));
-            TestNamedWriteable namedWriteableIn = new TestNamedWriteable(randomAsciiOfLengthBetween(1, 10),
-                    randomAsciiOfLengthBetween(1, 10));
+            TestNamedWriteable namedWriteableIn = new TestNamedWriteable(randomAlphaOfLengthBetween(1, 10),
+                    randomAlphaOfLengthBetween(1, 10));
             out.writeNamedWriteable(namedWriteableIn);
             byte[] bytes = BytesReference.toBytes(out.bytes());
 
@@ -360,7 +360,7 @@ public class BytesStreamsTests extends ESTestCase {
         int size = between(0, 100);
         List<BaseNamedWriteable> expected = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            expected.add(new TestNamedWriteable(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10)));
+            expected.add(new TestNamedWriteable(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)));
         }
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
@@ -386,8 +386,8 @@ public class BytesStreamsTests extends ESTestCase {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.singletonList(
                     new NamedWriteableRegistry.Entry(BaseNamedWriteable.class, TestNamedWriteable.NAME, (StreamInput in) -> null)));
-            TestNamedWriteable namedWriteableIn = new TestNamedWriteable(randomAsciiOfLengthBetween(1, 10),
-                    randomAsciiOfLengthBetween(1, 10));
+            TestNamedWriteable namedWriteableIn = new TestNamedWriteable(randomAlphaOfLengthBetween(1, 10),
+                    randomAlphaOfLengthBetween(1, 10));
             out.writeNamedWriteable(namedWriteableIn);
             byte[] bytes = BytesReference.toBytes(out.bytes());
             try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(bytes), namedWriteableRegistry)) {
@@ -400,7 +400,7 @@ public class BytesStreamsTests extends ESTestCase {
 
     public void testOptionalWriteableReaderReturnsNull() throws IOException {
         try (BytesStreamOutput out = new BytesStreamOutput()) {
-            out.writeOptionalWriteable(new TestNamedWriteable(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10)));
+            out.writeOptionalWriteable(new TestNamedWriteable(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)));
             StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
             IOException e = expectThrows(IOException.class, () -> in.readOptionalWriteable((StreamInput ignored) -> null));
             assertThat(e.getMessage(), endsWith("] returned null which is not allowed and probably means it screwed up the stream."));
@@ -417,8 +417,8 @@ public class BytesStreamsTests extends ESTestCase {
                                     return "intentionally-broken";
                                 }
                             })));
-            TestNamedWriteable namedWriteableIn = new TestNamedWriteable(randomAsciiOfLengthBetween(1, 10),
-                    randomAsciiOfLengthBetween(1, 10));
+            TestNamedWriteable namedWriteableIn = new TestNamedWriteable(randomAlphaOfLengthBetween(1, 10),
+                    randomAlphaOfLengthBetween(1, 10));
             out.writeNamedWriteable(namedWriteableIn);
             byte[] bytes = BytesReference.toBytes(out.bytes());
             try (StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(bytes), namedWriteableRegistry)) {
@@ -461,7 +461,7 @@ public class BytesStreamsTests extends ESTestCase {
         final int size = randomIntBetween(0, 100);
         final Map<String, String> expected = new HashMap<>(randomIntBetween(0, 100));
         for (int i = 0; i < size; ++i) {
-            expected.put(randomAsciiOfLength(2), randomAsciiOfLength(5));
+            expected.put(randomAlphaOfLength(2), randomAlphaOfLength(5));
         }
 
         final BytesStreamOutput out = new BytesStreamOutput();
@@ -482,10 +482,10 @@ public class BytesStreamsTests extends ESTestCase {
             List<String> list = new ArrayList<>(listSize);
 
             for (int j = 0; j < listSize; ++j) {
-                list.add(randomAsciiOfLength(5));
+                list.add(randomAlphaOfLength(5));
             }
 
-            expected.put(randomAsciiOfLength(2), list);
+            expected.put(randomAlphaOfLength(2), list);
         }
 
         final BytesStreamOutput out = new BytesStreamOutput();
@@ -633,8 +633,8 @@ public class BytesStreamsTests extends ESTestCase {
     public void testWriteMapWithConsistentOrder() throws IOException {
         Map<String, String> map =
             randomMap(new TreeMap<>(), randomIntBetween(2, 20),
-                () -> randomAsciiOfLength(5),
-                () -> randomAsciiOfLength(5));
+                () -> randomAlphaOfLength(5),
+                () -> randomAlphaOfLength(5));
 
         Map<String, Object> reverseMap = new TreeMap<>(Collections.reverseOrder());
         reverseMap.putAll(map);
@@ -655,8 +655,8 @@ public class BytesStreamsTests extends ESTestCase {
     public void testReadMapByUsingWriteMapWithConsistentOrder() throws IOException {
         Map<String, String> streamOutMap =
             randomMap(new HashMap<>(), randomIntBetween(2, 20),
-                () -> randomAsciiOfLength(5),
-                () -> randomAsciiOfLength(5));
+                () -> randomAlphaOfLength(5),
+                () -> randomAlphaOfLength(5));
         try (BytesStreamOutput streamOut = new BytesStreamOutput()) {
             streamOut.writeMapWithConsistentOrder(streamOutMap);
             StreamInput in = StreamInput.wrap(BytesReference.toBytes(streamOut.bytes()));

--- a/core/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/logging/DeprecationLoggerTests.java
@@ -58,7 +58,7 @@ public class DeprecationLoggerTests extends ESTestCase {
         try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
             final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
 
-            final String param = randomAsciiOfLengthBetween(1, 5);
+            final String param = randomAlphaOfLengthBetween(1, 5);
             logger.deprecated(threadContexts, "A simple message [{}]", param);
 
             final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
@@ -75,9 +75,9 @@ public class DeprecationLoggerTests extends ESTestCase {
         try (ThreadContext threadContext = new ThreadContext(Settings.EMPTY)) {
             final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
 
-            final String param = randomAsciiOfLengthBetween(1, 5);
+            final String param = randomAlphaOfLengthBetween(1, 5);
             logger.deprecated(threadContexts, "A simple message [{}]", param);
-            final String second = randomAsciiOfLengthBetween(1, 10);
+            final String second = randomAlphaOfLengthBetween(1, 10);
             logger.deprecated(threadContexts, second);
 
             final Map<String, List<String>> responseHeaders = threadContext.getResponseHeaders();
@@ -167,7 +167,7 @@ public class DeprecationLoggerTests extends ESTestCase {
     }
 
     public void testWarningValueFromWarningHeader() throws InterruptedException {
-        final String s = randomAsciiOfLength(16);
+        final String s = randomAlphaOfLength(16);
         final String first = DeprecationLogger.formatWarning(s);
         assertThat(DeprecationLogger.extractWarningValueFromWarningHeader(first), equalTo(s));
     }

--- a/core/src/test/java/org/elasticsearch/common/lucene/index/FreqTermsEnumTests.java
+++ b/core/src/test/java/org/elasticsearch/common/lucene/index/FreqTermsEnumTests.java
@@ -88,7 +88,7 @@ public class FreqTermsEnumTests extends ESTestCase {
         iw = new IndexWriter(dir, conf);
         terms = new String[scaledRandomIntBetween(10, 300)];
         for (int i = 0; i < terms.length; i++) {
-            terms[i] = randomAsciiOfLength(5);
+            terms[i] = randomAlphaOfLength(5);
         }
 
         int numberOfDocs = scaledRandomIntBetween(30, 300);

--- a/core/src/test/java/org/elasticsearch/common/settings/SecureStringTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SecureStringTests.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.sameInstance;
 public class SecureStringTests extends ESTestCase {
 
     public void testCloseableCharsDoesNotModifySecureString() {
-        final char[] password = randomAsciiOfLengthBetween(1, 32).toCharArray();
+        final char[] password = randomAlphaOfLengthBetween(1, 32).toCharArray();
         SecureString secureString = new SecureString(password);
         assertSecureStringEqualToChars(password, secureString);
         try (SecureString copy = secureString.clone()) {
@@ -41,7 +41,7 @@ public class SecureStringTests extends ESTestCase {
     }
 
     public void testClosingSecureStringDoesNotModifyCloseableChars() {
-        final char[] password = randomAsciiOfLengthBetween(1, 32).toCharArray();
+        final char[] password = randomAlphaOfLengthBetween(1, 32).toCharArray();
         SecureString secureString = new SecureString(password);
         assertSecureStringEqualToChars(password, secureString);
         SecureString copy = secureString.clone();
@@ -55,7 +55,7 @@ public class SecureStringTests extends ESTestCase {
     }
 
     public void testClosingChars() {
-        final char[] password = randomAsciiOfLengthBetween(1, 32).toCharArray();
+        final char[] password = randomAlphaOfLengthBetween(1, 32).toCharArray();
         SecureString secureString = new SecureString(password);
         assertSecureStringEqualToChars(password, secureString);
         SecureString copy = secureString.clone();
@@ -71,7 +71,7 @@ public class SecureStringTests extends ESTestCase {
     }
 
     public void testGetCloseableCharsAfterSecureStringClosed() {
-        final char[] password = randomAsciiOfLengthBetween(1, 32).toCharArray();
+        final char[] password = randomAlphaOfLengthBetween(1, 32).toCharArray();
         SecureString secureString = new SecureString(password);
         assertSecureStringEqualToChars(password, secureString);
         secureString.close();

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -69,7 +69,7 @@ public class SettingsTests extends ESTestCase {
     }
 
     public void testReplacePropertiesPlaceholderByEnvironmentVariables() {
-        final String hostname = randomAsciiOfLength(16);
+        final String hostname = randomAlphaOfLength(16);
         final Settings implicitEnvSettings = Settings.builder()
             .put("setting1", "${HOSTNAME}")
             .replacePropertyPlaceholders(name -> "HOSTNAME".equals(name) ? hostname : null)

--- a/core/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
+++ b/core/src/test/java/org/elasticsearch/common/unit/TimeValueTests.java
@@ -138,7 +138,7 @@ public class TimeValueTests extends ESTestCase {
     private static final String FRACTIONAL_TIME_VALUES_ARE_NOT_SUPPORTED = "fractional time values are not supported";
 
     public void testNonFractionalTimeValues() {
-        final String s = randomAsciiOfLength(10) + randomTimeUnit();
+        final String s = randomAlphaOfLength(10) + randomTimeUnit();
         final ElasticsearchParseException e =
             expectThrows(ElasticsearchParseException.class, () -> TimeValue.parseTimeValue(s, null, "test"));
         assertThat(e, hasToString(containsString("failed to parse [" + s + "]")));

--- a/core/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -63,7 +63,7 @@ public class BytesRefHashTests extends ESSingleNodeTestCase {
         final int len = randomIntBetween(1, 100000);
         final BytesRef[] values = new BytesRef[len];
         for (int i = 0; i < values.length; ++i) {
-            values[i] = new BytesRef(randomAsciiOfLength(5));
+            values[i] = new BytesRef(randomAlphaOfLength(5));
         }
         final ObjectLongMap<BytesRef> valueToId = new ObjectLongHashMap<>();
         final BytesRef[] idToValue = new BytesRef[values.length];

--- a/core/src/test/java/org/elasticsearch/common/util/IndexFolderUpgraderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/IndexFolderUpgraderTests.java
@@ -71,7 +71,7 @@ public class IndexFolderUpgraderTests extends ESTestCase {
             .put(NodeEnvironment.ADD_NODE_LOCK_ID_TO_CUSTOM_PATH.getKey(), randomBoolean())
             .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), customPath.toAbsolutePath().toString()).build();
         try (NodeEnvironment nodeEnv = newNodeEnvironment(nodeSettings)) {
-            final Index index = new Index(randomAsciiOfLength(10), UUIDs.randomBase64UUID());
+            final Index index = new Index(randomAlphaOfLength(10), UUIDs.randomBase64UUID());
             Settings settings = Settings.builder()
                 .put(nodeSettings)
                 .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
@@ -100,7 +100,7 @@ public class IndexFolderUpgraderTests extends ESTestCase {
             .put(NodeEnvironment.ADD_NODE_LOCK_ID_TO_CUSTOM_PATH.getKey(), randomBoolean())
             .put(Environment.PATH_SHARED_DATA_SETTING.getKey(), customPath.toAbsolutePath().toString()).build();
         try (NodeEnvironment nodeEnv = newNodeEnvironment(nodeSettings)) {
-            final Index index = new Index(randomAsciiOfLength(10), UUIDs.randomBase64UUID());
+            final Index index = new Index(randomAlphaOfLength(10), UUIDs.randomBase64UUID());
             Settings settings = Settings.builder()
                 .put(nodeSettings)
                 .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
@@ -139,7 +139,7 @@ public class IndexFolderUpgraderTests extends ESTestCase {
         final Settings nodeSettings = Settings.builder()
             .put(NodeEnvironment.ADD_NODE_LOCK_ID_TO_CUSTOM_PATH.getKey(), randomBoolean()).build();
         try (NodeEnvironment nodeEnv = newNodeEnvironment(nodeSettings)) {
-            final Index index = new Index(randomAsciiOfLength(10), UUIDs.randomBase64UUID());
+            final Index index = new Index(randomAlphaOfLength(10), UUIDs.randomBase64UUID());
             Settings settings = Settings.builder()
                 .put(nodeSettings)
                 .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())
@@ -164,7 +164,7 @@ public class IndexFolderUpgraderTests extends ESTestCase {
         try (NodeEnvironment nodeEnv = newNodeEnvironment(nodeSettings)) {
             Map<IndexSettings, Tuple<Integer, Integer>>  indexSettingsMap = new HashMap<>();
             for (int i = 0; i < randomIntBetween(2, 5); i++) {
-                final Index index = new Index(randomAsciiOfLength(10), UUIDs.randomBase64UUID());
+                final Index index = new Index(randomAlphaOfLength(10), UUIDs.randomBase64UUID());
                 Settings settings = Settings.builder()
                     .put(nodeSettings)
                     .put(IndexMetaData.SETTING_INDEX_UUID, index.getUUID())

--- a/core/src/test/java/org/elasticsearch/common/xcontent/ConstructingObjectParserTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/ConstructingObjectParserTests.java
@@ -66,12 +66,12 @@ public class ConstructingObjectParserTests extends ESTestCase {
      * Builds the object in random order and parses it.
      */
     public void testRandomOrder() throws Exception {
-        HasCtorArguments expected = new HasCtorArguments(randomAsciiOfLength(5), randomInt());
+        HasCtorArguments expected = new HasCtorArguments(randomAlphaOfLength(5), randomInt());
         expected.setMineral(randomInt());
         expected.setFruit(randomInt());
-        expected.setA(randomBoolean() ? null : randomAsciiOfLength(5));
-        expected.setB(randomBoolean() ? null : randomAsciiOfLength(5));
-        expected.setC(randomBoolean() ? null : randomAsciiOfLength(5));
+        expected.setA(randomBoolean() ? null : randomAlphaOfLength(5));
+        expected.setB(randomBoolean() ? null : randomAlphaOfLength(5));
+        expected.setC(randomBoolean() ? null : randomAlphaOfLength(5));
         expected.setD(randomBoolean());
         XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
         expected.toXContent(builder, ToXContent.EMPTY_PARAMS);

--- a/core/src/test/java/org/elasticsearch/common/xcontent/UnknownNamedObjectExceptionTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/UnknownNamedObjectExceptionTests.java
@@ -31,7 +31,7 @@ public class UnknownNamedObjectExceptionTests extends ESTestCase {
     public void testRoundTrip() throws IOException {
         XContentLocation location = new XContentLocation(between(1, 1000), between(1, 1000));
         UnknownNamedObjectException created = new UnknownNamedObjectException(location, UnknownNamedObjectExceptionTests.class,
-                randomAsciiOfLength(5));
+                randomAlphaOfLength(5));
         UnknownNamedObjectException roundTripped;
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
@@ -50,7 +50,7 @@ public class UnknownNamedObjectExceptionTests extends ESTestCase {
     public void testStatusCode() {
         XContentLocation location = new XContentLocation(between(1, 1000), between(1, 1000));
         UnknownNamedObjectException e = new UnknownNamedObjectException(location, UnknownNamedObjectExceptionTests.class,
-                randomAsciiOfLength(5));
+                randomAlphaOfLength(5));
         assertEquals(RestStatus.BAD_REQUEST, e.status());
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/FilterPathTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/FilterPathTests.java
@@ -202,7 +202,7 @@ public class FilterPathTests extends ESTestCase {
         assertThat(filterPath.isSimpleWildcard(), is(true));
         assertThat(filterPath.getSegment(), equalTo("*"));
 
-        FilterPath next = filterPath.matchProperty(randomAsciiOfLength(2));
+        FilterPath next = filterPath.matchProperty(randomAlphaOfLength(2));
         assertNotNull(next);
         assertSame(next, FilterPath.EMPTY);
     }
@@ -246,7 +246,7 @@ public class FilterPathTests extends ESTestCase {
         assertThat(filterPath.isDoubleWildcard(), is(true));
         assertThat(filterPath.getSegment(), equalTo("**"));
 
-        FilterPath next = filterPath.matchProperty(randomAsciiOfLength(2));
+        FilterPath next = filterPath.matchProperty(randomAlphaOfLength(2));
         assertNotNull(next);
         assertSame(next, FilterPath.EMPTY);
     }
@@ -263,7 +263,7 @@ public class FilterPathTests extends ESTestCase {
         assertThat(filterPath.matches(), is(false));
         assertThat(filterPath.getSegment(), equalTo("**"));
 
-        FilterPath next = filterPath.matchProperty(randomAsciiOfLength(2));
+        FilterPath next = filterPath.matchProperty(randomAlphaOfLength(2));
         assertNotNull(next);
         assertThat(next.matches(), is(false));
         assertThat(next.getSegment(), equalTo("bar"));

--- a/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/ZenFaultDetectionTests.java
@@ -234,7 +234,7 @@ public class ZenFaultDetectionTests extends ESTestCase {
     public void testMasterFaultDetectionConnectOnDisconnect() throws InterruptedException {
         Settings.Builder settings = Settings.builder();
         boolean shouldRetry = randomBoolean();
-        ClusterName clusterName = new ClusterName(randomAsciiOfLengthBetween(3, 20));
+        ClusterName clusterName = new ClusterName(randomAlphaOfLengthBetween(3, 20));
 
         // make sure we don't ping
         settings.put(FaultDetection.CONNECT_ON_NETWORK_DISCONNECT_SETTING.getKey(), shouldRetry)
@@ -272,7 +272,7 @@ public class ZenFaultDetectionTests extends ESTestCase {
 
     public void testMasterFaultDetectionNotSizeLimited() throws InterruptedException {
         boolean shouldRetry = randomBoolean();
-        ClusterName clusterName = new ClusterName(randomAsciiOfLengthBetween(3, 20));
+        ClusterName clusterName = new ClusterName(randomAlphaOfLengthBetween(3, 20));
         final Settings settings = Settings.builder()
             .put(FaultDetection.CONNECT_ON_NETWORK_DISCONNECT_SETTING.getKey(), shouldRetry)
             .put(FaultDetection.PING_INTERVAL_SETTING.getKey(), "1s")

--- a/core/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
@@ -613,7 +613,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
 
         logger.info("--> testing acceptances of any master when having no master");
         ClusterState state = ClusterState.builder(node.clusterState)
-                .nodes(DiscoveryNodes.builder(node.nodes()).masterNodeId(randomAsciiOfLength(10))).incrementVersion().build();
+                .nodes(DiscoveryNodes.builder(node.nodes()).masterNodeId(randomAlphaOfLength(10))).incrementVersion().build();
         node.action.validateIncomingState(state, null);
 
         // now set a master node
@@ -634,7 +634,7 @@ public class PublishClusterStateActionTests extends ESTestCase {
 
         logger.info("--> testing rejection of another cluster name");
         try {
-            node.action.validateIncomingState(ClusterState.builder(new ClusterName(randomAsciiOfLength(10)))
+            node.action.validateIncomingState(ClusterState.builder(new ClusterName(randomAlphaOfLength(10)))
                 .nodes(node.nodes()).build(), node.clusterState);
             fail("node accepted state with another cluster name");
         } catch (IllegalStateException OK) {

--- a/core/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/UnicastZenPingTests.java
@@ -504,7 +504,7 @@ public class UnicastZenPingTests extends ESTestCase {
     public void testUnknownHost() throws InterruptedException {
         final Logger logger = mock(Logger.class);
         final NetworkService networkService = new NetworkService(Settings.EMPTY, Collections.emptyList());
-        final String hostname = randomAsciiOfLength(8);
+        final String hostname = randomAlphaOfLength(8);
         final UnknownHostException unknownHostException = new UnknownHostException(hostname);
         final Transport transport = new MockTcpTransport(
             Settings.EMPTY,

--- a/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/fieldstats/FieldStatsTests.java
@@ -649,7 +649,7 @@ public class FieldStatsTests extends ESSingleNodeTestCase {
                 } else {
                     return new FieldStats.Text(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(),
                         randomNonNegativeLong(), randomBoolean(), randomBoolean(),
-                        new BytesRef(randomAsciiOfLength(10)), new BytesRef(randomAsciiOfLength(20)));
+                        new BytesRef(randomAlphaOfLength(10)), new BytesRef(randomAlphaOfLength(20)));
                 }
             case 4:
                 if (withNullMinMax && randomBoolean()) {

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.plugins.MetaDataUpgrader;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.test.TestCustomMetaData;
-import org.junit.Before;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -438,7 +437,7 @@ public class GatewayMetaStateTests extends ESAllocationTestCase {
         }
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
             builder.put(
-                IndexMetaData.builder(randomAsciiOfLength(10))
+                IndexMetaData.builder(randomAlphaOfLength(10))
                     .settings(settings(Version.CURRENT))
                     .numberOfReplicas(randomIntBetween(0, 3))
                     .numberOfShards(randomIntBetween(1, 5))

--- a/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/MetaDataStateFormatTests.java
@@ -327,12 +327,12 @@ public class MetaDataStateFormatTests extends ESTestCase {
         MetaData.Builder mdBuilder = MetaData.builder();
         mdBuilder.generateClusterUuidIfNeeded();
         for (int i = 0; i < numIndices; i++) {
-            mdBuilder.put(indexBuilder(randomAsciiOfLength(10) + "idx-"+i));
+            mdBuilder.put(indexBuilder(randomAlphaOfLength(10) + "idx-"+i));
         }
         int numDelIndices = randomIntBetween(0, 5);
         final IndexGraveyard.Builder graveyard = IndexGraveyard.builder();
         for (int i = 0; i < numDelIndices; i++) {
-            graveyard.addTombstone(new Index(randomAsciiOfLength(10) + "del-idx-" + i, UUIDs.randomBase64UUID()));
+            graveyard.addTombstone(new Index(randomAlphaOfLength(10) + "del-idx-" + i, UUIDs.randomBase64UUID()));
         }
         mdBuilder.indexGraveyard(graveyard.build());
         return mdBuilder.build();

--- a/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -176,8 +176,8 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
      * select the second node as target
      */
     public void testShardLockObtainFailedExceptionPreferOtherValidCopies() {
-        String allocId1 = randomAsciiOfLength(10);
-        String allocId2 = randomAsciiOfLength(10);
+        String allocId1 = randomAlphaOfLength(10);
+        String allocId2 = randomAlphaOfLength(10);
         final RoutingAllocation allocation = routingAllocationWithOnePrimaryNoReplicas(yesAllocationDeciders(), CLUSTER_RECOVERED,
             allocId1, allocId2);;
         testAllocator.addData(node1, allocId1, randomBoolean(),

--- a/core/src/test/java/org/elasticsearch/index/IndexTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexTests.java
@@ -50,7 +50,7 @@ public class IndexTests extends ESTestCase {
     }
 
     public void testXContent() throws IOException {
-        final String name = randomAsciiOfLengthBetween(4, 15);
+        final String name = randomAlphaOfLengthBetween(4, 15);
         final String uuid = UUIDs.randomBase64UUID();
         final Index original = new Index(name, uuid);
         final XContentBuilder builder = JsonXContent.contentBuilder();

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -3248,7 +3248,7 @@ public class InternalEngineTests extends ESTestCase {
                 };
             noOpEngine = createEngine(defaultSettings, store, primaryTranslogDir, newMergePolicy(), null, () -> seqNoService);
             final long primaryTerm = randomNonNegativeLong();
-            final String reason = randomAsciiOfLength(16);
+            final String reason = randomAlphaOfLength(16);
             noOpEngine.noOp(
                 new Engine.NoOp(
                     null,

--- a/core/src/test/java/org/elasticsearch/index/get/GetFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/index/get/GetFieldTests.java
@@ -89,10 +89,10 @@ public class GetFieldTests extends ESTestCase {
     public static Tuple<GetField, GetField> randomGetField(XContentType xContentType) {
         if (randomBoolean()) {
             String fieldName = randomFrom(ParentFieldMapper.NAME, RoutingFieldMapper.NAME, UidFieldMapper.NAME);
-            GetField getField = new GetField(fieldName, Collections.singletonList(randomAsciiOfLengthBetween(3, 10)));
+            GetField getField = new GetField(fieldName, Collections.singletonList(randomAlphaOfLengthBetween(3, 10)));
             return Tuple.tuple(getField, getField);
         }
-        String fieldName = randomAsciiOfLengthBetween(3, 10);
+        String fieldName = randomAlphaOfLengthBetween(3, 10);
         Tuple<List<Object>, List<Object>> tuple = RandomObjects.randomStoredFieldValues(random(), xContentType);
         GetField input = new GetField(fieldName, tuple.v1());
         GetField expected = new GetField(fieldName, tuple.v2());

--- a/core/src/test/java/org/elasticsearch/index/get/GetResultTests.java
+++ b/core/src/test/java/org/elasticsearch/index/get/GetResultTests.java
@@ -173,9 +173,9 @@ public class GetResultTests extends ESTestCase {
     }
 
     public static Tuple<GetResult, GetResult> randomGetResult(XContentType xContentType) {
-        final String index = randomAsciiOfLengthBetween(3, 10);
-        final String type = randomAsciiOfLengthBetween(3, 10);
-        final String id = randomAsciiOfLengthBetween(3, 10);
+        final String index = randomAlphaOfLengthBetween(3, 10);
+        final String type = randomAlphaOfLengthBetween(3, 10);
+        final String id = randomAlphaOfLengthBetween(3, 10);
         final long version;
         final boolean exists;
         BytesReference source = null;

--- a/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
@@ -30,15 +30,6 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DateFieldMapper;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.DocumentMapperParser;
-import org.elasticsearch.index.mapper.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.RootObjectMapper;
-import org.elasticsearch.index.mapper.TextFieldMapper;
-import org.elasticsearch.index.mapper.TokenCountFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
@@ -174,7 +165,7 @@ public class MultiFieldTests extends ESSingleNodeTestCase {
     public void testMultiFieldsInConsistentOrder() throws Exception {
         String[] multiFieldNames = new String[randomIntBetween(2, 10)];
         for (int i = 0; i < multiFieldNames.length; i++) {
-            multiFieldNames[i] = randomAsciiOfLength(4);
+            multiFieldNames[i] = randomAlphaOfLength(4);
         }
 
         XContentBuilder builder = jsonBuilder().startObject().startObject("type").startObject("properties")

--- a/core/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -73,7 +73,7 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
     public void testRangeQuery() throws Exception {
         Settings indexSettings = Settings.builder()
             .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAsciiOfLengthBetween(1, 10), indexSettings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAlphaOfLengthBetween(1, 10), indexSettings);
         QueryShardContext context = new QueryShardContext(0, idxSettings, null, null, null, null, null, xContentRegistry(),
                 null, null, () -> nowInMillis);
         RangeFieldMapper.RangeFieldType ft = new RangeFieldMapper.RangeFieldType(type);

--- a/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/query/AbstractTermQueryTestCase.java
@@ -30,7 +30,7 @@ public abstract class AbstractTermQueryTestCase<QB extends BaseTermQueryBuilder<
     protected abstract QB createQueryBuilder(String fieldName, Object value);
 
     public void testIllegalArguments() throws QueryShardException {
-        String term = randomAsciiOfLengthBetween(1, 30);
+        String term = randomAlphaOfLengthBetween(1, 30);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> createQueryBuilder(null, term));
         assertEquals("field name is null or empty", e.getMessage());
         e = expectThrows(IllegalArgumentException.class, () -> createQueryBuilder("", term));

--- a/core/src/test/java/org/elasticsearch/index/query/CommonTermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/CommonTermsQueryBuilderTests.java
@@ -44,13 +44,13 @@ public class CommonTermsQueryBuilderTests extends AbstractQueryTestCase<CommonTe
         int numberOfTerms = randomIntBetween(0, 10);
         StringBuilder text = new StringBuilder("");
         for (int i = 0; i < numberOfTerms; i++) {
-            text.append(randomAsciiOfLengthBetween(1, 10)).append(" ");
+            text.append(randomAlphaOfLengthBetween(1, 10)).append(" ");
         }
         // mapped or unmapped field
         if (randomBoolean()) {
             query = new CommonTermsQueryBuilder(STRING_FIELD_NAME, text.toString());
         } else {
-            query = new CommonTermsQueryBuilder(randomAsciiOfLengthBetween(1, 10), text.toString());
+            query = new CommonTermsQueryBuilder(randomAlphaOfLengthBetween(1, 10), text.toString());
         }
 
         if (randomBoolean()) {
@@ -88,8 +88,8 @@ public class CommonTermsQueryBuilderTests extends AbstractQueryTestCase<CommonTe
     @Override
     protected Map<String, CommonTermsQueryBuilder> getAlternateVersions() {
         Map<String, CommonTermsQueryBuilder> alternateVersions = new HashMap<>();
-        CommonTermsQueryBuilder commonTermsQuery = new CommonTermsQueryBuilder(randomAsciiOfLengthBetween(1, 10),
-                randomAsciiOfLengthBetween(1, 10));
+        CommonTermsQueryBuilder commonTermsQuery = new CommonTermsQueryBuilder(randomAlphaOfLengthBetween(1, 10),
+                randomAlphaOfLengthBetween(1, 10));
         String contentString = "{\n" +
                 "    \"common\" : {\n" +
                 "        \"" + commonTermsQuery.fieldName() + "\" : \"" + commonTermsQuery.value() + "\"\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -43,7 +43,7 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
         if (randomBoolean()) {
             fieldPattern = randomFrom(MAPPED_FIELD_NAMES);
         } else {
-            fieldPattern = randomAsciiOfLengthBetween(1, 10);
+            fieldPattern = randomAlphaOfLengthBetween(1, 10);
         }
         // also sometimes test wildcard patterns
         if (randomBoolean()) {

--- a/core/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilderTests.java
@@ -37,7 +37,7 @@ public class FieldMaskingSpanQueryBuilderTests extends AbstractQueryTestCase<Fie
         if (randomBoolean()) {
             fieldName = randomFrom(MAPPED_FIELD_NAMES);
         } else {
-            fieldName = randomAsciiOfLengthBetween(1, 10);
+            fieldName = randomAlphaOfLengthBetween(1, 10);
         }
         SpanTermQueryBuilder innerQuery = new SpanTermQueryBuilderTests().createTestQueryBuilder();
         return new FieldMaskingSpanQueryBuilder(innerQuery, fieldName);

--- a/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
@@ -62,7 +62,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
     @Override
     protected Map<String, FuzzyQueryBuilder> getAlternateVersions() {
         Map<String, FuzzyQueryBuilder> alternateVersions = new HashMap<>();
-        FuzzyQueryBuilder fuzzyQuery = new FuzzyQueryBuilder(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10));
+        FuzzyQueryBuilder fuzzyQuery = new FuzzyQueryBuilder(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10));
         String contentString = "{\n" +
                 "    \"fuzzy\" : {\n" +
                 "        \"" + fuzzyQuery.fieldName() + "\" : \"" + fuzzyQuery.value() + "\"\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -70,15 +70,15 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
             builder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, shape);
         } else {
             indexedShapeToReturn = shape;
-            indexedShapeId = randomAsciiOfLengthBetween(3, 20);
-            indexedShapeType = randomAsciiOfLengthBetween(3, 20);
+            indexedShapeId = randomAlphaOfLengthBetween(3, 20);
+            indexedShapeType = randomAlphaOfLengthBetween(3, 20);
             builder = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, indexedShapeId, indexedShapeType);
             if (randomBoolean()) {
-                indexedShapeIndex = randomAsciiOfLengthBetween(3, 20);
+                indexedShapeIndex = randomAlphaOfLengthBetween(3, 20);
                 builder.indexedShapeIndex(indexedShapeIndex);
             }
             if (randomBoolean()) {
-                indexedShapePath = randomAsciiOfLengthBetween(3, 20);
+                indexedShapePath = randomAlphaOfLengthBetween(3, 20);
                 builder.indexedShapePath(indexedShapePath);
             }
         }

--- a/core/src/test/java/org/elasticsearch/index/query/HasChildQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasChildQueryBuilderTests.java
@@ -109,7 +109,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
         hqb.ignoreUnmapped(randomBoolean());
         if (randomBoolean()) {
             hqb.innerHit(new InnerHitBuilder()
-                    .setName(randomAsciiOfLengthBetween(1, 10))
+                    .setName(randomAlphaOfLengthBetween(1, 10))
                     .setSize(randomIntBetween(0, 100))
                     .addSort(new FieldSortBuilder(STRING_FIELD_NAME_2).order(SortOrder.ASC)), hqb.ignoreUnmapped());
         }

--- a/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/HasParentQueryBuilderTests.java
@@ -88,7 +88,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
         hqb.ignoreUnmapped(randomBoolean());
         if (randomBoolean()) {
             hqb.innerHit(new InnerHitBuilder()
-                    .setName(randomAsciiOfLengthBetween(1, 10))
+                    .setName(randomAlphaOfLengthBetween(1, 10))
                     .setSize(randomIntBetween(0, 100))
                     .addSort(new FieldSortBuilder(STRING_FIELD_NAME_2).order(SortOrder.ASC)), hqb.ignoreUnmapped());
         }

--- a/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -45,7 +45,7 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
                 if (frequently()) {
                     types[i] = randomFrom(getCurrentTypes());
                 } else {
-                    types[i] = randomAsciiOfLengthBetween(1, 10);
+                    types[i] = randomAlphaOfLengthBetween(1, 10);
                 }
             }
         } else {
@@ -58,7 +58,7 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
         int numberOfIds = randomIntBetween(0, 10);
         String[] ids = new String[numberOfIds];
         for (int i = 0; i < numberOfIds; i++) {
-            ids[i] = randomAsciiOfLengthBetween(1, 10);
+            ids[i] = randomAlphaOfLengthBetween(1, 10);
         }
         IdsQueryBuilder query;
         if (types.length > 0 || randomBoolean()) {

--- a/core/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
@@ -297,16 +297,16 @@ public class InnerHitBuilderTests extends ESTestCase {
 
     public static InnerHitBuilder randomInnerHits(boolean recursive, boolean includeQueryTypeOrPath) {
         InnerHitBuilder innerHits = new InnerHitBuilder();
-        innerHits.setName(randomAsciiOfLengthBetween(1, 16));
+        innerHits.setName(randomAlphaOfLengthBetween(1, 16));
         innerHits.setFrom(randomIntBetween(0, 128));
         innerHits.setSize(randomIntBetween(0, 128));
         innerHits.setExplain(randomBoolean());
         innerHits.setVersion(randomBoolean());
         innerHits.setTrackScores(randomBoolean());
         if (randomBoolean()) {
-            innerHits.setStoredFieldNames(randomListStuff(16, () -> randomAsciiOfLengthBetween(1, 16)));
+            innerHits.setStoredFieldNames(randomListStuff(16, () -> randomAlphaOfLengthBetween(1, 16)));
         }
-        innerHits.setDocValueFields(randomListStuff(16, () -> randomAsciiOfLengthBetween(1, 16)));
+        innerHits.setDocValueFields(randomListStuff(16, () -> randomAlphaOfLengthBetween(1, 16)));
         // Random script fields deduped on their field name.
         Map<String, SearchSourceBuilder.ScriptField> scriptFields = new HashMap<>();
         for (SearchSourceBuilder.ScriptField field: randomListStuff(16, InnerHitBuilderTests::randomScript)) {
@@ -325,7 +325,7 @@ public class InnerHitBuilderTests extends ESTestCase {
         innerHits.setFetchSourceContext(randomFetchSourceContext);
         if (randomBoolean()) {
             innerHits.setSorts(randomListStuff(16,
-                    () -> SortBuilders.fieldSort(randomAsciiOfLengthBetween(5, 20)).order(randomFrom(SortOrder.values())))
+                    () -> SortBuilders.fieldSort(randomAlphaOfLengthBetween(5, 20)).order(randomFrom(SortOrder.values())))
             );
         }
         innerHits.setHighlightBuilder(HighlightBuilderTests.randomHighlighterBuilder());
@@ -337,11 +337,11 @@ public class InnerHitBuilderTests extends ESTestCase {
         }
 
         if (includeQueryTypeOrPath) {
-            QueryBuilder query = new MatchQueryBuilder(randomAsciiOfLengthBetween(1, 16), randomAsciiOfLengthBetween(1, 16));
+            QueryBuilder query = new MatchQueryBuilder(randomAlphaOfLengthBetween(1, 16), randomAlphaOfLengthBetween(1, 16));
             if (randomBoolean()) {
-                return new InnerHitBuilder(innerHits, randomAsciiOfLength(8), query, randomBoolean());
+                return new InnerHitBuilder(innerHits, randomAlphaOfLength(8), query, randomBoolean());
             } else {
-                return new InnerHitBuilder(innerHits, query, randomAsciiOfLength(8), randomBoolean());
+                return new InnerHitBuilder(innerHits, query, randomAlphaOfLength(8), randomBoolean());
             }
         } else {
             return innerHits;
@@ -366,14 +366,14 @@ public class InnerHitBuilderTests extends ESTestCase {
         modifiers.add(() -> copy.setExplain(!copy.isExplain()));
         modifiers.add(() -> copy.setVersion(!copy.isVersion()));
         modifiers.add(() -> copy.setTrackScores(!copy.isTrackScores()));
-        modifiers.add(() -> copy.setName(randomValueOtherThan(copy.getName(), () -> randomAsciiOfLengthBetween(1, 16))));
+        modifiers.add(() -> copy.setName(randomValueOtherThan(copy.getName(), () -> randomAlphaOfLengthBetween(1, 16))));
         modifiers.add(() -> {
             if (randomBoolean()) {
                 copy.setDocValueFields(randomValueOtherThan(copy.getDocValueFields(), () -> {
-                    return randomListStuff(16, () -> randomAsciiOfLengthBetween(1, 16));
+                    return randomListStuff(16, () -> randomAlphaOfLengthBetween(1, 16));
                 }));
             } else {
-                copy.addDocValueField(randomAsciiOfLengthBetween(1, 16));
+                copy.addDocValueField(randomAlphaOfLengthBetween(1, 16));
             }
         });
         modifiers.add(() -> {
@@ -400,12 +400,12 @@ public class InnerHitBuilderTests extends ESTestCase {
                 if (randomBoolean()) {
                     final List<SortBuilder<?>> sortBuilders = randomValueOtherThan(copy.getSorts(), () -> {
                         List<SortBuilder<?>> builders = randomListStuff(16,
-                                () -> SortBuilders.fieldSort(randomAsciiOfLengthBetween(5, 20)).order(randomFrom(SortOrder.values())));
+                                () -> SortBuilders.fieldSort(randomAlphaOfLengthBetween(5, 20)).order(randomFrom(SortOrder.values())));
                         return builders;
                     });
                     copy.setSorts(sortBuilders);
                 } else {
-                    copy.addSort(SortBuilders.fieldSort(randomAsciiOfLengthBetween(5, 20)));
+                    copy.addSort(SortBuilders.fieldSort(randomAlphaOfLengthBetween(5, 20)));
                 }
         });
         modifiers.add(() -> copy
@@ -415,10 +415,10 @@ public class InnerHitBuilderTests extends ESTestCase {
                     List<String> previous = copy.getStoredFieldsContext() == null ?
                         Collections.emptyList() : copy.getStoredFieldsContext().fieldNames();
                     List<String> newValues = randomValueOtherThan(previous,
-                            () -> randomListStuff(1, 16, () -> randomAsciiOfLengthBetween(1, 16)));
+                            () -> randomListStuff(1, 16, () -> randomAlphaOfLengthBetween(1, 16)));
                     copy.setStoredFieldNames(newValues);
                 } else {
-                    copy.getStoredFieldsContext().addFieldName(randomAsciiOfLengthBetween(1, 16));
+                    copy.getStoredFieldsContext().addFieldName(randomAlphaOfLengthBetween(1, 16));
                 }
         });
         randomFrom(modifiers).run();
@@ -431,12 +431,12 @@ public class InnerHitBuilderTests extends ESTestCase {
         if (randomBoolean()) {
             int numEntries = randomIntBetween(0, 32);
             for (int i = 0; i < numEntries; i++) {
-                randomMap.put(String.valueOf(i), randomAsciiOfLength(16));
+                randomMap.put(String.valueOf(i), randomAlphaOfLength(16));
             }
         }
-        Script script = new Script(randomScriptType, randomScriptType == ScriptType.STORED ? null : randomAsciiOfLengthBetween(1, 4),
-            randomAsciiOfLength(128), randomMap);
-        return new SearchSourceBuilder.ScriptField(randomAsciiOfLengthBetween(1, 32), script, randomBoolean());
+        Script script = new Script(randomScriptType, randomScriptType == ScriptType.STORED ? null : randomAlphaOfLengthBetween(1, 4),
+            randomAlphaOfLength(128), randomMap);
+        return new SearchSourceBuilder.ScriptField(randomAlphaOfLengthBetween(1, 32), script, randomBoolean());
     }
 
     static <T> List<T> randomListStuff(int maxSize, Supplier<T> valueSupplier) {

--- a/core/src/test/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilderTests.java
@@ -52,7 +52,7 @@ public class MatchPhrasePrefixQueryBuilderTests extends AbstractQueryTestCase<Ma
             int terms = randomIntBetween(0, 3);
             StringBuilder builder = new StringBuilder();
             for (int i = 0; i < terms; i++) {
-                builder.append(randomAsciiOfLengthBetween(1, 10)).append(" ");
+                builder.append(randomAlphaOfLengthBetween(1, 10)).append(" ");
             }
             value = builder.toString().trim();
         } else {
@@ -78,8 +78,8 @@ public class MatchPhrasePrefixQueryBuilderTests extends AbstractQueryTestCase<Ma
     @Override
     protected Map<String, MatchPhrasePrefixQueryBuilder> getAlternateVersions() {
         Map<String, MatchPhrasePrefixQueryBuilder> alternateVersions = new HashMap<>();
-        MatchPhrasePrefixQueryBuilder matchPhrasePrefixQuery = new MatchPhrasePrefixQueryBuilder(randomAsciiOfLengthBetween(1, 10),
-                randomAsciiOfLengthBetween(1, 10));
+        MatchPhrasePrefixQueryBuilder matchPhrasePrefixQuery = new MatchPhrasePrefixQueryBuilder(randomAlphaOfLengthBetween(1, 10),
+                randomAlphaOfLengthBetween(1, 10));
         String contentString = "{\n" +
                 "    \"match_phrase_prefix\" : {\n" +
                 "        \"" + matchPhrasePrefixQuery.fieldName() + "\" : \"" + matchPhrasePrefixQuery.value() + "\"\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
@@ -52,7 +52,7 @@ public class MatchPhraseQueryBuilderTests extends AbstractQueryTestCase<MatchPhr
             int terms = randomIntBetween(0, 3);
             StringBuilder builder = new StringBuilder();
             for (int i = 0; i < terms; i++) {
-                builder.append(randomAsciiOfLengthBetween(1, 10)).append(" ");
+                builder.append(randomAlphaOfLengthBetween(1, 10)).append(" ");
             }
             value = builder.toString().trim();
         } else {
@@ -74,8 +74,8 @@ public class MatchPhraseQueryBuilderTests extends AbstractQueryTestCase<MatchPhr
     @Override
     protected Map<String, MatchPhraseQueryBuilder> getAlternateVersions() {
         Map<String, MatchPhraseQueryBuilder> alternateVersions = new HashMap<>();
-        MatchPhraseQueryBuilder matchPhraseQuery = new MatchPhraseQueryBuilder(randomAsciiOfLengthBetween(1, 10),
-                randomAsciiOfLengthBetween(1, 10));
+        MatchPhraseQueryBuilder matchPhraseQuery = new MatchPhraseQueryBuilder(randomAlphaOfLengthBetween(1, 10),
+                randomAlphaOfLengthBetween(1, 10));
         String contentString = "{\n" +
                 "    \"match_phrase\" : {\n" +
                 "        \"" + matchPhraseQuery.fieldName() + "\" : \"" + matchPhraseQuery.value() + "\"\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -70,7 +70,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
             int terms = randomIntBetween(0, 3);
             StringBuilder builder = new StringBuilder();
             for (int i = 0; i < terms; i++) {
-                builder.append(randomAsciiOfLengthBetween(1, 10)).append(" ");
+                builder.append(randomAlphaOfLengthBetween(1, 10)).append(" ");
             }
             value = builder.toString().trim();
         } else {
@@ -130,7 +130,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
     @Override
     protected Map<String, MatchQueryBuilder> getAlternateVersions() {
         Map<String, MatchQueryBuilder> alternateVersions = new HashMap<>();
-        MatchQueryBuilder matchQuery = new MatchQueryBuilder(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10));
+        MatchQueryBuilder matchQuery = new MatchQueryBuilder(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10));
         String contentString = "{\n" +
                 "    \"match\" : {\n" +
                 "        \"" + matchQuery.fieldName() + "\" : \"" + matchQuery.value() + "\"\n" +

--- a/core/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilderTests.java
@@ -96,7 +96,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
         // indexed item or artificial document
         Item item;
         if (randomBoolean()) {
-            item = new Item(index, type, randomAsciiOfLength(10));
+            item = new Item(index, type, randomAlphaOfLength(10));
         } else {
             item = new Item(index, type, randomArtificialDoc());
         }
@@ -109,7 +109,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
             item.perFieldAnalyzer(randomPerFieldAnalyzer());
         }
         if (randomBoolean()) {
-            item.routing(randomAsciiOfLength(10));
+            item.routing(randomAlphaOfLength(10));
         }
         if (randomBoolean()) {
             item.version(randomInt(5));
@@ -125,7 +125,7 @@ public class MoreLikeThisQueryBuilderTests extends AbstractQueryTestCase<MoreLik
         try {
             doc = XContentFactory.jsonBuilder().startObject();
             for (String field : randomFields) {
-                doc.field(field, randomAsciiOfLength(10));
+                doc.field(field, randomAlphaOfLength(10));
             }
             doc.endObject();
         } catch (IOException e) {

--- a/core/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -23,7 +23,6 @@ import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ScoreMode;
-import org.apache.lucene.search.join.ToParentBlockJoinQuery;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.mapper.MapperService;
@@ -76,7 +75,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
         nqb.ignoreUnmapped(randomBoolean());
         if (randomBoolean()) {
             nqb.innerHit(new InnerHitBuilder()
-                    .setName(randomAsciiOfLengthBetween(1, 10))
+                    .setName(randomAlphaOfLengthBetween(1, 10))
                     .setSize(randomIntBetween(0, 100))
                     .addSort(new FieldSortBuilder(INT_FIELD_NAME).order(SortOrder.ASC)), nqb.ignoreUnmapped());
         }

--- a/core/src/test/java/org/elasticsearch/index/query/ParentIdQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ParentIdQueryBuilderTests.java
@@ -66,7 +66,7 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
 
     @Override
     protected ParentIdQueryBuilder doCreateTestQueryBuilder() {
-        return new ParentIdQueryBuilder(CHILD_TYPE, randomAsciiOfLength(4)).ignoreUnmapped(randomBoolean());
+        return new ParentIdQueryBuilder(CHILD_TYPE, randomAlphaOfLength(4)).ignoreUnmapped(randomBoolean());
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/PrefixQueryBuilderTests.java
@@ -60,8 +60,8 @@ public class PrefixQueryBuilderTests extends AbstractQueryTestCase<PrefixQueryBu
     }
 
     private static PrefixQueryBuilder randomPrefixQuery() {
-        String fieldName = randomBoolean() ? STRING_FIELD_NAME : randomAsciiOfLengthBetween(1, 10);
-        String value = randomAsciiOfLengthBetween(1, 10);
+        String fieldName = randomBoolean() ? STRING_FIELD_NAME : randomAlphaOfLengthBetween(1, 10);
+        String value = randomAlphaOfLengthBetween(1, 10);
         return new PrefixQueryBuilder(fieldName, value);
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -79,17 +79,17 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         String query = "";
         for (int i = 0; i < numTerms; i++) {
             //min length 4 makes sure that the text is not an operator (AND/OR) so toQuery won't break
-            query += (randomBoolean() ? STRING_FIELD_NAME + ":" : "") + randomAsciiOfLengthBetween(4, 10) + " ";
+            query += (randomBoolean() ? STRING_FIELD_NAME + ":" : "") + randomAlphaOfLengthBetween(4, 10) + " ";
         }
         QueryStringQueryBuilder queryStringQueryBuilder = new QueryStringQueryBuilder(query);
         if (randomBoolean()) {
             queryStringQueryBuilder.defaultField(randomBoolean() ?
-                STRING_FIELD_NAME : randomAsciiOfLengthBetween(1, 10));
+                STRING_FIELD_NAME : randomAlphaOfLengthBetween(1, 10));
         }
         if (randomBoolean()) {
             int numFields = randomIntBetween(1, 5);
             for (int i = 0; i < numFields; i++) {
-                String fieldName = randomBoolean() ? STRING_FIELD_NAME : randomAsciiOfLengthBetween(1, 10);
+                String fieldName = randomBoolean() ? STRING_FIELD_NAME : randomAlphaOfLengthBetween(1, 10);
                 if (randomBoolean()) {
                     queryStringQueryBuilder.field(fieldName);
                 } else {
@@ -144,7 +144,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             queryStringQueryBuilder.rewrite(getRandomRewriteMethod());
         }
         if (randomBoolean()) {
-            queryStringQueryBuilder.quoteFieldSuffix(randomAsciiOfLengthBetween(1, 3));
+            queryStringQueryBuilder.quoteFieldSuffix(randomAlphaOfLengthBetween(1, 3));
         }
         if (randomBoolean()) {
             queryStringQueryBuilder.tieBreaker(randomFloat());

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -86,8 +86,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
             case 2:
             default:
                 query = new RangeQueryBuilder(STRING_FIELD_NAME);
-                query.from("a" + randomAsciiOfLengthBetween(1, 10));
-                query.to("z" + randomAsciiOfLengthBetween(1, 10));
+                query.from("a" + randomAlphaOfLengthBetween(1, 10));
+                query.to("z" + randomAlphaOfLengthBetween(1, 10));
                 break;
         }
         query.includeLower(randomBoolean()).includeUpper(randomBoolean());
@@ -407,7 +407,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testRewriteDateToMatchAll() throws IOException {
-        String fieldName = randomAsciiOfLengthBetween(1, 20);
+        String fieldName = randomAlphaOfLengthBetween(1, 20);
         RangeQueryBuilder query = new RangeQueryBuilder(fieldName) {
             @Override
             protected MappedFieldType.Relation getRelation(QueryRewriteContext queryRewriteContext) throws IOException {
@@ -428,7 +428,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testRewriteDateToMatchAllWithTimezoneAndFormat() throws IOException {
-        String fieldName = randomAsciiOfLengthBetween(1, 20);
+        String fieldName = randomAlphaOfLengthBetween(1, 20);
         RangeQueryBuilder query = new RangeQueryBuilder(fieldName) {
             @Override
             protected MappedFieldType.Relation getRelation(QueryRewriteContext queryRewriteContext) throws IOException {
@@ -453,7 +453,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testRewriteDateToMatchNone() throws IOException {
-        String fieldName = randomAsciiOfLengthBetween(1, 20);
+        String fieldName = randomAlphaOfLengthBetween(1, 20);
         RangeQueryBuilder query = new RangeQueryBuilder(fieldName) {
             @Override
             protected MappedFieldType.Relation getRelation(QueryRewriteContext queryRewriteContext) throws IOException {
@@ -470,7 +470,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testRewriteDateToSame() throws IOException {
-        String fieldName = randomAsciiOfLengthBetween(1, 20);
+        String fieldName = randomAlphaOfLengthBetween(1, 20);
         RangeQueryBuilder query = new RangeQueryBuilder(fieldName) {
             @Override
             protected MappedFieldType.Relation getRelation(QueryRewriteContext queryRewriteContext) throws IOException {
@@ -487,7 +487,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testRewriteOpenBoundsToSame() throws IOException {
-        String fieldName = randomAsciiOfLengthBetween(1, 20);
+        String fieldName = randomAlphaOfLengthBetween(1, 20);
         RangeQueryBuilder query = new RangeQueryBuilder(fieldName) {
             @Override
             protected MappedFieldType.Relation getRelation(QueryRewriteContext queryRewriteContext) throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RegexpQueryBuilderTests.java
@@ -71,8 +71,8 @@ public class RegexpQueryBuilderTests extends AbstractQueryTestCase<RegexpQueryBu
 
     private static RegexpQueryBuilder randomRegexpQuery() {
         // mapped or unmapped fields
-        String fieldName = randomBoolean() ? STRING_FIELD_NAME : randomAsciiOfLengthBetween(1, 10);
-        String value = randomAsciiOfLengthBetween(1, 10);
+        String fieldName = randomBoolean() ? STRING_FIELD_NAME : randomAlphaOfLengthBetween(1, 10);
+        String value = randomAlphaOfLengthBetween(1, 10);
         return new RegexpQueryBuilder(fieldName, value);
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -56,7 +56,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
 
     @Override
     protected SimpleQueryStringBuilder doCreateTestQueryBuilder() {
-        SimpleQueryStringBuilder result = new SimpleQueryStringBuilder(randomAsciiOfLengthBetween(1, 10));
+        SimpleQueryStringBuilder result = new SimpleQueryStringBuilder(randomAlphaOfLengthBetween(1, 10));
         if (randomBoolean()) {
             result.analyzeWildcard(randomBoolean());
         }
@@ -87,9 +87,9 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
         Map<String, Float> fields = new HashMap<>();
         for (int i = 0; i < fieldCount; i++) {
             if (randomBoolean()) {
-                fields.put(randomAsciiOfLengthBetween(1, 10), AbstractQueryBuilder.DEFAULT_BOOST);
+                fields.put(randomAlphaOfLengthBetween(1, 10), AbstractQueryBuilder.DEFAULT_BOOST);
             } else {
-                fields.put(randomBoolean() ? STRING_FIELD_NAME : randomAsciiOfLengthBetween(1, 10), 2.0f / randomIntBetween(1, 20));
+                fields.put(randomBoolean() ? STRING_FIELD_NAME : randomAlphaOfLengthBetween(1, 10), 2.0f / randomIntBetween(1, 20));
             }
         }
         result.fields(fields);
@@ -197,7 +197,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
     }
 
     public void testDefaultFieldParsing() throws IOException {
-        String query = randomAsciiOfLengthBetween(1, 10).toLowerCase(Locale.ROOT);
+        String query = randomAlphaOfLengthBetween(1, 10).toLowerCase(Locale.ROOT);
         String contentString = "{\n" +
                 "    \"simple_query_string\" : {\n" +
                 "      \"query\" : \"" + query + "\"" +

--- a/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SpanTermQueryBuilderTests.java
@@ -45,7 +45,7 @@ public class SpanTermQueryBuilderTests extends AbstractTermQueryTestCase<SpanTer
             fieldName = STRING_FIELD_NAME;
         }
         if (frequently()) {
-            value = randomAsciiOfLengthBetween(1, 10);
+            value = randomAlphaOfLengthBetween(1, 10);
         } else {
             // generate unicode string in 10% of cases
             JsonStringEncoder encoder = JsonStringEncoder.getInstance();
@@ -53,7 +53,7 @@ public class SpanTermQueryBuilderTests extends AbstractTermQueryTestCase<SpanTer
         }
 
         if (fieldName == null) {
-            fieldName = randomAsciiOfLengthBetween(1, 10);
+            fieldName = randomAlphaOfLengthBetween(1, 10);
         }
         return createQueryBuilder(fieldName, value);
     }
@@ -92,7 +92,7 @@ public class SpanTermQueryBuilderTests extends AbstractTermQueryTestCase<SpanTer
                 spanTermQuery.boost(2.0f / randomIntBetween(1, 20));
             }
             if (randomBoolean()) {
-                spanTermQuery.queryName(randomAsciiOfLengthBetween(1, 10));
+                spanTermQuery.queryName(randomAlphaOfLengthBetween(1, 10));
             }
             clauses[i] = spanTermQuery;
         }

--- a/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermQueryBuilderTests.java
@@ -53,7 +53,7 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
                     fieldName = STRING_FIELD_NAME;
                 }
                 if (frequently()) {
-                    value = randomAsciiOfLengthBetween(1, 10);
+                    value = randomAlphaOfLengthBetween(1, 10);
                 } else {
                     // generate unicode string in 10% of cases
                     JsonStringEncoder encoder = JsonStringEncoder.getInstance();
@@ -77,7 +77,7 @@ public class TermQueryBuilderTests extends AbstractTermQueryTestCase<TermQueryBu
         }
 
         if (fieldName == null) {
-            fieldName = randomAsciiOfLengthBetween(1, 10);
+            fieldName = randomAlphaOfLengthBetween(1, 10);
         }
         return createQueryBuilder(fieldName, value);
     }

--- a/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -45,12 +45,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuilder> {
@@ -68,7 +66,7 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
             }
         }
         this.randomTerms = randomTerms;
-        termsPath = randomAsciiOfLength(10).replace('.', '_');
+        termsPath = randomAlphaOfLength(10).replace('.', '_');
     }
 
     @Override
@@ -89,14 +87,14 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
             query = new TermsQueryBuilder(fieldName, values);
         } else {
             // right now the mock service returns us a list of strings
-            query = new TermsQueryBuilder(randomBoolean() ? randomAsciiOfLengthBetween(1,10) : STRING_FIELD_NAME, randomTermsLookup());
+            query = new TermsQueryBuilder(randomBoolean() ? randomAlphaOfLengthBetween(1,10) : STRING_FIELD_NAME, randomTermsLookup());
         }
         return query;
     }
 
     private TermsLookup randomTermsLookup() {
-        return new TermsLookup(randomBoolean() ? randomAsciiOfLength(10) : null, randomAsciiOfLength(10), randomAsciiOfLength(10),
-                termsPath).routing(randomBoolean() ? randomAsciiOfLength(10) : null);
+        return new TermsLookup(randomBoolean() ? randomAlphaOfLength(10) : null, randomAlphaOfLength(10), randomAlphaOfLength(10),
+                termsPath).routing(randomBoolean() ? randomAlphaOfLength(10) : null);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -59,11 +59,11 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
 
     private static WildcardQueryBuilder randomWildcardQuery() {
         // mapped or unmapped field
-        String text = randomAsciiOfLengthBetween(1, 10);
+        String text = randomAlphaOfLengthBetween(1, 10);
         if (randomBoolean()) {
             return new WildcardQueryBuilder(STRING_FIELD_NAME, text);
         } else {
-            return new WildcardQueryBuilder(randomAsciiOfLengthBetween(1, 10), text);
+            return new WildcardQueryBuilder(randomAlphaOfLengthBetween(1, 10), text);
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilderTests.java
@@ -180,7 +180,7 @@ public class FunctionScoreQueryBuilderTests extends AbstractQueryTestCase<Functi
                 } else if (randomBoolean()) {
                     randomScoreFunctionBuilder.seed(randomInt());
                 } else {
-                    randomScoreFunctionBuilder.seed(randomAsciiOfLengthBetween(1, 10));
+                    randomScoreFunctionBuilder.seed(randomAlphaOfLengthBetween(1, 10));
                 }
             }
             functionBuilder = randomScoreFunctionBuilder;

--- a/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTests.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTests.java
@@ -115,7 +115,7 @@ public class GlobalCheckpointTests extends ESTestCase {
         allocations.keySet().forEach(aId -> tracker.updateLocalCheckpoint(aId, allocations.get(aId)));
 
         // now insert an unknown active/insync id , the checkpoint shouldn't change but a refresh should be requested.
-        final String extraId = "extra_" + randomAsciiOfLength(5);
+        final String extraId = "extra_" + randomAlphaOfLength(5);
 
         // first check that adding it without the master blessing doesn't change anything.
         tracker.updateLocalCheckpoint(extraId, maxLocalCheckpoint + 1 + randomInt(4));

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -213,7 +213,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
 
     public void testIndexDirIsDeletedWhenShardRemoved() throws Exception {
         Environment env = getInstanceFromNode(Environment.class);
-        Path idxPath = env.sharedDataFile().resolve(randomAsciiOfLength(10));
+        Path idxPath = env.sharedDataFile().resolve(randomAlphaOfLength(10));
         logger.info("--> idxPath: [{}]", idxPath);
         Settings idxSettings = Settings.builder()
             .put(IndexMetaData.SETTING_DATA_PATH, idxPath)
@@ -246,10 +246,10 @@ public class IndexShardIT extends ESSingleNodeTestCase {
 
     public void testIndexCanChangeCustomDataPath() throws Exception {
         Environment env = getInstanceFromNode(Environment.class);
-        Path idxPath = env.sharedDataFile().resolve(randomAsciiOfLength(10));
+        Path idxPath = env.sharedDataFile().resolve(randomAlphaOfLength(10));
         final String INDEX = "idx";
-        Path startDir = idxPath.resolve("start-" + randomAsciiOfLength(10));
-        Path endDir = idxPath.resolve("end-" + randomAsciiOfLength(10));
+        Path startDir = idxPath.resolve("start-" + randomAlphaOfLength(10));
+        Path endDir = idxPath.resolve("end-" + randomAlphaOfLength(10));
         logger.info("--> start dir: [{}]", startDir.toAbsolutePath().toString());
         logger.info("-->   end dir: [{}]", endDir.toAbsolutePath().toString());
         // temp dirs are automatically created, but the end dir is what

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexingOperationListenerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexingOperationListenerTests.java
@@ -44,7 +44,7 @@ public class IndexingOperationListenerTests extends ESTestCase{
         AtomicInteger preDelete = new AtomicInteger();
         AtomicInteger postDelete = new AtomicInteger();
         AtomicInteger postDeleteException = new AtomicInteger();
-        ShardId randomShardId = new ShardId(new Index(randomAsciiOfLength(10), randomAsciiOfLength(10)), randomIntBetween(1, 10));
+        ShardId randomShardId = new ShardId(new Index(randomAlphaOfLength(10), randomAlphaOfLength(10)), randomIntBetween(1, 10));
         IndexingOperationListener listener = new IndexingOperationListener() {
             @Override
             public Engine.Index preIndex(ShardId shardId, Engine.Index operation) {

--- a/core/src/test/java/org/elasticsearch/index/shard/ShardIdTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/ShardIdTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.test.ESTestCase;
 public class ShardIdTests extends ESTestCase {
 
     public void testShardIdFromString() {
-        String indexName = randomAsciiOfLengthBetween(3,50);
+        String indexName = randomAlphaOfLengthBetween(3,50);
         int shardId = randomInt();
         ShardId id = ShardId.fromString("["+indexName+"]["+shardId+"]");
         assertEquals(indexName, id.getIndexName());

--- a/core/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -48,7 +48,7 @@ public class FileInfoTests extends ESTestCase {
             for (int i = 0; i < hash.length; i++) {
                 hash.bytes[i] = randomByte();
             }
-            StoreFileMetaData meta = new StoreFileMetaData("foobar", Math.abs(randomLong()), randomAsciiOfLengthBetween(1, 10), Version.LATEST, hash);
+            StoreFileMetaData meta = new StoreFileMetaData("foobar", Math.abs(randomLong()), randomAlphaOfLengthBetween(1, 10), Version.LATEST, hash);
             ByteSizeValue size = new ByteSizeValue(Math.abs(randomLong()));
             BlobStoreIndexShardSnapshot.FileInfo info = new BlobStoreIndexShardSnapshot.FileInfo("_foobar", meta, size);
             XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).prettyPrint();

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -258,7 +258,7 @@ public class TranslogTests extends ESTestCase {
 
         final long seqNo = randomNonNegativeLong();
         final long primaryTerm = randomNonNegativeLong();
-        final String reason = randomAsciiOfLength(16);
+        final String reason = randomAlphaOfLength(16);
         addToTranslogAndList(translog, ops, new Translog.NoOp(seqNo, primaryTerm, reason));
 
         snapshot = translog.newSnapshot();
@@ -338,7 +338,7 @@ public class TranslogTests extends ESTestCase {
 
         final long seqNo = 1;
         final long primaryTerm = 1;
-        translog.add(new Translog.NoOp(seqNo, primaryTerm, randomAsciiOfLength(16)));
+        translog.add(new Translog.NoOp(seqNo, primaryTerm, randomAlphaOfLength(16)));
         {
             final TranslogStats stats = stats();
             assertThat(stats.estimatedNumberOfOperations(), equalTo(4L));
@@ -563,7 +563,7 @@ public class TranslogTests extends ESTestCase {
 
         int translogOperations = randomIntBetween(10, 100);
         for (int op = 0; op < translogOperations; op++) {
-            String ascii = randomAsciiOfLengthBetween(1, 50);
+            String ascii = randomAlphaOfLengthBetween(1, 50);
             locations.add(translog.add(new Translog.Index("test", "" + op, ascii.getBytes("UTF-8"))));
         }
         translog.sync();
@@ -589,7 +589,7 @@ public class TranslogTests extends ESTestCase {
 
         int translogOperations = randomIntBetween(10, 100);
         for (int op = 0; op < translogOperations; op++) {
-            String ascii = randomAsciiOfLengthBetween(1, 50);
+            String ascii = randomAlphaOfLengthBetween(1, 50);
             locations.add(translog.add(new Translog.Index("test", "" + op, ascii.getBytes("UTF-8"))));
         }
         translog.sync();
@@ -1406,7 +1406,7 @@ public class TranslogTests extends ESTestCase {
                                 randomFrom(VersionType.values()));
                             break;
                         case NO_OP:
-                            op = new Translog.NoOp(randomNonNegativeLong(), randomNonNegativeLong(), randomAsciiOfLength(16));
+                            op = new Translog.NoOp(randomNonNegativeLong(), randomNonNegativeLong(), randomAlphaOfLength(16));
                             break;
                         default:
                             throw new AssertionError("unsupported operation type [" + type + "]");

--- a/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -195,7 +195,7 @@ public class IndexActionIT extends ESIntegTestCase {
         int min = MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES + 1;
         int max = MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES * 2;
         try {
-            createIndex(randomAsciiOfLengthBetween(min, max).toLowerCase(Locale.ROOT));
+            createIndex(randomAlphaOfLengthBetween(min, max).toLowerCase(Locale.ROOT));
             fail("exception should have been thrown on too-long index name");
         } catch (InvalidIndexNameException e) {
             assertThat("exception contains message about index name too long: " + e.getMessage(),
@@ -203,7 +203,7 @@ public class IndexActionIT extends ESIntegTestCase {
         }
 
         try {
-            client().prepareIndex(randomAsciiOfLengthBetween(min, max).toLowerCase(Locale.ROOT), "mytype").setSource("foo", "bar").get();
+            client().prepareIndex(randomAlphaOfLengthBetween(min, max).toLowerCase(Locale.ROOT), "mytype").setSource("foo", "bar").get();
             fail("exception should have been thrown on too-long index name");
         } catch (InvalidIndexNameException e) {
             assertThat("exception contains message about index name too long: " + e.getMessage(),
@@ -212,7 +212,7 @@ public class IndexActionIT extends ESIntegTestCase {
 
         try {
             // Catch chars that are more than a single byte
-            client().prepareIndex(randomAsciiOfLength(MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES - 1).toLowerCase(Locale.ROOT) +
+            client().prepareIndex(randomAlphaOfLength(MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES - 1).toLowerCase(Locale.ROOT) +
                             "Ϟ".toLowerCase(Locale.ROOT),
                     "mytype").setSource("foo", "bar").get();
             fail("exception should have been thrown on too-long index name");
@@ -222,7 +222,7 @@ public class IndexActionIT extends ESIntegTestCase {
         }
 
         // we can create an index of max length
-        createIndex(randomAsciiOfLength(MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES).toLowerCase(Locale.ROOT));
+        createIndex(randomAlphaOfLength(MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES).toLowerCase(Locale.ROOT));
     }
 
     public void testInvalidIndexName() {

--- a/core/src/test/java/org/elasticsearch/indices/NodeIndicesStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/NodeIndicesStatsTests.java
@@ -31,7 +31,7 @@ public class NodeIndicesStatsTests extends ESTestCase {
 
     public void testInvalidLevel() {
         final NodeIndicesStats stats = new NodeIndicesStats();
-        final String level = randomAsciiOfLength(16);
+        final String level = randomAlphaOfLength(16);
         final ToXContent.Params params = new ToXContent.MapParams(Collections.singletonMap("level", level));
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> stats.toXContent(null, params));
         assertThat(

--- a/core/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.indices;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.indices.TermsLookup;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -30,11 +29,11 @@ import static org.hamcrest.Matchers.containsString;
 
 public class TermsLookupTests extends ESTestCase {
     public void testTermsLookup() {
-        String index = randomAsciiOfLengthBetween(1, 10);
-        String type = randomAsciiOfLengthBetween(1, 10);
-        String id = randomAsciiOfLengthBetween(1, 10);
-        String path = randomAsciiOfLengthBetween(1, 10);
-        String routing = randomAsciiOfLengthBetween(1, 10);
+        String index = randomAlphaOfLengthBetween(1, 10);
+        String type = randomAlphaOfLengthBetween(1, 10);
+        String id = randomAlphaOfLengthBetween(1, 10);
+        String path = randomAlphaOfLengthBetween(1, 10);
+        String routing = randomAlphaOfLengthBetween(1, 10);
         TermsLookup termsLookup = new TermsLookup(index, type, id, path);
         termsLookup.routing(routing);
         assertEquals(index, termsLookup.index());
@@ -45,9 +44,9 @@ public class TermsLookupTests extends ESTestCase {
     }
 
     public void testIllegalArguments() {
-        String type = randomAsciiOfLength(5);
-        String id = randomAsciiOfLength(5);
-        String path = randomAsciiOfLength(5);
+        String type = randomAlphaOfLength(5);
+        String id = randomAlphaOfLength(5);
+        String path = randomAlphaOfLength(5);
         switch (randomIntBetween(0, 2)) {
         case 0:
             type = null;
@@ -81,10 +80,10 @@ public class TermsLookupTests extends ESTestCase {
 
     public static TermsLookup randomTermsLookup() {
         return new TermsLookup(
-                randomBoolean() ? randomAsciiOfLength(10) : null,
-                randomAsciiOfLength(10),
-                randomAsciiOfLength(10),
-                randomAsciiOfLength(10).replace('.', '_')
-        ).routing(randomBoolean() ? randomAsciiOfLength(10) : null);
+                randomBoolean() ? randomAlphaOfLength(10) : null,
+                randomAlphaOfLength(10),
+                randomAlphaOfLength(10),
+                randomAlphaOfLength(10).replace('.', '_')
+        ).routing(randomBoolean() ? randomAlphaOfLength(10) : null);
     }
 }

--- a/core/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
@@ -54,7 +54,7 @@ public class PreBuiltAnalyzerIntegrationIT extends ESIntegTestCase {
         List<String> indexNames = new ArrayList<>();
         final int numIndices = scaledRandomIntBetween(2, 4);
         for (int i = 0; i < numIndices; i++) {
-            String indexName = randomAsciiOfLength(10).toLowerCase(Locale.ROOT);
+            String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
             indexNames.add(indexName);
 
             int randomInt = randomInt(PreBuiltAnalyzers.values().length-1);
@@ -91,7 +91,7 @@ public class PreBuiltAnalyzerIntegrationIT extends ESIntegTestCase {
             String randomId = randomInt() + "";
 
             Map<String, Object> data = new HashMap<>();
-            data.put("foo", randomAsciiOfLength(scaledRandomIntBetween(5, 50)));
+            data.put("foo", randomAlphaOfLength(scaledRandomIntBetween(5, 50)));
 
             index(randomIndex, "type", randomId, data);
         }

--- a/core/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -159,7 +159,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
      */
     public void testJoiningNewClusterOnlyRemovesInMemoryIndexStructures() {
         // a cluster state derived from the initial state that includes a created index
-        String name = "index_" + randomAsciiOfLength(8).toLowerCase(Locale.ROOT);
+        String name = "index_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
         ShardRoutingState[] replicaStates = new ShardRoutingState[randomIntBetween(0, 3)];
         Arrays.fill(replicaStates, ShardRoutingState.INITIALIZING);
         ClusterState stateWithIndex = ClusterStateCreationUtils.state(name, randomBoolean(), ShardRoutingState.INITIALIZING, replicaStates);
@@ -245,7 +245,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
             if (state.metaData().indices().size() > 200) {
                 break;
             }
-            String name = "index_" + randomAsciiOfLength(15).toLowerCase(Locale.ROOT);
+            String name = "index_" + randomAlphaOfLength(15).toLowerCase(Locale.ROOT);
             Settings.Builder settingsBuilder = Settings.builder()
                 .put(SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 3))
                 .put(SETTING_NUMBER_OF_REPLICAS, randomInt(2));

--- a/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -531,7 +531,7 @@ public class IndexRecoveryIT extends ESIntegTestCase {
         for (int i = 0; i < numDocs; i++) {
             docs[i] = client().prepareIndex(name, INDEX_TYPE).
                     setSource("foo-int", randomInt(),
-                            "foo-string", randomAsciiOfLength(32),
+                            "foo-string", randomAlphaOfLength(32),
                             "foo-float", randomFloat());
         }
 

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryTargetTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoveryTargetTests.java
@@ -521,7 +521,7 @@ public class RecoveryTargetTests extends ESTestCase {
             @Override
             public void run() {
                 for (int i = 0; i < 1000; i++) {
-                    index.addFileDetail(randomAsciiOfLength(10), 100, true);
+                    index.addFileDetail(randomAlphaOfLength(10), 100, true);
                 }
                 stop.set(true);
             }

--- a/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
@@ -20,38 +20,22 @@
 package org.elasticsearch.indices.store;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.threadpool.TestThreadPool;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportService;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
-import static org.elasticsearch.Version.CURRENT;
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
-import static org.elasticsearch.test.VersionUtils.randomVersion;
 
 public class IndicesStoreTests extends ESTestCase {
     private static final ShardRoutingState[] NOT_STARTED_STATES;
@@ -94,8 +78,8 @@ public class IndicesStoreTests extends ESTestCase {
                 if (state == ShardRoutingState.UNASSIGNED) {
                     unassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null);
                 }
-                String relocatingNodeId = state == ShardRoutingState.RELOCATING ? randomAsciiOfLength(10) : null;
-                routingTable.addShard(TestShardRouting.newShardRouting("test", i, randomAsciiOfLength(10), relocatingNodeId, j == 0, state, unassignedInfo));
+                String relocatingNodeId = state == ShardRoutingState.RELOCATING ? randomAlphaOfLength(10) : null;
+                routingTable.addShard(TestShardRouting.newShardRouting("test", i, randomAlphaOfLength(10), relocatingNodeId, j == 0, state, unassignedInfo));
             }
         }
 
@@ -111,10 +95,10 @@ public class IndicesStoreTests extends ESTestCase {
         for (int i = 0; i < numShards; i++) {
             int localNodeIndex = randomInt(numReplicas);
             boolean primaryOnLocalNode = i == localShardId && localNodeIndex == numReplicas;
-            routingTable.addShard(TestShardRouting.newShardRouting("test", i, primaryOnLocalNode ? localNode.getId() : randomAsciiOfLength(10), true, ShardRoutingState.STARTED));
+            routingTable.addShard(TestShardRouting.newShardRouting("test", i, primaryOnLocalNode ? localNode.getId() : randomAlphaOfLength(10), true, ShardRoutingState.STARTED));
             for (int j = 0; j < numReplicas; j++) {
                 boolean replicaOnLocalNode = i == localShardId && localNodeIndex == j;
-                routingTable.addShard(TestShardRouting.newShardRouting("test", i, replicaOnLocalNode ? localNode.getId() : randomAsciiOfLength(10), false, ShardRoutingState.STARTED));
+                routingTable.addShard(TestShardRouting.newShardRouting("test", i, replicaOnLocalNode ? localNode.getId() : randomAlphaOfLength(10), false, ShardRoutingState.STARTED));
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -912,12 +912,12 @@ public class IngestDocumentTests extends ESTestCase {
         Map<String, Object> sourceAndMetadata = RandomDocumentPicks.randomSource(random());
         int numFields = randomIntBetween(1, IngestDocument.MetaData.values().length);
         for (int i = 0; i < numFields; i++) {
-            sourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAsciiOfLengthBetween(5, 10));
+            sourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAlphaOfLengthBetween(5, 10));
         }
         Map<String, Object> ingestMetadata = new HashMap<>();
         numFields = randomIntBetween(1, 5);
         for (int i = 0; i < numFields; i++) {
-            ingestMetadata.put(randomAsciiOfLengthBetween(5, 10), randomAsciiOfLengthBetween(5, 10));
+            ingestMetadata.put(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10));
         }
         IngestDocument ingestDocument = new IngestDocument(sourceAndMetadata, ingestMetadata);
 
@@ -932,7 +932,7 @@ public class IngestDocumentTests extends ESTestCase {
         if (randomBoolean()) {
             numFields = randomIntBetween(1, IngestDocument.MetaData.values().length);
             for (int i = 0; i < numFields; i++) {
-                otherSourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAsciiOfLengthBetween(5, 10));
+                otherSourceAndMetadata.put(randomFrom(IngestDocument.MetaData.values()).getFieldName(), randomAlphaOfLengthBetween(5, 10));
             }
             changed = true;
         }
@@ -942,7 +942,7 @@ public class IngestDocumentTests extends ESTestCase {
             otherIngestMetadata = new HashMap<>();
             numFields = randomIntBetween(1, 5);
             for (int i = 0; i < numFields; i++) {
-                otherIngestMetadata.put(randomAsciiOfLengthBetween(5, 10), randomAsciiOfLengthBetween(5, 10));
+                otherIngestMetadata.put(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10));
             }
             changed = true;
         } else {

--- a/core/src/test/java/org/elasticsearch/monitor/fs/DeviceStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/fs/DeviceStatsTests.java
@@ -28,7 +28,7 @@ public class DeviceStatsTests extends ESTestCase {
     public void testDeviceStats() {
         final int majorDeviceNumber = randomIntBetween(1, 1 << 8);
         final int minorDeviceNumber = randomIntBetween(0, 1 << 5);
-        final String deviceName = randomAsciiOfLength(3);
+        final String deviceName = randomAlphaOfLength(3);
         final int readsCompleted = randomIntBetween(1, 1 << 16);
         final int sectorsRead = randomIntBetween(8 * readsCompleted, 16 * readsCompleted);
         final int writesCompleted = randomIntBetween(1, 1 << 16);

--- a/core/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
@@ -55,7 +55,7 @@ public class JvmGcMonitorServiceSettingsTests extends ESTestCase {
     }
 
     public void testNegativeSetting() throws InterruptedException {
-        String collector = randomAsciiOfLength(5);
+        String collector = randomAlphaOfLength(5);
         Settings settings = Settings.builder().put("monitor.jvm.gc.collector." + collector + ".warn", "-" + randomTimeValue()).build();
         execute(settings, (command, interval, name) -> null, e -> {
             assertThat(e, instanceOf(IllegalArgumentException.class));
@@ -64,7 +64,7 @@ public class JvmGcMonitorServiceSettingsTests extends ESTestCase {
     }
 
     public void testMissingSetting() throws InterruptedException {
-        String collector = randomAsciiOfLength(5);
+        String collector = randomAlphaOfLength(5);
         Set<AbstractMap.SimpleEntry<String, String>> entries = new HashSet<>();
         entries.add(new AbstractMap.SimpleEntry<>("monitor.jvm.gc.collector." + collector + ".warn", randomPositiveTimeValue()));
         entries.add(new AbstractMap.SimpleEntry<>("monitor.jvm.gc.collector." + collector + ".info", randomPositiveTimeValue()));

--- a/core/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceTests.java
@@ -37,7 +37,7 @@ public class JvmGcMonitorServiceTests extends ESTestCase {
         when(logger.isInfoEnabled()).thenReturn(true);
         when(logger.isDebugEnabled()).thenReturn(true);
         final JvmGcMonitorService.JvmMonitor.Threshold threshold = randomFrom(JvmGcMonitorService.JvmMonitor.Threshold.values());
-        final String name = randomAsciiOfLength(16);
+        final String name = randomAlphaOfLength(16);
         final long seq = randomIntBetween(1, 1 << 30);
         final int elapsedValue = randomIntBetween(1, 1 << 10);
         final long totalCollectionCount = randomIntBetween(1, 16);

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -148,7 +148,7 @@ public class OsProbeTests extends ESTestCase {
         assumeTrue("test runs on Linux only", Constants.LINUX);
 
         final boolean areCgroupStatsAvailable = randomBoolean();
-        final String hierarchy = randomAsciiOfLength(16);
+        final String hierarchy = randomAlphaOfLength(16);
 
         final OsProbe probe = new OsProbe() {
 

--- a/core/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/os/OsStatsTests.java
@@ -37,9 +37,9 @@ public class OsStatsTests extends ESTestCase {
         OsStats.Mem mem = new OsStats.Mem(randomLong(), randomLong());
         OsStats.Swap swap = new OsStats.Swap(randomLong(), randomLong());
         OsStats.Cgroup cgroup = new OsStats.Cgroup(
-            randomAsciiOfLength(8),
+            randomAlphaOfLength(8),
             randomNonNegativeLong(),
-            randomAsciiOfLength(8),
+            randomAlphaOfLength(8),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             new OsStats.Cgroup.CpuStat(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()));

--- a/core/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/core/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -113,9 +113,9 @@ public class NodeInfoStreamingTests extends ESTestCase {
             int availableProcessors = randomIntBetween(1, 64);
             int allocatedProcessors = randomIntBetween(1, availableProcessors);
             long refreshInterval = randomBoolean() ? -1 : randomNonNegativeLong();
-            String name = randomAsciiOfLengthBetween(3, 10);
-            String arch = randomAsciiOfLengthBetween(3, 10);
-            String version = randomAsciiOfLengthBetween(3, 10);
+            String name = randomAlphaOfLengthBetween(3, 10);
+            String arch = randomAlphaOfLengthBetween(3, 10);
+            String version = randomAlphaOfLengthBetween(3, 10);
             osInfo = new OsInfo(refreshInterval, availableProcessors, allocatedProcessors, name, arch, version);
         }
         ProcessInfo process = randomBoolean() ? null : new ProcessInfo(randomInt(), randomBoolean(), randomNonNegativeLong());
@@ -125,7 +125,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
             int numThreadPools = randomIntBetween(1, 10);
             List<ThreadPool.Info> threadPoolInfos = new ArrayList<>(numThreadPools);
             for (int i = 0; i < numThreadPools; i++) {
-                threadPoolInfos.add(new ThreadPool.Info(randomAsciiOfLengthBetween(3, 10),
+                threadPoolInfos.add(new ThreadPool.Info(randomAlphaOfLengthBetween(3, 10),
                         randomFrom(ThreadPool.ThreadPoolType.values()), randomInt()));
             }
             threadPoolInfo = new ThreadPoolInfo(threadPoolInfos);
@@ -142,14 +142,14 @@ public class NodeInfoStreamingTests extends ESTestCase {
             int numPlugins = randomIntBetween(0, 5);
             List<PluginInfo> plugins = new ArrayList<>();
             for (int i = 0; i < numPlugins; i++) {
-                plugins.add(new PluginInfo(randomAsciiOfLengthBetween(3, 10), randomAsciiOfLengthBetween(3, 10),
-                        randomAsciiOfLengthBetween(3, 10), randomAsciiOfLengthBetween(3, 10), randomBoolean()));
+                plugins.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
+                        randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10), randomBoolean()));
             }
             int numModules = randomIntBetween(0, 5);
             List<PluginInfo> modules = new ArrayList<>();
             for (int i = 0; i < numModules; i++) {
-                modules.add(new PluginInfo(randomAsciiOfLengthBetween(3, 10), randomAsciiOfLengthBetween(3, 10),
-                        randomAsciiOfLengthBetween(3, 10), randomAsciiOfLengthBetween(3, 10), randomBoolean()));
+                modules.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
+                        randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10), randomBoolean()));
             }
             pluginsAndModules = new PluginsAndModules(plugins, modules);
         }
@@ -159,7 +159,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
             int numProcessors = randomIntBetween(0, 5);
             List<ProcessorInfo> processors = new ArrayList<>(numProcessors);
             for (int i = 0; i < numProcessors; i++) {
-                processors.add(new ProcessorInfo(randomAsciiOfLengthBetween(3, 10)));
+                processors.add(new ProcessorInfo(randomAlphaOfLengthBetween(3, 10)));
             }
             ingestInfo = new IngestInfo(processors);
         }

--- a/core/src/test/java/org/elasticsearch/repositories/IndexIdTests.java
+++ b/core/src/test/java/org/elasticsearch/repositories/IndexIdTests.java
@@ -36,7 +36,7 @@ public class IndexIdTests extends ESTestCase {
 
     public void testEqualsAndHashCode() {
         // assert equals and hashcode
-        String name = randomAsciiOfLength(8);
+        String name = randomAlphaOfLength(8);
         String id = UUIDs.randomBase64UUID();
         IndexId indexId1 = new IndexId(name, id);
         IndexId indexId2 = new IndexId(name, id);
@@ -49,7 +49,7 @@ public class IndexIdTests extends ESTestCase {
         assertEquals(indexId1, indexId2);
         assertEquals(indexId1.hashCode(), indexId2.hashCode());
         //assert not equals when name or id differ
-        indexId2 = new IndexId(randomAsciiOfLength(8), id);
+        indexId2 = new IndexId(randomAlphaOfLength(8), id);
         assertNotEquals(indexId1, indexId2);
         assertNotEquals(indexId1.hashCode(), indexId2.hashCode());
         indexId2 = new IndexId(name, UUIDs.randomBase64UUID());
@@ -58,14 +58,14 @@ public class IndexIdTests extends ESTestCase {
     }
 
     public void testSerialization() throws IOException {
-        IndexId indexId = new IndexId(randomAsciiOfLength(8), UUIDs.randomBase64UUID());
+        IndexId indexId = new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
         BytesStreamOutput out = new BytesStreamOutput();
         indexId.writeTo(out);
         assertEquals(indexId, new IndexId(out.bytes().streamInput()));
     }
 
     public void testXContent() throws IOException {
-        IndexId indexId = new IndexId(randomAsciiOfLength(8), UUIDs.randomBase64UUID());
+        IndexId indexId = new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
         XContentBuilder builder = JsonXContent.contentBuilder();
         indexId.toXContent(builder, ToXContent.EMPTY_PARAMS);
         XContentParser parser = createParser(JsonXContent.jsonXContent, builder.bytes());

--- a/core/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/core/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -68,12 +68,12 @@ public class RepositoryDataTests extends ESTestCase {
         // test that adding the same snapshot id to the repository data throws an exception
         Map<String, IndexId> indexIdMap = repositoryData.getIndices();
         // test that adding a snapshot and its indices works
-        SnapshotId newSnapshot = new SnapshotId(randomAsciiOfLength(7), UUIDs.randomBase64UUID());
+        SnapshotId newSnapshot = new SnapshotId(randomAlphaOfLength(7), UUIDs.randomBase64UUID());
         List<IndexId> indices = new ArrayList<>();
         Set<IndexId> newIndices = new HashSet<>();
         int numNew = randomIntBetween(1, 10);
         for (int i = 0; i < numNew; i++) {
-            IndexId indexId = new IndexId(randomAsciiOfLength(7), UUIDs.randomBase64UUID());
+            IndexId indexId = new IndexId(randomAlphaOfLength(7), UUIDs.randomBase64UUID());
             newIndices.add(indexId);
             indices.add(indexId);
         }
@@ -99,7 +99,7 @@ public class RepositoryDataTests extends ESTestCase {
         final int numSnapshots = randomIntBetween(1, 30);
         final List<SnapshotId> snapshotIds = new ArrayList<>(numSnapshots);
         for (int i = 0; i < numSnapshots; i++) {
-            snapshotIds.add(new SnapshotId(randomAsciiOfLength(8), UUIDs.randomBase64UUID()));
+            snapshotIds.add(new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID()));
         }
         RepositoryData repositoryData = new RepositoryData(EMPTY_REPO_GEN, snapshotIds, Collections.emptyMap(), Collections.emptyList());
         // test that initializing indices works
@@ -131,7 +131,7 @@ public class RepositoryDataTests extends ESTestCase {
         String indexName = indexNames.iterator().next();
         IndexId indexId = indices.get(indexName);
         assertEquals(indexId, repositoryData.resolveIndexId(indexName));
-        String notInRepoData = randomAsciiOfLength(5);
+        String notInRepoData = randomAlphaOfLength(5);
         assertFalse(indexName.contains(notInRepoData));
         assertEquals(new IndexId(notInRepoData, notInRepoData), repositoryData.resolveIndexId(notInRepoData));
     }
@@ -149,7 +149,7 @@ public class RepositoryDataTests extends ESTestCase {
         final int numSnapshots = randomIntBetween(1, 30);
         final List<SnapshotId> snapshotIds = new ArrayList<>(origSnapshotIds);
         for (int i = 0; i < numSnapshots; i++) {
-            snapshotIds.add(new SnapshotId(randomAsciiOfLength(8), UUIDs.randomBase64UUID()));
+            snapshotIds.add(new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID()));
         }
         return snapshotIds;
     }
@@ -159,7 +159,7 @@ public class RepositoryDataTests extends ESTestCase {
         final int numIndices = randomIntBetween(1, 30);
         final Map<IndexId, Set<SnapshotId>> indices = new HashMap<>(numIndices);
         for (int i = 0; i < numIndices; i++) {
-            final IndexId indexId = new IndexId(randomAsciiOfLength(8), UUIDs.randomBase64UUID());
+            final IndexId indexId = new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
             final Set<SnapshotId> indexSnapshots = new LinkedHashSet<>();
             final int numIndicesForSnapshot = randomIntBetween(1, numIndices);
             for (int j = 0; j < numIndicesForSnapshot; j++) {

--- a/core/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/core/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -179,7 +179,7 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         final int numSnapshots = randomIntBetween(1, 20);
         final List<SnapshotId> snapshotIds = new ArrayList<>(numSnapshots);
         for (int i = 0; i < numSnapshots; i++) {
-            snapshotIds.add(new SnapshotId(randomAsciiOfLength(8), UUIDs.randomBase64UUID()));
+            snapshotIds.add(new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID()));
         }
         RepositoryData repositoryData = new RepositoryData(readData.getGenId(), Collections.emptyList(), Collections.emptyMap(),
                                                               snapshotIds);
@@ -210,11 +210,11 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
     private RepositoryData addRandomSnapshotsToRepoData(RepositoryData repoData, boolean inclIndices) {
         int numSnapshots = randomIntBetween(1, 20);
         for (int i = 0; i < numSnapshots; i++) {
-            SnapshotId snapshotId = new SnapshotId(randomAsciiOfLength(8), UUIDs.randomBase64UUID());
+            SnapshotId snapshotId = new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
             int numIndices = inclIndices ? randomIntBetween(0, 20) : 0;
             List<IndexId> indexIds = new ArrayList<>(numIndices);
             for (int j = 0; j < numIndices; j++) {
-                indexIds.add(new IndexId(randomAsciiOfLength(8), UUIDs.randomBase64UUID()));
+                indexIds.add(new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID()));
             }
             repoData = repoData.addSnapshot(snapshotId, indexIds);
         }

--- a/core/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
@@ -50,8 +50,8 @@ public class BaseRestHandlerTests extends ESTestCase {
         };
 
         final HashMap<String, String> params = new HashMap<>();
-        params.put("consumed", randomAsciiOfLength(8));
-        params.put("unconsumed", randomAsciiOfLength(8));
+        params.put("consumed", randomAlphaOfLength(8));
+        params.put("unconsumed", randomAlphaOfLength(8));
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
         RestChannel channel = new FakeRestChannel(request, randomBoolean(), 1);
         final IllegalArgumentException e =
@@ -71,9 +71,9 @@ public class BaseRestHandlerTests extends ESTestCase {
         };
 
         final HashMap<String, String> params = new HashMap<>();
-        params.put("consumed", randomAsciiOfLength(8));
-        params.put("unconsumed-first", randomAsciiOfLength(8));
-        params.put("unconsumed-second", randomAsciiOfLength(8));
+        params.put("consumed", randomAlphaOfLength(8));
+        params.put("unconsumed-first", randomAlphaOfLength(8));
+        params.put("unconsumed-second", randomAlphaOfLength(8));
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
         RestChannel channel = new FakeRestChannel(request, randomBoolean(), 1);
         final IllegalArgumentException e =
@@ -102,12 +102,12 @@ public class BaseRestHandlerTests extends ESTestCase {
         };
 
         final HashMap<String, String> params = new HashMap<>();
-        params.put("consumed", randomAsciiOfLength(8));
-        params.put("flied", randomAsciiOfLength(8));
-        params.put("respones_param", randomAsciiOfLength(8));
-        params.put("tokenzier", randomAsciiOfLength(8));
-        params.put("very_close_to_parametre", randomAsciiOfLength(8));
-        params.put("very_far_from_every_consumed_parameter", randomAsciiOfLength(8));
+        params.put("consumed", randomAlphaOfLength(8));
+        params.put("flied", randomAlphaOfLength(8));
+        params.put("respones_param", randomAlphaOfLength(8));
+        params.put("tokenzier", randomAlphaOfLength(8));
+        params.put("very_close_to_parametre", randomAlphaOfLength(8));
+        params.put("very_far_from_every_consumed_parameter", randomAlphaOfLength(8));
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
         RestChannel channel = new FakeRestChannel(request, randomBoolean(), 1);
         final IllegalArgumentException e =
@@ -140,8 +140,8 @@ public class BaseRestHandlerTests extends ESTestCase {
         };
 
         final HashMap<String, String> params = new HashMap<>();
-        params.put("consumed", randomAsciiOfLength(8));
-        params.put("response_param", randomAsciiOfLength(8));
+        params.put("consumed", randomAlphaOfLength(8));
+        params.put("response_param", randomAlphaOfLength(8));
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
         RestChannel channel = new FakeRestChannel(request, randomBoolean(), 1);
         handler.handleRequest(request, channel, mock(NodeClient.class));
@@ -158,8 +158,8 @@ public class BaseRestHandlerTests extends ESTestCase {
         };
 
         final HashMap<String, String> params = new HashMap<>();
-        params.put("format", randomAsciiOfLength(8));
-        params.put("filter_path", randomAsciiOfLength(8));
+        params.put("format", randomAlphaOfLength(8));
+        params.put("filter_path", randomAlphaOfLength(8));
         params.put("pretty", randomFrom("true", "false", "", null));
         params.put("human", null);
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
@@ -188,14 +188,14 @@ public class BaseRestHandlerTests extends ESTestCase {
         };
 
         final HashMap<String, String> params = new HashMap<>();
-        params.put("format", randomAsciiOfLength(8));
-        params.put("h", randomAsciiOfLength(8));
-        params.put("v", randomAsciiOfLength(8));
-        params.put("ts", randomAsciiOfLength(8));
-        params.put("pri", randomAsciiOfLength(8));
-        params.put("bytes", randomAsciiOfLength(8));
-        params.put("size", randomAsciiOfLength(8));
-        params.put("time", randomAsciiOfLength(8));
+        params.put("format", randomAlphaOfLength(8));
+        params.put("h", randomAlphaOfLength(8));
+        params.put("v", randomAlphaOfLength(8));
+        params.put("ts", randomAlphaOfLength(8));
+        params.put("pri", randomAlphaOfLength(8));
+        params.put("bytes", randomAlphaOfLength(8));
+        params.put("size", randomAlphaOfLength(8));
+        params.put("time", randomAlphaOfLength(8));
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
         RestChannel channel = new FakeRestChannel(request, randomBoolean(), 1);
         handler.handleRequest(request, channel, mock(NodeClient.class));

--- a/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/BytesRestResponseTests.java
@@ -302,8 +302,8 @@ public class BytesRestResponseTests extends ESTestCase {
                 expected.addMetadata("es.metadata_0", "0");
             }
             if (randomBoolean()) {
-                String resourceType = randomAsciiOfLength(5);
-                String resourceId = randomAsciiOfLength(5);
+                String resourceType = randomAlphaOfLength(5);
+                String resourceId = randomAlphaOfLength(5);
                 originalException.setResources(resourceType, resourceId);
                 expected.setResources(resourceType, resourceId);
             }

--- a/core/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/DeprecationRestHandlerTests.java
@@ -38,7 +38,7 @@ public class DeprecationRestHandlerTests extends ESTestCase {
     /**
      * Note: Headers should only use US ASCII (and this inevitably becomes one!).
      */
-    private final String deprecationMessage = randomAsciiOfLengthBetween(1, 30);
+    private final String deprecationMessage = randomAlphaOfLengthBetween(1, 30);
     private final DeprecationLogger deprecationLogger = mock(DeprecationLogger.class);
 
     public void testNullHandler() {

--- a/core/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -130,9 +130,9 @@ public class RestControllerTests extends ESTestCase {
         RestController controller = mock(RestController.class);
 
         RestRequest.Method method = randomFrom(RestRequest.Method.values());
-        String path = "/_" + randomAsciiOfLengthBetween(1, 6);
+        String path = "/_" + randomAlphaOfLengthBetween(1, 6);
         RestHandler handler = mock(RestHandler.class);
-        String deprecationMessage = randomAsciiOfLengthBetween(1, 10);
+        String deprecationMessage = randomAlphaOfLengthBetween(1, 10);
         DeprecationLogger logger = mock(DeprecationLogger.class);
 
         // don't want to test everything -- just that it actually wraps the handler
@@ -147,10 +147,10 @@ public class RestControllerTests extends ESTestCase {
         final RestController controller = mock(RestController.class);
 
         final RestRequest.Method method = randomFrom(RestRequest.Method.values());
-        final String path = "/_" + randomAsciiOfLengthBetween(1, 6);
+        final String path = "/_" + randomAlphaOfLengthBetween(1, 6);
         final RestHandler handler = mock(RestHandler.class);
         final RestRequest.Method deprecatedMethod = randomFrom(RestRequest.Method.values());
-        final String deprecatedPath = "/_" + randomAsciiOfLengthBetween(1, 6);
+        final String deprecatedPath = "/_" + randomAlphaOfLengthBetween(1, 6);
         final DeprecationLogger logger = mock(DeprecationLogger.class);
 
         final String deprecationMessage = "[" + deprecatedMethod.name() + " " + deprecatedPath + "] is deprecated! Use [" +
@@ -206,7 +206,7 @@ public class RestControllerTests extends ESTestCase {
 
     public void testDispatchRequestAddsAndFreesBytesOnSuccess() {
         int contentLength = BREAKER_LIMIT.bytesAsInt();
-        String content = randomAsciiOfLength(contentLength);
+        String content = randomAlphaOfLength(contentLength);
         TestRestRequest request = new TestRestRequest("/", content, XContentType.JSON);
         AssertingChannel channel = new AssertingChannel(request, true, RestStatus.OK);
 
@@ -218,7 +218,7 @@ public class RestControllerTests extends ESTestCase {
 
     public void testDispatchRequestAddsAndFreesBytesOnError() {
         int contentLength = BREAKER_LIMIT.bytesAsInt();
-        String content = randomAsciiOfLength(contentLength);
+        String content = randomAlphaOfLength(contentLength);
         TestRestRequest request = new TestRestRequest("/error", content, XContentType.JSON);
         AssertingChannel channel = new AssertingChannel(request, true, RestStatus.BAD_REQUEST);
 
@@ -230,7 +230,7 @@ public class RestControllerTests extends ESTestCase {
 
     public void testDispatchRequestAddsAndFreesBytesOnlyOnceOnError() {
         int contentLength = BREAKER_LIMIT.bytesAsInt();
-        String content = randomAsciiOfLength(contentLength);
+        String content = randomAlphaOfLength(contentLength);
         // we will produce an error in the rest handler and one more when sending the error response
         TestRestRequest request = new TestRestRequest("/error", content, XContentType.JSON);
         ExceptionThrowingChannel channel = new ExceptionThrowingChannel(request, true);
@@ -243,7 +243,7 @@ public class RestControllerTests extends ESTestCase {
 
     public void testDispatchRequestLimitsBytes() {
         int contentLength = BREAKER_LIMIT.bytesAsInt() + 1;
-        String content = randomAsciiOfLength(contentLength);
+        String content = randomAlphaOfLength(contentLength);
         TestRestRequest request = new TestRestRequest("/", content, XContentType.JSON);
         AssertingChannel channel = new AssertingChannel(request, true, RestStatus.SERVICE_UNAVAILABLE);
 
@@ -254,7 +254,7 @@ public class RestControllerTests extends ESTestCase {
     }
 
     public void testDispatchRequiresContentTypeForRequestsWithContent() {
-        String content = randomAsciiOfLengthBetween(1, BREAKER_LIMIT.bytesAsInt());
+        String content = randomAlphaOfLengthBetween(1, BREAKER_LIMIT.bytesAsInt());
         TestRestRequest request = new TestRestRequest("/", content, null);
         AssertingChannel channel = new AssertingChannel(request, true, RestStatus.NOT_ACCEPTABLE);
         restController = new RestController(
@@ -279,7 +279,7 @@ public class RestControllerTests extends ESTestCase {
     }
 
     public void testDispatchFailsWithPlainText() {
-        String content = randomAsciiOfLengthBetween(1, BREAKER_LIMIT.bytesAsInt());
+        String content = randomAlphaOfLengthBetween(1, BREAKER_LIMIT.bytesAsInt());
         FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withContent(new BytesArray(content), null).withPath("/foo")
             .withHeaders(Collections.singletonMap("Content-Type", Collections.singletonList("text/plain"))).build();
@@ -309,7 +309,7 @@ public class RestControllerTests extends ESTestCase {
 
     public void testDispatchWorksWithNewlineDelimitedJson() {
         final String mimeType = "application/x-ndjson";
-        String content = randomAsciiOfLengthBetween(1, BREAKER_LIMIT.bytesAsInt());
+        String content = randomAlphaOfLengthBetween(1, BREAKER_LIMIT.bytesAsInt());
         FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withContent(new BytesArray(content), null).withPath("/foo")
             .withHeaders(Collections.singletonMap("Content-Type", Collections.singletonList(mimeType))).build();
@@ -333,7 +333,7 @@ public class RestControllerTests extends ESTestCase {
 
     public void testDispatchWithContentStream() {
         final String mimeType = randomFrom("application/json", "application/smile");
-        String content = randomAsciiOfLengthBetween(1, BREAKER_LIMIT.bytesAsInt());
+        String content = randomAlphaOfLengthBetween(1, BREAKER_LIMIT.bytesAsInt());
         FakeRestRequest fakeRestRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withContent(new BytesArray(content), null).withPath("/foo")
             .withHeaders(Collections.singletonMap("Content-Type", Collections.singletonList(mimeType))).build();

--- a/core/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -113,7 +113,7 @@ public class RestRequestTests extends ESTestCase {
     }
 
     public void testPlainTextSupport() {
-        ContentRestRequest restRequest = new ContentRestRequest(randomAsciiOfLengthBetween(1, 30), Collections.emptyMap(),
+        ContentRestRequest restRequest = new ContentRestRequest(randomAlphaOfLengthBetween(1, 30), Collections.emptyMap(),
             Collections.singletonMap("Content-Type",
                 Collections.singletonList(randomFrom("text/plain", "text/plain; charset=utf-8", "text/plain;charset=utf-8"))));
         assertNull(restRequest.getXContentType());
@@ -132,7 +132,7 @@ public class RestRequestTests extends ESTestCase {
     }
 
     public void testMultipleContentTypeHeaders() {
-        List<String> headers = new ArrayList<>(randomUnique(() -> randomAsciiOfLengthBetween(1, 16), randomIntBetween(2, 10)));
+        List<String> headers = new ArrayList<>(randomUnique(() -> randomAlphaOfLengthBetween(1, 16), randomIntBetween(2, 10)));
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new ContentRestRequest("", Collections.emptyMap(),
             Collections.singletonMap("Content-Type", headers)));
         assertEquals("only one Content-Type header should be provided", e.getMessage());

--- a/core/src/test/java/org/elasticsearch/rest/action/RestMainActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/RestMainActionTests.java
@@ -43,7 +43,7 @@ public class RestMainActionTests extends ESTestCase {
     public void testHeadResponse() throws Exception {
         final String nodeName = "node1";
         final ClusterName clusterName = new ClusterName("cluster1");
-        final String clusterUUID = randomAsciiOfLengthBetween(10, 20);
+        final String clusterUUID = randomAlphaOfLengthBetween(10, 20);
         final boolean available = randomBoolean();
         final RestStatus expectedStatus = available ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
         final Version version = Version.CURRENT;
@@ -69,7 +69,7 @@ public class RestMainActionTests extends ESTestCase {
     public void testGetResponse() throws Exception {
         final String nodeName = "node1";
         final ClusterName clusterName = new ClusterName("cluster1");
-        final String clusterUUID = randomAsciiOfLengthBetween(10, 20);
+        final String clusterUUID = randomAlphaOfLengthBetween(10, 20);
         final boolean available = randomBoolean();
         final RestStatus expectedStatus = available ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
         final Version version = Version.CURRENT;

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.rest.action.admin.cluster;
 
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -49,7 +48,7 @@ public class RestNodesStatsActionTests extends ESTestCase {
 
     public void testUnrecognizedMetric() throws IOException {
         final HashMap<String, String> params = new HashMap<>();
-        final String metric = randomAsciiOfLength(64);
+        final String metric = randomAlphaOfLength(64);
         params.put("metric", metric);
         final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_nodes/stats").withParams(params).build();
         final IllegalArgumentException e = expectThrows(
@@ -86,7 +85,7 @@ public class RestNodesStatsActionTests extends ESTestCase {
     public void testUnrecognizedIndexMetric() {
         final HashMap<String, String> params = new HashMap<>();
         params.put("metric", "indices");
-        final String indexMetric = randomAsciiOfLength(64);
+        final String indexMetric = randomAlphaOfLength(64);
         params.put("index_metric", indexMetric);
         final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_nodes/stats").withParams(params).build();
         final IllegalArgumentException e = expectThrows(

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
@@ -46,7 +46,7 @@ public class RestIndicesStatsActionTests extends ESTestCase {
 
     public void testUnrecognizedMetric() throws IOException {
         final HashMap<String, String> params = new HashMap<>();
-        final String metric = randomAsciiOfLength(64);
+        final String metric = randomAlphaOfLength(64);
         params.put("metric", metric);
         final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_stats").withParams(params).build();
         final IllegalArgumentException e = expectThrows(

--- a/core/src/test/java/org/elasticsearch/rest/action/cat/RestIndicesActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/cat/RestIndicesActionTests.java
@@ -81,7 +81,7 @@ public class RestIndicesActionTests extends ESTestCase {
         final int numIndices = randomIntBetween(0, 5);
         Index[] indices = new Index[numIndices];
         for (int i = 0; i < numIndices; i++) {
-            indices[i] = new Index(randomAsciiOfLength(5), UUIDs.randomBase64UUID());
+            indices[i] = new Index(randomAlphaOfLength(5), UUIDs.randomBase64UUID());
         }
 
         final MetaData.Builder metaDataBuilder = MetaData.builder();

--- a/core/src/test/java/org/elasticsearch/rest/action/cat/RestRecoveryActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/cat/RestRecoveryActionTests.java
@@ -69,11 +69,11 @@ public class RestRecoveryActionTests extends ESTestCase {
             when(state.getStage()).thenReturn(randomFrom(RecoveryState.Stage.values()));
             final DiscoveryNode sourceNode = randomBoolean() ? mock(DiscoveryNode.class) : null;
             if (sourceNode != null) {
-                when(sourceNode.getHostName()).thenReturn(randomAsciiOfLength(8));
+                when(sourceNode.getHostName()).thenReturn(randomAlphaOfLength(8));
             }
             when(state.getSourceNode()).thenReturn(sourceNode);
             final DiscoveryNode targetNode = mock(DiscoveryNode.class);
-            when(targetNode.getHostName()).thenReturn(randomAsciiOfLength(8));
+            when(targetNode.getHostName()).thenReturn(randomAlphaOfLength(8));
             when(state.getTargetNode()).thenReturn(targetNode);
 
             RecoveryState.Index index = mock(RecoveryState.Index.class);

--- a/core/src/test/java/org/elasticsearch/script/ScriptMetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptMetaDataTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.script;
 import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -103,10 +102,10 @@ public class ScriptMetaDataTests extends AbstractSerializingTestCase<ScriptMetaD
         ScriptMetaData.Builder builder = new ScriptMetaData.Builder(null);
         int numScripts = scaledRandomIntBetween(0, 32);
         for (int i = 0; i < numScripts; i++) {
-            String lang = randomAsciiOfLength(4);
+            String lang = randomAlphaOfLength(4);
             XContentBuilder sourceBuilder = XContentBuilder.builder(sourceContentType.xContent());
-            sourceBuilder.startObject().field("script", randomAsciiOfLength(4)).endObject();
-            builder.storeScript(randomAsciiOfLength(i + 1),
+            sourceBuilder.startObject().field("script", randomAlphaOfLength(4)).endObject();
+            builder.storeScript(randomAlphaOfLength(i + 1),
                 StoredScriptSource.parse(lang, sourceBuilder.bytes(), sourceBuilder.contentType()));
         }
         return builder.build();

--- a/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
@@ -56,8 +56,8 @@ public class ScriptModesTests extends ESTestCase {
         //prevent duplicates using map
         Map<String, ScriptContext.Plugin> contexts = new HashMap<>();
         for (int i = 0; i < randomInt; i++) {
-            String plugin = randomAsciiOfLength(randomIntBetween(1, 10));
-            String operation = randomAsciiOfLength(randomIntBetween(1, 30));
+            String plugin = randomAlphaOfLength(randomIntBetween(1, 10));
+            String operation = randomAlphaOfLength(randomIntBetween(1, 30));
             String context = plugin + "-" + operation;
             contexts.put(context, new ScriptContext.Plugin(plugin, operation));
         }

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -95,11 +95,11 @@ public class ScriptServiceTests extends ESTestCase {
         for (int i = 0; i < randomInt; i++) {
             String plugin;
             do {
-                plugin = randomAsciiOfLength(randomIntBetween(1, 10));
+                plugin = randomAlphaOfLength(randomIntBetween(1, 10));
             } while (ScriptContextRegistry.RESERVED_SCRIPT_CONTEXTS.contains(plugin));
             String operation;
             do {
-                operation = randomAsciiOfLength(randomIntBetween(1, 30));
+                operation = randomAlphaOfLength(randomIntBetween(1, 30));
             } while (ScriptContextRegistry.RESERVED_SCRIPT_CONTEXTS.contains(operation));
             String context = plugin + "_" + operation;
             contexts.put(context, new ScriptContext.Plugin(plugin, operation));
@@ -324,8 +324,8 @@ public class ScriptServiceTests extends ESTestCase {
         String pluginName;
         String unknownContext;
         do {
-            pluginName = randomAsciiOfLength(randomIntBetween(1, 10));
-            unknownContext = randomAsciiOfLength(randomIntBetween(1, 30));
+            pluginName = randomAlphaOfLength(randomIntBetween(1, 10));
+            unknownContext = randomAlphaOfLength(randomIntBetween(1, 30));
         } while(scriptContextRegistry.isSupportedContext(new ScriptContext.Plugin(pluginName, unknownContext)));
 
         String type = scriptEngineService.getType();

--- a/core/src/test/java/org/elasticsearch/script/ScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptTests.java
@@ -67,12 +67,12 @@ public class ScriptTests extends ESTestCase {
         if (scriptType == ScriptType.INLINE) {
             try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
                 builder.startObject();
-                builder.field("field", randomAsciiOfLengthBetween(1, 5));
+                builder.field("field", randomAlphaOfLengthBetween(1, 5));
                 builder.endObject();
                 script = builder.string();
             }
         } else {
-            script = randomAsciiOfLengthBetween(1, 5);
+            script = randomAlphaOfLengthBetween(1, 5);
         }
         return new Script(
             scriptType,

--- a/core/src/test/java/org/elasticsearch/script/StoredScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/StoredScriptTests.java
@@ -343,8 +343,8 @@ public class StoredScriptTests extends AbstractSerializingTestCase<StoredScriptS
     @Override
     protected StoredScriptSource createTestInstance() {
         return new StoredScriptSource(
-            randomAsciiOfLength(randomIntBetween(4, 32)),
-            randomAsciiOfLength(randomIntBetween(4, 16383)),
+            randomAlphaOfLength(randomIntBetween(4, 32)),
+            randomAlphaOfLength(randomIntBetween(4, 16383)),
             Collections.emptyMap());
     }
 

--- a/core/src/test/java/org/elasticsearch/script/StoredScriptsIT.java
+++ b/core/src/test/java/org/elasticsearch/script/StoredScriptsIT.java
@@ -79,7 +79,7 @@ public class StoredScriptsIT extends ESIntegTestCase {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> client().admin().cluster().preparePutStoredScript()
                 .setLang(LANG)
                 .setId("foobar")
-                .setContent(new BytesArray(randomAsciiOfLength(SCRIPT_MAX_SIZE_IN_BYTES + 1)), XContentType.JSON)
+                .setContent(new BytesArray(randomAlphaOfLength(SCRIPT_MAX_SIZE_IN_BYTES + 1)), XContentType.JSON)
                 .get()
         );
         assertEquals("exceeded max allowed stored script size in bytes [64] with size [65] for script [foobar]", e.getMessage());

--- a/core/src/test/java/org/elasticsearch/search/AbstractSearchTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/AbstractSearchTestCase.java
@@ -83,7 +83,7 @@ public abstract class AbstractSearchTestCase extends ESTestCase {
             }
             List<SearchExtBuilder> searchExtBuilders = new ArrayList<>();
             for (String elementName : elementNames) {
-                searchExtBuilders.add(searchExtPlugin.getSupportedElements().get(elementName).apply(randomAsciiOfLengthBetween(3, 10)));
+                searchExtBuilders.add(searchExtPlugin.getSupportedElements().get(elementName).apply(randomAlphaOfLengthBetween(3, 10)));
             }
             return searchExtBuilders;
         };

--- a/core/src/test/java/org/elasticsearch/search/NestedIdentityTests.java
+++ b/core/src/test/java/org/elasticsearch/search/NestedIdentityTests.java
@@ -40,7 +40,7 @@ import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashC
 public class NestedIdentityTests extends ESTestCase {
 
     public static NestedIdentity createTestItem(int depth) {
-        String field = frequently() ? randomAsciiOfLengthBetween(1, 20) : randomRealisticUnicodeOfCodepointLengthBetween(1, 20);
+        String field = frequently() ? randomAlphaOfLengthBetween(1, 20) : randomRealisticUnicodeOfCodepointLengthBetween(1, 20);
         int offset = randomInt(10);
         NestedIdentity child = null;
         if (depth > 0) {

--- a/core/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -61,8 +61,8 @@ public class SearchHitTests extends ESTestCase {
 
     public static SearchHit createTestItem(boolean withOptionalInnerHits) {
         int internalId = randomInt();
-        String uid = randomAsciiOfLength(10);
-        Text type = new Text(randomAsciiOfLengthBetween(5, 10));
+        String uid = randomAlphaOfLength(10);
+        Text type = new Text(randomAlphaOfLengthBetween(5, 10));
         NestedIdentity nestedIdentity = null;
         if (randomBoolean()) {
             nestedIdentity = NestedIdentityTests.createTestItem(randomIntBetween(0, 2));
@@ -77,7 +77,7 @@ public class SearchHitTests extends ESTestCase {
                     String metaField = randomFrom(META_FIELDS);
                     fields.put(metaField, new SearchHitField(metaField, values.v1()));
                 } else {
-                    String fieldName = randomAsciiOfLengthBetween(5, 10);
+                    String fieldName = randomAlphaOfLengthBetween(5, 10);
                     fields.put(fieldName, new SearchHitField(fieldName, values.v1()));
                 }
             }
@@ -103,7 +103,7 @@ public class SearchHitTests extends ESTestCase {
             int size = randomIntBetween(0, 5);
             Map<String, HighlightField> highlightFields = new HashMap<>(size);
             for (int i = 0; i < size; i++) {
-                highlightFields.put(randomAsciiOfLength(5), HighlightFieldTests.createTestItem());
+                highlightFields.put(randomAlphaOfLength(5), HighlightFieldTests.createTestItem());
             }
             hit.highlightFields(highlightFields);
         }
@@ -111,7 +111,7 @@ public class SearchHitTests extends ESTestCase {
             int size = randomIntBetween(0, 5);
             String[] matchedQueries = new String[size];
             for (int i = 0; i < size; i++) {
-                matchedQueries[i] = randomAsciiOfLength(5);
+                matchedQueries[i] = randomAlphaOfLength(5);
             }
             hit.matchedQueries(matchedQueries);
         }
@@ -122,13 +122,13 @@ public class SearchHitTests extends ESTestCase {
             int innerHitsSize = randomIntBetween(0, 3);
             Map<String, SearchHits> innerHits = new HashMap<>(innerHitsSize);
             for (int i = 0; i < innerHitsSize; i++) {
-                innerHits.put(randomAsciiOfLength(5), SearchHitsTests.createTestItem());
+                innerHits.put(randomAlphaOfLength(5), SearchHitsTests.createTestItem());
             }
             hit.setInnerHits(innerHits);
         }
         if (randomBoolean()) {
-            hit.shard(new SearchShardTarget(randomAsciiOfLengthBetween(5, 10),
-                    new ShardId(new Index(randomAsciiOfLengthBetween(5, 10), randomAsciiOfLengthBetween(5, 10)), randomInt())));
+            hit.shard(new SearchShardTarget(randomAlphaOfLengthBetween(5, 10),
+                    new ShardId(new Index(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10)), randomInt())));
         }
         return hit;
     }
@@ -234,7 +234,7 @@ public class SearchHitTests extends ESTestCase {
     }
 
     private static Explanation createExplanation(int depth) {
-        String description = randomAsciiOfLengthBetween(5, 20);
+        String description = randomAlphaOfLengthBetween(5, 20);
         float value = randomFloat();
         List<Explanation> details = new ArrayList<>();
         if (depth > 0) {

--- a/core/src/test/java/org/elasticsearch/search/SearchRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchRequestTests.java
@@ -87,12 +87,12 @@ public class SearchRequestTests extends AbstractSearchTestCase {
     private SearchRequest mutate(SearchRequest searchRequest) throws IOException {
         SearchRequest mutation = copyRequest(searchRequest);
         List<Runnable> mutators = new ArrayList<>();
-        mutators.add(() -> mutation.indices(ArrayUtils.concat(searchRequest.indices(), new String[] { randomAsciiOfLength(10) })));
+        mutators.add(() -> mutation.indices(ArrayUtils.concat(searchRequest.indices(), new String[] { randomAlphaOfLength(10) })));
         mutators.add(() -> mutation.indicesOptions(randomValueOtherThan(searchRequest.indicesOptions(),
                 () -> IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()))));
-        mutators.add(() -> mutation.types(ArrayUtils.concat(searchRequest.types(), new String[] { randomAsciiOfLength(10) })));
-        mutators.add(() -> mutation.preference(randomValueOtherThan(searchRequest.preference(), () -> randomAsciiOfLengthBetween(3, 10))));
-        mutators.add(() -> mutation.routing(randomValueOtherThan(searchRequest.routing(), () -> randomAsciiOfLengthBetween(3, 10))));
+        mutators.add(() -> mutation.types(ArrayUtils.concat(searchRequest.types(), new String[] { randomAlphaOfLength(10) })));
+        mutators.add(() -> mutation.preference(randomValueOtherThan(searchRequest.preference(), () -> randomAlphaOfLengthBetween(3, 10))));
+        mutators.add(() -> mutation.routing(randomValueOtherThan(searchRequest.routing(), () -> randomAlphaOfLengthBetween(3, 10))));
         mutators.add(() -> mutation.requestCache((randomValueOtherThan(searchRequest.requestCache(), () -> randomBoolean()))));
         mutators.add(() -> mutation
                 .scroll(randomValueOtherThan(searchRequest.scroll(), () -> new Scroll(new TimeValue(randomNonNegativeLong() % 100000)))));

--- a/core/src/test/java/org/elasticsearch/search/SearchSortValuesTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchSortValuesTests.java
@@ -52,7 +52,7 @@ public class SearchSortValuesTests extends ESTestCase {
         valueSuppliers.add(() -> randomByte());
         valueSuppliers.add(() -> randomShort());
         valueSuppliers.add(() -> randomBoolean());
-        valueSuppliers.add(() -> frequently() ? randomAsciiOfLengthBetween(1, 30) : randomRealisticUnicodeOfCodepointLength(30));
+        valueSuppliers.add(() -> frequently() ? randomAlphaOfLengthBetween(1, 30) : randomRealisticUnicodeOfCodepointLength(30));
 
         int size = randomIntBetween(1, 20);
         Object[] values = new Object[size];

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
@@ -58,7 +58,7 @@ public class AggregatorFactoriesTests extends ESTestCase {
         // stick around for all of the subclasses
         currentTypes = new String[randomIntBetween(0, 5)];
         for (int i = 0; i < currentTypes.length; i++) {
-            String type = randomAsciiOfLengthBetween(1, 10);
+            String type = randomAlphaOfLengthBetween(1, 10);
             currentTypes[i] = type;
         }
         xContentRegistry = new NamedXContentRegistry(new SearchModule(settings, false, emptyList()).getNamedXContents());
@@ -174,7 +174,7 @@ public class AggregatorFactoriesTests extends ESTestCase {
     public void testSameAggregationName() throws Exception {
         assumeFalse("Test only makes sense if XContent parser doesn't have strict duplicate checks enabled",
             XContent.isStrictDuplicateDetectionEnabled());
-        final String name = randomAsciiOfLengthBetween(1, 10);
+        final String name = randomAlphaOfLengthBetween(1, 10);
         XContentBuilder source = JsonXContent.contentBuilder()
                 .startObject()
                     .startObject(name)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -85,7 +85,7 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
         //create some random type with some default field, those types will stick around for all of the subclasses
         currentTypes = new String[randomIntBetween(0, 5)];
         for (int i = 0; i < currentTypes.length; i++) {
-            String type = randomAsciiOfLengthBetween(1, 10);
+            String type = randomAlphaOfLengthBetween(1, 10);
             currentTypes[i] = type;
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/BasePipelineAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/BasePipelineAggregationTestCase.java
@@ -87,7 +87,7 @@ public abstract class BasePipelineAggregationTestCase<AF extends AbstractPipelin
         //create some random type with some default field, those types will stick around for all of the subclasses
         currentTypes = new String[randomIntBetween(0, 5)];
         for (int i = 0; i < currentTypes.length; i++) {
-            String type = randomAsciiOfLengthBetween(1, 10);
+            String type = randomAlphaOfLengthBetween(1, 10);
             currentTypes[i] = type;
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
@@ -51,7 +51,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
     }
 
     public void testReduceRandom() {
-        String name = randomAsciiOfLength(5);
+        String name = randomAlphaOfLength(5);
         List<T> inputs = new ArrayList<>();
         List<InternalAggregation> toReduce = new ArrayList<>();
         int toReduceSize = between(1, 200);
@@ -92,7 +92,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
 
     @Override
     protected final T createTestInstance() {
-        return createTestInstance(randomAsciiOfLength(5));
+        return createTestInstance(randomAlphaOfLength(5));
     }
 
     private T createTestInstance(String name) {
@@ -101,7 +101,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         Map<String, Object> metaData = new HashMap<>();
         int metaDataCount = randomBoolean() ? 0 : between(1, 10);
         while (metaData.size() < metaDataCount) {
-            metaData.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+            metaData.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
         }
         return createTestInstance(name, pipelineAggregators, metaData);
     }
@@ -113,7 +113,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         Map<String, Object> metaData = new HashMap<>();
         int metaDataCount = randomBoolean() ? 0 : between(1, 10);
         while (metaData.size() < metaDataCount) {
-            metaData.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+            metaData.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
         }
         return createUnmappedInstance(name, pipelineAggregators, metaData);
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ChildrenTests.java
@@ -26,8 +26,8 @@ public class ChildrenTests extends BaseAggregationTestCase<ChildrenAggregationBu
 
     @Override
     protected ChildrenAggregationBuilder createTestAggregatorBuilder() {
-        String name = randomAsciiOfLengthBetween(3, 20);
-        String childType = randomAsciiOfLengthBetween(5, 40);
+        String name = randomAlphaOfLengthBetween(3, 20);
+        String childType = randomAlphaOfLengthBetween(5, 40);
         ChildrenAggregationBuilder factory = new ChildrenAggregationBuilder(name, childType);
         return factory;
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -32,7 +32,7 @@ public class DateRangeTests extends BaseAggregationTestCase<DateRangeAggregation
         for (int i = 0; i < numRanges; i++) {
             String key = null;
             if (randomBoolean()) {
-                key = randomAsciiOfLengthBetween(1, 20);
+                key = randomAlphaOfLengthBetween(1, 20);
             }
             double from = randomBoolean() ? Double.NEGATIVE_INFINITY : randomIntBetween(Integer.MIN_VALUE, Integer.MAX_VALUE - 1000);
             double to = randomBoolean() ? Double.POSITIVE_INFINITY

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FilterAggregatorTests.java
@@ -54,7 +54,7 @@ public class FilterAggregatorTests extends AggregatorTestCase {
         indexWriter.close();
         IndexReader indexReader = DirectoryReader.open(directory);
         IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
-        QueryBuilder filter = QueryBuilders.termQuery("field", randomAsciiOfLength(5));
+        QueryBuilder filter = QueryBuilders.termQuery("field", randomAlphaOfLength(5));
         FilterAggregationBuilder builder = new FilterAggregationBuilder("test", filter);
         InternalFilter response = search(indexSearcher, new MatchAllDocsQuery(), builder,
                 fieldType);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersAggregatorTests.java
@@ -62,7 +62,7 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
         int numFilters = randomIntBetween(1, 10);
         QueryBuilder[] filters = new QueryBuilder[numFilters];
         for (int i = 0; i < filters.length; i++) {
-            filters[i] = QueryBuilders.termQuery("field", randomAsciiOfLength(5));
+            filters[i] = QueryBuilders.termQuery("field", randomAlphaOfLength(5));
         }
         FiltersAggregationBuilder builder = new FiltersAggregationBuilder("test", filters);
         builder.otherBucketKey("other");

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
@@ -37,7 +37,7 @@ public class GeoDistanceRangeTests extends BaseAggregationTestCase<GeoDistanceAg
         for (int i = 0; i < numRanges; i++) {
             String key = null;
             if (randomBoolean()) {
-                key = randomAsciiOfLengthBetween(1, 20);
+                key = randomAlphaOfLengthBetween(1, 20);
             }
             double from = randomBoolean() ? 0 : randomIntBetween(0, Integer.MAX_VALUE - 1000);
             double to = randomBoolean() ? Double.POSITIVE_INFINITY
@@ -45,7 +45,7 @@ public class GeoDistanceRangeTests extends BaseAggregationTestCase<GeoDistanceAg
                             : randomIntBetween((int) from, Integer.MAX_VALUE));
             factory.addRange(new Range(key, from, to));
         }
-        factory.field(randomAsciiOfLengthBetween(1, 20));
+        factory.field(randomAlphaOfLengthBetween(1, 20));
         if (randomBoolean()) {
             factory.keyed(randomBoolean());
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridTests.java
@@ -26,7 +26,7 @@ public class GeoHashGridTests extends BaseAggregationTestCase<GeoGridAggregation
 
     @Override
     protected GeoGridAggregationBuilder createTestAggregatorBuilder() {
-        String name = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
         GeoGridAggregationBuilder factory = new GeoGridAggregationBuilder(name);
         if (randomBoolean()) {
             int precision = randomIntBetween(1, 12);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalTests.java
@@ -26,7 +26,7 @@ public class GlobalTests extends BaseAggregationTestCase<GlobalAggregationBuilde
 
     @Override
     protected GlobalAggregationBuilder createTestAggregatorBuilder() {
-        return new GlobalAggregationBuilder(randomAsciiOfLengthBetween(3, 20));
+        return new GlobalAggregationBuilder(randomAlphaOfLengthBetween(3, 20));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpRangeTests.java
@@ -51,7 +51,7 @@ public class IpRangeTests extends BaseAggregationTestCase<IpRangeAggregationBuil
         for (int i = 0; i < numRanges; i++) {
             String key = null;
             if (randomBoolean()) {
-                key = randomAsciiOfLengthBetween(1, 20);
+                key = randomAlphaOfLengthBetween(1, 20);
             }
             switch (randomInt(3)) {
             case 0:

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -32,7 +32,7 @@ public class RangeTests extends BaseAggregationTestCase<RangeAggregationBuilder>
         for (int i = 0; i < numRanges; i++) {
             String key = null;
             if (randomBoolean()) {
-                key = randomAsciiOfLengthBetween(1, 20);
+                key = randomAlphaOfLengthBetween(1, 20);
             }
             double from = randomBoolean() ? Double.NEGATIVE_INFINITY : randomIntBetween(Integer.MIN_VALUE, Integer.MAX_VALUE - 1000);
             double to = randomBoolean() ? Double.POSITIVE_INFINITY

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsTests.java
@@ -51,9 +51,9 @@ public class SignificantTermsTests extends BaseAggregationTestCase<SignificantTe
 
     @Override
     protected SignificantTermsAggregationBuilder createTestAggregatorBuilder() {
-        String name = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
         SignificantTermsAggregationBuilder factory = new SignificantTermsAggregationBuilder(name, null);
-        String field = randomAsciiOfLengthBetween(3, 20);
+        String field = randomAlphaOfLengthBetween(3, 20);
         int randomFieldBranch = randomInt(2);
         switch (randomFieldBranch) {
         case 0:
@@ -131,7 +131,7 @@ public class SignificantTermsTests extends BaseAggregationTestCase<SignificantTe
                 SortedSet<BytesRef> includeValues = new TreeSet<>();
                 int numIncs = randomIntBetween(1, 20);
                 for (int i = 0; i < numIncs; i++) {
-                    includeValues.add(new BytesRef(randomAsciiOfLengthBetween(1, 30)));
+                    includeValues.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
                 SortedSet<BytesRef> excludeValues = null;
                 incExc = new IncludeExclude(includeValues, excludeValues);
@@ -141,7 +141,7 @@ public class SignificantTermsTests extends BaseAggregationTestCase<SignificantTe
                 SortedSet<BytesRef> excludeValues2 = new TreeSet<>();
                 int numExcs2 = randomIntBetween(1, 20);
                 for (int i = 0; i < numExcs2; i++) {
-                    excludeValues2.add(new BytesRef(randomAsciiOfLengthBetween(1, 30)));
+                    excludeValues2.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
                 incExc = new IncludeExclude(includeValues2, excludeValues2);
                 break;
@@ -149,12 +149,12 @@ public class SignificantTermsTests extends BaseAggregationTestCase<SignificantTe
                 SortedSet<BytesRef> includeValues3 = new TreeSet<>();
                 int numIncs3 = randomIntBetween(1, 20);
                 for (int i = 0; i < numIncs3; i++) {
-                    includeValues3.add(new BytesRef(randomAsciiOfLengthBetween(1, 30)));
+                    includeValues3.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
                 SortedSet<BytesRef> excludeValues3 = new TreeSet<>();
                 int numExcs3 = randomIntBetween(1, 20);
                 for (int i = 0; i < numExcs3; i++) {
-                    excludeValues3.add(new BytesRef(randomAsciiOfLengthBetween(1, 30)));
+                    excludeValues3.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
                 incExc = new IncludeExclude(includeValues3, excludeValues3);
                 break;

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/StringTermsIT.java
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -1095,10 +1093,10 @@ public class StringTermsIT extends AbstractTermsTestCase {
 
     public void testSingleValuedFieldOrderedBySubAggregationAscMultiHierarchyLevelsSpecialChars() throws Exception {
         StringBuilder filter2NameBuilder = new StringBuilder("filt.er2");
-        filter2NameBuilder.append(randomAsciiOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
+        filter2NameBuilder.append(randomAlphaOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
         String filter2Name = filter2NameBuilder.toString();
         StringBuilder statsNameBuilder = new StringBuilder("st.ats");
-        statsNameBuilder.append(randomAsciiOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
+        statsNameBuilder.append(randomAlphaOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
         String statsName = statsNameBuilder.toString();
         boolean asc = randomBoolean();
         SearchResponse response = client()
@@ -1158,10 +1156,10 @@ public class StringTermsIT extends AbstractTermsTestCase {
 
     public void testSingleValuedFieldOrderedBySubAggregationAscMultiHierarchyLevelsSpecialCharsNoDotNotation() throws Exception {
         StringBuilder filter2NameBuilder = new StringBuilder("filt.er2");
-        filter2NameBuilder.append(randomAsciiOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
+        filter2NameBuilder.append(randomAlphaOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
         String filter2Name = filter2NameBuilder.toString();
         StringBuilder statsNameBuilder = new StringBuilder("st.ats");
-        statsNameBuilder.append(randomAsciiOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
+        statsNameBuilder.append(randomAlphaOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
         String statsName = statsNameBuilder.toString();
         boolean asc = randomBoolean();
         SearchResponse response = client()

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsTests.java
@@ -47,9 +47,9 @@ public class TermsTests extends BaseAggregationTestCase<TermsAggregationBuilder>
 
     @Override
     protected TermsAggregationBuilder createTestAggregatorBuilder() {
-        String name = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
         TermsAggregationBuilder factory = new TermsAggregationBuilder(name, null);
-        String field = randomAsciiOfLengthBetween(3, 20);
+        String field = randomAlphaOfLengthBetween(3, 20);
         int randomFieldBranch = randomInt(2);
         switch (randomFieldBranch) {
         case 0:
@@ -131,7 +131,7 @@ public class TermsTests extends BaseAggregationTestCase<TermsAggregationBuilder>
                 SortedSet<BytesRef> includeValues = new TreeSet<>();
                 int numIncs = randomIntBetween(1, 20);
                 for (int i = 0; i < numIncs; i++) {
-                    includeValues.add(new BytesRef(randomAsciiOfLengthBetween(1, 30)));
+                    includeValues.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
                 SortedSet<BytesRef> excludeValues = null;
                 incExc = new IncludeExclude(includeValues, excludeValues);
@@ -141,7 +141,7 @@ public class TermsTests extends BaseAggregationTestCase<TermsAggregationBuilder>
                 SortedSet<BytesRef> excludeValues2 = new TreeSet<>();
                 int numExcs2 = randomIntBetween(1, 20);
                 for (int i = 0; i < numExcs2; i++) {
-                    excludeValues2.add(new BytesRef(randomAsciiOfLengthBetween(1, 30)));
+                    excludeValues2.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
                 incExc = new IncludeExclude(includeValues2, excludeValues2);
                 break;
@@ -149,12 +149,12 @@ public class TermsTests extends BaseAggregationTestCase<TermsAggregationBuilder>
                 SortedSet<BytesRef> includeValues3 = new TreeSet<>();
                 int numIncs3 = randomIntBetween(1, 20);
                 for (int i = 0; i < numIncs3; i++) {
-                    includeValues3.add(new BytesRef(randomAsciiOfLengthBetween(1, 30)));
+                    includeValues3.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
                 SortedSet<BytesRef> excludeValues3 = new TreeSet<>();
                 int numExcs3 = randomIntBetween(1, 20);
                 for (int i = 0; i < numExcs3; i++) {
-                    excludeValues3.add(new BytesRef(randomAsciiOfLengthBetween(1, 30)));
+                    excludeValues3.add(new BytesRef(randomAlphaOfLengthBetween(1, 30)));
                 }
                 incExc = new IncludeExclude(includeValues3, excludeValues3);
                 break;
@@ -188,10 +188,10 @@ public class TermsTests extends BaseAggregationTestCase<TermsAggregationBuilder>
             orders.add(Terms.Order.count(randomBoolean()));
             break;
         case 2:
-            orders.add(Terms.Order.aggregation(randomAsciiOfLengthBetween(3, 20), randomBoolean()));
+            orders.add(Terms.Order.aggregation(randomAlphaOfLengthBetween(3, 20), randomBoolean()));
             break;
         case 3:
-            orders.add(Terms.Order.aggregation(randomAsciiOfLengthBetween(3, 20), randomAsciiOfLengthBetween(3, 20), randomBoolean()));
+            orders.add(Terms.Order.aggregation(randomAlphaOfLengthBetween(3, 20), randomAlphaOfLengthBetween(3, 20), randomBoolean()));
             break;
         case 4:
             int numOrders = randomIntBetween(1, 3);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedTests.java
@@ -25,7 +25,7 @@ public class NestedTests extends BaseAggregationTestCase<NestedAggregationBuilde
 
     @Override
     protected NestedAggregationBuilder createTestAggregatorBuilder() {
-        return new NestedAggregationBuilder(randomAsciiOfLengthBetween(1, 20), randomAsciiOfLengthBetween(3, 40));
+        return new NestedAggregationBuilder(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(3, 40));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedTests.java
@@ -25,9 +25,9 @@ public class ReverseNestedTests extends BaseAggregationTestCase<ReverseNestedAgg
 
     @Override
     protected ReverseNestedAggregationBuilder createTestAggregatorBuilder() {
-        ReverseNestedAggregationBuilder factory = new ReverseNestedAggregationBuilder(randomAsciiOfLengthBetween(1, 20));
+        ReverseNestedAggregationBuilder factory = new ReverseNestedAggregationBuilder(randomAlphaOfLengthBetween(1, 20));
         if (randomBoolean()) {
-            factory.path(randomAsciiOfLengthBetween(3, 40));
+            factory.path(randomAlphaOfLengthBetween(3, 40));
         }
         return factory;
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -42,8 +42,8 @@ public class InternalBinaryRangeTests extends InternalAggregationTestCase<Intern
         Tuple<BytesRef, BytesRef>[] ranges = new Tuple[numRanges];
         for (int i = 0; i < numRanges; i++) {
             BytesRef[] values = new BytesRef[2];
-            values[0] = new BytesRef(randomAsciiOfLength(15));
-            values[1] = new BytesRef(randomAsciiOfLength(15));
+            values[0] = new BytesRef(randomAlphaOfLength(15));
+            values[1] = new BytesRef(randomAlphaOfLength(15));
             Arrays.sort(values);
             ranges[i] = new Tuple(values[0], values[1]);
         }
@@ -60,7 +60,7 @@ public class InternalBinaryRangeTests extends InternalAggregationTestCase<Intern
         List<InternalBinaryRange.Bucket> buckets = new ArrayList<>();
         for (int i = 0; i < RANGES.length; ++i) {
             final int docCount = randomIntBetween(1, 100);
-            buckets.add(new InternalBinaryRange.Bucket(format, keyed, randomAsciiOfLength(10),
+            buckets.add(new InternalBinaryRange.Bucket(format, keyed, randomAlphaOfLength(10),
                 RANGES[i].v1(), RANGES[i].v2(), docCount, InternalAggregations.EMPTY));
         }
         return new InternalBinaryRange(name, format, keyed, buckets, pipelineAggregators, Collections.emptyMap());

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTermsTests.java
@@ -62,7 +62,7 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
         List<SignificantStringTerms.Bucket> buckets = new ArrayList<>(numBuckets);
         Set<BytesRef> terms = new HashSet<>();
         for (int i = 0; i < numBuckets; ++i) {
-            BytesRef term = randomValueOtherThanMany(b -> terms.add(b) == false, () -> new BytesRef(randomAsciiOfLength(10)));
+            BytesRef term = randomValueOtherThanMany(b -> terms.add(b) == false, () -> new BytesRef(randomAlphaOfLength(10)));
 
             int subsetDf = randomIntBetween(1, 10);
             int supersetDf = randomIntBetween(subsetDf, 20);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
@@ -50,7 +50,7 @@ public class StringTermsTests extends InternalTermsTestCase {
         final int numBuckets = randomInt(shardSize);
         Set<BytesRef> terms = new HashSet<>();
         for (int i = 0; i < numBuckets; ++i) {
-            BytesRef term = randomValueOtherThanMany(b -> terms.add(b) == false, () -> new BytesRef(randomAsciiOfLength(10)));
+            BytesRef term = randomValueOtherThanMany(b -> terms.add(b) == false, () -> new BytesRef(randomAlphaOfLength(10)));
             int docCount = randomIntBetween(1, 100);
             buckets.add(new StringTerms.Bucket(term, docCount, InternalAggregations.EMPTY,
                     showTermDocCountError, docCountError, format));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AdjacencyMatrixTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AdjacencyMatrixTests.java
@@ -36,10 +36,10 @@ public class AdjacencyMatrixTests extends BaseAggregationTestCase<AdjacencyMatri
         int size = randomIntBetween(1, 20);
         AdjacencyMatrixAggregationBuilder factory;
         Map<String, QueryBuilder> filters = new HashMap<>(size);
-        for (String key : randomUnique(() -> randomAsciiOfLengthBetween(1, 20), size)) {
-            filters.put(key, QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
+        for (String key : randomUnique(() -> randomAlphaOfLengthBetween(1, 20), size)) {
+            filters.put(key, QueryBuilders.termQuery(randomAlphaOfLengthBetween(5, 20), randomAlphaOfLengthBetween(5, 20)));
         }
-        factory = new AdjacencyMatrixAggregationBuilder(randomAsciiOfLengthBetween(1, 20), filters)
+        factory = new AdjacencyMatrixAggregationBuilder(randomAlphaOfLengthBetween(1, 20), filters)
                 .separator(randomFrom("&","+","\t"));       
         return factory;
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/FilterTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/FilterTests.java
@@ -27,8 +27,8 @@ public class FilterTests extends BaseAggregationTestCase<FilterAggregationBuilde
 
     @Override
     protected FilterAggregationBuilder createTestAggregatorBuilder() {
-        FilterAggregationBuilder factory = new FilterAggregationBuilder(randomAsciiOfLengthBetween(1, 20),
-                QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
+        FilterAggregationBuilder factory = new FilterAggregationBuilder(randomAlphaOfLengthBetween(1, 20),
+                QueryBuilders.termQuery(randomAlphaOfLengthBetween(5, 20), randomAlphaOfLengthBetween(5, 20)));
         // NORELEASE make RandomQueryBuilder work outside of the
         // AbstractQueryTestCase
         // builder.query(RandomQueryBuilder.createQuery(getRandom()));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/FiltersTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/FiltersTests.java
@@ -43,23 +43,23 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregationBuil
         if (randomBoolean()) {
             KeyedFilter[] filters = new KeyedFilter[size];
             int i = 0;
-            for (String key : randomUnique(() -> randomAsciiOfLengthBetween(1, 20), size)) {
+            for (String key : randomUnique(() -> randomAlphaOfLengthBetween(1, 20), size)) {
                 filters[i++] = new KeyedFilter(key,
-                        QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
+                        QueryBuilders.termQuery(randomAlphaOfLengthBetween(5, 20), randomAlphaOfLengthBetween(5, 20)));
             }
-            factory = new FiltersAggregationBuilder(randomAsciiOfLengthBetween(1, 20), filters);
+            factory = new FiltersAggregationBuilder(randomAlphaOfLengthBetween(1, 20), filters);
         } else {
             QueryBuilder[] filters = new QueryBuilder[size];
             for (int i = 0; i < size; i++) {
-                filters[i] = QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20));
+                filters[i] = QueryBuilders.termQuery(randomAlphaOfLengthBetween(5, 20), randomAlphaOfLengthBetween(5, 20));
             }
-            factory = new FiltersAggregationBuilder(randomAsciiOfLengthBetween(1, 20), filters);
+            factory = new FiltersAggregationBuilder(randomAlphaOfLengthBetween(1, 20), filters);
         }
         if (randomBoolean()) {
             factory.otherBucket(randomBoolean());
         }
         if (randomBoolean()) {
-            factory.otherBucketKey(randomAsciiOfLengthBetween(1, 20));
+            factory.otherBucketKey(randomAlphaOfLengthBetween(1, 20));
         }
         return factory;
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsTests.java
@@ -26,8 +26,8 @@ public class GeoBoundsTests extends BaseAggregationTestCase<GeoBoundsAggregation
 
     @Override
     protected GeoBoundsAggregationBuilder createTestAggregatorBuilder() {
-        GeoBoundsAggregationBuilder factory = new GeoBoundsAggregationBuilder(randomAsciiOfLengthBetween(1, 20));
-        String field = randomAsciiOfLengthBetween(3, 20);
+        GeoBoundsAggregationBuilder factory = new GeoBoundsAggregationBuilder(randomAlphaOfLengthBetween(1, 20));
+        String field = randomAlphaOfLengthBetween(3, 20);
         factory.field(field);
         if (randomBoolean()) {
             factory.wrapLongitude(randomBoolean());

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidTests.java
@@ -27,7 +27,7 @@ public class GeoCentroidTests extends BaseAggregationTestCase<GeoCentroidAggrega
 
     @Override
     protected GeoCentroidAggregationBuilder createTestAggregatorBuilder() {
-        GeoCentroidAggregationBuilder factory = new GeoCentroidAggregationBuilder(randomAsciiOfLengthBetween(1, 20));
+        GeoCentroidAggregationBuilder factory = new GeoCentroidAggregationBuilder(randomAlphaOfLengthBetween(1, 20));
         String field = randomNumericField();
         int randomFieldBranch = randomInt(3);
         switch (randomFieldBranch) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentileRanksTests.java
@@ -27,7 +27,7 @@ public class PercentileRanksTests extends BaseAggregationTestCase<PercentileRank
 
     @Override
     protected PercentileRanksAggregationBuilder createTestAggregatorBuilder() {
-        PercentileRanksAggregationBuilder factory = new PercentileRanksAggregationBuilder(randomAsciiOfLengthBetween(1, 20));
+        PercentileRanksAggregationBuilder factory = new PercentileRanksAggregationBuilder(randomAlphaOfLengthBetween(1, 20));
         if (randomBoolean()) {
             factory.keyed(randomBoolean());
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -27,7 +27,7 @@ public class PercentilesTests extends BaseAggregationTestCase<PercentilesAggrega
 
     @Override
     protected PercentilesAggregationBuilder createTestAggregatorBuilder() {
-        PercentilesAggregationBuilder factory = new PercentilesAggregationBuilder(randomAsciiOfLengthBetween(1, 20));
+        PercentilesAggregationBuilder factory = new PercentilesAggregationBuilder(randomAlphaOfLengthBetween(1, 20));
         if (randomBoolean()) {
             factory.keyed(randomBoolean());
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -205,7 +205,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         numDocs = randomIntBetween(10, 100);
         for (int i = 0; i < numDocs; i++) {
             builders.add(client().prepareIndex("idx", "type", "" + i).setSource(
-                    jsonBuilder().startObject().field("value", randomAsciiOfLengthBetween(5, 15))
+                    jsonBuilder().startObject().field("value", randomAlphaOfLengthBetween(5, 15))
                             .field("l_value", i).endObject()));
         }
         indexRandom(true, builders);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricTests.java
@@ -32,7 +32,7 @@ public class ScriptedMetricTests extends BaseAggregationTestCase<ScriptedMetricA
 
     @Override
     protected ScriptedMetricAggregationBuilder createTestAggregatorBuilder() {
-        ScriptedMetricAggregationBuilder factory = new ScriptedMetricAggregationBuilder(randomAsciiOfLengthBetween(1, 20));
+        ScriptedMetricAggregationBuilder factory = new ScriptedMetricAggregationBuilder(randomAlphaOfLengthBetween(1, 20));
         if (randomBoolean()) {
             factory.initScript(randomScript("initScript"));
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
@@ -73,7 +73,7 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
                 int fieldsSize = randomInt(25);
                 List<String> fields = new ArrayList<>(fieldsSize);
                 for (int i = 0; i < fieldsSize; i++) {
-                    fields.add(randomAsciiOfLengthBetween(5, 50));
+                    fields.add(randomAlphaOfLengthBetween(5, 50));
                 }
                 factory.storedFields(fields);
                 break;
@@ -83,16 +83,16 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
         if (randomBoolean()) {
             int fieldDataFieldsSize = randomInt(25);
             for (int i = 0; i < fieldDataFieldsSize; i++) {
-                factory.fieldDataField(randomAsciiOfLengthBetween(5, 50));
+                factory.fieldDataField(randomAlphaOfLengthBetween(5, 50));
             }
         }
         if (randomBoolean()) {
             int scriptFieldsSize = randomInt(25);
             for (int i = 0; i < scriptFieldsSize; i++) {
                 if (randomBoolean()) {
-                    factory.scriptField(randomAsciiOfLengthBetween(5, 50), new Script("foo"), randomBoolean());
+                    factory.scriptField(randomAlphaOfLengthBetween(5, 50), new Script("foo"), randomBoolean());
                 } else {
-                    factory.scriptField(randomAsciiOfLengthBetween(5, 50), new Script("foo"));
+                    factory.scriptField(randomAlphaOfLengthBetween(5, 50), new Script("foo"));
                 }
             }
         }
@@ -101,11 +101,11 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
             int branch = randomInt(5);
             String[] includes = new String[randomIntBetween(0, 20)];
             for (int i = 0; i < includes.length; i++) {
-                includes[i] = randomAsciiOfLengthBetween(5, 20);
+                includes[i] = randomAlphaOfLengthBetween(5, 20);
             }
             String[] excludes = new String[randomIntBetween(0, 20)];
             for (int i = 0; i < excludes.length; i++) {
-                excludes[i] = randomAsciiOfLengthBetween(5, 20);
+                excludes[i] = randomAlphaOfLengthBetween(5, 20);
             }
             switch (branch) {
                 case 0:
@@ -115,8 +115,8 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
                     fetchSourceContext = new FetchSourceContext(true, includes, excludes);
                     break;
                 case 2:
-                    fetchSourceContext = new FetchSourceContext(true, new String[]{randomAsciiOfLengthBetween(5, 20)},
-                        new String[]{randomAsciiOfLengthBetween(5, 20)});
+                    fetchSourceContext = new FetchSourceContext(true, new String[]{randomAlphaOfLengthBetween(5, 20)},
+                        new String[]{randomAlphaOfLengthBetween(5, 20)});
                     break;
                 case 3:
                     fetchSourceContext = new FetchSourceContext(true, includes, excludes);
@@ -125,7 +125,7 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
                     fetchSourceContext = new FetchSourceContext(true, includes, null);
                     break;
                 case 5:
-                    fetchSourceContext = new FetchSourceContext(true, new String[] {randomAsciiOfLengthBetween(5, 20)}, null);
+                    fetchSourceContext = new FetchSourceContext(true, new String[] {randomAlphaOfLengthBetween(5, 20)}, null);
                     break;
                 default:
                     throw new IllegalStateException();
@@ -138,10 +138,10 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
                 int branch = randomInt(5);
                 switch (branch) {
                 case 0:
-                    factory.sort(SortBuilders.fieldSort(randomAsciiOfLengthBetween(5, 20)).order(randomFrom(SortOrder.values())));
+                    factory.sort(SortBuilders.fieldSort(randomAlphaOfLengthBetween(5, 20)).order(randomFrom(SortOrder.values())));
                     break;
                 case 1:
-                    factory.sort(SortBuilders.geoDistanceSort(randomAsciiOfLengthBetween(5, 20), AbstractQueryTestCase.randomGeohash(1, 12))
+                    factory.sort(SortBuilders.geoDistanceSort(randomAlphaOfLengthBetween(5, 20), AbstractQueryTestCase.randomGeohash(1, 12))
                             .order(randomFrom(SortOrder.values())));
                     break;
                 case 2:
@@ -151,10 +151,10 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
                     factory.sort(SortBuilders.scriptSort(new Script("foo"), ScriptSortType.NUMBER).order(randomFrom(SortOrder.values())));
                     break;
                 case 4:
-                    factory.sort(randomAsciiOfLengthBetween(5, 20));
+                    factory.sort(randomAlphaOfLengthBetween(5, 20));
                     break;
                 case 5:
-                    factory.sort(randomAsciiOfLengthBetween(5, 20), randomFrom(SortOrder.values()));
+                    factory.sort(randomAlphaOfLengthBetween(5, 20), randomFrom(SortOrder.values()));
                     break;
                 }
             }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetricTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetricTests.java
@@ -50,13 +50,13 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
             Map<String, Object> metaData) {
         Map<String, Object> params = new HashMap<>();
         if (randomBoolean()) {
-            params.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+            params.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
         }
         Script reduceScript = null;
         if (hasReduceScript) {
             reduceScript = new Script(ScriptType.INLINE, MockScriptEngine.NAME, REDUCE_SCRIPT_NAME, params);
         }
-        return new InternalScriptedMetric(name, randomAsciiOfLength(5), reduceScript, pipelineAggregators, metaData);
+        return new InternalScriptedMetric(name, randomAlphaOfLength(5), reduceScript, pipelineAggregators, metaData);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHitsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHitsTests.java
@@ -122,9 +122,9 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
         case SCORE:
             return randomFloat();
         case STRING:
-            return new BytesRef(randomAsciiOfLength(5));
+            return new BytesRef(randomAlphaOfLength(5));
         case STRING_VAL:
-            return new BytesRef(randomAsciiOfLength(5));
+            return new BytesRef(randomAlphaOfLength(5));
         default:
             throw new UnsupportedOperationException("Unkown SortField.Type: " + type);
         }
@@ -168,7 +168,7 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
         SortField[] sortFields = new SortField[between(1, 5)];
         Set<String> usedSortFields = new HashSet<>();
         for (int i = 0; i < sortFields.length; i++) {
-            String sortField = randomValueOtherThanMany(usedSortFields::contains, () -> randomAsciiOfLength(5));
+            String sortField = randomValueOtherThanMany(usedSortFields::contains, () -> randomAlphaOfLength(5));
             usedSortFields.add(sortField);
             SortField.Type type = randomValueOtherThanMany(t -> t == SortField.Type.CUSTOM || t == SortField.Type.REWRITEABLE,
                     () -> randomFrom(SortField.Type.values()));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptTests.java
@@ -32,11 +32,11 @@ public class BucketScriptTests extends BasePipelineAggregationTestCase<BucketScr
 
     @Override
     protected BucketScriptPipelineAggregationBuilder createTestAggregatorFactory() {
-        String name = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
         Map<String, String> bucketsPaths = new HashMap<>();
         int numBucketPaths = randomIntBetween(1, 10);
         for (int i = 0; i < numBucketPaths; i++) {
-            bucketsPaths.put(randomAsciiOfLengthBetween(1, 20), randomAsciiOfLengthBetween(1, 40));
+            bucketsPaths.put(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 40));
         }
         Script script;
         if (randomBoolean()) {
@@ -52,7 +52,7 @@ public class BucketScriptTests extends BasePipelineAggregationTestCase<BucketScr
         }
         BucketScriptPipelineAggregationBuilder factory = new BucketScriptPipelineAggregationBuilder(name, bucketsPaths, script);
         if (randomBoolean()) {
-            factory.format(randomAsciiOfLengthBetween(1, 10));
+            factory.format(randomAlphaOfLengthBetween(1, 10));
         }
         if (randomBoolean()) {
             factory.gapPolicy(randomFrom(GapPolicy.values()));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketSelectorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketSelectorTests.java
@@ -32,11 +32,11 @@ public class BucketSelectorTests extends BasePipelineAggregationTestCase<BucketS
 
     @Override
     protected BucketSelectorPipelineAggregationBuilder createTestAggregatorFactory() {
-        String name = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
         Map<String, String> bucketsPaths = new HashMap<>();
         int numBucketPaths = randomIntBetween(1, 10);
         for (int i = 0; i < numBucketPaths; i++) {
-            bucketsPaths.put(randomAsciiOfLengthBetween(1, 20), randomAsciiOfLengthBetween(1, 40));
+            bucketsPaths.put(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 40));
         }
         Script script;
         if (randomBoolean()) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumTests.java
@@ -26,11 +26,11 @@ public class CumulativeSumTests extends BasePipelineAggregationTestCase<Cumulati
 
     @Override
     protected CumulativeSumPipelineAggregationBuilder createTestAggregatorFactory() {
-        String name = randomAsciiOfLengthBetween(3, 20);
-        String bucketsPath = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
+        String bucketsPath = randomAlphaOfLengthBetween(3, 20);
         CumulativeSumPipelineAggregationBuilder factory = new CumulativeSumPipelineAggregationBuilder(name, bucketsPath);
         if (randomBoolean()) {
-            factory.format(randomAsciiOfLengthBetween(1, 10));
+            factory.format(randomAlphaOfLengthBetween(1, 10));
         }
         return factory;
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeTests.java
@@ -27,11 +27,11 @@ public class DerivativeTests extends BasePipelineAggregationTestCase<DerivativeP
 
     @Override
     protected DerivativePipelineAggregationBuilder createTestAggregatorFactory() {
-        String name = randomAsciiOfLengthBetween(3, 20);
-        String bucketsPath = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
+        String bucketsPath = randomAlphaOfLengthBetween(3, 20);
         DerivativePipelineAggregationBuilder factory = new DerivativePipelineAggregationBuilder(name, bucketsPath);
         if (randomBoolean()) {
-            factory.format(randomAsciiOfLengthBetween(1, 10));
+            factory.format(randomAlphaOfLengthBetween(1, 10));
         }
         if (randomBoolean()) {
             factory.gapPolicy(randomFrom(GapPolicy.values()));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/SerialDifferenceTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/SerialDifferenceTests.java
@@ -27,11 +27,11 @@ public class SerialDifferenceTests extends BasePipelineAggregationTestCase<Seria
 
     @Override
     protected SerialDiffPipelineAggregationBuilder createTestAggregatorFactory() {
-        String name = randomAsciiOfLengthBetween(3, 20);
-        String bucketsPath = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
+        String bucketsPath = randomAlphaOfLengthBetween(3, 20);
         SerialDiffPipelineAggregationBuilder factory = new SerialDiffPipelineAggregationBuilder(name, bucketsPath);
         if (randomBoolean()) {
-            factory.format(randomAsciiOfLengthBetween(1, 10));
+            factory.format(randomAlphaOfLengthBetween(1, 10));
         }
         if (randomBoolean()) {
             factory.gapPolicy(randomFrom(GapPolicy.values()));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/AbstractBucketMetricsTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/AbstractBucketMetricsTestCase.java
@@ -27,11 +27,11 @@ public abstract class AbstractBucketMetricsTestCase<PAF extends BucketMetricsPip
 
     @Override
     protected final PAF createTestAggregatorFactory() {
-        String name = randomAsciiOfLengthBetween(3, 20);
-        String bucketsPath = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
+        String bucketsPath = randomAlphaOfLengthBetween(3, 20);
         PAF factory = doCreateTestAggregatorFactory(name, bucketsPath);
         if (randomBoolean()) {
-            factory.format(randomAsciiOfLengthBetween(1, 10));
+            factory.format(randomAlphaOfLengthBetween(1, 10));
         }
         if (randomBoolean()) {
             factory.gapPolicy(randomFrom(GapPolicy.values()));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/moving/avg/MovAvgTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/moving/avg/MovAvgTests.java
@@ -35,11 +35,11 @@ public class MovAvgTests extends BasePipelineAggregationTestCase<MovAvgPipelineA
 
     @Override
     protected MovAvgPipelineAggregationBuilder createTestAggregatorFactory() {
-        String name = randomAsciiOfLengthBetween(3, 20);
-        String bucketsPath = randomAsciiOfLengthBetween(3, 20);
+        String name = randomAlphaOfLengthBetween(3, 20);
+        String bucketsPath = randomAlphaOfLengthBetween(3, 20);
         MovAvgPipelineAggregationBuilder factory = new MovAvgPipelineAggregationBuilder(name, bucketsPath);
         if (randomBoolean()) {
-            factory.format(randomAsciiOfLengthBetween(1, 10));
+            factory.format(randomAlphaOfLengthBetween(1, 10));
         }
         if (randomBoolean()) {
             factory.gapPolicy(randomFrom(GapPolicy.values()));

--- a/core/src/test/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/SearchWhileCreatingIndexIT.java
@@ -56,11 +56,11 @@ public class SearchWhileCreatingIndexIT extends ESIntegTestCase {
 
         // TODO: randomize the wait for active shards value on index creation and ensure the appropriate
         // number of data nodes are started for the randomized active shard count value
-        String id = randomAsciiOfLength(5);
+        String id = randomAlphaOfLength(5);
         // we will go the primary or the replica, but in a
         // randomized re-creatable manner
         int counter = 0;
-        String preference = randomAsciiOfLength(5);
+        String preference = randomAlphaOfLength(5);
 
         logger.info("running iteration for id {}, preference {}", id, preference);
 

--- a/core/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -67,7 +67,7 @@ public class CollapseBuilderTests extends AbstractWireSerializingTestCase {
     }
 
     public static CollapseBuilder randomCollapseBuilder() {
-        CollapseBuilder builder = new CollapseBuilder(randomAsciiOfLength(10));
+        CollapseBuilder builder = new CollapseBuilder(randomAlphaOfLength(10));
         builder.setMaxConcurrentGroupRequests(randomIntBetween(1, 48));
         if (randomBoolean()) {
             InnerHitBuilder innerHit = InnerHitBuilderTests.randomInnerHits(false, false);

--- a/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -262,7 +262,7 @@ public class HighlightBuilderTests extends ESTestCase {
     public void testBuildSearchContextHighlight() throws IOException {
         Settings indexSettings = Settings.builder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        Index index = new Index(randomAsciiOfLengthBetween(1, 10), "_na_");
+        Index index = new Index(randomAlphaOfLengthBetween(1, 10), "_na_");
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index, indexSettings);
         // shard context will only need indicesQueriesRegistry for building Query objects nested in highlighter
         QueryShardContext mockShardContext = new QueryShardContext(0, idxSettings, null, null, null, null, null, xContentRegistry(),
@@ -496,7 +496,7 @@ public class HighlightBuilderTests extends ESTestCase {
         }
         int numberOfFields = randomIntBetween(1,5);
         for (int i = 0; i < numberOfFields; i++) {
-            Field field = new Field(i + "_" + randomAsciiOfLengthBetween(1, 10));
+            Field field = new Field(i + "_" + randomAlphaOfLengthBetween(1, 10));
             setRandomCommonOptions(field);
             if (randomBoolean()) {
                 field.fragmentOffset(randomIntBetween(1, 100));
@@ -523,10 +523,10 @@ public class HighlightBuilderTests extends ESTestCase {
             highlightBuilder.numOfFragments(randomIntBetween(0, 10));
         }
         if (randomBoolean()) {
-            highlightBuilder.highlighterType(randomAsciiOfLengthBetween(1, 10));
+            highlightBuilder.highlighterType(randomAlphaOfLengthBetween(1, 10));
         }
         if (randomBoolean()) {
-            highlightBuilder.fragmenter(randomAsciiOfLengthBetween(1, 10));
+            highlightBuilder.fragmenter(randomAlphaOfLengthBetween(1, 10));
         }
         if (randomBoolean()) {
             QueryBuilder highlightQuery;
@@ -539,7 +539,7 @@ public class HighlightBuilderTests extends ESTestCase {
                 break;
             default:
             case 2:
-                highlightQuery = new TermQueryBuilder(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10));
+                highlightQuery = new TermQueryBuilder(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10));
                 break;
             }
             highlightQuery.boost((float) randomDoubleBetween(0, 10, false));
@@ -571,7 +571,7 @@ public class HighlightBuilderTests extends ESTestCase {
             highlightBuilder.boundaryMaxScan(randomIntBetween(0, 10));
         }
         if (randomBoolean()) {
-            highlightBuilder.boundaryChars(randomAsciiOfLengthBetween(1, 10).toCharArray());
+            highlightBuilder.boundaryChars(randomAlphaOfLengthBetween(1, 10).toCharArray());
         }
         if (randomBoolean()) {
             highlightBuilder.boundaryScannerLocale(randomLocale(random()).toLanguageTag());
@@ -589,7 +589,7 @@ public class HighlightBuilderTests extends ESTestCase {
                 Object value = null;
                 switch (randomInt(2)) {
                 case 0:
-                    value = randomAsciiOfLengthBetween(1, 10);
+                    value = randomAlphaOfLengthBetween(1, 10);
                     break;
                 case 1:
                     value = new Integer(randomInt(1000));
@@ -598,7 +598,7 @@ public class HighlightBuilderTests extends ESTestCase {
                     value = new Boolean(randomBoolean());
                     break;
                 }
-                options.put(randomAsciiOfLengthBetween(1, 10), value);
+                options.put(randomAlphaOfLengthBetween(1, 10), value);
             }
         }
         if (randomBoolean()) {
@@ -622,13 +622,13 @@ public class HighlightBuilderTests extends ESTestCase {
             highlightBuilder.numOfFragments(randomIntBetween(11, 20));
             break;
         case 5:
-            highlightBuilder.highlighterType(randomAsciiOfLengthBetween(11, 20));
+            highlightBuilder.highlighterType(randomAlphaOfLengthBetween(11, 20));
             break;
         case 6:
-            highlightBuilder.fragmenter(randomAsciiOfLengthBetween(11, 20));
+            highlightBuilder.fragmenter(randomAlphaOfLengthBetween(11, 20));
             break;
         case 7:
-            highlightBuilder.highlightQuery(new TermQueryBuilder(randomAsciiOfLengthBetween(11, 20), randomAsciiOfLengthBetween(11, 20)));
+            highlightBuilder.highlightQuery(new TermQueryBuilder(randomAlphaOfLengthBetween(11, 20), randomAlphaOfLengthBetween(11, 20)));
             break;
         case 8:
             if (highlightBuilder.order() == Order.NONE) {
@@ -647,7 +647,7 @@ public class HighlightBuilderTests extends ESTestCase {
             highlightBuilder.boundaryMaxScan(randomIntBetween(11, 20));
             break;
         case 12:
-            highlightBuilder.boundaryChars(randomAsciiOfLengthBetween(11, 20).toCharArray());
+            highlightBuilder.boundaryChars(randomAlphaOfLengthBetween(11, 20).toCharArray());
             break;
         case 13:
             highlightBuilder.noMatchSize(randomIntBetween(11, 20));
@@ -659,7 +659,7 @@ public class HighlightBuilderTests extends ESTestCase {
             int items = 6;
             Map<String, Object> options = new HashMap<>(items);
             for (int i = 0; i < items; i++) {
-                options.put(randomAsciiOfLengthBetween(1, 10), randomAsciiOfLengthBetween(1, 10));
+                options.put(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10));
             }
             highlightBuilder.options(options);
             break;
@@ -685,7 +685,7 @@ public class HighlightBuilderTests extends ESTestCase {
         int size = randomIntBetween(minSize, maxSize);
         Set<String> randomStrings = new HashSet<>(size);
         for (int f = 0; f < size; f++) {
-            randomStrings.add(randomAsciiOfLengthBetween(3, 10));
+            randomStrings.add(randomAlphaOfLengthBetween(3, 10));
         }
         return randomStrings.toArray(new String[randomStrings.size()]);
     }
@@ -703,11 +703,11 @@ public class HighlightBuilderTests extends ESTestCase {
                 case 0:
                     mutation.useExplicitFieldOrder(!original.useExplicitFieldOrder()); break;
                 case 1:
-                    mutation.encoder(original.encoder() + randomAsciiOfLength(2)); break;
+                    mutation.encoder(original.encoder() + randomAlphaOfLength(2)); break;
                 case 2:
                     if (randomBoolean()) {
                         // add another field
-                        mutation.field(new Field(randomAsciiOfLength(10)));
+                        mutation.field(new Field(randomAlphaOfLength(10)));
                     } else {
                         // change existing fields
                         List<Field> originalFields = original.fields();

--- a/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightFieldTests.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightFieldTests.java
@@ -38,14 +38,14 @@ import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashC
 public class HighlightFieldTests extends ESTestCase {
 
     public static HighlightField createTestItem() {
-        String name = frequently() ? randomAsciiOfLengthBetween(5, 20) : randomRealisticUnicodeOfCodepointLengthBetween(5, 20);
+        String name = frequently() ? randomAlphaOfLengthBetween(5, 20) : randomRealisticUnicodeOfCodepointLengthBetween(5, 20);
         Text[] fragments = null;
         if (frequently()) {
             int size = randomIntBetween(0, 5);
             fragments = new Text[size];
             for (int i = 0; i < size; i++) {
                 fragments[i] = new Text(
-                        frequently() ? randomAsciiOfLengthBetween(10, 30) : randomRealisticUnicodeOfCodepointLengthBetween(10, 30));
+                        frequently() ? randomAlphaOfLengthBetween(10, 30) : randomRealisticUnicodeOfCodepointLengthBetween(10, 30));
             }
         }
         return new HighlightField(name, fragments);

--- a/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -2761,7 +2761,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         for (int i = 0; i < COUNT; i++) {
             //generating text with word to highlight in a different position
             //(https://github.com/elastic/elasticsearch/issues/4103)
-            String prefix = randomAsciiOfLengthBetween(5, 30);
+            String prefix = randomAlphaOfLengthBetween(5, 30);
             prefixes.put(String.valueOf(i), prefix);
             indexRequestBuilders[i] = client().prepareIndex("test", "type1", Integer.toString(i)).setSource("field1", "Sentence " + prefix
                     + " test. Sentence two.");

--- a/core/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
@@ -87,7 +87,7 @@ public class ShardSearchTransportRequestTests extends AbstractSearchTestCase {
 
     private ShardSearchTransportRequest createShardSearchTransportRequest() throws IOException {
         SearchRequest searchRequest = createSearchRequest();
-        ShardId shardId = new ShardId(randomAsciiOfLengthBetween(2, 10), randomAsciiOfLengthBetween(2, 10), randomInt());
+        ShardId shardId = new ShardId(randomAlphaOfLengthBetween(2, 10), randomAlphaOfLengthBetween(2, 10), randomInt());
         final AliasFilter filteringAliases;
         if (randomBoolean()) {
             String[] strings = generateRandomStringArray(10, 10, false, false);

--- a/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/ProfileResultTests.java
@@ -41,8 +41,8 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 public class ProfileResultTests extends ESTestCase {
 
     public static ProfileResult createTestItem(int depth) {
-        String type = randomAsciiOfLengthBetween(5, 10);
-        String description = randomAsciiOfLengthBetween(5, 10);
+        String type = randomAlphaOfLengthBetween(5, 10);
+        String description = randomAlphaOfLengthBetween(5, 10);
         int timingsSize = randomIntBetween(0, 5);
         Map<String, Long> timings = new HashMap<>(timingsSize);
         for (int i = 0; i < timingsSize; i++) {
@@ -51,7 +51,7 @@ public class ProfileResultTests extends ESTestCase {
                 // also often use "small" values in tests
                 time = randomNonNegativeLong() % 10000;
             }
-            timings.put(randomAsciiOfLengthBetween(5, 10), time); // don't overflow Long.MAX_VALUE;
+            timings.put(randomAlphaOfLengthBetween(5, 10), time); // don't overflow Long.MAX_VALUE;
         }
         int childrenSize = depth > 0 ? randomIntBetween(0, 1) : 0;
         List<ProfileResult> children = new ArrayList<>(childrenSize);

--- a/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/SearchProfileShardResultsTests.java
@@ -51,7 +51,7 @@ public class SearchProfileShardResultsTests  extends ESTestCase {
                 queryProfileResults.add(QueryProfileShardResultTests.createTestItem());
             }
             AggregationProfileShardResult aggProfileShardResult = AggregationProfileShardResultTests.createTestItem(1);
-            searchProfileResults.put(randomAsciiOfLengthBetween(5, 10), new ProfileShardResult(queryProfileResults, aggProfileShardResult));
+            searchProfileResults.put(randomAlphaOfLengthBetween(5, 10), new ProfileShardResult(queryProfileResults, aggProfileShardResult));
         }
         return new SearchProfileShardResults(searchProfileResults);
     }

--- a/core/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfilerIT.java
@@ -28,8 +28,6 @@ import org.elasticsearch.search.aggregations.metrics.avg.AvgAggregator;
 import org.elasticsearch.search.aggregations.metrics.max.MaxAggregator;
 import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.search.profile.ProfileShardResult;
-import org.elasticsearch.search.profile.aggregation.AggregationProfileShardResult;
-import org.elasticsearch.search.profile.aggregation.AggregationTimingType;
 import org.elasticsearch.test.ESIntegTestCase;
 import java.util.ArrayList;
 import java.util.List;
@@ -68,7 +66,7 @@ public class AggregationProfilerIT extends ESIntegTestCase {
 
         String[] randomStrings = new String[randomIntBetween(2, 10)];
         for (int i = 0; i < randomStrings.length; i++) {
-            randomStrings[i] = randomAsciiOfLength(10);
+            randomStrings[i] = randomAlphaOfLength(10);
         }
 
         for (int i = 0; i < 5; i++) {

--- a/core/src/test/java/org/elasticsearch/search/profile/query/CollectorResultTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/query/CollectorResultTests.java
@@ -39,8 +39,8 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 public class CollectorResultTests extends ESTestCase {
 
     public static CollectorResult createTestItem(int depth) {
-        String name = randomAsciiOfLengthBetween(5, 10);
-        String reason = randomAsciiOfLengthBetween(5, 10);
+        String name = randomAlphaOfLengthBetween(5, 10);
+        String reason = randomAlphaOfLengthBetween(5, 10);
         long time = randomNonNegativeLong();
         if (randomBoolean()) {
             // also often use relatively "small" values, otherwise we will mostly test huge longs

--- a/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
@@ -720,7 +720,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
 
     private static List<String> fillRandom(List<String> list, int times) {
         for (int i = 0; i < times; i++) {
-            list.add(randomAsciiOfLength(5));
+            list.add(randomAlphaOfLength(5));
         }
         return list;
     }

--- a/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/rescore/QueryRescoreBuilderTests.java
@@ -135,7 +135,7 @@ public class QueryRescoreBuilderTests extends ESTestCase {
         final long nowInMillis = randomNonNegativeLong();
         Settings indexSettings = Settings.builder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
-        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAsciiOfLengthBetween(1, 10), indexSettings);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAlphaOfLengthBetween(1, 10), indexSettings);
         // shard context will only need indicesQueriesRegistry for building Query objects nested in query rescorer
         QueryShardContext mockShardContext = new QueryShardContext(0, idxSettings, null, null, null, null, null, xContentRegistry(),
                 null, null, () -> nowInMillis) {
@@ -303,7 +303,7 @@ public class QueryRescoreBuilderTests extends ESTestCase {
      */
     public static QueryRescorerBuilder randomRescoreBuilder() {
         QueryBuilder queryBuilder = new MatchAllQueryBuilder().boost(randomFloat())
-                .queryName(randomAsciiOfLength(20));
+                .queryName(randomAlphaOfLength(20));
         org.elasticsearch.search.rescore.QueryRescorerBuilder rescorer = new
                 org.elasticsearch.search.rescore.QueryRescorerBuilder(queryBuilder);
         if (randomBoolean()) {

--- a/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
@@ -58,7 +58,7 @@ public class SearchAfterBuilderTests extends ESTestCase {
                     values[i] = randomDouble();
                     break;
                 case 4:
-                    values[i] = randomAsciiOfLengthBetween(5, 20);
+                    values[i] = randomAlphaOfLengthBetween(5, 20);
                     break;
                 case 5:
                     values[i] = randomBoolean();
@@ -70,7 +70,7 @@ public class SearchAfterBuilderTests extends ESTestCase {
                     values[i] = randomShort();
                     break;
                 case 8:
-                    values[i] = new Text(randomAsciiOfLengthBetween(5, 20));
+                    values[i] = new Text(randomAlphaOfLengthBetween(5, 20));
                     break;
                 case 9:
                     values[i] = null;
@@ -106,7 +106,7 @@ public class SearchAfterBuilderTests extends ESTestCase {
                     jsonBuilder.value(randomDouble());
                     break;
                 case 4:
-                    jsonBuilder.value(randomAsciiOfLengthBetween(5, 20));
+                    jsonBuilder.value(randomAlphaOfLengthBetween(5, 20));
                     break;
                 case 5:
                     jsonBuilder.value(randomBoolean());
@@ -118,7 +118,7 @@ public class SearchAfterBuilderTests extends ESTestCase {
                     jsonBuilder.value(randomShort());
                     break;
                 case 8:
-                    jsonBuilder.value(new Text(randomAsciiOfLengthBetween(5, 20)));
+                    jsonBuilder.value(new Text(randomAlphaOfLengthBetween(5, 20)));
                     break;
                 case 9:
                     jsonBuilder.nullValue();

--- a/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
+++ b/core/src/test/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.SearchContextException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.transport.RemoteTransportException;
 import org.hamcrest.Matchers;
 
 import java.util.List;
@@ -201,7 +200,7 @@ public class SearchAfterIT extends ESIntegTestCase {
                         values.add(randomDouble());
                         break;
                     case 6:
-                        values.add(randomAsciiOfLengthBetween(5, 20));
+                        values.add(randomAlphaOfLengthBetween(5, 20));
                         break;
                 }
             }

--- a/core/src/test/java/org/elasticsearch/search/slice/SearchSliceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/slice/SearchSliceIT.java
@@ -83,7 +83,7 @@ public class SearchSliceIT extends ESIntegTestCase {
         for (int i = 0; i < NUM_DOCS; i++) {
             XContentBuilder builder = jsonBuilder();
             builder.startObject();
-            builder.field("invalid_random_kw", randomAsciiOfLengthBetween(5, 20));
+            builder.field("invalid_random_kw", randomAlphaOfLengthBetween(5, 20));
             builder.field("random_int", randomInt());
             builder.field("static_int", 0);
             builder.field("invalid_random_int", randomInt());

--- a/core/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
@@ -64,7 +64,7 @@ public class SliceBuilderTests extends ESTestCase {
     private static SliceBuilder randomSliceBuilder() throws IOException {
         int max = randomIntBetween(2, MAX_SLICE);
         int id = randomIntBetween(1, max - 1);
-        String field = randomAsciiOfLengthBetween(5, 20);
+        String field = randomAlphaOfLengthBetween(5, 20);
         return new SliceBuilder(field, id, max);
     }
 

--- a/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -70,7 +70,6 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
@@ -191,7 +190,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
     }
 
     protected QueryShardContext createMockShardContext() {
-        Index index = new Index(randomAsciiOfLengthBetween(1, 10), "_na_");
+        Index index = new Index(randomAlphaOfLengthBetween(1, 10), "_na_");
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index,
             Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
         IndicesFieldDataCache cache = new IndicesFieldDataCache(Settings.EMPTY, null);
@@ -245,7 +244,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
             case 0: return (new MatchAllQueryBuilder()).boost(randomFloat());
             case 1: return (new IdsQueryBuilder()).boost(randomFloat());
             case 2: return (new TermQueryBuilder(
-                    randomAsciiOfLengthBetween(1, 10),
+                    randomAlphaOfLengthBetween(1, 10),
                     randomDouble()).boost(randomFloat()));
             default: throw new IllegalStateException("Only three query builders supported for testing sort");
         }

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -44,7 +44,7 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
 
 
     public FieldSortBuilder randomFieldSortBuilder() {
-        String fieldName = rarely() ? FieldSortBuilder.DOC_FIELD_NAME : randomAsciiOfLengthBetween(1, 10);
+        String fieldName = rarely() ? FieldSortBuilder.DOC_FIELD_NAME : randomAlphaOfLengthBetween(1, 10);
         FieldSortBuilder builder = new FieldSortBuilder(fieldName);
         if (randomBoolean()) {
             builder.order(randomFrom(SortOrder.values()));
@@ -55,7 +55,7 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         }
 
         if (randomBoolean()) {
-            builder.unmappedType(randomAsciiOfLengthBetween(1, 10));
+            builder.unmappedType(randomAlphaOfLengthBetween(1, 10));
         }
 
         if (randomBoolean()) {
@@ -67,7 +67,7 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         }
 
         if (randomBoolean()) {
-            builder.setNestedPath(randomAsciiOfLengthBetween(1, 10));
+            builder.setNestedPath(randomAlphaOfLengthBetween(1, 10));
         }
 
         return builder;
@@ -81,7 +81,7 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         case 0:
             mutated.setNestedPath(randomValueOtherThan(
                     original.getNestedPath(),
-                    () -> randomAsciiOfLengthBetween(1, 10)));
+                    () -> randomAlphaOfLengthBetween(1, 10)));
             break;
         case 1:
             mutated.setNestedFilter(randomValueOtherThan(
@@ -94,7 +94,7 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         case 3:
             mutated.unmappedType(randomValueOtherThan(
                     original.unmappedType(),
-                    () -> randomAsciiOfLengthBetween(1, 10)));
+                    () -> randomAlphaOfLengthBetween(1, 10)));
             break;
         case 4:
             mutated.missing(randomValueOtherThan(original.missing(), () -> randomFrom(missingContent)));

--- a/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
@@ -50,7 +50,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
     }
 
     public static GeoDistanceSortBuilder randomGeoDistanceSortBuilder() {
-        String fieldName = randomAsciiOfLengthBetween(1, 10);
+        String fieldName = randomAlphaOfLengthBetween(1, 10);
         GeoDistanceSortBuilder result = null;
 
         int id = randomIntBetween(0, 2);
@@ -94,7 +94,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
             result.setNestedPath(
                     randomValueOtherThan(
                             result.getNestedPath(),
-                            () -> randomAsciiOfLengthBetween(1, 10)));
+                            () -> randomAlphaOfLengthBetween(1, 10)));
         }
         if (randomBoolean()) {
             result.validation(randomValueOtherThan(result.validation(), () -> randomFrom(GeoValidationMethod.values())));
@@ -166,7 +166,7 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
         case 7:
             result.setNestedPath(randomValueOtherThan(
                     result.getNestedPath(),
-                    () -> randomAsciiOfLengthBetween(1, 10)));
+                    () -> randomAlphaOfLengthBetween(1, 10)));
             break;
         case 8:
             result.validation(randomValueOtherThan(result.validation(), () -> randomFrom(GeoValidationMethod.values())));

--- a/core/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
@@ -43,7 +43,7 @@ public class ScriptSortBuilderTests extends AbstractSortTestCase<ScriptSortBuild
 
     public static ScriptSortBuilder randomScriptSortBuilder() {
         ScriptSortType type = randomBoolean() ? ScriptSortType.NUMBER : ScriptSortType.STRING;
-        ScriptSortBuilder builder = new ScriptSortBuilder(new Script(randomAsciiOfLengthBetween(5, 10)),
+        ScriptSortBuilder builder = new ScriptSortBuilder(new Script(randomAlphaOfLengthBetween(5, 10)),
                 type);
         if (randomBoolean()) {
                 builder.order(randomFrom(SortOrder.values()));
@@ -63,7 +63,7 @@ public class ScriptSortBuilderTests extends AbstractSortTestCase<ScriptSortBuild
             builder.setNestedFilter(randomNestedFilter());
         }
         if (randomBoolean()) {
-            builder.setNestedPath(randomAsciiOfLengthBetween(1, 10));
+            builder.setNestedPath(randomAlphaOfLengthBetween(1, 10));
         }
         return builder;
     }

--- a/core/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
@@ -189,7 +189,7 @@ public class SortBuilderTests extends ESTestCase {
                 list.add(new ScoreSortBuilder());
                 break;
             case 1:
-                String fieldName = rarely() ? FieldSortBuilder.DOC_FIELD_NAME : randomAsciiOfLengthBetween(1, 10);
+                String fieldName = rarely() ? FieldSortBuilder.DOC_FIELD_NAME : randomAlphaOfLengthBetween(1, 10);
                 list.add(new FieldSortBuilder(fieldName));
                 break;
             case 2:

--- a/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -82,10 +82,10 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
     }
 
     public static void setCommonPropertiesOnRandomBuilder(SuggestionBuilder<?> randomSuggestion) {
-        randomSuggestion.text(randomAsciiOfLengthBetween(2, 20)); // have to set the text because we don't know if the global text was set
-        maybeSet(randomSuggestion::prefix, randomAsciiOfLengthBetween(2, 20));
-        maybeSet(randomSuggestion::regex, randomAsciiOfLengthBetween(2, 20));
-        maybeSet(randomSuggestion::analyzer, randomAsciiOfLengthBetween(2, 20));
+        randomSuggestion.text(randomAlphaOfLengthBetween(2, 20)); // have to set the text because we don't know if the global text was set
+        maybeSet(randomSuggestion::prefix, randomAlphaOfLengthBetween(2, 20));
+        maybeSet(randomSuggestion::regex, randomAlphaOfLengthBetween(2, 20));
+        maybeSet(randomSuggestion::analyzer, randomAlphaOfLengthBetween(2, 20));
         maybeSet(randomSuggestion::size, randomIntBetween(1, 20));
         maybeSet(randomSuggestion::shardSize, randomIntBetween(1, 20));
     }
@@ -146,16 +146,16 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
         if (randomBoolean()) {
             switch (randomIntBetween(0, 5)) {
             case 0:
-                mutation.text(randomValueOtherThan(mutation.text(), () -> randomAsciiOfLengthBetween(2, 20)));
+                mutation.text(randomValueOtherThan(mutation.text(), () -> randomAlphaOfLengthBetween(2, 20)));
                 break;
             case 1:
-                mutation.prefix(randomValueOtherThan(mutation.prefix(), () -> randomAsciiOfLengthBetween(2, 20)));
+                mutation.prefix(randomValueOtherThan(mutation.prefix(), () -> randomAlphaOfLengthBetween(2, 20)));
                 break;
             case 2:
-                mutation.regex(randomValueOtherThan(mutation.regex(), () -> randomAsciiOfLengthBetween(2, 20)));
+                mutation.regex(randomValueOtherThan(mutation.regex(), () -> randomAlphaOfLengthBetween(2, 20)));
                 break;
             case 3:
-                mutation.analyzer(randomValueOtherThan(mutation.analyzer(), () -> randomAsciiOfLengthBetween(2, 20)));
+                mutation.analyzer(randomValueOtherThan(mutation.analyzer(), () -> randomAlphaOfLengthBetween(2, 20)));
                 break;
             case 4:
                 mutation.size(randomValueOtherThan(mutation.size(), () -> randomIntBetween(1, 20)));

--- a/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestionOptionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestionOptionTests.java
@@ -42,7 +42,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 public class CompletionSuggestionOptionTests extends ESTestCase {
 
     public static Option createTestItem() {
-        Text text = new Text(randomAsciiOfLengthBetween(5, 15));
+        Text text = new Text(randomAlphaOfLengthBetween(5, 15));
         int docId = randomInt();
         int numberOfContexts = randomIntBetween(0, 3);
         Map<String, Set<CharSequence>> contexts = new HashMap<>();
@@ -50,9 +50,9 @@ public class CompletionSuggestionOptionTests extends ESTestCase {
             int numberOfValues = randomIntBetween(0, 3);
             Set<CharSequence> values = new HashSet<>();
             for (int v = 0; v < numberOfValues; v++) {
-                values.add(randomAsciiOfLengthBetween(5, 15));
+                values.add(randomAlphaOfLengthBetween(5, 15));
             }
-            contexts.put(randomAsciiOfLengthBetween(5, 15), values);
+            contexts.put(randomAlphaOfLengthBetween(5, 15), values);
         }
         SearchHit hit = null;
         float score = randomFloat();

--- a/core/src/test/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
@@ -631,7 +631,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
 
         refresh();
 
-        String suggestionName = randomAsciiOfLength(10);
+        String suggestionName = randomAlphaOfLength(10);
         CompletionSuggestionBuilder context = SuggestBuilders.completionSuggestion(FIELD).text("h").size(10)
                 .contexts(Collections.singletonMap("st", Collections.singletonList(GeoQueryContext.builder().setGeoPoint(new GeoPoint(52.52, 13.4)).build())));
         SearchResponse searchResponse = client().prepareSearch(INDEX).suggest(new SuggestBuilder().addSuggestion(suggestionName, context)).get();

--- a/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchIT.java
@@ -82,9 +82,9 @@ public class CustomSuggesterSearchIT extends ESIntegTestCase {
                 .endObject())
                 .setRefreshPolicy(IMMEDIATE).get();
 
-        String randomText = randomAsciiOfLength(10);
-        String randomField = randomAsciiOfLength(10);
-        String randomSuffix = randomAsciiOfLength(10);
+        String randomText = randomAlphaOfLength(10);
+        String randomField = randomAlphaOfLength(10);
+        String randomSuffix = randomAlphaOfLength(10);
         SuggestBuilder suggestBuilder = new SuggestBuilder();
         suggestBuilder.addSuggestion("someName", new CustomSuggestionBuilder(randomField, randomSuffix).text(randomText));
         SearchRequestBuilder searchRequestBuilder = client().prepareSearch("test").setTypes("test").setFrom(0).setSize(1)

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestBuilderTests.java
@@ -129,9 +129,9 @@ public class SuggestBuilderTests extends ESTestCase {
             mutation.addSuggestion(suggestionBuilder.getKey(), suggestionBuilder.getValue());
         }
         if (randomBoolean()) {
-            mutation.setGlobalText(randomAsciiOfLengthBetween(5, 60));
+            mutation.setGlobalText(randomAlphaOfLengthBetween(5, 60));
         } else {
-            mutation.addSuggestion(randomAsciiOfLength(10), PhraseSuggestionBuilderTests.randomPhraseSuggestionBuilder());
+            mutation.addSuggestion(randomAlphaOfLength(10), PhraseSuggestionBuilderTests.randomPhraseSuggestionBuilder());
         }
         return mutation;
     }
@@ -139,11 +139,11 @@ public class SuggestBuilderTests extends ESTestCase {
     public static SuggestBuilder randomSuggestBuilder() {
         SuggestBuilder builder = new SuggestBuilder();
         if (randomBoolean()) {
-            builder.setGlobalText(randomAsciiOfLengthBetween(1, 20));
+            builder.setGlobalText(randomAlphaOfLengthBetween(1, 20));
         }
         final int numSuggestions = randomIntBetween(1, 5);
         for (int i = 0; i < numSuggestions; i++) {
-            builder.addSuggestion(randomAsciiOfLengthBetween(5, 10), randomSuggestionBuilder());
+            builder.addSuggestion(randomAlphaOfLengthBetween(5, 10), randomSuggestionBuilder());
         }
         return builder;
     }

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestTests.java
@@ -125,9 +125,9 @@ public class SuggestTests extends ESTestCase {
 
     public void testFilter() throws Exception {
         List<Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>>> suggestions;
-        CompletionSuggestion completionSuggestion = new CompletionSuggestion(randomAsciiOfLength(10), 2);
-        PhraseSuggestion phraseSuggestion = new PhraseSuggestion(randomAsciiOfLength(10), 2);
-        TermSuggestion termSuggestion = new TermSuggestion(randomAsciiOfLength(10), 2, SortBy.SCORE);
+        CompletionSuggestion completionSuggestion = new CompletionSuggestion(randomAlphaOfLength(10), 2);
+        PhraseSuggestion phraseSuggestion = new PhraseSuggestion(randomAlphaOfLength(10), 2);
+        TermSuggestion termSuggestion = new TermSuggestion(randomAlphaOfLength(10), 2, SortBy.SCORE);
         suggestions = Arrays.asList(completionSuggestion, phraseSuggestion, termSuggestion);
         Suggest suggest = new Suggest(suggestions);
         List<PhraseSuggestion> phraseSuggestions = suggest.filter(PhraseSuggestion.class);
@@ -146,7 +146,7 @@ public class SuggestTests extends ESTestCase {
         suggestions = new ArrayList<>();
         int n = randomIntBetween(2, 5);
         for (int i = 0; i < n; i++) {
-            suggestions.add(new CompletionSuggestion(randomAsciiOfLength(10), randomIntBetween(3, 5)));
+            suggestions.add(new CompletionSuggestion(randomAlphaOfLength(10), randomIntBetween(3, 5)));
         }
         Collections.shuffle(suggestions, random());
         Suggest suggest = new Suggest(suggestions);

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionEntryTests.java
@@ -55,7 +55,7 @@ public class SuggestionEntryTests extends ESTestCase {
      */
     @SuppressWarnings("unchecked")
     public static <O extends Option> Entry<O> createTestItem(Class<? extends Entry> entryType) {
-        Text entryText = new Text(randomAsciiOfLengthBetween(5, 15));
+        Text entryText = new Text(randomAlphaOfLengthBetween(5, 15));
         int offset = randomInt();
         int length = randomInt();
         Entry entry;

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionOptionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionOptionTests.java
@@ -35,9 +35,9 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 public class SuggestionOptionTests extends ESTestCase {
 
     public static Option createTestItem() {
-        Text text = new Text(randomAsciiOfLengthBetween(5, 15));
+        Text text = new Text(randomAlphaOfLengthBetween(5, 15));
         float score = randomFloat();
-        Text highlighted = randomFrom((Text) null, new Text(randomAsciiOfLengthBetween(5, 15)));
+        Text highlighted = randomFrom((Text) null, new Text(randomAlphaOfLengthBetween(5, 15)));
         Boolean collateMatch = randomFrom((Boolean) null, randomBoolean());
         return new Option(text, highlighted, score, collateMatch);
     }

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
@@ -65,7 +65,7 @@ public class SuggestionTests extends ESTestCase {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static Suggestion<? extends Entry<? extends Option>> createTestItem(Class<? extends Suggestion> type) {
-        String name = randomAsciiOfLengthBetween(5, 10);
+        String name = randomAlphaOfLengthBetween(5, 10);
         // note: size will not be rendered via "toXContent", only passed on internally on transport layer
         int size = randomInt();
         Supplier<Entry> entrySupplier = null;

--- a/core/src/test/java/org/elasticsearch/search/suggest/TermSuggestionOptionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/TermSuggestionOptionTests.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 public class TermSuggestionOptionTests extends ESTestCase {
 
     public static Option createTestItem() {
-        Text text = new Text(randomAsciiOfLengthBetween(5, 15));
+        Text text = new Text(randomAlphaOfLengthBetween(5, 15));
         float score = randomFloat();
         int freq = randomInt();
         return new Option(text, freq, score);

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryQueryContextTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryQueryContextTests.java
@@ -28,7 +28,7 @@ public class CategoryQueryContextTests extends QueryContextTestCase<CategoryQuer
 
     public static CategoryQueryContext randomCategoryQueryContext() {
         final CategoryQueryContext.Builder builder = CategoryQueryContext.builder();
-        builder.setCategory(randomAsciiOfLength(10));
+        builder.setCategory(randomAlphaOfLength(10));
         maybeSet(builder::setBoost, randomIntBetween(1, 10));
         maybeSet(builder::setPrefix, randomBoolean());
         return builder.build();

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
@@ -54,20 +54,20 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
 
     private static BuilderAndInfo randomSuggestionBuilderWithContextInfo() {
         final BuilderAndInfo builderAndInfo = new BuilderAndInfo();
-        CompletionSuggestionBuilder testBuilder = new CompletionSuggestionBuilder(randomAsciiOfLengthBetween(2, 20));
+        CompletionSuggestionBuilder testBuilder = new CompletionSuggestionBuilder(randomAlphaOfLengthBetween(2, 20));
         setCommonPropertiesOnRandomBuilder(testBuilder);
         switch (randomIntBetween(0, 3)) {
             case 0:
-                testBuilder.prefix(randomAsciiOfLength(10));
+                testBuilder.prefix(randomAlphaOfLength(10));
                 break;
             case 1:
-                testBuilder.prefix(randomAsciiOfLength(10), FuzzyOptionsTests.randomFuzzyOptions());
+                testBuilder.prefix(randomAlphaOfLength(10), FuzzyOptionsTests.randomFuzzyOptions());
                 break;
             case 2:
-                testBuilder.prefix(randomAsciiOfLength(10), randomFrom(Fuzziness.ZERO, Fuzziness.ONE, Fuzziness.TWO));
+                testBuilder.prefix(randomAlphaOfLength(10), randomFrom(Fuzziness.ZERO, Fuzziness.ONE, Fuzziness.TWO));
                 break;
             case 3:
-                testBuilder.regex(randomAsciiOfLength(10), RegexOptionsTests.randomRegexOptions());
+                testBuilder.regex(randomAlphaOfLength(10), RegexOptionsTests.randomRegexOptions());
                 break;
         }
         Map<String, List<? extends ToXContent>> contextMap = new HashMap<>();
@@ -77,7 +77,7 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
             for (int i = 0; i < numContext; i++) {
                 contexts.add(CategoryQueryContextTests.randomCategoryQueryContext());
             }
-            String name = randomAsciiOfLength(10);
+            String name = randomAlphaOfLength(10);
             contextMap.put(name, contexts);
             builderAndInfo.catContexts.add(name);
         }
@@ -87,7 +87,7 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
             for (int i = 0; i < numContext; i++) {
                 contexts.add(GeoQueryContextTests.randomGeoQueryContext());
             }
-            String name = randomAsciiOfLength(10);
+            String name = randomAlphaOfLength(10);
             contextMap.put(name, contexts);
             builderAndInfo.geoContexts.add(name);
         }
@@ -114,7 +114,7 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
                 for (int i = 0; i < nCatContext; i++) {
                     contexts.add(CategoryQueryContextTests.randomCategoryQueryContext());
                 }
-                builder.contexts(Collections.singletonMap(randomAsciiOfLength(10), contexts));
+                builder.contexts(Collections.singletonMap(randomAlphaOfLength(10), contexts));
                 break;
             case 1:
                 int nGeoContext = randomIntBetween(1, 5);
@@ -122,16 +122,16 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
                 for (int i = 0; i < nGeoContext; i++) {
                     geoContexts.add(GeoQueryContextTests.randomGeoQueryContext());
                 }
-                builder.contexts(Collections.singletonMap(randomAsciiOfLength(10), geoContexts));
+                builder.contexts(Collections.singletonMap(randomAlphaOfLength(10), geoContexts));
                 break;
             case 2:
-                builder.prefix(randomAsciiOfLength(10), FuzzyOptionsTests.randomFuzzyOptions());
+                builder.prefix(randomAlphaOfLength(10), FuzzyOptionsTests.randomFuzzyOptions());
                 break;
             case 3:
-                builder.prefix(randomAsciiOfLength(10), randomFrom(Fuzziness.ZERO, Fuzziness.ONE, Fuzziness.TWO));
+                builder.prefix(randomAlphaOfLength(10), randomFrom(Fuzziness.ZERO, Fuzziness.ONE, Fuzziness.TWO));
                 break;
             case 4:
-                builder.regex(randomAsciiOfLength(10), RegexOptionsTests.randomRegexOptions());
+                builder.regex(randomAlphaOfLength(10), RegexOptionsTests.randomRegexOptions());
                 break;
             default:
                 throw new IllegalStateException("should not through");

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionTests.java
@@ -35,7 +35,7 @@ public class CompletionSuggestionTests extends ESTestCase {
     public void testToReduce() throws Exception {
         List<Suggest.Suggestion<CompletionSuggestion.Entry>> shardSuggestions = new ArrayList<>();
         int nShards = randomIntBetween(1, 10);
-        String name = randomAsciiOfLength(10);
+        String name = randomAlphaOfLength(10);
         int size = randomIntBetween(3, 5);
         for (int i = 0; i < nShards; i++) {
             CompletionSuggestion suggestion = new CompletionSuggestion(name, size);

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
@@ -177,7 +177,7 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
      * create random {@link DirectCandidateGeneratorBuilder}
      */
     public static DirectCandidateGeneratorBuilder randomCandidateGenerator() {
-        DirectCandidateGeneratorBuilder generator = new DirectCandidateGeneratorBuilder(randomAsciiOfLength(10));
+        DirectCandidateGeneratorBuilder generator = new DirectCandidateGeneratorBuilder(randomAlphaOfLength(10));
         maybeSet(generator::accuracy, randomFloat());
         maybeSet(generator::maxEdits, randomIntBetween(1, 2));
         maybeSet(generator::maxInspections, randomIntBetween(1, 20));
@@ -185,8 +185,8 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
         maybeSet(generator::minDocFreq, randomFloat());
         maybeSet(generator::minWordLength, randomIntBetween(1, 20));
         maybeSet(generator::prefixLength, randomIntBetween(1, 20));
-        maybeSet(generator::preFilter, randomAsciiOfLengthBetween(1, 20));
-        maybeSet(generator::postFilter, randomAsciiOfLengthBetween(1, 20));
+        maybeSet(generator::preFilter, randomAlphaOfLengthBetween(1, 20));
+        maybeSet(generator::postFilter, randomAlphaOfLengthBetween(1, 20));
         maybeSet(generator::size, randomIntBetween(1, 20));
         maybeSet(generator::sort, randomFrom("score", "frequency"));
         maybeSet(generator::stringDistance, randomFrom("internal", "damerau_levenshtein", "levenstein", "jarowinkler", "ngram"));

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -33,13 +33,13 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
     }
 
     public static PhraseSuggestionBuilder randomPhraseSuggestionBuilder() {
-        PhraseSuggestionBuilder testBuilder = new PhraseSuggestionBuilder(randomAsciiOfLengthBetween(2, 20));
+        PhraseSuggestionBuilder testBuilder = new PhraseSuggestionBuilder(randomAlphaOfLengthBetween(2, 20));
         setCommonPropertiesOnRandomBuilder(testBuilder);
         maybeSet(testBuilder::maxErrors, randomFloat());
-        maybeSet(testBuilder::separator, randomAsciiOfLengthBetween(1, 10));
+        maybeSet(testBuilder::separator, randomAlphaOfLengthBetween(1, 10));
         maybeSet(testBuilder::realWordErrorLikelihood, randomFloat());
         maybeSet(testBuilder::confidence, randomFloat());
-        maybeSet(testBuilder::collateQuery, randomAsciiOfLengthBetween(3, 20));
+        maybeSet(testBuilder::collateQuery, randomAlphaOfLengthBetween(3, 20));
         // collate query prune and parameters will only be used when query is set
         if (testBuilder.collateQuery() != null) {
             maybeSet(testBuilder::collatePrune, randomBoolean());
@@ -47,14 +47,14 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
                 Map<String, Object> collateParams = new HashMap<>();
                 int numParams = randomIntBetween(1, 5);
                 for (int i = 0; i < numParams; i++) {
-                    collateParams.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+                    collateParams.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
                 }
                 testBuilder.collateParams(collateParams );
             }
         }
         if (randomBoolean()) {
             // preTag, postTag
-            testBuilder.highlight(randomAsciiOfLengthBetween(3, 20), randomAsciiOfLengthBetween(3, 20));
+            testBuilder.highlight(randomAlphaOfLengthBetween(3, 20), randomAlphaOfLengthBetween(3, 20));
         }
         maybeSet(testBuilder::gramSize, randomIntBetween(1, 5));
         maybeSet(testBuilder::forceUnigrams, randomBoolean());
@@ -106,14 +106,14 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
             builder.tokenLimit(randomValueOtherThan(builder.tokenLimit(), () -> randomIntBetween(1, 20)));
             break;
         case 5:
-            builder.separator(randomValueOtherThan(builder.separator(), () -> randomAsciiOfLengthBetween(1, 10)));
+            builder.separator(randomValueOtherThan(builder.separator(), () -> randomAlphaOfLengthBetween(1, 10)));
             break;
         case 6:
             Script collateQuery = builder.collateQuery();
             if (collateQuery != null) {
-                builder.collateQuery(randomValueOtherThan(collateQuery.getIdOrCode(), () -> randomAsciiOfLengthBetween(3, 20)));
+                builder.collateQuery(randomValueOtherThan(collateQuery.getIdOrCode(), () -> randomAlphaOfLengthBetween(3, 20)));
             } else {
-                builder.collateQuery(randomAsciiOfLengthBetween(3, 20));
+                builder.collateQuery(randomAlphaOfLengthBetween(3, 20));
             }
             break;
         case 7:
@@ -126,7 +126,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
                 // simply double both values
                 builder.highlight(builder.preTag() + builder.preTag(), builder.postTag() + builder.postTag());
             } else {
-                builder.highlight(randomAsciiOfLengthBetween(3, 20), randomAsciiOfLengthBetween(3, 20));
+                builder.highlight(randomAlphaOfLengthBetween(3, 20), randomAlphaOfLengthBetween(3, 20));
             }
             break;
         case 9:
@@ -134,7 +134,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
             break;
         case 10:
             Map<String, Object> collateParams = builder.collateParams() == null ? new HashMap<>(1) : builder.collateParams();
-            collateParams.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+            collateParams.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
             builder.collateParams(collateParams);
             break;
         case 11:
@@ -155,7 +155,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
         e = expectThrows(IllegalArgumentException.class, () -> new PhraseSuggestionBuilder(""));
         assertEquals("suggestion field name is empty", e.getMessage());
 
-        PhraseSuggestionBuilder builder = new PhraseSuggestionBuilder(randomAsciiOfLengthBetween(2, 20));
+        PhraseSuggestionBuilder builder = new PhraseSuggestionBuilder(randomAlphaOfLengthBetween(2, 20));
 
         e = expectThrows(IllegalArgumentException.class, () -> builder.gramSize(0));
         assertEquals("gramSize must be >= 1", e.getMessage());

--- a/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
@@ -58,7 +58,7 @@ public class TermSuggestionBuilderTests extends AbstractSuggestionBuilderTestCas
      * Creates a random TermSuggestionBuilder
      */
     public static TermSuggestionBuilder randomTermSuggestionBuilder() {
-        TermSuggestionBuilder testBuilder = new TermSuggestionBuilder(randomAsciiOfLengthBetween(2, 20));
+        TermSuggestionBuilder testBuilder = new TermSuggestionBuilder(randomAlphaOfLengthBetween(2, 20));
         setCommonPropertiesOnRandomBuilder(testBuilder);
         maybeSet(testBuilder::suggestMode, randomSuggestMode());
         maybeSet(testBuilder::accuracy, randomFloat());
@@ -151,7 +151,7 @@ public class TermSuggestionBuilderTests extends AbstractSuggestionBuilderTestCas
         e = expectThrows(IllegalArgumentException.class, () -> new TermSuggestionBuilder(""));
         assertEquals("suggestion field name is empty", e.getMessage());
 
-        TermSuggestionBuilder builder = new TermSuggestionBuilder(randomAsciiOfLengthBetween(2, 20));
+        TermSuggestionBuilder builder = new TermSuggestionBuilder(randomAlphaOfLengthBetween(2, 20));
 
         // test invalid accuracy values
         expectThrows(IllegalArgumentException.class, () -> builder.accuracy(-0.5f));
@@ -193,7 +193,7 @@ public class TermSuggestionBuilderTests extends AbstractSuggestionBuilderTestCas
     }
 
     public void testDefaultValuesSet() {
-        TermSuggestionBuilder builder = new TermSuggestionBuilder(randomAsciiOfLengthBetween(2, 20));
+        TermSuggestionBuilder builder = new TermSuggestionBuilder(randomAlphaOfLengthBetween(2, 20));
         assertEquals(DEFAULT_ACCURACY, builder.accuracy(), Float.MIN_VALUE);
         assertEquals(DEFAULT_MAX_EDITS, builder.maxEdits());
         assertEquals(DEFAULT_MAX_INSPECTIONS, builder.maxInspections());

--- a/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/BlobStoreFormatIT.java
@@ -151,7 +151,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
     public void testBlobCorruption() throws IOException {
         BlobStore blobStore = createTestBlobStore();
         BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
-        String testString = randomAsciiOfLength(randomInt(10000));
+        String testString = randomAlphaOfLength(randomInt(10000));
         BlobObj blobObj = new BlobObj(testString);
         ChecksumBlobStoreFormat<BlobObj> checksumFormat = new ChecksumBlobStoreFormat<>(BLOB_CODEC, "%s", BlobObj::fromXContent,
             xContentRegistry(), randomBoolean(), randomBoolean() ? XContentType.SMILE : XContentType.JSON);
@@ -171,7 +171,7 @@ public class BlobStoreFormatIT extends AbstractSnapshotIntegTestCase {
     public void testAtomicWrite() throws Exception {
         final BlobStore blobStore = createTestBlobStore();
         final BlobContainer blobContainer = blobStore.blobContainer(BlobPath.cleanPath());
-        String testString = randomAsciiOfLength(randomInt(10000));
+        String testString = randomAlphaOfLength(randomInt(10000));
         final CountDownLatch block = new CountDownLatch(1);
         final CountDownLatch unblock = new CountDownLatch(1);
         final BlobObj blobObj = new BlobObj(testString) {

--- a/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -347,7 +347,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
                 .setType("mock").setSettings(
                         Settings.builder()
                                 .put("location", randomRepoPath())
-                                .put("random", randomAsciiOfLength(10))
+                                .put("random", randomAlphaOfLength(10))
                                 .put("wait_after_unblock", 200)
                 ).get();
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
@@ -395,7 +395,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
                 .setType("mock").setSettings(
                         Settings.builder()
                                 .put("location", repo)
-                                .put("random", randomAsciiOfLength(10))
+                                .put("random", randomAlphaOfLength(10))
                                 .put("wait_after_unblock", 200)
                 ).get();
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));

--- a/core/src/test/java/org/elasticsearch/snapshots/MinThreadsSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/MinThreadsSnapshotRestoreIT.java
@@ -59,7 +59,7 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         assertAcked(client().admin().cluster().preparePutRepository(repo).setType("mock").setSettings(
             Settings.builder()
                 .put("location", randomRepoPath())
-                .put("random", randomAsciiOfLength(10))
+                .put("random", randomAlphaOfLength(10))
                 .put("wait_after_unblock", 200)).get());
 
         logger.info("--> snapshot twice");
@@ -113,7 +113,7 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         assertAcked(client().admin().cluster().preparePutRepository(repo).setType("mock").setSettings(
             Settings.builder()
                 .put("location", randomRepoPath())
-                .put("random", randomAsciiOfLength(10))
+                .put("random", randomAlphaOfLength(10))
                 .put("wait_after_unblock", 200)).get());
 
         logger.info("--> snapshot");
@@ -160,7 +160,7 @@ public class MinThreadsSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
         assertAcked(client().admin().cluster().preparePutRepository(repo).setType("mock").setSettings(
             Settings.builder()
                 .put("location", randomRepoPath())
-                .put("random", randomAsciiOfLength(10))
+                .put("random", randomAlphaOfLength(10))
                 .put("wait_after_unblock", 200)).get());
 
         logger.info("--> snapshot");

--- a/core/src/test/java/org/elasticsearch/snapshots/RepositoriesMetaDataSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/RepositoriesMetaDataSerializationTests.java
@@ -42,7 +42,7 @@ public class RepositoriesMetaDataSerializationTests extends AbstractDiffableSeri
         int numberOfRepositories = randomInt(10);
         List<RepositoryMetaData> entries = new ArrayList<>();
         for (int i = 0; i < numberOfRepositories; i++) {
-            entries.add(new RepositoryMetaData(randomAsciiOfLength(10), randomAsciiOfLength(10), randomSettings()));
+            entries.add(new RepositoryMetaData(randomAlphaOfLength(10), randomAlphaOfLength(10), randomSettings()));
         }
         entries.sort(Comparator.comparing(RepositoryMetaData::name));
         return new RepositoriesMetaData(entries.toArray(new RepositoryMetaData[entries.size()]));
@@ -60,7 +60,7 @@ public class RepositoriesMetaDataSerializationTests extends AbstractDiffableSeri
             int numberOfSettings = randomInt(10);
             Settings.Builder builder = Settings.builder();
             for (int i = 0; i < numberOfSettings; i++) {
-                builder.put(randomAsciiOfLength(10), randomAsciiOfLength(20));
+                builder.put(randomAlphaOfLength(10), randomAlphaOfLength(20));
             }
             return builder.build();
         }
@@ -79,7 +79,7 @@ public class RepositoriesMetaDataSerializationTests extends AbstractDiffableSeri
             // add some elements
             int addElements = randomInt(10);
             for (int i = 0; i < addElements; i++) {
-                repos.add(new RepositoryMetaData(randomAsciiOfLength(10), randomAsciiOfLength(10), randomSettings()));
+                repos.add(new RepositoryMetaData(randomAlphaOfLength(10), randomAlphaOfLength(10), randomSettings()));
             }
         }
         return new RepositoriesMetaData(repos.toArray(new RepositoryMetaData[repos.size()]));

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -657,7 +657,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .setType("mock").setSettings(
                         Settings.builder()
                                 .put("location", randomRepoPath())
-                                .put("random", randomAsciiOfLength(10))
+                                .put("random", randomAlphaOfLength(10))
                                 .put("random_control_io_exception_rate", 0.2))
                 .setVerify(false));
 
@@ -707,7 +707,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .setType("mock").setSettings(
                         Settings.builder()
                                 .put("location", randomRepoPath())
-                                .put("random", randomAsciiOfLength(10))
+                                .put("random", randomAlphaOfLength(10))
                                 .put("random_data_file_io_exception_rate", 0.3)));
 
         createIndex("test-idx");
@@ -792,7 +792,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .setType("mock").setSettings(
                         Settings.builder()
                                 .put("location", repositoryLocation)
-                                .put("random", randomAsciiOfLength(10))
+                                .put("random", randomAlphaOfLength(10))
                                 .put("random_data_file_io_exception_rate", 0.3)));
 
         // Test restore after index deletion
@@ -833,7 +833,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             .setType("mock").setSettings(
                 Settings.builder()
                     .put("location", repositoryLocation)
-                    .put("random", randomAsciiOfLength(10))
+                    .put("random", randomAlphaOfLength(10))
                     .put("use_lucene_corruption", true)
                     .put("max_failure_number", 10000000L)
                     .put("random_data_file_io_exception_rate", 1.0)));
@@ -879,7 +879,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .setType("mock").setSettings(
                         Settings.builder()
                                 .put("location", repositoryLocation)
-                                .put("random", randomAsciiOfLength(10))
+                                .put("random", randomAlphaOfLength(10))
                                 .put("random_data_file_io_exception_rate", 1.0) // Fail completely
                 ));
 
@@ -1312,7 +1312,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .setType("mock").setSettings(
                         Settings.builder()
                                 .put("location", repositoryLocation)
-                                .put("random", randomAsciiOfLength(10))
+                                .put("random", randomAlphaOfLength(10))
                                 .put("wait_after_unblock", 200)));
 
         // Create index on 2 nodes and make sure each node has a primary by setting no replicas
@@ -1373,7 +1373,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .setType("mock").setSettings(
                         Settings.builder()
                                 .put("location", repositoryLocation)
-                                .put("random", randomAsciiOfLength(10))
+                                .put("random", randomAlphaOfLength(10))
                                 .put("wait_after_unblock", 200)
                 ).get();
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
@@ -1569,7 +1569,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 .setType("mock").setSettings(
                         Settings.builder()
                                 .put("location", repositoryLocation)
-                                .put("random", randomAsciiOfLength(10))
+                                .put("random", randomAlphaOfLength(10))
                                 .put("wait_after_unblock", 200)
                 ).get();
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
@@ -2533,7 +2533,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> take {} snapshot(s)", numSnapshots - 1);
         final String[] snapshotNames = new String[numSnapshots];
         for (int i = 0; i < numSnapshots - 1; i++) {
-            final String snapshotName = randomAsciiOfLength(8).toLowerCase(Locale.ROOT);
+            final String snapshotName = randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
             CreateSnapshotResponse createSnapshotResponse = client.admin()
                                                                   .cluster()
                                                                   .prepareCreateSnapshot(repositoryName, snapshotName)
@@ -2550,7 +2550,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         }
         refresh();
 
-        final String inProgressSnapshot = randomAsciiOfLength(8).toLowerCase(Locale.ROOT);
+        final String inProgressSnapshot = randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
         snapshotNames[numSnapshots - 1] = inProgressSnapshot;
         // block a node so the create snapshot operation can remain in progress
         final String blockedNode = blockNodeWithIndex(repositoryName, indexName);
@@ -2644,7 +2644,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         PutRepositoryResponse putRepositoryResponse =
             client().admin().cluster().preparePutRepository(repo).setType("mock").setSettings(Settings.builder()
                 .put("location", randomRepoPath())
-                .put("random", randomAsciiOfLength(10))
+                .put("random", randomAlphaOfLength(10))
                 .put("wait_after_unblock", 200)
             ).get();
         assertTrue(putRepositoryResponse.isAcknowledged());
@@ -2688,7 +2688,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                     .put("random_control_io_exception_rate", randomIntBetween(5, 20) / 100f)
                     // test that we can take a snapshot after a failed one, even if a partial index-N was written
                     .put("atomic_move", false)
-                    .put("random", randomAsciiOfLength(10))));
+                    .put("random", randomAlphaOfLength(10))));
 
         logger.info("--> indexing some data");
         assertAcked(prepareCreate("test-idx").setSettings(

--- a/core/src/test/java/org/elasticsearch/snapshots/SnapshotTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SnapshotTests.java
@@ -46,8 +46,8 @@ public class SnapshotTests extends ESTestCase {
     }
 
     public void testSerialization() throws IOException {
-        final SnapshotId snapshotId = new SnapshotId(randomAsciiOfLength(randomIntBetween(2, 8)), UUIDs.randomBase64UUID());
-        final Snapshot original = new Snapshot(randomAsciiOfLength(randomIntBetween(2, 8)), snapshotId);
+        final SnapshotId snapshotId = new SnapshotId(randomAlphaOfLength(randomIntBetween(2, 8)), UUIDs.randomBase64UUID());
+        final Snapshot original = new Snapshot(randomAlphaOfLength(randomIntBetween(2, 8)), snapshotId);
         final BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
         assertThat(new Snapshot(out.bytes().streamInput()), equalTo(original));

--- a/core/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -49,22 +49,22 @@ public class SnapshotsInProgressSerializationTests extends AbstractDiffableWireS
     }
 
     private Entry randomSnapshot() {
-        Snapshot snapshot = new Snapshot(randomAsciiOfLength(10), new SnapshotId(randomAsciiOfLength(10), randomAsciiOfLength(10)));
+        Snapshot snapshot = new Snapshot(randomAlphaOfLength(10), new SnapshotId(randomAlphaOfLength(10), randomAlphaOfLength(10)));
         boolean includeGlobalState = randomBoolean();
         boolean partial = randomBoolean();
         State state = randomFrom(State.values());
         int numberOfIndices = randomIntBetween(0, 10);
         List<IndexId> indices = new ArrayList<>();
         for (int i = 0; i < numberOfIndices; i++) {
-            indices.add(new IndexId(randomAsciiOfLength(10), randomAsciiOfLength(10)));
+            indices.add(new IndexId(randomAlphaOfLength(10), randomAlphaOfLength(10)));
         }
         long startTime = randomLong();
         long repositoryStateId = randomLong();
         ImmutableOpenMap.Builder<ShardId, SnapshotsInProgress.ShardSnapshotStatus> builder = ImmutableOpenMap.builder();
         int shardsCount = randomIntBetween(0, 10);
         for (int j = 0; j < shardsCount; j++) {
-            ShardId shardId = new ShardId(new Index(randomAsciiOfLength(10), randomAsciiOfLength(10)), randomIntBetween(0, 10));
-            String nodeId = randomAsciiOfLength(10);
+            ShardId shardId = new ShardId(new Index(randomAlphaOfLength(10), randomAlphaOfLength(10)), randomIntBetween(0, 10));
+            String nodeId = randomAlphaOfLength(10);
             State shardState = randomFrom(State.values());
             builder.put(shardId, new SnapshotsInProgress.ShardSnapshotStatus(nodeId, shardState));
         }

--- a/core/src/test/java/org/elasticsearch/tasks/TaskResultTests.java
+++ b/core/src/test/java/org/elasticsearch/tasks/TaskResultTests.java
@@ -89,10 +89,10 @@ public class TaskResultTests extends ESTestCase {
 
     private static TaskInfo randomTaskInfo() throws IOException {
         TaskId taskId = randomTaskId();
-        String type = randomAsciiOfLength(5);
-        String action = randomAsciiOfLength(5);
+        String type = randomAlphaOfLength(5);
+        String action = randomAlphaOfLength(5);
         Task.Status status = randomBoolean() ? randomRawTaskStatus() : null;
-        String description = randomBoolean() ? randomAsciiOfLength(5) : null;
+        String description = randomBoolean() ? randomAlphaOfLength(5) : null;
         long startTime = randomLong();
         long runningTimeNanos = randomLong();
         boolean cancellable = randomBoolean();
@@ -101,7 +101,7 @@ public class TaskResultTests extends ESTestCase {
     }
 
     private static TaskId randomTaskId() {
-        return new TaskId(randomAsciiOfLength(5), randomLong());
+        return new TaskId(randomAlphaOfLength(5), randomLong());
     }
 
     private static RawTaskStatus randomRawTaskStatus() throws IOException {
@@ -109,7 +109,7 @@ public class TaskResultTests extends ESTestCase {
             builder.startObject();
             int fields = between(0, 10);
             for (int f = 0; f < fields; f++) {
-                builder.field(randomAsciiOfLength(5), randomAsciiOfLength(5));
+                builder.field(randomAlphaOfLength(5), randomAlphaOfLength(5));
             }
             builder.endObject();
             return new RawTaskStatus(builder.bytes());
@@ -120,7 +120,7 @@ public class TaskResultTests extends ESTestCase {
         Map<String, String> result = new TreeMap<>();
         int fields = between(0, 10);
         for (int f = 0; f < fields; f++) {
-            result.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+            result.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
         }
         return new ToXContent() {
             @Override

--- a/core/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -166,7 +166,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
         NetworkHandle handleA = startServices("TS_A", settings, Version.CURRENT);
         NetworkHandle handleB = startServices("TS_B", settings, Version.CURRENT);
         DiscoveryNode discoveryNode = new DiscoveryNode(
-            randomAsciiOfLength(10),
+            randomAlphaOfLength(10),
             handleB.discoveryNode.getAddress(),
             emptyMap(),
             emptySet(),

--- a/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
@@ -504,8 +504,8 @@ public class TribeIT extends ESIntegTestCase {
     public void testMergingCustomMetaData() throws Exception {
         removeCustomMetaData(cluster1, MergableCustomMetaData1.TYPE);
         removeCustomMetaData(cluster2, MergableCustomMetaData1.TYPE);
-        MergableCustomMetaData1 customMetaData1 = new MergableCustomMetaData1(randomAsciiOfLength(10));
-        MergableCustomMetaData1 customMetaData2 = new MergableCustomMetaData1(randomAsciiOfLength(10));
+        MergableCustomMetaData1 customMetaData1 = new MergableCustomMetaData1(randomAlphaOfLength(10));
+        MergableCustomMetaData1 customMetaData2 = new MergableCustomMetaData1(randomAlphaOfLength(10));
         List<MergableCustomMetaData1> customMetaDatas = Arrays.asList(customMetaData1, customMetaData2);
         Collections.sort(customMetaDatas, (cm1, cm2) -> cm2.getData().compareTo(cm1.getData()));
         final MergableCustomMetaData1 tribeNodeCustomMetaData = customMetaDatas.get(0);
@@ -521,10 +521,10 @@ public class TribeIT extends ESIntegTestCase {
     public void testMergingMultipleCustomMetaData() throws Exception {
         removeCustomMetaData(cluster1, MergableCustomMetaData1.TYPE);
         removeCustomMetaData(cluster2, MergableCustomMetaData1.TYPE);
-        MergableCustomMetaData1 firstCustomMetaDataType1 = new MergableCustomMetaData1(randomAsciiOfLength(10));
-        MergableCustomMetaData1 secondCustomMetaDataType1 = new MergableCustomMetaData1(randomAsciiOfLength(10));
-        MergableCustomMetaData2 firstCustomMetaDataType2 = new MergableCustomMetaData2(randomAsciiOfLength(10));
-        MergableCustomMetaData2 secondCustomMetaDataType2 = new MergableCustomMetaData2(randomAsciiOfLength(10));
+        MergableCustomMetaData1 firstCustomMetaDataType1 = new MergableCustomMetaData1(randomAlphaOfLength(10));
+        MergableCustomMetaData1 secondCustomMetaDataType1 = new MergableCustomMetaData1(randomAlphaOfLength(10));
+        MergableCustomMetaData2 firstCustomMetaDataType2 = new MergableCustomMetaData2(randomAlphaOfLength(10));
+        MergableCustomMetaData2 secondCustomMetaDataType2 = new MergableCustomMetaData2(randomAlphaOfLength(10));
         List<MergableCustomMetaData1> mergedCustomMetaDataType1 = Arrays.asList(firstCustomMetaDataType1, secondCustomMetaDataType1);
         List<MergableCustomMetaData2> mergedCustomMetaDataType2 = Arrays.asList(firstCustomMetaDataType2, secondCustomMetaDataType2);
         Collections.sort(mergedCustomMetaDataType1, (cm1, cm2) -> cm2.getData().compareTo(cm1.getData()));

--- a/core/src/test/java/org/elasticsearch/update/UpdateNoopIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateNoopIT.java
@@ -51,9 +51,9 @@ public class UpdateNoopIT extends ESIntegTestCase {
 
     public void testTwoFields() throws Exception {
         // Use random keys so we get random iteration order.
-        String key1 = 1 + randomAsciiOfLength(3);
-        String key2 = 2 + randomAsciiOfLength(3);
-        String key3 = 3 + randomAsciiOfLength(3);
+        String key1 = 1 + randomAlphaOfLength(3);
+        String key2 = 2 + randomAlphaOfLength(3);
+        String key3 = 3 + randomAlphaOfLength(3);
         updateAndCheckSource(1, fields(key1, "foo", key2, "baz"));
         updateAndCheckSource(1, fields(key1, "foo", key2, "baz"));
         updateAndCheckSource(2, fields(key1, "foo", key2, "bir"));
@@ -90,9 +90,9 @@ public class UpdateNoopIT extends ESIntegTestCase {
 
     public void testMap() throws Exception {
         // Use random keys so we get variable iteration order.
-        String key1 = 1 + randomAsciiOfLength(3);
-        String key2 = 2 + randomAsciiOfLength(3);
-        String key3 = 3 + randomAsciiOfLength(3);
+        String key1 = 1 + randomAlphaOfLength(3);
+        String key2 = 2 + randomAlphaOfLength(3);
+        String key3 = 3 + randomAlphaOfLength(3);
         updateAndCheckSource(1, XContentFactory.jsonBuilder().startObject()
                 .startObject("test")
                     .field(key1, "foo")

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorFactoryTests.java
@@ -51,7 +51,7 @@ public class AppendProcessorFactoryTests extends ESTestCase {
             value = Arrays.asList("value1", "value2", "value3");
         }
         config.put("value", value);
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         AppendProcessor appendProcessor = factory.create(null, processorTag, config);
         assertThat(appendProcessor.getTag(), equalTo(processorTag));
         assertThat(appendProcessor.getField().execute(Collections.emptyMap()), equalTo("field1"));
@@ -97,7 +97,7 @@ public class AppendProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("value", "value1");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, () -> factory.create(null, processorTag, config));
         assertThat(exception.getMessage(), equalTo("java.lang.RuntimeException: could not compile script"));
         assertThat(exception.getHeader("processor_tag").get(0), equalTo(processorTag));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/AppendProcessorTests.java
@@ -130,13 +130,13 @@ public class AppendProcessorTests extends ESTestCase {
         List<String> values = new ArrayList<>();
         Processor appendProcessor;
         if (randomBoolean()) {
-            String value = randomAsciiOfLengthBetween(1, 10);
+            String value = randomAlphaOfLengthBetween(1, 10);
             values.add(value);
             appendProcessor = createAppendProcessor(randomMetaData.getFieldName(), value);
         } else {
             int valuesSize = randomIntBetween(0, 10);
             for (int i = 0; i < valuesSize; i++) {
-                values.add(randomAsciiOfLengthBetween(1, 10));
+                values.add(randomAlphaOfLengthBetween(1, 10));
             }
             appendProcessor = createAppendProcessor(randomMetaData.getFieldName(), values);
         }
@@ -158,7 +158,7 @@ public class AppendProcessorTests extends ESTestCase {
 
     private static Processor createAppendProcessor(String fieldName, Object fieldValue) {
         TemplateService templateService = TestTemplateService.instance();
-        return new AppendProcessor(randomAsciiOfLength(10), templateService.compile(fieldName), ValueSource.wrap(fieldValue,
+        return new AppendProcessor(randomAlphaOfLength(10), templateService.compile(fieldName), ValueSource.wrap(fieldValue,
                 templateService));
     }
 
@@ -186,7 +186,7 @@ public class AppendProcessorTests extends ESTestCase {
         }, STRING {
             @Override
             Object randomValue() {
-                return randomAsciiOfLengthBetween(1, 10);
+                return randomAlphaOfLengthBetween(1, 10);
             }
         }, MAP {
             @Override
@@ -194,7 +194,7 @@ public class AppendProcessorTests extends ESTestCase {
                 int numItems = randomIntBetween(1, 10);
                 Map<String, Object> map = new HashMap<>(numItems);
                 for (int i = 0; i < numItems; i++) {
-                    map.put(randomAsciiOfLengthBetween(1, 10), randomFrom(Scalar.values()).randomValue());
+                    map.put(randomAlphaOfLengthBetween(1, 10), randomFrom(Scalar.values()).randomValue());
                 }
                 return map;
             }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorFactoryTests.java
@@ -38,7 +38,7 @@ public class ConvertProcessorFactoryTests extends ESTestCase {
         ConvertProcessor.Type type = randomFrom(ConvertProcessor.Type.values());
         config.put("field", "field1");
         config.put("type", type.toString());
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ConvertProcessor convertProcessor = factory.create(null, processorTag, config);
         assertThat(convertProcessor.getTag(), equalTo(processorTag));
         assertThat(convertProcessor.getField(), equalTo("field1"));
@@ -50,7 +50,7 @@ public class ConvertProcessorFactoryTests extends ESTestCase {
     public void testCreateUnsupportedType() throws Exception {
         ConvertProcessor.Factory factory = new ConvertProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String type = "type-" + randomAsciiOfLengthBetween(1, 10);
+        String type = "type-" + randomAlphaOfLengthBetween(1, 10);
         config.put("field", "field1");
         config.put("type", type);
         try {
@@ -67,7 +67,7 @@ public class ConvertProcessorFactoryTests extends ESTestCase {
     public void testCreateNoFieldPresent() throws Exception {
         ConvertProcessor.Factory factory = new ConvertProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String type = "type-" + randomAsciiOfLengthBetween(1, 10);
+        String type = "type-" + randomAlphaOfLengthBetween(1, 10);
         config.put("type", type);
         try {
             factory.create(null, null, config);
@@ -96,7 +96,7 @@ public class ConvertProcessorFactoryTests extends ESTestCase {
         config.put("field", "field1");
         config.put("target_field", "field2");
         config.put("type", type.toString());
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ConvertProcessor convertProcessor = factory.create(null, processorTag, config);
         assertThat(convertProcessor.getTag(), equalTo(processorTag));
         assertThat(convertProcessor.getField(), equalTo("field1"));
@@ -112,7 +112,7 @@ public class ConvertProcessorFactoryTests extends ESTestCase {
         config.put("field", "field1");
         config.put("type", type.toString());
         config.put("ignore_missing", true);
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ConvertProcessor convertProcessor = factory.create(null, processorTag, config);
         assertThat(convertProcessor.getTag(), equalTo(processorTag));
         assertThat(convertProcessor.getField(), equalTo("field1"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
@@ -43,7 +43,7 @@ public class ConvertProcessorTests extends ESTestCase {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         int randomInt = randomInt();
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, randomInt);
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.INTEGER, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.INTEGER, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, Integer.class), equalTo(randomInt));
     }
@@ -59,7 +59,7 @@ public class ConvertProcessorTests extends ESTestCase {
             expectedList.add(randomInt);
         }
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.INTEGER, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.INTEGER, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, List.class), equalTo(expectedList));
     }
@@ -67,10 +67,10 @@ public class ConvertProcessorTests extends ESTestCase {
     public void testConvertIntError() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        String value = "string-" + randomAsciiOfLengthBetween(1, 10);
+        String value = "string-" + randomAlphaOfLengthBetween(1, 10);
         ingestDocument.setFieldValue(fieldName, value);
 
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.INTEGER, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.INTEGER, false);
         try {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");
@@ -86,7 +86,7 @@ public class ConvertProcessorTests extends ESTestCase {
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, randomFloat);
         expectedResult.put(fieldName, randomFloat);
 
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.FLOAT, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.FLOAT, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, Float.class), equalTo(randomFloat));
     }
@@ -102,7 +102,7 @@ public class ConvertProcessorTests extends ESTestCase {
             expectedList.add(randomFloat);
         }
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.FLOAT, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.FLOAT, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, List.class), equalTo(expectedList));
     }
@@ -110,10 +110,10 @@ public class ConvertProcessorTests extends ESTestCase {
     public void testConvertFloatError() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        String value = "string-" + randomAsciiOfLengthBetween(1, 10);
+        String value = "string-" + randomAlphaOfLengthBetween(1, 10);
         ingestDocument.setFieldValue(fieldName, value);
 
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.FLOAT, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.FLOAT, false);
         try {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");
@@ -131,7 +131,7 @@ public class ConvertProcessorTests extends ESTestCase {
         }
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, booleanString);
 
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.BOOLEAN, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.BOOLEAN, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, Boolean.class), equalTo(randomBoolean));
     }
@@ -151,7 +151,7 @@ public class ConvertProcessorTests extends ESTestCase {
             expectedList.add(randomBoolean);
         }
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.BOOLEAN, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.BOOLEAN, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, List.class), equalTo(expectedList));
     }
@@ -161,14 +161,14 @@ public class ConvertProcessorTests extends ESTestCase {
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         String fieldValue;
         if (randomBoolean()) {
-            fieldValue = "string-" + randomAsciiOfLengthBetween(1, 10);
+            fieldValue = "string-" + randomAlphaOfLengthBetween(1, 10);
         } else {
             //verify that only proper boolean values are supported and we are strict about it
             fieldValue = randomFrom("on", "off", "yes", "no", "0", "1");
         }
         ingestDocument.setFieldValue(fieldName, fieldValue);
 
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.BOOLEAN, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.BOOLEAN, false);
         try {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");
@@ -202,7 +202,7 @@ public class ConvertProcessorTests extends ESTestCase {
         }
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
 
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.STRING, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.STRING, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, String.class), equalTo(expectedFieldValue));
     }
@@ -238,7 +238,7 @@ public class ConvertProcessorTests extends ESTestCase {
             expectedList.add(randomValueString);
         }
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, Type.STRING, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, Type.STRING, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, List.class), equalTo(expectedList));
     }
@@ -247,7 +247,7 @@ public class ConvertProcessorTests extends ESTestCase {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         Type type = randomFrom(Type.values());
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, type, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, type, false);
         try {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");
@@ -259,7 +259,7 @@ public class ConvertProcessorTests extends ESTestCase {
     public void testConvertNullField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
         Type type = randomFrom(Type.values());
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), "field", "field", type, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), "field", "field", type, false);
         try {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");
@@ -273,7 +273,7 @@ public class ConvertProcessorTests extends ESTestCase {
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         Type type = randomFrom(Type.values());
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, fieldName, type, true);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, fieldName, type, true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
     }
@@ -282,7 +282,7 @@ public class ConvertProcessorTests extends ESTestCase {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         Type type = randomFrom(Type.values());
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), "field", "field", type, true);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), "field", "field", type, true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
     }
@@ -306,7 +306,7 @@ public class ConvertProcessorTests extends ESTestCase {
                 throw new UnsupportedOperationException();
         }
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", randomValue));
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), "field", "field", Type.AUTO, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), "field", "field", Type.AUTO, false);
         processor.execute(ingestDocument);
         Object convertedValue = ingestDocument.getFieldValue("field", Object.class);
         assertThat(convertedValue, sameInstance(randomValue));
@@ -315,7 +315,7 @@ public class ConvertProcessorTests extends ESTestCase {
     public void testAutoConvertStringNotMatched() throws Exception {
         String value = "notAnIntFloatOrBool";
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", value));
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), "field", "field", Type.AUTO, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), "field", "field", Type.AUTO, false);
         processor.execute(ingestDocument);
         Object convertedValue = ingestDocument.getFieldValue("field", Object.class);
         assertThat(convertedValue, sameInstance(value));
@@ -326,7 +326,7 @@ public class ConvertProcessorTests extends ESTestCase {
         String booleanString = Boolean.toString(randomBoolean);
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("field", booleanString));
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), "field", "field", Type.AUTO, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), "field", "field", Type.AUTO, false);
         processor.execute(ingestDocument);
         Object convertedValue = ingestDocument.getFieldValue("field", Object.class);
         assertThat(convertedValue, equalTo(randomBoolean));
@@ -336,7 +336,7 @@ public class ConvertProcessorTests extends ESTestCase {
         int randomInt = randomInt();
         String randomString = Integer.toString(randomInt);
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", randomString));
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), "field", "field", Type.AUTO, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), "field", "field", Type.AUTO, false);
         processor.execute(ingestDocument);
         Object convertedValue = ingestDocument.getFieldValue("field", Object.class);
         assertThat(convertedValue, equalTo(randomInt));
@@ -346,7 +346,7 @@ public class ConvertProcessorTests extends ESTestCase {
         float randomFloat = randomFloat();
         String randomString = Float.toString(randomFloat);
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", randomString));
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), "field", "field", Type.AUTO, false);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), "field", "field", Type.AUTO, false);
         processor.execute(ingestDocument);
         Object convertedValue = ingestDocument.getFieldValue("field", Object.class);
         assertThat(convertedValue, equalTo(randomFloat));
@@ -356,8 +356,8 @@ public class ConvertProcessorTests extends ESTestCase {
         IngestDocument ingestDocument = new IngestDocument(new HashMap<>(), new HashMap<>());
         int randomInt = randomInt();
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, String.valueOf(randomInt));
-        String targetField = fieldName + randomAsciiOfLength(5);
-        Processor processor = new ConvertProcessor(randomAsciiOfLength(10), fieldName, targetField, Type.INTEGER, false);
+        String targetField = fieldName + randomAlphaOfLength(5);
+        Processor processor = new ConvertProcessor(randomAlphaOfLength(10), fieldName, targetField, Type.INTEGER, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, String.class), equalTo(String.valueOf(randomInt)));
         assertThat(ingestDocument.getFieldValue(targetField, Integer.class), equalTo(randomInt));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
@@ -81,6 +81,6 @@ public class DateFormatTests extends ESTestCase {
         assertThat(DateFormat.fromString("iso8601"), equalTo(DateFormat.Joda));
         assertThat(DateFormat.fromString("TAI64N"), equalTo(DateFormat.Tai64n));
         assertThat(DateFormat.fromString("tai64n"), equalTo(DateFormat.Joda));
-        assertThat(DateFormat.fromString("prefix-" + randomAsciiOfLengthBetween(1, 10)), equalTo(DateFormat.Joda));
+        assertThat(DateFormat.fromString("prefix-" + randomAlphaOfLengthBetween(1, 10)), equalTo(DateFormat.Joda));
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorFactoryTests.java
@@ -37,10 +37,10 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testBuildDefaults() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String sourceField = randomAsciiOfLengthBetween(1, 10);
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("formats", Collections.singletonList("dd/MM/yyyyy"));
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         DateProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getField(), equalTo(sourceField));
@@ -53,7 +53,7 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testMatchFieldIsMandatory() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String targetField = randomAsciiOfLengthBetween(1, 10);
+        String targetField = randomAlphaOfLengthBetween(1, 10);
         config.put("target_field", targetField);
         config.put("formats", Collections.singletonList("dd/MM/yyyyy"));
 
@@ -68,8 +68,8 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testMatchFormatsIsMandatory() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String sourceField = randomAsciiOfLengthBetween(1, 10);
-        String targetField = randomAsciiOfLengthBetween(1, 10);
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
+        String targetField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("target_field", targetField);
 
@@ -84,7 +84,7 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testParseLocale() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String sourceField = randomAsciiOfLengthBetween(1, 10);
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("formats", Collections.singletonList("dd/MM/yyyyy"));
         Locale locale = randomLocale(random());
@@ -97,7 +97,7 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testParseInvalidLocale() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String sourceField = randomAsciiOfLengthBetween(1, 10);
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("formats", Collections.singletonList("dd/MM/yyyyy"));
         config.put("locale", "invalid_locale");
@@ -112,7 +112,7 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testParseTimezone() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String sourceField = randomAsciiOfLengthBetween(1, 10);
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("formats", Collections.singletonList("dd/MM/yyyyy"));
 
@@ -125,7 +125,7 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testParseInvalidTimezone() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String sourceField = randomAsciiOfLengthBetween(1, 10);
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("match_formats", Collections.singletonList("dd/MM/yyyyy"));
         config.put("timezone", "invalid_timezone");
@@ -140,7 +140,7 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testParseMatchFormats() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String sourceField = randomAsciiOfLengthBetween(1, 10);
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("formats", Arrays.asList("dd/MM/yyyy", "dd-MM-yyyy"));
 
@@ -151,7 +151,7 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testParseMatchFormatsFailure() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String sourceField = randomAsciiOfLengthBetween(1, 10);
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("formats", "dd/MM/yyyy");
 
@@ -166,8 +166,8 @@ public class DateProcessorFactoryTests extends ESTestCase {
     public void testParseTargetField() throws Exception {
         DateProcessor.Factory factory = new DateProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String sourceField = randomAsciiOfLengthBetween(1, 10);
-        String targetField = randomAsciiOfLengthBetween(1, 10);
+        String sourceField = randomAlphaOfLengthBetween(1, 10);
+        String targetField = randomAlphaOfLengthBetween(1, 10);
         config.put("field", sourceField);
         config.put("target_field", targetField);
         config.put("formats", Arrays.asList("dd/MM/yyyy", "dd-MM-yyyy"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -38,7 +38,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class DateProcessorTests extends ESTestCase {
 
     public void testJodaPattern() {
-        DateProcessor dateProcessor = new DateProcessor(randomAsciiOfLength(10), DateTimeZone.forID("Europe/Amsterdam"), Locale.ENGLISH,
+        DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10), DateTimeZone.forID("Europe/Amsterdam"), Locale.ENGLISH,
                 "date_as_string", Collections.singletonList("yyyy dd MM hh:mm:ss"), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "2010 12 06 11:05:15");
@@ -52,7 +52,7 @@ public class DateProcessorTests extends ESTestCase {
         matchFormats.add("yyyy dd MM");
         matchFormats.add("dd/MM/yyyy");
         matchFormats.add("dd-MM-yyyy");
-        DateProcessor dateProcessor = new DateProcessor(randomAsciiOfLength(10), DateTimeZone.forID("Europe/Amsterdam"), Locale.ENGLISH,
+        DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10), DateTimeZone.forID("Europe/Amsterdam"), Locale.ENGLISH,
                 "date_as_string", matchFormats, "date_as_date");
 
         Map<String, Object> document = new HashMap<>();
@@ -86,7 +86,7 @@ public class DateProcessorTests extends ESTestCase {
 
     public void testInvalidJodaPattern() {
         try {
-            new DateProcessor(randomAsciiOfLength(10), DateTimeZone.UTC, randomLocale(random()),
+            new DateProcessor(randomAlphaOfLength(10), DateTimeZone.UTC, randomLocale(random()),
                 "date_as_string", Collections.singletonList("invalid pattern"), "date_as_date");
             fail("date processor initialization should have failed");
         } catch(IllegalArgumentException e) {
@@ -95,7 +95,7 @@ public class DateProcessorTests extends ESTestCase {
     }
 
     public void testJodaPatternLocale() {
-        DateProcessor dateProcessor = new DateProcessor(randomAsciiOfLength(10), DateTimeZone.forID("Europe/Amsterdam"), Locale.ITALIAN,
+        DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10), DateTimeZone.forID("Europe/Amsterdam"), Locale.ITALIAN,
                 "date_as_string", Collections.singletonList("yyyy dd MMM"), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "2010 12 giugno");
@@ -105,7 +105,7 @@ public class DateProcessorTests extends ESTestCase {
     }
 
     public void testJodaPatternDefaultYear() {
-        DateProcessor dateProcessor = new DateProcessor(randomAsciiOfLength(10), DateTimeZone.forID("Europe/Amsterdam"), Locale.ENGLISH,
+        DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10), DateTimeZone.forID("Europe/Amsterdam"), Locale.ENGLISH,
             "date_as_string", Collections.singletonList("dd/MM"), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "12/06");
@@ -116,7 +116,7 @@ public class DateProcessorTests extends ESTestCase {
     }
 
     public void testTAI64N() {
-        DateProcessor dateProcessor = new DateProcessor(randomAsciiOfLength(10), DateTimeZone.forOffsetHours(2), randomLocale(random()),
+        DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10), DateTimeZone.forOffsetHours(2), randomLocale(random()),
                 "date_as_string", Collections.singletonList("TAI64N"), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         String dateAsString = (randomBoolean() ? "@" : "") + "4000000050d506482dbdf024";
@@ -127,7 +127,7 @@ public class DateProcessorTests extends ESTestCase {
     }
 
     public void testUnixMs() {
-        DateProcessor dateProcessor = new DateProcessor(randomAsciiOfLength(10), DateTimeZone.UTC, randomLocale(random()),
+        DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10), DateTimeZone.UTC, randomLocale(random()),
                 "date_as_string", Collections.singletonList("UNIX_MS"), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "1000500");
@@ -137,7 +137,7 @@ public class DateProcessorTests extends ESTestCase {
     }
 
     public void testUnix() {
-        DateProcessor dateProcessor = new DateProcessor(randomAsciiOfLength(10), DateTimeZone.UTC, randomLocale(random()),
+        DateProcessor dateProcessor = new DateProcessor(randomAlphaOfLength(10), DateTimeZone.UTC, randomLocale(random()),
                 "date_as_string", Collections.singletonList("UNIX"), "date_as_date");
         Map<String, Object> document = new HashMap<>();
         document.put("date_as_string", "1000.5");

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/FailProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/FailProcessorFactoryTests.java
@@ -43,7 +43,7 @@ public class FailProcessorFactoryTests extends ESTestCase {
     public void testCreate() throws Exception {
         Map<String, Object> config = new HashMap<>();
         config.put("message", "error");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         FailProcessor failProcessor = factory.create(null, processorTag, config);
         assertThat(failProcessor.getTag(), equalTo(processorTag));
         assertThat(failProcessor.getMessage().execute(Collections.emptyMap()), equalTo("error"));
@@ -63,7 +63,7 @@ public class FailProcessorFactoryTests extends ESTestCase {
         FailProcessor.Factory factory = new FailProcessor.Factory(TestTemplateService.instance(true));
         Map<String, Object> config = new HashMap<>();
         config.put("message", "error");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, () -> factory.create(null, processorTag, config));
         assertThat(exception.getMessage(), equalTo("java.lang.RuntimeException: could not compile script"));
         assertThat(exception.getHeader("processor_tag").get(0), equalTo(processorTag));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/FailProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/FailProcessorTests.java
@@ -31,8 +31,8 @@ public class FailProcessorTests extends ESTestCase {
 
     public void test() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
-        String message = randomAsciiOfLength(10);
-        Processor processor = new FailProcessor(randomAsciiOfLength(10), new TestTemplateService.MockTemplate(message));
+        String message = randomAlphaOfLength(10);
+        Processor processor = new FailProcessor(randomAlphaOfLength(10), new TestTemplateService.MockTemplate(message));
         try {
             processor.execute(ingestDocument);
             fail("fail processor should throw an exception");

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorFactoryTests.java
@@ -38,7 +38,7 @@ public class GrokProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("patterns", Collections.singletonList("(?<foo>\\w+)"));
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         GrokProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getMatchField(), equalTo("_field"));
@@ -53,7 +53,7 @@ public class GrokProcessorFactoryTests extends ESTestCase {
         config.put("field", "_field");
         config.put("patterns", Collections.singletonList("(?<foo>\\w+)"));
         config.put("ignore_missing", true);
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         GrokProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getMatchField(), equalTo("_field"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorTests.java
@@ -38,7 +38,7 @@ public class GrokProcessorTests extends ESTestCase {
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         doc.setFieldValue(fieldName, "1");
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), Collections.singletonMap("ONE", "1"),
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), Collections.singletonMap("ONE", "1"),
             Collections.singletonList("%{ONE:one}"), fieldName, false, false);
         processor.execute(doc);
         assertThat(doc.getFieldValue("one", String.class), equalTo("1"));
@@ -48,7 +48,7 @@ public class GrokProcessorTests extends ESTestCase {
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         doc.setFieldValue(fieldName, "23");
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), Collections.singletonMap("ONE", "1"),
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), Collections.singletonMap("ONE", "1"),
             Collections.singletonList("%{ONE:one}"), fieldName, false, false);
         Exception e = expectThrows(Exception.class, () -> processor.execute(doc));
         assertThat(e.getMessage(), equalTo("Provided Grok expressions do not match field value: [23]"));
@@ -59,7 +59,7 @@ public class GrokProcessorTests extends ESTestCase {
         IngestDocument originalDoc = new IngestDocument(new HashMap<>(), new HashMap<>());
         originalDoc.setFieldValue(fieldName, fieldName);
         IngestDocument doc = new IngestDocument(originalDoc);
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), Collections.emptyMap(),
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), Collections.emptyMap(),
             Collections.singletonList(fieldName), fieldName, false, false);
         processor.execute(doc);
         assertThat(doc, equalTo(originalDoc));
@@ -69,7 +69,7 @@ public class GrokProcessorTests extends ESTestCase {
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         doc.setFieldValue(fieldName, null);
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), Collections.singletonMap("ONE", "1"),
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), Collections.singletonMap("ONE", "1"),
             Collections.singletonList("%{ONE:one}"), fieldName, false, false);
         Exception e = expectThrows(Exception.class, () -> processor.execute(doc));
         assertThat(e.getMessage(), equalTo("field [" + fieldName + "] is null, cannot process it."));
@@ -80,7 +80,7 @@ public class GrokProcessorTests extends ESTestCase {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         originalIngestDocument.setFieldValue(fieldName, null);
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), Collections.singletonMap("ONE", "1"),
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), Collections.singletonMap("ONE", "1"),
             Collections.singletonList("%{ONE:one}"), fieldName, false, true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
@@ -90,7 +90,7 @@ public class GrokProcessorTests extends ESTestCase {
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         doc.setFieldValue(fieldName, 1);
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), Collections.singletonMap("ONE", "1"),
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), Collections.singletonMap("ONE", "1"),
             Collections.singletonList("%{ONE:one}"), fieldName, false, false);
         Exception e = expectThrows(Exception.class, () -> processor.execute(doc));
         assertThat(e.getMessage(), equalTo("field [" + fieldName + "] of type [java.lang.Integer] cannot be cast to [java.lang.String]"));
@@ -100,7 +100,7 @@ public class GrokProcessorTests extends ESTestCase {
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         doc.setFieldValue(fieldName, 1);
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), Collections.singletonMap("ONE", "1"),
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), Collections.singletonMap("ONE", "1"),
             Collections.singletonList("%{ONE:one}"), fieldName, false, true);
         Exception e = expectThrows(Exception.class, () -> processor.execute(doc));
         assertThat(e.getMessage(), equalTo("field [" + fieldName + "] of type [java.lang.Integer] cannot be cast to [java.lang.String]"));
@@ -109,7 +109,7 @@ public class GrokProcessorTests extends ESTestCase {
     public void testMissingField() {
         String fieldName = "foo.bar";
         IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), Collections.singletonMap("ONE", "1"),
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), Collections.singletonMap("ONE", "1"),
             Collections.singletonList("%{ONE:one}"), fieldName, false, false);
         Exception e = expectThrows(Exception.class, () -> processor.execute(doc));
         assertThat(e.getMessage(), equalTo("field [foo] not present as part of path [foo.bar]"));
@@ -119,7 +119,7 @@ public class GrokProcessorTests extends ESTestCase {
         String fieldName = "foo.bar";
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), Collections.singletonMap("ONE", "1"),
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), Collections.singletonMap("ONE", "1"),
             Collections.singletonList("%{ONE:one}"), fieldName, false, true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
@@ -133,7 +133,7 @@ public class GrokProcessorTests extends ESTestCase {
         patternBank.put("ONE", "1");
         patternBank.put("TWO", "2");
         patternBank.put("THREE", "3");
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), patternBank,
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), patternBank,
             Arrays.asList("%{ONE:one}", "%{TWO:two}", "%{THREE:three}"), fieldName, false, false);
         processor.execute(doc);
         assertThat(doc.hasField("one"), equalTo(false));
@@ -149,7 +149,7 @@ public class GrokProcessorTests extends ESTestCase {
         patternBank.put("ONE", "1");
         patternBank.put("TWO", "2");
         patternBank.put("THREE", "3");
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), patternBank,
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), patternBank,
             Arrays.asList("%{ONE:one}", "%{TWO:two}", "%{THREE:three}"), fieldName, true, false);
         processor.execute(doc);
         assertThat(doc.hasField("one"), equalTo(false));
@@ -164,7 +164,7 @@ public class GrokProcessorTests extends ESTestCase {
         doc.setFieldValue(fieldName, "first1");
         Map<String, String> patternBank = new HashMap<>();
         patternBank.put("ONE", "1");
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), patternBank,
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), patternBank,
             Arrays.asList("%{ONE:one}"), fieldName, true, false);
         processor.execute(doc);
         assertThat(doc.hasField("one"), equalTo(true));
@@ -195,7 +195,7 @@ public class GrokProcessorTests extends ESTestCase {
         patternBank.put("ONE", "1");
         patternBank.put("TWO", "2");
         patternBank.put("THREE", "3");
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), patternBank,
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), patternBank,
             Arrays.asList("%{ONE:first}-%{TWO:second}", "%{ONE:first}-%{THREE:second}"), fieldName, randomBoolean(), randomBoolean());
         processor.execute(doc);
         assertThat(doc.getFieldValue("first", String.class), equalTo("1"));
@@ -208,7 +208,7 @@ public class GrokProcessorTests extends ESTestCase {
         doc.setFieldValue(fieldName, "12");
         Map<String, String> patternBank = new HashMap<>();
         patternBank.put("ONETWO", "1|2");
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), patternBank,
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), patternBank,
             Collections.singletonList("%{ONETWO:first}%{ONETWO:first}"), fieldName, randomBoolean(), randomBoolean());
         processor.execute(doc);
         assertThat(doc.getFieldValue("first", String.class), equalTo("1"));
@@ -221,7 +221,7 @@ public class GrokProcessorTests extends ESTestCase {
         Map<String, String> patternBank = new HashMap<>();
         patternBank.put("ONETWO", "1|2");
         patternBank.put("THREE", "3");
-        GrokProcessor processor = new GrokProcessor(randomAsciiOfLength(10), patternBank,
+        GrokProcessor processor = new GrokProcessor(randomAlphaOfLength(10), patternBank,
             Collections.singletonList("%{ONETWO:first}|%{THREE:second}"), fieldName, randomBoolean(), randomBoolean());
         processor.execute(doc);
         assertFalse(doc.hasField("first"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorFactoryTests.java
@@ -36,7 +36,7 @@ public class GsubProcessorFactoryTests extends ESTestCase {
         config.put("field", "field1");
         config.put("pattern", "\\.");
         config.put("replacement", "-");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         GsubProcessor gsubProcessor = factory.create(null, processorTag, config);
         assertThat(gsubProcessor.getTag(), equalTo(processorTag));
         assertThat(gsubProcessor.getField(), equalTo("field1"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorTests.java
@@ -36,7 +36,7 @@ public class GsubProcessorTests extends ESTestCase {
     public void testGsub() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "127.0.0.1");
-        Processor processor = new GsubProcessor(randomAsciiOfLength(10), fieldName, Pattern.compile("\\."), "-");
+        Processor processor = new GsubProcessor(randomAlphaOfLength(10), fieldName, Pattern.compile("\\."), "-");
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, String.class), equalTo("127-0-0-1"));
     }
@@ -45,7 +45,7 @@ public class GsubProcessorTests extends ESTestCase {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         ingestDocument.setFieldValue(fieldName, 123);
-        Processor processor = new GsubProcessor(randomAsciiOfLength(10), fieldName, Pattern.compile("\\."), "-");
+        Processor processor = new GsubProcessor(randomAlphaOfLength(10), fieldName, Pattern.compile("\\."), "-");
         try {
             processor.execute(ingestDocument);
             fail("processor execution should have failed");
@@ -58,7 +58,7 @@ public class GsubProcessorTests extends ESTestCase {
     public void testGsubFieldNotFound() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        Processor processor = new GsubProcessor(randomAsciiOfLength(10), fieldName, Pattern.compile("\\."), "-");
+        Processor processor = new GsubProcessor(randomAlphaOfLength(10), fieldName, Pattern.compile("\\."), "-");
         try {
             processor.execute(ingestDocument);
             fail("processor execution should have failed");
@@ -69,7 +69,7 @@ public class GsubProcessorTests extends ESTestCase {
 
     public void testGsubNullValue() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
-        Processor processor = new GsubProcessor(randomAsciiOfLength(10), "field", Pattern.compile("\\."), "-");
+        Processor processor = new GsubProcessor(randomAlphaOfLength(10), "field", Pattern.compile("\\."), "-");
         try {
             processor.execute(ingestDocument);
             fail("processor execution should have failed");

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JoinProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JoinProcessorFactoryTests.java
@@ -34,7 +34,7 @@ public class JoinProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("separator", "-");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         JoinProcessor joinProcessor = factory.create(null, processorTag, config);
         assertThat(joinProcessor.getTag(), equalTo(processorTag));
         assertThat(joinProcessor.getField(), equalTo("field1"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JoinProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JoinProcessorTests.java
@@ -43,7 +43,7 @@ public class JoinProcessorTests extends ESTestCase {
         List<String> fieldValue = new ArrayList<>(numItems);
         String expectedResult = "";
         for (int j = 0; j < numItems; j++) {
-            String value = randomAsciiOfLengthBetween(1, 10);
+            String value = randomAlphaOfLengthBetween(1, 10);
             fieldValue.add(value);
             expectedResult += value;
             if (j < numItems - 1) {
@@ -51,7 +51,7 @@ public class JoinProcessorTests extends ESTestCase {
             }
         }
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new JoinProcessor(randomAsciiOfLength(10), fieldName, separator);
+        Processor processor = new JoinProcessor(randomAlphaOfLength(10), fieldName, separator);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, String.class), equalTo(expectedResult));
     }
@@ -71,7 +71,7 @@ public class JoinProcessorTests extends ESTestCase {
             }
         }
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new JoinProcessor(randomAsciiOfLength(10), fieldName, separator);
+        Processor processor = new JoinProcessor(randomAlphaOfLength(10), fieldName, separator);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, String.class), equalTo(expectedResult));
     }
@@ -79,8 +79,8 @@ public class JoinProcessorTests extends ESTestCase {
     public void testJoinNonListField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        ingestDocument.setFieldValue(fieldName, randomAsciiOfLengthBetween(1, 10));
-        Processor processor = new JoinProcessor(randomAsciiOfLength(10), fieldName, "-");
+        ingestDocument.setFieldValue(fieldName, randomAlphaOfLengthBetween(1, 10));
+        Processor processor = new JoinProcessor(randomAlphaOfLength(10), fieldName, "-");
         try {
             processor.execute(ingestDocument);
         } catch(IllegalArgumentException e) {
@@ -91,7 +91,7 @@ public class JoinProcessorTests extends ESTestCase {
     public void testJoinNonExistingField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        Processor processor = new JoinProcessor(randomAsciiOfLength(10), fieldName, "-");
+        Processor processor = new JoinProcessor(randomAlphaOfLength(10), fieldName, "-");
         try {
             processor.execute(ingestDocument);
         } catch(IllegalArgumentException e) {
@@ -101,7 +101,7 @@ public class JoinProcessorTests extends ESTestCase {
 
     public void testJoinNullValue() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
-        Processor processor = new JoinProcessor(randomAsciiOfLength(10), "field", "-");
+        Processor processor = new JoinProcessor(randomAlphaOfLength(10), "field", "-");
         try {
             processor.execute(ingestDocument);
         } catch(IllegalArgumentException e) {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorFactoryTests.java
@@ -21,11 +21,8 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.test.ESTestCase;
-import org.junit.Before;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,9 +33,9 @@ public class JsonProcessorFactoryTests extends ESTestCase {
     private static final JsonProcessor.Factory FACTORY = new JsonProcessor.Factory();
 
     public void testCreate() throws Exception {
-        String processorTag = randomAsciiOfLength(10);
-        String randomField = randomAsciiOfLength(10);
-        String randomTargetField = randomAsciiOfLength(5);
+        String processorTag = randomAlphaOfLength(10);
+        String randomField = randomAlphaOfLength(10);
+        String randomTargetField = randomAlphaOfLength(5);
         Map<String, Object> config = new HashMap<>();
         config.put("field", randomField);
         config.put("target_field", randomTargetField);
@@ -49,8 +46,8 @@ public class JsonProcessorFactoryTests extends ESTestCase {
     }
 
     public void testCreateWithAddToRoot() throws Exception {
-        String processorTag = randomAsciiOfLength(10);
-        String randomField = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
+        String randomField = randomAlphaOfLength(10);
         Map<String, Object> config = new HashMap<>();
         config.put("field", randomField);
         config.put("add_to_root", true);
@@ -62,8 +59,8 @@ public class JsonProcessorFactoryTests extends ESTestCase {
     }
 
     public void testCreateWithDefaultTarget() throws Exception {
-        String processorTag = randomAsciiOfLength(10);
-        String randomField = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
+        String randomField = randomAlphaOfLength(10);
         Map<String, Object> config = new HashMap<>();
         config.put("field", randomField);
         JsonProcessor jsonProcessor = FACTORY.create(null, processorTag, config);
@@ -74,21 +71,21 @@ public class JsonProcessorFactoryTests extends ESTestCase {
 
     public void testCreateWithMissingField() throws Exception {
         Map<String, Object> config = new HashMap<>();
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ElasticsearchException exception = expectThrows(ElasticsearchParseException.class,
             () -> FACTORY.create(null, processorTag, config));
         assertThat(exception.getMessage(), equalTo("[field] required property is missing"));
     }
 
     public void testCreateWithBothTargetFieldAndAddToRoot() throws Exception {
-        String randomField = randomAsciiOfLength(10);
-        String randomTargetField = randomAsciiOfLength(5);
+        String randomField = randomAlphaOfLength(10);
+        String randomTargetField = randomAlphaOfLength(5);
         Map<String, Object> config = new HashMap<>();
         config.put("field", randomField);
         config.put("target_field", randomTargetField);
         config.put("add_to_root", true);
         ElasticsearchException exception = expectThrows(ElasticsearchParseException.class,
-            () -> FACTORY.create(null, randomAsciiOfLength(10), config));
+            () -> FACTORY.create(null, randomAlphaOfLength(10), config));
         assertThat(exception.getMessage(), equalTo("[target_field] Cannot set a target field while also setting `add_to_root` to true"));
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
@@ -36,9 +36,9 @@ public class JsonProcessorTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testExecute() throws Exception {
-        String processorTag = randomAsciiOfLength(3);
-        String randomField = randomAsciiOfLength(3);
-        String randomTargetField = randomAsciiOfLength(2);
+        String processorTag = randomAlphaOfLength(3);
+        String randomField = randomAlphaOfLength(3);
+        String randomTargetField = randomAlphaOfLength(2);
         JsonProcessor jsonProcessor = new JsonProcessor(processorTag, randomField, randomTargetField, false);
         Map<String, Object> document = new HashMap<>();
 
@@ -76,8 +76,8 @@ public class JsonProcessorTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testAddToRoot() throws Exception {
-        String processorTag = randomAsciiOfLength(3);
-        String randomTargetField = randomAsciiOfLength(2);
+        String processorTag = randomAlphaOfLength(3);
+        String randomTargetField = randomAlphaOfLength(2);
         JsonProcessor jsonProcessor = new JsonProcessor(processorTag, "a", randomTargetField, true);
         Map<String, Object> document = new HashMap<>();
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/KeyValueProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/KeyValueProcessorFactoryTests.java
@@ -39,7 +39,7 @@ public class KeyValueProcessorFactoryTests extends ESTestCase {
         config.put("field", "field1");
         config.put("field_split", "&");
         config.put("value_split", "=");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         KeyValueProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getField(), equalTo("field1"));
@@ -59,7 +59,7 @@ public class KeyValueProcessorFactoryTests extends ESTestCase {
         config.put("target_field", "target");
         config.put("include_keys", Arrays.asList("a", "b"));
         config.put("ignore_missing", true);
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         KeyValueProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getField(), equalTo("field1"));
@@ -73,7 +73,7 @@ public class KeyValueProcessorFactoryTests extends ESTestCase {
     public void testCreateWithMissingField() {
         KeyValueProcessor.Factory factory = new KeyValueProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ElasticsearchException exception = expectThrows(ElasticsearchParseException.class,
             () -> factory.create(null, processorTag, config));
         assertThat(exception.getMessage(), equalTo("[field] required property is missing"));
@@ -83,7 +83,7 @@ public class KeyValueProcessorFactoryTests extends ESTestCase {
         KeyValueProcessor.Factory factory = new KeyValueProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ElasticsearchException exception = expectThrows(ElasticsearchParseException.class,
             () -> factory.create(null, processorTag, config));
         assertThat(exception.getMessage(), equalTo("[field_split] required property is missing"));
@@ -94,7 +94,7 @@ public class KeyValueProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("field_split", "&");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ElasticsearchException exception = expectThrows(ElasticsearchParseException.class,
             () -> factory.create(null, processorTag, config));
         assertThat(exception.getMessage(), equalTo("[value_split] required property is missing"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/KeyValueProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/KeyValueProcessorTests.java
@@ -36,7 +36,7 @@ public class KeyValueProcessorTests extends ESTestCase {
     public void test() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "first=hello&second=world&second=universe");
-        Processor processor = new KeyValueProcessor(randomAsciiOfLength(10), fieldName, "&", "=", null, "target", false);
+        Processor processor = new KeyValueProcessor(randomAlphaOfLength(10), fieldName, "&", "=", null, "target", false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue("target.first", String.class), equalTo("hello"));
         assertThat(ingestDocument.getFieldValue("target.second", List.class), equalTo(Arrays.asList("world", "universe")));
@@ -45,7 +45,7 @@ public class KeyValueProcessorTests extends ESTestCase {
     public void testRootTarget() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         ingestDocument.setFieldValue("myField", "first=hello&second=world&second=universe");
-        Processor processor = new KeyValueProcessor(randomAsciiOfLength(10), "myField", "&", "=", null, null, false);
+        Processor processor = new KeyValueProcessor(randomAlphaOfLength(10), "myField", "&", "=", null, null, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue("first", String.class), equalTo("hello"));
         assertThat(ingestDocument.getFieldValue("second", List.class), equalTo(Arrays.asList("world", "universe")));
@@ -54,7 +54,7 @@ public class KeyValueProcessorTests extends ESTestCase {
     public void testKeySameAsSourceField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         ingestDocument.setFieldValue("first", "first=hello");
-        Processor processor = new KeyValueProcessor(randomAsciiOfLength(10), "first", "&", "=", null, null, false);
+        Processor processor = new KeyValueProcessor(randomAlphaOfLength(10), "first", "&", "=", null, null, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue("first", List.class), equalTo(Arrays.asList("first=hello", "hello")));
     }
@@ -62,7 +62,7 @@ public class KeyValueProcessorTests extends ESTestCase {
     public void testIncludeKeys() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "first=hello&second=world&second=universe");
-        Processor processor = new KeyValueProcessor(randomAsciiOfLength(10), fieldName, "&", "=",
+        Processor processor = new KeyValueProcessor(randomAlphaOfLength(10), fieldName, "&", "=",
             Collections.singletonList("first"), "target", false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue("target.first", String.class), equalTo("hello"));
@@ -71,7 +71,7 @@ public class KeyValueProcessorTests extends ESTestCase {
 
     public void testMissingField() {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
-        Processor processor = new KeyValueProcessor(randomAsciiOfLength(10), "unknown", "&", "=", null, "target", false);
+        Processor processor = new KeyValueProcessor(randomAlphaOfLength(10), "unknown", "&", "=", null, "target", false);
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
         assertThat(exception.getMessage(), equalTo("field [unknown] not present as part of path [unknown]"));
     }
@@ -81,7 +81,7 @@ public class KeyValueProcessorTests extends ESTestCase {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap(fieldName, null));
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
-        Processor processor = new KeyValueProcessor(randomAsciiOfLength(10), fieldName, "", "", null, "target", true);
+        Processor processor = new KeyValueProcessor(randomAlphaOfLength(10), fieldName, "", "", null, "target", true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
     }
@@ -89,7 +89,7 @@ public class KeyValueProcessorTests extends ESTestCase {
     public void testNonExistentWithIgnoreMissing() throws Exception {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
-        Processor processor = new KeyValueProcessor(randomAsciiOfLength(10), "unknown", "", "", null, "target", true);
+        Processor processor = new KeyValueProcessor(randomAlphaOfLength(10), "unknown", "", "", null, "target", true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
     }
@@ -97,7 +97,7 @@ public class KeyValueProcessorTests extends ESTestCase {
     public void testFailFieldSplitMatch() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "first=hello|second=world|second=universe");
-        Processor processor = new KeyValueProcessor(randomAsciiOfLength(10), fieldName, "&", "=", null, "target", false);
+        Processor processor = new KeyValueProcessor(randomAlphaOfLength(10), fieldName, "&", "=", null, "target", false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue("target.first", String.class), equalTo("hello|second=world|second=universe"));
         assertFalse(ingestDocument.hasField("target.second"));
@@ -105,7 +105,7 @@ public class KeyValueProcessorTests extends ESTestCase {
 
     public void testFailValueSplitMatch() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("foo", "bar"));
-        Processor processor = new KeyValueProcessor(randomAsciiOfLength(10), "foo", "&", "=", null, "target", false);
+        Processor processor = new KeyValueProcessor(randomAlphaOfLength(10), "foo", "&", "=", null, "target", false);
         Exception exception = expectThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
         assertThat(exception.getMessage(), equalTo("field [foo] does not contain value_split [=]"));
     }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/LowercaseProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/LowercaseProcessorFactoryTests.java
@@ -34,7 +34,7 @@ public class LowercaseProcessorFactoryTests extends ESTestCase {
         LowercaseProcessor.Factory factory = new LowercaseProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         LowercaseProcessor uppercaseProcessor = (LowercaseProcessor)factory.create(null, processorTag, config);
         assertThat(uppercaseProcessor.getTag(), equalTo(processorTag));
         assertThat(uppercaseProcessor.getField(), equalTo("field1"));
@@ -46,7 +46,7 @@ public class LowercaseProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("ignore_missing", true);
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         LowercaseProcessor uppercaseProcessor = (LowercaseProcessor)factory.create(null, processorTag, config);
         assertThat(uppercaseProcessor.getTag(), equalTo(processorTag));
         assertThat(uppercaseProcessor.getField(), equalTo("field1"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/LowercaseProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/LowercaseProcessorTests.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 public class LowercaseProcessorTests extends AbstractStringProcessorTestCase {
     @Override
     protected AbstractStringProcessor newProcessor(String field, boolean ignoreMissing) {
-        return new LowercaseProcessor(randomAsciiOfLength(10), field, ignoreMissing);
+        return new LowercaseProcessor(randomAlphaOfLength(10), field, ignoreMissing);
     }
 
     @Override

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorFactoryTests.java
@@ -43,7 +43,7 @@ public class RemoveProcessorFactoryTests extends ESTestCase {
     public void testCreate() throws Exception {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         RemoveProcessor removeProcessor = factory.create(null, processorTag, config);
         assertThat(removeProcessor.getTag(), equalTo(processorTag));
         assertThat(removeProcessor.getField().execute(Collections.emptyMap()), equalTo("field1"));
@@ -63,7 +63,7 @@ public class RemoveProcessorFactoryTests extends ESTestCase {
         RemoveProcessor.Factory factory = new RemoveProcessor.Factory(TestTemplateService.instance(true));
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, () -> factory.create(null, processorTag, config));
         assertThat(exception.getMessage(), equalTo("java.lang.RuntimeException: could not compile script"));
         assertThat(exception.getHeader("processor_tag").get(0), equalTo(processorTag));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
@@ -35,7 +35,7 @@ public class RemoveProcessorTests extends ESTestCase {
     public void testRemoveFields() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String field = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
-        Processor processor = new RemoveProcessor(randomAsciiOfLength(10), new TestTemplateService.MockTemplate(field));
+        Processor processor = new RemoveProcessor(randomAlphaOfLength(10), new TestTemplateService.MockTemplate(field));
         processor.execute(ingestDocument);
         assertThat(ingestDocument.hasField(field), equalTo(false));
     }
@@ -43,7 +43,7 @@ public class RemoveProcessorTests extends ESTestCase {
     public void testRemoveNonExistingField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        Processor processor = new RemoveProcessor(randomAsciiOfLength(10), new TestTemplateService.MockTemplate(fieldName));
+        Processor processor = new RemoveProcessor(randomAlphaOfLength(10), new TestTemplateService.MockTemplate(fieldName));
         try {
             processor.execute(ingestDocument);
             fail("remove field should have failed");

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RenameProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RenameProcessorFactoryTests.java
@@ -34,7 +34,7 @@ public class RenameProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "old_field");
         config.put("target_field", "new_field");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         RenameProcessor renameProcessor = factory.create(null, processorTag, config);
         assertThat(renameProcessor.getTag(), equalTo(processorTag));
         assertThat(renameProcessor.getField(), equalTo("old_field"));
@@ -48,7 +48,7 @@ public class RenameProcessorFactoryTests extends ESTestCase {
         config.put("field", "old_field");
         config.put("target_field", "new_field");
         config.put("ignore_missing", true);
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         RenameProcessor renameProcessor = factory.create(null, processorTag, config);
         assertThat(renameProcessor.getTag(), equalTo(processorTag));
         assertThat(renameProcessor.getField(), equalTo("old_field"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RenameProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RenameProcessorTests.java
@@ -45,7 +45,7 @@ public class RenameProcessorTests extends ESTestCase {
         do {
             newFieldName = RandomDocumentPicks.randomFieldName(random());
         } while (RandomDocumentPicks.canAddField(newFieldName, ingestDocument) == false || newFieldName.equals(fieldName));
-        Processor processor = new RenameProcessor(randomAsciiOfLength(10), fieldName, newFieldName, false);
+        Processor processor = new RenameProcessor(randomAlphaOfLength(10), fieldName, newFieldName, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(newFieldName, Object.class), equalTo(fieldValue));
     }
@@ -63,7 +63,7 @@ public class RenameProcessorTests extends ESTestCase {
         document.put("one", one);
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
 
-        Processor processor = new RenameProcessor(randomAsciiOfLength(10), "list.0", "item", false);
+        Processor processor = new RenameProcessor(randomAlphaOfLength(10), "list.0", "item", false);
         processor.execute(ingestDocument);
         Object actualObject = ingestDocument.getSourceAndMetadata().get("list");
         assertThat(actualObject, instanceOf(List.class));
@@ -76,7 +76,7 @@ public class RenameProcessorTests extends ESTestCase {
         assertThat(actualObject, instanceOf(String.class));
         assertThat(actualObject, equalTo("item1"));
 
-        processor = new RenameProcessor(randomAsciiOfLength(10), "list.0", "list.3", false);
+        processor = new RenameProcessor(randomAlphaOfLength(10), "list.0", "list.3", false);
         try {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");
@@ -91,7 +91,7 @@ public class RenameProcessorTests extends ESTestCase {
     public void testRenameNonExistingField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        Processor processor = new RenameProcessor(randomAsciiOfLength(10), fieldName,
+        Processor processor = new RenameProcessor(randomAlphaOfLength(10), fieldName,
             RandomDocumentPicks.randomFieldName(random()), false);
         try {
             processor.execute(ingestDocument);
@@ -105,7 +105,7 @@ public class RenameProcessorTests extends ESTestCase {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        Processor processor = new RenameProcessor(randomAsciiOfLength(10), fieldName,
+        Processor processor = new RenameProcessor(randomAlphaOfLength(10), fieldName,
             RandomDocumentPicks.randomFieldName(random()), true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
@@ -114,7 +114,7 @@ public class RenameProcessorTests extends ESTestCase {
     public void testRenameNewFieldAlreadyExists() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String fieldName = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
-        Processor processor = new RenameProcessor(randomAsciiOfLength(10), RandomDocumentPicks.randomExistingFieldName(
+        Processor processor = new RenameProcessor(randomAlphaOfLength(10), RandomDocumentPicks.randomExistingFieldName(
                 random(), ingestDocument), fieldName, false);
         try {
             processor.execute(ingestDocument);
@@ -129,7 +129,7 @@ public class RenameProcessorTests extends ESTestCase {
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         ingestDocument.setFieldValue(fieldName, null);
         String newFieldName = RandomDocumentPicks.randomFieldName(random());
-        Processor processor = new RenameProcessor(randomAsciiOfLength(10), fieldName, newFieldName, false);
+        Processor processor = new RenameProcessor(randomAlphaOfLength(10), fieldName, newFieldName, false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.hasField(fieldName), equalTo(false));
         assertThat(ingestDocument.hasField(newFieldName), equalTo(true));
@@ -149,7 +149,7 @@ public class RenameProcessorTests extends ESTestCase {
         source.put("list", Collections.singletonList("item"));
 
         IngestDocument ingestDocument = new IngestDocument(source, Collections.emptyMap());
-        Processor processor = new RenameProcessor(randomAsciiOfLength(10), "list", "new_field", false);
+        Processor processor = new RenameProcessor(randomAlphaOfLength(10), "list", "new_field", false);
         try {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");
@@ -173,7 +173,7 @@ public class RenameProcessorTests extends ESTestCase {
         source.put("list", Collections.singletonList("item"));
 
         IngestDocument ingestDocument = new IngestDocument(source, Collections.emptyMap());
-        Processor processor = new RenameProcessor(randomAsciiOfLength(10), "list", "new_field", false);
+        Processor processor = new RenameProcessor(randomAlphaOfLength(10), "list", "new_field", false);
         try {
             processor.execute(ingestDocument);
             fail("processor execute should have failed");
@@ -188,12 +188,12 @@ public class RenameProcessorTests extends ESTestCase {
         Map<String, Object> source = new HashMap<>();
         source.put("foo", "bar");
         IngestDocument ingestDocument = new IngestDocument(source, Collections.emptyMap());
-        Processor processor1 = new RenameProcessor(randomAsciiOfLength(10), "foo", "foo.bar", false);
+        Processor processor1 = new RenameProcessor(randomAlphaOfLength(10), "foo", "foo.bar", false);
         processor1.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue("foo", Map.class), equalTo(Collections.singletonMap("bar", "bar")));
         assertThat(ingestDocument.getFieldValue("foo.bar", String.class), equalTo("bar"));
 
-        Processor processor2 = new RenameProcessor(randomAsciiOfLength(10), "foo.bar", "foo.bar.baz", false);
+        Processor processor2 = new RenameProcessor(randomAlphaOfLength(10), "foo.bar", "foo.bar.baz", false);
         processor2.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue("foo", Map.class), equalTo(Collections.singletonMap("bar",
                 Collections.singletonMap("baz", "bar"))));
@@ -201,7 +201,7 @@ public class RenameProcessorTests extends ESTestCase {
         assertThat(ingestDocument.getFieldValue("foo.bar.baz", String.class), equalTo("bar"));
 
         // for fun lets try to restore it (which don't allow today)
-        Processor processor3 = new RenameProcessor(randomAsciiOfLength(10), "foo.bar.baz", "foo", false);
+        Processor processor3 = new RenameProcessor(randomAlphaOfLength(10), "foo.bar.baz", "foo", false);
         Exception e = expectThrows(IllegalArgumentException.class, () -> processor3.execute(ingestDocument));
         assertThat(e.getMessage(), equalTo("field [foo] already exists"));
     }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorFactoryTests.java
@@ -57,7 +57,7 @@ public class ScriptProcessorFactoryTests extends ESTestCase {
         Map<String, Object> configMap = new HashMap<>();
         String randomType = randomFrom("id", "inline", "file");
         configMap.put(randomType, "foo");
-        ScriptProcessor processor = factory.create(null, randomAsciiOfLength(10), configMap);
+        ScriptProcessor processor = factory.create(null, randomAlphaOfLength(10), configMap);
         assertThat(processor.getScript().getLang(), equalTo(Script.DEFAULT_SCRIPT_LANG));
         assertThat(processor.getScript().getType().toString(), equalTo(ingestScriptParamToType.get(randomType)));
         assertThat(processor.getScript().getParams(), equalTo(Collections.emptyMap()));
@@ -66,10 +66,10 @@ public class ScriptProcessorFactoryTests extends ESTestCase {
     public void testFactoryValidationWithParams() throws Exception {
         Map<String, Object> configMap = new HashMap<>();
         String randomType = randomFrom("id", "inline", "file");
-        Map<String, Object> randomParams = Collections.singletonMap(randomAsciiOfLength(10), randomAsciiOfLength(10));
+        Map<String, Object> randomParams = Collections.singletonMap(randomAlphaOfLength(10), randomAlphaOfLength(10));
         configMap.put(randomType, "foo");
         configMap.put("params", randomParams);
-        ScriptProcessor processor = factory.create(null, randomAsciiOfLength(10), configMap);
+        ScriptProcessor processor = factory.create(null, randomAlphaOfLength(10), configMap);
         assertThat(processor.getScript().getLang(), equalTo(Script.DEFAULT_SCRIPT_LANG));
         assertThat(processor.getScript().getType().toString(), equalTo(ingestScriptParamToType.get(randomType)));
         assertThat(processor.getScript().getParams(), equalTo(randomParams));
@@ -88,7 +88,7 @@ public class ScriptProcessorFactoryTests extends ESTestCase {
         configMap.put("lang", "mockscript");
 
         ElasticsearchException exception = expectThrows(ElasticsearchException.class,
-            () -> factory.create(null, randomAsciiOfLength(10), configMap));
+            () -> factory.create(null, randomAlphaOfLength(10), configMap));
         assertThat(exception.getMessage(), is("Only one of [file], [id], or [inline] may be configured"));
     }
 
@@ -97,7 +97,7 @@ public class ScriptProcessorFactoryTests extends ESTestCase {
         configMap.put("lang", "mockscript");
 
         ElasticsearchException exception = expectThrows(ElasticsearchException.class,
-            () -> factory.create(null, randomAsciiOfLength(10), configMap));
+            () -> factory.create(null, randomAlphaOfLength(10), configMap));
 
         assertThat(exception.getMessage(), is("Need [file], [id], or [inline] parameter to refer to scripts"));
     }
@@ -115,7 +115,7 @@ public class ScriptProcessorFactoryTests extends ESTestCase {
         configMap.put(randomType, "my_script");
 
         ElasticsearchException exception = expectThrows(ElasticsearchException.class,
-            () -> factory.create(null, randomAsciiOfLength(10), configMap));
+            () -> factory.create(null, randomAlphaOfLength(10), configMap));
 
         assertThat(exception.getMessage(), is("compile-time exception"));
     }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorTests.java
@@ -58,7 +58,7 @@ public class ScriptProcessorTests extends ESTestCase {
             return null;
         }).when(executableScript).run();
 
-        ScriptProcessor processor = new ScriptProcessor(randomAsciiOfLength(10), script, scriptService);
+        ScriptProcessor processor = new ScriptProcessor(randomAlphaOfLength(10), script, scriptService);
 
         processor.execute(ingestDocument);
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorFactoryTests.java
@@ -44,7 +44,7 @@ public class SetProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("value", "value1");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         SetProcessor setProcessor = factory.create(null, processorTag, config);
         assertThat(setProcessor.getTag(), equalTo(processorTag));
         assertThat(setProcessor.getField().execute(Collections.emptyMap()), equalTo("field1"));
@@ -58,7 +58,7 @@ public class SetProcessorFactoryTests extends ESTestCase {
         config.put("field", "field1");
         config.put("value", "value1");
         config.put("override", overrideEnabled);
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         SetProcessor setProcessor = factory.create(null, processorTag, config);
         assertThat(setProcessor.getTag(), equalTo(processorTag));
         assertThat(setProcessor.getField().execute(Collections.emptyMap()), equalTo("field1"));
@@ -105,7 +105,7 @@ public class SetProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("value", "value1");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         ElasticsearchException exception = expectThrows(ElasticsearchException.class, () -> factory.create(null, processorTag, config));
         assertThat(exception.getMessage(), equalTo("java.lang.RuntimeException: could not compile script"));
         assertThat(exception.getHeader("processor_tag").get(0), equalTo(processorTag));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorTests.java
@@ -110,7 +110,7 @@ public class SetProcessorTests extends ESTestCase {
 
     private static Processor createSetProcessor(String fieldName, Object fieldValue, boolean overrideEnabled) {
         TemplateService templateService = TestTemplateService.instance();
-        return new SetProcessor(randomAsciiOfLength(10), templateService.compile(fieldName),
+        return new SetProcessor(randomAlphaOfLength(10), templateService.compile(fieldName),
                 ValueSource.wrap(fieldValue, templateService), overrideEnabled);
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SortProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SortProcessorTests.java
@@ -42,7 +42,7 @@ public class SortProcessorTests extends ESTestCase {
         List<String> fieldValue = new ArrayList<>(numItems);
         List<String> expectedResult = new ArrayList<>(numItems);
         for (int j = 0; j < numItems; j++) {
-            String value = randomAsciiOfLengthBetween(1, 10);
+            String value = randomAlphaOfLengthBetween(1, 10);
             fieldValue.add(value);
             expectedResult.add(value);
         }
@@ -54,7 +54,7 @@ public class SortProcessorTests extends ESTestCase {
         }
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         processor.execute(ingestDocument);
         assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
     }
@@ -68,7 +68,7 @@ public class SortProcessorTests extends ESTestCase {
         Collections.shuffle(fieldValue, random());
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, SortOrder.ASCENDING);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, SortOrder.ASCENDING);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, List.class).toArray(), equalTo(expectedResult));
     }
@@ -91,7 +91,7 @@ public class SortProcessorTests extends ESTestCase {
         }
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         processor.execute(ingestDocument);
         assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
     }
@@ -114,7 +114,7 @@ public class SortProcessorTests extends ESTestCase {
         }
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         processor.execute(ingestDocument);
         assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
     }
@@ -137,7 +137,7 @@ public class SortProcessorTests extends ESTestCase {
         }
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         processor.execute(ingestDocument);
         assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
     }
@@ -160,7 +160,7 @@ public class SortProcessorTests extends ESTestCase {
         }
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         processor.execute(ingestDocument);
         assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
     }
@@ -183,7 +183,7 @@ public class SortProcessorTests extends ESTestCase {
         }
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         processor.execute(ingestDocument);
         assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
     }
@@ -206,7 +206,7 @@ public class SortProcessorTests extends ESTestCase {
         }
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         processor.execute(ingestDocument);
         assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
     }
@@ -221,7 +221,7 @@ public class SortProcessorTests extends ESTestCase {
             if (randomBoolean()) {
                 value = String.valueOf(randomIntBetween(0, 100));
             } else {
-                value = randomAsciiOfLengthBetween(1, 10);
+                value = randomAlphaOfLengthBetween(1, 10);
             }
             fieldValue.add(value);
             expectedResult.add(value);
@@ -234,7 +234,7 @@ public class SortProcessorTests extends ESTestCase {
         }
 
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, fieldValue);
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         processor.execute(ingestDocument);
         assertEquals(ingestDocument.getFieldValue(fieldName, List.class), expectedResult);
     }
@@ -242,9 +242,9 @@ public class SortProcessorTests extends ESTestCase {
     public void testSortNonListField() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        ingestDocument.setFieldValue(fieldName, randomAsciiOfLengthBetween(1, 10));
+        ingestDocument.setFieldValue(fieldName, randomAlphaOfLengthBetween(1, 10));
         SortOrder order = randomBoolean() ? SortOrder.ASCENDING : SortOrder.DESCENDING;
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         try {
             processor.execute(ingestDocument);
         } catch(IllegalArgumentException e) {
@@ -256,7 +256,7 @@ public class SortProcessorTests extends ESTestCase {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         SortOrder order = randomBoolean() ? SortOrder.ASCENDING : SortOrder.DESCENDING;
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), fieldName, order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), fieldName, order);
         try {
             processor.execute(ingestDocument);
         } catch(IllegalArgumentException e) {
@@ -267,7 +267,7 @@ public class SortProcessorTests extends ESTestCase {
     public void testSortNullValue() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
         SortOrder order = randomBoolean() ? SortOrder.ASCENDING : SortOrder.DESCENDING;
-        Processor processor = new SortProcessor(randomAsciiOfLength(10), "field", order);
+        Processor processor = new SortProcessor(randomAlphaOfLength(10), "field", order);
         try {
             processor.execute(ingestDocument);
         } catch(IllegalArgumentException e) {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SplitProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SplitProcessorFactoryTests.java
@@ -34,7 +34,7 @@ public class SplitProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("separator", "\\.");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         SplitProcessor splitProcessor = factory.create(null, processorTag, config);
         assertThat(splitProcessor.getTag(), equalTo(processorTag));
         assertThat(splitProcessor.getField(), equalTo("field1"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SplitProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SplitProcessorTests.java
@@ -39,7 +39,7 @@ public class SplitProcessorTests extends ESTestCase {
     public void testSplit() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         String fieldName = RandomDocumentPicks.addRandomField(random(), ingestDocument, "127.0.0.1");
-        Processor processor = new SplitProcessor(randomAsciiOfLength(10), fieldName, "\\.", false);
+        Processor processor = new SplitProcessor(randomAlphaOfLength(10), fieldName, "\\.", false);
         processor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue(fieldName, List.class), equalTo(Arrays.asList("127", "0", "0", "1")));
     }
@@ -47,7 +47,7 @@ public class SplitProcessorTests extends ESTestCase {
     public void testSplitFieldNotFound() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
-        Processor processor = new SplitProcessor(randomAsciiOfLength(10), fieldName, "\\.", false);
+        Processor processor = new SplitProcessor(randomAlphaOfLength(10), fieldName, "\\.", false);
         try {
             processor.execute(ingestDocument);
             fail("split processor should have failed");
@@ -59,7 +59,7 @@ public class SplitProcessorTests extends ESTestCase {
     public void testSplitNullValue() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("field", null));
-        Processor processor = new SplitProcessor(randomAsciiOfLength(10), "field", "\\.", false);
+        Processor processor = new SplitProcessor(randomAlphaOfLength(10), "field", "\\.", false);
         try {
             processor.execute(ingestDocument);
             fail("split processor should have failed");
@@ -73,7 +73,7 @@ public class SplitProcessorTests extends ESTestCase {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap(fieldName, null));
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
-        Processor processor = new SplitProcessor(randomAsciiOfLength(10), fieldName, "\\.", true);
+        Processor processor = new SplitProcessor(randomAlphaOfLength(10), fieldName, "\\.", true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
     }
@@ -81,7 +81,7 @@ public class SplitProcessorTests extends ESTestCase {
     public void testSplitNonExistentWithIgnoreMissing() throws Exception {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
-        Processor processor = new SplitProcessor(randomAsciiOfLength(10), "field", "\\.", true);
+        Processor processor = new SplitProcessor(randomAlphaOfLength(10), "field", "\\.", true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
     }
@@ -90,7 +90,7 @@ public class SplitProcessorTests extends ESTestCase {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
         String fieldName = RandomDocumentPicks.randomFieldName(random());
         ingestDocument.setFieldValue(fieldName, randomInt());
-        Processor processor = new SplitProcessor(randomAsciiOfLength(10), fieldName, "\\.", false);
+        Processor processor = new SplitProcessor(randomAlphaOfLength(10), fieldName, "\\.", false);
         try {
             processor.execute(ingestDocument);
             fail("split processor should have failed");

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/TrimProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/TrimProcessorFactoryTests.java
@@ -34,7 +34,7 @@ public class TrimProcessorFactoryTests extends ESTestCase {
         TrimProcessor.Factory factory = new TrimProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         TrimProcessor uppercaseProcessor = (TrimProcessor)factory.create(null, processorTag, config);
         assertThat(uppercaseProcessor.getTag(), equalTo(processorTag));
         assertThat(uppercaseProcessor.getField(), equalTo("field1"));
@@ -46,7 +46,7 @@ public class TrimProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
         config.put("ignore_missing", true);
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         TrimProcessor uppercaseProcessor = (TrimProcessor)factory.create(null, processorTag, config);
         assertThat(uppercaseProcessor.getTag(), equalTo(processorTag));
         assertThat(uppercaseProcessor.getField(), equalTo("field1"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/TrimProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/TrimProcessorTests.java
@@ -23,7 +23,7 @@ public class TrimProcessorTests extends AbstractStringProcessorTestCase {
 
     @Override
     protected AbstractStringProcessor newProcessor(String field, boolean ignoreMissing) {
-        return new TrimProcessor(randomAsciiOfLength(10), field, ignoreMissing);
+        return new TrimProcessor(randomAlphaOfLength(10), field, ignoreMissing);
     }
 
     @Override

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UppercaseProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UppercaseProcessorFactoryTests.java
@@ -33,7 +33,7 @@ public class UppercaseProcessorFactoryTests extends ESTestCase {
         UppercaseProcessor.Factory factory = new UppercaseProcessor.Factory();
         Map<String, Object> config = new HashMap<>();
         config.put("field", "field1");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         UppercaseProcessor uppercaseProcessor = (UppercaseProcessor)factory.create(null, processorTag, config);
         assertThat(uppercaseProcessor.getTag(), equalTo(processorTag));
         assertThat(uppercaseProcessor.getField(), equalTo("field1"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UppercaseProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UppercaseProcessorTests.java
@@ -25,7 +25,7 @@ public class UppercaseProcessorTests extends AbstractStringProcessorTestCase {
 
     @Override
     protected AbstractStringProcessor newProcessor(String field, boolean ignoreMissing) {
-        return new UppercaseProcessor(randomAsciiOfLength(10), field, ignoreMissing);
+        return new UppercaseProcessor(randomAlphaOfLength(10), field, ignoreMissing);
     }
 
     @Override

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheTests.java
@@ -377,7 +377,7 @@ public class MustacheTests extends ESTestCase {
         assertScript("{{#url}}{{index}}{{/url}}", singletonMap("index", "<logstash-{now/d{YYYY.MM.dd|+12:00}}>"),
                 equalTo("%3Clogstash-%7Bnow%2Fd%7BYYYY.MM.dd%7C%2B12%3A00%7D%7D%3E"));
 
-        final String random = randomAsciiOfLength(10);
+        final String random = randomAlphaOfLength(10);
         assertScript("{{#url}}prefix_{{s}}{{/url}}", singletonMap("s", random),
                 equalTo("prefix_" + URLEncoder.encode(random, StandardCharsets.UTF_8.name())));
     }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ImplementInterfacesTests.java
@@ -62,7 +62,7 @@ public class ImplementInterfacesTests extends ScriptTestCase {
     public void testOneArg() {
         Object rando = randomInt();
         assertEquals(rando, scriptEngine.compile(OneArg.class, null, "arg", emptyMap()).execute(rando));
-        rando = randomAsciiOfLength(5);
+        rando = randomAlphaOfLength(5);
         assertEquals(rando, scriptEngine.compile(OneArg.class, null, "arg", emptyMap()).execute(rando));
 
         Exception e = expectScriptThrows(IllegalArgumentException.class, () ->
@@ -79,7 +79,7 @@ public class ImplementInterfacesTests extends ScriptTestCase {
         Object execute(String[] arg);
     }
     public void testArrayArg() {
-        String rando = randomAsciiOfLength(5);
+        String rando = randomAlphaOfLength(5);
         assertEquals(rando, scriptEngine.compile(ArrayArg.class, null, "arg[0]", emptyMap()).execute(new String[] {rando, "foo"}));
     }
 
@@ -99,7 +99,7 @@ public class ImplementInterfacesTests extends ScriptTestCase {
     public void testDefArrayArg() {
         Object rando = randomInt();
         assertEquals(rando, scriptEngine.compile(DefArrayArg.class, null, "arg[0]", emptyMap()).execute(new Object[] {rando, 10}));
-        rando = randomAsciiOfLength(5);
+        rando = randomAlphaOfLength(5);
         assertEquals(rando, scriptEngine.compile(DefArrayArg.class, null, "arg[0]", emptyMap()).execute(new Object[] {rando, 10}));
         assertEquals(5, scriptEngine.compile(DefArrayArg.class, null, "arg[0].length()", emptyMap()).execute(new Object[] {rando, 10}));
     }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
@@ -85,8 +85,8 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
 
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
-        queryField = randomAsciiOfLength(4);
-        docType = randomAsciiOfLength(4);
+        queryField = randomAlphaOfLength(4);
+        docType = randomAlphaOfLength(4);
         mapperService.merge("query_type", new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef("query_type",
                 queryField, "type=percolator"
         ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
@@ -103,11 +103,11 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     private PercolateQueryBuilder doCreateTestQueryBuilder(boolean indexedDocument) {
         documentSource = randomSource();
         if (indexedDocument) {
-            indexedDocumentIndex = randomAsciiOfLength(4);
-            indexedDocumentType = randomAsciiOfLength(4);
-            indexedDocumentId = randomAsciiOfLength(4);
-            indexedDocumentRouting = randomAsciiOfLength(4);
-            indexedDocumentPreference = randomAsciiOfLength(4);
+            indexedDocumentIndex = randomAlphaOfLength(4);
+            indexedDocumentType = randomAlphaOfLength(4);
+            indexedDocumentId = randomAlphaOfLength(4);
+            indexedDocumentRouting = randomAlphaOfLength(4);
+            indexedDocumentPreference = randomAlphaOfLength(4);
             indexedDocumentVersion = (long) randomIntBetween(0, Integer.MAX_VALUE);
             return new PercolateQueryBuilder(queryField, docType, indexedDocumentIndex, indexedDocumentType, indexedDocumentId,
                     indexedDocumentRouting, indexedDocumentPreference, indexedDocumentVersion);

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -134,8 +134,8 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     }
 
     private void addQueryMapping() throws Exception {
-        typeName = randomAsciiOfLength(4);
-        fieldName = randomAsciiOfLength(4);
+        typeName = randomAlphaOfLength(4);
+        fieldName = randomAlphaOfLength(4);
         String percolatorMapper = XContentFactory.jsonBuilder().startObject().startObject(typeName)
                 .startObject("properties").startObject(fieldName).field("type", "percolator").endObject().endObject()
                 .endObject().endObject().string();

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
@@ -467,7 +467,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
 
 
     public void testManyPercolatorFields() throws Exception {
-        String queryFieldName = randomAsciiOfLength(8);
+        String queryFieldName = randomAlphaOfLength(8);
         createIndex("test", client().admin().indices().prepareCreate("test")
                 .addMapping("doc_type", "field", "type=keyword")
                 .addMapping("query_type1", queryFieldName, "type=percolator")
@@ -487,7 +487,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
     }
 
     public void testWithMultiplePercolatorFields() throws Exception {
-        String queryFieldName = randomAsciiOfLength(8);
+        String queryFieldName = randomAlphaOfLength(8);
         createIndex("test1", client().admin().indices().prepareCreate("test1")
                 .addMapping("doc_type", "field", "type=keyword")
                 .addMapping("query_type", queryFieldName, "type=percolator"));

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
@@ -536,7 +536,7 @@ public class QueryAnalyzerTests extends ESTestCase {
         while (sumTermLength > 0) {
             int length = randomInt(sumTermLength);
             shortestTerms1Length = Math.min(shortestTerms1Length, length);
-            terms1.add(new Term("field", randomAsciiOfLength(length)));
+            terms1.add(new Term("field", randomAlphaOfLength(length)));
             sumTermLength -= length;
         }
 
@@ -546,7 +546,7 @@ public class QueryAnalyzerTests extends ESTestCase {
         while (sumTermLength > 0) {
             int length = randomInt(sumTermLength);
             shortestTerms2Length = Math.min(shortestTerms2Length, length);
-            terms2.add(new Term("field", randomAsciiOfLength(length)));
+            terms2.add(new Term("field", randomAlphaOfLength(length)));
             sumTermLength -= length;
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/BulkIndexByScrollResponseTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/BulkIndexByScrollResponseTests.java
@@ -43,13 +43,13 @@ public class BulkIndexByScrollResponseTests extends ESTestCase {
         List<BulkItemResponse.Failure> allBulkFailures = new ArrayList<>();
         List<SearchFailure> allSearchFailures = new ArrayList<>();
         boolean timedOut = false;
-        String reasonCancelled = rarely() ? randomAsciiOfLength(5) : null;
+        String reasonCancelled = rarely() ? randomAlphaOfLength(5) : null;
 
         for (int i = 0; i < mergeCount; i++) {
             // One of the merged responses gets the expected value for took, the others get a smaller value
             TimeValue thisTook = timeValueMillis(i == tookIndex ? took : between(0, took));
             // The actual status doesn't matter too much - we test merging those elsewhere
-            String thisReasonCancelled = rarely() ? randomAsciiOfLength(5) : null;
+            String thisReasonCancelled = rarely() ? randomAlphaOfLength(5) : null;
             BulkByScrollTask.Status status = new BulkByScrollTask.Status(i, 0, 0, 0, 0, 0, 0, 0, 0, 0, timeValueMillis(0), 0f,
                     thisReasonCancelled, timeValueMillis(0));
             List<BulkItemResponse.Failure> bulkFailures = frequently() ? emptyList()

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryBasicTests.java
@@ -166,7 +166,7 @@ public class DeleteByQueryBasicTests extends ReindexTestCase {
         List<IndexRequestBuilder> builders = new ArrayList<>();
         for (int i = 0; i < docs; i++) {
             builders.add(client().prepareIndex("test", "test", Integer.toString(i))
-                    .setRouting(randomAsciiOfLengthBetween(1, 5))
+                    .setRouting(randomAlphaOfLengthBetween(1, 5))
                     .setSource("foo", "bar"));
         }
         indexRandom(true, true, true, builders);

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFromRemoteWhitelistTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexFromRemoteWhitelistTests.java
@@ -50,7 +50,7 @@ public class ReindexFromRemoteWhitelistTests extends ESTestCase {
      * Build a {@link RemoteInfo}, defaulting values that we don't care about in this test to values that don't hurt anything.
      */
     private RemoteInfo newRemoteInfo(String host, int port) {
-        return new RemoteInfo(randomAsciiOfLength(5), host, port, new BytesArray("test"), null, null, emptyMap(),
+        return new RemoteInfo(randomAlphaOfLength(5), host, port, new BytesArray("test"), null, null, emptyMap(),
                 RemoteInfo.DEFAULT_SOCKET_TIMEOUT, RemoteInfo.DEFAULT_CONNECT_TIMEOUT);
     }
 
@@ -64,7 +64,7 @@ public class ReindexFromRemoteWhitelistTests extends ESTestCase {
 
     public void testWhitelistedByPrefix() {
         checkRemoteWhitelist(buildRemoteWhitelist(singletonList("*.example.com:9200")),
-                new RemoteInfo(randomAsciiOfLength(5), "es.example.com", 9200, new BytesArray("test"), null, null, emptyMap(),
+                new RemoteInfo(randomAlphaOfLength(5), "es.example.com", 9200, new BytesArray("test"), null, null, emptyMap(),
                         RemoteInfo.DEFAULT_SOCKET_TIMEOUT, RemoteInfo.DEFAULT_CONNECT_TIMEOUT));
         checkRemoteWhitelist(buildRemoteWhitelist(singletonList("*.example.com:9200")),
                 newRemoteInfo("6e134134a1.us-east-1.aws.example.com", 9200));
@@ -114,7 +114,7 @@ public class ReindexFromRemoteWhitelistTests extends ESTestCase {
         int size = between(1, 100);
         List<String> whitelist = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            whitelist.add(randomAsciiOfLength(5) + ':' + between(1, Integer.MAX_VALUE));
+            whitelist.add(randomAlphaOfLength(5) + ':' + between(1, Integer.MAX_VALUE));
         }
         return whitelist;
     }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
@@ -40,7 +40,7 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
     public void testReindexFromRemoteDoesNotSupportSearchQuery() {
         ReindexRequest reindex = newRequest();
         reindex.setRemoteInfo(
-                new RemoteInfo(randomAsciiOfLength(5), randomAsciiOfLength(5), between(1, Integer.MAX_VALUE), new BytesArray("real_query"),
+                new RemoteInfo(randomAlphaOfLength(5), randomAlphaOfLength(5), between(1, Integer.MAX_VALUE), new BytesArray("real_query"),
                         null, null, emptyMap(), RemoteInfo.DEFAULT_SOCKET_TIMEOUT, RemoteInfo.DEFAULT_CONNECT_TIMEOUT));
         reindex.getSearchRequest().source().query(matchAllQuery()); // Unsupported place to put query
         ActionRequestValidationException e = reindex.validate();
@@ -51,7 +51,7 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
     public void testReindexFromRemoteDoesNotSupportWorkers() {
         ReindexRequest reindex = newRequest();
         reindex.setRemoteInfo(
-                new RemoteInfo(randomAsciiOfLength(5), randomAsciiOfLength(5), between(1, Integer.MAX_VALUE), new BytesArray("real_query"),
+                new RemoteInfo(randomAlphaOfLength(5), randomAlphaOfLength(5), between(1, Integer.MAX_VALUE), new BytesArray("real_query"),
                         null, null, emptyMap(), RemoteInfo.DEFAULT_SOCKET_TIMEOUT, RemoteInfo.DEFAULT_CONNECT_TIMEOUT));
         reindex.setSlices(between(2, Integer.MAX_VALUE));
         ActionRequestValidationException e = reindex.validate();
@@ -71,11 +71,11 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
     @Override
     protected void extraRandomizationForSlice(ReindexRequest original) {
         if (randomBoolean()) {
-            original.setScript(new Script(randomAsciiOfLength(5)));
+            original.setScript(new Script(randomAlphaOfLength(5)));
         }
         if (randomBoolean()) {
-            original.setRemoteInfo(new RemoteInfo(randomAsciiOfLength(5), randomAsciiOfLength(5), between(1, 10000),
-                    new BytesArray(randomAsciiOfLength(5)), null, null, emptyMap(),
+            original.setRemoteInfo(new RemoteInfo(randomAlphaOfLength(5), randomAlphaOfLength(5), between(1, 10000),
+                    new BytesArray(randomAlphaOfLength(5)), null, null, emptyMap(),
                     parseTimeValue(randomPositiveTimeValue(), "socket_timeout"),
                     parseTimeValue(randomPositiveTimeValue(), "connect_timeout")));
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexSourceTargetValidationTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexSourceTargetValidationTests.java
@@ -89,10 +89,10 @@ public class ReindexSourceTargetValidationTests extends ESTestCase {
 
     public void testRemoteInfoSkipsValidation() {
         // The index doesn't have to exist
-        succeeds(new RemoteInfo(randomAsciiOfLength(5), "test", 9200, new BytesArray("test"), null, null, emptyMap(),
+        succeeds(new RemoteInfo(randomAlphaOfLength(5), "test", 9200, new BytesArray("test"), null, null, emptyMap(),
                 RemoteInfo.DEFAULT_SOCKET_TIMEOUT, RemoteInfo.DEFAULT_CONNECT_TIMEOUT), "does_not_exist", "target");
         // And it doesn't matter if they are the same index. They are considered to be different because the remote one is, well, remote.
-        succeeds(new RemoteInfo(randomAsciiOfLength(5), "test", 9200, new BytesArray("test"), null, null, emptyMap(),
+        succeeds(new RemoteInfo(randomAlphaOfLength(5), "test", 9200, new BytesArray("test"), null, null, emptyMap(),
                 RemoteInfo.DEFAULT_SOCKET_TIMEOUT, RemoteInfo.DEFAULT_CONNECT_TIMEOUT), "target", "target");
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
@@ -56,17 +56,17 @@ public class RoundTripTests extends ESTestCase {
         reindex.getDestination().index("test");
         if (randomBoolean()) {
             int port = between(1, Integer.MAX_VALUE);
-            BytesReference query = new BytesArray(randomAsciiOfLength(5));
-            String username = randomBoolean() ? randomAsciiOfLength(5) : null;
-            String password = username != null && randomBoolean() ? randomAsciiOfLength(5) : null;
+            BytesReference query = new BytesArray(randomAlphaOfLength(5));
+            String username = randomBoolean() ? randomAlphaOfLength(5) : null;
+            String password = username != null && randomBoolean() ? randomAlphaOfLength(5) : null;
             int headersCount = randomBoolean() ? 0 : between(1, 10);
             Map<String, String> headers = new HashMap<>(headersCount);
             while (headers.size() < headersCount) {
-                headers.put(randomAsciiOfLength(5), randomAsciiOfLength(5));
+                headers.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
             }
             TimeValue socketTimeout = parseTimeValue(randomPositiveTimeValue(), "socketTimeout");
             TimeValue connectTimeout = parseTimeValue(randomPositiveTimeValue(), "connectTimeout");
-            reindex.setRemoteInfo(new RemoteInfo(randomAsciiOfLength(5), randomAsciiOfLength(5), port, query, username, password, headers,
+            reindex.setRemoteInfo(new RemoteInfo(randomAlphaOfLength(5), randomAlphaOfLength(5), port, query, username, password, headers,
                     socketTimeout, connectTimeout));
         }
         ReindexRequest tripped = new ReindexRequest();
@@ -90,7 +90,7 @@ public class RoundTripTests extends ESTestCase {
         UpdateByQueryRequest update = new UpdateByQueryRequest(new SearchRequest());
         randomRequest(update);
         if (randomBoolean()) {
-            update.setPipeline(randomAsciiOfLength(5));
+            update.setPipeline(randomAlphaOfLength(5));
         }
         UpdateByQueryRequest tripped = new UpdateByQueryRequest();
         roundTrip(update, tripped);
@@ -196,7 +196,7 @@ public class RoundTripTests extends ESTestCase {
         if (randomBoolean()) {
             request.setActions(randomFrom(UpdateByQueryAction.NAME, ReindexAction.NAME));
         } else {
-            request.setTaskId(new TaskId(randomAsciiOfLength(5), randomLong()));
+            request.setTaskId(new TaskId(randomAlphaOfLength(5), randomLong()));
         }
         RethrottleRequest tripped = new RethrottleRequest();
         roundTrip(request, tripped);

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/TransportRethrottleActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/TransportRethrottleActionTests.java
@@ -68,7 +68,7 @@ public class TransportRethrottleActionTests extends ESTestCase {
     private void rethrottleTestCase(int runningSlices, Consumer<ActionListener<ListTasksResponse>> simulator,
             Consumer<ActionListener<TaskInfo>> verifier) {
         Client client = mock(Client.class);
-        String localNodeId = randomAsciiOfLength(5);
+        String localNodeId = randomAlphaOfLength(5);
         float newRequestsPerSecond = randomValueOtherThanMany(f -> f <= 0, () -> randomFloat());
         @SuppressWarnings("unchecked")
         ActionListener<TaskInfo> listener = mock(ActionListener.class);

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
@@ -62,16 +62,16 @@ public class UpdateByQueryRequestTests extends AbstractBulkByScrollRequestTestCa
 
     @Override
     protected UpdateByQueryRequest newRequest() {
-        return new UpdateByQueryRequest(new SearchRequest(randomAsciiOfLength(5)));
+        return new UpdateByQueryRequest(new SearchRequest(randomAlphaOfLength(5)));
     }
 
     @Override
     protected void extraRandomizationForSlice(UpdateByQueryRequest original) {
         if (randomBoolean()) {
-            original.setScript(new Script(randomAsciiOfLength(5)));
+            original.setScript(new Script(randomAlphaOfLength(5)));
         }
         if (randomBoolean()) {
-            original.setPipeline(randomAsciiOfLength(5));
+            original.setPipeline(randomAlphaOfLength(5));
         }
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuildersTests.java
@@ -185,7 +185,7 @@ public class RemoteRequestBuildersTests extends ESTestCase {
     }
 
     public void testScrollEntity() throws IOException {
-        String scroll = randomAsciiOfLength(30);
+        String scroll = randomAlphaOfLength(30);
         HttpEntity entity = scrollEntity(scroll, Version.V_5_0_0);
         assertEquals(ContentType.APPLICATION_JSON.toString(), entity.getContentType().getValue());
         assertThat(Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)),
@@ -198,7 +198,7 @@ public class RemoteRequestBuildersTests extends ESTestCase {
     }
 
     public void testClearScrollEntity() throws IOException {
-        String scroll = randomAsciiOfLength(30);
+        String scroll = randomAlphaOfLength(30);
         HttpEntity entity = clearScrollEntity(scroll, Version.V_5_0_0);
         assertEquals(ContentType.APPLICATION_JSON.toString(), entity.getContentType().getValue());
         assertThat(Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8)),

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -370,7 +370,7 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
     }
 
     public void testThreadContextRestored() throws Exception {
-        String header = randomAsciiOfLength(5);
+        String header = randomAlphaOfLength(5);
         threadPool.getThreadContext().putHeader("test", header);
         AtomicBoolean called = new AtomicBoolean();
         sourceWithMockedRemoteCall("start_ok.json").doStart(r -> {

--- a/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobStoreTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/common/blobstore/url/URLBlobStoreTests.java
@@ -52,7 +52,7 @@ public class URLBlobStoreTests extends ESTestCase {
         for (int i = 0; i < message.length; ++i) {
             message[i] = randomByte();
         }
-        blobName = randomAsciiOfLength(8);
+        blobName = randomAlphaOfLength(8);
 
         httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress().getHostAddress(), 6001), 0);
 

--- a/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorFactoryTests.java
+++ b/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorFactoryTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.ingest.attachment;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -45,7 +44,7 @@ public class AttachmentProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
 
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
 
         AttachmentProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
@@ -61,7 +60,7 @@ public class AttachmentProcessorFactoryTests extends ESTestCase {
         config.put("field", "_field");
         config.put("indexed_chars", indexedChars);
 
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
         AttachmentProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
         assertThat(processor.getIndexedChars(), is(indexedChars));
@@ -127,7 +126,7 @@ public class AttachmentProcessorFactoryTests extends ESTestCase {
         config.put("field", "_field");
         config.put("ignore_missing", true);
 
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
 
         AttachmentProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));

--- a/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
+++ b/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
@@ -42,7 +42,6 @@ import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocumen
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -56,7 +55,7 @@ public class AttachmentProcessorTests extends ESTestCase {
 
     @Before
     public void createStandardProcessor() throws IOException {
-        processor = new AttachmentProcessor(randomAsciiOfLength(10), "source_field",
+        processor = new AttachmentProcessor(randomAlphaOfLength(10), "source_field",
             "target_field", EnumSet.allOf(AttachmentProcessor.Property.class), 10000, false);
     }
 
@@ -89,7 +88,7 @@ public class AttachmentProcessorTests extends ESTestCase {
         if (randomBoolean()) {
             selectedProperties.add(AttachmentProcessor.Property.DATE);
         }
-        processor = new AttachmentProcessor(randomAsciiOfLength(10), "source_field",
+        processor = new AttachmentProcessor(randomAlphaOfLength(10), "source_field",
             "target_field", selectedProperties, 10000, false);
 
         Map<String, Object> attachmentData = parseDocument("htmlWithEmptyDateMeta.html", processor);
@@ -243,7 +242,7 @@ public class AttachmentProcessorTests extends ESTestCase {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
-        Processor processor = new AttachmentProcessor(randomAsciiOfLength(10), "source_field", "randomTarget", null, 10, true);
+        Processor processor = new AttachmentProcessor(randomAlphaOfLength(10), "source_field", "randomTarget", null, 10, true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
     }
@@ -251,7 +250,7 @@ public class AttachmentProcessorTests extends ESTestCase {
     public void testNonExistentWithIgnoreMissing() throws Exception {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
-        Processor processor = new AttachmentProcessor(randomAsciiOfLength(10), "source_field", "randomTarget", null, 10, true);
+        Processor processor = new AttachmentProcessor(randomAlphaOfLength(10), "source_field", "randomTarget", null, 10, true);
         processor.execute(ingestDocument);
         assertIngestDocument(originalIngestDocument, ingestDocument);
     }
@@ -260,7 +259,7 @@ public class AttachmentProcessorTests extends ESTestCase {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
-        Processor processor = new AttachmentProcessor(randomAsciiOfLength(10), "source_field", "randomTarget", null, 10, false);
+        Processor processor = new AttachmentProcessor(randomAlphaOfLength(10), "source_field", "randomTarget", null, 10, false);
         Exception exception = expectThrows(Exception.class, () -> processor.execute(ingestDocument));
         assertThat(exception.getMessage(), equalTo("field [source_field] is null, cannot parse."));
     }
@@ -268,7 +267,7 @@ public class AttachmentProcessorTests extends ESTestCase {
     public void testNonExistentWithoutIgnoreMissing() throws Exception {
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
-        Processor processor = new AttachmentProcessor(randomAsciiOfLength(10), "source_field", "randomTarget", null, 10, false);
+        Processor processor = new AttachmentProcessor(randomAlphaOfLength(10), "source_field", "randomTarget", null, 10, false);
         Exception exception = expectThrows(Exception.class, () -> processor.execute(ingestDocument));
         assertThat(exception.getMessage(), equalTo("field [source_field] not present as part of path [source_field]"));
     }

--- a/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -76,7 +76,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
 
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
 
         GeoIpProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
@@ -93,7 +93,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("ignore_missing", true);
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
 
         GeoIpProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
@@ -110,7 +110,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-Country.mmdb.gz");
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
 
         GeoIpProcessor processor = factory.create(null, processorTag, config);
 

--- a/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.ingest.geoip;
 
 import com.maxmind.geoip2.DatabaseReader;
-import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.test.ESTestCase;
@@ -42,7 +41,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testCity() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-City.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
                 new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false);
 
         Map<String, Object> document = new HashMap<>();
@@ -69,7 +68,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNullValueWithIgnoreMissing() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-City.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
             new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), true);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
@@ -80,7 +79,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNonExistentWithIgnoreMissing() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-City.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
             new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), true);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
@@ -90,7 +89,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNullWithoutIgnoreMissing() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-City.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
             new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
@@ -101,7 +100,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testNonExistentWithoutIgnoreMissing() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-City.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
             new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
@@ -111,7 +110,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testCity_withIpV6() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-City.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
                 new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false);
 
         String address = "2602:306:33d3:8000::3257:9652";
@@ -139,7 +138,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testCityWithMissingLocation() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-City.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
             new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false);
 
         Map<String, Object> document = new HashMap<>();
@@ -156,7 +155,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testCountry() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-Country.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
                 new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false);
 
         Map<String, Object> document = new HashMap<>();
@@ -176,7 +175,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testCountryWithMissingLocation() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-Country.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
             new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false);
 
         Map<String, Object> document = new HashMap<>();
@@ -193,7 +192,7 @@ public class GeoIpProcessorTests extends ESTestCase {
 
     public void testAddressIsNotInTheDatabase() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-City.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
                 new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false);
 
         Map<String, Object> document = new HashMap<>();
@@ -206,7 +205,7 @@ public class GeoIpProcessorTests extends ESTestCase {
     /** Don't silently do DNS lookups or anything trappy on bogus data */
     public void testInvalid() throws Exception {
         InputStream database = getDatabaseFileInputStream("/GeoLite2-City.mmdb.gz");
-        GeoIpProcessor processor = new GeoIpProcessor(randomAsciiOfLength(10), "source_field",
+        GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), "source_field",
                 new DatabaseReader.Builder(database).build(), "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false);
 
         Map<String, Object> document = new HashMap<>();

--- a/plugins/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorFactoryTests.java
+++ b/plugins/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorFactoryTests.java
@@ -79,7 +79,7 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
 
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
 
         UserAgentProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));
@@ -99,7 +99,7 @@ public class UserAgentProcessorFactoryTests extends ESTestCase {
         config.put("field", "_field");
         config.put("ignore_missing", true);
 
-        String processorTag = randomAsciiOfLength(10);
+        String processorTag = randomAlphaOfLength(10);
 
         UserAgentProcessor processor = factory.create(null, processorTag, config);
         assertThat(processor.getTag(), equalTo(processorTag));

--- a/plugins/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
+++ b/plugins/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/UserAgentProcessorTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.ingest.useragent;
 
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.ingest.IngestDocument;
-import org.elasticsearch.ingest.useragent.UserAgentProcessor;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.BeforeClass;
 
@@ -46,14 +45,14 @@ public class UserAgentProcessorTests extends ESTestCase {
         InputStream regexStream = UserAgentProcessor.class.getResourceAsStream("/regexes.yaml");
         assertNotNull(regexStream);
 
-        UserAgentParser parser = new UserAgentParser(randomAsciiOfLength(10), regexStream, new UserAgentCache(1000));
+        UserAgentParser parser = new UserAgentParser(randomAlphaOfLength(10), regexStream, new UserAgentCache(1000));
 
-        processor = new UserAgentProcessor(randomAsciiOfLength(10), "source_field", "target_field", parser,
+        processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", parser,
                 EnumSet.allOf(UserAgentProcessor.Property.class), false);
     }
 
     public void testNullValueWithIgnoreMissing() throws Exception {
-        UserAgentProcessor processor = new UserAgentProcessor(randomAsciiOfLength(10), "source_field", "target_field", null,
+        UserAgentProcessor processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", null,
             EnumSet.allOf(UserAgentProcessor.Property.class), true);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
@@ -63,7 +62,7 @@ public class UserAgentProcessorTests extends ESTestCase {
     }
 
     public void testNonExistentWithIgnoreMissing() throws Exception {
-        UserAgentProcessor processor = new UserAgentProcessor(randomAsciiOfLength(10), "source_field", "target_field", null,
+        UserAgentProcessor processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", null,
             EnumSet.allOf(UserAgentProcessor.Property.class), true);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
@@ -72,7 +71,7 @@ public class UserAgentProcessorTests extends ESTestCase {
     }
 
     public void testNullWithoutIgnoreMissing() throws Exception {
-        UserAgentProcessor processor = new UserAgentProcessor(randomAsciiOfLength(10), "source_field", "target_field", null,
+        UserAgentProcessor processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", null,
             EnumSet.allOf(UserAgentProcessor.Property.class), false);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(),
             Collections.singletonMap("source_field", null));
@@ -82,7 +81,7 @@ public class UserAgentProcessorTests extends ESTestCase {
     }
 
     public void testNonExistentWithoutIgnoreMissing() throws Exception {
-        UserAgentProcessor processor = new UserAgentProcessor(randomAsciiOfLength(10), "source_field", "target_field", null,
+        UserAgentProcessor processor = new UserAgentProcessor(randomAlphaOfLength(10), "source_field", "target_field", null,
             EnumSet.allOf(UserAgentProcessor.Property.class), false);
         IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.emptyMap());
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStoreContainerTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStoreContainerTests.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 public class GoogleCloudStorageBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
     @Override
     protected BlobStore newBlobStore() throws IOException {
-        String bucket = randomAsciiOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        String bucket = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
         return new GoogleCloudStorageBlobStore(Settings.EMPTY, bucket, MockHttpTransport.newStorage(bucket, getTestName()));
     }
 }

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStoreTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/common/blobstore/gcs/GoogleCloudStorageBlobStoreTests.java
@@ -30,7 +30,7 @@ public class GoogleCloudStorageBlobStoreTests extends ESBlobStoreTestCase {
 
     @Override
     protected BlobStore newBlobStore() throws IOException {
-        String bucket = randomAsciiOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        String bucket = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
         return new GoogleCloudStorageBlobStore(Settings.EMPTY, bucket, MockHttpTransport.newStorage(bucket, getTestName()));
     }
 }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStoreContainerTests.java
@@ -31,7 +31,7 @@ import java.util.Locale;
 public class S3BlobStoreContainerTests extends ESBlobStoreContainerTestCase {
     protected BlobStore newBlobStore() throws IOException {
         MockAmazonS3 client = new MockAmazonS3();
-        String bucket = randomAsciiOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        String bucket = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
 
         return new S3BlobStore(Settings.EMPTY, client, bucket, false,
             new ByteSizeValue(10, ByteSizeUnit.MB), 5, "public-read-write", "standard");

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -92,7 +92,7 @@ public class EvilBootstrapChecksTests extends ESTestCase {
     }
 
     public void testInvalidValue() {
-        final String value = randomAsciiOfLength(8);
+        final String value = randomAlphaOfLength(8);
         setEsEnforceBootstrapChecks(value);
         final boolean enforceLimits = randomBoolean();
         final IllegalArgumentException e = expectThrows(

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilElasticsearchCliTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilElasticsearchCliTests.java
@@ -33,7 +33,7 @@ public class EvilElasticsearchCliTests extends ESElasticsearchCliTestCase {
     @SuppressForbidden(reason = "manipulates system properties for testing")
     public void testPathHome() throws Exception {
         final String pathHome = System.getProperty("es.path.home");
-        final String value = randomAsciiOfLength(16);
+        final String value = randomAlphaOfLength(16);
         System.setProperty("es.path.home", value);
 
         runTest(
@@ -48,7 +48,7 @@ public class EvilElasticsearchCliTests extends ESElasticsearchCliTestCase {
                 });
 
         System.clearProperty("es.path.home");
-        final String commandLineValue = randomAsciiOfLength(16);
+        final String commandLineValue = randomAlphaOfLength(16);
         runTest(
                 ExitCodes.OK,
                 true,

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
@@ -179,7 +179,7 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
         assertThat(loggerConfigs, hasKey("bar"));
         assertThat(loggerConfigs.get("bar").getLevel(), equalTo(barLevel));
 
-        assertThat(ctx.getLogger(randomAsciiOfLength(16)).getLevel(), equalTo(rootLevel));
+        assertThat(ctx.getLogger(randomAlphaOfLength(16)).getLevel(), equalTo(rootLevel));
     }
 
 }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -37,16 +37,12 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.hamcrest.RegexMatcher;
 
-import javax.management.MBeanServerPermission;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessControlException;
-import java.security.Permission;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -126,7 +122,7 @@ public class EvilLoggerTests extends ESTestCase {
     public void testPrefixLogger() throws IOException, IllegalAccessException, UserException {
         setupLogging("prefix");
 
-        final String prefix = randomBoolean() ? null : randomAsciiOfLength(16);
+        final String prefix = randomBoolean() ? null : randomAlphaOfLength(16);
         final Logger logger = Loggers.getLogger("prefix", prefix);
         logger.info("test");
         logger.info("{}", "test");
@@ -156,9 +152,9 @@ public class EvilLoggerTests extends ESTestCase {
     }
 
     public void testProperties() throws IOException, UserException {
-        final Settings.Builder builder = Settings.builder().put("cluster.name", randomAsciiOfLength(16));
+        final Settings.Builder builder = Settings.builder().put("cluster.name", randomAlphaOfLength(16));
         if (randomBoolean()) {
-            builder.put("node.name", randomAsciiOfLength(16));
+            builder.put("node.name", randomAlphaOfLength(16));
         }
         final Settings settings = builder.build();
         setupLogging("minimal", settings);

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ContextAndHeaderTransportIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ContextAndHeaderTransportIT.java
@@ -76,9 +76,9 @@ import static org.hamcrest.Matchers.is;
 public class ContextAndHeaderTransportIT extends HttpSmokeTestCase {
     private static final List<RequestAndHeaders> requests =  new CopyOnWriteArrayList<>();
     private static final String CUSTOM_HEADER = "SomeCustomHeader";
-    private String randomHeaderValue = randomAsciiOfLength(20);
-    private String queryIndex = "query-" + randomAsciiOfLength(10).toLowerCase(Locale.ROOT);
-    private String lookupIndex = "lookup-" + randomAsciiOfLength(10).toLowerCase(Locale.ROOT);
+    private String randomHeaderValue = randomAlphaOfLength(20);
+    private String queryIndex = "query-" + randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+    private String lookupIndex = "lookup-" + randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/test/framework/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractBulkByScrollRequestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractBulkByScrollRequestTestCase.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.action.bulk.byscroll;
 
-import org.elasticsearch.action.bulk.byscroll.AbstractBulkByScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.tasks.TaskId;
@@ -45,7 +44,7 @@ public abstract class AbstractBulkByScrollRequestTestCase<R extends AbstractBulk
                 randomBoolean() ? Float.POSITIVE_INFINITY : randomValueOtherThanMany(r -> r < 0, ESTestCase::randomFloat));
         original.setSize(randomBoolean() ? AbstractBulkByScrollRequest.SIZE_ALL_MATCHES : between(0, Integer.MAX_VALUE));
 
-        TaskId slicingTask = new TaskId(randomAsciiOfLength(5), randomLong());
+        TaskId slicingTask = new TaskId(randomAlphaOfLength(5), randomLong());
         SearchRequest sliceRequest = new SearchRequest();
         R forSliced = original.forSlice(slicingTask, sliceRequest);
         assertEquals(original.isAbortOnVersionConflict(), forSliced.isAbortOnVersionConflict());

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
@@ -27,7 +27,7 @@ import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.ESTestCase;
 
-import static org.elasticsearch.test.ESTestCase.randomAsciiOfLength;
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 
 /**
  * A helper that allows to create shard routing instances within tests, while not requiring to expose
@@ -131,7 +131,7 @@ public class TestShardRouting {
             RecoverySource.PeerRecoverySource.INSTANCE,
             RecoverySource.LocalShardsRecoverySource.INSTANCE,
             new RecoverySource.SnapshotRecoverySource(
-                new Snapshot("repo", new SnapshotId(randomAsciiOfLength(8), UUIDs.randomBase64UUID())),
+                new Snapshot("repo", new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID())),
                 Version.CURRENT,
                 "some_index"));
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -173,7 +173,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
      * @param listeners an optional set of listeners to add to the shard
      */
     protected IndexShard newShard(ShardId shardId, boolean primary, IndexingOperationListener... listeners) throws IOException {
-        ShardRouting shardRouting = TestShardRouting.newShardRouting(shardId, randomAsciiOfLength(5), primary,
+        ShardRouting shardRouting = TestShardRouting.newShardRouting(shardId, randomAlphaOfLength(5), primary,
             ShardRoutingState.INITIALIZING,
             primary ? RecoverySource.StoreRecoverySource.EMPTY_STORE_INSTANCE : RecoverySource.PeerRecoverySource.INSTANCE);
         return newShard(shardRouting, listeners);

--- a/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
@@ -48,7 +48,7 @@ public class NodeTests extends ESTestCase {
 
     public void testNodeName() throws IOException {
         final Path tempDir = createTempDir();
-        final String name = randomBoolean() ? randomAsciiOfLength(10) : null;
+        final String name = randomBoolean() ? randomAlphaOfLength(10) : null;
         Settings.Builder settings = Settings.builder()
             .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), InternalTestCluster.clusterName("single-node-cluster", randomLong()))
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
@@ -88,7 +88,7 @@ public class NodeTests extends ESTestCase {
 
     public void testLoadPluginBootstrapChecks() throws IOException {
         final Path tempDir = createTempDir();
-        final String name = randomBoolean() ? randomAsciiOfLength(10) : null;
+        final String name = randomBoolean() ? randomAlphaOfLength(10) : null;
         Settings.Builder settings = Settings.builder()
             .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), InternalTestCluster.clusterName("single-node-cluster", randomLong()))
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
@@ -139,7 +139,7 @@ public class NodeTests extends ESTestCase {
     }
 
     public void testNodeAttributes() throws IOException {
-        String attr = randomAsciiOfLength(5);
+        String attr = randomAlphaOfLength(5);
         Settings.Builder settings = baseSettings().put(Node.NODE_ATTRIBUTES.getKey() + "test_attr", attr);
         try (Node node = new MockNode(settings.build(), Collections.singleton(MockTcpTransportPlugin.class))) {
             final Settings nodeSettings = randomBoolean() ? node.settings() : node.getEnvironment().settings();

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -222,7 +222,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
         IndexRequestBuilder[] indexRequestBuilders = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
             indexRequestBuilders[i] = client().prepareIndex(name, name, Integer.toString(i))
-                .setRouting(randomAsciiOfLength(randomIntBetween(1, 10))).setSource("field", "value");
+                .setRouting(randomAlphaOfLength(randomIntBetween(1, 10))).setSource("field", "value");
         }
         indexRandom(true, indexRequestBuilders);
     }
@@ -262,6 +262,6 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
     }
 
     public static String randomAsciiName() {
-        return randomAsciiOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        return randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -52,7 +52,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.test.ESTestCase.between;
 import static org.elasticsearch.test.ESTestCase.generateRandomStringArray;
-import static org.elasticsearch.test.ESTestCase.randomAsciiOfLengthBetween;
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomByte;
 import static org.elasticsearch.test.ESTestCase.randomDouble;
@@ -89,13 +89,13 @@ public class RandomSearchRequestGenerator {
             searchRequest.types(generateRandomStringArray(10, 10, false, false));
         }
         if (randomBoolean()) {
-            searchRequest.preference(randomAsciiOfLengthBetween(3, 10));
+            searchRequest.preference(randomAlphaOfLengthBetween(3, 10));
         }
         if (randomBoolean()) {
             searchRequest.requestCache(randomBoolean());
         }
         if (randomBoolean()) {
-            searchRequest.routing(randomAsciiOfLengthBetween(3, 10));
+            searchRequest.routing(randomAlphaOfLengthBetween(3, 10));
         }
         if (randomBoolean()) {
             searchRequest.scroll(randomPositiveTimeValue());
@@ -152,7 +152,7 @@ public class RandomSearchRequestGenerator {
                 int fieldsSize = randomInt(25);
                 List<String> fields = new ArrayList<>(fieldsSize);
                 for (int i = 0; i < fieldsSize; i++) {
-                    fields.add(randomAsciiOfLengthBetween(5, 50));
+                    fields.add(randomAlphaOfLengthBetween(5, 50));
                 }
                 builder.storedFields(fields);
                 break;
@@ -164,9 +164,9 @@ public class RandomSearchRequestGenerator {
             int scriptFieldsSize = randomInt(25);
             for (int i = 0; i < scriptFieldsSize; i++) {
                 if (randomBoolean()) {
-                    builder.scriptField(randomAsciiOfLengthBetween(5, 50), new Script("foo"), randomBoolean());
+                    builder.scriptField(randomAlphaOfLengthBetween(5, 50), new Script("foo"), randomBoolean());
                 } else {
-                    builder.scriptField(randomAsciiOfLengthBetween(5, 50), new Script("foo"));
+                    builder.scriptField(randomAlphaOfLengthBetween(5, 50), new Script("foo"));
                 }
             }
         }
@@ -175,11 +175,11 @@ public class RandomSearchRequestGenerator {
             int branch = randomInt(5);
             String[] includes = new String[randomIntBetween(0, 20)];
             for (int i = 0; i < includes.length; i++) {
-                includes[i] = randomAsciiOfLengthBetween(5, 20);
+                includes[i] = randomAlphaOfLengthBetween(5, 20);
             }
             String[] excludes = new String[randomIntBetween(0, 20)];
             for (int i = 0; i < excludes.length; i++) {
-                excludes[i] = randomAsciiOfLengthBetween(5, 20);
+                excludes[i] = randomAlphaOfLengthBetween(5, 20);
             }
             switch (branch) {
                 case 0:
@@ -189,8 +189,8 @@ public class RandomSearchRequestGenerator {
                     fetchSourceContext = new FetchSourceContext(true, includes, excludes);
                     break;
                 case 2:
-                    fetchSourceContext = new FetchSourceContext(true, new String[]{randomAsciiOfLengthBetween(5, 20)},
-                        new String[]{randomAsciiOfLengthBetween(5, 20)});
+                    fetchSourceContext = new FetchSourceContext(true, new String[]{randomAlphaOfLengthBetween(5, 20)},
+                        new String[]{randomAlphaOfLengthBetween(5, 20)});
                     break;
                 case 3:
                     fetchSourceContext = new FetchSourceContext(true, includes, excludes);
@@ -199,7 +199,7 @@ public class RandomSearchRequestGenerator {
                     fetchSourceContext = new FetchSourceContext(true, includes, null);
                     break;
                 case 5:
-                    fetchSourceContext = new FetchSourceContext(true, new String[] {randomAsciiOfLengthBetween(5, 20)}, null);
+                    fetchSourceContext = new FetchSourceContext(true, new String[] {randomAlphaOfLengthBetween(5, 20)}, null);
                     break;
                 default:
                     throw new IllegalStateException();
@@ -210,21 +210,21 @@ public class RandomSearchRequestGenerator {
             int size = randomIntBetween(0, 20);
             List<String> statsGroups = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
-                statsGroups.add(randomAsciiOfLengthBetween(5, 20));
+                statsGroups.add(randomAlphaOfLengthBetween(5, 20));
             }
             builder.stats(statsGroups);
         }
         if (randomBoolean()) {
             int indexBoostSize = randomIntBetween(1, 10);
             for (int i = 0; i < indexBoostSize; i++) {
-                builder.indexBoost(randomAsciiOfLengthBetween(5, 20), randomFloat() * 10);
+                builder.indexBoost(randomAlphaOfLengthBetween(5, 20), randomFloat() * 10);
             }
         }
         if (randomBoolean()) {
-            builder.query(QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
+            builder.query(QueryBuilders.termQuery(randomAlphaOfLengthBetween(5, 20), randomAlphaOfLengthBetween(5, 20)));
         }
         if (randomBoolean()) {
-            builder.postFilter(QueryBuilders.termQuery(randomAsciiOfLengthBetween(5, 20), randomAsciiOfLengthBetween(5, 20)));
+            builder.postFilter(QueryBuilders.termQuery(randomAlphaOfLengthBetween(5, 20), randomAlphaOfLengthBetween(5, 20)));
         }
         if (randomBoolean()) {
             int numSorts = randomIntBetween(1, 5);
@@ -232,10 +232,10 @@ public class RandomSearchRequestGenerator {
                 int branch = randomInt(5);
                 switch (branch) {
                     case 0:
-                        builder.sort(SortBuilders.fieldSort(randomAsciiOfLengthBetween(5, 20)).order(randomFrom(SortOrder.values())));
+                        builder.sort(SortBuilders.fieldSort(randomAlphaOfLengthBetween(5, 20)).order(randomFrom(SortOrder.values())));
                         break;
                     case 1:
-                        builder.sort(SortBuilders.geoDistanceSort(randomAsciiOfLengthBetween(5, 20),
+                        builder.sort(SortBuilders.geoDistanceSort(randomAlphaOfLengthBetween(5, 20),
                                 AbstractQueryTestCase.randomGeohash(1, 12)).order(randomFrom(SortOrder.values())));
                         break;
                     case 2:
@@ -246,10 +246,10 @@ public class RandomSearchRequestGenerator {
                                 ScriptSortBuilder.ScriptSortType.NUMBER).order(randomFrom(SortOrder.values())));
                         break;
                     case 4:
-                        builder.sort(randomAsciiOfLengthBetween(5, 20));
+                        builder.sort(randomAlphaOfLengthBetween(5, 20));
                         break;
                     case 5:
-                        builder.sort(randomAsciiOfLengthBetween(5, 20), randomFrom(SortOrder.values()));
+                        builder.sort(randomAlphaOfLengthBetween(5, 20), randomFrom(SortOrder.values()));
                         break;
                 }
             }
@@ -281,7 +281,7 @@ public class RandomSearchRequestGenerator {
                             jsonBuilder.value(randomDouble());
                             break;
                         case 4:
-                            jsonBuilder.value(randomAsciiOfLengthBetween(5, 20));
+                            jsonBuilder.value(randomAlphaOfLengthBetween(5, 20));
                             break;
                         case 5:
                             jsonBuilder.value(randomBoolean());
@@ -293,7 +293,7 @@ public class RandomSearchRequestGenerator {
                             jsonBuilder.value(randomShort());
                             break;
                         case 8:
-                            jsonBuilder.value(new Text(randomAsciiOfLengthBetween(5, 20)));
+                            jsonBuilder.value(new Text(randomAlphaOfLengthBetween(5, 20)));
                             break;
                     }
                 }
@@ -322,13 +322,13 @@ public class RandomSearchRequestGenerator {
             }
         }
         if (randomBoolean()) {
-            builder.aggregation(AggregationBuilders.avg(randomAsciiOfLengthBetween(5, 20)));
+            builder.aggregation(AggregationBuilders.avg(randomAlphaOfLengthBetween(5, 20)));
         }
         if (randomBoolean()) {
             builder.ext(randomExtBuilders.get());
         }
         if (randomBoolean()) {
-            String field = randomBoolean() ? null : randomAsciiOfLengthBetween(5, 20);
+            String field = randomBoolean() ? null : randomAlphaOfLengthBetween(5, 20);
             int max = between(2, 1000);
             int id = randomInt(max-1);
             if (field == null) {

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -183,12 +183,12 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         indexSettings = Settings.builder()
                 .put(IndexMetaData.SETTING_VERSION_CREATED, indexVersionCreated).build();
 
-        index = new Index(randomAsciiOfLengthBetween(1, 10), "_na_");
+        index = new Index(randomAlphaOfLengthBetween(1, 10), "_na_");
 
         //create some random type with some default field, those types will stick around for all of the subclasses
         currentTypes = new String[randomIntBetween(0, 5)];
         for (int i = 0; i < currentTypes.length; i++) {
-            String type = randomAsciiOfLengthBetween(1, 10);
+            String type = randomAlphaOfLengthBetween(1, 10);
             currentTypes[i] = type;
         }
         //set some random types to be queried as part the search request, before each test
@@ -248,7 +248,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
      * make sure query names are unique by suffixing them with increasing counter
      */
     private static String createUniqueRandomName() {
-        String queryName = randomAsciiOfLengthBetween(1, 10) + queryNameId;
+        String queryName = randomAlphaOfLengthBetween(1, 10) + queryNameId;
         queryNameId++;
         return queryName;
     }
@@ -597,8 +597,8 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
             QB secondQuery = copyQuery(firstQuery);
             // query _name never should affect the result of toQuery, we randomly set it to make sure
             if (randomBoolean()) {
-                secondQuery.queryName(secondQuery.queryName() == null ? randomAsciiOfLengthBetween(1, 30) : secondQuery.queryName()
-                        + randomAsciiOfLengthBetween(1, 10));
+                secondQuery.queryName(secondQuery.queryName() == null ? randomAlphaOfLengthBetween(1, 30) : secondQuery.queryName()
+                        + randomAlphaOfLengthBetween(1, 10));
             }
             searchContext = getSearchContext(randomTypes, context);
             Query secondLuceneQuery = rewriteQuery(secondQuery, context).toQuery(context);
@@ -733,8 +733,8 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
     private QB changeNameOrBoost(QB original) throws IOException {
         QB secondQuery = copyQuery(original);
         if (randomBoolean()) {
-            secondQuery.queryName(secondQuery.queryName() == null ? randomAsciiOfLengthBetween(1, 30) : secondQuery.queryName()
-                    + randomAsciiOfLengthBetween(1, 10));
+            secondQuery.queryName(secondQuery.queryName() == null ? randomAlphaOfLengthBetween(1, 30) : secondQuery.queryName()
+                    + randomAlphaOfLengthBetween(1, 10));
         } else {
             secondQuery.boost(original.boost() + 1f + randomFloat());
         }
@@ -773,7 +773,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
                     JsonStringEncoder encoder = JsonStringEncoder.getInstance();
                     value = new String(encoder.quoteAsString(randomUnicodeOfLength(10)));
                 } else {
-                    value = randomAsciiOfLengthBetween(1, 10);
+                    value = randomAlphaOfLengthBetween(1, 10);
                 }
                 break;
             case INT_FIELD_NAME:
@@ -789,7 +789,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
                 value = new DateTime(System.currentTimeMillis(), DateTimeZone.UTC).toString();
                 break;
             default:
-                value = randomAsciiOfLengthBetween(1, 10);
+                value = randomAlphaOfLengthBetween(1, 10);
         }
         return value;
     }
@@ -798,7 +798,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         int terms = randomIntBetween(0, 3);
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < terms; i++) {
-            builder.append(randomAsciiOfLengthBetween(1, 10)).append(" ");
+            builder.append(randomAlphaOfLengthBetween(1, 10)).append(" ");
         }
         return builder.toString().trim();
     }
@@ -809,7 +809,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
     protected static String getRandomFieldName() {
         // if no type is set then return a random field name
         if (currentTypes.length == 0 || randomBoolean()) {
-            return randomAsciiOfLengthBetween(1, 10);
+            return randomAlphaOfLengthBetween(1, 10);
         }
         return randomFrom(MAPPED_LEAF_FIELD_NAMES);
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -705,7 +705,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         }
         // 30% of the time
         if (randomInt(9) < 3) {
-            final String dataPath = randomAsciiOfLength(10);
+            final String dataPath = randomAlphaOfLength(10);
             logger.info("using custom data_path for index: [{}]", dataPath);
             builder.put(IndexMetaData.SETTING_DATA_PATH, dataPath);
         }
@@ -1963,7 +1963,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         assert repoFiles.length > 0;
         Path path;
         do {
-            path = repoFiles[0].resolve(randomAsciiOfLength(10));
+            path = repoFiles[0].resolve(randomAlphaOfLength(10));
         } while (Files.exists(path));
         return path;
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -572,11 +572,11 @@ public abstract class ESTestCase extends LuceneTestCase {
         return RandomPicks.randomFrom(random, collection);
     }
 
-    public static String randomAsciiOfLengthBetween(int minCodeUnits, int maxCodeUnits) {
+    public static String randomAlphaOfLengthBetween(int minCodeUnits, int maxCodeUnits) {
         return RandomizedTest.randomAsciiOfLengthBetween(minCodeUnits, maxCodeUnits);
     }
 
-    public static String randomAsciiOfLength(int codeUnits) {
+    public static String randomAlphaOfLength(int codeUnits) {
         return RandomizedTest.randomAsciiOfLength(codeUnits);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/NetworkDisruptionTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/NetworkDisruptionTests.java
@@ -48,10 +48,10 @@ public class NetworkDisruptionTests extends ESTestCase {
             assertTrue(topology.disrupt(randomFrom(partition2), randomFrom(partition1)));
             assertFalse(topology.disrupt(randomFrom(partition1), randomFrom(partition1)));
             assertFalse(topology.disrupt(randomFrom(partition2), randomFrom(partition2)));
-            assertFalse(topology.disrupt(randomAsciiOfLength(10), randomFrom(partition1)));
-            assertFalse(topology.disrupt(randomAsciiOfLength(10), randomFrom(partition2)));
-            assertFalse(topology.disrupt(randomFrom(partition1), randomAsciiOfLength(10)));
-            assertFalse(topology.disrupt(randomFrom(partition2), randomAsciiOfLength(10)));
+            assertFalse(topology.disrupt(randomAlphaOfLength(10), randomFrom(partition1)));
+            assertFalse(topology.disrupt(randomAlphaOfLength(10), randomFrom(partition2)));
+            assertFalse(topology.disrupt(randomFrom(partition1), randomAlphaOfLength(10)));
+            assertFalse(topology.disrupt(randomFrom(partition2), randomAlphaOfLength(10)));
         }
         assertTrue(topology.getMajoritySide().size() >= topology.getMinoritySide().size());
     }
@@ -74,7 +74,7 @@ public class NetworkDisruptionTests extends ESTestCase {
     public void testBridge() {
         Set<String> partition1 = generateRandomStringSet(1, 10);
         Set<String> partition2 = generateRandomStringSet(1, 10);
-        String bridgeNode = randomAsciiOfLength(10);
+        String bridgeNode = randomAlphaOfLength(10);
         Bridge topology = new Bridge(bridgeNode, partition1, partition2);
         checkBridge(topology, bridgeNode, partition1, partition2);
     }
@@ -97,12 +97,12 @@ public class NetworkDisruptionTests extends ESTestCase {
             assertFalse(topology.disrupt(randomFrom(partition2), randomFrom(partition2)));
             assertFalse(topology.disrupt(randomFrom(partition2), bridgeNode));
             assertFalse(topology.disrupt(bridgeNode, randomFrom(partition2)));
-            assertFalse(topology.disrupt(randomAsciiOfLength(10), randomFrom(partition1)));
-            assertFalse(topology.disrupt(randomAsciiOfLength(10), randomFrom(partition2)));
-            assertFalse(topology.disrupt(randomAsciiOfLength(10), bridgeNode));
-            assertFalse(topology.disrupt(randomFrom(partition1), randomAsciiOfLength(10)));
-            assertFalse(topology.disrupt(randomFrom(partition2), randomAsciiOfLength(10)));
-            assertFalse(topology.disrupt(bridgeNode, randomAsciiOfLength(10)));
+            assertFalse(topology.disrupt(randomAlphaOfLength(10), randomFrom(partition1)));
+            assertFalse(topology.disrupt(randomAlphaOfLength(10), randomFrom(partition2)));
+            assertFalse(topology.disrupt(randomAlphaOfLength(10), bridgeNode));
+            assertFalse(topology.disrupt(randomFrom(partition1), randomAlphaOfLength(10)));
+            assertFalse(topology.disrupt(randomFrom(partition2), randomAlphaOfLength(10)));
+            assertFalse(topology.disrupt(bridgeNode, randomAlphaOfLength(10)));
         }
     }
 
@@ -110,7 +110,7 @@ public class NetworkDisruptionTests extends ESTestCase {
         assert maxSize >= minSize;
         Set<String> result = new HashSet<>();
         for (int i = 0; i < minSize + randomInt(maxSize - minSize); i++) {
-            result.add(randomAsciiOfLength(10));
+            result.add(randomAlphaOfLength(10));
         }
         return result;
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -80,7 +80,7 @@ public class ESTestCaseTests extends ESTestCase {
         Map<String, Object> result = new HashMap<>();
         int entries = randomInt(10);
         for (int i = 0; i < entries; i++) {
-            String key = randomAsciiOfLengthBetween(5, 15);
+            String key = randomAlphaOfLengthBetween(5, 15);
             int suprise = randomIntBetween(0, 4);
             switch (suprise) {
             case 0:
@@ -108,7 +108,7 @@ public class ESTestCaseTests extends ESTestCase {
             }
         }
         if (depth > 0) {
-            result.put(randomAsciiOfLengthBetween(5, 15), randomStringObjectMap(depth - 1));
+            result.put(randomAlphaOfLengthBetween(5, 15), randomStringObjectMap(depth - 1));
         }
         return result;
     }
@@ -123,6 +123,6 @@ public class ESTestCaseTests extends ESTestCase {
     }
 
     public void testRandomUniqueNormalUsageAlwayMoreThanOne() {
-        assertThat(randomUnique(() -> randomAsciiOfLengthBetween(1, 20), 10), hasSize(greaterThan(0)));
+        assertThat(randomUnique(() -> randomAlphaOfLengthBetween(1, 20), 10), hasSize(greaterThan(0)));
     }
 }


### PR DESCRIPTION
This commit renames the random ASCII helper methods in ESTestCase. This is because this method ultimately uses the random ASCII methods from randomized runner, but these methods actually only produce random strings generated from [a-zA-Z].
