### PR TITLE
Templates: Add compileTemplate method to ScriptService for template consumers

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -30,6 +30,7 @@ import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.template.CompiledTemplate;
 
 import java.util.function.LongSupplier;
 
@@ -105,8 +106,7 @@ public class QueryRewriteContext {
     }
 
     public BytesReference getTemplateBytes(Script template) {
-        CompiledScript compiledTemplate = scriptService.compile(template, ScriptContext.Standard.SEARCH);
-        ExecutableScript executable = scriptService.executable(compiledTemplate, template.getParams());
-        return (BytesReference) executable.run();
+        CompiledTemplate compiledTemplate = scriptService.compileTemplate(template, ScriptContext.Standard.SEARCH);
+        return compiledTemplate.run(template.getParams());
     }
 }

--- a/core/src/main/java/org/elasticsearch/ingest/InternalTemplateService.java
+++ b/core/src/main/java/org/elasticsearch/ingest/InternalTemplateService.java
@@ -19,16 +19,16 @@
 
 package org.elasticsearch.ingest;
 
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.script.CompiledScript;
-import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
-
-import java.util.Collections;
-import java.util.Map;
+import org.elasticsearch.template.CompiledTemplate;
 
 public class InternalTemplateService implements TemplateService {
 
@@ -44,16 +44,11 @@ public class InternalTemplateService implements TemplateService {
         int mustacheEnd = template.indexOf("}}");
         if (mustacheStart != -1 && mustacheEnd != -1 && mustacheStart < mustacheEnd) {
             Script script = new Script(ScriptType.INLINE, "mustache", template, Collections.emptyMap());
-            CompiledScript compiledScript = scriptService.compile(script, ScriptContext.Standard.INGEST);
+            CompiledTemplate compiledTemplate = scriptService.compileTemplate(script, ScriptContext.Standard.INGEST);
             return new Template() {
                 @Override
                 public String execute(Map<String, Object> model) {
-                    ExecutableScript executableScript = scriptService.executable(compiledScript, model);
-                    Object result = executableScript.run();
-                    if (result instanceof BytesReference) {
-                        return ((BytesReference) result).utf8ToString();
-                    }
-                    return String.valueOf(result);
+                    return compiledTemplate.run(model).utf8ToString();
                 }
 
                 @Override

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -324,7 +324,6 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
 
     /** Compiles a template. Note this will be moved to a separate TemplateService in the future. */
     public CompiledTemplate compileTemplate(Script script, ScriptContext scriptContext) {
-        assert script.getLang().equals("mustache"); // mustache is the only template language truly supported right now
         CompiledScript compiledScript = compile(script, scriptContext);
         return params -> (BytesReference)executable(compiledScript, params).run();
     }

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.cache.RemovalListener;
@@ -56,6 +57,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.template.CompiledTemplate;
 import org.elasticsearch.watcher.FileChangesListener;
 import org.elasticsearch.watcher.FileWatcher;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -318,6 +320,13 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
 
             return compiledScript;
         }
+    }
+
+    /** Compiles a template. Note this will be moved toa  separate TemplateService in the future. */
+    public CompiledTemplate compileTemplate(Script script, ScriptContext scriptContext) {
+        assert script.getLang().equals("mustache"); // mustache is the only template language truly supported right now
+        CompiledScript compiledScript = compile(script, scriptContext);
+        return params -> (BytesReference)executable(compiledScript, params).run();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -322,7 +322,7 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
         }
     }
 
-    /** Compiles a template. Note this will be moved toa  separate TemplateService in the future. */
+    /** Compiles a template. Note this will be moved to a separate TemplateService in the future. */
     public CompiledTemplate compileTemplate(Script script, ScriptContext scriptContext) {
         assert script.getLang().equals("mustache"); // mustache is the only template language truly supported right now
         CompiledScript compiledScript = compile(script, scriptContext);

--- a/core/src/main/java/org/elasticsearch/template/CompiledTemplate.java
+++ b/core/src/main/java/org/elasticsearch/template/CompiledTemplate.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.template;
+
+import java.util.Map;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.script.CompiledScript;
+import org.elasticsearch.script.ScriptType;
+
+/**
+ * A template that may be executed.
+ */
+public interface CompiledTemplate {
+
+    /** Run a template and return the resulting string, encoded in utf8 bytes. */
+    BytesReference run(Map<String, Object> params);
+}

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.script.mustache;
 
+import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -39,6 +40,7 @@ import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.template.CompiledTemplate;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -72,10 +74,8 @@ public class TransportSearchTemplateAction extends HandledTransportAction<Search
         try {
             Script script = new Script(request.getScriptType(), TEMPLATE_LANG, request.getScript(),
                 request.getScriptParams() == null ? Collections.emptyMap() : request.getScriptParams());
-            CompiledScript compiledScript = scriptService.compile(script, SEARCH);
-            ExecutableScript executable = scriptService.executable(compiledScript, script.getParams());
-
-            BytesReference source = (BytesReference) executable.run();
+            CompiledTemplate compiledScript = scriptService.compileTemplate(script, SEARCH);
+            BytesReference source = compiledScript.run(script.getParams());
             response.setSource(source);
 
             if (request.isSimulate()) {


### PR DESCRIPTION
This commit adds a compileTemplate method to the ScriptService.
Eventually this will be used to easily cutover all consumers to a new
TemplateService.

relates #16314