### PR TITLE
Don't expose cleaned-up tasks as pending in PrioritizedEsThreadPoolExecutor

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
@@ -91,7 +91,13 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
         for (Runnable runnable : runnables) {
             if (runnable instanceof TieBreakingPrioritizedRunnable) {
                 TieBreakingPrioritizedRunnable t = (TieBreakingPrioritizedRunnable) runnable;
-                pending.add(new Pending(unwrap(t.runnable), t.priority(), t.insertionOrder, executing));
+                Runnable innerRunnable = t.runnable;
+                if (innerRunnable != null) {
+                    /** innerRunnable can be null if task is finished but not removed from executor yet,
+                     * see {@link TieBreakingPrioritizedRunnable#run} and {@link TieBreakingPrioritizedRunnable#runAndClean}
+                     */
+                    pending.add(new Pending(unwrap(innerRunnable), t.priority(), t.insertionOrder, executing));
+                }
             } else if (runnable instanceof PrioritizedFutureTask) {
                 PrioritizedFutureTask t = (PrioritizedFutureTask) runnable;
                 Object task = t.task;


### PR DESCRIPTION
Changes in #24102 exposed the following oddity: `PrioritizedEsThreadPoolExecutor.getPending()` can return `Pending` entries where `pending.task == null`.

This can happen for example when tasks are added to the pending list while they are in the clean up phase, i.e. `TieBreakingPrioritizedRunnable#runAndClean` has run already, but `afterExecute` has not removed the task yet.

Instead of safeguarding consumers of the API (as was done before #24102) I think that we should not count these tasks as pending at all.

Test failures: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+java9-periodic/2235/consoleFull

```
ERROR   0.76s J2 | SharedClusterSnapshotRestoreIT.testBatchingShardUpdateTask <<< FAILURES!
   > Throwable #1: java.lang.NullPointerException
   > 	at org.elasticsearch.cluster.service.ClusterService.lambda$pendingTasks$2(ClusterService.java:491)
   > 	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
   > 	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
   > 	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
   > 	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
   > 	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
   > 	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
   > 	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:511)
   > 	at org.elasticsearch.cluster.service.ClusterService.pendingTasks(ClusterService.java:495)
   > 	at org.elasticsearch.action.admin.cluster.tasks.TransportPendingClusterTasksAction.masterOperation(TransportPendingClusterTasksAction.java:68)
   > 	at org.elasticsearch.action.admin.cluster.tasks.TransportPendingClusterTasksAction.masterOperation(TransportPendingClusterTasksAction.java:38)
   > 	at org.elasticsearch.action.support.master.TransportMasterNodeAction.masterOperation(TransportMasterNodeAction.java:87)
   > 	at  ...
```