### PR TITLE
Skip hidden files when spawning

### DIFF
--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -157,6 +157,21 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         }
     }
 
+    public void testSpawnerSkipsHiddenFiles() throws IOException {
+        final Path esHome = createTempDir().resolve("home");
+        final Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(Environment.PATH_HOME_SETTING.getKey(), esHome.toString());
+        final Settings settings = settingsBuilder.build();
+
+        final Environment environment = new Environment(settings);
+
+        final Path hidden = environment.pluginsFile().resolve(".hidden");
+        Files.createDirectories(hidden);
+
+        Spawner spawner = new Spawner();
+        spawner.spawnNativePluginControllers(environment);
+    }
+
     public void testControllerSpawnWithIncorrectDescriptor() throws IOException {
         // this plugin will have a controller daemon
         Path esHome = createTempDir().resolve("esHome");

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -158,6 +158,8 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
     }
 
     public void testSpawnerSkipsHiddenFiles() throws IOException {
+        assert Version.CURRENT.before(Version.fromString("5.5.0"))
+                : "remove support for skipping hidden files in 5.5.0";
         final Path esHome = createTempDir().resolve("home");
         final Settings.Builder settingsBuilder = Settings.builder();
         settingsBuilder.put(Environment.PATH_HOME_SETTING.getKey(), esHome.toString());


### PR DESCRIPTION
When spawning a native controller, for now we should skip hidden directories in the plugin folder. Future versions of Elasticsearch will not be lenient here.

