### PR TITLE
Deprecate Stats#getCountAsString

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/Stats.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/Stats.java
@@ -52,7 +52,9 @@ public interface Stats extends NumericMetricsAggregation.MultiValue {
 
     /**
      * @return The number of values that were aggregated as a String.
+     * @deprecated use String.valueOf(getCount()) instead if the count is needed as a string
      */
+    @Deprecated
     String getCountAsString();
 
     /**


### PR DESCRIPTION
We don't render an "count_as_string" in the rest response,
so the method should also be removed in favour of just using
String.valueOf(getCount()) if a string version of the count is needed.

