### PR TITLE
Fix possible hang in local transport when nodes get concurrently disconnected

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -853,7 +853,7 @@ public class TransportService extends AbstractLifecycleComponent {
         @Override
         public void onNodeDisconnected(final DiscoveryNode node) {
             try {
-                threadPool.generic().execute( () -> {
+                threadPool.generic().execute(() -> {
                     for (final TransportConnectionListener connectionListener : connectionListeners) {
                         connectionListener.onNodeDisconnected(node);
                     }

--- a/core/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/local/LocalTransport.java
@@ -47,6 +47,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ActionNotFoundTransportException;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
+import org.elasticsearch.transport.NodeDisconnectedException;
 import org.elasticsearch.transport.NodeNotConnectedException;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.RequestHandlerRegistry;
@@ -207,21 +208,7 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
         if (targetTransport == null) {
             throw new NodeNotConnectedException(node, "Node not connected");
         }
-        return new Connection() {
-            @Override
-            public DiscoveryNode getNode() {
-                return node;
-            }
-
-            @Override
-            public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
-                throws IOException, TransportException {
-                LocalTransport.this.sendRequest(targetTransport, node, requestId, action, request, options);
-            }
-
-            @Override
-            public void close() throws IOException {}
-        };
+        return getConnectionForTransport(targetTransport, node);
     }
 
     @Override
@@ -230,6 +217,10 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
         if (targetTransport == null) {
             throw new ConnectTransportException(node, "Failed to connect");
         }
+        return getConnectionForTransport(targetTransport, node);
+    }
+
+    private Connection getConnectionForTransport(LocalTransport targetTransport, DiscoveryNode node) {
         return new Connection() {
             @Override
             public DiscoveryNode getNode() {
@@ -239,13 +230,20 @@ public class LocalTransport extends AbstractLifecycleComponent implements Transp
             @Override
             public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
                 throws IOException, TransportException {
+                if (transports.get(node.getAddress()) != targetTransport) {
+                    // we double check that we are still connected since due to the nature of local transport we won't get any errors
+                    // when we send to a closed / disconnected transport. Yet, if the target transport is closed concurrently before
+                    // the transport service registers the client handler local transport will simply ignore the request which can cause
+                    // requests to hang. By checking again here we guarantee to throw an exception which causes the client handler to run
+                    // in such a situation, if the client handler is not registered yet when the connections is obtained.
+                    throw new NodeNotConnectedException(node, " got disconnected");
+                }
                 LocalTransport.this.sendRequest(targetTransport, node, requestId, action, request, options);
             }
 
             @Override
             public void close() throws IOException {}
         };
-
     }
 
     protected void sendRequest(LocalTransport targetTransport, final DiscoveryNode node, final long requestId, final String action,


### PR DESCRIPTION
There is a very small race that can cause requests to hang if nodes are concurrently
disconnected while a connection is fetched form the transport and the client handler
is installed in the TransportService. The code relies on the fact that closed connections
either fully work or fail and cause the requests to be ended / finished with an exception.
This is not necessarily true in local transport since it doesn't really maintain connections
in the classical sense.
This change adds additional checking for disconnected nodes when the connection is used to ensure
the connection is never used with a disconnected transport.

Closes #23942
