### PR TITLE
Use the correct key when checking the map.

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/core/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -199,7 +199,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             Map<String, List<ShardId>> waitingIndicesMap = new HashMap<>();
             for (ObjectObjectCursor<ShardId, ShardSnapshotStatus> entry : shards) {
                 if (entry.value.state() == State.WAITING) {
-                    List<ShardId> waitingShards = waitingIndicesMap.get(entry.key.getIndex());
+                    List<ShardId> waitingShards = waitingIndicesMap.get(entry.key.getIndexName());
                     if (waitingShards == null) {
                         waitingShards = new ArrayList<>();
                         waitingIndicesMap.put(entry.key.getIndexName(), waitingShards);


### PR DESCRIPTION
Bug caught during compilation by ErrorProne: http://errorprone.info/docs/installation