### PR TITLE
Enabled sorting `terms` aggregation by aggregations containing `nested`

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactory.java
@@ -58,6 +58,10 @@ public abstract class AggregatorFactory<AF extends AggregatorFactory<AF>> {
             return first.getClass();
         }
 
+        public Aggregator getWrapped() {
+            return first;
+        }
+
         @Override
         public String name() {
             return first.name();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/valuecount/ValueCountAggregator.java
@@ -82,7 +82,7 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public double metric(long owningBucketOrd) {
-        return valuesSource == null ? 0 : counts.get(owningBucketOrd);
+        return valuesSource == null || owningBucketOrd >= counts.size() ? 0 : counts.get(owningBucketOrd);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/AggregationPath.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/AggregationPath.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.HasAggregations;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregator;
@@ -257,6 +258,9 @@ public class AggregationPath {
         for (int i = 0; i < pathElements.size(); i++) {
             AggregationPath.PathElement token = pathElements.get(i);
             aggregator = aggregator.subAggregator(token.name);
+            if (aggregator instanceof AggregatorFactory.MultiBucketAggregatorWrapper) {
+                aggregator = ((AggregatorFactory.MultiBucketAggregatorWrapper) aggregator).getWrapped();
+            }
             assert (aggregator instanceof SingleBucketAggregator && i <= pathElements.size() - 1)
                     || (aggregator instanceof NumericMetricsAggregator && i == pathElements.size() - 1) :
                     "this should be picked up before aggregation execution - on validate";
@@ -273,6 +277,9 @@ public class AggregationPath {
     public Aggregator resolveTopmostAggregator(Aggregator root) {
         AggregationPath.PathElement token = pathElements.get(0);
         Aggregator aggregator = root.subAggregator(token.name);
+        if (aggregator instanceof AggregatorFactory.MultiBucketAggregatorWrapper) {
+            aggregator = ((AggregatorFactory.MultiBucketAggregatorWrapper) aggregator).getWrapped();
+        }
         assert (aggregator instanceof SingleBucketAggregator )
                 || (aggregator instanceof NumericMetricsAggregator) : "this should be picked up before aggregation execution - on validate";
         return aggregator;
@@ -295,6 +302,9 @@ public class AggregationPath {
 
                 // we're in the middle of the path, so the aggregator can only be a single-bucket aggregator
 
+                if (aggregator instanceof AggregatorFactory.MultiBucketAggregatorWrapper) {
+                    aggregator = ((AggregatorFactory.MultiBucketAggregatorWrapper) aggregator).getWrapped();
+                }
                 if (!(aggregator instanceof SingleBucketAggregator)) {
                     throw new AggregationExecutionException("Invalid terms aggregation order path [" + this +
                             "]. Terms buckets can only be sorted on a sub-aggregator path " +


### PR DESCRIPTION
This change enables ordering `terms` by containing `nested` iaggregation inside `order` path. https://github.com/elastic/elasticsearch/issues/16838

The changes are compatible with both `master` and `5.3` branches.

Only thing I am not entirely sure of is the `ValueCountAggregator.metric()` change.

PS: It is somehow related to https://github.com/elastic/elasticsearch/pull/22303 but I took entirely different (and way less invasive) approach and written the tests.