### PR TITLE
Document that disable_coord only applies to classic similarity

### DIFF
--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -41,7 +41,8 @@ clauses then at least one `should` clause is required to match.
 ========================================================================
 
 The bool query also supports `disable_coord` parameter (defaults to
-`false`). Basically the coord similarity computes a score factor based
+`false`) which changes how the `classic` similarity calculates the `bool`
+query's score. Basically the coord similarity computes a score factor based
 on the fraction of all query terms that a document contains. See Lucene
 `BooleanQuery` for more details.
 


### PR DESCRIPTION
Documents that the `bool` query's `disable_coord` option only
applies to the `classic` similarity.

Closes #24267
