### PR TITLE
Replace deprecated pluginList with Arrays.asList

### DIFF
--- a/docs/reference/testing/testing-framework.asciidoc
+++ b/docs/reference/testing/testing-framework.asciidoc
@@ -171,7 +171,7 @@ As elasticsearch is using JUnit 4, using the `@Before` and `@After` annotations 
 -----------------------------------------
 @Override
 protected Collection<Class<? extends Plugin>> nodePlugins() {
-  return pluginList(CustomSuggesterPlugin.class);
+  return Arrays.asList(CustomSuggesterPlugin.class);
 }
 -----------------------------------------
 


### PR DESCRIPTION
ESIntegTestCase#pluginList was removed in ES 5.0. We are using Arrays.asList instead.

[Source: Plugin changes in 5.0](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_plugins.html#_testing_custom_plugins)