### PR TITLE
Allow painless to load stored fields

### DIFF
--- a/docs/reference/modules/scripting/fields.asciidoc
+++ b/docs/reference/modules/scripting/fields.asciidoc
@@ -48,13 +48,13 @@ relevance `_score` of each document:
 
 [source,js]
 -------------------------------------
-PUT my_index/my_type/1
+PUT my_index/my_type/1?refresh
 {
   "text": "quick brown fox",
   "popularity": 1
 }
 
-PUT my_index/my_type/2
+PUT my_index/my_type/2?refresh
 {
   "text": "quick fox",
   "popularity": 5
@@ -93,7 +93,7 @@ store, enabled by default on all fields except for <<text,analyzed `text` fields
 
 [source,js]
 -------------------------------
-PUT my_index/my_type/1
+PUT my_index/my_type/1?refresh
 {
   "cost_price": 100
 }
@@ -186,7 +186,7 @@ PUT my_index
   }
 }
 
-PUT my_index/my_type/1
+PUT my_index/my_type/1?refresh
 {
   "title": "Mr",
   "first_name": "Barry",
@@ -229,4 +229,3 @@ The only time it really makes sense to use stored fields instead of the
 access a few small stored fields instead of the entire `_source`.
 
 =======================================================
-

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
@@ -156,3 +156,9 @@ class org.elasticsearch.painless.FeatureTest -> org.elasticsearch.painless.Featu
   boolean overloadedStatic(boolean)
   Object twoFunctionsOfX(Function,Function)
 }
+
+class org.elasticsearch.search.lookup.FieldLookup -> org.elasticsearch.search.lookup.FieldLookup extends Object {
+  def getValue()
+  List getValues()
+  boolean isEmpty()
+}


### PR DESCRIPTION
We document that painless can load stored fields but it can't
because the classes that make that work aren't whitelisted.
