### PR TITLE
Fix compilation in Eclipse again

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -616,7 +616,9 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         };
 
         ThreadPool threadPool = new ThreadPool(Settings.builder().put("node.name", getClass().getName()).build());
-        try(BulkProcessor processor = new BulkProcessor.Builder(highLevelClient()::bulkAsync, listener, threadPool)
+        // Pull the client to a variable to work around https://bugs.eclipse.org/bugs/show_bug.cgi?id=514884
+        RestHighLevelClient hlClient = highLevelClient();
+        try(BulkProcessor processor = new BulkProcessor.Builder(hlClient::bulkAsync, listener, threadPool)
             .setConcurrentRequests(0)
             .setBulkSize(new ByteSizeValue(5, ByteSizeUnit.GB))
             .setBulkActions(nbItems + 1)


### PR DESCRIPTION
Eclipse seems to have trouble with CrudIT. It throws an NPE back
to the user. I've filed a bug:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=514884
but for now we should work around it.
