### PR TITLE
 [Test] Always check the XContent equivalent when parsing aggregations

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
@@ -203,15 +203,8 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         assumeTrue("This test does not support the aggregation type yet",
                 getNamedXContents().stream().filter(entry -> entry.name.match(aggregation.getType())).count() > 0);
 
-        final ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
-        final boolean humanReadable = randomBoolean();
         final XContentType xContentType = randomFrom(XContentType.values());
-        final BytesReference originalBytes = toShuffledXContent(aggregation, xContentType, params, humanReadable);
-
-        final Aggregation parsedAggregation = parse(aggregation, xContentType, humanReadable, randomBoolean());
-
-        final BytesReference parsedBytes = toXContent((ToXContent) parsedAggregation, xContentType, params, humanReadable);
-        assertToXContentEquivalent(originalBytes, parsedBytes, xContentType);
+        final Aggregation parsedAggregation = parseAndAssert(aggregation, xContentType, randomBoolean(), randomBoolean());
         assertFromXContent(aggregation, (ParsedAggregation) parsedAggregation);
     }
 
@@ -220,10 +213,10 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
     }
 
     @SuppressWarnings("unchecked")
-    protected <P extends ParsedAggregation> P parse(final InternalAggregation aggregation,
-                                                    final XContentType xContentType,
-                                                    final boolean humanReadable,
-                                                    final boolean shuffled) throws IOException {
+    protected <P extends ParsedAggregation> P parseAndAssert(final InternalAggregation aggregation,
+                                                             final XContentType xContentType,
+                                                             final boolean humanReadable,
+                                                             final boolean shuffled) throws IOException {
 
         final ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
         final BytesReference originalBytes;
@@ -255,6 +248,10 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
             assertTrue(parsedAggregation instanceof ParsedAggregation);
             assertEquals(aggregation.getType(), ((ParsedAggregation) parsedAggregation).getType());
         }
+
+        BytesReference parsedBytes = toXContent((ToXContent) parsedAggregation, xContentType, params, humanReadable);
+        assertToXContentEquivalent(originalBytes, parsedBytes, xContentType);
+
         return (P) parsedAggregation;
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
@@ -203,8 +203,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         assumeTrue("This test does not support the aggregation type yet",
                 getNamedXContents().stream().filter(entry -> entry.name.match(aggregation.getType())).count() > 0);
 
-        final XContentType xContentType = randomFrom(XContentType.values());
-        final Aggregation parsedAggregation = parseAndAssert(aggregation, xContentType, randomBoolean(), randomBoolean());
+        final Aggregation parsedAggregation = parseAndAssert(aggregation, randomBoolean());
         assertFromXContent(aggregation, (ParsedAggregation) parsedAggregation);
     }
 
@@ -214,11 +213,12 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
 
     @SuppressWarnings("unchecked")
     protected <P extends ParsedAggregation> P parseAndAssert(final InternalAggregation aggregation,
-                                                             final XContentType xContentType,
-                                                             final boolean humanReadable,
                                                              final boolean shuffled) throws IOException {
 
         final ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
+        final XContentType xContentType = randomFrom(XContentType.values());
+        final boolean humanReadable = randomBoolean();
+
         final BytesReference originalBytes;
         if (shuffled) {
             originalBytes = toShuffledXContent(aggregation, xContentType, params, humanReadable);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesTestCase.java
@@ -62,7 +62,8 @@ public abstract class AbstractPercentilesTestCase<T extends InternalAggregation 
 
     public void testPercentilesIterators() throws IOException {
         final T aggregation = createTestInstance();
-        final Iterable<Percentile> parsedAggregation = parseAndAssert(aggregation, randomFrom(XContentType.values()), randomBoolean(), false);
+        final Iterable<Percentile> parsedAggregation =
+                parseAndAssert(aggregation, randomFrom(XContentType.values()), randomBoolean(), false);
 
         Iterator<Percentile> it = aggregation.iterator();
         Iterator<Percentile> parsedIt = parsedAggregation.iterator();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesTestCase.java
@@ -62,8 +62,7 @@ public abstract class AbstractPercentilesTestCase<T extends InternalAggregation 
 
     public void testPercentilesIterators() throws IOException {
         final T aggregation = createTestInstance();
-        final Iterable<Percentile> parsedAggregation =
-                parseAndAssert(aggregation, randomFrom(XContentType.values()), randomBoolean(), false);
+        final Iterable<Percentile> parsedAggregation = parseAndAssert(aggregation, false);
 
         Iterator<Percentile> it = aggregation.iterator();
         Iterator<Percentile> parsedIt = parsedAggregation.iterator();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesTestCase.java
@@ -62,7 +62,7 @@ public abstract class AbstractPercentilesTestCase<T extends InternalAggregation 
 
     public void testPercentilesIterators() throws IOException {
         final T aggregation = createTestInstance();
-        final Iterable<Percentile> parsedAggregation = parse(aggregation, randomFrom(XContentType.values()), randomBoolean(), false);
+        final Iterable<Percentile> parsedAggregation = parseAndAssert(aggregation, randomFrom(XContentType.values()), randomBoolean(), false);
 
         Iterator<Percentile> it = aggregation.iterator();
         Iterator<Percentile> parsedIt = parsedAggregation.iterator();


### PR DESCRIPTION
I mixed up things in #24183 when adding the parse() method in  `InternalAggregationTestCase`.

This pull request fixes `InternalAggregationTestCase` so that it always checks that the internal aggregation and the parsed aggregation always produce the same XContent (using `assertToXContentEquivalent()`) even when the original internal aggregation has been shuffled.
