### PR TITLE
Set allow_no_indices to false for delete index

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
@@ -38,7 +38,7 @@ public class DeleteIndexRequest extends AcknowledgedRequest<DeleteIndexRequest> 
 
     private String[] indices;
     // Delete index should work by default on both open and closed indices.
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true);
+    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, true);
 
     public DeleteIndexRequest() {
     }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexIT.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.delete;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+public class DeleteIndexIT extends ESSingleNodeTestCase {
+    
+    // by default, if the wildcard cannot be resolved to an index, throw IndexNotFoundException
+    public void testIndicesDoNotExistDefault() {
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareDelete("test").execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareDelete("test*").execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareDelete("*").execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareDelete("_all").execute().actionGet());
+    }
+    
+    // if allow_no_indices=true and the wildcard cannot be resolved to a concrete index, delete is a no-op
+    public void testIndicesDoNotExistAllowNoIndices() throws InterruptedException, ExecutionException {
+        IndicesOptions deleteIndicesOptions = IndicesOptions.fromOptions(false, true, true, true);
+        expectThrows(IndexNotFoundException.class,
+                () -> client().admin().indices().prepareDelete("test").setIndicesOptions(deleteIndicesOptions).execute().actionGet());
+        assertAcked(client().admin().indices().prepareDelete("test*").setIndicesOptions(deleteIndicesOptions).execute().get());
+        assertAcked(client().admin().indices().prepareDelete("*").setIndicesOptions(deleteIndicesOptions).execute().get());
+        assertAcked(client().admin().indices().prepareDelete("_all").setIndicesOptions(deleteIndicesOptions).execute().get());
+    }
+}

--- a/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -500,19 +500,20 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
     }
 
     public void testDeleteIndexWildcard() throws Exception {
-        verify(client().admin().indices().prepareDelete("_all"), false);
+        IndicesOptions deleteOptions = IndicesOptions.fromOptions(false, true, true, true);
+        verify(client().admin().indices().prepareDelete("_all").setIndicesOptions(deleteOptions), false);
 
         createIndex("foo", "foobar", "bar", "barbaz");
 
-        verify(client().admin().indices().prepareDelete("foo*"), false);
+        verify(client().admin().indices().prepareDelete("foo*").setIndicesOptions(deleteOptions), false);
         assertThat(client().admin().indices().prepareExists("foo").get().isExists(), equalTo(false));
         assertThat(client().admin().indices().prepareExists("foobar").get().isExists(), equalTo(false));
         assertThat(client().admin().indices().prepareExists("bar").get().isExists(), equalTo(true));
         assertThat(client().admin().indices().prepareExists("barbaz").get().isExists(), equalTo(true));
 
-        verify(client().admin().indices().prepareDelete("foo*"), false);
+        verify(client().admin().indices().prepareDelete("foo*").setIndicesOptions(deleteOptions), false);
 
-        verify(client().admin().indices().prepareDelete("_all"), false);
+        verify(client().admin().indices().prepareDelete("_all").setIndicesOptions(deleteOptions), false);
         assertThat(client().admin().indices().prepareExists("foo").get().isExists(), equalTo(false));
         assertThat(client().admin().indices().prepareExists("foobar").get().isExists(), equalTo(false));
         assertThat(client().admin().indices().prepareExists("bar").get().isExists(), equalTo(false));

--- a/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
@@ -21,6 +21,7 @@ package org.elasticsearch.tribe;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.support.DestructiveOperations;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -187,7 +188,8 @@ public class TribeIT extends ESIntegTestCase {
         doWithAllClusters(c -> {
             final String clusterName = c.getClusterName();
             try {
-                c.client().admin().indices().prepareDelete(MetaData.ALL).get();
+                IndicesOptions deleteOptions = IndicesOptions.fromOptions(false, true, true, true);
+                c.client().admin().indices().prepareDelete(MetaData.ALL).setIndicesOptions(deleteOptions).get();
                 c.afterTest();
             } catch (IOException e) {
                 throw new RuntimeException("Failed to clean up remote cluster [" + clusterName + "]", e);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -19,10 +19,12 @@
 package org.elasticsearch.test;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
+
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.ClusterName;
@@ -37,7 +39,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
@@ -112,7 +113,9 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     public void tearDown() throws Exception {
         logger.info("[{}#{}]: cleaning up after test", getTestClass().getSimpleName(), getTestName());
         super.tearDown();
-        assertAcked(client().admin().indices().prepareDelete("*").get());
+        IndicesOptions deleteOptions = IndicesOptions.fromOptions(false, true, true, true);
+        assertAcked(client().admin().indices().prepareDelete("*").setIndicesOptions(deleteOptions).get());
+
         MetaData metaData = client().admin().cluster().prepareState().get().getState().getMetaData();
         assertThat("test leaves persistent cluster metadata behind: " + metaData.persistentSettings().getAsMap(),
                 metaData.persistentSettings().size(), equalTo(0));

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -51,6 +51,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -186,7 +187,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         if (preserveIndicesUponCompletion() == false) {
             // wipe indices
             try {
-                adminClient().performRequest("DELETE", "*");
+                adminClient().performRequest("DELETE", "*", new HashMap<String, String>() {{
+                    put("allow_no_indices","true");
+                }});
             } catch (ResponseException e) {
                 // 404 here just means we had no indexes
                 if (e.getResponse().getStatusLine().getStatusCode() != 404) {


### PR DESCRIPTION
delete index should require at least one index to be specified as target. However the default setting for `allow_no_indices` is `true`. If the wildcard does not match any index, an acknowledgement response is sent. By changing the `allow_no_indices`to `false` an no index can be matched, an `index_not_found_exception` will be thrown.

Fixes #24104