### PR TITLE
Open and close index to honour allow_no_indices option

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/close/TransportCloseIndexAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.close;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -97,6 +98,10 @@ public class TransportCloseIndexAction extends TransportMasterNodeAction<CloseIn
     @Override
     protected void masterOperation(final CloseIndexRequest request, final ClusterState state, final ActionListener<CloseIndexResponse> listener) {
         final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
+        if (concreteIndices == null || concreteIndices.length == 0) {
+            listener.onResponse(new CloseIndexResponse(true));
+            return;
+        }
         CloseIndexClusterStateUpdateRequest updateRequest = new CloseIndexClusterStateUpdateRequest()
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .indices(concreteIndices);

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/open/TransportOpenIndexAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.admin.indices.open;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -82,6 +83,10 @@ public class TransportOpenIndexAction extends TransportMasterNodeAction<OpenInde
     @Override
     protected void masterOperation(final OpenIndexRequest request, final ClusterState state, final ActionListener<OpenIndexResponse> listener) {
         final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
+        if (concreteIndices == null || concreteIndices.length == 0) {
+            listener.onResponse(new OpenIndexResponse(true));
+            return;
+        }
         OpenIndexClusterStateUpdateRequest updateRequest = new OpenIndexClusterStateUpdateRequest()
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .indices(concreteIndices);

--- a/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -192,7 +192,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     }
     
     // if there are no indices to open/close throw an exception
-    public void testOpenCloseWildCardsNoIdcicesDefault() {
+    public void testOpenCloseWildCardsNoIndicesDefault() {
         expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("test").execute().actionGet());
         expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("test").execute().actionGet());
         
@@ -207,21 +207,23 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     }
     
     // if there are no indices to open/close and allow_no_indices=true, the open/close is a no-op
-    public void testOpenCloseWildCardsNoIdcicesAllowNoIndices() {
-        IndicesOptions openIncidesOptions = IndicesOptions.fromOptions(false, true, false, true);
-        IndicesOptions closeIncidesOptions = IndicesOptions.fromOptions(false, true, true, false);
+    public void testOpenCloseWildCardsNoIndicesAllowNoIndices() throws InterruptedException, ExecutionException {
+        IndicesOptions openIndicesOptions = IndicesOptions.fromOptions(false, true, false, true);
+        IndicesOptions closeIndicesOptions = IndicesOptions.fromOptions(false, true, true, false);
 
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("test").execute().actionGet());
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("test").execute().actionGet());
+        expectThrows(IndexNotFoundException.class,
+                () -> client().admin().indices().prepareOpen("test").setIndicesOptions(openIndicesOptions).execute().actionGet());
+        expectThrows(IndexNotFoundException.class,
+                () -> client().admin().indices().prepareClose("test").setIndicesOptions(closeIndicesOptions).execute().actionGet());
+
+        assertAcked(client().admin().indices().prepareOpen("test*").setIndicesOptions(openIndicesOptions).execute().get());
+        assertAcked(client().admin().indices().prepareClose("test*").setIndicesOptions(closeIndicesOptions).execute().get());
         
-        assertAcked(client().admin().indices().prepareClose("test*").setIndicesOptions(openIncidesOptions).execute().actionGet());
-        assertAcked(client().admin().indices().prepareClose("test*").setIndicesOptions(closeIncidesOptions).execute().actionGet());
+        assertAcked(client().admin().indices().prepareOpen("*").setIndicesOptions(openIndicesOptions).execute().get());
+        assertAcked(client().admin().indices().prepareClose("*").setIndicesOptions(closeIndicesOptions).execute().get());
         
-        assertAcked(client().admin().indices().prepareClose("*").setIndicesOptions(openIncidesOptions).execute().actionGet());
-        assertAcked(client().admin().indices().prepareClose("*").setIndicesOptions(closeIncidesOptions).execute().actionGet());
-        
-        assertAcked(client().admin().indices().prepareClose("_all").setIndicesOptions(openIncidesOptions).execute().actionGet());
-        assertAcked(client().admin().indices().prepareClose("_all").setIndicesOptions(closeIncidesOptions).execute().actionGet());
+        assertAcked(client().admin().indices().prepareOpen("_all").setIndicesOptions(openIndicesOptions).execute().get());
+        assertAcked(client().admin().indices().prepareClose("_all").setIndicesOptions(closeIndicesOptions).execute().get());
     }
 
     public void testCloseNoIndex() {

--- a/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -190,6 +190,39 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1", "test2", "test3");
     }
+    
+    // if there are no indices to open/close throw an exception
+    public void testOpenCloseWildCardsNoIdcicesDefault() {
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("test").execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("test").execute().actionGet());
+        
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("test*").execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("test*").execute().actionGet());
+        
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("*").execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("*").execute().actionGet());
+        
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("_all").execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("_all").execute().actionGet());
+    }
+    
+    // if there are no indices to open/close and allow_no_indices=true, the open/close is a no-op
+    public void testOpenCloseWildCardsNoIdcicesAllowNoIndices() {
+        IndicesOptions openIncidesOptions = IndicesOptions.fromOptions(false, true, false, true);
+        IndicesOptions closeIncidesOptions = IndicesOptions.fromOptions(false, true, true, false);
+
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("test").execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("test").execute().actionGet());
+        
+        assertAcked(client().admin().indices().prepareClose("test*").setIndicesOptions(openIncidesOptions).execute().actionGet());
+        assertAcked(client().admin().indices().prepareClose("test*").setIndicesOptions(closeIncidesOptions).execute().actionGet());
+        
+        assertAcked(client().admin().indices().prepareClose("*").setIndicesOptions(openIncidesOptions).execute().actionGet());
+        assertAcked(client().admin().indices().prepareClose("*").setIndicesOptions(closeIncidesOptions).execute().actionGet());
+        
+        assertAcked(client().admin().indices().prepareClose("_all").setIndicesOptions(openIncidesOptions).execute().actionGet());
+        assertAcked(client().admin().indices().prepareClose("_all").setIndicesOptions(closeIncidesOptions).execute().actionGet());
+    }
 
     public void testCloseNoIndex() {
         Client client = client();


### PR DESCRIPTION
The endpoints `_open` and `_close` require at least one index to be specified as the target for the requested action. Under the default setting of ` allow_no_indices` (`false`) `_open` allows the use of a wildcard resolving to a currently closed index. If the wildcard does not match any such index, the `index_not_found_exception` is thrown. `_close` has the same behavior.

However setting `allow_no_indices=true` both `_open` and `_close` would still throw an exception if there is no matching target index. In other words `allow_no_indices` is ignored in this context.

This PR addresses the above inconsistency.
 
Fixes #24031