### PR TITLE
Allow passing single scrollID in clear scroll API body

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestClearScrollAction.java
@@ -78,10 +78,17 @@ public class RestClearScrollAction extends BaseRestHandler {
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
-                } else if ("scroll_id".equals(currentFieldName) && token == XContentParser.Token.START_ARRAY) {
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                } else if ("scroll_id".equals(currentFieldName)){
+                    if (token == XContentParser.Token.START_ARRAY) {
+                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            if (token.isValue() == false) {
+                                throw new IllegalArgumentException("scroll_id array element should only contain scroll_id");
+                            }
+                            clearScrollRequest.addScrollId(parser.text());
+                        }
+                    } else {
                         if (token.isValue() == false) {
-                            throw new IllegalArgumentException("scroll_id array element should only contain scroll_id");
+                            throw new IllegalArgumentException("scroll_id element should only contain scroll_id");
                         }
                         clearScrollRequest.addScrollId(parser.text());
                     }

--- a/docs/reference/search/request/scroll.asciidoc
+++ b/docs/reference/search/request/scroll.asciidoc
@@ -144,7 +144,7 @@ cleared as soon as the scroll is not being used anymore using the
 ---------------------------------------
 DELETE /_search/scroll
 {
-    "scroll_id" : ["DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ=="]
+    "scroll_id" : "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ=="
 }
 ---------------------------------------
 // CONSOLE

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/11_clear.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/11_clear.yaml
@@ -38,7 +38,7 @@
           scroll_id: $scroll_id1
 
 ---
-"Body params override query string":
+"Body params with array param override query string":
   - do:
       indices.create:
           index:  test_scroll
@@ -66,6 +66,47 @@
       clear_scroll:
         scroll_id: "invalid_scroll_id"
         body: { "scroll_id": [ "$scroll_id1" ]}
+
+  - do:
+      catch: missing
+      scroll:
+        scroll_id: $scroll_id1
+
+  - do:
+        catch: missing
+        clear_scroll:
+          scroll_id: $scroll_id1
+
+
+---
+"Body params with string param scroll id override query string":
+  - do:
+      indices.create:
+          index:  test_scroll
+  - do:
+      index:
+          index:  test_scroll
+          type:   test
+          id:     42
+          body:   { foo: bar }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test_scroll
+        scroll: 1m
+        body:
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id1}
+
+  - do:
+      clear_scroll:
+        scroll_id: "invalid_scroll_id"
+        body: { "scroll_id": "$scroll_id1" }
 
   - do:
       catch: missing

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/11_clear.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/11_clear.yaml
@@ -79,6 +79,10 @@
 
 ---
 "Body params with string param scroll id override query string":
+  - skip:
+      version: " - 5.99.99"
+      reason:  this uses a new API that has been added in 6.0
+
   - do:
       indices.create:
           index:  test_scroll

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/11_clear.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/11_clear.yaml
@@ -77,7 +77,6 @@
         clear_scroll:
           scroll_id: $scroll_id1
 
-
 ---
 "Body params with string param scroll id override query string":
   - do:


### PR DESCRIPTION
Allow passing a single scroll id as string instead of array.

Close #24233 