### PR TITLE
Move aggs CommonFields and TYPED_KEYS_DELIMITER from InternalAggregation to Aggregation

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
@@ -18,12 +18,17 @@
  */
 package org.elasticsearch.search.aggregations;
 
+import org.elasticsearch.common.ParseField;
+
 import java.util.Map;
 
 /**
  * An aggregation
  */
 public interface Aggregation {
+
+    /** Delimiter used when prefixing aggregation names with their type using the typed_keys parameter **/
+    String TYPED_KEYS_DELIMITER = "#";
 
     /**
      * @return The name of this aggregation.
@@ -34,4 +39,22 @@ public interface Aggregation {
      * Get the optional byte array metadata that was set on the aggregation
      */
     Map<String, Object> getMetaData();
+
+    /**
+     * Common xcontent fields that are shared among addAggregation
+     */
+    final class CommonFields extends ParseField.CommonFields {
+        public static final ParseField META = new ParseField("meta");
+        public static final ParseField BUCKETS = new ParseField("buckets");
+        public static final ParseField VALUE = new ParseField("value");
+        public static final ParseField VALUES = new ParseField("values");
+        public static final ParseField VALUE_AS_STRING = new ParseField("value_as_string");
+        public static final ParseField DOC_COUNT = new ParseField("doc_count");
+        public static final ParseField KEY = new ParseField("key");
+        public static final ParseField KEY_AS_STRING = new ParseField("key_as_string");
+        public static final ParseField FROM = new ParseField("from");
+        public static final ParseField FROM_AS_STRING = new ParseField("from_as_string");
+        public static final ParseField TO = new ParseField("to");
+        public static final ParseField TO_AS_STRING = new ParseField("to_as_string");
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
@@ -27,7 +27,10 @@ import java.util.Map;
  */
 public interface Aggregation {
 
-    /** Delimiter used when prefixing aggregation names with their type using the typed_keys parameter **/
+    /**
+     * Delimiter used when prefixing aggregation names with their type
+     * using the typed_keys parameter
+     */
     String TYPED_KEYS_DELIMITER = "#";
 
     /**

--- a/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.search.aggregations;
 
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -39,9 +38,6 @@ import java.util.Objects;
  * An internal implementation of {@link Aggregation}. Serves as a base class for all aggregation implementations.
  */
 public abstract class InternalAggregation implements Aggregation, ToXContent, NamedWriteable {
-
-    /** Delimiter used when prefixing aggregation names with their type using the typed_keys parameter **/
-    public static final String TYPED_KEYS_DELIMITER = "#";
 
     public static class ReduceContext {
 
@@ -242,21 +238,4 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, Na
         return this == obj;
     }
 
-    /**
-     * Common xcontent fields that are shared among addAggregation
-     */
-    public static final class CommonFields extends ParseField.CommonFields {
-        public static final ParseField META = new ParseField("meta");
-        public static final ParseField BUCKETS = new ParseField("buckets");
-        public static final ParseField VALUE = new ParseField("value");
-        public static final ParseField VALUES = new ParseField("values");
-        public static final ParseField VALUE_AS_STRING = new ParseField("value_as_string");
-        public static final ParseField DOC_COUNT = new ParseField("doc_count");
-        public static final ParseField KEY = new ParseField("key");
-        public static final ParseField KEY_AS_STRING = new ParseField("key_as_string");
-        public static final ParseField FROM = new ParseField("from");
-        public static final ParseField FROM_AS_STRING = new ParseField("from_as_string");
-        public static final ParseField TO = new ParseField("to");
-        public static final ParseField TO_AS_STRING = new ParseField("to_as_string");
-    }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/UnmappedSampler.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/UnmappedSampler.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.aggregations.bucket.sampler;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
@@ -59,7 +60,7 @@ public class UnmappedSampler extends InternalSampler {
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        builder.field(InternalAggregation.CommonFields.DOC_COUNT.getPreferredName(), 0);
+        builder.field(Aggregation.CommonFields.DOC_COUNT.getPreferredName(), 0);
         return builder;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -34,7 +34,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.action.search.RestSearchAction;
-import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
@@ -373,7 +373,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             if (params.paramAsBoolean(RestSearchAction.TYPED_KEYS_PARAM, false)) {
                 // Concatenates the type and the name of the suggestion (ex: completion#foo)
-                builder.startArray(String.join(InternalAggregation.TYPED_KEYS_DELIMITER, getType(), getName()));
+                builder.startArray(String.join(Aggregation.TYPED_KEYS_DELIMITER, getType(), getName()));
             } else {
                 builder.startArray(getName());
             }
@@ -389,7 +389,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
             String typeAndName = parser.currentName();
             // we need to extract the type prefix from the name and throw error if it is not present
-            int delimiterPos = typeAndName.indexOf(InternalAggregation.TYPED_KEYS_DELIMITER);
+            int delimiterPos = typeAndName.indexOf(Aggregation.TYPED_KEYS_DELIMITER);
             String type;
             String name;
             if (delimiterPos > 0) {


### PR DESCRIPTION
These will be shared between internal objects and objects exposed through high level REST client, so they should be moved from internal classes.