### PR TITLE
Rewrite description of `bool`'s `should`

### DIFF
--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -22,7 +22,7 @@ and clauses are considered for caching.
 `filter` clause then a document will match the `bool` query even if none of the
 `should` queries match. In this case these clauses are only used to influence
 the score. If the `bool` query is a <<query-filter-context,filter context>>
-or has neither `must` or `should` then at least one of the `should` queries
+or has neither `must` or `filter` then at least one of the `should` queries
 must match a document for it to match the `bool` query. This behavior may be
 explicitly controlled by settings the
 <<query-dsl-minimum-should-match,`minimum_should_match`>> parameter.

--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -17,12 +17,15 @@ contribute to the score.
 in <<query-filter-context,filter context>>, meaning that scoring is ignored
 and clauses are considered for caching.
 
-|`should` |The clause (query) should appear in the matching document. In
-a boolean query with no `must` or `filter` clauses, one or more `should` clauses
-must match a document. The minimum number of should clauses to match can
-be set using the
-<<query-dsl-minimum-should-match,`minimum_should_match`>>
-parameter.
+|`should` |The clause (query) should appear in the matching document. If the
+`bool` query is in a <<query-filter-context,query context>> and has a `must` or
+`filter` clause then a document will match the `bool` query even if none of the
+`should` queries match. In this case these clauses are only used to influence
+the score. If the `bool` query is a <<query-filter-context,filter context>>
+or has neither `must` or `should` then at least one of the `should` queries
+must match a document for it to match the `bool` query. This behavior may be
+explicitly controlled by settings the
+<<query-dsl-minimum-should-match,`minimum_should_match`>> parameter.
 
 |`must_not` |The clause (query) must not appear in the matching
 documents.  Clauses are executed in <<query-filter-context,filter context>> meaning


### PR DESCRIPTION
Rewrites the description of the `bool` query's `should`
clauses so it is (hopefully) more clear what the defaults
for `minimum_should_match` are.

There is still an `[IMPORTANT]` section about `minimum_should_match`
in a filter context. I think it is worth keeping because it is, well,
important.

Closes #23831
