### PR TITLE
Removal of dead code in ScriptedMetricAggregationBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregationBuilder.java
@@ -37,10 +37,8 @@ import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 
 public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder<ScriptedMetricAggregationBuilder> {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregationBuilder.java
@@ -239,11 +239,6 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
         Map<String, Object> params = null;
         XContentParser.Token token;
         String currentFieldName = null;
-        Set<String> scriptParameters = new HashSet<>();
-        scriptParameters.add(INIT_SCRIPT_FIELD.getPreferredName());
-        scriptParameters.add(MAP_SCRIPT_FIELD.getPreferredName());
-        scriptParameters.add(COMBINE_SCRIPT_FIELD.getPreferredName());
-        scriptParameters.add(REDUCE_SCRIPT_FIELD.getPreferredName());
 
         XContentParser parser = context.parser();
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {


### PR DESCRIPTION
This code removes a few lines of dead code from ScriptedMetricAggregationBuilder. Just completely dead code, it adds things to a Set that is then not used in any way.

This PR is related to PR #24321 as requested by @jasontedor 

===========

1. Contributor agreement: Has been signed

2. Contributor guidelines: I have read them.

3. Gradle check: build successful.

4. PR is against master

5. The PR is not OS specific.

6. I'm not part of a class.