### PR TITLE
Move back to 140chars line length

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ For Eclipse, go to `Preferences->Java->Installed JREs` and add `-ea` to
 Please follow these formatting guidelines:
 
 * Java indent is 4 spaces
-* Line width is 100 characters
+* Line width is 140 characters
 * The rest is left to Java coding standards
 * Disable “auto-format on save” to prevent unnecessary format changes. This makes reviews much harder as it generates unnecessary formatting changes. If your IDE supports formatting only modified chunks that is fine to do.
 * Wildcard imports (`import foo.bar.baz.*`) are forbidden and will cause the build to fail. Please attempt to tame your IDE so it doesn't make them and please send a PR against this document with instructions for your IDE if it doesn't contain them.

--- a/buildSrc/src/main/resources/checkstyle.xml
+++ b/buildSrc/src/main/resources/checkstyle.xml
@@ -22,7 +22,7 @@
       suppress the check there but enforce it everywhere else. This prevents the list from getting longer even if it is
       unfair. -->
     <module name="LineLength">
-      <property name="max" value="100"/>
+      <property name="max" value="140"/>
     </module>
 
     <module name="AvoidStarImport" />


### PR DESCRIPTION
This reverts the line limit change in #23623 - this PR doesn't touch the suppression file since we are moving towards automatic code formatting which makes it mainly obsolete. 