### PR TITLE
Remove count() method from GeoCentroid aggregation interface

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/GeoCentroid.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/GeoCentroid.java
@@ -27,5 +27,4 @@ import org.elasticsearch.search.aggregations.Aggregation;
  */
 public interface GeoCentroid extends Aggregation {
     GeoPoint centroid();
-    long count();
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/InternalGeoCentroid.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/InternalGeoCentroid.java
@@ -97,11 +97,6 @@ public class InternalGeoCentroid extends InternalAggregation implements GeoCentr
     }
 
     @Override
-    public long count() {
-        return count;
-    }
-
-    @Override
     public InternalGeoCentroid doReduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
         double lonSum = Double.NaN;
         double latSum = Double.NaN;


### PR DESCRIPTION
This change removes the `count()` method from the GeoCentroid interface used for the `geo_centroid` aggregation. It seems to be unused at least in our own codebase and we also don't write the `count` value to the aggregation Rest response but only use it in the reduce method. 
This is the main reason for removing the method from the interface. When adding parsing for the aggregation responses for the
Highl level Rest Client we strive to provide all information available via the REST API to the user through the aggregation interface and it only makes sense to provide values through the interface that are also provided via REST.
The method could be deprecated in 5.x if necessary.
