### PR TITLE
Add parsing for InternalGeoCentroid

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/InternalGeoCentroid.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/InternalGeoCentroid.java
@@ -149,17 +149,13 @@ public class InternalGeoCentroid extends InternalAggregation implements GeoCentr
 
     static class Fields {
         static final ParseField CENTROID = new ParseField("location");
+        static final ParseField COUNT = new ParseField("count");
         static final ParseField CENTROID_LAT = new ParseField("lat");
         static final ParseField CENTROID_LON = new ParseField("lon");
-        static final ParseField COUNT = new ParseField("count");
     }
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        return renderXContent(builder, params, centroid, count);
-    }
-
-    static XContentBuilder renderXContent(XContentBuilder builder, Params params, GeoPoint centroid, long count) throws IOException {
         if (centroid != null) {
             builder.startObject(Fields.CENTROID.getPreferredName());
             {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/ParsedGeoCentroid.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/geocentroid/ParsedGeoCentroid.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.metrics.geocentroid;
+
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.ParsedAggregation;
+import org.elasticsearch.search.aggregations.metrics.geocentroid.InternalGeoCentroid.Fields;
+
+import java.io.IOException;
+
+/**
+ * Serialization and merge logic for {@link GeoCentroidAggregator}.
+ */
+public class ParsedGeoCentroid extends ParsedAggregation implements GeoCentroid {
+    private GeoPoint centroid;
+    private long count;
+
+    @Override
+    public GeoPoint centroid() {
+        return centroid;
+    }
+
+    @Override
+    public long count() {
+        return count;
+    }
+
+    @Override
+    protected String getType() {
+        return GeoCentroidAggregationBuilder.NAME;
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        if (centroid != null) {
+            builder.startObject(Fields.CENTROID.getPreferredName());
+            {
+                builder.field(Fields.CENTROID_LAT.getPreferredName(), centroid.lat());
+                builder.field(Fields.CENTROID_LON.getPreferredName(), centroid.lon());
+            }
+            builder.endObject();
+        }
+        builder.field(Fields.COUNT.getPreferredName(), count);
+        return builder;
+    }
+
+    private static final ObjectParser<ParsedGeoCentroid, Void> PARSER = new ObjectParser<>(ParsedGeoCentroid.class.getSimpleName(), true,
+            ParsedGeoCentroid::new);
+
+    private static final ObjectParser<GeoPoint, Void> GEO_POINT_PARSER = new ObjectParser<>(
+            ParsedGeoCentroid.class.getSimpleName() + "_POINT", true, GeoPoint::new);
+
+    static {
+        declareAggregationFields(PARSER);
+        PARSER.declareObject((agg, centroid) -> agg.centroid = centroid, GEO_POINT_PARSER, Fields.CENTROID);
+        PARSER.declareLong((agg, count) -> agg.count = count, Fields.COUNT);
+
+        GEO_POINT_PARSER.declareDouble(GeoPoint::resetLat, Fields.CENTROID_LAT);
+        GEO_POINT_PARSER.declareDouble(GeoPoint::resetLon, Fields.CENTROID_LON);
+    }
+
+    public static ParsedGeoCentroid fromXContent(XContentParser parser, final String name) {
+        ParsedGeoCentroid geoCentroid = PARSER.apply(parser, null);
+        geoCentroid.setName(name);
+        return geoCentroid;
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalAggregationTestCase.java
@@ -40,6 +40,8 @@ import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityAggr
 import org.elasticsearch.search.aggregations.metrics.cardinality.ParsedCardinality;
 import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBoundsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.geobounds.ParsedGeoBounds;
+import org.elasticsearch.search.aggregations.metrics.geocentroid.GeoCentroidAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.geocentroid.ParsedGeoCentroid;
 import org.elasticsearch.search.aggregations.metrics.max.MaxAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.max.ParsedMax;
 import org.elasticsearch.search.aggregations.metrics.min.MinAggregationBuilder;
@@ -118,6 +120,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         namedXContents.put(ExtendedStatsBucketPipelineAggregationBuilder.NAME,
                 (p, c) -> ParsedExtendedStatsBucket.fromXContent(p, (String) c));
         namedXContents.put(GeoBoundsAggregationBuilder.NAME, (p, c) -> ParsedGeoBounds.fromXContent(p, (String) c));
+        namedXContents.put(GeoCentroidAggregationBuilder.NAME, (p, c) -> ParsedGeoCentroid.fromXContent(p, (String) c));
 
         return namedXContents.entrySet().stream()
                 .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue()))

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/geocentroid/InternalGeoCentroidTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/geocentroid/InternalGeoCentroidTests.java
@@ -22,6 +22,7 @@ import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
+import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
 
@@ -69,5 +70,14 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
         assertEquals(latSum/totalCount, reduced.centroid().getLat(), 1E-5D);
         assertEquals(lonSum/totalCount, reduced.centroid().getLon(), 1E-5D);
         assertEquals(totalCount, reduced.count());
+    }
+
+    @Override
+    protected void assertFromXContent(InternalGeoCentroid aggregation, ParsedAggregation parsedAggregation) {
+        assertTrue(parsedAggregation instanceof ParsedGeoCentroid);
+        ParsedGeoCentroid parsed = (ParsedGeoCentroid) parsedAggregation;
+
+        assertEquals(aggregation.centroid(), parsed.centroid());
+        assertEquals(aggregation.count(), parsed.count());
     }
 }


### PR DESCRIPTION
This adds parsing to the InternalGeoCentroid aggregation. One problem I encountered here is that we don't render the `count` parameter that is available through the `count()` method in the GeoCentroid interface to REST (see #24366). After discussing this it looks like we should add this parameter to the REST output of the aggregation. I did this in this PR already but I think I will also open a separate PR to do this in master already. 
I'm not sure we can do anything in 5.x if we backport, we will need to work with a dummy constant for the `count` value there since it is not available via REST. 
