### PR TITLE
Removing unneeded getTookInMillis method

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -671,7 +671,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         BulkRequest bulkRequest = requestRef.get();
 
         assertEquals(RestStatus.OK, bulkResponse.status());
-        assertTrue(bulkResponse.getTookInMillis() > 0);
+        assertTrue(bulkResponse.getTook().getMillis() > 0);
         assertEquals(nbItems, bulkResponse.getItems().length);
         assertNull(error.get());
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -580,7 +580,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
 
         BulkResponse bulkResponse = execute(bulkRequest, highLevelClient()::bulk, highLevelClient()::bulkAsync);
         assertEquals(RestStatus.OK, bulkResponse.status());
-        assertTrue(bulkResponse.getTookInMillis() > 0);
+        assertTrue(bulkResponse.getTook().getMillis() > 0);
         assertEquals(nbItems, bulkResponse.getItems().length);
 
         validateBulkResponses(nbItems, errors, bulkResponse, bulkRequest);

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -70,13 +70,6 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
     }
 
     /**
-     * How long the bulk execution took. Excluding ingest preprocessing.
-     */
-    public TimeValue getTook() {
-        return new TimeValue(tookInMillis);
-    }
-
-    /**
      * How long the bulk execution took in milliseconds. Excluding ingest preprocessing.
      */
     public long getTookInMillis() {

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -70,10 +70,10 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
     }
 
     /**
-     * How long the bulk execution took in milliseconds. Excluding ingest preprocessing.
+     * How long the bulk execution took. Excluding ingest preprocessing.
      */
