### PR TITLE
Test: Fix repro line for platformTest

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -477,10 +477,10 @@ class VagrantTestPlugin implements Plugin<Project> {
                     }
                 }
             }
-            packaging.doFirst {
+            platform.doFirst {
                 project.gradle.addListener(platformReproListener)
             }
-            packaging.doLast {
+            platform.doLast {
                 project.gradle.removeListener(platformReproListener)
             }
             if (project.extensions.esvagrant.boxes.contains(box)) {


### PR DESCRIPTION
This was accidentally being added to packagingTest, which then had two
repro lines.