### PR TITLE
Wrong behavior deleting alias

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -61,7 +61,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
 
     //indices options that require every specified index to exist, expand wildcards only to open indices and
     //don't allow that no indices are resolved from wildcard expressions
-    private static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, false);
+    private static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, false, true, false, true);
 
     public IndicesAliasesRequest() {
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -59,8 +59,9 @@ import static org.elasticsearch.common.xcontent.ObjectParser.fromList;
 public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesRequest> {
     private List<AliasActions> allAliasActions = new ArrayList<>();
 
-    //indices options that require every specified index to exist, expand wildcards only to open indices and
-    //don't allow that no indices are resolved from wildcard expressions
+    // indices options that require every specified index to exist, expand wildcards only to open
+    // indices, don't allow that no indices are resolved from wildcard expressions and resolve the
+    // expressions only against indices
     private static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, false, true, false, true);
 
     public IndicesAliasesRequest() {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -94,7 +94,7 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeAction<Ind
         // Resolve all the AliasActions into AliasAction instances and gather all the aliases
         Set<String> aliases = new HashSet<>();
         for (AliasActions action : actions) {
-            String[] concreteIndices = indexNameExpressionResolver.concreteIndexNamesIndexExpression(state, request.indicesOptions(), action.indices());
+            String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(state, request.indicesOptions(), action.indices());
             Collections.addAll(aliases, action.aliases());
             for (String index : concreteIndices) {
                 switch (action.actionType()) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -94,7 +94,7 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeAction<Ind
         // Resolve all the AliasActions into AliasAction instances and gather all the aliases
         Set<String> aliases = new HashSet<>();
         for (AliasActions action : actions) {
-            String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(state, request.indicesOptions(), action.indices());
+            String[] concreteIndices = indexNameExpressionResolver.concreteIndexNamesIndexExpression(state, request.indicesOptions(), action.indices());
             Collections.addAll(aliases, action.aliases());
             for (String index : concreteIndices) {
                 switch (action.actionType()) {

--- a/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -43,6 +43,7 @@ public class IndicesOptions {
     private static final byte EXPAND_WILDCARDS_CLOSED = 8;
     private static final byte FORBID_ALIASES_TO_MULTIPLE_INDICES = 16;
     private static final byte FORBID_CLOSED_INDICES = 32;
+    private static final byte IGNORE_ALIASES = 64;
 
     private static final byte STRICT_EXPAND_OPEN = 6;
     private static final byte LENIENT_EXPAND_OPEN = 7;
@@ -51,10 +52,10 @@ public class IndicesOptions {
     private static final byte STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED = 48;
 
     static {
-        byte max = 1 << 6;
+        short max = 1 << 7;
         VALUES = new IndicesOptions[max];
-        for (byte id = 0; id < max; id++) {
-            VALUES[id] = new IndicesOptions(id);
+        for (short id = 0; id < max; id++) {
+            VALUES[id] = new IndicesOptions((byte)id);
         }
     }
 
@@ -111,6 +112,13 @@ public class IndicesOptions {
         return (id & FORBID_ALIASES_TO_MULTIPLE_INDICES) == 0;
     }
 
+    /**
+     * @return whether aliases should be ignored (when resolving a wildcard)
+     */
+    public boolean ignoreAliases() {
+        return (id & IGNORE_ALIASES) != 0;
+    }
+    
     public void writeIndicesOptions(StreamOutput out) throws IOException {
         out.write(id);
     }
@@ -133,8 +141,16 @@ public class IndicesOptions {
         return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, defaultOptions.allowAliasesToMultipleIndices(), defaultOptions.forbidClosedIndices());
     }
 
-    static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices, boolean expandToClosedIndices, boolean allowAliasesToMultipleIndices, boolean forbidClosedIndices) {
-        byte id = toByte(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, allowAliasesToMultipleIndices, forbidClosedIndices);
+    public static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices,
+            boolean expandToClosedIndices, boolean allowAliasesToMultipleIndices, boolean forbidClosedIndices) {
+        return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, allowAliasesToMultipleIndices,
+                forbidClosedIndices, false);
+    }
+
+    public static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices,
+            boolean expandToClosedIndices, boolean allowAliasesToMultipleIndices, boolean forbidClosedIndices, boolean ignoreAliases) {
+        byte id = toByte(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, allowAliasesToMultipleIndices,
+                forbidClosedIndices, ignoreAliases);
         return VALUES[id];
     }
 
@@ -246,7 +262,7 @@ public class IndicesOptions {
     }
 
     private static byte toByte(boolean ignoreUnavailable, boolean allowNoIndices, boolean wildcardExpandToOpen,
-                               boolean wildcardExpandToClosed, boolean allowAliasesToMultipleIndices, boolean forbidClosedIndices) {
+            boolean wildcardExpandToClosed, boolean allowAliasesToMultipleIndices, boolean forbidClosedIndices, boolean ignoreAliases) {
         byte id = 0;
         if (ignoreUnavailable) {
             id |= IGNORE_UNAVAILABLE;
@@ -268,6 +284,9 @@ public class IndicesOptions {
         if (forbidClosedIndices) {
             id |= FORBID_CLOSED_INDICES;
         }
+        if (ignoreAliases) {
+            id |= IGNORE_ALIASES;
+        }
         return id;
     }
 
@@ -281,6 +300,7 @@ public class IndicesOptions {
                 ", expand_wildcards_closed=" + expandWildcardsClosed() +
                 ", allow_aliases_to_multiple_indices=" + allowAliasesToMultipleIndices() +
                 ", forbid_closed_indices=" + forbidClosedIndices() +
+                ", ignore_aliases=" + ignoreAliases() +
                 ']';
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -121,7 +121,7 @@ public class IndicesOptions {
     }
     
     public void writeIndicesOptions(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha2_UNRELEASED)) {
+        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha2)) {
             out.write(id);
         } else {
             // if we are talking to a node that doesn't support the newly added flag (ignoreAliases)

--- a/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -108,8 +108,8 @@ public class IndicesOptions {
      * @return whether aliases pointing to multiple indices are allowed
      */
     public boolean allowAliasesToMultipleIndices() {
-        //true is default here, for bw comp we keep the first 16 values
-        //in the array same as before + the default value for the new flag
+        // true is default here, for bw comp we keep the first 16 values
+        // in the array same as before + the default value for the new flag
         return (id & FORBID_ALIASES_TO_MULTIPLE_INDICES) == 0;
     }
 
@@ -121,9 +121,11 @@ public class IndicesOptions {
     }
     
     public void writeIndicesOptions(StreamOutput out) throws IOException {
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
+        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha2_UNRELEASED)) {
             out.write(id);
         } else {
+            // if we are talking to a node that doesn't support the newly added flag (ignoreAliases)
+            // flip to 0 all the bits starting from the 7th
             out.write(id & 0x3f);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.action.support;
 
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.rest.RestRequest;
@@ -120,12 +121,16 @@ public class IndicesOptions {
     }
     
     public void writeIndicesOptions(StreamOutput out) throws IOException {
-        out.write(id);
+        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
+            out.write(id);
+        } else {
+            out.write(id & 0x3f);
+        }
     }
 
     public static IndicesOptions readIndicesOptions(StreamInput in) throws IOException {
-        //if we read from a node that doesn't support the newly added flag (allowAliasesToMultipleIndices)
-        //we just receive the old corresponding value with the new flag set to true (default)
+        //if we read from a node that doesn't support the newly added flag (ignoreAliases)
+        //we just receive the old corresponding value with the new flag set to false (default)
         byte id = in.readByte();
         if (id >= VALUES.length) {
             throw new IllegalArgumentException("No valid missing index type id: " + id);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -697,12 +697,13 @@ public class IndexNameExpressionResolver extends AbstractComponent {
         public static Map<String, AliasOrIndex> matches(Context context, MetaData metaData, String expression) {
             if (Regex.isMatchAllPattern(expression)) {
                 // Can only happen if the expressions was initially: '-*'
-                if (!context.getOptions().ignoreAliases()) {
+                if (context.getOptions().ignoreAliases()) {
+                    return metaData.getAliasAndIndexLookup().entrySet().stream()
+                            .filter(e -> e.getValue().isAlias() == false)
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                } else {
                     return metaData.getAliasAndIndexLookup();
                 }
-                return metaData.getAliasAndIndexLookup().entrySet().stream()
-                        .filter(e -> !e.getValue().isAlias())
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             } else if (expression.indexOf("*") == expression.length() - 1) {
                 return suffixWildcard(context, metaData, expression);
             } else {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -79,6 +79,15 @@ public class IndexNameExpressionResolver extends AbstractComponent {
     }
 
     /**
+     * Same as {@link #concreteIndexNames(ClusterState state, IndicesRequest request)}, but the
+     * indexExpressions are resolved only against indices
+     */
+    public String[] concreteIndexNamesIndexExpression(ClusterState state, IndicesRequest request) {
+        Context context = new Context(state, request.indicesOptions(), System.currentTimeMillis(), false, true);
+        return concreteIndexNames(context, request.indices());
+    }
+
+    /**
      * Same as {@link #concreteIndices(ClusterState, IndicesOptions, String...)}, but the index expressions and options
      * are encapsulated in the specified request.
      */
@@ -101,6 +110,17 @@ public class IndexNameExpressionResolver extends AbstractComponent {
      * indices options in the context don't allow such a case.
      */
     public String[] concreteIndexNames(ClusterState state, IndicesOptions options, String... indexExpressions) {
+        Context context = new Context(state, options);
+        return concreteIndexNames(context, indexExpressions);
+    }
+
+    /**
+     * Same as
+     * {@link #concreteIndexNames(ClusterState state, IndicesOptions options, String... indexExpressions)},
+     * but the indexExpressions are resolved only against indices
+     */
+
+    public String[] concreteIndexNamesIndexExpression(ClusterState state, IndicesOptions options, String... indexExpressions) {
         Context context = new Context(state, options, System.currentTimeMillis(), false, true);
         return concreteIndexNames(context, indexExpressions);
     }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -182,10 +182,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
         final Set<Index> concreteIndices = new HashSet<>(expressions.size());
         for (String expression : expressions) {
             AliasOrIndex aliasOrIndex = metaData.getAliasAndIndexLookup().get(expression);
-            if (context.getOptions().ignoreAliases() && aliasOrIndex.isAlias()) {
-                aliasOrIndex = null;
-            }
-            if (aliasOrIndex == null) {
+            if (aliasOrIndex == null || (aliasOrIndex.isAlias() && context.getOptions().ignoreAliases())) {
                 if (failNoIndices) {
                     IndexNotFoundException infe = new IndexNotFoundException(expression);
                     infe.setResources("index_expression", expression);
@@ -722,7 +719,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
             SortedMap<String,AliasOrIndex> subMap = metaData.getAliasAndIndexLookup().subMap(fromPrefix, toPrefix);
             if (context.getOptions().ignoreAliases()) {
                  return subMap.entrySet().stream()
-                        .filter(p -> !p.getValue().isAlias())
+                        .filter(entry -> entry.getValue().isAlias() == false)
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             }
             return subMap;

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -182,6 +182,9 @@ public class IndexNameExpressionResolver extends AbstractComponent {
         final Set<Index> concreteIndices = new HashSet<>(expressions.size());
         for (String expression : expressions) {
             AliasOrIndex aliasOrIndex = metaData.getAliasAndIndexLookup().get(expression);
+            if (context.getOptions().ignoreAliases() && aliasOrIndex.isAlias()) {
+                aliasOrIndex = null;
+            }
             if (aliasOrIndex == null) {
                 if (failNoIndices) {
                     IndexNotFoundException infe = new IndexNotFoundException(expression);
@@ -720,7 +723,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
             if (context.getOptions().ignoreAliases()) {
                  return subMap.entrySet().stream()
                         .filter(p -> !p.getValue().isAlias())
-                        .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue()));
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             }
             return subMap;
         }
@@ -730,7 +733,7 @@ public class IndexNameExpressionResolver extends AbstractComponent {
             return metaData.getAliasAndIndexLookup()
                 .entrySet()
                 .stream()
-                .filter(e -> context.getOptions().ignoreAliases() ? !e.getValue().isAlias() : true)
+                .filter(e -> context.getOptions().ignoreAliases() == false || e.getValue().isAlias() == false)
                 .filter(e -> Regex.simpleMatch(pattern, e.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }

--- a/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -32,7 +32,7 @@ public class IndicesOptionsTests extends ESTestCase {
         int iterations = randomIntBetween(5, 20);
         for (int i = 0; i < iterations; i++) {
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(
-                randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+                randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
 
             BytesStreamOutput output = new BytesStreamOutput();
             Version outputVersion = randomVersion(random());
@@ -50,6 +50,12 @@ public class IndicesOptionsTests extends ESTestCase {
 
             assertThat(indicesOptions2.forbidClosedIndices(), equalTo(indicesOptions.forbidClosedIndices()));
             assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(indicesOptions.allowAliasesToMultipleIndices()));
+
+            if(output.getVersion().onOrAfter(Version.V_6_0_0_alpha2_UNRELEASED)) {
+                assertEquals(indicesOptions2.ignoreAliases(), indicesOptions.ignoreAliases());
+            } else {
+                assertFalse(indicesOptions2.ignoreAliases());
+            }
         }
     }
 
@@ -62,9 +68,11 @@ public class IndicesOptionsTests extends ESTestCase {
             boolean expandToClosedIndices = randomBoolean();
             boolean allowAliasesToMultipleIndices = randomBoolean();
             boolean forbidClosedIndices = randomBoolean();
+            boolean ignoreAliases = randomBoolean();
+
             IndicesOptions indicesOptions = IndicesOptions.fromOptions(
                     ignoreUnavailable, allowNoIndices,expandToOpenIndices, expandToClosedIndices,
-                    allowAliasesToMultipleIndices, forbidClosedIndices
+                    allowAliasesToMultipleIndices, forbidClosedIndices, ignoreAliases
             );
 
             assertThat(indicesOptions.ignoreUnavailable(), equalTo(ignoreUnavailable));
@@ -74,6 +82,7 @@ public class IndicesOptionsTests extends ESTestCase {
             assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
             assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
             assertThat(indicesOptions.forbidClosedIndices(), equalTo(forbidClosedIndices));
+            assertEquals(ignoreAliases, indicesOptions.ignoreAliases());
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -51,7 +51,7 @@ public class IndicesOptionsTests extends ESTestCase {
             assertThat(indicesOptions2.forbidClosedIndices(), equalTo(indicesOptions.forbidClosedIndices()));
             assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(indicesOptions.allowAliasesToMultipleIndices()));
 
-            if (output.getVersion().onOrAfter(Version.V_6_0_0_alpha2_UNRELEASED)) {
+            if (output.getVersion().onOrAfter(Version.V_6_0_0_alpha2)) {
                 assertEquals(indicesOptions2.ignoreAliases(), indicesOptions.ignoreAliases());
             } else {
                 assertFalse(indicesOptions2.ignoreAliases());

--- a/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -51,7 +51,7 @@ public class IndicesOptionsTests extends ESTestCase {
             assertThat(indicesOptions2.forbidClosedIndices(), equalTo(indicesOptions.forbidClosedIndices()));
             assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(indicesOptions.allowAliasesToMultipleIndices()));
 
-            if(output.getVersion().onOrAfter(Version.V_6_0_0_alpha2_UNRELEASED)) {
+            if (output.getVersion().onOrAfter(Version.V_6_0_0_alpha2_UNRELEASED)) {
                 assertEquals(indicesOptions2.ignoreAliases(), indicesOptions.ignoreAliases());
             } else {
                 assertFalse(indicesOptions2.ignoreAliases());

--- a/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.aliases;
 
-import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.admin.indices.alias.exists.AliasesExistResponse;
@@ -64,7 +63,6 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_ME
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_READ;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_BLOCKS_WRITE;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_READ_ONLY;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.CollectionAssertions.hasKey;
@@ -804,7 +802,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
     }
 
     // aliases can be added only to indices
-    public void testAddAliasesOnlyToIndices() throws Exception {
+    public void testAliasesCanBeAddedToIndicesOnly() throws Exception {
         logger.info("--> creating index [2017-05-20]");
         assertAcked(prepareCreate("2017-05-20"));
         ensureGreen();
@@ -812,8 +810,9 @@ public class IndexAliasesIT extends ESIntegTestCase {
         logger.info("--> adding [week_20] alias to [2017-05-20]");
         assertAcked(admin().indices().prepareAliases().addAlias("2017-05-20", "week_20"));
 
-        expectThrows(IndexNotFoundException.class, () -> admin().indices().prepareAliases()
+        IndexNotFoundException infe = expectThrows(IndexNotFoundException.class, () -> admin().indices().prepareAliases()
                 .addAliasAction(AliasActions.add().index("week_20").alias("tmp")).execute().actionGet());
+        assertEquals("week_20", infe.getIndex().getName());
 
         assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("2017-05-20").alias("tmp")).execute().get());
     }

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -643,7 +643,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertEquals(0, indexNames.length);
     }
 
-    // issue #23960
+    // concreteIndexNames must resolve the provided wildcard only against the defined indices
     public void testConcreteIndicesWildcardAndAliases() {
         MetaData.Builder mdBuilder = MetaData.builder()
                 .put(indexBuilder("foo_foo").state(State.OPEN).putAlias(AliasMetaData.builder("foo")))

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -650,26 +651,46 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 .put(indexBuilder("bar_bar").state(State.OPEN).putAlias(AliasMetaData.builder("foo")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
 
-        String[] indexNames = indexNameExpressionResolver.concreteIndexNames(state,
+        String[] indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNamesIndexExpression(state,
                 IndicesOptions.lenientExpandOpen(), "foo*");
 
-        assertEquals(1, indexNames.length);
-        assertEquals("foo_foo", indexNames[0]);
+        assertEquals(1, indexNamesIndexWildcard.length);
+        assertEquals("foo_foo", indexNamesIndexWildcard[0]);
 
-        indexNames = indexNameExpressionResolver.concreteIndexNames(state,
+        indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNamesIndexExpression(state,
                 IndicesOptions.lenientExpandOpen(), "*o");
 
-        assertEquals(1, indexNames.length);
-        assertEquals("foo_foo", indexNames[0]);
+        assertEquals(1, indexNamesIndexWildcard.length);
+        assertEquals("foo_foo", indexNamesIndexWildcard[0]);
 
-        indexNames = indexNameExpressionResolver.concreteIndexNames(state,
+        indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNamesIndexExpression(state,
                 IndicesOptions.lenientExpandOpen(), "f*o");
 
-        assertEquals(1, indexNames.length);
-        assertEquals("foo_foo", indexNames[0]);
+        assertEquals(1, indexNamesIndexWildcard.length);
+        assertEquals("foo_foo", indexNamesIndexWildcard[0]);
+
+        List<String> indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state,
+                IndicesOptions.lenientExpandOpen(), "foo*"));
+
+        assertEquals(2, indexNames.size());
+        assertTrue(indexNames.contains("foo_foo"));
+        assertTrue(indexNames.contains("bar_bar"));
+
+        indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state,
+                IndicesOptions.lenientExpandOpen(), "*o"));
+
+        assertEquals(2, indexNames.size());
+        assertTrue(indexNames.contains("foo_foo"));
+        assertTrue(indexNames.contains("bar_bar"));
+
+        indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state,
+                IndicesOptions.lenientExpandOpen(), "f*o"));
+
+        assertEquals(2, indexNames.size());
+        assertTrue(indexNames.contains("foo_foo"));
+        assertTrue(indexNames.contains("bar_bar"));
     }
 
-    
     /**
      * test resolving _all pattern (null, empty array or "_all") for random IndicesOptions
      */

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -669,36 +669,30 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertEquals(1, indexNamesIndexWildcard.length);
         assertEquals("foo_foo", indexNamesIndexWildcard[0]);
 
-        try {
-            indexNameExpressionResolver.concreteIndexNames(state, ignoreAliasesOptions, "foo");
-            fail();
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getIndex().getName(), equalTo("foo"));
-        }
+        IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                () -> indexNameExpressionResolver.concreteIndexNames(state, ignoreAliasesOptions, "foo"));
+        assertThat(infe.getIndex().getName(), equalTo("foo"));
 
         // when ignoreAliases option is not set, concreteIndexNames resolves the provided
         // expressions against the defined indices and aliases
         IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, false);
-        List<String> indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state, indicesAndAliasesOptions, "foo*"));
 
+        List<String> indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state, indicesAndAliasesOptions, "foo*"));
         assertEquals(2, indexNames.size());
         assertTrue(indexNames.contains("foo_foo"));
         assertTrue(indexNames.contains("bar_bar"));
 
         indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state, indicesAndAliasesOptions, "*o"));
-
         assertEquals(2, indexNames.size());
         assertTrue(indexNames.contains("foo_foo"));
         assertTrue(indexNames.contains("bar_bar"));
 
         indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state, indicesAndAliasesOptions, "f*o"));
-
         assertEquals(2, indexNames.size());
         assertTrue(indexNames.contains("foo_foo"));
         assertTrue(indexNames.contains("bar_bar"));
 
         indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state, indicesAndAliasesOptions, "foo"));
-
         assertEquals(2, indexNames.size());
         assertTrue(indexNames.contains("foo_foo"));
         assertTrue(indexNames.contains("bar_bar"));

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -644,47 +644,45 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertEquals(0, indexNames.length);
     }
 
-    // concreteIndexNames must resolve the provided wildcard only against the defined indices
+    // concreteIndexNames must be able to resolve the provided wildcard only against the defined
+    // indices when ignoreAliases option is set or against the defined indices and aliases otherwise
     public void testConcreteIndicesWildcardAndAliases() {
         MetaData.Builder mdBuilder = MetaData.builder()
                 .put(indexBuilder("foo_foo").state(State.OPEN).putAlias(AliasMetaData.builder("foo")))
                 .put(indexBuilder("bar_bar").state(State.OPEN).putAlias(AliasMetaData.builder("foo")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
 
-        String[] indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNamesIndexExpression(state,
-                IndicesOptions.lenientExpandOpen(), "foo*");
+        IndicesOptions ignoreAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, true);
+        
+        String[] indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNames(state, ignoreAliasesOptions, "foo*");
 
         assertEquals(1, indexNamesIndexWildcard.length);
         assertEquals("foo_foo", indexNamesIndexWildcard[0]);
 
-        indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNamesIndexExpression(state,
-                IndicesOptions.lenientExpandOpen(), "*o");
+        indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNames(state, ignoreAliasesOptions, "*o");
 
         assertEquals(1, indexNamesIndexWildcard.length);
         assertEquals("foo_foo", indexNamesIndexWildcard[0]);
 
-        indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNamesIndexExpression(state,
-                IndicesOptions.lenientExpandOpen(), "f*o");
+        indexNamesIndexWildcard = indexNameExpressionResolver.concreteIndexNames(state, ignoreAliasesOptions, "f*o");
 
         assertEquals(1, indexNamesIndexWildcard.length);
         assertEquals("foo_foo", indexNamesIndexWildcard[0]);
 
-        List<String> indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state,
-                IndicesOptions.lenientExpandOpen(), "foo*"));
+        IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, false);
+        List<String> indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state, indicesAndAliasesOptions, "foo*"));
 
         assertEquals(2, indexNames.size());
         assertTrue(indexNames.contains("foo_foo"));
         assertTrue(indexNames.contains("bar_bar"));
 
-        indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state,
-                IndicesOptions.lenientExpandOpen(), "*o"));
+        indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state, indicesAndAliasesOptions, "*o"));
 
         assertEquals(2, indexNames.size());
         assertTrue(indexNames.contains("foo_foo"));
         assertTrue(indexNames.contains("bar_bar"));
 
-        indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state,
-                IndicesOptions.lenientExpandOpen(), "f*o"));
+        indexNames = Arrays.asList(indexNameExpressionResolver.concreteIndexNames(state, indicesAndAliasesOptions, "f*o"));
 
         assertEquals(2, indexNames.size());
         assertTrue(indexNames.contains("foo_foo"));

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -127,17 +127,19 @@ public class WildcardExpressionResolverTests extends ESTestCase {
     }
 
     // WildcardExpressionResolver must be able to resolve the provided wildcard only against the
-    // defined indices or against the defined indices and aliases (#23960)
+    // defined indices when ignoreAliases option is set or against the defined indices and aliases
+    // otherwise
     public void testConcreteIndicesWildcardAndAliases() {
         MetaData.Builder mdBuilder = MetaData.builder()
                 .put(indexBuilder("foo_foo").state(State.OPEN).putAlias(AliasMetaData.builder("foo")))
                 .put(indexBuilder("bar_bar").state(State.OPEN).putAlias(AliasMetaData.builder("foo")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
 
-        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state,
-                IndicesOptions.lenientExpandOpen());
-        IndexNameExpressionResolver.Context contextIndices = new IndexNameExpressionResolver.Context(
-                state, IndicesOptions.lenientExpandOpen(), System.currentTimeMillis(), false, true);
+        IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, false);
+        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, indicesAndAliasesOptions);
+
+        IndicesOptions ignoreAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, true);
+        IndexNameExpressionResolver.Context contextIndices = new IndexNameExpressionResolver.Context(state, ignoreAliasesOptions);
 
         assertThat(
                 IndexNameExpressionResolver.WildcardExpressionResolver

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -135,47 +135,47 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         // when ignoreAliases option is not set, WildcardExpressionResolver resolves the provided
         // expressions against the defined indices and aliases
         IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, false);
-        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, indicesAndAliasesOptions);
+        IndexNameExpressionResolver.Context indicesAndAliasesContext = new IndexNameExpressionResolver.Context(state, indicesAndAliasesOptions);
 
         // ignoreAliases option is set, WildcardExpressionResolver resolves the provided expressions
         // only against the defined indices
-        IndicesOptions ignoreAliasesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, true);
-        IndexNameExpressionResolver.Context contextIndices = new IndexNameExpressionResolver.Context(state, ignoreAliasesOptions);
+        IndicesOptions onlyIndicesOptions = IndicesOptions.fromOptions(false, false, true, false, true, false, true);
+        IndexNameExpressionResolver.Context onlyIndicesContext = new IndexNameExpressionResolver.Context(state, onlyIndicesOptions);
 
         assertThat(
                 IndexNameExpressionResolver.WildcardExpressionResolver
-                        .matches(context, state.getMetaData(), "*").keySet(),
+                        .matches(indicesAndAliasesContext, state.getMetaData(), "*").keySet(),
                 equalTo(newHashSet("bar_bar", "foo_foo", "foo")));
         assertThat(
                 IndexNameExpressionResolver.WildcardExpressionResolver
-                        .matches(contextIndices, state.getMetaData(), "*").keySet(),
+                        .matches(onlyIndicesContext, state.getMetaData(), "*").keySet(),
                 equalTo(newHashSet("bar_bar", "foo_foo")));
 
         assertThat(
                 IndexNameExpressionResolver.WildcardExpressionResolver
-                        .matches(context, state.getMetaData(), "foo*").keySet(),
+                        .matches(indicesAndAliasesContext, state.getMetaData(), "foo*").keySet(),
                 equalTo(newHashSet("foo", "foo_foo")));
         assertThat(
                 IndexNameExpressionResolver.WildcardExpressionResolver
-                        .matches(contextIndices, state.getMetaData(), "foo*").keySet(),
+                        .matches(onlyIndicesContext, state.getMetaData(), "foo*").keySet(),
                 equalTo(newHashSet("foo_foo")));
 
         assertThat(
                 IndexNameExpressionResolver.WildcardExpressionResolver
-                        .matches(context, state.getMetaData(), "f*o").keySet(),
+                        .matches(indicesAndAliasesContext, state.getMetaData(), "f*o").keySet(),
                 equalTo(newHashSet("foo", "foo_foo")));
         assertThat(
                 IndexNameExpressionResolver.WildcardExpressionResolver
-                        .matches(contextIndices, state.getMetaData(), "f*o").keySet(),
+                        .matches(onlyIndicesContext, state.getMetaData(), "f*o").keySet(),
                 equalTo(newHashSet("foo_foo")));
 
         assertThat(
                 IndexNameExpressionResolver.WildcardExpressionResolver
-                        .matches(context, state.getMetaData(), "foo").keySet(),
+                        .matches(indicesAndAliasesContext, state.getMetaData(), "foo").keySet(),
                 equalTo(newHashSet("foo")));
         assertThat(
                 IndexNameExpressionResolver.WildcardExpressionResolver
-                        .matches(contextIndices, state.getMetaData(), "foo").keySet(),
+                        .matches(onlyIndicesContext, state.getMetaData(), "foo").keySet(),
                 equalTo(newHashSet()));
     }
 

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -126,7 +126,8 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         assertThat(newHashSet(resolver.resolve(context, Arrays.asList("_all"))), equalTo(newHashSet("testXXX", "testXYY", "testYYY")));
     }
 
