### PR TITLE
Updated section 'Introducing the Query Language'

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -683,7 +683,7 @@ Here is the same exact search above using the alternative request body method:
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match_all": {} },
   "sort": [
@@ -747,7 +747,7 @@ Going back to our last example, we executed this query:
 
 [source,js]
 --------------------------------------------------
-GET /bank/_search
+POST /bank/_search
 {
   "query": { "match_all": {} }
 }


### PR DESCRIPTION
The method used in _search API should be POST but it mentions GET everywhere. Please change it or let us know we will do it
