### PR TITLE
Remove getCountAsString() from InternalStats and Stats interface

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/InternalStats.java
@@ -113,11 +113,6 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
     }
 
     @Override
-    public String getCountAsString() {
-        return valueAsString(Metrics.count.name());
-    }
-
-    @Override
     public String getMinAsString() {
         return valueAsString(Metrics.min.name());
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/Stats.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/Stats.java
@@ -51,11 +51,6 @@ public interface Stats extends NumericMetricsAggregation.MultiValue {
     double getSum();
 
     /**
-     * @return The number of values that were aggregated as a String.
-     */
-    String getCountAsString();
-
-    /**
      * @return The minimum value of all aggregated values as a String.
      */
     String getMinAsString();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
@@ -214,7 +214,6 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
         assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
         assertThat(stats.getSumAsString(), equalTo("0055.0"));
         assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getCountAsString(), equalTo("0010.0"));
         assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
         assertThat(stats.getSumOfSquaresAsString(), equalTo("0385.0"));
         assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
@@ -162,7 +162,6 @@ public class StatsIT extends AbstractNumericTestCase {
         assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
         assertThat(stats.getSumAsString(), equalTo("0055.0"));
         assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getCountAsString(), equalTo("0010.0"));
     }
 
     @Override

--- a/docs/reference/migration/migrate_6_0/java.asciidoc
+++ b/docs/reference/migration/migrate_6_0/java.asciidoc
@@ -13,3 +13,9 @@ providing the source in bytes or as a string.
 In previous versions of Elasticsearch, delete by query requests without an explicit query
 were accepted, match_all was used as the default query and all documents were deleted
 as a result. From version 6.0.0, a `DeleteByQueryRequest` requires an explicit query be set.
+
+=== `InternalStats` and `Stats` getCountAsString() method removed
+
+The `count` value in the stats aggregation represents a doc count that shouldnn't require a formatted 
+version. This method was deprecated in 5.4 in favour of just using
+`String.valueOf(getCount())` if needed


### PR DESCRIPTION
The `count` value in the stats aggregation represents a simple doc count
that shouldn't require a formatted version. We didn't render an "as_string"
version for count in the rest response, so the method should also be
removed in favour of just using String.valueOf(getCount()) if a string
version of the count is needed.

Closes #24287

