### PR TITLE
Test: add support for replacing stashed values within headers of REST tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -76,9 +76,17 @@ public class ClientYamlTestExecutionContext {
             }
         }
 
-        HttpEntity entity = createEntity(bodies, headers);
+        //make a copy of the headers before modifying them for this specific request
+        HashMap<String, String> requestHeaders = new HashMap<>(headers);
+        for (Map.Entry<String, String> entry : requestHeaders.entrySet()) {
+            if (stash.containsStashedValue(entry.getValue())) {
+                entry.setValue(stash.getValue(entry.getValue()).toString());
+            }
+        }
+
+        HttpEntity entity = createEntity(bodies, requestHeaders);
         try {
-            response = callApiInternal(apiName, requestParams, entity, headers);
+            response = callApiInternal(apiName, requestParams, entity, requestHeaders);
             return response;
         } catch(ClientYamlTestResponseException e) {
             response = e.getRestTestResponse();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -56,7 +56,7 @@ public class ClientYamlTestExecutionContext {
 
     private final boolean randomizeContentType;
 
-    public ClientYamlTestExecutionContext(ClientYamlTestClient clientYamlTestClient, boolean randomizeContentType) {
+    ClientYamlTestExecutionContext(ClientYamlTestClient clientYamlTestClient, boolean randomizeContentType) {
         this.clientYamlTestClient = clientYamlTestClient;
         this.randomizeContentType = randomizeContentType;
     }
@@ -68,7 +68,7 @@ public class ClientYamlTestExecutionContext {
     public ClientYamlTestResponse callApi(String apiName, Map<String, String> params, List<Map<String, Object>> bodies,
                                     Map<String, String> headers) throws IOException {
         //makes a copy of the parameters before modifying them for this specific request
-        HashMap<String, String> requestParams = new HashMap<>(params);
+        Map<String, String> requestParams = new HashMap<>(params);
         requestParams.putIfAbsent("error_trace", "true"); // By default ask for error traces, this my be overridden by params
         for (Map.Entry<String, String> entry : requestParams.entrySet()) {
             if (stash.containsStashedValue(entry.getValue())) {
@@ -77,7 +77,7 @@ public class ClientYamlTestExecutionContext {
         }
 
         //make a copy of the headers before modifying them for this specific request
-        HashMap<String, String> requestHeaders = new HashMap<>(headers);
+        Map<String, String> requestHeaders = new HashMap<>(headers);
         for (Map.Entry<String, String> entry : requestHeaders.entrySet()) {
             if (stash.containsStashedValue(entry.getValue())) {
                 entry.setValue(stash.getValue(entry.getValue()).toString());
@@ -151,7 +151,8 @@ public class ClientYamlTestExecutionContext {
         }
     }
 
-    private ClientYamlTestResponse callApiInternal(String apiName, Map<String, String> params,
+    // pkg-private for testing
+    ClientYamlTestResponse callApiInternal(String apiName, Map<String, String> params,
                                                    HttpEntity entity, Map<String, String> headers) throws IOException  {
         return clientYamlTestClient.callApi(apiName, params, entity, headers);
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContextTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContextTests.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.test.rest.yaml;
+
+import org.apache.http.HttpEntity;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ClientYamlTestExecutionContextTests extends ESTestCase {
+
+    public void testHeadersSupportStashedValueReplacement() throws IOException {
+        final AtomicReference<Map<String, String>> headersRef = new AtomicReference<>();
+        final ClientYamlTestExecutionContext context =
+            new ClientYamlTestExecutionContext(null, randomBoolean()) {
+                @Override
+                ClientYamlTestResponse callApiInternal(String apiName, Map<String, String> params,
+                                                       HttpEntity entity,
+                                                       Map<String, String> headers) {
+                    headersRef.set(headers);
+                    return null;
+                }
+            };
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("foo", "$bar");
+        headers.put("foo1", "baz ${c}");
+
+        context.stash().stashValue("bar", "foo2");
+        context.stash().stashValue("c", "bar1");
+
+        assertNull(headersRef.get());
+        context.callApi("test", Collections.emptyMap(), Collections.emptyList(), headers);
+        assertNotNull(headersRef.get());
+        assertNotEquals(headers, headersRef.get());
+
+        assertEquals("foo2", headersRef.get().get("foo"));
+        assertEquals("baz bar1", headersRef.get().get("foo1"));
+    }
+}


### PR DESCRIPTION
This commit adds support for replacing a stashed value within a header of a REST test. This is
useful for requests that may want to use a value previously obtained within a header.
