### PR TITLE
Provide informative error message in case of unknown suggestion context.

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
@@ -81,7 +81,9 @@ public class ContextMappings implements ToXContent {
     public ContextMapping get(String name) {
         ContextMapping contextMapping = contextNameMap.get(name);
         if (contextMapping == null) {
-            throw new IllegalArgumentException("Unknown context name[" + name + "], must be one of " + contextNameMap.keySet().toString());
+            List<String> keys = new ArrayList<>(contextNameMap.keySet());
+            Collections.sort(keys);
+            throw new IllegalArgumentException("Unknown context name [" + name + "], must be one of " + keys.toString());
         }
         return contextMapping;
     }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMappings.java
@@ -81,7 +81,7 @@ public class ContextMappings implements ToXContent {
     public ContextMapping get(String name) {
         ContextMapping contextMapping = contextNameMap.get(name);
         if (contextMapping == null) {
-            throw new IllegalArgumentException("Unknown context name[" + name + "], must be one of " + contextNameMap.size());
+            throw new IllegalArgumentException("Unknown context name[" + name + "], must be one of " + contextNameMap.keySet().toString());
         }
         return contextMapping;
     }

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -697,7 +697,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         CompletionFieldType completionFieldType = (CompletionFieldType) fieldMapper.fieldType();
         
         Exception e = expectThrows(IllegalArgumentException.class, () -> completionFieldType.getContextMappings().get("brand"));
-        assertEquals("Unknown context name[brand], must be one of [type, ctx]", e.getMessage());
+        assertEquals("Unknown context name [brand], must be one of [ctx, type]", e.getMessage());
     }
 
     public void testParsingContextFromDocument() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.mapper.CompletionFieldMapper.CompletionFieldType;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -672,6 +673,31 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
 
         Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(createParseContext(parser)));
         assertEquals("category context must be an object, string, number or boolean", e.getMessage());
+    }
+    
+    public void testUnknownQueryContextParsing() throws Exception {
+        String mapping = jsonBuilder().startObject().startObject("type1")
+                .startObject("properties").startObject("completion")
+                .field("type", "completion")
+                .startArray("contexts")
+                .startObject()
+                .field("name", "ctx")
+                .field("type", "category")
+                .endObject()
+                .startObject()
+                .field("name", "type")
+                .field("type", "category")
+                .endObject()
+                .endArray()
+                .endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
+        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        CompletionFieldType completionFieldType = (CompletionFieldType) fieldMapper.fieldType();
+        
+        Exception e = expectThrows(IllegalArgumentException.class, () -> completionFieldType.getContextMappings().get("brand"));
+        assertEquals("Unknown context name[brand], must be one of [type, ctx]", e.getMessage());
     }
 
     public void testParsingContextFromDocument() throws Exception {


### PR DESCRIPTION
At present providing unknown context in a suggestion context query does not provide informative error message.
Consider below mapping and correspongding query

**Mapping**

```
{
    "mappings": {
        "products" : {
            "properties" : {
                "suggest" : {
                    "type" : "completion",
                    "contexts": [
                        { 
                            "name": "product_type",
                            "type": "category",
                            "path": "cat"
                        },
                        { 
                            "name": "product_color",
                            "type": "category",
                            "path": "cat"
                        },
                        { 
                            "name": "product_size",
                            "type": "category",
                            "path": "cat"
                        }
                    ]
                }
            }
        }
    }
}
```

**Query**

```
{
    "suggest": {
        "products_suggestion" : {
            "prefix" : "sho",
            "completion" : {
                "field" : "suggest",
                "size": 10,
                "contexts": {
                    "product_type": "casual",
                    "product_brand": "reebok"
                }
            }
        }
    }
}
```
Executing the above query will show error message as below

"Unknown context name[product_brand], must be one of 3"

This error message is not very informative as it only convey the number of context supported. However printing all the accepted contexts will be more informative, like below:

"Unknown context name[product_brand], must be one of [product_size, product_color, product_type]"

This pull request fixes the issue mentioned.