### PR TITLE
Remove getProperty method from Aggregations interface and impl

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
@@ -45,14 +45,4 @@ public interface Aggregations extends Iterable<Aggregation> {
      * Returns the aggregation that is associated with the specified name.
      */
     <A extends Aggregation> A get(String name);
-
-    /**
-     * Get the value of specified path in the aggregation.
-     * 
-     * @param path
-     *            the path to the property in the aggregation tree
-     * @return the value of the property
-     */
-    Object getProperty(String path);
-
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.aggregations.InternalAggregation.ReduceContext;
-import org.elasticsearch.search.aggregations.support.AggregationPath;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -105,24 +104,6 @@ public class InternalAggregations implements Aggregations, ToXContent, Streamabl
     @Override
     public <A extends Aggregation> A get(String name) {
         return (A) asMap().get(name);
-    }
-
-    @Override
-    public Object getProperty(String path) {
-        AggregationPath aggPath = AggregationPath.parse(path);
-        return getProperty(aggPath.getPathElementsAsStringList());
-    }
-
-    public Object getProperty(List<String> path) {
-        if (path.isEmpty()) {
-            return this;
-        }
-        String aggName = path.get(0);
-        InternalAggregation aggregation = get(aggName);
-        if (aggregation == null) {
-            throw new IllegalArgumentException("Cannot find an aggregation named [" + aggName + "]");
-        }
-        return aggregation.getProperty(path.subList(1, path.size()));
     }
 
     /**


### PR DESCRIPTION
The `getProperty` method is an internal method needed to run pipeline aggregations and retrieve info by path from the aggs tree. It is not needed in the `Aggregations` interface, which is returned to users running aggregations from the transport client. Furthermore, the method is currenty unused by pipeline aggs too, as only InternalAggregation#getProperty is used. It can then be removed