### PR TITLE
`search_analyzer` parameter in keyword.asciidoc

### DIFF
--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -99,11 +99,6 @@ The following parameters are accepted by `keyword` fields:
     the <<mapping-source-field,`_source`>> field. Accepts `true` or `false`
     (default).
 
-<<search-analyzer,`search_analyzer`>>::
-
-    The <<analyzer,`analyzer`>> that should be used at search time on
-    <<mapping-index,`analyzed`>> fields. Defaults to the `analyzer` setting.
-
 <<similarity,`similarity`>>::
 
     Which scoring algorithm or _similarity_ should be used. Defaults


### PR DESCRIPTION
This parameter doesn't work on keyword fields.
Why is it available in documentation?
