### PR TITLE
Add note on risk of split brains to zen.asciidoc

### DIFF
--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -77,9 +77,10 @@ complete and for the elected node to accept its mastership. The same setting con
 active master eligible nodes that should be a part of any active cluster. If this requirement is not met the
 active master node will step down and a new master election will be begin.
 
-This setting must be set to a quorum of your <<modules-node,master eligible nodes>>. It is recommended to avoid
-having only two master eligible nodes, since a quorum of two is two. Therefore, a loss
-of either master eligible node will result in an inoperable cluster.
+This setting must be set to a <<minimum_master_nodes,quorum>> of your master
+eligible nodes. It is recommended to avoid having only two master eligible
+nodes, since a quorum of two is two. Therefore, a loss of either master
+eligible node will result in an inoperable cluster.
 
 [float]
 [[fault-detection]]

--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -77,7 +77,7 @@ complete and for the elected node to accept its mastership. The same setting con
 active master eligible nodes that should be a part of any active cluster. If this requirement is not met the
 active master node will step down and a new master election will be begin.
 
-This setting must be set to a quorum of your master eligible nodes. It is recommended to avoid
+This setting must be set to a quorum of your <<modules-node,master eligible nodes>>. It is recommended to avoid
 having only two master eligible nodes, since a quorum of two is two. Therefore, a loss
 of either master eligible node will result in an inoperable cluster.
 
@@ -140,7 +140,7 @@ The `discovery.zen.no_master_block` setting has two valid options:
 `all`:: All operations on the node--i.e. both read & writes--will be rejected. This also applies for api cluster state
 read or write operations, like the get index settings, put mapping and cluster state api.
 `write`:: (default) Write operations will be rejected. Read operations will succeed, based on the last known cluster configuration.
-This may result in partial reads of stale data as this node may be isolated from the rest of the cluster. 
+This may result in partial reads of stale data as this node may be isolated from the rest of the cluster.
 
 The `discovery.zen.no_master_block` setting doesn't apply to nodes-based apis (for example cluster stats, node info and
 node stats apis).  Requests to these apis will not be blocked and can run on any available node.


### PR DESCRIPTION
I propose this change to clarify documentation and to verify my
understanding of the implications of minimum_master_nodes and the
number of actual master nodes.

