### PR TITLE
Fix delete of plugin directory on remove plugin

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
@@ -114,21 +114,22 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
          */
         try (Stream<Path> paths = Files.list(pluginDir)) {
             pluginPaths.addAll(paths.collect(Collectors.toList()));
-            try {
-                Files.createFile(removing);
-            } catch (final FileAlreadyExistsException e) {
-                /*
-                 * We need to suppress the marker file already existing as we could be in this state if a previous removal attempt failed
-                 * and the user is attempting to remove the plugin again.
-                 */
-                terminal.println(VERBOSE, "marker file [" + removing + "] already exists");
-            }
-            // now add the marker file
-            pluginPaths.add(removing);
-            // finally, delete the plugin directory
-            pluginPaths.add(pluginDir);
-            IOUtils.rm(pluginPaths.toArray(new Path[pluginPaths.size()]));
         }
+        try {
+            Files.createFile(removing);
+        } catch (final FileAlreadyExistsException e) {
+            /*
+             * We need to suppress the marker file already existing as we could be in this state if a previous removal attempt failed and
+             * the user is attempting to remove the plugin again.
+             */
+            terminal.println(VERBOSE, "marker file [" + removing + "] already exists");
+        }
+        // now add the marker file
+        pluginPaths.add(removing);
+        // finally, delete the plugin directory
+        pluginPaths.add(pluginDir);
+        IOUtils.rm(pluginPaths.toArray(new Path[pluginPaths.size()]));
+
 
         /*
          * We preserve the config files in case the user is upgrading the plugin, but we print a

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
@@ -126,7 +126,7 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
         }
         // now add the marker file
         pluginPaths.add(removing);
-        // finally, delete the plugin directory
+        // finally, add the plugin directory
         pluginPaths.add(pluginDir);
         IOUtils.rm(pluginPaths.toArray(new Path[pluginPaths.size()]));
 

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
@@ -36,6 +36,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.cli.Terminal.Verbosity.VERBOSE;
 
@@ -110,21 +112,23 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
          * Add the contents of the plugin directory before creating the marker file and adding it to the list of paths to be deleted so
          * that the marker file is the last file to be deleted.
          */
-        Files.list(pluginDir).forEach(pluginPaths::add);
-        try {
-            Files.createFile(removing);
-        } catch (final FileAlreadyExistsException e) {
+        try (Stream<Path> paths =  Files.list(pluginDir)) {
+            pluginPaths.addAll(paths.collect(Collectors.toList()));
+            try {
+                Files.createFile(removing);
+            } catch (final FileAlreadyExistsException e) {
             /*
              * We need to suppress the marker file already existing as we could be in this state if a previous removal attempt failed and
              * the user is attempting to remove the plugin again.
              */
-            terminal.println(VERBOSE, "marker file [" + removing + "] already exists");
+                terminal.println(VERBOSE, "marker file [" + removing + "] already exists");
+            }
+            // now add the marker file
+            pluginPaths.add(removing);
+            // finally, delete the plugin directory
+            pluginPaths.add(pluginDir);
+            IOUtils.rm(pluginPaths.toArray(new Path[pluginPaths.size()]));
         }
-        // now add the marker file
-        pluginPaths.add(removing);
-        IOUtils.rm(pluginPaths.toArray(new Path[pluginPaths.size()]));
-        // at this point, the plugin directory is empty and we can execute a simple directory removal
-        Files.delete(pluginDir);
 
         /*
          * We preserve the config files in case the user is upgrading the plugin, but we print a

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
@@ -112,15 +112,15 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
          * Add the contents of the plugin directory before creating the marker file and adding it to the list of paths to be deleted so
          * that the marker file is the last file to be deleted.
          */
-        try (Stream<Path> paths =  Files.list(pluginDir)) {
+        try (Stream<Path> paths = Files.list(pluginDir)) {
             pluginPaths.addAll(paths.collect(Collectors.toList()));
             try {
                 Files.createFile(removing);
             } catch (final FileAlreadyExistsException e) {
-            /*
-             * We need to suppress the marker file already existing as we could be in this state if a previous removal attempt failed and
-             * the user is attempting to remove the plugin again.
-             */
+                /*
+                 * We need to suppress the marker file already existing as we could be in this state if a previous removal attempt failed
+                 * and the user is attempting to remove the plugin again.
+                 */
                 terminal.println(VERBOSE, "marker file [" + removing + "] already exists");
             }
             // now add the marker file


### PR DESCRIPTION
This commit fixes an issue when deleting the plugin directory while executing the remove plugin command. Namely, we take out a file descriptor on the plugin directory to traverse its contents to obtain the list of files to delete. We leaked this file descriptor. On Unix-based filesystems, this is not a problem, deleting the plugin directory deletes the plugin directory. On Windows though, a delete is not executed until the last file descriptor is closed. Since we leaked this file descriptor, the plugin was not actually deleted. This led to test failures that tried to cleanup left behind temporary directories but these test failures were just exposing this bug. This commit fixes this issue by ensuring that we close the file descriptor to the plugin directory when we are finished with it.

Relates #24252
 
