### PR TITLE
Painless: encapsulate Struct logic

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -332,7 +332,7 @@ public final class Def {
          }
          int arity = interfaceMethod.arguments.size();
          Method implMethod = lookupMethodInternal(definition, receiverClass, name, arity);
-        return lookupReferenceInternal(definition, lookup, interfaceType, implMethod.owner.name,
+        return lookupReferenceInternal(definition, lookup, interfaceType, implMethod.owner.getName(),
                 implMethod.name, receiverClass);
      }
      

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -361,16 +361,16 @@ public final class Definition {
     }
 
     public static final class Struct {
-        public final String name;
-        public final Class<?> clazz;
-        public final org.objectweb.asm.Type type;
+        private final String name;
+        private final Class<?> clazz;
+        private final org.objectweb.asm.Type type;
 
-        public final Map<MethodKey, Method> constructors;
-        public final Map<MethodKey, Method> staticMethods;
-        public final Map<MethodKey, Method> methods;
+        private final Map<MethodKey, Method> constructors;
+        private final Map<MethodKey, Method> staticMethods;
+        private final Map<MethodKey, Method> methods;
 
-        public final Map<String, Field> staticMembers;
-        public final Map<String, Field> members;
+        private final Map<String, Field> staticMembers;
+        private final Map<String, Field> members;
 
         private final SetOnce<Method> functionalMethod;
 
@@ -426,6 +426,71 @@ public final class Definition {
         @Override
         public int hashCode() {
             return name.hashCode();
+        }
+
+        /** The name that Painless scripts use to refer to this {@linkplain Struct}. */
+        public String getName() {
+            return name;
+        }
+
+        /** The JVM {@link Class} that backs this {@linkplain Struct}. */
+        public Class<?> getClazz() {
+            return clazz;
+        }
+
+        /** The ASM {@link org.objectweb.asm.Type} that backs this {@linkplain Struct}. */
+        public org.objectweb.asm.Type getType() {
+            return type;
+        }
+
+        /** Get the static method with the specified name and arity or {@code null} if there is no such method. */
+        public Method getStaticMethod(String name, int arity) {
+            return staticMethods.get(new MethodKey(name, arity));
+        }
+
+        /** Get all the static methods. Used for documentation generation. */
+        Collection<Method> getStaticMethods() {
+            return staticMethods.values();
+        }
+
+        /** Get the constructor with the specified arity or {@code null} if there is no such constructor. */
+        public Method getConstructor(int arity) {
+            return constructors.get(new MethodKey("<init>", arity));
+        }
+
+        /** Get all the constructors. Used for documentation generation. */
+        Collection<Method> getConstructors() {
+            return constructors.values();
+        }
+
+        /** Get the non-static method with the specified name and arity or {@code null} if there is no such method. */
+        public Method getMethod(String name, int arity) {
+            return methods.get(new MethodKey(name, arity));
+        }
+
+        /** Get all the non-static methods. Used for documentation generation. */
+        Collection<Method> getMethods() {
+            return methods.values();
+        }
+
+        /** Get the named member or {@code null} if there is no such member. */
+        public Field getStaticMember(String name) {
+            return staticMembers.get(name);
+        }
+
+        /** Get all the static members. Used for documentation generation. */
+        Collection<Field> getStaticMembers() {
+            return staticMembers.values();
+        }
+
+        /** Get the named non-static member or {@code null} if there is no such member. */
+        public Field getMember(String name) {
+            return members.get(name);
+        }
+
+        /** Get all the non-static members. Used for documentation generation. */
+        Collection<Field> getMembers() {
+            return members.values();
         }
 
         /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
@@ -85,7 +85,7 @@ public class FunctionRef {
             tag = Opcodes.H_NEWINVOKESPECIAL;
         } else if (Modifier.isStatic(impl.modifiers)) {
             tag = Opcodes.H_INVOKESTATIC;
-        } else if (impl.owner.clazz.isInterface()) {
+        } else if (impl.owner.getClazz().isInterface()) {
             tag = Opcodes.H_INVOKEINTERFACE;
         } else {
             tag = Opcodes.H_INVOKEVIRTUAL;
@@ -100,8 +100,8 @@ public class FunctionRef {
             ownerIsInterface = false;
             owner = WriterConstants.AUGMENTATION_TYPE.getInternalName();
         } else {
-            ownerIsInterface = impl.owner.clazz.isInterface();
-            owner = impl.owner.type.getInternalName();
+            ownerIsInterface = impl.owner.getClazz().isInterface();
+            owner = impl.owner.getType().getInternalName();
         }
         implMethodASM = new Handle(tag, owner, impl.name, impl.method.getDescriptor(), ownerIsInterface);
         implMethod = impl.handle;
@@ -152,10 +152,10 @@ public class FunctionRef {
         final Definition.Method impl;
         // ctor ref
         if ("new".equals(call)) {
-            impl = struct.constructors.get(new Definition.MethodKey("<init>", method.arguments.size()));
+            impl = struct.getConstructor(method.arguments.size());
         } else {
             // look for a static impl first
-            Definition.Method staticImpl = struct.staticMethods.get(new Definition.MethodKey(call, method.arguments.size()));
+            Definition.Method staticImpl = struct.getStaticMethod(call, method.arguments.size());
             if (staticImpl == null) {
                 // otherwise a virtual impl
                 final int arity;
@@ -166,7 +166,7 @@ public class FunctionRef {
                     // receiver passed
                     arity = method.arguments.size() - 1;
                 }
-                impl = struct.methods.get(new Definition.MethodKey(call, arity));
+                impl = struct.getMethod(call, arity);
             } else {
                 impl = staticImpl;
             }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessExplainError.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessExplainError.java
@@ -56,7 +56,7 @@ public class PainlessExplainError extends Error {
             javaClassName = objectToExplain.getClass().getName();
             Definition.RuntimeClass runtimeClass = definition.getRuntimeClass(objectToExplain.getClass());
             if (runtimeClass != null) {
-                painlessClassName = runtimeClass.getStruct().name;
+                painlessClassName = runtimeClass.getStruct().getName();
             }
         }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EListInit.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EListInit.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -60,13 +59,13 @@ public final class EListInit extends AExpression {
 
         actual = Definition.ARRAY_LIST_TYPE;
 
-        constructor = actual.struct.constructors.get(new MethodKey("<init>", 0));
+        constructor = actual.struct.getConstructor(0);
 
         if (constructor == null) {
             throw createError(new IllegalStateException("Illegal tree structure."));
         }
 
-        method = actual.struct.methods.get(new MethodKey("add", 1));
+        method = actual.struct.getMethod("add", 1);
 
         if (method == null) {
             throw createError(new IllegalStateException("Illegal tree structure."));
@@ -88,7 +87,7 @@ public final class EListInit extends AExpression {
 
         writer.newInstance(actual.type);
         writer.dup();
-        writer.invokeConstructor(constructor.owner.type, constructor.method);
+        writer.invokeConstructor(constructor.owner.getType(), constructor.method);
 
         for (AExpression value : values) {
             writer.dup();

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EMapInit.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EMapInit.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -66,13 +65,13 @@ public final class EMapInit extends AExpression {
 
         actual = Definition.HASH_MAP_TYPE;
 
-        constructor = actual.struct.constructors.get(new MethodKey("<init>", 0));
+        constructor = actual.struct.getConstructor(0);
 
         if (constructor == null) {
             throw createError(new IllegalStateException("Illegal tree structure."));
         }
 
-        method = actual.struct.methods.get(new MethodKey("put", 2));
+        method = actual.struct.getMethod("put", 2);
 
         if (method == null) {
             throw createError(new IllegalStateException("Illegal tree structure."));
@@ -107,7 +106,7 @@ public final class EMapInit extends AExpression {
 
         writer.newInstance(actual.type);
         writer.dup();
-        writer.invokeConstructor(constructor.owner.type, constructor.method);
+        writer.invokeConstructor(constructor.owner.getType(), constructor.method);
 
         for (int index = 0; index < keys.size(); ++index) {
             AExpression key = keys.get(index);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewArray.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewArray.java
@@ -87,7 +87,7 @@ public final class ENewArray extends AExpression {
 
         if (initialize) {
             writer.push(arguments.size());
-            writer.newArray(actual.struct.type);
+            writer.newArray(actual.struct.getType());
 
             for (int index = 0; index < arguments.size(); ++index) {
                 AExpression argument = arguments.get(index);
@@ -95,7 +95,7 @@ public final class ENewArray extends AExpression {
                 writer.dup();
                 writer.push(index);
                 argument.write(writer, globals);
-                writer.arrayStore(actual.struct.type);
+                writer.arrayStore(actual.struct.getType());
             }
         } else {
             for (AExpression argument : arguments) {
@@ -105,7 +105,7 @@ public final class ENewArray extends AExpression {
             if (arguments.size() > 1) {
                 writer.visitMultiANewArrayInsn(actual.type.getDescriptor(), actual.type.getDimensions());
             } else {
-                writer.newArray(actual.struct.type);
+                writer.newArray(actual.struct.getType());
             }
         }
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Method;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.Type;
@@ -67,14 +66,14 @@ public final class ENewObj extends AExpression {
         }
 
         Struct struct = type.struct;
-        constructor = struct.constructors.get(new Definition.MethodKey("<init>", arguments.size()));
+        constructor = struct.getConstructor(arguments.size());
 
         if (constructor != null) {
             Type[] types = new Type[constructor.arguments.size()];
             constructor.arguments.toArray(types);
 
             if (constructor.arguments.size() != arguments.size()) {
-                throw createError(new IllegalArgumentException("When calling constructor on type [" + struct.name + "]" +
+                throw createError(new IllegalArgumentException("When calling constructor on type [" + struct.getName() + "]" +
                     " expected [" + constructor.arguments.size() + "] arguments, but found [" + arguments.size() + "]."));
             }
 
@@ -90,7 +89,7 @@ public final class ENewObj extends AExpression {
             statement = true;
             actual = type;
         } else {
-            throw createError(new IllegalArgumentException("Unknown new call on type [" + struct.name + "]."));
+            throw createError(new IllegalArgumentException("Unknown new call on type [" + struct.getName() + "]."));
         }
     }
 
@@ -108,7 +107,7 @@ public final class ENewObj extends AExpression {
             argument.write(writer, globals);
         }
 
-        writer.invokeConstructor(constructor.owner.type, constructor.method);
+        writer.invokeConstructor(constructor.owner.getType(), constructor.method);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
@@ -76,8 +75,8 @@ public final class PCallInvoke extends AExpression {
             struct = locals.getDefinition().getType(prefix.actual.sort.boxed.getSimpleName()).struct;
         }
 
-        MethodKey methodKey = new MethodKey(name, arguments.size());
-        Method method = prefix instanceof EStatic ? struct.staticMethods.get(methodKey) : struct.methods.get(methodKey);
+        Method method = prefix instanceof EStatic ?
+                struct.getStaticMethod(name, arguments.size()) : struct.getMethod(name, arguments.size());
 
         if (method != null) {
             sub = new PSubCallInvoke(location, method, prefix.actual, arguments);
@@ -85,7 +84,7 @@ public final class PCallInvoke extends AExpression {
             sub = new PSubDefCall(location, name, arguments);
         } else {
             throw createError(new IllegalArgumentException(
-                "Unknown call [" + name + "] with [" + arguments.size() + "] arguments on type [" + struct.name + "]."));
+                "Unknown call [" + name + "] with [" + arguments.size() + "] arguments on type [" + struct.getName() + "]."));
         }
 
         if (nullSafe) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Field;
 import org.elasticsearch.painless.Definition.Method;
 import org.elasticsearch.painless.Definition.Sort;
@@ -71,21 +70,18 @@ public final class PField extends AStoreable {
             sub = new PSubDefField(location, value);
         } else {
             Struct struct = prefix.actual.struct;
-            Field field = prefix instanceof EStatic ? struct.staticMembers.get(value) : struct.members.get(value);
+            Field field = prefix instanceof EStatic ? struct.getStaticMember(value) : struct.getMember(value);
 
             if (field != null) {
                 sub = new PSubField(location, field);
             } else {
-                Method getter = struct.methods.get(
-                    new Definition.MethodKey("get" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0));
+                Method getter = struct.getMethod("get" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0);
 
                 if (getter == null) {
-                    getter = struct.methods.get(
-                        new Definition.MethodKey("is" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0));
+                    getter = struct.getMethod("is" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0);
                 }
 
-                Method setter = struct.methods.get(
-                    new Definition.MethodKey("set" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 1));
+                Method setter = struct.getMethod("set" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 1);
 
                 if (getter != null || setter != null) {
                     sub = new PSubShortcut(location, value, prefix.actual.name, getter, setter);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubField.java
@@ -63,9 +63,9 @@ final class PSubField extends AStoreable {
         writer.writeDebugInfo(location);
 
         if (java.lang.reflect.Modifier.isStatic(field.modifiers)) {
-            writer.getStatic(field.owner.type, field.javaName, field.type.type);
+            writer.getStatic(field.owner.getType(), field.javaName, field.type.type);
         } else {
-            writer.getField(field.owner.type, field.javaName, field.type.type);
+            writer.getField(field.owner.getType(), field.javaName, field.type.type);
         }
     }
 
@@ -94,9 +94,9 @@ final class PSubField extends AStoreable {
         writer.writeDebugInfo(location);
 
         if (java.lang.reflect.Modifier.isStatic(field.modifiers)) {
-            writer.getStatic(field.owner.type, field.javaName, field.type.type);
+            writer.getStatic(field.owner.getType(), field.javaName, field.type.type);
         } else {
-            writer.getField(field.owner.type, field.javaName, field.type.type);
+            writer.getField(field.owner.getType(), field.javaName, field.type.type);
         }
     }
 
@@ -105,9 +105,9 @@ final class PSubField extends AStoreable {
         writer.writeDebugInfo(location);
 
         if (java.lang.reflect.Modifier.isStatic(field.modifiers)) {
-            writer.putStatic(field.owner.type, field.javaName, field.type.type);
+            writer.putStatic(field.owner.getType(), field.javaName, field.type.type);
         } else {
-            writer.putField(field.owner.type, field.javaName, field.type.type);
+            writer.putField(field.owner.getType(), field.javaName, field.type.type);
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
@@ -58,16 +58,16 @@ final class PSubListShortcut extends AStoreable {
 
     @Override
     void analyze(Locals locals) {
-        getter = struct.methods.get(new Definition.MethodKey("get", 1));
-        setter = struct.methods.get(new Definition.MethodKey("set", 2));
+        getter = struct.getMethod("get", 1);
+        setter = struct.getMethod("set", 2);
 
         if (getter != null && (getter.rtn.sort == Sort.VOID || getter.arguments.size() != 1 ||
             getter.arguments.get(0).sort != Sort.INT)) {
-            throw createError(new IllegalArgumentException("Illegal list get shortcut for type [" + struct.name + "]."));
+            throw createError(new IllegalArgumentException("Illegal list get shortcut for type [" + struct.getName() + "]."));
         }
 
         if (setter != null && (setter.arguments.size() != 2 || setter.arguments.get(0).sort != Sort.INT)) {
-            throw createError(new IllegalArgumentException("Illegal list set shortcut for type [" + struct.name + "]."));
+            throw createError(new IllegalArgumentException("Illegal list set shortcut for type [" + struct.getName() + "]."));
         }
 
         if (getter != null && setter != null && (!getter.arguments.get(0).equals(setter.arguments.get(0))
@@ -82,7 +82,7 @@ final class PSubListShortcut extends AStoreable {
 
             actual = setter != null ? setter.arguments.get(1) : getter.rtn;
         } else {
-            throw createError(new IllegalArgumentException("Illegal list shortcut for type [" + struct.name + "]."));
+            throw createError(new IllegalArgumentException("Illegal list shortcut for type [" + struct.getName() + "]."));
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
@@ -19,19 +19,17 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition;
+import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
+import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
-import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.Sort;
+import org.elasticsearch.painless.MethodWriter;
 
 import java.util.Objects;
 import java.util.Set;
-
-import org.elasticsearch.painless.Locals;
-import org.elasticsearch.painless.MethodWriter;
 
 /**
  * Represents a map load/store shortcut. (Internal only.)
@@ -58,15 +56,15 @@ final class PSubMapShortcut extends AStoreable {
 
     @Override
     void analyze(Locals locals) {
-        getter = struct.methods.get(new Definition.MethodKey("get", 1));
-        setter = struct.methods.get(new Definition.MethodKey("put", 2));
+        getter = struct.getMethod("get", 1);
+        setter = struct.getMethod("put", 2);
 
         if (getter != null && (getter.rtn.sort == Sort.VOID || getter.arguments.size() != 1)) {
-            throw createError(new IllegalArgumentException("Illegal map get shortcut for type [" + struct.name + "]."));
+            throw createError(new IllegalArgumentException("Illegal map get shortcut for type [" + struct.getName() + "]."));
         }
 
         if (setter != null && setter.arguments.size() != 2) {
-            throw createError(new IllegalArgumentException("Illegal map set shortcut for type [" + struct.name + "]."));
+            throw createError(new IllegalArgumentException("Illegal map set shortcut for type [" + struct.getName() + "]."));
         }
 
         if (getter != null && setter != null &&
@@ -81,7 +79,7 @@ final class PSubMapShortcut extends AStoreable {
 
             actual = setter != null ? setter.arguments.get(1) : getter.rtn;
         } else {
-            throw createError(new IllegalArgumentException("Illegal map shortcut for type [" + struct.name + "]."));
+            throw createError(new IllegalArgumentException("Illegal map shortcut for type [" + struct.getName() + "]."));
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
@@ -24,7 +24,6 @@ import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -77,7 +76,7 @@ final class SSubEachIterable extends AStatement {
         if (expression.actual.sort == Sort.DEF) {
             method = null;
         } else {
-            method = expression.actual.struct.methods.get(new MethodKey("iterator", 0));
+            method = expression.actual.struct.getMethod("iterator", 0);
 
             if (method == null) {
                 throw createError(new IllegalArgumentException(

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
@@ -24,15 +24,13 @@ import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Definition.Field;
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.MethodKey;
-import org.elasticsearch.painless.Definition.RuntimeClass;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.FeatureTest;
 import org.elasticsearch.painless.GenericElasticsearchScript;
 import org.elasticsearch.painless.Locals.Variable;
 import org.elasticsearch.painless.Location;
-import org.elasticsearch.painless.ScriptInterface;
 import org.elasticsearch.painless.Operation;
+import org.elasticsearch.painless.ScriptInterface;
 import org.elasticsearch.painless.antlr.Walker;
 import org.elasticsearch.test.ESTestCase;
 
@@ -401,15 +399,14 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testPSubCallInvoke() {
         Location l = new Location(getTestName(), 0);
-        RuntimeClass c = definition.getRuntimeClass(Integer.class);
-        Method m = c.methods.get(new MethodKey("toString", 0));
+        Method m = Definition.INT_OBJ_TYPE.struct.getMethod("toString", 0);
         PSubCallInvoke node = new PSubCallInvoke(l, m, null, emptyList());
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubCallInvoke (EVariable a) toString)", node.toString());
         assertEquals("(PSubNullSafeCallInvoke (PSubCallInvoke (EVariable a) toString))", new PSubNullSafeCallInvoke(l, node).toString());
 
         l = new Location(getTestName(), 1);
-        m = c.methods.get(new MethodKey("equals", 1));
+        m = Definition.INT_OBJ_TYPE.struct.getMethod("equals", 1);
         node = new PSubCallInvoke(l, m, null, singletonList(new EVariable(l, "b")));
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubCallInvoke (EVariable a) equals (Args (EVariable b)))", node.toString());
@@ -457,7 +454,7 @@ public class NodeToStringTests extends ESTestCase {
     public void testPSubField() {
         Location l = new Location(getTestName(), 0);
         Struct s = definition.getType(Boolean.class.getSimpleName()).struct;
-        Field f = s.staticMembers.get("TRUE");
+        Field f = s.getStaticMember("TRUE");
         PSubField node = new PSubField(l, f);
         node.prefix = new EStatic(l, "Boolean");
         assertEquals("(PSubField (EStatic Boolean) TRUE)", node.toString());
@@ -499,8 +496,8 @@ public class NodeToStringTests extends ESTestCase {
     public void testPSubShortcut() {
         Location l = new Location(getTestName(), 0);
         Struct s = definition.getType(FeatureTest.class.getName()).struct;
-        Method getter = s.methods.get(new MethodKey("getX", 0));
-        Method setter = s.methods.get(new MethodKey("setX", 1));
+        Method getter = s.getMethod("getX", 0);
+        Method setter = s.getMethod("setX", 1);
         PSubShortcut node = new PSubShortcut(l, "x", FeatureTest.class.getName(), getter, setter);
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubShortcut (EVariable a) x)", node.toString());


### PR DESCRIPTION
It feels like we should do this if we're going to support whitelist
nesting. We think we want whitelist nesting because the whitelists
take up a non-trivial amount of heap.