-    public long getTookInMillis() {
-        return tookInMillis;
+    public TimeValue getTook() {
+        return new TimeValue(tookInMillis);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -569,9 +569,9 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         ActionListener<BulkResponse> wrapActionListenerIfNeeded(long ingestTookInMillis, ActionListener<BulkResponse> actionListener) {
             if (itemResponses.isEmpty()) {
                 return ActionListener.wrap(
-                    response -> actionListener.onResponse(
-                        new BulkResponse(response.getItems(), response.getTookInMillis(), ingestTookInMillis)),
-                    actionListener::onFailure);
+                        response -> actionListener.onResponse(new BulkResponse(response.getItems(),
+                                response.getTook().getMillis(), ingestTookInMillis)),
+                        actionListener::onFailure);
             } else {
                 return new IngestBulkResponseListener(ingestTookInMillis, originalSlots, itemResponses, actionListener);
             }
@@ -610,7 +610,9 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
             for (int i = 0; i < items.length; i++) {
                 itemResponses.add(originalSlots[i], response.getItems()[i]);
             }
-            actionListener.onResponse(new BulkResponse(itemResponses.toArray(new BulkItemResponse[itemResponses.size()]), response.getTookInMillis(), ingestTookInMillis));
+            actionListener.onResponse(new BulkResponse(
+                    itemResponses.toArray(new BulkItemResponse[itemResponses.size()]),
+                    response.getTook().getMillis(), ingestTookInMillis));
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -129,13 +129,6 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
     }
 
     /**
-     * How long the search took.
-     */
-    public TimeValue getTook() {
-        return new TimeValue(tookInMillis);
-    }
-
-    /**
      * How long the search took in milliseconds.
      */
     public long getTookInMillis() {

--- a/core/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -129,10 +129,10 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
     }
 
     /**
-     * How long the search took in milliseconds.
+     * How long the search took.
      */
-    public long getTookInMillis() {
-        return tookInMillis;
+    public TimeValue getTook() {
+        return new TimeValue(tookInMillis);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
@@ -334,10 +334,6 @@ public class TermVectorsResponse extends ActionResponse implements ToXContentObj
         return new TimeValue(tookInMillis);
     }
 
-    public long getTookInMillis() {
-        return tookInMillis;
-    }
-
     private void buildScore(XContentBuilder builder, BoostAttribute boostAtt) throws IOException {
         if (hasScores) {
             builder.field(FieldStrings.SCORE, boostAtt.getBoost());

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkResponseTests.java
@@ -95,7 +95,7 @@ public class BulkResponseTests extends ESTestCase {
             assertNull(parser.nextToken());
         }
 
-        assertEquals(took, parsedBulkResponse.getTookInMillis());
+        assertEquals(took, parsedBulkResponse.getTook().getMillis());
         assertEquals(ingestTook, parsedBulkResponse.getIngestTookInMillis());
         assertEquals(expectedBulkItems.length, parsedBulkResponse.getItems().length);
 

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -187,11 +187,11 @@ public class TransportBulkActionTookTests extends ESTestCase {
             public void onResponse(BulkResponse bulkItemResponses) {
                 if (controlled) {
                     assertThat(
-                            bulkItemResponses.getTookInMillis(),
+                            bulkItemResponses.getTook().getMillis(),
                             equalTo(TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS)));
                 } else {
                     assertThat(
-                            bulkItemResponses.getTookInMillis(),
+                            bulkItemResponses.getTook().getMillis(),
                             greaterThanOrEqualTo(TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS)));
                 }
             }

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -187,11 +187,11 @@ public class TransportBulkActionTookTests extends ESTestCase {
             public void onResponse(BulkResponse bulkItemResponses) {
                 if (controlled) {
                     assertThat(
-                            bulkItemResponses.getTook().getMillis(),
+                            bulkItemResponses.getTookInMillis(),
                             equalTo(TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS)));
                 } else {
                     assertThat(
-                            bulkItemResponses.getTook().getMillis(),
+                            bulkItemResponses.getTookInMillis(),
                             greaterThanOrEqualTo(TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS)));
                 }
             }

--- a/core/src/test/java/org/elasticsearch/index/termvectors/TermVectorsServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/termvectors/TermVectorsServiceTests.java
@@ -73,7 +73,8 @@ public class TermVectorsServiceTests extends ESSingleNodeTestCase {
         TermVectorsResponse response = TermVectorsService.getTermVectors(shard, request, longs.iterator()::next);
 
         assertThat(response, notNullValue());
-        assertThat(response.getTookInMillis(), equalTo(TimeUnit.NANOSECONDS.toMillis(longs.get(1) - longs.get(0))));
+        assertThat(response.getTook().getMillis(),
+                equalTo(TimeUnit.NANOSECONDS.toMillis(longs.get(1) - longs.get(0))));
     }
 
     public void testDocFreqs() throws IOException {

--- a/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -802,7 +802,8 @@ public class HighlighterSearchIT extends ESIntegTestCase {
          * in the neighborhood of 300ms and the large phrase limit is in the
          * neighborhood of 8 seconds.
          */
-        assertThat(defaultPhraseLimit.getTookInMillis(), lessThan(largePhraseLimit.getTookInMillis()));
+        assertThat(defaultPhraseLimit.getTook().getMillis(),
+                lessThan(largePhraseLimit.getTook().getMillis()));
     }
 
 

--- a/docs/reference/migration/migrate_6_0/java.asciidoc
+++ b/docs/reference/migration/migrate_6_0/java.asciidoc
@@ -35,3 +35,9 @@ code for ordering buckets. The `BucketOrder` class must be used instead of `Term
 `Histogram.Order`. The `static` methods in the `BucketOrder` class must be called instead of directly
 accessing internal order instances, e.g. `BucketOrder.count(boolean)` and `BucketOrder.aggregation(String, boolean)`.
 Use `BucketOrder.key(boolean)` to order the `terms` aggregation buckets by `_term`.
+
+=== `getTookInMillis()` removed in `BulkResponse`, `SearchResponse` and `TermVectorsResponse`
+
+In `BulkResponse`, `SearchResponse` and `TermVectorsResponse` `getTookInMiilis()` method
+has been removed in favor of `getTook` method. `getTookInMiilis()` is easily replaced by
+`getTook().getMillis()`.


### PR DESCRIPTION
According to https://github.com/elastic/elasticsearch/pull/23767/files/7b70704ab45eb3ba98e0c31ce4eb8e65dd963381#r109564828 `getTook()` methods should be removed from `BulkResponse` and `SearchResponse` as there is an alternative `getTookInMillis()` which can be used.

Edit : use `getTook()`  instead of `getTookInMillis()`