### PR TITLE
Bans ':' in cluster and index name

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterName.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterName.java
@@ -33,6 +33,8 @@ public class ClusterName implements Writeable {
     public static final Setting<ClusterName> CLUSTER_NAME_SETTING = new Setting<>("cluster.name", "elasticsearch", (s) -> {
         if (s.isEmpty()) {
             throw new IllegalArgumentException("[cluster.name] must not be empty");
+        } else if(s.contains(":")){
+            throw new IllegalArgumentException("[cluster.name] must not contains ':' character");
         }
         return new ClusterName(s);
     }, Setting.Property.NodeScope);

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterName.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterName.java
@@ -33,8 +33,8 @@ public class ClusterName implements Writeable {
     public static final Setting<ClusterName> CLUSTER_NAME_SETTING = new Setting<>("cluster.name", "elasticsearch", (s) -> {
         if (s.isEmpty()) {
             throw new IllegalArgumentException("[cluster.name] must not be empty");
-        } else if(s.contains(":")){
-            throw new IllegalArgumentException("[cluster.name] must not contains ':' character");
+        } else if (s.contains(":")) {
+            throw new IllegalArgumentException("[cluster.name] must not contains ':' character but was [" + s + "]");
         }
         return new ClusterName(s);
     }, Setting.Property.NodeScope);

--- a/core/src/main/java/org/elasticsearch/index/Index.java
+++ b/core/src/main/java/org/elasticsearch/index/Index.java
@@ -52,6 +52,9 @@ public class Index implements Writeable, ToXContent {
     public Index(String name, String uuid) {
         this.name = Objects.requireNonNull(name).intern();
         this.uuid = Objects.requireNonNull(uuid).intern();
+        if(this.name.contains(":")){
+            throw new IllegalArguementException("[index.name] must not contains ':' character");
+        }
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/Index.java
+++ b/core/src/main/java/org/elasticsearch/index/Index.java
@@ -53,7 +53,7 @@ public class Index implements Writeable, ToXContent {
         this.name = Objects.requireNonNull(name).intern();
         this.uuid = Objects.requireNonNull(uuid).intern();
         if(this.name.contains(":")){
-            throw new IllegalArguementException("[index.name] must not contains ':' character");
+            throw new IllegalArgumentException("[index.name] must not contains ':' character");
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/Index.java
+++ b/core/src/main/java/org/elasticsearch/index/Index.java
@@ -52,8 +52,8 @@ public class Index implements Writeable, ToXContent {
     public Index(String name, String uuid) {
         this.name = Objects.requireNonNull(name).intern();
         this.uuid = Objects.requireNonNull(uuid).intern();
-        if(this.name.contains(":")){
-            throw new IllegalArgumentException("[index.name] must not contains ':' character");
+        if (this.name.contains(":")) {
+            throw new IllegalArgumentException("[index.name] must not contains ':' character but was [" + this.name + "]");
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/IndexTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexTests.java
@@ -49,6 +49,12 @@ public class IndexTests extends ESTestCase {
         }
     }
 
+    public void testIndexName() {
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> new Index("cluster:index", "uuid"));
+        assertThat(e.getMessage(), equalTo("[index.name] must not contains ':' character"));
+    }
+
     public void testXContent() throws IOException {
         final String name = randomAsciiOfLengthBetween(4, 15);
         final String uuid = UUIDs.randomBase64UUID();

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -6,7 +6,7 @@ settings which need to be configured manually and should definitely be
 configured before going into production.
 
 * <<path-settings,`path.data` and `path.logs`>>
-* <<cluster.name,`cluster.name`>>
+* <<cluster.name,`  cluster.name`>>
 * <<node.name,`node.name`>>
 * <<bootstrap.memory_lock,`bootstrap.memory_lock`>>
 * <<network.host,`network.host`>>
@@ -55,7 +55,8 @@ path:
 A node can only join a cluster when it shares its `cluster.name` with all the
 other nodes in the cluster. The default name is `elasticsearch`, but you
 should change it to an appropriate name which describes the purpose of the
-cluster.
+cluster. The `cluster.name` must not contains `:` character in order to avoid
+problems while running queries over multiple clusters.
 
 [source,yaml]
 --------------------------------------------------

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -6,7 +6,7 @@ settings which need to be configured manually and should definitely be
 configured before going into production.
 
 * <<path-settings,`path.data` and `path.logs`>>
-* <<cluster.name,`  cluster.name`>>
+* <<cluster.name,`cluster.name`>>
 * <<node.name,`node.name`>>
 * <<bootstrap.memory_lock,`bootstrap.memory_lock`>>
 * <<network.host,`network.host`>>

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -9,7 +9,7 @@
         "index": {
           "type" : "string",
           "required" : true,
-          "description" : "The name of the index"
+          "description" : "The name of the index. The name must not contains ':' character."
         }
       },
       "params": {


### PR DESCRIPTION
This pull request prevent from creating cluster name and index name containing `:` character

Close #23892
