### PR TITLE
Add the ability to include extra notices in a plugin's NOTICES file

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/NoticeTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/NoticeTask.groovy
@@ -22,12 +22,14 @@ package org.elasticsearch.gradle
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 /**
- * A task to create a notice file which includes dependencies' notices.
+ * A task to create a notice file which includes dependencies' notices
+ * and, optionally, notices from a list of extra directories.
  */
 public class NoticeTask extends DefaultTask {
 
@@ -40,6 +42,10 @@ public class NoticeTask extends DefaultTask {
     /** Configurations to inspect dependencies*/
     private List<Project> dependencies = new ArrayList<>()
 
+    /** Extra directories to include notices from */
+    @InputDirectory
+    private List<File> extraLicensesDirs = new ArrayList<>()
+
     public NoticeTask() {
         description = 'Create a notice file from dependencies'
     }
@@ -49,23 +55,36 @@ public class NoticeTask extends DefaultTask {
         dependencies.add(project)
     }
 
+    /** Add notices from an extra directory. */
+    public void extraLicensesDir(File extraLicensesDir) {
+        extraLicensesDirs.add(extraLicensesDir)
+    }
+
     @TaskAction
     public void generateNotice() {
         StringBuilder output = new StringBuilder()
         output.append(inputFile.getText('UTF-8'))
         output.append('\n\n')
-        Set<String> seen = new HashSet<>()
+        Map<String, File> seen = new TreeMap<>()
         for (Project dep : dependencies) {
-            File licensesDir = new File(dep.projectDir, 'licenses')
-            if (licensesDir.exists() == false) continue
-            licensesDir.eachFileMatch({ it ==~ /.*-NOTICE\.txt/ && seen.contains(it) == false}) { File file ->
-                String name = file.name.substring(0, file.name.length() - '-NOTICE.txt'.length())
-                appendFile(file, name, 'NOTICE', output)
-                appendFile(new File(file.parentFile, "${name}-LICENSE.txt"), name, 'LICENSE', output)
-                seen.add(file.name)
-            }
+            iterateLicensesDir(new File(dep.projectDir, 'licenses'), seen, true)
+        }
+        for (File extraLicensesDir : extraLicensesDirs) {
+            iterateLicensesDir(extraLicensesDir, seen, false)
+        }
+        for (File file : seen.values()) {
+            String name = file.name.substring(0, file.name.length() - '-NOTICE.txt'.length())
+            appendFile(file, name, 'NOTICE', output)
+            appendFile(new File(file.parentFile, "${name}-LICENSE.txt"), name, 'LICENSE', output)
         }
         outputFile.setText(output.toString(), 'UTF-8')
+    }
+
+    static void iterateLicensesDir(File licensesDir, Map<String, File> seen, boolean isOptional) {
+        if (isOptional && licensesDir.exists() == false) return
+        licensesDir.eachFileMatch({ it ==~ /.*-NOTICE\.txt/ }) { File file ->
+            seen.put(file.name, file)
+        }
     }
 
     static void appendFile(File file, String name, String type, StringBuilder output) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -260,10 +260,6 @@ public class PluginBuildPlugin extends BuildPlugin {
         File noticeFile = project.pluginProperties.extension.noticeFile
         if (noticeFile != null) {
             NoticeTask generateNotice = project.tasks.create('generateNotice', NoticeTask.class)
-            File licensesDir = new File(project.projectDir, 'licenses')
-            if (licensesDir.exists()) {
-                generateNotice.licensesDir(licensesDir)
-            }
             generateNotice.inputFile = noticeFile
             project.bundlePlugin.from(generateNotice)
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -260,7 +260,10 @@ public class PluginBuildPlugin extends BuildPlugin {
         File noticeFile = project.pluginProperties.extension.noticeFile
         if (noticeFile != null) {
             NoticeTask generateNotice = project.tasks.create('generateNotice', NoticeTask.class)
-            generateNotice.dependencies(project)
+            File licensesDir = new File(project.projectDir, 'licenses')
+            if (licensesDir.exists()) {
+                generateNotice.licensesDir(licensesDir)
+            }
             generateNotice.inputFile = noticeFile
             project.bundlePlugin.from(generateNotice)
         }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -49,12 +49,12 @@ Collection distributions = project.subprojects.findAll {
 
 // integ test zip only uses core, so a different notice file is needed there
 task buildCoreNotice(type: NoticeTask) {
-  dependencies project(':core')
+  licensesDir new File(project(':core').projectDir, 'licenses')
 }
 
 // other distributions include notices from modules as well, which are added below later
 task buildFullNotice(type: NoticeTask) {
-  dependencies project(':core')
+  licensesDir new File(project(':core').projectDir, 'licenses')
 }
 
 /*****************************************************************************
@@ -73,7 +73,10 @@ ext.restTestExpansions = [
 // loop over modules to also setup cross task dependencies and increment our modules counter
 project.rootProject.subprojects.findAll { it.path.startsWith(':modules:') }.each { Project module ->
   buildFullNotice {
-    dependencies module
+    def defaultLicensesDir = new File(module.projectDir, 'licenses')
+    if (defaultLicensesDir.exists()) {
+      licensesDir defaultLicensesDir
+    }
   }
   buildModules {
     dependsOn({ project(module.path).bundlePlugin })


### PR DESCRIPTION
This PR adds the option for a plugin to specify extra directories containing
notices and licenses files to be incorporated into the overall notices file that
is generated for the plugin.

This can be useful, for example, where the plugin has a non-Java dependency
that itself incorporates many 3rd party components.

To avoid changing many build files, licenses/notices are still picked up from
the licenses sub-directory of the plugin project if such a directory exists.  If
extra directories are specified, however, they _must_ exist or the build will be
failed.