### PR TITLE
Tests: Ensure highlighter fields order in TopHitsTests

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
@@ -160,7 +160,9 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
             }
         }
         if (randomBoolean()) {
-            factory.highlighter(HighlightBuilderTests.randomHighlighterBuilder());
+            // parent test shuffles xContent, we need to make sure highlight fields are ordered
+            factory.highlighter(
+                    HighlightBuilderTests.randomHighlighterBuilder().useExplicitFieldOrder(true));
         }
         return factory;
     }


### PR DESCRIPTION
Shuffling xContent breaks the order of the highlighter fields in the
internal list if the highlighter doesn't use the array syntax. In other tests we
avoid shuffling this json level, but since this is done in the base test for
aggregations we should ensure the highlight builder uses the array syntax here.
