### PR TITLE
Remove customization of ES_USER and ES_GROUP

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -32,10 +32,6 @@ fi
 
 # The following variables can be overwritten in $DEFAULT
 
-# Run Elasticsearch as this user ID and group ID
-ES_USER=elasticsearch
-ES_GROUP=elasticsearch
-
 # Directory where the Elasticsearch binary distribution resides
 ES_HOME=/usr/share/$NAME
 
@@ -73,6 +69,12 @@ fi
 # CONF_FILE setting was removed
 if [ ! -z "$CONF_FILE" ]; then
     echo "CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed."
+    exit 1
+fi
+
+# ES_USER and ES_GROUP settings were removed
+if [ ! -z "$ES_USER" ] || [ ! -z "$ES_GROUP" ]; then
+    echo "ES_USER and ES_GROUP settings are no longer supported. To run as a custom user/group use the archive distribution of Elasticsearch."
     exit 1
 fi
 
@@ -119,10 +121,10 @@ case "$1" in
 
 	# Ensure that the PID_DIR exists (it is cleaned at OS startup time)
 	if [ -n "$PID_DIR" ] && [ ! -e "$PID_DIR" ]; then
-		mkdir -p "$PID_DIR" && chown "$ES_USER":"$ES_GROUP" "$PID_DIR"
+		mkdir -p "$PID_DIR" && chown elasticsearch:elasticsearch "$PID_DIR"
 	fi
 	if [ -n "$PID_FILE" ] && [ ! -e "$PID_FILE" ]; then
-		touch "$PID_FILE" && chown "$ES_USER":"$ES_GROUP" "$PID_FILE"
+		touch "$PID_FILE" && chown elasticsearch:elasticsearch "$PID_FILE"
 	fi
 
 	if [ -n "$MAX_OPEN_FILES" ]; then
@@ -138,7 +140,7 @@ case "$1" in
 	fi
 
 	# Start Daemon
-	start-stop-daemon -d $ES_HOME --start --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
+	start-stop-daemon -d $ES_HOME --start --user elasticsearch -c elasticsearch --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
 	return=$?
 	if [ $return -eq 0 ]; then
 		i=0
@@ -162,7 +164,7 @@ case "$1" in
 
 	if [ -f "$PID_FILE" ]; then
 		start-stop-daemon --stop --pidfile "$PID_FILE" \
-			--user "$ES_USER" \
+			--user elasticsearch \
 			--quiet \
 			--retry forever/TERM/20 > /dev/null
 		if [ $? -eq 1 ]; then

--- a/distribution/rpm/src/main/packaging/init.d/elasticsearch
+++ b/distribution/rpm/src/main/packaging/init.d/elasticsearch
@@ -32,8 +32,6 @@ if [ -f /etc/rc.d/init.d/functions ]; then
 fi
 
 # Sets the default values for elasticsearch variables used in this script
-ES_USER="elasticsearch"
-ES_GROUP="elasticsearch"
 ES_HOME="/usr/share/elasticsearch"
 MAX_OPEN_FILES=65536
 MAX_MAP_COUNT=262144
@@ -55,6 +53,12 @@ if [ ! -z "$CONF_FILE" ]; then
     exit 1
 fi
 
+# ES_USER and ES_GROUP settings were removed
+if [ ! -z "$ES_USER" ] || [ ! -z "$ES_GROUP" ]; then
+    echo "ES_USER and ES_GROUP settings are no longer supported. To run as a custom user/group use the archive distribution of Elasticsearch."
+    exit 1
+fi
+
 exec="$ES_HOME/bin/elasticsearch"
 prog="elasticsearch"
 pidfile="$PID_DIR/${prog}.pid"
@@ -66,11 +70,6 @@ export ES_JVM_OPTIONS
 export ES_STARTUP_SLEEP_TIME
 
 lockfile=/var/lock/subsys/$prog
-
-# backwards compatibility for old config sysconfig files, pre 0.90.1
-if [ -n $USER ] && [ -z $ES_USER ] ; then
-   ES_USER=$USER
-fi
 
 if [ ! -x "$exec" ]; then
     echo "The elasticsearch startup script does not exists or it is not executable, tried: $exec"
