### PR TITLE
Add note to docs on whitespace in Log4j settings

### DIFF
--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -133,6 +133,10 @@ appender.rolling.policies.time.modulate = true <6>
 <6> Align rolls on the day boundary (as opposed to rolling every twenty-four
     hours)
 
+NOTE: Log4j's configuration parsing gets confused by any extraneous whitespace;
+if you copy and paste the above settings, or enter any Log4j configuration in
+general, be sure to trim any leading and trailing whitespace.
+
 If you append `.gz` or `.zip` to `appender.rolling.filePattern`, then the logs
 will be compressed as they are rolled.
 


### PR DESCRIPTION
A confusing thing that can happen when configuring Log4j is that extraneous whitespace throws off its configuration parsing yet the error messages that arise give no indication that this is the problem. This commit adds a note to the docs.
