### PR TITLE
The parseObject method in DocumentParse can be void.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -455,10 +455,9 @@ final class DocumentParser {
         }
     }
 
-    private static ObjectMapper parseObject(final ParseContext context, ObjectMapper mapper, String currentFieldName) throws IOException {
+    private static void parseObject(final ParseContext context, ObjectMapper mapper, String currentFieldName) throws IOException {
         assert currentFieldName != null;
 
-        ObjectMapper update = null;
         Mapper objectMapper = getMapper(mapper, currentFieldName);
         if (objectMapper != null) {
             context.path().add(currentFieldName);
@@ -492,8 +491,6 @@ final class DocumentParser {
                 context.path().remove();
             }
         }
-
-        return update;
     }
 
     private static void parseArray(ParseContext context, ObjectMapper parentMapper, String lastFieldName) throws IOException {


### PR DESCRIPTION
This very small PR is related to issue #24226

I came across this method that had a seemingly pointless variable created that is then never used and then returned.

I had Eclipse check the points of use, there are 2:

https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java#L381

and

https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java#L553

So since the return is both not related to the actual tasks performed by the method and not actually picked up, I turned this method into a `void`, like most the other `parse...` methods already are.

===========

1. Contributor agreement: Has been signed

2. Contributor guidelines: I have read them.

3. Gradle check: build successful.

4. PR is against master

5. The PR is not OS specific.

6. I'm not part of a class.