### PR TITLE
Tests: Extend rest test timeout to 30 minutes for windows

### DIFF
--- a/distribution/integ-test-zip/build.gradle
+++ b/distribution/integ-test-zip/build.gradle
@@ -18,6 +18,7 @@
  */
 
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin
+import org.apache.tools.ant.taskdefs.condition.Os
 
 task buildZip(type: Zip) {
   dependsOn createPluginsDir
@@ -58,6 +59,13 @@ publishing {
         scmNode.appendNode('url', project.scminfo.origin)
       }
     }
+  }
+}
+
+integTestRunner {
+  if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    // override the suite timeout to 30 mins for windows, because it has the most inefficient filesystem known to man
+    systemProperty 'tests.timeoutSuite', '1800000!'
   }
 }
 

--- a/distribution/integ-test-zip/build.gradle
+++ b/distribution/integ-test-zip/build.gradle
@@ -63,7 +63,7 @@ publishing {
 }
 
 integTestRunner {
-  if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+  if (Os.isFamily(Os.FAMILY_WINDOWS) && System.getProperty('tests.timeoutSuite') == null) {
     // override the suite timeout to 30 mins for windows, because it has the most inefficient filesystem known to man
     systemProperty 'tests.timeoutSuite', '1800000!'
   }


### PR DESCRIPTION
Windoes rest tests consistenly fail because the filesystem appears to be
an order of magnitude slower than that of *nix, at least in the context
of our rest tests. This commit overrides the suite timeout to 30 mins
for windows. From past failures, it appears this should be enough, as
the tests seem to fail when they are almost complete. The default suite
timeout for ESTestCase is 20 mins, so this leaves ample buffer for
windows shenanigans.