### PR TITLE
Add parsing methods for InternalDateHistogram and InternalHistogram

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
@@ -111,10 +111,9 @@ public final class XContentParserUtils {
     }
 
     /**
-     * This method expects that the current token is a {@code XContentParser.Token.FIELD_NAME} and
-     * that the current field name is the concatenation of a type, delimiter and name (ex: terms#foo
-     * where "terms" refers to the type of a registered {@link NamedXContentRegistry.Entry}, "#" is
-     * the delimiter and "foo" the name of the object to parse).
+     * This method expects that the current field name is the concatenation of a type, a delimiter and a name
+     * (ex: terms#foo where "terms" refers to the type of a registered {@link NamedXContentRegistry.Entry},
+     * "#" is the delimiter and "foo" the name of the object to parse).
      *
      * The method splits the field's name to extract the type and name and then parses the object
      * using the {@link XContentParser#namedObject(Class, String, Object)} method.
@@ -128,7 +127,6 @@ public final class XContentParserUtils {
      *                     from the field's name
      */
     public static <T> T parseTypedKeysObject(XContentParser parser, String delimiter, Class<T> objectClass) throws IOException {
-        ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
         String currentFieldName = parser.currentName();
         if (Strings.hasLength(currentFieldName)) {
             int position = currentFieldName.indexOf(delimiter);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
@@ -47,7 +47,7 @@ public class Aggregations implements Iterable<Aggregation>, ToXContent {
     protected Aggregations() {
     }
 
-    protected Aggregations(List<? extends Aggregation> aggregations) {
+    public Aggregations(List<? extends Aggregation> aggregations) {
         this.aggregations = aggregations;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
@@ -47,7 +47,7 @@ public class Aggregations implements Iterable<Aggregation>, ToXContent {
     protected Aggregations() {
     }
 
-    public Aggregations(List<? extends Aggregation> aggregations) {
+    protected Aggregations(List<? extends Aggregation> aggregations) {
         this.aggregations = aggregations;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public abstract class ParsedMultiBucketAggregation extends ParsedAggregation implements MultiBucketsAggregation {
+
+    public static class ParsedBucket<T> implements MultiBucketsAggregation.Bucket {
+
+        private List<? extends Aggregation> aggregations = Collections.emptyList();
+        private T key;
+        private String keyAsString;
+        private long docCount;
+        private String keyedString;
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            //norelease MultiBucketsAggregation.Bucket must not extend Writeable in core - fix that
+        }
+        protected void setKey(T key) {
+            this.key = key;
+        }
+
+        @Override
+        public Object getKey() {
+            return key;
+        }
+
+        protected void setKeyAsString(String keyAsString) {
+            this.keyAsString = keyAsString;
+        }
+
+        @Override
+        public String getKeyAsString() {
+            if (keyAsString != null) {
+                return keyAsString;
+            } else if (keyedString != null) {
+                return keyedString;
+            } else {
+                return String.valueOf(key);
+            }
+        }
+
+        protected void setDocCount(long docCount) {
+            this.docCount = docCount;
+        }
+
+        @Override
+        public long getDocCount() {
+            return docCount;
+        }
+
+        protected void setKeyedString(String keyedString) {
+            this.keyedString = keyedString;
+        }
+
+        protected void setAggregations(List<? extends Aggregation> aggregations) {
+            this.aggregations = aggregations;
+        }
+
+        @Override
+        public Aggregations getAggregations() {
+            //norelease use Aggregations abstract class once it is available (#24184)
+            return new Aggregations() {
+
+                @Override
+                public List<Aggregation> asList() {
+                    return Collections.unmodifiableList(new ArrayList<>(aggregations));
+                }
+
+                @Override
+                public Map<String, Aggregation> asMap() {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public Map<String, Aggregation> getAsMap() {
+                    Map<String, Aggregation> map = new HashMap<>(aggregations.size());
+                    for (Aggregation aggregation : aggregations) {
+                        map.put(aggregation.getName(), aggregation);
+                    }
+                    return map;
+                }
+
+                @Override
+                public <A extends Aggregation> A get(String name) {
+                    return (A) getAsMap().get(name);
+                }
+
+                @Override
+                public Iterator<Aggregation> iterator() {
+                    return asList().iterator();
+                }
+            };
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            if (keyedString != null) {
+                builder.startObject(keyedString);
+            } else {
+                builder.startObject();
+            }
+            if (keyAsString != null) {
+                builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), keyAsString);
+            }
+            builder.field(CommonFields.KEY.getPreferredName(), key);
+            builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
+            for (Aggregation aggregation : aggregations) {
+                if (aggregation instanceof ParsedAggregation) {
+                    ((ParsedAggregation) aggregation).toXContent(builder, params);
+                }
+            }
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -135,7 +135,7 @@ public abstract class ParsedMultiBucketAggregation extends ParsedAggregation imp
                 builder.startObject();
             }
             if (keyAsString != null) {
-                builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), keyAsString);
+                builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), getKeyAsString());
             }
             builder.field(CommonFields.KEY.getPreferredName(), key);
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -54,8 +54,8 @@ public abstract class ParsedMultiBucketAggregation extends ParsedAggregation imp
     }
 
     protected static void declareMultiBucketAggregationFields(final ObjectParser<? extends ParsedMultiBucketAggregation, Void> objectParser,
-                                                              final CheckedFunction<XContentParser, ParsedBucket<?>, IOException> bucketParser,
-                                                              final CheckedFunction<XContentParser, ParsedBucket<?>, IOException> keyedBucketParser) {
+                                                  final CheckedFunction<XContentParser, ParsedBucket<?>, IOException> bucketParser,
+                                                  final CheckedFunction<XContentParser, ParsedBucket<?>, IOException> keyedBucketParser) {
         declareAggregationFields(objectParser);
         objectParser.declareField((parser, aggregation, context) -> {
             XContentParser.Token token = parser.currentToken();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.histogram;
+
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+public class ParsedDateHistogram extends ParsedMultiBucketAggregation implements Histogram {
+
+    private final List<ParsedBucket> buckets = new ArrayList<>();
+    private boolean keyed;
+
+    @Override
+    protected String getType() {
+        return DateHistogramAggregationBuilder.NAME;
+    }
+
+    @Override
+    public List<? extends Histogram.Bucket> getBuckets() {
+        return buckets;
+    }
+
+    private void setKeyed(boolean keyed) {
+        this.keyed = keyed;
+    }
+
+    private void addBucket(ParsedBucket bucket) {
+        buckets.add(bucket);
+    }
+
+    @Override
+    protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        if (keyed) {
+            builder.startObject(CommonFields.BUCKETS.getPreferredName());
+        } else {
+            builder.startArray(CommonFields.BUCKETS.getPreferredName());
+        }
+        for (ParsedBucket bucket : buckets) {
+            bucket.toXContent(builder, params);
+        }
+        if (keyed) {
+            builder.endObject();
+        } else {
+            builder.endArray();
+        }
+        return builder;
+    }
+
+    private static ObjectParser<ParsedDateHistogram, Void> PARSER =
+            new ObjectParser<>(ParsedDateHistogram.class.getSimpleName(), true, ParsedDateHistogram::new);
+    static {
+        declareAggregationFields(PARSER);
+        PARSER.declareField((parser, aggregation, context) -> {
+            XContentParser.Token token = parser.currentToken();
+            if (token == XContentParser.Token.START_OBJECT) {
+                aggregation.setKeyed(true);
+                while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                    aggregation.addBucket(ParsedBucket.fromXContent(parser, true));
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                aggregation.setKeyed(false);
+                while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                    aggregation.addBucket(ParsedBucket.fromXContent(parser, false));
+                }
+            }
+
+        }, CommonFields.BUCKETS, ObjectParser.ValueType.OBJECT_ARRAY);
+    }
+
+    public static ParsedDateHistogram fromXContent(XContentParser parser, String name) throws IOException {
+        ParsedDateHistogram aggregation = PARSER.parse(parser, null);
+        aggregation.setName(name);
+        return aggregation;
+    }
+
+    public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket<Long> implements Histogram.Bucket {
+
+        @Override
+        public Object getKey() {
+            return new DateTime(super.getKey(), DateTimeZone.UTC);
+        }
+
+        static ParsedBucket fromXContent(XContentParser parser, boolean keyed) throws IOException {
+            final ParsedBucket bucket = new ParsedBucket();
+
+            XContentParser.Token token = parser.currentToken();
+            String currentFieldName = parser.currentName();
+
+            if (keyed) {
+                ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+                bucket.setKeyedString(currentFieldName);
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            }
+
+            List<Aggregation> aggregations = new ArrayList<>();
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (token.isValue()) {
+                    if (CommonFields.KEY_AS_STRING.getPreferredName().equals(currentFieldName)) {
+                        bucket.setKeyAsString(parser.text());
+                    } else if (CommonFields.KEY.getPreferredName().equals(currentFieldName)) {
+                        bucket.setKey(parser.longValue());
+                    } else if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
+                        bucket.setDocCount(parser.longValue());
+                    }
+                } else if (token == XContentParser.Token.START_OBJECT) {
+                    String typeAndName = parser.currentName();
+                    int delimiterPos = typeAndName.indexOf(Aggregation.TYPED_KEYS_DELIMITER);
+                    String type;
+                    String name;
+                    if (delimiterPos > 0) {
+                        type = typeAndName.substring(0, delimiterPos);
+                        name = typeAndName.substring(delimiterPos + 1);
+                        aggregations.add(parser.namedObject(Aggregation.class, type, name));
+                    } else {
+                        throw new ParsingException(parser.getTokenLocation(),
+                                "Cannot parse bucket's aggregation without type information. Set [" + RestSearchAction.TYPED_KEYS_PARAM
+                                        + "] parameter on the request to ensure the type information is added to the response output");
+                    }
+                }
+            }
+
+            bucket.setAggregations(aggregations);
+            return bucket;
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
@@ -19,11 +19,10 @@
 
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.joda.time.DateTime;
@@ -32,13 +31,11 @@ import org.joda.time.DateTimeZone;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 public class ParsedDateHistogram extends ParsedMultiBucketAggregation implements Histogram {
-
-    private final List<ParsedBucket> buckets = new ArrayList<>();
-    private boolean keyed;
 
     @Override
     protected String getType() {
@@ -47,54 +44,15 @@ public class ParsedDateHistogram extends ParsedMultiBucketAggregation implements
 
     @Override
     public List<? extends Histogram.Bucket> getBuckets() {
-        return buckets;
-    }
-
-    private void setKeyed(boolean keyed) {
-        this.keyed = keyed;
-    }
-
-    private void addBucket(ParsedBucket bucket) {
-        buckets.add(bucket);
-    }
-
-    @Override
-    protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        if (keyed) {
-            builder.startObject(CommonFields.BUCKETS.getPreferredName());
-        } else {
-            builder.startArray(CommonFields.BUCKETS.getPreferredName());
-        }
-        for (ParsedBucket bucket : buckets) {
-            bucket.toXContent(builder, params);
-        }
-        if (keyed) {
-            builder.endObject();
-        } else {
-            builder.endArray();
-        }
-        return builder;
+        return buckets.stream().map(bucket -> (Histogram.Bucket) bucket).collect(Collectors.toList());
     }
 
     private static ObjectParser<ParsedDateHistogram, Void> PARSER =
             new ObjectParser<>(ParsedDateHistogram.class.getSimpleName(), true, ParsedDateHistogram::new);
     static {
-        declareAggregationFields(PARSER);
-        PARSER.declareField((parser, aggregation, context) -> {
-            XContentParser.Token token = parser.currentToken();
-            if (token == XContentParser.Token.START_OBJECT) {
-                aggregation.setKeyed(true);
-                while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-                    aggregation.addBucket(ParsedBucket.fromXContent(parser, true));
-                }
-            } else if (token == XContentParser.Token.START_ARRAY) {
-                aggregation.setKeyed(false);
-                while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                    aggregation.addBucket(ParsedBucket.fromXContent(parser, false));
-                }
-            }
-
-        }, CommonFields.BUCKETS, ObjectParser.ValueType.OBJECT_ARRAY);
+        declareMultiBucketAggregationFields(PARSER,
+                parser -> ParsedBucket.fromXContent(parser, false),
+                parser -> ParsedBucket.fromXContent(parser, true));
     }
 
     public static ParsedDateHistogram fromXContent(XContentParser parser, String name) throws IOException {
@@ -110,19 +68,28 @@ public class ParsedDateHistogram extends ParsedMultiBucketAggregation implements
             return new DateTime(super.getKey(), DateTimeZone.UTC);
         }
 
+        @Override
+        public String getKeyAsString() {
+            String keyAsString = super.getKeyAsString();
+            if (keyAsString != null) {
+                return keyAsString;
+            } else {
+                return DocValueFormat.RAW.format((Long) super.getKey());
+            }
+        }
+
         static ParsedBucket fromXContent(XContentParser parser, boolean keyed) throws IOException {
             final ParsedBucket bucket = new ParsedBucket();
+            bucket.setKeyed(keyed);
 
             XContentParser.Token token = parser.currentToken();
             String currentFieldName = parser.currentName();
-
             if (keyed) {
                 ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
-                bucket.setKeyedString(currentFieldName);
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             }
 
-            List<Aggregation> aggregations = new ArrayList<>();
+            final List<Aggregation> aggregations = new ArrayList<>();
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
@@ -135,19 +102,7 @@ public class ParsedDateHistogram extends ParsedMultiBucketAggregation implements
                         bucket.setDocCount(parser.longValue());
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    String typeAndName = parser.currentName();
-                    int delimiterPos = typeAndName.indexOf(Aggregation.TYPED_KEYS_DELIMITER);
-                    String type;
-                    String name;
-                    if (delimiterPos > 0) {
-                        type = typeAndName.substring(0, delimiterPos);
-                        name = typeAndName.substring(delimiterPos + 1);
-                        aggregations.add(parser.namedObject(Aggregation.class, type, name));
-                    } else {
-                        throw new ParsingException(parser.getTokenLocation(),
-                                "Cannot parse bucket's aggregation without type information. Set [" + RestSearchAction.TYPED_KEYS_PARAM
-                                        + "] parameter on the request to ensure the type information is added to the response output");
-                    }
+                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
                 }
             }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
@@ -21,19 +21,14 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 public class ParsedDateHistogram extends ParsedMultiBucketAggregation implements Histogram {
 
@@ -79,35 +74,7 @@ public class ParsedDateHistogram extends ParsedMultiBucketAggregation implements
         }
 
         static ParsedBucket fromXContent(XContentParser parser, boolean keyed) throws IOException {
-            final ParsedBucket bucket = new ParsedBucket();
-            bucket.setKeyed(keyed);
-
-            XContentParser.Token token = parser.currentToken();
-            String currentFieldName = parser.currentName();
-            if (keyed) {
-                ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
-                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
-            }
-
-            final List<Aggregation> aggregations = new ArrayList<>();
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (token.isValue()) {
-                    if (CommonFields.KEY_AS_STRING.getPreferredName().equals(currentFieldName)) {
-                        bucket.setKeyAsString(parser.text());
-                    } else if (CommonFields.KEY.getPreferredName().equals(currentFieldName)) {
-                        bucket.setKey(parser.longValue());
-                    } else if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
-                        bucket.setDocCount(parser.longValue());
-                    }
-                } else if (token == XContentParser.Token.START_OBJECT) {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
-                }
-            }
-
-            bucket.setAggregations(aggregations);
-            return bucket;
+            return parseXContent(parser, keyed, ParsedBucket::new, XContentParser::longValue);
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.histogram;
+
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+public class ParsedHistogram extends ParsedMultiBucketAggregation implements Histogram {
+
+    private final List<ParsedBucket> buckets = new ArrayList<>();
+    private boolean keyed;
+
+    @Override
+    protected String getType() {
+        return HistogramAggregationBuilder.NAME;
+    }
+
+    @Override
+    public List<? extends Histogram.Bucket> getBuckets() {
+        return buckets;
+    }
+
+    private void setKeyed(boolean keyed) {
+        this.keyed = keyed;
+    }
+
+    private void addBucket(ParsedHistogram.ParsedBucket bucket) {
+        buckets.add(bucket);
+    }
+
+    @Override
+    protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        if (keyed) {
+            builder.startObject(CommonFields.BUCKETS.getPreferredName());
+        } else {
+            builder.startArray(CommonFields.BUCKETS.getPreferredName());
+        }
+        for (ParsedBucket bucket : buckets) {
+            bucket.toXContent(builder, params);
+        }
+        if (keyed) {
+            builder.endObject();
+        } else {
+            builder.endArray();
+        }
+        return builder;
+    }
+
+    private static ObjectParser<ParsedHistogram, Void> PARSER =
+            new ObjectParser<>(ParsedHistogram.class.getSimpleName(), true, ParsedHistogram::new);
+    static {
+        declareAggregationFields(PARSER);
+        PARSER.declareField((parser, aggregation, context) -> {
+            XContentParser.Token token = parser.currentToken();
+            if (token == XContentParser.Token.START_OBJECT) {
+                aggregation.setKeyed(true);
+                while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                    aggregation.addBucket(ParsedHistogram.ParsedBucket.fromXContent(parser, true));
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                aggregation.setKeyed(false);
+                while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                    aggregation.addBucket(ParsedHistogram.ParsedBucket.fromXContent(parser, false));
+                }
+            }
+
+        }, CommonFields.BUCKETS, ObjectParser.ValueType.OBJECT_ARRAY);
+    }
+
+    public static ParsedHistogram fromXContent(XContentParser parser, String name) throws IOException {
+        ParsedHistogram aggregation = PARSER.parse(parser, null);
+        aggregation.setName(name);
+        return aggregation;
+    }
+
+    public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket<Double> implements Histogram.Bucket {
+
+        static ParsedBucket fromXContent(XContentParser parser, boolean keyed) throws IOException {
+            final ParsedBucket bucket = new ParsedBucket();
+
+            XContentParser.Token token = parser.currentToken();
+            String currentFieldName = parser.currentName();
+
+            if (keyed) {
+                ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+                bucket.setKeyedString(currentFieldName);
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            }
+
+            List<Aggregation> aggregations = new ArrayList<>();
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (token.isValue()) {
+                    if (CommonFields.KEY_AS_STRING.getPreferredName().equals(currentFieldName)) {
+                        bucket.setKeyAsString(parser.text());
+                    } else if (CommonFields.KEY.getPreferredName().equals(currentFieldName)) {
+                        bucket.setKey(parser.doubleValue());
+                    } else if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
+                        bucket.setDocCount(parser.longValue());
+                    }
+                } else if (token == XContentParser.Token.START_OBJECT) {
+                    String typeAndName = parser.currentName();
+                    int delimiterPos = typeAndName.indexOf(Aggregation.TYPED_KEYS_DELIMITER);
+                    String type;
+                    String name;
+                    if (delimiterPos > 0) {
+                        type = typeAndName.substring(0, delimiterPos);
+                        name = typeAndName.substring(delimiterPos + 1);
+                        aggregations.add(parser.namedObject(Aggregation.class, type, name));
+                    } else {
+                        throw new ParsingException(parser.getTokenLocation(),
+                                "Cannot parse bucket's aggregation without type information. Set [" + RestSearchAction.TYPED_KEYS_PARAM
+                                        + "] parameter on the request to ensure the type information is added to the response output");
+                    }
+                }
+            }
+
+            bucket.setAggregations(aggregations);
+            return bucket;
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
@@ -21,17 +21,12 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 public class ParsedHistogram extends ParsedMultiBucketAggregation implements Histogram {
 
@@ -71,38 +66,8 @@ public class ParsedHistogram extends ParsedMultiBucketAggregation implements His
             }
         }
 
