### PR TITLE
Change snapshot status error to use generic SnapshotException

### DIFF
--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -954,7 +954,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             try {
                 return indexShardSnapshotFormat(version).read(blobContainer, snapshotId.getUUID());
             } catch (IOException ex) {
-                throw new IndexShardRestoreFailedException(shardId, "failed to read shard snapshot file", ex);
+                throw new SnapshotException(metadata.name(), snapshotId, "failed to read shard snapshot file for " + shardId, ex);
             }
         }
 


### PR DESCRIPTION
Changes the snapshot status read exception from the (misleading)
IndexShardRestoreFailedException to the generic SnapshotException

Closes #24225