### PR TITLE
Add Vagrant based testing fixture

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/AntFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/AntFixture.groovy
@@ -28,7 +28,7 @@ import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Input
 
 /**
- * A fixture for integration tests which runs in a separate process.
+ * A fixture for integration tests which runs in a separate process launched by Ant.
  */
 public class AntFixture extends AntTask implements Fixture {
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/AntFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/AntFixture.groovy
@@ -1,0 +1,291 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.test
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.elasticsearch.gradle.AntTask
+import org.elasticsearch.gradle.LoggedExec
+import org.gradle.api.GradleException
+import org.gradle.api.Task
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.Input
+
+/**
+ * A fixture for integration tests which runs in a separate process.
+ */
+public class AntFixture extends AntTask implements Fixture {
+
+    /** The path to the executable that starts the fixture. */
+    @Input
+    String executable
+
+    private final List<Object> arguments = new ArrayList<>()
+
+    @Input
+    public void args(Object... args) {
+        arguments.addAll(args)
+    }
+
+    /**
+     * Environment variables for the fixture process. The value can be any object, which
+     * will have toString() called at execution time.
+     */
+    private final Map<String, Object> environment = new HashMap<>()
+
+    @Input
+    public void env(String key, Object value) {
+        environment.put(key, value)
+    }
+
+    /** A flag to indicate whether the command should be executed from a shell. */
+    @Input
+    boolean useShell = false
+
+    /**
+     * A flag to indicate whether the fixture should be run in the foreground, or spawned.
+     * It is protected so subclasses can override (eg RunTask).
+     */
+    protected boolean spawn = true
+
+    /**
+     * A closure to call before the fixture is considered ready. The closure is passed the fixture object,
+     * as well as a groovy AntBuilder, to enable running ant condition checks. The default wait
+     * condition is for http on the http port.
+     */
+    @Input
+    Closure waitCondition = { AntFixture fixture, AntBuilder ant ->
+        File tmpFile = new File(fixture.cwd, 'wait.success')
+        ant.get(src: "http://${fixture.addressAndPort}",
+                dest: tmpFile.toString(),
+                ignoreerrors: true, // do not fail on error, so logging information can be flushed
+                retries: 10)
+        return tmpFile.exists()
+    }
+
+    private final Task stopTask
+
+    public AntFixture() {
+        stopTask = createStopTask()
+        finalizedBy(stopTask)
+    }
+
+    @Override
+    public Task getStopTask() {
+        return stopTask
+    }
+
+    @Override
+    protected void runAnt(AntBuilder ant) {
+        project.delete(baseDir) // reset everything
+        cwd.mkdirs()
+        final String realExecutable
+        final List<Object> realArgs = new ArrayList<>()
+        final Map<String, Object> realEnv = environment
+        // We need to choose which executable we are using. In shell mode, or when we
+        // are spawning and thus using the wrapper script, the executable is the shell.
+        if (useShell || spawn) {
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                realExecutable = 'cmd'
+                realArgs.add('/C')
+                realArgs.add('"') // quote the entire command
+            } else {
+                realExecutable = 'sh'
+            }
+        } else {
+            realExecutable = executable
+            realArgs.addAll(arguments)
+        }
+        if (spawn) {
+            writeWrapperScript(executable)
+            realArgs.add(wrapperScript)
+            realArgs.addAll(arguments)
+        }
+        if (Os.isFamily(Os.FAMILY_WINDOWS) && (useShell || spawn)) {
+            realArgs.add('"')
+        }
+        commandString.eachLine { line -> logger.info(line) }
+
+        ant.exec(executable: realExecutable, spawn: spawn, dir: cwd, taskname: name) {
+            realEnv.each { key, value -> env(key: key, value: value) }
+            realArgs.each { arg(value: it) }
+        }
+
+        String failedProp = "failed${name}"
+        // first wait for resources, or the failure marker from the wrapper script
+        ant.waitfor(maxwait: '30', maxwaitunit: 'second', checkevery: '500', checkeveryunit: 'millisecond', timeoutproperty: failedProp) {
+            or {
+                resourceexists {
+                    file(file: failureMarker.toString())
+                }
+                and {
+                    resourceexists {
+                        file(file: pidFile.toString())
+                    }
+                    resourceexists {
+                        file(file: portsFile.toString())
+                    }
+                }
+            }
+        }
+
+        if (ant.project.getProperty(failedProp) || failureMarker.exists()) {
+            fail("Failed to start ${name}")
+        }
+
+        // the process is started (has a pid) and is bound to a network interface
+        // so now wait undil the waitCondition has been met
+        // TODO: change this to a loop?
+        boolean success
+        try {
+            success = waitCondition(this, ant) == false
+        } catch (Exception e) {
+            String msg = "Wait condition caught exception for ${name}"
+            logger.error(msg, e)
+            fail(msg, e)
+        }
+        if (success == false) {
+            fail("Wait condition failed for ${name}")
+        }
+    }
+
+    /** Returns a debug string used to log information about how the fixture was run. */
+    protected String getCommandString() {
+        String commandString = "\n${name} configuration:\n"
+        commandString += "-----------------------------------------\n"
+        commandString += "  cwd: ${cwd}\n"
+        commandString += "  command: ${executable} ${arguments.join(' ')}\n"
+        commandString += '  environment:\n'
+        environment.each { k, v -> commandString += "    ${k}: ${v}\n" }
+        if (spawn) {
+            commandString += "\n  [${wrapperScript.name}]\n"
+            wrapperScript.eachLine('UTF-8', { line -> commandString += "    ${line}\n"})
+        }
+        return commandString
+    }
+
+    /**
+     * Writes a script to run the real executable, so that stdout/stderr can be captured.
+     * TODO: this could be removed if we do use our own ProcessBuilder and pump output from the process
+     */
+    private void writeWrapperScript(String executable) {
+        wrapperScript.parentFile.mkdirs()
+        String argsPasser = '"$@"'
+        String exitMarker = "; if [ \$? != 0 ]; then touch run.failed; fi"
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            argsPasser = '%*'
+            exitMarker = "\r\n if \"%errorlevel%\" neq \"0\" ( type nul >> run.failed )"
+        }
+        wrapperScript.setText("\"${executable}\" ${argsPasser} > run.log 2>&1 ${exitMarker}", 'UTF-8')
+    }
+
+    /** Fail the build with the given message, and logging relevant info*/
+    private void fail(String msg, Exception... suppressed) {
+        if (logger.isInfoEnabled() == false) {
+            // We already log the command at info level. No need to do it twice.
+            commandString.eachLine { line -> logger.error(line) }
+        }
+        logger.error("${name} output:")
+        logger.error("-----------------------------------------")
+        logger.error("  failure marker exists: ${failureMarker.exists()}")
+        logger.error("  pid file exists: ${pidFile.exists()}")
+        logger.error("  ports file exists: ${portsFile.exists()}")
+        // also dump the log file for the startup script (which will include ES logging output to stdout)
+        if (runLog.exists()) {
+            logger.error("\n  [log]")
+            runLog.eachLine { line -> logger.error("    ${line}") }
+        }
+        logger.error("-----------------------------------------")
+        GradleException toThrow = new GradleException(msg)
+        for (Exception e : suppressed) {
+            toThrow.addSuppressed(e)
+        }
+        throw toThrow
+    }
+
+    /** Adds a task to kill an elasticsearch node with the given pidfile */
+    private Task createStopTask() {
+        final AntFixture fixture = this
+        final Object pid = "${ -> fixture.pid }"
+        Exec stop = project.tasks.create(name: "${name}#stop", type: LoggedExec)
+        stop.onlyIf { fixture.pidFile.exists() }
+        stop.doFirst {
+            logger.info("Shutting down ${fixture.name} with pid ${pid}")
+        }
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            stop.executable = 'Taskkill'
+            stop.args('/PID', pid, '/F')
+        } else {
+            stop.executable = 'kill'
+            stop.args('-9', pid)
+        }
+        stop.doLast {
+            project.delete(fixture.pidFile)
+        }
+        return stop
+    }
+
+    /**
+     * A path relative to the build dir that all configuration and runtime files
+     * will live in for this fixture
+     */
+    protected File getBaseDir() {
+        return new File(project.buildDir, "fixtures/${name}")
+    }
+
+    /** Returns the working directory for the process. Defaults to "cwd" inside baseDir. */
+    protected File getCwd() {
+        return new File(baseDir, 'cwd')
+    }
+
+    /** Returns the file the process writes its pid to. Defaults to "pid" inside baseDir. */
+    protected File getPidFile() {
+        return new File(baseDir, 'pid')
+    }
+
+    /** Reads the pid file and returns the process' pid */
+    public int getPid() {
+        return Integer.parseInt(pidFile.getText('UTF-8').trim())
+    }
+
+    /** Returns the file the process writes its bound ports to. Defaults to "ports" inside baseDir. */
+    protected File getPortsFile() {
+        return new File(baseDir, 'ports')
+    }
+
+    /** Returns an address and port suitable for a uri to connect to this node over http */
+    public String getAddressAndPort() {
+        return portsFile.readLines("UTF-8").get(0)
+    }
+
+    /** Returns a file that wraps around the actual command when {@code spawn == true}. */
+    protected File getWrapperScript() {
+        return new File(cwd, Os.isFamily(Os.FAMILY_WINDOWS) ? 'run.bat' : 'run')
+    }
+
+    /** Returns a file that the wrapper script writes when the command failed. */
+    protected File getFailureMarker() {
+        return new File(cwd, 'run.failed')
+    }
+
+    /** Returns a file that the wrapper script writes when the command failed. */
+    protected File getRunLog() {
+        return new File(cwd, 'run.log')
+    }
+}

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -208,7 +208,7 @@ class ClusterFormationTasks {
             start.finalizedBy(stop)
             for (Object dependency : config.dependencies) {
                 if (dependency instanceof Fixture) {
-                    Task depStop = ((Fixture)dependency).stopTask
+                    def depStop = ((Fixture)dependency).stopTask
                     runner.finalizedBy(depStop)
                     start.finalizedBy(depStop)
                 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/Fixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/Fixture.groovy
@@ -20,7 +20,10 @@ package org.elasticsearch.gradle.test
 
 import org.gradle.api.Task
 
-
+/**
+ * Any object that can produce an accompanying stop task, meant to tear down
+ * a previously instantiated service.
+ */
 public interface Fixture {
 
     /** A task which will stop this fixture. This should be used as a finalizedBy for any tasks that use the fixture. */

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/Fixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/Fixture.groovy
@@ -18,8 +18,6 @@
  */
 package org.elasticsearch.gradle.test
 
-import org.gradle.api.Task
-
 /**
  * Any object that can produce an accompanying stop task, meant to tear down
  * a previously instantiated service.
@@ -27,6 +25,6 @@ import org.gradle.api.Task
 public interface Fixture {
 
     /** A task which will stop this fixture. This should be used as a finalizedBy for any tasks that use the fixture. */
-    public Task getStopTask()
+    public Object getStopTask()
 
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -129,7 +129,7 @@ public class RestIntegTestTask extends DefaultTask {
         runner.dependsOn(dependencies)
         for (Object dependency : dependencies) {
             if (dependency instanceof Fixture) {
-                runner.finalizedBy(((Fixture)dependency).stopTask)
+                runner.finalizedBy(((Fixture)dependency).getStopTask())
             }
         }
         return this
@@ -140,7 +140,7 @@ public class RestIntegTestTask extends DefaultTask {
         runner.setDependsOn(dependencies)
         for (Object dependency : dependencies) {
             if (dependency instanceof Fixture) {
-                runner.finalizedBy(((Fixture)dependency).stopTask)
+                runner.finalizedBy(((Fixture)dependency).getStopTask())
             }
         }
     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
@@ -18,12 +18,29 @@
  */
 package org.elasticsearch.gradle.test
 
+import org.elasticsearch.gradle.vagrant.VagrantCommandTask
 import org.gradle.api.Task
 
+class VagrantFixture extends VagrantCommandTask implements Fixture {
 
-public interface Fixture {
+    private final Task stopTask
 
-    /** A task which will stop this fixture. This should be used as a finalizedBy for any tasks that use the fixture. */
-    public Task getStopTask()
+    public VagrantFixture() {
+        stopTask = createStopTask()
+        finalizedBy(stopTask)
+    }
 
+    private Task createStopTask() {
+        VagrantCommandTask halt = project.tasks.create(name: "${name}#stop", type: VagrantCommandTask) {
+            args 'halt', box
+        }
+        halt.boxName = this.boxName
+        halt.environmentVars = this.environmentVars
+        return halt;
+    }
+
+    @Override
+    public Task getStopTask() {
+        return stopTask
+    }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
@@ -21,6 +21,9 @@ package org.elasticsearch.gradle.test
 import org.elasticsearch.gradle.vagrant.VagrantCommandTask
 import org.gradle.api.Task
 
+/**
+ * A fixture for integration tests which runs in a virtual machine launched by Vagrant.
+ */
 class VagrantFixture extends VagrantCommandTask implements Fixture {
 
     private Task stopTask = null
@@ -45,7 +48,7 @@ class VagrantFixture extends VagrantCommandTask implements Fixture {
     @Override
     public Task getStopTask() {
         // Lazy init the stop task since creating it in the constructor
-        // means that it captures variable names that may not be set in
+        // means that it captures variable values that may not be set in
         // the task yet.
         if (stopTask == null) {
             stopTask = createStopTask()

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
@@ -19,6 +19,7 @@
 package org.elasticsearch.gradle.test
 
 import org.elasticsearch.gradle.vagrant.VagrantCommandTask
+import org.gradle.api.Task
 
 /**
  * A fixture for integration tests which runs in a virtual machine launched by Vagrant.
@@ -28,25 +29,6 @@ class VagrantFixture extends VagrantCommandTask implements Fixture {
     private VagrantCommandTask stopTask
 
     public VagrantFixture() {
-        // Our stop task is a VagrandCommandTask that halts the VM that we supposedly just stood up.
-        // VagrantCommandTask schedules an afterEvaluate closure that sets the env variables for the vagrant
-        // command to use. We want the following closure to run before that does, because the following closure
-        // configures the stop task with the same environment variables and box name from the start command on
-        // the fixture. If this does not run first, then the stop task will capture an empty set of environment
-        // variables at the end of the project set up instead of the environment variables of the start command.
-//        project.afterEvaluate {
-//            def startCommandBoxName = this.boxName
-//            def startCommandEnvVariables = this.environmentVars
-//            VagrantCommandTask halt = project.tasks.getByName("${name}#stop") {
-//                boxName startCommandBoxName
-//                environmentVars startCommandEnvVariables
-//                args 'halt', startCommandBoxName
-//            }
-//            finalizedBy(halt)
-//        }
-        // Now that is scheduled, create the stop command. We'll configure it after the project is
-        // done evaluating with the above closure so that it picks up any new configurations to the
-        // Fixture after the constructor is done running (like the box name and the environment variables)
         this.stopTask = project.tasks.create(name: "${name}#stop", type: VagrantCommandTask) {
             command 'halt'
         }
@@ -66,7 +48,7 @@ class VagrantFixture extends VagrantCommandTask implements Fixture {
     }
 
     @Override
-    public String getStopTask() {
+    public Task getStopTask() {
         return this.stopTask
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
@@ -25,6 +25,8 @@ import org.elasticsearch.gradle.vagrant.VagrantCommandTask
  */
 class VagrantFixture extends VagrantCommandTask implements Fixture {
 
+    private VagrantCommandTask stopTask
+
     public VagrantFixture() {
         // Our stop task is a VagrandCommandTask that halts the VM that we supposedly just stood up.
         // VagrantCommandTask schedules an afterEvaluate closure that sets the env variables for the vagrant
@@ -32,24 +34,39 @@ class VagrantFixture extends VagrantCommandTask implements Fixture {
         // configures the stop task with the same environment variables and box name from the start command on
         // the fixture. If this does not run first, then the stop task will capture an empty set of environment
         // variables at the end of the project set up instead of the environment variables of the start command.
-        project.afterEvaluate {
-            def startCommandBoxName = this.boxName
-            def startCommandEnvVariables = this.environmentVars
-            VagrantCommandTask halt = project.tasks.getByName("${name}#stop") {
-                boxName startCommandBoxName
-                environmentVars startCommandEnvVariables
-                args 'halt', startCommandBoxName
-            }
-            finalizedBy(halt)
-        }
+//        project.afterEvaluate {
+//            def startCommandBoxName = this.boxName
+//            def startCommandEnvVariables = this.environmentVars
+//            VagrantCommandTask halt = project.tasks.getByName("${name}#stop") {
+//                boxName startCommandBoxName
+//                environmentVars startCommandEnvVariables
+//                args 'halt', startCommandBoxName
+//            }
+//            finalizedBy(halt)
+//        }
         // Now that is scheduled, create the stop command. We'll configure it after the project is
         // done evaluating with the above closure so that it picks up any new configurations to the
         // Fixture after the constructor is done running (like the box name and the environment variables)
-        project.tasks.create(name: "${name}#stop", type: VagrantCommandTask)
+        this.stopTask = project.tasks.create(name: "${name}#stop", type: VagrantCommandTask) {
+            command 'halt'
+        }
+        finalizedBy this.stopTask
+    }
+
+    @Override
+    void setBoxName(String boxName) {
+        super.setBoxName(boxName)
+        this.stopTask.setBoxName(boxName)
+    }
+
+    @Override
+    void setEnvironmentVars(Map<String, String> environmentVars) {
+        super.setEnvironmentVars(environmentVars)
+        this.stopTask.setEnvironmentVars(environmentVars)
     }
 
     @Override
     public String getStopTask() {
-        return "${name}#stop"
+        return this.stopTask
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/VagrantFixture.groovy
@@ -19,41 +19,37 @@
 package org.elasticsearch.gradle.test
 
 import org.elasticsearch.gradle.vagrant.VagrantCommandTask
-import org.gradle.api.Task
 
 /**
  * A fixture for integration tests which runs in a virtual machine launched by Vagrant.
  */
 class VagrantFixture extends VagrantCommandTask implements Fixture {
 
-    private Task stopTask = null
-
     public VagrantFixture() {
+        // Our stop task is a VagrandCommandTask that halts the VM that we supposedly just stood up.
+        // VagrantCommandTask schedules an afterEvaluate closure that sets the env variables for the vagrant
+        // command to use. We want the following closure to run before that does, because the following closure
+        // configures the stop task with the same environment variables and box name from the start command on
+        // the fixture. If this does not run first, then the stop task will capture an empty set of environment
+        // variables at the end of the project set up instead of the environment variables of the start command.
         project.afterEvaluate {
-            // force the initialization of the stop task at the end
-            // of the project if it hasn't been yet.
-            getStopTask()
+            def startCommandBoxName = this.boxName
+            def startCommandEnvVariables = this.environmentVars
+            VagrantCommandTask halt = project.tasks.getByName("${name}#stop") {
+                boxName startCommandBoxName
+                environmentVars startCommandEnvVariables
+                args 'halt', startCommandBoxName
+            }
+            finalizedBy(halt)
         }
-    }
-
-    private Task createStopTask() {
-        VagrantCommandTask halt = project.tasks.create(name: "${name}#stop", type: VagrantCommandTask) {
-            args 'halt', this.boxName
-        }
-        halt.boxName = this.boxName
-        halt.environmentVars = this.environmentVars
-        return halt;
+        // Now that is scheduled, create the stop command. We'll configure it after the project is
+        // done evaluating with the above closure so that it picks up any new configurations to the
+        // Fixture after the constructor is done running (like the box name and the environment variables)
+        project.tasks.create(name: "${name}#stop", type: VagrantCommandTask)
     }
 
     @Override
-    public Task getStopTask() {
-        // Lazy init the stop task since creating it in the constructor
-        // means that it captures variable values that may not be set in
-        // the task yet.
-        if (stopTask == null) {
-            stopTask = createStopTask()
-            finalizedBy(stopTask)
-        }
-        return stopTask
+    public String getStopTask() {
+        return "${name}#stop"
     }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/BatsOverVagrantTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/BatsOverVagrantTask.groovy
@@ -30,10 +30,16 @@ public class BatsOverVagrantTask extends VagrantCommandTask {
     String remoteCommand
 
     BatsOverVagrantTask() {
-        project.afterEvaluate {
-            command 'ssh'
-            args '--command', remoteCommand
+        command = 'ssh'
+    }
+
+    void setRemoteCommand(String remoteCommand) {
+        if (remoteCommand == null) {
+            // Sanity check, otherwise you might get a confusing NPE when reading args
+            throw new IllegalArgumentException("remoteCommand == null!");
         }
+        this.remoteCommand = remoteCommand
+        setArgs(['--command', remoteCommand])
     }
 
     @Override

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/BatsOverVagrantTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/BatsOverVagrantTask.groovy
@@ -34,11 +34,7 @@ public class BatsOverVagrantTask extends VagrantCommandTask {
     }
 
     void setRemoteCommand(String remoteCommand) {
-        if (remoteCommand == null) {
-            // Sanity check, otherwise you might get a confusing NPE when reading args
-            throw new IllegalArgumentException("remoteCommand == null!");
-        }
-        this.remoteCommand = remoteCommand
+        this.remoteCommand = Objects.requireNonNull(remoteCommand)
         setArgs(['--command', remoteCommand])
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/BatsOverVagrantTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/BatsOverVagrantTask.groovy
@@ -27,11 +27,12 @@ import org.gradle.api.tasks.Input
 public class BatsOverVagrantTask extends VagrantCommandTask {
 
     @Input
-    String command
+    String remoteCommand
 
     BatsOverVagrantTask() {
         project.afterEvaluate {
-            args 'ssh', boxName, '--command', command
+            command 'ssh'
+            args '--command', remoteCommand
         }
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
@@ -47,24 +47,20 @@ public class VagrantCommandTask extends LoggedExec {
 
     public VagrantCommandTask() {
         executable = 'vagrant'
-    }
+        doFirst {
+            // Build our command line for vagrant
+            def vagrantCommand = [executable, command]
+            if (subcommand != null) {
+                vagrantCommand + subcommand
+            }
+            commandLine([*vagrantCommand, boxName, *args])
 
-    @Override @TaskAction
-    protected void exec() {
-        // Build our command line for vagrant
-        def vagrantCommand = [executable, command]
-        if (subcommand != null) {
-            vagrantCommand + subcommand
+            // It'd be nice if --machine-readable were, well, nice
+            standardOutput = new TeeOutputStream(standardOutput, createLoggerOutputStream())
+            if (environmentVars != null) {
+                environment environmentVars
+            }
         }
-        commandLine([*vagrantCommand, boxName, *args])
-
-        // It'd be nice if --machine-readable were, well, nice
-        standardOutput = new TeeOutputStream(standardOutput, createLoggerOutputStream())
-        if (environmentVars != null) {
-            environment environmentVars
-        }
-
-        super.exec()
     }
 
     @Inject

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle.vagrant
 import org.apache.commons.io.output.TeeOutputStream
 import org.elasticsearch.gradle.LoggedExec
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 
@@ -35,7 +36,7 @@ public class VagrantCommandTask extends LoggedExec {
     @Input
     String command
 
-    @Input
+    @Input @Optional
     String subcommand
 
     @Input
@@ -51,7 +52,6 @@ public class VagrantCommandTask extends LoggedExec {
             // It'd be nice if --machine-readable were, well, nice
             standardOutput = new TeeOutputStream(standardOutput, createLoggerOutputStream())
             if (environmentVars != null) {
-                println "$name Passing Env..."
                 environment environmentVars
             }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle.vagrant
 import org.apache.commons.io.output.TeeOutputStream
 import org.elasticsearch.gradle.LoggedExec
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 
 import javax.inject.Inject
@@ -30,6 +31,12 @@ import javax.inject.Inject
  * formatter and defaults to `vagrant` as first part of commandLine.
  */
 public class VagrantCommandTask extends LoggedExec {
+
+    @Input
+    String command
+
+    @Input
+    String subcommand
 
     @Input
     String boxName
@@ -47,6 +54,12 @@ public class VagrantCommandTask extends LoggedExec {
                 println "$name Passing Env..."
                 environment environmentVars
             }
+
+            def vagrantCommand = [executable, command]
+            if (subcommand != null) {
+                vagrantCommand + subcommand
+            }
+            commandLine([*vagrantCommand, boxName, *args])
         }
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
@@ -47,20 +47,24 @@ public class VagrantCommandTask extends LoggedExec {
 
     public VagrantCommandTask() {
         executable = 'vagrant'
+    }
 
-        project.afterEvaluate {
-            // It'd be nice if --machine-readable were, well, nice
-            standardOutput = new TeeOutputStream(standardOutput, createLoggerOutputStream())
-            if (environmentVars != null) {
-                environment environmentVars
-            }
-
-            def vagrantCommand = [executable, command]
-            if (subcommand != null) {
-                vagrantCommand + subcommand
-            }
-            commandLine([*vagrantCommand, boxName, *args])
+    @Override @TaskAction
+    protected void exec() {
+        // Build our command line for vagrant
+        def vagrantCommand = [executable, command]
+        if (subcommand != null) {
+            vagrantCommand + subcommand
         }
+        commandLine([*vagrantCommand, boxName, *args])
+
+        // It'd be nice if --machine-readable were, well, nice
+        standardOutput = new TeeOutputStream(standardOutput, createLoggerOutputStream())
+        if (environmentVars != null) {
+            environment environmentVars
+        }
+
+        super.exec()
     }
 
     @Inject

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
@@ -51,10 +51,14 @@ public class VagrantCommandTask extends LoggedExec {
 
     public VagrantCommandTask() {
         executable = 'vagrant'
+
+        // We're using afterEvaluate here to slot in some logic that captures configurations and
+        // modifies the command line right before the main execution happens. The reason that we
+        // call doFirst instead of just doing the work in the afterEvaluate is that the latter
+        // restricts how subclasses can extend functionality. Calling afterEvaluate is like having
+        // all the logic of a task happening at construction time, instead of at execution time
+        // where a subclass can override or extend the logic.
         project.afterEvaluate {
-            // Schedule an action to set the values for exec before it runs.
-            // If you don't do this from within 'afterEvaluate', then
-            // the exec and configure actions are run out of order.
             doFirst {
                 if (environmentVars != null) {
                     environment environmentVars

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantCommandTask.groovy
@@ -44,6 +44,7 @@ public class VagrantCommandTask extends LoggedExec {
             // It'd be nice if --machine-readable were, well, nice
             standardOutput = new TeeOutputStream(standardOutput, createLoggerOutputStream())
             if (environmentVars != null) {
+                println "$name Passing Env..."
                 environment environmentVars
             }
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -394,7 +394,6 @@ class VagrantTestPlugin implements Plugin<Project> {
                 command 'halt'
                 boxName box
                 environmentVars vagrantEnvVars
-//                args 'halt', box
             }
             stop.dependsOn(halt)
 
@@ -403,7 +402,6 @@ class VagrantTestPlugin implements Plugin<Project> {
                 subcommand 'update'
                 boxName box
                 environmentVars vagrantEnvVars
-//                args 'box', 'update', box
                 dependsOn vagrantCheckVersion, virtualboxCheckVersion
             }
             update.mustRunAfter(setupBats)
@@ -422,7 +420,6 @@ class VagrantTestPlugin implements Plugin<Project> {
                   vagrant's default but its possible to change that default and folks do.
                   But the boxes that we use are unlikely to work properly with other
                   virtualization providers. Thus the lock. */
-//                args 'up', box, '--provision', '--provider', 'virtualbox'
                 args '--provision', '--provider', 'virtualbox'
                 /* It'd be possible to check if the box is already up here and output
                   SKIPPED but that would require running vagrant status which is slow! */
@@ -471,7 +468,6 @@ class VagrantTestPlugin implements Plugin<Project> {
                 environmentVars vagrantEnvVars
                 dependsOn up
                 finalizedBy halt
-//                args 'ssh', boxName, '--command', PLATFORM_TEST_COMMAND + " -Dtests.seed=${-> project.extensions.esvagrant.formattedTestSeed}"
                 args '--command', PLATFORM_TEST_COMMAND + " -Dtests.seed=${-> project.extensions.esvagrant.formattedTestSeed}"
             }
             TaskExecutionAdapter platformReproListener = new TaskExecutionAdapter() {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -391,21 +391,25 @@ class VagrantTestPlugin implements Plugin<Project> {
 
             // always add a halt task for all boxes, so clean makes sure they are all shutdown
             Task halt = project.tasks.create("vagrant${boxTask}#halt", VagrantCommandTask) {
+                command 'halt'
                 boxName box
                 environmentVars vagrantEnvVars
-                args 'halt', box
+//                args 'halt', box
             }
             stop.dependsOn(halt)
 
             Task update = project.tasks.create("vagrant${boxTask}#update", VagrantCommandTask) {
+                command 'box'
+                subcommand 'update'
                 boxName box
                 environmentVars vagrantEnvVars
-                args 'box', 'update', box
+//                args 'box', 'update', box
                 dependsOn vagrantCheckVersion, virtualboxCheckVersion
             }
             update.mustRunAfter(setupBats)
 
             Task up = project.tasks.create("vagrant${boxTask}#up", VagrantCommandTask) {
+                command 'up'
                 boxName box
                 environmentVars vagrantEnvVars
                 /* Its important that we try to reprovision the box even if it already
@@ -418,7 +422,8 @@ class VagrantTestPlugin implements Plugin<Project> {
                   vagrant's default but its possible to change that default and folks do.
                   But the boxes that we use are unlikely to work properly with other
                   virtualization providers. Thus the lock. */
-                args 'up', box, '--provision', '--provider', 'virtualbox'
+//                args 'up', box, '--provision', '--provider', 'virtualbox'
+                args '--provision', '--provider', 'virtualbox'
                 /* It'd be possible to check if the box is already up here and output
                   SKIPPED but that would require running vagrant status which is slow! */
                 dependsOn update
@@ -438,7 +443,7 @@ class VagrantTestPlugin implements Plugin<Project> {
                 environmentVars vagrantEnvVars
                 dependsOn up, setupBats
                 finalizedBy halt
-                command BATS_TEST_COMMAND
+                remoteCommand BATS_TEST_COMMAND
             }
 
             TaskExecutionAdapter packagingReproListener = new TaskExecutionAdapter() {
@@ -461,11 +466,13 @@ class VagrantTestPlugin implements Plugin<Project> {
             }
 
             Task platform = project.tasks.create("vagrant${boxTask}#platformTest", VagrantCommandTask) {
+                command 'ssh'
                 boxName box
                 environmentVars vagrantEnvVars
                 dependsOn up
                 finalizedBy halt
-                args 'ssh', boxName, '--command', PLATFORM_TEST_COMMAND + " -Dtests.seed=${-> project.extensions.esvagrant.formattedTestSeed}"
+//                args 'ssh', boxName, '--command', PLATFORM_TEST_COMMAND + " -Dtests.seed=${-> project.extensions.esvagrant.formattedTestSeed}"
+                args '--command', PLATFORM_TEST_COMMAND + " -Dtests.seed=${-> project.extensions.esvagrant.formattedTestSeed}"
             }
             TaskExecutionAdapter platformReproListener = new TaskExecutionAdapter() {
                 @Override

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -439,11 +439,11 @@ class VagrantTestPlugin implements Plugin<Project> {
             vagrantSmokeTest.dependsOn(smoke)
 
             Task packaging = project.tasks.create("vagrant${boxTask}#packagingTest", BatsOverVagrantTask) {
+                remoteCommand BATS_TEST_COMMAND
                 boxName box
                 environmentVars vagrantEnvVars
                 dependsOn up, setupBats
                 finalizedBy halt
-                remoteCommand BATS_TEST_COMMAND
             }
 
             TaskExecutionAdapter packagingReproListener = new TaskExecutionAdapter() {

--- a/plugins/jvm-example/build.gradle
+++ b/plugins/jvm-example/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   exampleFixture project(':test:fixtures:example-fixture')
 }
 
-task exampleFixture(type: org.elasticsearch.gradle.test.Fixture) {
+task exampleFixture(type: org.elasticsearch.gradle.test.AntFixture) {
   dependsOn project.configurations.exampleFixture
   executable = new File(project.javaHome, 'bin/java')
   args '-cp', "${ -> project.configurations.exampleFixture.asPath }",

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -60,7 +60,7 @@ dependencyLicenses {
   mapping from: /hadoop-.*/, to: 'hadoop'
 }
 
-task hdfsFixture(type: org.elasticsearch.gradle.test.Fixture) {
+task hdfsFixture(type: org.elasticsearch.gradle.test.AntFixture) {
   dependsOn project.configurations.hdfsFixture
   executable = new File(project.javaHome, 'bin/java')
   env 'CLASSPATH', "${ -> project.configurations.hdfsFixture.asPath }"


### PR DESCRIPTION
This PR extends the functionality of the existing testing fixture code in our gradle build source. Previously, testing fixtures were locked into being executed by an Ant task. In order to take advantage of the existing enhanced Vagrant logging support in the build code, I have split the existing Fixture object into an interface (`Fixture.groovy`) and an implementation (`AntFixture.groovy`), and added a new implementation (`VagrantFixture.groovy`) that is based on the existing `VagrantCommand` task.

This is related to #23439 in that the integration tests will need to spin up a Kerberos KDC based in a virtual machine run by Vagrant.