### PR TITLE
Un-deprecate NamedXContentRegistry.Entry constructor that takes a context

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
@@ -69,9 +69,8 @@ public class NamedXContentRegistry {
         }
         /**
          * Creates a new entry which can be stored by the registry.
-         * @deprecated prefer {@link Entry#Entry(Class, ParseField, CheckedFunction)}. Contexts will be removed when possible
+         * Prefer {@link Entry#Entry(Class, ParseField, CheckedFunction)} unless you need a context to carry around while parsing.
          */
-        @Deprecated
         public <T> Entry(Class<T> categoryClass, ParseField name, ContextParser<Object, ? extends T> parser) {
             this.categoryClass = Objects.requireNonNull(categoryClass);
             this.name = Objects.requireNonNull(name);


### PR DESCRIPTION
We deprecated this method in the past because we thought it was a temporary thing that could go away over time. We radically trimmed down the usages of a context while parsing when we got rid of the `ParseFieldMatcher`, but the usages that are left are legit and we will hardly get rid of them. Also, working on aggs parsing we will need a context to carry around the aggregation name that gets parsed through `XContentParser#namedObject`.