-        //norelease ParsedDateHistogram and ParsedHistogram share a lot of logic in this method,
-        // maybe it could be factored out in a common static method?
         static ParsedBucket fromXContent(XContentParser parser, boolean keyed) throws IOException {
-            final ParsedBucket bucket = new ParsedBucket();
-            bucket.setKeyed(keyed);
-
-            XContentParser.Token token = parser.currentToken();
-            String currentFieldName = parser.currentName();
-            if (keyed) {
-                ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
-                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
-            }
-
-            List<Aggregation> aggregations = new ArrayList<>();
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (token.isValue()) {
-                    if (CommonFields.KEY_AS_STRING.getPreferredName().equals(currentFieldName)) {
-                        bucket.setKeyAsString(parser.text());
-                    } else if (CommonFields.KEY.getPreferredName().equals(currentFieldName)) {
-                        bucket.setKey(parser.doubleValue());
-                    } else if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
-                        bucket.setDocCount(parser.longValue());
-                    }
-                } else if (token == XContentParser.Token.START_OBJECT) {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
-                }
-            }
-
-            bucket.setAggregations(aggregations);
-            return bucket;
+            return parseXContent(parser, keyed, ParsedBucket::new, XContentParser::doubleValue);
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -386,6 +386,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
         @SuppressWarnings("unchecked")
         public static Suggestion<? extends Entry<? extends Option>> fromXContent(XContentParser parser) throws IOException {
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
             return XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggestion.class);
         }
 

