### PR TITLE
Correct handling of default settings and path.data

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -269,6 +269,9 @@ final class Security {
         for (Path path : environment.dataFiles()) {
             addPath(policy, Environment.PATH_DATA_SETTING.getKey(), path, "read,readlink,write,delete");
         }
+        if (environment.defaultPathData() != null) {
+            addPath(policy, Environment.DEFAULT_PATH_DATA_SETTING.getKey(), environment.defaultPathData(), "read,readlink,write,delete");
+        }
         for (Path path : environment.repoFiles()) {
             addPath(policy, Environment.PATH_REPO_SETTING.getKey(), path, "read,readlink,write,delete");
         }

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -311,6 +311,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     HunspellService.HUNSPELL_IGNORE_CASE,
                     HunspellService.HUNSPELL_DICTIONARY_OPTIONS,
                     IndicesStore.INDICES_STORE_DELETE_SHARD_TIMEOUT,
+                    Environment.DEFAULT_PATH_DATA_SETTING,
                     Environment.PATH_CONF_SETTING,
                     Environment.PATH_DATA_SETTING,
                     Environment.PATH_HOME_SETTING,

--- a/core/src/main/java/org/elasticsearch/env/Environment.java
+++ b/core/src/main/java/org/elasticsearch/env/Environment.java
@@ -163,14 +163,14 @@ public class Environment {
                     this.defaultPathData = defaultPathData;
                 }
             } else {
-                defaultPathData = null;
+                this.defaultPathData = null;
             }
         } else {
             dataFiles = new Path[]{homeFile.resolve("data")};
             dataWithClusterFiles = new Path[]{homeFile.resolve("data").resolve(clusterName.value())};
             assert !DEFAULT_PATH_DATA_SETTING.exists(settings)
                     : "expected default.path.data to be unset but was [" + DEFAULT_PATH_DATA_SETTING.get(settings) + "]";
-            defaultPathData = null;
+            this.defaultPathData = null;
         }
         if (PATH_SHARED_DATA_SETTING.exists(settings)) {
             sharedDataFile = PathUtils.get(cleanPath(PATH_SHARED_DATA_SETTING.get(settings)));

--- a/core/src/main/java/org/elasticsearch/env/Environment.java
+++ b/core/src/main/java/org/elasticsearch/env/Environment.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.env;
 
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Setting;
@@ -68,6 +69,7 @@ public class Environment {
 
     private final Path[] dataFiles;
 
+    @Nullable
     private final Path defaultPathData;
 
     private final Path[] dataWithClusterFiles;
@@ -224,6 +226,12 @@ public class Environment {
         return dataFiles;
     }
 
+    /**
+     * The default data path which is set only if default.path.data did not overwrite path.data.
+     *
+     * @return the default data path
+     */
+    @Nullable
     public Path defaultPathData() {
         return defaultPathData;
     }

--- a/core/src/main/java/org/elasticsearch/env/Environment.java
+++ b/core/src/main/java/org/elasticsearch/env/Environment.java
@@ -162,7 +162,6 @@ public class Environment {
                 } else {
                     this.defaultPathData = defaultPathData;
                 }
-
             } else {
                 defaultPathData = null;
             }

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -797,6 +797,13 @@ public final class NodeEnvironment  implements Closeable {
 
     }
 
+    /**
+     * Return all directory names in the nodes/{node.id}/indices directory for the given node path.
+     *
+     * @param nodePath the node path
+     * @return all directories that could be indices for the given node path.
+     * @throws IOException if an I/O exception occurs traversing the filesystem
+     */
     public Set<String> availableIndexFoldersForPath(final NodePath nodePath) throws IOException {
         if (nodePaths == null || locks == null) {
             throw new IllegalStateException("node is not configured to store local location");

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -190,7 +190,7 @@ public final class NodeEnvironment  implements Closeable {
         }
         final NodePath[] nodePaths = new NodePath[environment.dataWithClusterFiles().length];
         NodePath defaultNodePath = null;
-        final int extra = environment.defaultPathData() != null ? 1 : 0;
+        final int extra = environment.defaultPathData() == null ? 0 : 1;
         final Lock[] locks = new Lock[nodePaths.length + extra];
 
         boolean success = false;

--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -266,12 +266,12 @@ public final class NodeEnvironment  implements Closeable {
             this.nodeLockId = nodeLockId;
             this.locks = locks;
             this.nodePaths = nodePaths;
-            if (environment.defaultPathData() != null) {
-                assert defaultNodePath != null;
-                this.defaultNodePath = defaultNodePath;
-            } else {
+            if (environment.defaultPathData() == null) {
                 assert defaultNodePath == null;
                 this.defaultNodePath = null;
+            } else {
+                assert defaultNodePath != null;
+                this.defaultNodePath = defaultNodePath;
             }
 
             maybeLogPathDetails();

--- a/core/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
+++ b/core/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
@@ -135,6 +135,11 @@ public class InternalSettingsPreparer {
                         .and(key -> output.get(STRIP_PROPERTY_DEFAULTS_PREFIX.apply(key)) == null)
                         .and(key -> output.get(STRIP_PROPERTY_DEFAULTS_PREFIX.apply(key) + ".0") == null),
             STRIP_PROPERTY_DEFAULTS_PREFIX);
+        /*
+         * We have to treat default.path.data separately due to a bug in Elasticsearch 5.3.0 where if multiple path.data were specified as
+         * an array and default.path.data was configured then the settings were not properly merged. We need to preserve default.path.data
+         * so that we can detect this situation.
+         */
         final String key = Environment.DEFAULT_PATH_DATA_SETTING.getKey();
         if (esSettings.containsKey(key)) {
             output.put(Environment.DEFAULT_PATH_DATA_SETTING.getKey(), esSettings.get(key));

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -512,14 +512,14 @@ public class Node implements Closeable {
             final String message = String.format(
                     Locale.ROOT,
                     "detected index data in default.path.data [%s] where there should not be any",
-                    nodeEnv.defaultNodePath().path);
+                    nodeEnv.defaultNodePath().indicesPath);
             logger.error(message);
             for (final String availableIndexFolder : availableIndexFolders) {
                 logger.info(
                         "index folder [{}] in default.path.data [{}] must be moved to any of {}",
                         availableIndexFolder,
-                        nodeEnv.defaultNodePath().path,
-                        nodeEnv.nodeDataPaths());
+                        nodeEnv.defaultNodePath().indicesPath,
+                        Arrays.stream(nodeEnv.nodePaths()).map(np -> np.indicesPath).collect(Collectors.toList()));
             }
             throw new IllegalStateException(message);
         }

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -264,7 +264,9 @@ public class Node implements Closeable {
             Logger logger = Loggers.getLogger(Node.class, tmpSettings);
             final String nodeId = nodeEnvironment.nodeId();
             tmpSettings = addNodeNameIfNeeded(tmpSettings, nodeId);
-            checkForIndexDataInDefaultPathData(nodeEnvironment, logger);
+            if (DiscoveryNode.nodeRequiresLocalStorage(tmpSettings)) {
+                checkForIndexDataInDefaultPathData(nodeEnvironment, logger);
+            }
             // this must be captured after the node name is possibly added to the settings
             final String nodeName = NODE_NAME_SETTING.get(tmpSettings);
             if (hadPredefinedNodeName == false) {

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -146,7 +146,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -262,6 +264,7 @@ public class Node implements Closeable {
             Logger logger = Loggers.getLogger(Node.class, tmpSettings);
             final String nodeId = nodeEnvironment.nodeId();
             tmpSettings = addNodeNameIfNeeded(tmpSettings, nodeId);
+            checkForIndexDataInDefaultPathData(nodeEnvironment, logger);
             // this must be captured after the node name is possibly added to the settings
             final String nodeName = NODE_NAME_SETTING.get(tmpSettings);
             if (hadPredefinedNodeName == false) {
@@ -497,6 +500,28 @@ public class Node implements Closeable {
             if (!success) {
                 IOUtils.closeWhileHandlingException(resourcesToClose);
             }
+        }
+    }
+
+    static void checkForIndexDataInDefaultPathData(final NodeEnvironment nodeEnv, final Logger logger) throws IOException {
+        if (nodeEnv.defaultNodePath() == null) {
+            return;
+        }
+        final Set<String> availableIndexFolders = nodeEnv.availableIndexFoldersForPath(nodeEnv.defaultNodePath());
+        if (!availableIndexFolders.isEmpty()) {
+            final String message = String.format(
+                    Locale.ROOT,
+                    "detected index data in default.path.data [%s] where there should not be any",
+                    nodeEnv.defaultNodePath().path);
+            logger.error(message);
+            for (final String availableIndexFolder : availableIndexFolders) {
+                logger.info(
+                        "index folder [{}] in default.path.data [{}] must be moved to any of {}",
+                        availableIndexFolder,
+                        nodeEnv.defaultNodePath().path,
+                        nodeEnv.nodeDataPaths());
+            }
+            throw new IllegalStateException(message);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -509,22 +509,25 @@ public class Node implements Closeable {
         if (nodeEnv.defaultNodePath() == null) {
             return;
         }
+
         final Set<String> availableIndexFolders = nodeEnv.availableIndexFoldersForPath(nodeEnv.defaultNodePath());
-        if (!availableIndexFolders.isEmpty()) {
-            final String message = String.format(
-                    Locale.ROOT,
-                    "detected index data in default.path.data [%s] where there should not be any",
-                    nodeEnv.defaultNodePath().indicesPath);
-            logger.error(message);
-            for (final String availableIndexFolder : availableIndexFolders) {
-                logger.info(
-                        "index folder [{}] in default.path.data [{}] must be moved to any of {}",
-                        availableIndexFolder,
-                        nodeEnv.defaultNodePath().indicesPath,
-                        Arrays.stream(nodeEnv.nodePaths()).map(np -> np.indicesPath).collect(Collectors.toList()));
-            }
-            throw new IllegalStateException(message);
+        if (availableIndexFolders.isEmpty()) {
+            return;
         }
+
+        final String message = String.format(
+                Locale.ROOT,
+                "detected index data in default.path.data [%s] where there should not be any",
+                nodeEnv.defaultNodePath().indicesPath);
+        logger.error(message);
+        for (final String availableIndexFolder : availableIndexFolders) {
+            logger.info(
+                    "index folder [{}] in default.path.data [{}] must be moved to any of {}",
+                    availableIndexFolder,
+                    nodeEnv.defaultNodePath().indicesPath,
+                    Arrays.stream(nodeEnv.nodePaths()).map(np -> np.indicesPath).collect(Collectors.toList()));
+        }
+        throw new IllegalStateException(message);
     }
 
     // visible for testing

--- a/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -45,6 +46,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -423,6 +425,41 @@ public class NodeEnvironmentTests extends ESTestCase {
             locations[i] = PathUtils.get(strings[i], additional);
         }
         return locations;
+    }
+
+    public void testDefaultPathData() throws IOException {
+        final Path zero = createTempDir().toAbsolutePath();
+        final Path one = createTempDir().toAbsolutePath();
+
+        final Settings.Builder builder = Settings.builder()
+                .put("path.home", "/home")
+                .put("path.data.0", zero)
+                .put("path.data.1", one);
+        final boolean defaultPathDataSet = randomBoolean();
+        final Path defaultPathData;
+        if (defaultPathDataSet) {
+            defaultPathData = createTempDir().toAbsolutePath();
+            builder.put("default.path.data", defaultPathData);
+        } else {
+            defaultPathData = null;
+        }
+        try (NodeEnvironment nodeEnv = newNodeEnvironment(builder.build())) {
+            final Set<Path> actual = Arrays.stream(nodeEnv.nodePaths()).map(np -> np.path).collect(Collectors.toSet());
+            final Set<Path> expected = new HashSet<>(Arrays.asList(zero.resolve("nodes/0"), one.resolve("nodes/0")));
+            assertThat(actual, equalTo(expected));
+
+            if (defaultPathDataSet) {
+                assertThat(nodeEnv.defaultNodePath().path, equalTo(defaultPathData.resolve("nodes/0")));
+            }
+
+            for (final NodeEnvironment.NodePath nodePath : nodeEnv.nodePaths()) {
+                assertTrue(Files.exists(nodePath.path.resolve("node.lock")));
+            }
+
+            if (defaultPathDataSet) {
+                assertTrue(Files.exists(nodeEnv.defaultNodePath().path.resolve("node.lock")));
+            }
+        }
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -453,11 +453,11 @@ public class NodeEnvironmentTests extends ESTestCase {
             }
 
             for (final NodeEnvironment.NodePath nodePath : nodeEnv.nodePaths()) {
-                assertTrue(Files.exists(nodePath.path.resolve("node.lock")));
+                assertTrue(Files.exists(nodePath.path.resolve(NodeEnvironment.NODE_LOCK_FILENAME)));
             }
 
             if (defaultPathDataSet) {
-                assertTrue(Files.exists(nodeEnv.defaultNodePath().path.resolve("node.lock")));
+                assertTrue(Files.exists(nodeEnv.defaultNodePath().path.resolve(NodeEnvironment.NODE_LOCK_FILENAME)));
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/node/InternalSettingsPreparerTests.java
+++ b/core/src/test/java/org/elasticsearch/node/InternalSettingsPreparerTests.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.node.internal;
+package org.elasticsearch.node;
 
 import org.elasticsearch.cli.MockTerminal;
 import org.elasticsearch.cluster.ClusterName;
@@ -28,7 +28,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.node.InternalSettingsPreparer;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -38,7 +37,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
@@ -196,4 +194,26 @@ public class InternalSettingsPreparerTests extends ESTestCase {
         Environment env = InternalSettingsPreparer.prepareEnvironment(baseEnvSettings, null, props);
         assertEquals("bar", env.settings().get("setting"));
     }
+
+    public void testDefaultWithArray() {
+        final Settings.Builder output = Settings.builder().put("foobar.0", "bar").put("foobar.1", "baz");
+        final Map<String, String> esSettings = Collections.singletonMap("default.foobar", "foo");
+        InternalSettingsPreparer.initializeSettings(output, Settings.EMPTY, esSettings);
+        final Settings settings = output.build();
+        assertThat(settings.get("foobar.0"), equalTo("bar"));
+        assertThat(settings.get("foobar.1"), equalTo("baz"));
+        assertNull(settings.get("foobar"));
+    }
+
+    public void testDefaultPathDataWithArray() {
+        final Settings.Builder output = Settings.builder().put("path.data.0", "/mnt/zero").put("path.data.1", "/mnt/one");
+        final Map<String, String> esSettings = Collections.singletonMap("default.path.data", "/mnt/default");
+        InternalSettingsPreparer.initializeSettings(output, Settings.EMPTY, esSettings);
+        final Settings settings = output.build();
+        assertThat(settings.get("path.data.0"), equalTo("/mnt/zero"));
+        assertThat(settings.get("path.data.1"), equalTo("/mnt/one"));
+        assertThat(settings.get("default.path.data"), equalTo("/mnt/default"));
+        assertNull(settings.get("path.data"));
+    }
+
 }

--- a/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
@@ -223,8 +223,7 @@ public class NodeTests extends ESTestCase {
             final boolean indexExists = randomBoolean();
             final List<String> indices;
             if (indexExists) {
-                final int numberOfIndices = randomIntBetween(1, 3);
-                indices = IntStream.range(0, numberOfIndices).mapToObj(i -> UUIDs.randomBase64UUID()).collect(Collectors.toList());
+                indices = IntStream.range(0, randomIntBetween(1, 3)).mapToObj(i -> UUIDs.randomBase64UUID()).collect(Collectors.toList());
                 for (final String index : indices) {
                     Files.createDirectories(nodeEnv.defaultNodePath().indicesPath.resolve(index));
                 }

--- a/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -203,7 +202,7 @@ public class NodeTests extends ESTestCase {
             final String message = String.format(
                     Locale.ROOT,
                     "detected index data in default.path.data [%s] where there should not be any",
-                    defaultPathData.resolve("nodes/0"));
+                    defaultPathData.resolve("nodes/0/indices"));
             assertThat(e, hasToString(containsString(message)));
         } else {
             try (Node ignored = constructor.get()) {
@@ -242,15 +241,15 @@ public class NodeTests extends ESTestCase {
                 final String message = String.format(
                         Locale.ROOT,
                         "detected index data in default.path.data [%s] where there should not be any",
-                        defaultPathData.resolve("nodes/0"));
+                        defaultPathData.resolve("nodes/0/indices"));
                 assertThat(e, hasToString(containsString(message)));
                 verify(mock).error(message);
                 for (final String index : indices) {
                     verify(mock).info(
                             "index folder [{}] in default.path.data [{}] must be moved to any of {}",
                             index,
-                            nodeEnv.defaultNodePath().path,
-                            nodeEnv.nodeDataPaths());
+                            nodeEnv.defaultNodePath().indicesPath,
+                            Arrays.stream(nodeEnv.nodePaths()).map(np -> np.indicesPath).collect(Collectors.toList()));
                 }
                 verifyNoMoreInteractions(mock);
             } else {

--- a/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
@@ -196,7 +196,7 @@ public class NodeTests extends ESTestCase {
                 Files.createDirectories(defaultPathData.resolve("nodes/0/indices").resolve(index));
             }
         }
-        Supplier<MockNode> constructor = () -> new MockNode(settings, Collections.singletonList(MockTcpTransportPlugin.class));
+        final Supplier<MockNode> constructor = () -> new MockNode(settings, Collections.singletonList(MockTcpTransportPlugin.class));
         if (indexExists) {
             final IllegalStateException e = expectThrows(IllegalStateException.class, constructor::get);
             final String message = String.format(

--- a/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
@@ -190,10 +190,8 @@ public class NodeTests extends ESTestCase {
         Files.createDirectories(defaultPathData.resolve("nodes/0"));
         final boolean indexExists = randomBoolean();
         if (indexExists) {
-            final int numberOfIndices = randomIntBetween(1, 3);
-            for (final String index :
-                    IntStream.range(0, numberOfIndices).mapToObj(i -> UUIDs.randomBase64UUID()).collect(Collectors.toList())) {
-                Files.createDirectories(defaultPathData.resolve("nodes/0/indices").resolve(index));
+            for (int i = 0; i < randomIntBetween(1, 3); i++) {
+                Files.createDirectories(defaultPathData.resolve("nodes/0/indices").resolve(UUIDs.randomBase64UUID()));
             }
         }
         final Supplier<MockNode> constructor = () -> new MockNode(settings, Collections.singletonList(MockTcpTransportPlugin.class));

--- a/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/NodeTests.java
@@ -22,23 +22,33 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.transport.MockTcpTransportPlugin;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -162,6 +172,106 @@ public class NodeTests extends ESTestCase {
             fail("should not allow a node attribute with trailing whitespace");
         } catch (IllegalArgumentException e) {
             assertEquals("node.attr.test_attr cannot have leading or trailing whitespace [trailing ]", e.getMessage());
+        }
+    }
+
+    public void testNodeConstructionWithDefaultPathDataSet() throws IOException {
+        final Path home = createTempDir().toAbsolutePath();
+        final Path zero = createTempDir().toAbsolutePath();
+        final Path one = createTempDir().toAbsolutePath();
+        final Path defaultPathData = createTempDir().toAbsolutePath();
+        final Settings settings = Settings.builder()
+                .put("path.home", home)
+                .put("path.data.0", zero)
+                .put("path.data.1", one)
+                .put("default.path.data", defaultPathData)
+                .put("http.enabled", false)
+                .put("transport.type", "mock-socket-network")
+                .build();
+        Files.createDirectories(defaultPathData.resolve("nodes/0"));
+        final boolean indexExists = randomBoolean();
+        if (indexExists) {
+            final int numberOfIndices = randomIntBetween(1, 3);
+            for (final String index :
+                    IntStream.range(0, numberOfIndices).mapToObj(i -> UUIDs.randomBase64UUID()).collect(Collectors.toList())) {
+                Files.createDirectories(defaultPathData.resolve("nodes/0/indices").resolve(index));
+            }
+        }
+        Supplier<MockNode> constructor = () -> new MockNode(settings, Collections.singletonList(MockTcpTransportPlugin.class));
+        if (indexExists) {
+            final IllegalStateException e = expectThrows(IllegalStateException.class, constructor::get);
+            final String message = String.format(
+                    Locale.ROOT,
+                    "detected index data in default.path.data [%s] where there should not be any",
+                    defaultPathData.resolve("nodes/0"));
+            assertThat(e, hasToString(containsString(message)));
+        } else {
+            try (Node ignored = constructor.get()) {
+                // node construction should be okay
+            }
+        }
+    }
+
+    public void testDefaultPathDataSet() throws IOException {
+        final Path zero = createTempDir().toAbsolutePath();
+        final Path one = createTempDir().toAbsolutePath();
+        final Path defaultPathData = createTempDir().toAbsolutePath();
+        final Settings settings = Settings.builder()
+                .put("path.home", "/home")
+                .put("path.data.0", zero)
+                .put("path.data.1", one)
+                .put("default.path.data", defaultPathData)
+                .build();
+        try (NodeEnvironment nodeEnv = new NodeEnvironment(settings, new Environment(settings))) {
+            final boolean indexExists = randomBoolean();
+            final List<String> indices;
+            if (indexExists) {
+                final int numberOfIndices = randomIntBetween(1, 3);
+                indices = IntStream.range(0, numberOfIndices).mapToObj(i -> UUIDs.randomBase64UUID()).collect(Collectors.toList());
+                for (final String index : indices) {
+                    Files.createDirectories(nodeEnv.defaultNodePath().indicesPath.resolve(index));
+                }
+            } else {
+                indices = Collections.emptyList();
+            }
+            final Logger mock = mock(Logger.class);
+            if (indexExists) {
+                final IllegalStateException e = expectThrows(
+                        IllegalStateException.class,
+                        () -> Node.checkForIndexDataInDefaultPathData(nodeEnv, mock));
+                final String message = String.format(
+                        Locale.ROOT,
+                        "detected index data in default.path.data [%s] where there should not be any",
+                        defaultPathData.resolve("nodes/0"));
+                assertThat(e, hasToString(containsString(message)));
+                verify(mock).error(message);
+                for (final String index : indices) {
+                    verify(mock).info(
+                            "index folder [{}] in default.path.data [{}] must be moved to any of {}",
+                            index,
+                            nodeEnv.defaultNodePath().path,
+                            nodeEnv.nodeDataPaths());
+                }
+                verifyNoMoreInteractions(mock);
+            } else {
+                Node.checkForIndexDataInDefaultPathData(nodeEnv, mock);
+                verifyNoMoreInteractions(mock);
+            }
+        }
+    }
+
+    public void testDefaultPathDataNotSet() throws IOException {
+        final Path zero = createTempDir().toAbsolutePath();
+        final Path one = createTempDir().toAbsolutePath();
+        final Settings settings = Settings.builder()
+                .put("path.home", "/home")
+                .put("path.data.0", zero)
+                .put("path.data.1", one)
+                .build();
+        try (NodeEnvironment nodeEnv = new NodeEnvironment(settings, new Environment(settings))) {
+            final Logger mock = mock(Logger.class);
+            Node.checkForIndexDataInDefaultPathData(nodeEnv, mock);
+            verifyNoMoreInteractions(mock);
         }
     }
 


### PR DESCRIPTION
In Elasticsearch 5.3.0 a bug was introduced in the merging of default settings when the target setting existed as an array. This arose due to the fact that when a target setting is an array, the setting key is broken into key.0, key.1, ..., key.n, one for each element of the array. When settings are replaced by default.key, we are looking for the target key but not the target key.0. This leads to key, and key.0, ..., key.n being present in the constructed settings object. When this concerns path.data, we end up in a situation where path.data.0, ..., path.data.n are configured and path.data is configured too. Since our packaging sets default.path.data, users that configure multiple data paths vian an array and use the packaging are subject to having shards land in default.path.data when that is very likely not what they intended.

This commit is an attempt to rectify this situation. First, we fix the merging of default settings when the target setting exists an array. We have to hold on to default.path.data though so that we can detect its presence. For this, we elevate default.path.data to an actual setting and give it special treatment when merging settings.

After we have done this, we take a lock on all configured data directories in path.data, and default.path.data too. We look for the presence of indices in default.path.data and if there are any, we fail the node. 

Closes #23981