### PR TITLE
Build: Support offline build of bwc zip

### DIFF
--- a/distribution/bwc-zip/build.gradle
+++ b/distribution/bwc-zip/build.gradle
@@ -65,6 +65,7 @@ task addUpstream(type: LoggedExec) {
 }
 
 task fetchLatest(type: LoggedExec) {
+  onlyIf { project.gradle.startParameter.isOffline() == false }
   dependsOn addUpstream
   workingDir = checkoutDir
   commandLine = ['git', 'fetch', 'upstream']


### PR DESCRIPTION
The bwc checkout for backcompat tests currently always tries to fetch
the latest from the upstream remote. This change makes fetching from
upstream conditional on not running an offline build.