@@ -106,16 +105,16 @@ start() {
 
     # Ensure that the PID_DIR exists (it is cleaned at OS startup time)
     if [ -n "$PID_DIR" ] && [ ! -e "$PID_DIR" ]; then
-        mkdir -p "$PID_DIR" && chown "$ES_USER":"$ES_GROUP" "$PID_DIR"
+        mkdir -p "$PID_DIR" && chown elasticsearch:elasticsearch "$PID_DIR"
     fi
     if [ -n "$pidfile" ] && [ ! -e "$pidfile" ]; then
-        touch "$pidfile" && chown "$ES_USER":"$ES_GROUP" "$pidfile"
+        touch "$pidfile" && chown elasticsearch:elasticsearch "$pidfile"
     fi
 
     cd $ES_HOME
     echo -n $"Starting $prog: "
     # if not running, start it up here, usually something like "daemon $exec"
-    daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -d -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR
+    daemon --user elasticsearch --pidfile $pidfile $exec -p $pidfile -d -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile

--- a/distribution/src/main/packaging/env/elasticsearch
+++ b/distribution/src/main/packaging/env/elasticsearch
@@ -32,14 +32,6 @@
 
 # SysV init.d
 #
-# When executing the init script, this user will be used to run the elasticsearch service.
-# The default value is 'elasticsearch' and is declared in the init.d file.
-# Note that this setting is only used by the init script. If changed, make sure that
-# the configured user can read and write into the data, work, plugins and log directories.
-# For systemd service, the user is usually configured in file /usr/lib/systemd/system/elasticsearch.service
-#ES_USER=elasticsearch
-#ES_GROUP=elasticsearch
-
 # The number of seconds to wait before checking if Elasticsearch started successfully as a daemon process
 ES_STARTUP_SLEEP_TIME=5
 

--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -10,10 +10,6 @@
 
 
 
-# Sets the default values for elasticsearch variables used in this script
-ES_USER="elasticsearch"
-ES_GROUP="elasticsearch"
-
 # Source the default env file
 ES_ENV_FILE="${path.env}"
 if [ -f "$ES_ENV_FILE" ]; then
@@ -110,9 +106,9 @@ elif [ "$RESTART_ON_UPGRADE" = "true" ]; then
     echo " OK"
 fi
 
-chown -R $ES_USER:$ES_GROUP /var/lib/elasticsearch
-chown -R $ES_USER:$ES_GROUP /var/log/elasticsearch
-chown -R root:$ES_GROUP /etc/elasticsearch
+chown -R elasticsearch:elasticsearch /var/lib/elasticsearch
+chown -R elasticsearch:elasticsearch /var/log/elasticsearch
+chown -R root:elasticsearch /etc/elasticsearch
 chmod 0750 /etc/elasticsearch
 chmod 0750 /etc/elasticsearch/scripts
 

--- a/distribution/src/main/packaging/scripts/postrm
+++ b/distribution/src/main/packaging/scripts/postrm
@@ -46,8 +46,6 @@ case "$1" in
 esac
 
 # Sets the default values for elasticsearch variables used in this script
-ES_USER="elasticsearch"
-ES_GROUP="elasticsearch"
 LOG_DIR="/var/log/elasticsearch"
 PLUGINS_DIR="/usr/share/elasticsearch/plugins"
 PID_DIR="/var/run/elasticsearch"
@@ -95,12 +93,12 @@ if [ "$REMOVE_DIRS" = "true" ]; then
 fi
 
 if [ "$REMOVE_USER_AND_GROUP" = "true" ]; then
-    if id "$ES_USER" > /dev/null 2>&1 ; then
-        userdel "$ES_USER"
+    if id elasticsearch > /dev/null 2>&1 ; then
+        userdel elasticsearch
     fi
 
-    if getent group "$ES_GROUP" > /dev/null 2>&1 ; then
-        groupdel "$ES_GROUP"
+    if getent group elasticsearch > /dev/null 2>&1 ; then
+        groupdel elasticsearch
     fi
 fi
 

--- a/distribution/src/main/packaging/scripts/preinst
+++ b/distribution/src/main/packaging/scripts/preinst
@@ -11,10 +11,6 @@
 
 
 
-# Sets the default values for elasticsearch variables used in this script
-ES_USER="elasticsearch"
-ES_GROUP="elasticsearch"
-
 # Source the default env file
 ES_ENV_FILE="${path.env}"
 if [ -f "$ES_ENV_FILE" ]; then
@@ -27,22 +23,22 @@ case "$1" in
     install|upgrade)
 
         # Create elasticsearch group if not existing
