### PR TITLE
Add version constant for 5.5

### DIFF
--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -78,6 +78,8 @@ public class Version implements Comparable<Version> {
     public static final Version V_5_3_1_UNRELEASED = new Version(V_5_3_1_ID_UNRELEASED, org.apache.lucene.util.Version.LUCENE_6_4_2);
     public static final int V_5_4_0_ID_UNRELEASED = 5040099;
     public static final Version V_5_4_0_UNRELEASED = new Version(V_5_4_0_ID_UNRELEASED, org.apache.lucene.util.Version.LUCENE_6_5_0);
+    public static final int V_5_5_0_ID_UNRELEASED = 5050099;
+    public static final Version V_5_5_0_UNRELEASED = new Version(V_5_5_0_ID_UNRELEASED, org.apache.lucene.util.Version.LUCENE_6_5_0);
     public static final int V_6_0_0_alpha1_ID_UNRELEASED = 6000001;
     public static final Version V_6_0_0_alpha1_UNRELEASED =
         new Version(V_6_0_0_alpha1_ID_UNRELEASED, org.apache.lucene.util.Version.LUCENE_6_5_0);
@@ -98,6 +100,8 @@ public class Version implements Comparable<Version> {
         switch (id) {
             case V_6_0_0_alpha1_ID_UNRELEASED:
                 return V_6_0_0_alpha1_UNRELEASED;
+            case V_5_5_0_ID_UNRELEASED:
+                return V_5_5_0_UNRELEASED;
             case V_5_4_0_ID_UNRELEASED:
                 return V_5_4_0_UNRELEASED;
             case V_5_3_1_ID_UNRELEASED:


### PR DESCRIPTION
This is required in master now that #24071 is in or else we fail during BWC testing because the 5.x branch contains 5.5 but the build thinks it should contain 5.4.