### PR TITLE
Plugins: Remove leniency for missing plugins dir

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -205,11 +205,6 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
         if (pluginId == null) {
             throw new UserException(ExitCodes.USAGE, "plugin id is required");
         }
-        // TODO: remove this leniency!! is it needed anymore?
-        if (Files.exists(env.pluginsFile()) == false) {
-            terminal.println("Plugins directory [" + env.pluginsFile() + "] does not exist. Creating...");
-            Files.createDirectory(env.pluginsFile());
-        }
 
         Path pluginZip = download(terminal, pluginId, env.tmpFile());
         Path extractedZip = unzip(pluginZip, env.pluginsFile());

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -345,15 +345,6 @@ public class InstallPluginCommandTests extends ESTestCase {
         assertTrue(e.getMessage(), e.getMessage().contains("Unknown plugin foo"));
     }
 
-    public void testPluginsDirMissing() throws Exception {
-        Tuple<Path, Environment> env = createEnv(fs, temp);
-        Files.delete(env.v2().pluginsFile());
-        Path pluginDir = createPluginDir(temp);
-        String pluginZip = createPlugin("fake", pluginDir);
-        installPlugin(pluginZip, env.v1());
-        assertPlugin("fake", pluginDir, env.v2());
-    }
-
     public void testPluginsDirReadOnly() throws Exception {
         assumeTrue("posix and filesystem", isPosix && isReal);
         Tuple<Path, Environment> env = createEnv(fs, temp);


### PR DESCRIPTION
This leniency was left in after plugin installer refactoring for 2.0
because some tests still relied on it. However, the need for this
leniency no longer exists.