--- a/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
@@ -65,12 +65,10 @@ public class XContentParserUtilsTests extends ESTestCase {
 
         BytesReference bytes = toXContent((builder, params) -> builder.field("test", 0), xContentType, randomBoolean());
         try (XContentParser parser = xContentType.xContent().createParser(namedXContentRegistry, bytes)) {
-            parser.nextToken();
-            ParsingException e = expectThrows(ParsingException.class, () -> parseTypedKeysObject(parser, delimiter, Boolean.class));
-            assertEquals("Failed to parse object: expecting token of type [FIELD_NAME] but found [START_OBJECT]", e.getMessage());
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
 
-            parser.nextToken();
-            e = expectThrows(ParsingException.class, () -> parseTypedKeysObject(parser, delimiter, Boolean.class));
+            ParsingException e = expectThrows(ParsingException.class, () -> parseTypedKeysObject(parser, delimiter, Boolean.class));
             assertEquals("Cannot parse object of class [Boolean] without type information. Set [typed_keys] parameter " +
                     "on the request to ensure the type information is added to the response output", e.getMessage());
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
@@ -34,6 +34,10 @@ import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
+import org.elasticsearch.search.aggregations.bucket.histogram.ParsedHistogram;
 import org.elasticsearch.search.aggregations.metrics.avg.AvgAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.avg.ParsedAvg;
 import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityAggregationBuilder;
@@ -121,6 +125,8 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
                 (p, c) -> ParsedExtendedStatsBucket.fromXContent(p, (String) c));
         namedXContents.put(GeoBoundsAggregationBuilder.NAME, (p, c) -> ParsedGeoBounds.fromXContent(p, (String) c));
         namedXContents.put(GeoCentroidAggregationBuilder.NAME, (p, c) -> ParsedGeoCentroid.fromXContent(p, (String) c));
+        namedXContents.put(HistogramAggregationBuilder.NAME, (p, c) -> ParsedHistogram.fromXContent(p, (String) c));
+        namedXContents.put(DateHistogramAggregationBuilder.NAME, (p, c) -> ParsedDateHistogram.fromXContent(p, (String) c));
 
         return namedXContents.entrySet().stream()
                 .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue()))

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregationTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+public abstract class InternalMultiBucketAggregationTestCase<T extends InternalAggregation & MultiBucketsAggregation>
+        extends InternalAggregationTestCase<T> {
+
+    private boolean hasSubAggregations;
+
+    @Before
+    public void initHasSubAggregations() {
+        hasSubAggregations = randomBoolean();
+    }
+
+    @Override
+    protected final T createTestInstance(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        List<InternalAggregation> internal = new ArrayList<>();
+        if (hasSubAggregations) {
+            final int numAggregations = randomIntBetween(1, 3);
+            for (int i = 0; i <numAggregations; i++) {
+                internal.add(createTestInstance(randomAlphaOfLength(5), pipelineAggregators, emptyMap(), InternalAggregations.EMPTY));
+            }
+        }
+        return createTestInstance(name, pipelineAggregators, metaData, new InternalAggregations(internal));
+    }
+
+    protected abstract T createTestInstance(String name, List<PipelineAggregator> pipelineAggregators,
+                                            Map<String, Object> metaData, InternalAggregations aggregations);
+
+    protected abstract Class<? extends ParsedMultiBucketAggregation> implementationClass();
+
+    @Override
+    protected final void assertFromXContent(T aggregation, ParsedAggregation parsedAggregation) {
+        assertMultiBucketsAggregation(aggregation, parsedAggregation, false);
+    }
+
+    public void testIterators() throws IOException {
+        final T aggregation = createTestInstance();
+        assertMultiBucketsAggregation(aggregation, parseAndAssert(aggregation, false), true);
+    }
+
+    private void assertMultiBucketsAggregation(Aggregation expected, Aggregation actual, boolean checkOrder) {
+        assertTrue(expected instanceof MultiBucketsAggregation);
+        MultiBucketsAggregation expectedMultiBucketsAggregation = (MultiBucketsAggregation) expected;
+
+        assertTrue(actual instanceof MultiBucketsAggregation);
+        MultiBucketsAggregation actualMultiBucketsAggregation = (MultiBucketsAggregation) actual;
+
+        Class<? extends ParsedMultiBucketAggregation> parsedClass = implementationClass();
+        assertTrue(parsedClass != null && parsedClass.isInstance(actual));
+
+        assertTrue(expected instanceof InternalAggregation && actual instanceof ParsedAggregation);
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getMetaData(), actual.getMetaData());
+        assertEquals(((InternalAggregation) expected).getType(), ((ParsedAggregation) actual).getType());
+
+        List<? extends MultiBucketsAggregation.Bucket> expectedBuckets = expectedMultiBucketsAggregation.getBuckets();
+        List<? extends MultiBucketsAggregation.Bucket> actualBuckets = actualMultiBucketsAggregation.getBuckets();
+        assertEquals(expectedBuckets.size(), actualBuckets.size());
+
+        if (checkOrder) {
+            Iterator<? extends MultiBucketsAggregation.Bucket> expectedIt = expectedBuckets.iterator();
+            Iterator<? extends MultiBucketsAggregation.Bucket> actualIt = actualBuckets.iterator();
+            while (expectedIt.hasNext()) {
+                MultiBucketsAggregation.Bucket expectedBucket = expectedIt.next();
+                MultiBucketsAggregation.Bucket actualBucket = actualIt.next();
+                assertBucket(expectedBucket, actualBucket, true);
+            }
+        } else {
+            for (MultiBucketsAggregation.Bucket expectedBucket : expectedBuckets) {
+                boolean found = false;
+                for (MultiBucketsAggregation.Bucket actualBucket : actualBuckets) {
+                    if (actualBucket.getKey().equals(expectedBucket.getKey())) {
+                        found = true;
+                        assertBucket(expectedBucket, actualBucket, false);
+                        break;
+                    }
+                }
+                assertTrue("Failed to find bucket with key [" + expectedBucket.getKey() + "]", found);
+            }
+        }
+    }
+
+    private void assertBucket(MultiBucketsAggregation.Bucket expected, MultiBucketsAggregation.Bucket actual, boolean checkOrder) {
+        assertTrue(expected instanceof InternalMultiBucketAggregation.InternalBucket);
+        assertTrue(actual instanceof ParsedMultiBucketAggregation.ParsedBucket);
+
+        assertEquals(expected.getKey(), actual.getKey());
+        assertEquals(expected.getKeyAsString(), actual.getKeyAsString());
+        assertEquals(expected.getDocCount(), actual.getDocCount());
+
+        Aggregations expectedAggregations = expected.getAggregations();
+        Aggregations actualAggregations = actual.getAggregations();
+        assertEquals(expectedAggregations.asList().size(), actualAggregations.asList().size());
+
+        if (checkOrder) {
+            Iterator<Aggregation> expectedIt = expectedAggregations.iterator();
+            Iterator<Aggregation> actualIt = actualAggregations.iterator();
+
+            while (expectedIt.hasNext()) {
+                Aggregation expectedAggregation = expectedIt.next();
+                Aggregation actualAggregation = actualIt.next();
+                assertMultiBucketsAggregation(expectedAggregation, actualAggregation, true);
+            }
+        } else {
+            for (Aggregation expectedAggregation : expectedAggregations) {
+                Aggregation actualAggregation = actualAggregations.get(expectedAggregation.getName());
+                assertNotNull(actualAggregation);
+                assertMultiBucketsAggregation(expectedAggregation, actualAggregation, false);
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
-import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.joda.time.DateTime;
+import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,14 +37,22 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueHours;
 import static org.elasticsearch.common.unit.TimeValue.timeValueMinutes;
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
 
-public class InternalDateHistogramTests extends InternalAggregationTestCase<InternalDateHistogram> {
+public class InternalDateHistogramTests extends InternalMultiBucketAggregationTestCase<InternalDateHistogram> {
+
+    private boolean keyed;
+    private DocValueFormat format;
+
+    @Before
+    public void init() {
+        keyed = randomBoolean();
+        format = randomNumericDocValueFormat();
+    }
 
     @Override
-    protected InternalDateHistogram createTestInstance(String name, List<PipelineAggregator> pipelineAggregators,
-                                                       Map<String, Object> metaData) {
-
-        boolean keyed = randomBoolean();
-        DocValueFormat format = DocValueFormat.RAW;
+    protected InternalDateHistogram createTestInstance(String name,
+                                                       List<PipelineAggregator> pipelineAggregators,
+                                                       Map<String, Object> metaData,
+                                                       InternalAggregations aggregations) {
         int nbBuckets = randomInt(10);
         List<InternalDateHistogram.Bucket> buckets = new ArrayList<>(nbBuckets);
         long startingDate = System.currentTimeMillis();
@@ -54,7 +62,7 @@ public class InternalDateHistogramTests extends InternalAggregationTestCase<Inte
 
         for (int i = 0; i < nbBuckets; i++) {
             long key = startingDate + (intervalMillis * i);
-            buckets.add(i, new InternalDateHistogram.Bucket(key, randomIntBetween(1, 100), keyed, format, InternalAggregations.EMPTY));
+            buckets.add(i, new InternalDateHistogram.Bucket(key, randomIntBetween(1, 100), keyed, format, aggregations));
         }
 
         InternalOrder order = (InternalOrder) randomFrom(InternalHistogram.Order.KEY_ASC, InternalHistogram.Order.KEY_DESC);
@@ -81,5 +89,10 @@ public class InternalDateHistogramTests extends InternalAggregationTestCase<Inte
     @Override
     protected Writeable.Reader<InternalDateHistogram> instanceReader() {
         return InternalDateHistogram::new;
+    }
+
+    @Override
+    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+        return ParsedDateHistogram.class;
     }
 }


### PR DESCRIPTION
Note: this pull request is against a feature branch.

This pull request adds the logic to parse `InternalDateHistogram` and `InternalHistogram` aggregations. To do that, it introduces a `ParsedMultiBucketAggregation` that implements the `MultiBucketsAggregation` from core. This class provides a base `ParsedBucket` that can be extended by parsed implementations to fit their specific needs.

For now, the parsing logic for aggregations and buckets reside in the `ParsedHistogram` and `ParsedDateHistogram` implementations. Some code could be shared but it makes everything harder to read and understand (I'm still looking at how to improve this). 

The `ParsedHistogram.ParsedBucket` and `ParsedDateHistogram.ParsedBucket` are able to parse sub aggregations. They also handle the parsing logic when aggregations and buckets are keyed/not keyed.

It also introduces a `InternalMultiBucketAggregationTestCase` that takes care of verifying the aggregations and multiple buckets. It has a `assertMultiBucketsAggregation` that can checks the buckets in order or not.

Similarly to the existing `InternalSingleBucketAggregationTestCase`, the `InternalMultiBucketAggregationTestCase` randomly creates multi bucket aggregations that have sub aggregations of the same type (ie during tests, InternalDateHistogram can only have buckets with aggregations of type InternalDateHistogram). This makes things easier when checking the aggregations contained in a bucket - it uses a recursive call to `assertMultiBucketsAggregation`.