-    // issue #23960
+    // WildcardExpressionResolver must be able to resolve the provided wildcard only against the
+    // defined indices or against the defined indices and aliases (#23960)
     public void testConcreteIndicesWildcardAndAliases() {
         MetaData.Builder mdBuilder = MetaData.builder()
                 .put(indexBuilder("foo_foo").state(State.OPEN).putAlias(AliasMetaData.builder("foo")))

--- a/docs/reference/migration/migrate_6_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_6_0/indices.asciidoc
@@ -53,6 +53,6 @@ will be marked for deletion.
 
 ==== Indices aliases api resolves indices expressions only against indices
 
-The default bahavior for the indices aliases api is changed so that the indices
-expressions are resolved only against the indices. As a result an alias can be
-added only to an index.
+The index parameter in the update-aliases, put-alias, and delete-alias APIs no
+longer accepts alias names. Instead, it accepts only index names (or wildcards
+which will expand to matching indices).

--- a/docs/reference/migration/migrate_6_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_6_0/indices.asciidoc
@@ -50,3 +50,9 @@ default when a provided wildcard expression doesn't match any closed/open index.
 Delete a document from non-existing index has been modified to not create the index.
 However if an external versioning is used the index will be created and the document
 will be marked for deletion. 
+
+==== Indices aliases api resolves indices expressions only against indices
+
+The default bahavior for the indices aliases api is changed so that the indices
+expressions are resolved only against the indices. As a result an alias can be
+added only to an index.


### PR DESCRIPTION
Indices wildcards were resolved against all indices and aliases. And if an alias matched, then all indices with this alias were returned as matching.

In other words
```
POST /_aliases
{
    "actions" : [
        { "add" : { "index" : "foo_foo", "alias" : "foo" } },
        { "add" : { "index" : "bar_bar", "alias" : "foo" } }
    ]
}
```
```
POST /_aliases 
{
  "actions": [
    {
      "remove": {
        "index": "foo*",
        "alias": "foo"
      }
    }
  ]
}
```
will actually return both indices `foo_foo` and `bar_bar` as the common alias `foo` matched the wildcard. Which led to deleting the alias for both indices.

Related to #23960

Relates to #10106 