-        if ! getent group "$ES_GROUP" > /dev/null 2>&1 ; then
-            echo -n "Creating $ES_GROUP group..."
-            addgroup --quiet --system "$ES_GROUP"
+        if ! getent group elasticsearch > /dev/null 2>&1 ; then
+            echo -n "Creating elasticsearch group..."
+            addgroup --quiet --system elasticsearch
             echo " OK"
         fi
 
         # Create elasticsearch user if not existing
-        if ! id $ES_USER > /dev/null 2>&1 ; then
-            echo -n "Creating $ES_USER user..."
+        if ! id elasticsearch > /dev/null 2>&1 ; then
+            echo -n "Creating elasticsearch user..."
             adduser --quiet \
                     --system \
                     --no-create-home \
-                    --ingroup "$ES_GROUP" \
+                    --ingroup elasticsearch \
                     --disabled-password \
                     --shell /bin/false \
-                    "$ES_USER"
+                    elasticsearch
             echo " OK"
         fi
     ;;
@@ -53,21 +49,21 @@ case "$1" in
     1|2)
 
         # Create elasticsearch group if not existing
-        if ! getent group "$ES_GROUP" > /dev/null 2>&1 ; then
-            echo -n "Creating $ES_GROUP group..."
-            groupadd -r "$ES_GROUP"
+        if ! getent group elasticsearch > /dev/null 2>&1 ; then
+            echo -n "Creating elasticsearch group..."
+            groupadd -r elasticsearch
             echo " OK"
         fi
 
         # Create elasticsearch user if not existing
-        if ! id $ES_USER > /dev/null 2>&1 ; then
-            echo -n "Creating $ES_USER user..."
+        if ! id elasticsearch > /dev/null 2>&1 ; then
+            echo -n "Creating elasticsearch user..."
             useradd -r \
                     -M \
-                    --gid "$ES_GROUP" \
+                    --gid elasticsearch \
                     --shell /sbin/nologin \
                     --comment "elasticsearch user" \
-                    "$ES_USER"
+                    elasticsearch
             echo " OK"
         fi
     ;;

--- a/docs/reference/migration/migrate_6_0.asciidoc
+++ b/docs/reference/migration/migrate_6_0.asciidoc
@@ -39,6 +39,7 @@ way to reindex old indices is to use the `reindex` API.
 * <<breaking_60_ingest_changes>>
 * <<breaking_60_percolator_changes>>
 * <<breaking_60_java_changes>>
+* <<breaking_60_packaging_changes>>
 
 include::migrate_6_0/cat.asciidoc[]
 
@@ -69,3 +70,5 @@ include::migrate_6_0/ingest.asciidoc[]
 include::migrate_6_0/percolator.asciidoc[]
 
 include::migrate_6_0/java.asciidoc[]
+
+include::migrate_6_0/packaging.asciidoc[]

--- a/docs/reference/migration/migrate_6_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_6_0/packaging.asciidoc
@@ -1,0 +1,11 @@
+[[breaking_60_packaging_changes]]
+=== Packaging changes
+
+==== Configuring custom user and group for package is no longer allowed
+
+Previously someone could configure the `$ES_USER` and `$ES_GROUP` variables to
+change which user and group Elasticsearch was run as. This is no longer
+possible, the DEB and RPM packages now exclusively use the user and group
+`elasticsearch`. If a custom user or group is needed then a provisioning system
+should use the tarball distribution instead of the provided RPM and DEB
+packages.

--- a/docs/reference/setup/install/sysconfig-file.asciidoc
+++ b/docs/reference/setup/install/sysconfig-file.asciidoc
@@ -1,12 +1,4 @@
 [horizontal]
-`ES_USER`::
-
-  The user to run as, defaults to `elasticsearch`.
-
-`ES_GROUP`::
-
-  The group to run as, defaults to `elasticsearch`.
-
 `JAVA_HOME`::
 
   Set a custom Java path to be used.


### PR DESCRIPTION
This removes the ability to configure Elasticsearch to use custom username
and/or group when it is run.

Resolves #23848
