### PR TITLE
Update exists-query.asciidoc

### DIFF
--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -51,7 +51,7 @@ instance, if the `user` field were mapped as follows:
 [source,js]
 --------------------------------------------------
   "user": {
-    "type": "text",
+    "type": "keyword",
     "null_value": "_null_"
   }
 --------------------------------------------------


### PR DESCRIPTION
`null_value` parameter is not supported for `text` data type. So I changed mapping of `user` from `text` to `keyword`.
