### PR TITLE
Scripts: Remove unwrap method from executable scripts

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractAsyncBulkByScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractAsyncBulkByScrollAction.java
@@ -799,8 +799,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
             executable.setNextVar("ctx", context);
             executable.run();
 
-            Map<String, Object> resultCtx = (Map<String, Object>) executable.unwrap(context);
-            String newOp = (String) resultCtx.remove("op");
+            String newOp = (String) context.remove("op");
             if (newOp == null) {
                 throw new IllegalArgumentException("Script cleared operation type");
             }
@@ -809,25 +808,25 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
              * It'd be lovely to only set the source if we know its been modified
              * but it isn't worth keeping two copies of it around just to check!
              */
-            request.setSource((Map<String, Object>) resultCtx.remove(SourceFieldMapper.NAME));
+            request.setSource((Map<String, Object>) context.remove(SourceFieldMapper.NAME));
 
-            Object newValue = resultCtx.remove(IndexFieldMapper.NAME);
+            Object newValue = context.remove(IndexFieldMapper.NAME);
             if (false == doc.getIndex().equals(newValue)) {
                 scriptChangedIndex(request, newValue);
             }
-            newValue = resultCtx.remove(TypeFieldMapper.NAME);
+            newValue = context.remove(TypeFieldMapper.NAME);
             if (false == doc.getType().equals(newValue)) {
                 scriptChangedType(request, newValue);
             }
-            newValue = resultCtx.remove(IdFieldMapper.NAME);
+            newValue = context.remove(IdFieldMapper.NAME);
             if (false == doc.getId().equals(newValue)) {
                 scriptChangedId(request, newValue);
             }
-            newValue = resultCtx.remove(VersionFieldMapper.NAME);
+            newValue = context.remove(VersionFieldMapper.NAME);
             if (false == Objects.equals(oldVersion, newValue)) {
                 scriptChangedVersion(request, newValue);
             }
-            newValue = resultCtx.remove(ParentFieldMapper.NAME);
+            newValue = context.remove(ParentFieldMapper.NAME);
             if (false == Objects.equals(oldParent, newValue)) {
                 scriptChangedParent(request, newValue);
             }
@@ -835,7 +834,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
              * Its important that routing comes after parent in case you want to
              * change them both.
              */
-            newValue = resultCtx.remove(RoutingFieldMapper.NAME);
+            newValue = context.remove(RoutingFieldMapper.NAME);
             if (false == Objects.equals(oldRouting, newValue)) {
                 scriptChangedRouting(request, newValue);
             }
@@ -845,8 +844,8 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
                 return scriptChangedOpType(request, oldOpType, newOpType);
             }
 
-            if (false == resultCtx.isEmpty()) {
-                throw new IllegalArgumentException("Invalid fields added to context [" + String.join(",", resultCtx.keySet()) + ']');
+            if (false == context.isEmpty()) {
+                throw new IllegalArgumentException("Invalid fields added to context [" + String.join(",", context.keySet()) + ']');
             }
             return request;
         }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -216,8 +216,6 @@ public class UpdateHelper extends AbstractComponent {
                 ExecutableScript executableScript = scriptService.executable(script, ScriptContext.Standard.UPDATE);
                 executableScript.setNextVar("ctx", ctx);
                 executableScript.run();
-                // we need to unwrap the ctx...
-                ctx = (Map<String, Object>) executableScript.unwrap(ctx);
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("failed to execute script", e);

--- a/core/src/main/java/org/elasticsearch/script/ExecutableScript.java
+++ b/core/src/main/java/org/elasticsearch/script/ExecutableScript.java
@@ -38,14 +38,4 @@ public interface ExecutableScript {
      * Executes the script.
      */
     Object run();
-
-    /**
-     * Unwraps a possible script value. For example, when passing vars and
-     * expecting the returned value to be part of the vars. Javascript and
-     * Python need this but other scripting engines just return the values
-     * passed in.
-     */
-    default Object unwrap(Object value) {
-        return value;
-    }
 }

--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/ScriptFieldsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/ScriptFieldsFetchSubPhase.java
@@ -50,7 +50,7 @@ public final class ScriptFieldsFetchSubPhase implements FetchSubPhase {
 
             final Object value;
             try {
-                value = leafScript.unwrap(leafScript.run());
+                value = leafScript.run();
             } catch (RuntimeException e) {
                 if (scriptField.ignoreException()) {
                     continue;

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -565,11 +565,6 @@ public class SumIT extends AbstractNumericTestCase {
                     return new LeafSearchScript() {
 
                         @Override
-                        public Object unwrap(Object value) {
-                            throw new UnsupportedOperationException();
-                        }
-
-                        @Override
                         public void setNextVar(String name, Object value) {
                             vars.put(name, value);
                         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
@@ -306,11 +306,6 @@ public class ValueCountIT extends ESIntegTestCase {
                     return new LeafSearchScript() {
 
                         @Override
-                        public Object unwrap(Object value) {
-                            throw new UnsupportedOperationException();
-                        }
-
-                        @Override
                         public void setNextVar(String name, Object value) {
                             vars.put(name, value);
                         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/support/ScriptValuesTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/support/ScriptValuesTests.java
@@ -59,11 +59,6 @@ public class ScriptValuesTests extends ESTestCase {
         }
 
         @Override
-        public Object unwrap(Object value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public void setScorer(Scorer scorer) {
         }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/SimpleExecutableScript.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/SimpleExecutableScript.java
@@ -50,16 +50,4 @@ public class SimpleExecutableScript implements ExecutableScript {
             throw new IllegalArgumentException("Unsupported var [" + name + "]");
         }
     }
-
-    @Override
-    public Object unwrap(Object value) {
-        // Some script engines (javascript) copy any maps they unwrap
-        if (randomBoolean()) {
-            if (value instanceof Map) {
-                return new HashMap<>((Map<?, ?>) value);
-            }
-        }
-        // Others just return the objects plain (painless)
-        return value;
-    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/script/TestScript.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/script/TestScript.java
@@ -56,9 +56,4 @@ public abstract class TestScript implements ExecutableScript{
         Objects.requireNonNull(_superset_freq, "_superset_freq");
         Objects.requireNonNull(_superset_size, "_superset_size");
     }
-
-    @Override
-    public Double unwrap(Object value) {
-        return ((Number) value).doubleValue();
-    }
 }


### PR DESCRIPTION
The unwrap method was leftover from support javascript and python. Since
those languages are removed in 6.0, this commit removes the unwrap
feature from scripts.