### PR TITLE
Give LongGCDisruptionTests longer to trigger

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/LongGCDisruption.java
@@ -229,7 +229,7 @@ public class LongGCDisruption extends SingleNodeDisruption {
                     liveThreadsFound = true;
                     logger.trace("stopping thread [{}]", threadName);
                     thread.suspend();
-                    // double check the thread is not in a shared resource like logging. If so, let it go and come back..
+                    // double check the thread is not in a shared resource like logging. If so, let it go and come back.
                     boolean safe = true;
                     safe:
                     for (StackTraceElement stackElement : thread.getStackTrace()) {

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
@@ -61,7 +61,7 @@ public class LongGCDisruptionTests extends ESTestCase {
 
             @Override
             protected long getStoppingTimeoutInMillis() {
-                return 100;
+                return 1000; // 100ms has failed spuriously in the past so let's try a second....
             }
         };
         final AtomicBoolean stop = new AtomicBoolean();
@@ -229,7 +229,7 @@ public class LongGCDisruptionTests extends ESTestCase {
             // make sure some threads of test_node are under lock
             underLock.await();
             disruption.startDisrupting();
-            waitForBlockDetectionResult.await(30, TimeUnit.SECONDS);
+            assertTrue("didn't catch a blocked thread after 30 seconds", waitForBlockDetectionResult.await(30, TimeUnit.SECONDS));
             disruption.stopDisrupting();
 
             ThreadInfo threadInfo = blockDetectionResult.get();


### PR DESCRIPTION
The newly resurrected LongGCDisruptionTests failed to trigger a
disruption in 100ms in this build:
https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+5.x+multijob-unix-compatibility/os=debian/730/consoleFull

Let's give them a whole second to trigger a disruption!
