### PR TITLE
WIP: Add parsing to InternalCardinality

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.xcontent.AbstractObjectParser;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.action.search.RestSearchAction;
@@ -191,6 +192,11 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, Na
         doXContentBody(builder, params);
         builder.endObject();
         return builder;
+    }
+
+    protected static void declareCommonField(AbstractObjectParser<Map<String, Object>, Void> parser) {
+        parser.declareObject((map, metaMap) -> map.put(CommonFields.META.getPreferredName(), metaMap),
+                (p, c) -> p.map(), CommonFields.META);
     }
 
     public abstract XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException;

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinalityTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/cardinality/InternalCardinalityTests.java
@@ -19,19 +19,29 @@
 
 package org.elasticsearch.search.aggregations.metrics.cardinality;
 
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 
 public class InternalCardinalityTests extends InternalAggregationTestCase<InternalCardinality> {
     private static List<HyperLogLogPlusPlus> algos;
@@ -71,6 +81,31 @@ public class InternalCardinalityTests extends InternalAggregationTestCase<Intern
             }
             assertEquals(result.cardinality(0), reduced.value(), 0);
         }
+    }
+
+    public void testFromXContent() throws IOException {
+        InternalCardinality cardinality = createTestInstance();
+        ToXContent.Params params = new ToXContent.MapParams(Collections.singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
+        boolean humanReadable = randomBoolean();
+        XContentType xContentType = randomFrom(XContentType.values());
+        BytesReference originalBytes = toXContent(cardinality, xContentType, params, humanReadable);
+
+        InternalCardinality parsed;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+            assertEquals(cardinality.getWriteableName() + "#" + cardinality.getName(), parser.currentName());
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+            parsed = InternalCardinality.parseXContentBody(cardinality.getName(), parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
+            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+            assertNull(parser.nextToken());
+        }
+        assertEquals(cardinality.getName(), parsed.getName());
+        assertEquals(cardinality.getValue(), parsed.getValue(), Double.MIN_VALUE);
+        assertEquals(cardinality.getValueAsString(), parsed.getValueAsString());
+        assertEquals(cardinality.getMetaData(), parsed.getMetaData());
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, params, humanReadable), xContentType);
     }
 
     @After


### PR DESCRIPTION
WIP: First version of adding parsing for InternalCardinality. This solution pulls the calculated cardinality value only once 
from the unterlying HLL object and provides a private ctor do provide this value directly when we can parse it from the rest response.