### PR TITLE
Remove Ubuntu 12.04

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -345,7 +345,6 @@ VM running trusty by running
 
 These are the linux flavors the Vagrantfile currently supports:
 
-* ubuntu-1204 aka precise
 * ubuntu-1404 aka trusty
 * ubuntu-1604 aka xenial
 * debian-8 aka jessie, the current debian stable distribution
@@ -431,7 +430,7 @@ gradle vagrantFedora24#up
 -------------------------------------------------
 
 Or any of vagrantCentos6#up, vagrantDebian8#up, vagrantFedora24#up, vagrantOel6#up,
-vagrantOel7#up, vagrantOpensuse13#up, vagrantSles12#up, vagrantUbuntu1204#up,
+vagrantOel7#up, vagrantOpensuse13#up, vagrantSles12#up, vagrantUbuntu1404#up,
 vagrantUbuntu1604#up.
 
 Once up, you can then connect to the VM using SSH from the elasticsearch directory:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,10 +22,6 @@
 # under the License.
 
 Vagrant.configure(2) do |config|
-  config.vm.define "ubuntu-1204" do |config|
-    config.vm.box = "elastic/ubuntu-12.04-x86_64"
-    ubuntu_common config
-  end
   config.vm.define "ubuntu-1404" do |config|
     config.vm.box = "elastic/ubuntu-14.04-x86_64"
     ubuntu_common config

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -22,7 +22,6 @@ class VagrantTestPlugin implements Plugin<Project> {
             'oel-7',
             'opensuse-13',
             'sles-12',
-            'ubuntu-1204',
             'ubuntu-1404',
             'ubuntu-1604'
     ]

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -169,7 +169,7 @@ Before starting, you need to have:
 * A http://www.windowsazure.com/[Windows Azure account]
 * OpenSSL that isn't from MacPorts, specifically `OpenSSL 1.0.1f 6 Jan
   2014` doesn't seem to create a valid keypair for ssh. FWIW,
- `OpenSSL 1.0.1c 10 May 2012` on Ubuntu 12.04 LTS is known to work.
+ `OpenSSL 1.0.1c 10 May 2012` on Ubuntu 14.04 LTS is known to work.
 * SSH keys and certificate
 +
 --


### PR DESCRIPTION
Ubuntu 12.04 will be EOL on April 28, 2017, I think we can remove it for all 5.x and master packaging tests.