### PR TITLE
Add parsing for InternalStatsBucket and InternalExtendedStatsBucket

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ParsedExtendedStats.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/stats/extended/ParsedExtendedStats.java
@@ -142,6 +142,11 @@ public class ParsedExtendedStats extends ParsedStats implements ExtendedStats {
     private static final ObjectParser<ParsedExtendedStats, Void> PARSER = new ObjectParser<>(ParsedExtendedStats.class.getSimpleName(), true,
             ParsedExtendedStats::new);
 
+    static {
+        declareExtendedStatsFields(PARSER);
+    }
+
+
     private static final ConstructingObjectParser<Tuple<Double, Double>, Void> STD_BOUNDS_PARSER = new ConstructingObjectParser<>(
             ParsedExtendedStats.class.getSimpleName() + "_STD_BOUNDS", true, args -> new Tuple<>((Double) args[0], (Double) args[1]));
     static {
@@ -158,23 +163,23 @@ public class ParsedExtendedStats extends ParsedStats implements ExtendedStats {
         STD_BOUNDS_AS_STRING_PARSER.declareString(constructorArg(), new ParseField(Fields.UPPER));
     }
 
-    static {
-        declareAggregationFields(PARSER);
-        declareStatsFields(PARSER);
-        PARSER.declareField((agg, value) -> agg.sumOfSquares = value, (parser, context) -> parseDouble(parser, 0),
+    protected static void declareExtendedStatsFields(ObjectParser<? extends ParsedExtendedStats, Void> objectParser) {
+        declareAggregationFields(objectParser);
+        declareStatsFields(objectParser);
+        objectParser.declareField((agg, value) -> agg.sumOfSquares = value, (parser, context) -> parseDouble(parser, 0),
                 new ParseField(Fields.SUM_OF_SQRS), ValueType.DOUBLE_OR_NULL);
-        PARSER.declareField((agg, value) -> agg.variance = value, (parser, context) -> parseDouble(parser, 0),
+        objectParser.declareField((agg, value) -> agg.variance = value, (parser, context) -> parseDouble(parser, 0),
                 new ParseField(Fields.VARIANCE), ValueType.DOUBLE_OR_NULL);
-        PARSER.declareField((agg, value) -> agg.stdDeviation = value, (parser, context) -> parseDouble(parser, 0),
+        objectParser.declareField((agg, value) -> agg.stdDeviation = value, (parser, context) -> parseDouble(parser, 0),
                 new ParseField(Fields.STD_DEVIATION), ValueType.DOUBLE_OR_NULL);
-        PARSER.declareObject(ParsedExtendedStats::setStdDeviationBounds, STD_BOUNDS_PARSER, new ParseField(Fields.STD_DEVIATION_BOUNDS));
-        PARSER.declareString((agg, value) -> agg.valueAsString.put(Fields.SUM_OF_SQRS_AS_STRING, value),
+        objectParser.declareObject(ParsedExtendedStats::setStdDeviationBounds, STD_BOUNDS_PARSER, new ParseField(Fields.STD_DEVIATION_BOUNDS));
+        objectParser.declareString((agg, value) -> agg.valueAsString.put(Fields.SUM_OF_SQRS_AS_STRING, value),
                 new ParseField(Fields.SUM_OF_SQRS_AS_STRING));
-        PARSER.declareString((agg, value) -> agg.valueAsString.put(Fields.VARIANCE_AS_STRING, value),
+        objectParser.declareString((agg, value) -> agg.valueAsString.put(Fields.VARIANCE_AS_STRING, value),
                 new ParseField(Fields.VARIANCE_AS_STRING));
-        PARSER.declareString((agg, value) -> agg.valueAsString.put(Fields.STD_DEVIATION_AS_STRING, value),
+        objectParser.declareString((agg, value) -> agg.valueAsString.put(Fields.STD_DEVIATION_AS_STRING, value),
                 new ParseField(Fields.STD_DEVIATION_AS_STRING));
-        PARSER.declareObject(ParsedExtendedStats::setStdDeviationBoundsAsString, STD_BOUNDS_AS_STRING_PARSER,
+        objectParser.declareObject(ParsedExtendedStats::setStdDeviationBoundsAsString, STD_BOUNDS_AS_STRING_PARSER,
                 new ParseField(Fields.STD_DEVIATION_BOUNDS_AS_STRING));
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/ParsedStatsBucket.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/ParsedStatsBucket.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats;
+
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.metrics.stats.ParsedStats;
+
+
+public class ParsedStatsBucket extends ParsedStats implements StatsBucket {
+
+    @Override
+    protected String getType() {
+        return StatsBucketPipelineAggregationBuilder.NAME;
+    }
+
+    private static final ObjectParser<ParsedStatsBucket, Void> PARSER = new ObjectParser<>(
+            ParsedStatsBucket.class.getSimpleName(), true, ParsedStatsBucket::new);
+
+    static {
+        declareStatsFields(PARSER);
+    }
+
+    public static ParsedStatsBucket fromXContent(XContentParser parser, final String name) {
+        ParsedStatsBucket parsedStatsBucket = PARSER.apply(parser, null);
+        parsedStatsBucket.setName(name);
+        return parsedStatsBucket;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/extended/ParsedExtendedStatsBucket.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/extended/ParsedExtendedStatsBucket.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.extended;
+
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.ParsedExtendedStats;
+
+
+public class ParsedExtendedStatsBucket extends ParsedExtendedStats implements ExtendedStatsBucket {
+
+    @Override
+    protected String getType() {
+        return ExtendedStatsBucketPipelineAggregationBuilder.NAME;
+    }
+
+    private static final ObjectParser<ParsedExtendedStatsBucket, Void> PARSER = new ObjectParser<>(
+            ParsedExtendedStatsBucket.class.getSimpleName(), true, ParsedExtendedStatsBucket::new);
+
+    static {
+        declareExtendedStatsFields(PARSER);
+    }
+
+    public static ParsedExtendedStatsBucket fromXContent(XContentParser parser, final String name) {
+        ParsedExtendedStatsBucket parsedStatsBucket = PARSER.apply(parser, null);
+        parsedStatsBucket.setName(name);
+        return parsedStatsBucket;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
@@ -63,6 +63,8 @@ import org.elasticsearch.search.aggregations.pipeline.ParsedSimpleValue;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.InternalBucketMetricValue;
 import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.ParsedBucketMetricValue;
+import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.ParsedStatsBucket;
+import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.StatsBucketPipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.extended.ExtendedStatsBucketPipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.extended.ParsedExtendedStatsBucket;
 import org.elasticsearch.search.aggregations.pipeline.derivative.DerivativePipelineAggregationBuilder;
@@ -106,6 +108,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         namedXContents.put(DerivativePipelineAggregationBuilder.NAME, (p, c) -> ParsedDerivative.fromXContent(p, (String) c));
         namedXContents.put(InternalBucketMetricValue.NAME, (p, c) -> ParsedBucketMetricValue.fromXContent(p, (String) c));
         namedXContents.put(StatsAggregationBuilder.NAME, (p, c) -> ParsedStats.fromXContent(p, (String) c));
+        namedXContents.put(StatsBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedStatsBucket.fromXContent(p, (String) c));
         namedXContents.put(ExtendedStatsAggregationBuilder.NAME, (p, c) -> ParsedExtendedStats.fromXContent(p, (String) c));
         namedXContents.put(ExtendedStatsBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedExtendedStatsBucket.fromXContent(p, (String) c));
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
@@ -63,6 +63,8 @@ import org.elasticsearch.search.aggregations.pipeline.ParsedSimpleValue;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.InternalBucketMetricValue;
 import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.ParsedBucketMetricValue;
+import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.extended.ExtendedStatsBucketPipelineAggregationBuilder;
+import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.extended.ParsedExtendedStatsBucket;
 import org.elasticsearch.search.aggregations.pipeline.derivative.DerivativePipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.derivative.ParsedDerivative;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -105,6 +107,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         namedXContents.put(InternalBucketMetricValue.NAME, (p, c) -> ParsedBucketMetricValue.fromXContent(p, (String) c));
         namedXContents.put(StatsAggregationBuilder.NAME, (p, c) -> ParsedStats.fromXContent(p, (String) c));
         namedXContents.put(ExtendedStatsAggregationBuilder.NAME, (p, c) -> ParsedExtendedStats.fromXContent(p, (String) c));
+        namedXContents.put(ExtendedStatsBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedExtendedStatsBucket.fromXContent(p, (String) c));
 
         return namedXContents.entrySet().stream()
                 .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue()))

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 public class InternalExtendedStatsTests extends InternalAggregationTestCase<InternalExtendedStats> {
-    private double sigma;
+    protected double sigma;
 
     @Before
     public void randomSigma() {
@@ -48,8 +48,12 @@ public class InternalExtendedStatsTests extends InternalAggregationTestCase<Inte
         double max = randomDoubleBetween(-1000000, 1000000, true);
         double sum = randomDoubleBetween(-1000000, 1000000, true);
         DocValueFormat format = randomNumericDocValueFormat();
-        return new InternalExtendedStats(name, count, sum, min, max, randomDoubleBetween(0, 1000000, true), sigma, format,
-                pipelineAggregators, metaData);
+        return createInstance(name, count, sum, min, max, randomDoubleBetween(0, 1000000, true), sigma, format, pipelineAggregators, metaData);
+    }
+
+    protected InternalExtendedStats createInstance(String name, long count, double sum, double min, double max, double sumOfSqrs,
+            double sigma, DocValueFormat formatter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        return new InternalExtendedStats(name, count, sum, min, max, sumOfSqrs, sigma, formatter, pipelineAggregators, metaData);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsBucketTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsBucketTests.java
@@ -17,26 +17,26 @@
  * under the License.
  */
 
-package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.extended;
+package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.metrics.InternalExtendedStatsTests;
-import org.elasticsearch.search.aggregations.metrics.stats.extended.InternalExtendedStats;
+import org.elasticsearch.search.aggregations.metrics.stats.InternalStats;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.InternalStatsBucket;
+import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.ParsedStatsBucket;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class InternalExtendedStatsBucketTests extends InternalExtendedStatsTests {
+public class InternalStatsBucketTests extends InternalStatsTests {
 
     @Override
-    protected InternalExtendedStatsBucket createInstance(String name, long count, double sum, double min, double max, double sumOfSqrs,
-            double sigma, DocValueFormat formatter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        return new InternalExtendedStatsBucket(name, count, sum, min, max, sumOfSqrs, sigma, formatter, pipelineAggregators,
-                Collections.emptyMap());
+    protected InternalStatsBucket createInstance(String name, long count, double sum, double min, double max,
+            DocValueFormat formatter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        return new InternalStatsBucket(name, count, sum, min, max, formatter, pipelineAggregators, metaData);
     }
 
     @Override
@@ -46,18 +46,18 @@ public class InternalExtendedStatsBucketTests extends InternalExtendedStatsTests
     }
 
     @Override
-    protected void assertReduced(InternalExtendedStats reduced, List<InternalExtendedStats> inputs) {
+    protected void assertReduced(InternalStats reduced, List<InternalStats> inputs) {
         // no test since reduce operation is unsupported
     }
 
     @Override
-    protected Writeable.Reader<InternalExtendedStats> instanceReader() {
-        return InternalExtendedStatsBucket::new;
+    protected Writeable.Reader<InternalStats> instanceReader() {
+        return InternalStatsBucket::new;
     }
 
     @Override
-    protected void assertFromXContent(InternalExtendedStats aggregation, ParsedAggregation parsedAggregation) {
+    protected void assertFromXContent(InternalStats aggregation, ParsedAggregation parsedAggregation) {
         super.assertFromXContent(aggregation, parsedAggregation);
-        assertTrue(parsedAggregation instanceof ParsedExtendedStatsBucket);
+        assertTrue(parsedAggregation instanceof ParsedStatsBucket);
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
@@ -38,7 +38,12 @@ public class InternalStatsTests extends InternalAggregationTestCase<InternalStat
         double max = randomDoubleBetween(-1000000, 1000000, true);
         double sum = randomDoubleBetween(-1000000, 1000000, true);
         DocValueFormat format = randomNumericDocValueFormat();
-        return new InternalStats(name, count, sum, min, max, format, pipelineAggregators, metaData);
+        return createInstance(name, count, sum, min, max, format, pipelineAggregators, metaData);
+    }
+
+    protected InternalStats createInstance(String name, long count, double sum, double min, double max, DocValueFormat formatter,
+            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        return new InternalStats(name, count, sum, min, max, formatter, pipelineAggregators, metaData);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/extended/InternalExtendedStatsBucketTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/stats/extended/InternalExtendedStatsBucketTests.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.extended;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.metrics.InternalExtendedStatsTests;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.InternalExtendedStats;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class InternalExtendedStatsBucketTests extends InternalExtendedStatsTests {
+
+    @Override
+    protected InternalExtendedStatsBucket createInstance(String name, long count, double sum, double min, double max, double sumOfSqrs,
+            double sigma, DocValueFormat formatter, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+        return new InternalExtendedStatsBucket(name, count, sum, min, max, sumOfSqrs, sigma, formatter, pipelineAggregators,
+                Collections.emptyMap());
+    }
+
+    @Override
+    public void testReduceRandom() {
+        expectThrows(UnsupportedOperationException.class,
+                () -> createTestInstance("name", Collections.emptyList(), null).reduce(null, null));
+    }
+
+    @Override
+    protected void assertReduced(InternalExtendedStats reduced, List<InternalExtendedStats> inputs) {
+        // no test since reduce operation is unsupported
+    }
+
+    @Override
+    protected Writeable.Reader<InternalExtendedStats> instanceReader() {
+        return InternalExtendedStatsBucket::new;
+    }
+}


### PR DESCRIPTION
These are variant of the InternalStats and InternalExtendedStats. Most of the existing code can be shared,
so this PR only rearranges some common code to be accessible by the new subclasses.

Based on #24284 which should go in first.
PR is against feature branch.