### PR TITLE
Align behavior HDR percentiles iterator with percentile() method

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentiles.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentiles.java
@@ -98,7 +98,9 @@ public class InternalHDRPercentiles extends AbstractInternalHDRPercentiles imple
 
         @Override
         public Percentile next() {
-            final Percentile next = new Percentile(percents[i], state.getValueAtPercentile(percents[i]));
+            double percent = percents[i];
+            double value = (state.getTotalCount() == 0) ? Double.NaN : state.getValueAtPercentile(percent);
+            final Percentile next = new Percentile(percent, value);
             ++i;
             return next;
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentilesTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentilesTestCase.java
@@ -50,7 +50,7 @@ public abstract class InternalPercentilesTestCase<T extends InternalAggregation>
     protected abstract T createTestInstance(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData,
                                                boolean keyed, DocValueFormat format, double[] percents, double[] values);
 
-    private static double[] randomPercents() {
+    protected static double[] randomPercents() {
         List<Double> randomCdfValues = randomSubsetOf(randomIntBetween(1, 7), 0.01d, 0.05d, 0.25d, 0.50d, 0.75d, 0.95d, 0.99d);
         double[] percents = new double[randomCdfValues.size()];
         for (int i = 0; i < randomCdfValues.size(); i++) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentilesTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentilesTests.java
@@ -23,11 +23,16 @@ import org.HdrHistogram.DoubleHistogram;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.metrics.percentiles.InternalPercentilesTestCase;
+import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 
 public class InternalHDRPercentilesTests extends InternalPercentilesTestCase<InternalHDRPercentiles> {
 
@@ -56,5 +61,25 @@ public class InternalHDRPercentilesTests extends InternalPercentilesTestCase<Int
     @Override
     protected Writeable.Reader<InternalHDRPercentiles> instanceReader() {
         return InternalHDRPercentiles::new;
+    }
+
+    public void testIterator() {
+        final double[] percents =  randomPercents();
+        final double[] values = new double[frequently() ? randomIntBetween(1, 10) : 0];
+        for (int i = 0; i < values.length; ++i) {
+            values[i] = randomDouble();
+        }
+
+        InternalHDRPercentiles aggregation =
+                createTestInstance("test", emptyList(), emptyMap(), false, randomNumericDocValueFormat(), percents, values);
+
+        Iterator<Percentile> iterator = aggregation.iterator();
+        for (double percent : percents) {
+            assertTrue(iterator.hasNext());
+
+            Percentile percentile = iterator.next();
+            assertEquals(percent, percentile.getPercent(), 0.0d);
+            assertEquals(aggregation.percentile(percent), percentile.getValue(), 0.0d);
+        }
     }
 }


### PR DESCRIPTION
This pull request aligns the percentiles values returned by the `iterator()` method with what is returned by the `percentile(double percent)` method in the `InternalHDRPercentile` class.

The `InternalHDRPercentile.percentile(double percent)` has some logic when no values have been recorded in the `DoubleHistogram` state:

```
public double percentile(double percent) {
         if (state.getTotalCount() == 0) {
             return Double.NaN;
         }
         return state.getValueAtPercentile(percent);
}
```

but when a `Percentile` object it instantiated in the `next()` method of the iterator it does not use the same logic:
```
 final Percentile next = new Percentile(percents[i], state.getValueAtPercentile(percents[i]));
```

So the value returned by `hdr.percentile(0.99)` can be `Double.NaN` but when accessed using the iterator returns the value returned for the same percentile is `0`.