### PR TITLE
Add mention about field index setting to _all

### DIFF
--- a/docs/reference/mapping/fields/all-field.asciidoc
+++ b/docs/reference/mapping/fields/all-field.asciidoc
@@ -74,6 +74,8 @@ The `_all` field is not free: it requires extra CPU cycles and uses more disk
 space. For this reason, it is disabled by default. If needed, it can be
 <<enabling-all-field,enabled>>.
 
+If a field is not <<mapping-index,indexed>>, it will also not be included in `_all`.
+
 [[querying-all-field]]
 ==== Using the `_all` field in queries
 


### PR DESCRIPTION
Disabling `_all` has a near-zero impact on disk usage if `index: false` is used on all the index's fields. Additionally, I can't find documents by querying `_all` even if it's enabled, and the field's `index` is disabled. So pretty safe to conclude that `_all` only contains content of indexed fields. Although this might be very obvious to some I think it's still valuable to mention that Elasticsearch behaves this way.

I would appreciate an engineer to confirm my observations though, in case something was missed.