### PR TITLE
Remove hidden file leniency from spawner

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -77,12 +77,6 @@ final class Spawner implements Closeable {
          */
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(pluginsFile)) {
             for (final Path plugin : stream) {
-                if (FileSystemUtils.isHidden(plugin)) {
-                    logger.trace(
-                            "skipping hidden path in plugin directory [{}]",
-                            plugin.toAbsolutePath());
-                    continue;
-                }
                 final PluginInfo info = PluginInfo.readFromProperties(plugin);
                 final Path spawnPath = Platforms.nativeControllerPath(plugin);
                 if (!Files.isRegularFile(spawnPath)) {

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -157,24 +157,6 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         }
     }
 
-    public void testSpawnerSkipsHiddenFiles() throws IOException {
-        assert Version.CURRENT.before(Version.fromString("5.5.0"))
-                : "remove support for skipping hidden files in 5.5.0";
-        final Path esHome = createTempDir().resolve("home");
-        final Settings.Builder settingsBuilder = Settings.builder();
-        settingsBuilder.put(Environment.PATH_HOME_SETTING.getKey(), esHome.toString());
-        final Settings settings = settingsBuilder.build();
-
-        final Environment environment = new Environment(settings);
-
-        final Path hidden = environment.pluginsFile().resolve(".hidden");
-        Files.createDirectories(hidden);
-
-        final Spawner spawner = new Spawner();
-        // if the spawner were not skipping hidden files this would explode
-        spawner.spawnNativePluginControllers(environment);
-    }
-
     public void testControllerSpawnWithIncorrectDescriptor() throws IOException {
         // this plugin will have a controller daemon
         Path esHome = createTempDir().resolve("esHome");


### PR DESCRIPTION
We added some leniency to the spawner in 5.4.0 with the intention to immediately remove it in 5.5.0. This commit removes that leniency.

Relates #23980
