### PR TITLE
Agg builder accessibility fixes

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -68,6 +69,16 @@ public abstract class AggregationBuilder
 
     /** Add a sub aggregation to this builder. */
     public abstract AggregationBuilder subAggregation(PipelineAggregationBuilder aggregation);
+
+    /** Return the configured set of subaggregations **/
+    public List<AggregationBuilder> getSubAggregations() {
+        return factoriesBuilder.getAggregatorFactories();
+    }
+
+    /** Return the configured set of pipeline aggregations **/
+    public List<PipelineAggregationBuilder> getPipelineAggregations() {
+        return factoriesBuilder.getPipelineAggregatorFactories();
+    }
 
     /**
      * Internal: Registers sub-factories with this factory. The sub-factory will be

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregationBuilder.java
@@ -102,4 +102,8 @@ public class FilterAggregationBuilder extends AbstractAggregationBuilder<FilterA
     public String getType() {
         return NAME;
     }
+
+    public QueryBuilder getFilter() {
+        return filter;
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilder.java
@@ -164,7 +164,7 @@ public class DateHistogramAggregationBuilder
     }
 
     /** Get the current interval in milliseconds that is set on this builder. */
-    public double interval() {
+    public long interval() {
         return interval;
     }
 
@@ -196,7 +196,7 @@ public class DateHistogramAggregationBuilder
     }
 
     /** Get the offset to use when rounding, which is a number of milliseconds. */
-    public double offset() {
+    public long offset() {
         return offset;
     }
 


### PR DESCRIPTION
Just some minor tweaks.  Was walking aggregation trees but found that some getters were not available... and I couldn't see a particular reason why they shouldn't be.

- Add getter for the filter in a FilterAgg
- Add getters for subaggs / pipelines in base AggregationBuilder
- Getters for DateHisto `interval` and ~~`order`~~ `offset` should return a long, not double

