### PR TITLE
Do not set path.data in environment if not set

### DIFF
--- a/core/src/main/java/org/elasticsearch/env/Environment.java
+++ b/core/src/main/java/org/elasticsearch/env/Environment.java
@@ -183,7 +183,9 @@ public class Environment {
 
         Settings.Builder finalSettings = Settings.builder().put(settings);
         finalSettings.put(PATH_HOME_SETTING.getKey(), homeFile);
-        finalSettings.putArray(PATH_DATA_SETTING.getKey(), dataPaths);
+        if (PATH_DATA_SETTING.exists(settings)) {
+            finalSettings.putArray(PATH_DATA_SETTING.getKey(), dataPaths);
+        }
         finalSettings.put(PATH_LOGS_SETTING.getKey(), logsFile);
         this.settings = finalSettings.build();
 

--- a/core/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/core/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -102,6 +102,19 @@ public class EnvironmentTests extends ESTestCase {
         assertThat(environment.dataFiles(), equalTo(new Path[]{pathHome.resolve("data")}));
     }
 
+    public void testPathDataNotSetInEnvironmentIfNotSet() {
+        final Path defaultPathData = createTempDir().toAbsolutePath();
+        final Settings settings = Settings.builder()
+                .put("path.home", createTempDir().toAbsolutePath())
+                .put("default.path.data", defaultPathData)
+                .build();
+        assertFalse(Environment.PATH_DATA_SETTING.exists(settings));
+        assertTrue(Environment.DEFAULT_PATH_DATA_SETTING.exists(settings));
+        final Environment environment = new Environment(settings);
+        assertFalse(Environment.PATH_DATA_SETTING.exists(environment.settings()));
+        assertTrue(Environment.DEFAULT_PATH_DATA_SETTING.exists(environment.settings()));
+    }
+
     public void testDefaultPathLogs() {
         final Path defaultPathLogs = createTempDir().toAbsolutePath();
         final Settings settings = Settings.builder()


### PR DESCRIPTION
When preparing the final settings in the environment, we unconditionally set path.data even if path.data was not explicitly set. This confounds detection for whether or not path.data was explicitly set, and this is trappy. This commit adds logic to only set path.data in the final settings if path.data was explicitly set, and provides a test case that fails without this logic.

Relates #24099
