### PR TITLE
Repository S3: Simplify client method

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/AwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/AwsS3Service.java
@@ -150,5 +150,5 @@ interface AwsS3Service extends LifecycleComponent {
     /**
      * Creates an {@code AmazonS3} client from the given repository metadata and node settings.
      */
-    AmazonS3 client(RepositoryMetaData metadata, Settings repositorySettings);
+    AmazonS3 client(Settings repositorySettings);
 }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/InternalAwsS3Service.java
@@ -63,7 +63,7 @@ class InternalAwsS3Service extends AbstractLifecycleComponent implements AwsS3Se
     }
 
     @Override
-    public synchronized AmazonS3 client(RepositoryMetaData metadata, Settings repositorySettings) {
+    public synchronized AmazonS3 client(Settings repositorySettings) {
         String clientName = CLIENT_NAME.get(repositorySettings);
         String foundEndpoint = findEndpoint(logger, repositorySettings, settings, clientName);
 
@@ -75,18 +75,18 @@ class InternalAwsS3Service extends AbstractLifecycleComponent implements AwsS3Se
             return client;
         }
 
-        Integer maxRetries = getValue(metadata.settings(), settings,
+        Integer maxRetries = getValue(repositorySettings, settings,
             S3Repository.Repository.MAX_RETRIES_SETTING,
             S3Repository.Repositories.MAX_RETRIES_SETTING);
-        boolean useThrottleRetries = getValue(metadata.settings(), settings,
+        boolean useThrottleRetries = getValue(repositorySettings, settings,
             S3Repository.Repository.USE_THROTTLE_RETRIES_SETTING,
             S3Repository.Repositories.USE_THROTTLE_RETRIES_SETTING);
         // If the user defined a path style access setting, we rely on it,
         // otherwise we use the default value set by the SDK
         Boolean pathStyleAccess = null;
-        if (S3Repository.Repository.PATH_STYLE_ACCESS_SETTING.exists(metadata.settings()) ||
+        if (S3Repository.Repository.PATH_STYLE_ACCESS_SETTING.exists(repositorySettings) ||
                 S3Repository.Repositories.PATH_STYLE_ACCESS_SETTING.exists(settings)) {
-            pathStyleAccess = getValue(metadata.settings(), settings,
+            pathStyleAccess = getValue(repositorySettings, settings,
                 S3Repository.Repository.PATH_STYLE_ACCESS_SETTING,
                 S3Repository.Repositories.PATH_STYLE_ACCESS_SETTING);
         }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -328,7 +328,7 @@ class S3Repository extends BlobStoreRepository {
             "buffer_size [{}], cannedACL [{}], storageClass [{}]",
             bucket, chunkSize, serverSideEncryption, bufferSize, cannedACL, storageClass);
 
-        AmazonS3 client = s3Service.client(metadata, metadata.settings());
+        AmazonS3 client = s3Service.client(metadata.settings());
         blobStore = new S3BlobStore(settings, client, bucket, serverSideEncryption, bufferSize, cannedACL, storageClass);
 
         String basePath = getValue(metadata.settings(), settings, Repository.BASE_PATH_SETTING, Repositories.BASE_PATH_SETTING);

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AbstractS3SnapshotRestoreTest.java
@@ -197,7 +197,7 @@ public abstract class AbstractS3SnapshotRestoreTest extends AbstractAwsTestCase 
         Settings settings = internalCluster().getInstance(Settings.class);
         Settings bucket = settings.getByPrefix("repositories.s3.");
         RepositoryMetaData metadata = new RepositoryMetaData("test-repo", "fs", Settings.EMPTY);
-        AmazonS3 s3Client = internalCluster().getInstance(AwsS3Service.class).client(metadata, repositorySettings);
+        AmazonS3 s3Client = internalCluster().getInstance(AwsS3Service.class).client(repositorySettings);
 
         String bucketName = bucket.get("bucket");
         logger.info("--> verify encryption for bucket [{}], prefix [{}]", bucketName, basePath);
@@ -464,9 +464,8 @@ public abstract class AbstractS3SnapshotRestoreTest extends AbstractAwsTestCase 
 
             // We check that settings has been set in elasticsearch.yml integration test file
             // as described in README
-            assertThat("Your settings in elasticsearch.yml are incorrects. Check README file.", bucketName, notNullValue());
-            RepositoryMetaData metadata = new RepositoryMetaData("test-repo", "fs", Settings.EMPTY);
-            AmazonS3 client = internalCluster().getInstance(AwsS3Service.class).client(metadata,
+            assertThat("Your settings in elasticsearch.yml are incorrect. Check README file.", bucketName, notNullValue());
+            AmazonS3 client = internalCluster().getInstance(AwsS3Service.class).client(
                 Settings.builder().put(S3Repository.Repository.USE_THROTTLE_RETRIES_SETTING.getKey(), randomBoolean()).build());
             try {
                 ObjectListing prevListing = null;

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -60,7 +60,7 @@ public class S3RepositoryTests extends ESTestCase {
         @Override
         protected void doClose() {}
         @Override
-        public AmazonS3 client(RepositoryMetaData metadata, Settings settings) {
+        public AmazonS3 client(Settings settings) {
             return new DummyS3Client();
         }
     }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/TestAwsS3Service.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/TestAwsS3Service.java
@@ -42,8 +42,8 @@ public class TestAwsS3Service extends InternalAwsS3Service {
 
 
     @Override
-    public synchronized AmazonS3 client(RepositoryMetaData metadata, Settings repositorySettings) {
-        return cachedWrapper(super.client(metadata, repositorySettings));
+    public synchronized AmazonS3 client(Settings repositorySettings) {
+        return cachedWrapper(super.client(repositorySettings));
     }
 
     private AmazonS3 cachedWrapper(AmazonS3 client) {


### PR DESCRIPTION
This commit removes passing the repository metadata object through to
s3 client creation. It is not needed, and in fact in tests was confusing
because you could create the metadata but have it contain different
settings than were passed in as repository settings.