### PR TITLE
Fixed "dates before" query example

### DIFF
--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -136,6 +136,10 @@ curly brackets `{min TO max}`.
 
     date:[2012-01-01 TO 2012-12-31]
 
+* Dates before 2012
+
+    date:[* TO 2012-01-01]
+
 * Numbers 1..5
 
     count:[1 TO 5]
@@ -147,10 +151,6 @@ curly brackets `{min TO max}`.
 * Numbers from 10 upwards
 
     count:[10 TO *]
-
-* Dates before 2012
-
-    date:{* TO 2012-01-01}
 
 Curly and square brackets can be combined:
 


### PR DESCRIPTION
Query doesn't work with {} syntax but does with []

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
