### PR TITLE
Doc Addition: add link to newly open-sourced Scala REST client "escalar"

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -238,16 +238,19 @@ The following projects appear to be abandoned:
 * https://github.com/sksamuel/elastic4s[elastic4s]:
   Scala DSL.
 
-* https://github.com/scalastuff/esclient[esclient]:
-  Thin Scala client.
-
 * https://github.com/gphat/wabisabi[wabisabi]:
   Asynchronous REST API Scala client.
+  
+* https://github.com/workday/escalar[escalar]:
+  Type-safe Scala wrapper for the REST API.
 
 * https://github.com/SumoLogic/elasticsearch-client[elasticsearch-client]:
   Scala DSL that uses the REST API. Akka and AWS helpers included.
 
-The following project appears to be abandoned:
+The following projects appear to be abandoned:
+
+* https://github.com/scalastuff/esclient[esclient]:
+  Thin Scala client.
 
 * https://github.com/bsadeh/scalastic[scalastic]:
   Scala client.


### PR DESCRIPTION
Workday recently open-sourced our internal Scala wrapper for the Elasticsearch REST API. We plan to continue maintaining the library and use it in our products. Thought it would be a good idea to link it under the Community Contributed Clients in case anyone else is interested in using it!

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

 - **✓** Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
 - **✓** Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
 - **[N/A]** If submitting code, have you built your formula locally prior to submission with `gradle check`?
 - **[N/A]** If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
 - **[N/A]** If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
 - **[N/A]** If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
