### PR TITLE
Removes the retry mechanism from the S3 blob store

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/AwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/AwsS3Service.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.services.s3.AmazonS3;
+import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
@@ -159,5 +160,8 @@ interface AwsS3Service extends LifecycleComponent {
             Setting.timeSetting("cloud.aws.s3.read_timeout", AwsS3Service.READ_TIMEOUT, Property.NodeScope, Property.Deprecated);
     }
 
-    AmazonS3 client(Settings repositorySettings, Integer maxRetries, boolean useThrottleRetries, Boolean pathStyleAccess);
+    /**
+     * Creates an {@code AmazonS3} client from the given repository metadata and node settings.
+     */
+    AmazonS3 client(RepositoryMetaData metadata, Settings repositorySettings);
 }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -73,25 +73,17 @@ class S3BlobContainer extends AbstractBlobContainer {
 
     @Override
     public InputStream readBlob(String blobName) throws IOException {
-        int retry = 0;
-        while (retry <= blobStore.numberOfRetries()) {
-            try {
-                S3Object s3Object = SocketAccess.doPrivileged(() -> blobStore.client().getObject(blobStore.bucket(), buildKey(blobName)));
-                return s3Object.getObjectContent();
-            } catch (AmazonClientException e) {
-                if (blobStore.shouldRetry(e) && (retry < blobStore.numberOfRetries())) {
-                    retry++;
-                } else {
-                    if (e instanceof AmazonS3Exception) {
-                        if (404 == ((AmazonS3Exception) e).getStatusCode()) {
-                            throw new NoSuchFileException("Blob object [" + blobName + "] not found: " + e.getMessage());
-                        }
-                    }
-                    throw e;
+        try {
+            S3Object s3Object = SocketAccess.doPrivileged(() -> blobStore.client().getObject(blobStore.bucket(), buildKey(blobName)));
+            return s3Object.getObjectContent();
+        } catch (AmazonClientException e) {
+            if (e instanceof AmazonS3Exception) {
+                if (404 == ((AmazonS3Exception) e).getStatusCode()) {
+                    throw new NoSuchFileException("Blob object [" + blobName + "] not found: " + e.getMessage());
                 }
             }
+            throw e;
         }
-        throw new BlobStoreException("retries exhausted while attempting to access blob object [name:" + blobName + ", bucket:" + blobStore.bucket() + "]");
     }
 
     @Override
@@ -120,7 +112,7 @@ class S3BlobContainer extends AbstractBlobContainer {
     private OutputStream createOutput(final String blobName) throws IOException {
         // UploadS3OutputStream does buffering & retry logic internally
         return new DefaultS3OutputStream(blobStore, blobStore.bucket(), buildKey(blobName),
-            blobStore.bufferSizeInBytes(), blobStore.numberOfRetries(), blobStore.serverSideEncryption());
+            blobStore.bufferSizeInBytes(), blobStore.serverSideEncryption());
     }
 
     @Override

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
@@ -51,21 +51,18 @@ class S3BlobStore extends AbstractComponent implements BlobStore {
 
     private final boolean serverSideEncryption;
 
-    private final int numberOfRetries;
-
     private final CannedAccessControlList cannedACL;
 
     private final StorageClass storageClass;
 
     S3BlobStore(Settings settings, AmazonS3 client, String bucket, boolean serverSideEncryption,
-                       ByteSizeValue bufferSize, int maxRetries, String cannedACL, String storageClass) {
+                ByteSizeValue bufferSize, String cannedACL, String storageClass) {
         super(settings);
         this.client = client;
         this.bucket = bucket;
         this.serverSideEncryption = serverSideEncryption;
         this.bufferSize = bufferSize;
         this.cannedACL = initCannedACL(cannedACL);
-        this.numberOfRetries = maxRetries;
         this.storageClass = initStorageClass(storageClass);
 
         // Note: the method client.doesBucketExist() may return 'true' is the bucket exists
@@ -100,10 +97,6 @@ class S3BlobStore extends AbstractComponent implements BlobStore {
 
     public int bufferSizeInBytes() {
         return bufferSize.bytesAsInt();
-    }
-
-    public int numberOfRetries() {
-        return numberOfRetries;
     }
 
     @Override

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3OutputStream.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3OutputStream.java
@@ -39,7 +39,6 @@ abstract class S3OutputStream extends OutputStream {
     private S3BlobStore blobStore;
     private String bucketName;
     private String blobName;
-    private int numberOfRetries;
     private boolean serverSideEncryption;
 
     private byte[] buffer;
@@ -48,11 +47,10 @@ abstract class S3OutputStream extends OutputStream {
 
     private int flushCount = 0;
 
-    S3OutputStream(S3BlobStore blobStore, String bucketName, String blobName, int bufferSizeInBytes, int numberOfRetries, boolean serverSideEncryption) {
+    S3OutputStream(S3BlobStore blobStore, String bucketName, String blobName, int bufferSizeInBytes, boolean serverSideEncryption) {
         this.blobStore = blobStore;
         this.bucketName = bucketName;
         this.blobName = blobName;
-        this.numberOfRetries = numberOfRetries;
         this.serverSideEncryption = serverSideEncryption;
 
         if (bufferSizeInBytes < MULTIPART_MIN_SIZE.getBytes()) {
@@ -105,10 +103,6 @@ abstract class S3OutputStream extends OutputStream {
 
     public int getBufferSize() {
         return buffer.length;
-    }
-
-    public int getNumberOfRetries() {
-        return numberOfRetries;
     }
 
     public boolean isServerSideEncryption() {

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -340,7 +340,7 @@ class S3Repository extends BlobStoreRepository {
             storageClass, pathStyleAccess);
 
         AmazonS3 client = s3Service.client(metadata.settings(), maxRetries, useThrottleRetries, pathStyleAccess);
-        blobStore = new S3BlobStore(settings, client, bucket, serverSideEncryption, bufferSize, maxRetries, cannedACL, storageClass);
+        blobStore = new S3BlobStore(settings, client, bucket, serverSideEncryption, bufferSize, cannedACL, storageClass);
 
         String basePath = getValue(metadata.settings(), settings, Repository.BASE_PATH_SETTING, Repositories.BASE_PATH_SETTING);
         if (Strings.hasLength(basePath)) {

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -311,8 +311,6 @@ class S3Repository extends BlobStoreRepository {
 
         boolean serverSideEncryption = getValue(metadata.settings(), settings, Repository.SERVER_SIDE_ENCRYPTION_SETTING, Repositories.SERVER_SIDE_ENCRYPTION_SETTING);
         ByteSizeValue bufferSize = getValue(metadata.settings(), settings, Repository.BUFFER_SIZE_SETTING, Repositories.BUFFER_SIZE_SETTING);
-        Integer maxRetries = getValue(metadata.settings(), settings, Repository.MAX_RETRIES_SETTING, Repositories.MAX_RETRIES_SETTING);
-        boolean useThrottleRetries = getValue(metadata.settings(), settings, Repository.USE_THROTTLE_RETRIES_SETTING, Repositories.USE_THROTTLE_RETRIES_SETTING);
         this.chunkSize = getValue(metadata.settings(), settings, Repository.CHUNK_SIZE_SETTING, Repositories.CHUNK_SIZE_SETTING);
         this.compress = getValue(metadata.settings(), settings, Repository.COMPRESS_SETTING, Repositories.COMPRESS_SETTING);
 
@@ -326,20 +324,11 @@ class S3Repository extends BlobStoreRepository {
         String storageClass = getValue(metadata.settings(), settings, Repository.STORAGE_CLASS_SETTING, Repositories.STORAGE_CLASS_SETTING);
         String cannedACL = getValue(metadata.settings(), settings, Repository.CANNED_ACL_SETTING, Repositories.CANNED_ACL_SETTING);
 
-        // If the user defined a path style access setting, we rely on it otherwise we use the default
-        // value set by the SDK
-        Boolean pathStyleAccess = null;
-        if (Repository.PATH_STYLE_ACCESS_SETTING.exists(metadata.settings()) ||
-            Repositories.PATH_STYLE_ACCESS_SETTING.exists(settings)) {
-            pathStyleAccess = getValue(metadata.settings(), settings, Repository.PATH_STYLE_ACCESS_SETTING, Repositories.PATH_STYLE_ACCESS_SETTING);
-        }
-
         logger.debug("using bucket [{}], chunk_size [{}], server_side_encryption [{}], " +
-            "buffer_size [{}], max_retries [{}], use_throttle_retries [{}], cannedACL [{}], storageClass [{}], path_style_access [{}]",
-            bucket, chunkSize, serverSideEncryption, bufferSize, maxRetries, useThrottleRetries, cannedACL,
-            storageClass, pathStyleAccess);
+            "buffer_size [{}], cannedACL [{}], storageClass [{}]",
+            bucket, chunkSize, serverSideEncryption, bufferSize, cannedACL, storageClass);
 
-        AmazonS3 client = s3Service.client(metadata.settings(), maxRetries, useThrottleRetries, pathStyleAccess);
+        AmazonS3 client = s3Service.client(metadata, metadata.settings());
         blobStore = new S3BlobStore(settings, client, bucket, serverSideEncryption, bufferSize, cannedACL, storageClass);
 
         String basePath = getValue(metadata.settings(), settings, Repository.BASE_PATH_SETTING, Repositories.BASE_PATH_SETTING);

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
@@ -26,9 +26,6 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.repositories.s3.AwsS3Service;
-import org.elasticsearch.repositories.s3.InternalAwsS3Service;
-import org.elasticsearch.repositories.s3.S3Repository;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.instanceOf;

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockDefaultS3OutputStream.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockDefaultS3OutputStream.java
@@ -42,7 +42,7 @@ public class MockDefaultS3OutputStream extends DefaultS3OutputStream {
     private int numberOfUploadRequests = 0;
 
     public MockDefaultS3OutputStream(int bufferSizeInBytes) {
-        super(null, "test-bucket", "test-blobname", bufferSizeInBytes, 3, false);
+        super(null, "test-bucket", "test-blobname", bufferSizeInBytes, false);
     }
 
     @Override

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -34,6 +34,6 @@ public class S3BlobStoreContainerTests extends ESBlobStoreContainerTestCase {
         String bucket = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
 
         return new S3BlobStore(Settings.EMPTY, client, bucket, false,
-            new ByteSizeValue(10, ByteSizeUnit.MB), 5, "public-read-write", "standard");
+            new ByteSizeValue(10, ByteSizeUnit.MB), "public-read-write", "standard");
     }
 }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -60,8 +60,7 @@ public class S3RepositoryTests extends ESTestCase {
         @Override
         protected void doClose() {}
         @Override
-        public AmazonS3 client(Settings repositorySettings, Integer maxRetries,
-                               boolean useThrottleRetries, Boolean pathStyleAccess) {
+        public AmazonS3 client(RepositoryMetaData metadata, Settings settings) {
             return new DummyS3Client();
         }
     }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/TestAwsS3Service.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/TestAwsS3Service.java
@@ -23,6 +23,7 @@ import java.util.IdentityHashMap;
 
 import com.amazonaws.services.s3.AmazonS3;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.common.settings.Settings;
 
 public class TestAwsS3Service extends InternalAwsS3Service {
@@ -33,7 +34,7 @@ public class TestAwsS3Service extends InternalAwsS3Service {
         }
     }
 
-    IdentityHashMap<AmazonS3, TestAmazonS3> clients = new IdentityHashMap<AmazonS3, TestAmazonS3>();
+    IdentityHashMap<AmazonS3, TestAmazonS3> clients = new IdentityHashMap<>();
 
     public TestAwsS3Service(Settings settings) {
         super(settings);
@@ -41,9 +42,8 @@ public class TestAwsS3Service extends InternalAwsS3Service {
 
 
     @Override
-    public synchronized AmazonS3 client(Settings repositorySettings, Integer maxRetries,
-                                              boolean useThrottleRetries, Boolean pathStyleAccess) {
-        return cachedWrapper(super.client(repositorySettings, maxRetries, useThrottleRetries, pathStyleAccess));
+    public synchronized AmazonS3 client(RepositoryMetaData metadata, Settings repositorySettings) {
+        return cachedWrapper(super.client(metadata, repositorySettings));
     }
 
     private AmazonS3 cachedWrapper(AmazonS3 client) {


### PR DESCRIPTION
Currently, both the Amazon S3 client provides a retry mechanism, and the
S3 blob store also attempts retries for failed read/write requests.
Both retry mechanisms are controlled by the
`repositories.s3.max_retries` setting.  However, the S3 blob store retry
mechanism is unnecessary because the Amazon S3 client provided by the
Amazon SDK already handles retries (with exponential backoff) based on
the provided max retry configuration setting (defaults to 3) as long as
the request is retryable.  Hence, this commit removes the unneeded retry
logic in the S3 blob store and the S3OutputStream.

Closes #22845