### PR TITLE
AWS Plugins: Remove signer type setting

### DIFF
--- a/docs/reference/migration/migrate_6_0/plugins.asciidoc
+++ b/docs/reference/migration/migrate_6_0/plugins.asciidoc
@@ -21,6 +21,8 @@ region inside the repository settings. Instead, specify the full endpoint if a c
 s3 location is needed, or rely on the default behavior which automatically locates
 the region of the configured bucket.
 
+* Specifying s3 signer type has been removed, including `cloud.aws.signer` and `cloud.aws.s3.signer`.
+
 ==== Azure Repository plugin
 
 * The container an azure repository is configured with will no longer be created automatically.
@@ -33,3 +35,7 @@ name space have been removed. This includes `repositories.azure.account`, `repos
 You must set those settings per repository instead. Respectively `account`, `container`, `base_path`,
 `location_mode`, `chunk_size` and `compress`.
 See {plugins}/repository-azure-usage.html#repository-azure-repository-settings[Azure Repository settings].
+
+==== EC2 Discovery plugin
+
+* Specifying ec2 signer type has been removed, including `cloud.aws.signer` and `cloud.aws.ec2.signer`.

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2Service.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2Service.java
@@ -77,10 +77,6 @@ interface AwsEc2Service {
     Setting<SecureString> PROXY_PASSWORD_SETTING = new Setting<>("cloud.aws.proxy.password", "", SecureString::new,
         Property.NodeScope, Property.Filtered, Property.Shared, Property.Deprecated);
     /**
-     * cloud.aws.signer: If you are using an old AWS API version, you can define a Signer. Shared with repository-s3 plugin
-     */
-    Setting<String> SIGNER_SETTING = Setting.simpleString("cloud.aws.signer", Property.NodeScope, Property.Shared, Property.Deprecated);
-    /**
      * cloud.aws.region: Region. Shared with repository-s3 plugin
      */
     Setting<String> REGION_SETTING =
@@ -140,13 +136,6 @@ interface AwsEc2Service {
          */
         Setting<SecureString> PROXY_PASSWORD_SETTING = new Setting<>("cloud.aws.ec2.proxy.password", AwsEc2Service.PROXY_PASSWORD_SETTING,
             SecureString::new, Property.NodeScope, Property.Filtered, Property.Deprecated);
-        /**
-         * cloud.aws.ec2.signer: If you are using an old AWS API version, you can define a Signer. Specific for EC2 API calls.
-         * Defaults to cloud.aws.signer.
-         * @see AwsEc2Service#SIGNER_SETTING
-         */
-        Setting<String> SIGNER_SETTING = new Setting<>("cloud.aws.ec2.signer", AwsEc2Service.SIGNER_SETTING, Function.identity(),
-            Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.ec2.region: Region specific for EC2 API calls. Defaults to cloud.aws.region.
          * @see AwsEc2Service#REGION_SETTING

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImpl.java
@@ -104,13 +104,6 @@ class AwsEc2ServiceImpl extends AbstractComponent implements AwsEc2Service, Clos
             }
         }
 
-        // #155: we might have 3rd party users using older EC2 API version
-        String awsSigner = CLOUD_EC2.SIGNER_SETTING.get(settings);
-        if (Strings.hasText(awsSigner)) {
-            logger.debug("using AWS API signer [{}]", awsSigner);
-            AwsSigner.configureSigner(awsSigner, clientConfiguration);
-        }
-
         // Increase the number of retries in case of 5xx API responses
         final Random rand = Randomness.get();
         RetryPolicy retryPolicy = new RetryPolicy(

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -127,7 +127,6 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Close
         AwsEc2Service.PROXY_PORT_SETTING,
         AwsEc2Service.PROXY_USERNAME_SETTING,
         AwsEc2Service.PROXY_PASSWORD_SETTING,
-        AwsEc2Service.SIGNER_SETTING,
         AwsEc2Service.REGION_SETTING,
         AwsEc2Service.READ_TIMEOUT,
         // Register EC2 specific settings: cloud.aws.ec2
@@ -138,7 +137,6 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Close
         AwsEc2Service.CLOUD_EC2.PROXY_PORT_SETTING,
         AwsEc2Service.CLOUD_EC2.PROXY_USERNAME_SETTING,
         AwsEc2Service.CLOUD_EC2.PROXY_PASSWORD_SETTING,
-        AwsEc2Service.CLOUD_EC2.SIGNER_SETTING,
         AwsEc2Service.CLOUD_EC2.REGION_SETTING,
         AwsEc2Service.CLOUD_EC2.ENDPOINT_SETTING,
         AwsEc2Service.CLOUD_EC2.READ_TIMEOUT,

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
@@ -98,7 +98,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
     }
 
     public void testAWSDefaultConfiguration() {
-        launchAWSConfigurationTest(Settings.EMPTY, Protocol.HTTPS, null, -1, null, null, null,
+        launchAWSConfigurationTest(Settings.EMPTY, Protocol.HTTPS, null, -1, null, null,
             ClientConfiguration.DEFAULT_SOCKET_TIMEOUT);
     }
 
@@ -113,8 +113,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             .put("discovery.ec2.read_timeout", "10s")
             .setSecureSettings(secureSettings)
             .build();
-        launchAWSConfigurationTest(settings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username", "aws_proxy_password",
-            null, 10000);
+        launchAWSConfigurationTest(settings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username", "aws_proxy_password", 10000);
     }
 
     public void testAWSConfigurationWithAwsSettingsBackcompat() {
@@ -127,7 +126,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             .put(AwsEc2Service.READ_TIMEOUT.getKey(), "10s")
             .build();
         launchAWSConfigurationTest(settings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username", "aws_proxy_password",
-            "AWS3SignerType", 10000);
+            10000);
         assertSettingDeprecationsAndWarnings(new Setting<?>[] {
             AwsEc2Service.PROTOCOL_SETTING,
             AwsEc2Service.PROXY_HOST_SETTING,
@@ -153,8 +152,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             .put(AwsEc2Service.CLOUD_EC2.PROXY_PASSWORD_SETTING.getKey(), "ec2_proxy_password")
             .put(AwsEc2Service.CLOUD_EC2.READ_TIMEOUT.getKey(), "10s")
             .build();
-        launchAWSConfigurationTest(settings, Protocol.HTTPS, "ec2_proxy_host", 8081, "ec2_proxy_username", "ec2_proxy_password",
-            "NoOpSignerType", 10000);
+        launchAWSConfigurationTest(settings, Protocol.HTTPS, "ec2_proxy_host", 8081, "ec2_proxy_username", "ec2_proxy_password", 10000);
         assertSettingDeprecationsAndWarnings(new Setting<?>[] {
             AwsEc2Service.PROTOCOL_SETTING,
             AwsEc2Service.PROXY_HOST_SETTING,
@@ -177,7 +175,6 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
                                               int expectedProxyPort,
                                               String expectedProxyUsername,
                                               String expectedProxyPassword,
-                                              String expectedSigner,
                                               int expectedReadTimeout) {
         ClientConfiguration configuration = AwsEc2ServiceImpl.buildConfiguration(logger, settings);
 
@@ -187,7 +184,6 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
         assertThat(configuration.getProxyPort(), is(expectedProxyPort));
         assertThat(configuration.getProxyUsername(), is(expectedProxyUsername));
         assertThat(configuration.getProxyPassword(), is(expectedProxyPassword));
-        assertThat(configuration.getSignerOverride(), is(expectedSigner));
         assertThat(configuration.getSocketTimeout(), is(expectedReadTimeout));
     }
 

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
@@ -124,7 +124,6 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             .put(AwsEc2Service.PROXY_PORT_SETTING.getKey(), 8080)
             .put(AwsEc2Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
             .put(AwsEc2Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
-            .put(AwsEc2Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
             .put(AwsEc2Service.READ_TIMEOUT.getKey(), "10s")
             .build();
         launchAWSConfigurationTest(settings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username", "aws_proxy_password",
@@ -135,7 +134,6 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             AwsEc2Service.PROXY_PORT_SETTING,
             AwsEc2Service.PROXY_USERNAME_SETTING,
             AwsEc2Service.PROXY_PASSWORD_SETTING,
-            AwsEc2Service.SIGNER_SETTING,
             AwsEc2Service.READ_TIMEOUT
         });
     }
@@ -147,14 +145,12 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             .put(AwsEc2Service.PROXY_PORT_SETTING.getKey(), 8080)
             .put(AwsEc2Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
             .put(AwsEc2Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
-            .put(AwsEc2Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
             .put(AwsEc2Service.READ_TIMEOUT.getKey(), "20s")
             .put(AwsEc2Service.CLOUD_EC2.PROTOCOL_SETTING.getKey(), "https")
             .put(AwsEc2Service.CLOUD_EC2.PROXY_HOST_SETTING.getKey(), "ec2_proxy_host")
             .put(AwsEc2Service.CLOUD_EC2.PROXY_PORT_SETTING.getKey(), 8081)
             .put(AwsEc2Service.CLOUD_EC2.PROXY_USERNAME_SETTING.getKey(), "ec2_proxy_username")
             .put(AwsEc2Service.CLOUD_EC2.PROXY_PASSWORD_SETTING.getKey(), "ec2_proxy_password")
-            .put(AwsEc2Service.CLOUD_EC2.SIGNER_SETTING.getKey(), "NoOpSignerType")
             .put(AwsEc2Service.CLOUD_EC2.READ_TIMEOUT.getKey(), "10s")
             .build();
         launchAWSConfigurationTest(settings, Protocol.HTTPS, "ec2_proxy_host", 8081, "ec2_proxy_username", "ec2_proxy_password",
@@ -165,14 +161,12 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             AwsEc2Service.PROXY_PORT_SETTING,
             AwsEc2Service.PROXY_USERNAME_SETTING,
             AwsEc2Service.PROXY_PASSWORD_SETTING,
-            AwsEc2Service.SIGNER_SETTING,
             AwsEc2Service.READ_TIMEOUT,
             AwsEc2Service.CLOUD_EC2.PROTOCOL_SETTING,
             AwsEc2Service.CLOUD_EC2.PROXY_HOST_SETTING,
             AwsEc2Service.CLOUD_EC2.PROXY_PORT_SETTING,
             AwsEc2Service.CLOUD_EC2.PROXY_USERNAME_SETTING,
             AwsEc2Service.CLOUD_EC2.PROXY_PASSWORD_SETTING,
-            AwsEc2Service.CLOUD_EC2.SIGNER_SETTING,
             AwsEc2Service.CLOUD_EC2.READ_TIMEOUT
         });
     }

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoverySettingsTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoverySettingsTests.java
@@ -37,7 +37,6 @@ public class Ec2DiscoverySettingsTests extends ESTestCase {
         .put(AwsEc2Service.PROXY_PORT_SETTING.getKey(), 10000)
         .put(AwsEc2Service.PROXY_USERNAME_SETTING.getKey(), "global-proxy-username")
         .put(AwsEc2Service.PROXY_PASSWORD_SETTING.getKey(), "global-proxy-password")
-        .put(AwsEc2Service.SIGNER_SETTING.getKey(), "global-signer")
         .put(AwsEc2Service.REGION_SETTING.getKey(), "global-region")
         .build();
 
@@ -49,7 +48,6 @@ public class Ec2DiscoverySettingsTests extends ESTestCase {
         .put(AwsEc2Service.CLOUD_EC2.PROXY_PORT_SETTING.getKey(), 20000)
         .put(AwsEc2Service.CLOUD_EC2.PROXY_USERNAME_SETTING.getKey(), "ec2-proxy-username")
         .put(AwsEc2Service.CLOUD_EC2.PROXY_PASSWORD_SETTING.getKey(), "ec2-proxy-password")
-        .put(AwsEc2Service.CLOUD_EC2.SIGNER_SETTING.getKey(), "ec2-signer")
         .put(AwsEc2Service.CLOUD_EC2.REGION_SETTING.getKey(), "ec2-region")
         .put(AwsEc2Service.CLOUD_EC2.ENDPOINT_SETTING.getKey(), "ec2-endpoint")
         .build();
@@ -66,7 +64,6 @@ public class Ec2DiscoverySettingsTests extends ESTestCase {
         assertThat(AwsEc2Service.CLOUD_EC2.PROXY_PORT_SETTING.get(nodeSettings), is(10000));
         assertThat(AwsEc2Service.CLOUD_EC2.PROXY_USERNAME_SETTING.get(nodeSettings), is("global-proxy-username"));
         assertThat(AwsEc2Service.CLOUD_EC2.PROXY_PASSWORD_SETTING.get(nodeSettings), is("global-proxy-password"));
-        assertThat(AwsEc2Service.CLOUD_EC2.SIGNER_SETTING.get(nodeSettings), is("global-signer"));
         assertThat(AwsEc2Service.CLOUD_EC2.REGION_SETTING.get(nodeSettings), is("global-region"));
         assertThat(AwsEc2Service.CLOUD_EC2.ENDPOINT_SETTING.get(nodeSettings), isEmptyString());
         assertSettingDeprecationsAndWarnings(new Setting<?>[] {
@@ -77,7 +74,6 @@ public class Ec2DiscoverySettingsTests extends ESTestCase {
                 AwsEc2Service.PROXY_PORT_SETTING,
                 AwsEc2Service.PROXY_USERNAME_SETTING,
                 AwsEc2Service.PROXY_PASSWORD_SETTING,
-                AwsEc2Service.SIGNER_SETTING,
                 AwsEc2Service.REGION_SETTING
         });
     }
@@ -94,7 +90,6 @@ public class Ec2DiscoverySettingsTests extends ESTestCase {
         assertThat(AwsEc2Service.CLOUD_EC2.PROXY_PORT_SETTING.get(nodeSettings), is(20000));
         assertThat(AwsEc2Service.CLOUD_EC2.PROXY_USERNAME_SETTING.get(nodeSettings), is("ec2-proxy-username"));
         assertThat(AwsEc2Service.CLOUD_EC2.PROXY_PASSWORD_SETTING.get(nodeSettings), is("ec2-proxy-password"));
-        assertThat(AwsEc2Service.CLOUD_EC2.SIGNER_SETTING.get(nodeSettings), is("ec2-signer"));
         assertThat(AwsEc2Service.CLOUD_EC2.REGION_SETTING.get(nodeSettings), is("ec2-region"));
         assertThat(AwsEc2Service.CLOUD_EC2.ENDPOINT_SETTING.get(nodeSettings), is("ec2-endpoint"));
         assertSettingDeprecationsAndWarnings(new Setting<?>[] {
@@ -105,7 +100,6 @@ public class Ec2DiscoverySettingsTests extends ESTestCase {
             AwsEc2Service.PROXY_PORT_SETTING,
             AwsEc2Service.PROXY_USERNAME_SETTING,
             AwsEc2Service.PROXY_PASSWORD_SETTING,
-            AwsEc2Service.SIGNER_SETTING,
             AwsEc2Service.REGION_SETTING,
             AwsEc2Service.CLOUD_EC2.KEY_SETTING,
             AwsEc2Service.CLOUD_EC2.SECRET_SETTING,
@@ -114,7 +108,6 @@ public class Ec2DiscoverySettingsTests extends ESTestCase {
             AwsEc2Service.CLOUD_EC2.PROXY_PORT_SETTING,
             AwsEc2Service.CLOUD_EC2.PROXY_USERNAME_SETTING,
             AwsEc2Service.CLOUD_EC2.PROXY_PASSWORD_SETTING,
-            AwsEc2Service.CLOUD_EC2.SIGNER_SETTING,
             AwsEc2Service.CLOUD_EC2.REGION_SETTING,
             AwsEc2Service.CLOUD_EC2.ENDPOINT_SETTING
         });

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/AwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/AwsS3Service.java
@@ -74,11 +74,6 @@ interface AwsS3Service extends LifecycleComponent {
     Setting<SecureString> PROXY_PASSWORD_SETTING = new Setting<>("cloud.aws.proxy.password", "", SecureString::new,
         Property.NodeScope, Property.Filtered, Property.Deprecated, Property.Shared);
     /**
-     * cloud.aws.signer: If you are using an old AWS API version, you can define a Signer. Shared with discovery-ec2 plugin
-     */
-    Setting<String> SIGNER_SETTING = Setting.simpleString("cloud.aws.signer",
-        Property.NodeScope, Property.Deprecated, Property.Shared);
-    /**
      * cloud.aws.read_timeout: Socket read timeout. Shared with discovery-ec2 plugin
      */
     Setting<TimeValue> READ_TIMEOUT = Setting.timeSetting("cloud.aws.read_timeout",
@@ -140,14 +135,6 @@ interface AwsS3Service extends LifecycleComponent {
         Setting<SecureString> PROXY_PASSWORD_SETTING =
             new Setting<>("cloud.aws.s3.proxy.password", AwsS3Service.PROXY_PASSWORD_SETTING, SecureString::new,
                 Property.NodeScope, Property.Filtered, Property.Deprecated);
-        /**
-         * cloud.aws.s3.signer: If you are using an old AWS API version, you can define a Signer. Specific for S3 API calls.
-         * Defaults to cloud.aws.signer.
-         * @see AwsS3Service#SIGNER_SETTING
-         */
-        Setting<String> SIGNER_SETTING =
-            new Setting<>("cloud.aws.s3.signer", AwsS3Service.SIGNER_SETTING, Function.identity(),
-                Property.NodeScope, Property.Deprecated);
         /**
          * cloud.aws.s3.endpoint: Endpoint.
          */

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/InternalAwsS3Service.java
@@ -147,13 +147,6 @@ class InternalAwsS3Service extends AbstractLifecycleComponent implements AwsS3Se
         }
         clientConfiguration.setUseThrottleRetries(useThrottleRetries);
 
-        // #155: we might have 3rd party users using older S3 API version
-        String awsSigner = CLOUD_S3.SIGNER_SETTING.get(settings);
-        if (Strings.hasText(awsSigner)) {
-            logger.debug("using AWS API signer [{}]", awsSigner);
-            AwsSigner.configureSigner(awsSigner, clientConfiguration, endpoint);
-        }
-
         TimeValue readTimeout = getConfigValue(null, settings, clientName,
                                                S3Repository.READ_TIMEOUT_SETTING, null, CLOUD_S3.READ_TIMEOUT);
         clientConfiguration.setSocketTimeout((int)readTimeout.millis());

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -98,7 +98,6 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
             AwsS3Service.PROXY_PORT_SETTING,
             AwsS3Service.PROXY_USERNAME_SETTING,
             AwsS3Service.PROXY_PASSWORD_SETTING,
-            AwsS3Service.SIGNER_SETTING,
             AwsS3Service.READ_TIMEOUT,
 
             // Register S3 specific settings: cloud.aws.s3
@@ -109,7 +108,6 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin {
             AwsS3Service.CLOUD_S3.PROXY_PORT_SETTING,
             AwsS3Service.CLOUD_S3.PROXY_USERNAME_SETTING,
             AwsS3Service.CLOUD_S3.PROXY_PASSWORD_SETTING,
-            AwsS3Service.CLOUD_S3.SIGNER_SETTING,
             AwsS3Service.CLOUD_S3.ENDPOINT_SETTING,
             AwsS3Service.CLOUD_S3.READ_TIMEOUT,
 

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
@@ -210,7 +210,6 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .put(AwsS3Service.PROXY_PORT_SETTING.getKey(), 8080)
             .put(AwsS3Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
             .put(AwsS3Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
-            .put(AwsS3Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
             .put(AwsS3Service.READ_TIMEOUT.getKey(), "10s")
             .build();
         launchAWSConfigurationTest(settings, Settings.EMPTY, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
@@ -221,7 +220,6 @@ public class AwsS3ServiceImplTests extends ESTestCase {
                 AwsS3Service.PROTOCOL_SETTING,
                 AwsS3Service.PROXY_HOST_SETTING,
                 AwsS3Service.PROXY_PORT_SETTING,
-                AwsS3Service.SIGNER_SETTING,
                 AwsS3Service.READ_TIMEOUT});
     }
 
@@ -232,14 +230,12 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .put(AwsS3Service.PROXY_PORT_SETTING.getKey(), 8080)
             .put(AwsS3Service.PROXY_USERNAME_SETTING.getKey(), "aws_proxy_username")
             .put(AwsS3Service.PROXY_PASSWORD_SETTING.getKey(), "aws_proxy_password")
-            .put(AwsS3Service.SIGNER_SETTING.getKey(), "AWS3SignerType")
             .put(AwsS3Service.READ_TIMEOUT.getKey(), "5s")
             .put(AwsS3Service.CLOUD_S3.PROTOCOL_SETTING.getKey(), "https")
             .put(AwsS3Service.CLOUD_S3.PROXY_HOST_SETTING.getKey(), "s3_proxy_host")
             .put(AwsS3Service.CLOUD_S3.PROXY_PORT_SETTING.getKey(), 8081)
             .put(AwsS3Service.CLOUD_S3.PROXY_USERNAME_SETTING.getKey(), "s3_proxy_username")
             .put(AwsS3Service.CLOUD_S3.PROXY_PASSWORD_SETTING.getKey(), "s3_proxy_password")
-            .put(AwsS3Service.CLOUD_S3.SIGNER_SETTING.getKey(), "NoOpSignerType")
             .put(AwsS3Service.CLOUD_S3.READ_TIMEOUT.getKey(), "10s")
             .build();
         launchAWSConfigurationTest(settings, Settings.EMPTY, Protocol.HTTPS, "s3_proxy_host", 8081, "s3_proxy_username",
@@ -250,14 +246,12 @@ public class AwsS3ServiceImplTests extends ESTestCase {
                 AwsS3Service.PROTOCOL_SETTING,
                 AwsS3Service.PROXY_HOST_SETTING,
                 AwsS3Service.PROXY_PORT_SETTING,
-                AwsS3Service.SIGNER_SETTING,
                 AwsS3Service.READ_TIMEOUT,
                 AwsS3Service.CLOUD_S3.PROXY_USERNAME_SETTING,
                 AwsS3Service.CLOUD_S3.PROXY_PASSWORD_SETTING,
                 AwsS3Service.CLOUD_S3.PROTOCOL_SETTING,
                 AwsS3Service.CLOUD_S3.PROXY_HOST_SETTING,
                 AwsS3Service.CLOUD_S3.PROXY_PORT_SETTING,
-                AwsS3Service.CLOUD_S3.SIGNER_SETTING,
                 AwsS3Service.CLOUD_S3.READ_TIMEOUT});
     }
 

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
@@ -184,7 +184,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     }
 
     public void testAWSDefaultConfiguration() {
-        launchAWSConfigurationTest(Settings.EMPTY, Settings.EMPTY, Protocol.HTTPS, null, -1, null, null, null, 3, false,
+        launchAWSConfigurationTest(Settings.EMPTY, Settings.EMPTY, Protocol.HTTPS, null, -1, null, null, 3, false,
             ClientConfiguration.DEFAULT_SOCKET_TIMEOUT);
     }
 
@@ -200,7 +200,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .put("s3.client.default.read_timeout", "10s")
             .build();
         launchAWSConfigurationTest(settings, Settings.EMPTY, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
-            "aws_proxy_password", null, 3, false, 10000);
+            "aws_proxy_password", 3, false, 10000);
     }
 
     public void testAWSConfigurationWithAwsSettingsBackcompat() {
@@ -213,7 +213,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .put(AwsS3Service.READ_TIMEOUT.getKey(), "10s")
             .build();
         launchAWSConfigurationTest(settings, Settings.EMPTY, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
-            "aws_proxy_password", "AWS3SignerType", 3, false, 10000);
+            "aws_proxy_password", 3, false, 10000);
          assertSettingDeprecationsAndWarnings(new Setting<?>[]{
                 AwsS3Service.PROXY_USERNAME_SETTING,
                 AwsS3Service.PROXY_PASSWORD_SETTING,
@@ -239,7 +239,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .put(AwsS3Service.CLOUD_S3.READ_TIMEOUT.getKey(), "10s")
             .build();
         launchAWSConfigurationTest(settings, Settings.EMPTY, Protocol.HTTPS, "s3_proxy_host", 8081, "s3_proxy_username",
-            "s3_proxy_password", "NoOpSignerType", 3, false, 10000);
+            "s3_proxy_password", 3, false, 10000);
          assertSettingDeprecationsAndWarnings(new Setting<?>[] {
                 AwsS3Service.PROXY_USERNAME_SETTING,
                 AwsS3Service.PROXY_PASSWORD_SETTING,
@@ -260,7 +260,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .put(S3Repository.Repositories.MAX_RETRIES_SETTING.getKey(), 10)
             .build();
         launchAWSConfigurationTest(settings, Settings.EMPTY, Protocol.HTTPS, null, -1, null,
-            null, null, 10, false, 50000);
+            null, 10, false, 50000);
     }
 
     public void testRepositoryMaxRetries() {
@@ -269,7 +269,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .put(S3Repository.Repositories.MAX_RETRIES_SETTING.getKey(), 10)
             .build();
         launchAWSConfigurationTest(settings, repositorySettings, Protocol.HTTPS, null, -1, null,
-            null, null, 20, false, 50000);
+            null, 20, false, 50000);
     }
 
     protected void launchAWSConfigurationTest(Settings settings,
@@ -279,7 +279,6 @@ public class AwsS3ServiceImplTests extends ESTestCase {
                                               int expectedProxyPort,
                                               String expectedProxyUsername,
                                               String expectedProxyPassword,
-                                              String expectedSigner,
                                               Integer expectedMaxRetries,
                                               boolean expectedUseThrottleRetries,
                                               int expectedReadTimeout) {
@@ -297,7 +296,6 @@ public class AwsS3ServiceImplTests extends ESTestCase {
         assertThat(configuration.getProxyPort(), is(expectedProxyPort));
         assertThat(configuration.getProxyUsername(), is(expectedProxyUsername));
         assertThat(configuration.getProxyPassword(), is(expectedProxyPassword));
-        assertThat(configuration.getSignerOverride(), is(expectedSigner));
         assertThat(configuration.getMaxErrorRetry(), is(expectedMaxRetries));
         assertThat(configuration.useThrottledRetries(), is(expectedUseThrottleRetries));
         assertThat(configuration.getSocketTimeout(), is(expectedReadTimeout));


### PR DESCRIPTION
This commit removes support for s3 signer type in 6.0, and adds a note
to the migration guide.

closes #22599