### PR TITLE
Preserve response headers when creating an index

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/ContextPreservingActionListener.java
+++ b/core/src/main/java/org/elasticsearch/action/support/ContextPreservingActionListener.java
@@ -50,4 +50,12 @@ public final class ContextPreservingActionListener<R> implements ActionListener<
             delegate.onFailure(e);
         }
     }
+
+    /**
+     * Wraps the provided action listener in a {@link ContextPreservingActionListener} that will
+     * also copy the response headers when the {@link ThreadContext.StoredContext} is closed
+     */
+    public static <R> ContextPreservingActionListener<R> wrapPreservingContext(ActionListener<R> listener, ThreadContext threadContext) {
+        return new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), listener);
+    }
 }

--- a/core/src/test/java/org/elasticsearch/action/support/ContextPreservingActionListenerTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/ContextPreservingActionListenerTests.java
@@ -33,11 +33,10 @@ public class ContextPreservingActionListenerTests extends ESTestCase {
             if (nonEmptyContext) {
                 threadContext.putHeader("not empty", "value");
             }
-            ContextPreservingActionListener<Void> actionListener;
+            final ContextPreservingActionListener<Void> actionListener;
             try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
                 threadContext.putHeader("foo", "bar");
-                actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true),
-                        new ActionListener<Void>() {
+                final ActionListener<Void> delegate = new ActionListener<Void>() {
                     @Override
                     public void onResponse(Void aVoid) {
                         assertEquals("bar", threadContext.getHeader("foo"));
@@ -48,7 +47,12 @@ public class ContextPreservingActionListenerTests extends ESTestCase {
                     public void onFailure(Exception e) {
                         throw new RuntimeException("onFailure shouldn't be called", e);
                     }
-                });
+                };
+                if (randomBoolean()) {
+                    actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), delegate);
+                } else {
+                    actionListener = ContextPreservingActionListener.wrapPreservingContext(delegate, threadContext);
+                }
             }
 
             assertNull(threadContext.getHeader("foo"));
@@ -67,22 +71,28 @@ public class ContextPreservingActionListenerTests extends ESTestCase {
             if (nonEmptyContext) {
                 threadContext.putHeader("not empty", "value");
             }
-            ContextPreservingActionListener<Void> actionListener;
+            final ContextPreservingActionListener<Void> actionListener;
             try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
                 threadContext.putHeader("foo", "bar");
-                actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true),
-                        new ActionListener<Void>() {
-                            @Override
-                            public void onResponse(Void aVoid) {
-                                throw new RuntimeException("onResponse shouldn't be called");
-                            }
+                final ActionListener<Void> delegate = new ActionListener<Void>() {
+                    @Override
+                    public void onResponse(Void aVoid) {
+                        throw new RuntimeException("onResponse shouldn't be called");
+                    }
 
-                            @Override
-                            public void onFailure(Exception e) {
-                                assertEquals("bar", threadContext.getHeader("foo"));
-                                assertNull(threadContext.getHeader("not empty"));
-                            }
-                        });
+                    @Override
+                    public void onFailure(Exception e) {
+                        assertEquals("bar", threadContext.getHeader("foo"));
+                        assertNull(threadContext.getHeader("not empty"));
+                    }
+                };
+
+                if (randomBoolean()) {
+                    actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), delegate);
+                } else {
+                    actionListener = ContextPreservingActionListener.wrapPreservingContext(delegate, threadContext);
+                }
+
             }
 
             assertNull(threadContext.getHeader("foo"));
@@ -101,25 +111,30 @@ public class ContextPreservingActionListenerTests extends ESTestCase {
             if (nonEmptyContext) {
                 threadContext.putHeader("not empty", "value");
             }
-            ContextPreservingActionListener<Void> actionListener;
+            final ContextPreservingActionListener<Void> actionListener;
             try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
                 threadContext.putHeader("foo", "bar");
-                actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true),
-                        new ActionListener<Void>() {
-                            @Override
-                            public void onResponse(Void aVoid) {
-                                assertEquals("bar", threadContext.getHeader("foo"));
-                                assertNull(threadContext.getHeader("not empty"));
-                                throw new RuntimeException("onResponse called");
-                            }
+                final ActionListener<Void> delegate = new ActionListener<Void>() {
+                    @Override
+                    public void onResponse(Void aVoid) {
+                        assertEquals("bar", threadContext.getHeader("foo"));
+                        assertNull(threadContext.getHeader("not empty"));
+                        throw new RuntimeException("onResponse called");
+                    }
 
-                            @Override
-                            public void onFailure(Exception e) {
-                                assertEquals("bar", threadContext.getHeader("foo"));
-                                assertNull(threadContext.getHeader("not empty"));
-                                throw new RuntimeException("onFailure called");
-                            }
-                        });
+                    @Override
+                    public void onFailure(Exception e) {
+                        assertEquals("bar", threadContext.getHeader("foo"));
+                        assertNull(threadContext.getHeader("not empty"));
+                        throw new RuntimeException("onFailure called");
+                    }
+                };
+
+                if (randomBoolean()) {
+                    actionListener = new ContextPreservingActionListener<>(threadContext.newRestorableContext(true), delegate);
+                } else {
+                    actionListener = ContextPreservingActionListener.wrapPreservingContext(delegate, threadContext);
+                }
             }
 
             assertNull(threadContext.getHeader("foo"));

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_warnings.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.create/20_warnings.yaml
@@ -1,0 +1,28 @@
+---
+"Create index with deprecated settings":
+
+  - skip:
+      version: "all"
+      reason: removed in 6.0
+      features: "warnings"
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            number_of_shards: 1
+            shadow_replicas: true
+            shared_filesystem: false
+          mappings:
+            type:
+              properties:
+                field:
+                  type: "string"
+                field2:
+                  type: "long"
+                  store : "no"
+      warnings:
+        - "[index.shadow_replicas] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
+        - "[index.shared_filesystem] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
+        - "The [string] field is deprecated, please use [text] or [keyword] instead on [field]"
+        - "Expected a boolean [true/false] for property [field2.store] but got [no]"


### PR DESCRIPTION
This commit preserves the response headers when creating an index and updating settings for an
index.

Closes #23947