### PR TITLE
Update production notes in docs for Docker

### DIFF
--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -99,6 +99,7 @@ that *if* the `bootstrap.memory_lock` setting is enabled, that the JVM
 was successfully able to lock the heap. To pass the memory lock check,
 you might have to configure <<mlockall,`mlockall`>>.
 
+[[max-number-threads-check]]
 === Maximum number of threads check
 
 Elasticsearch executes requests by breaking the request down into stages

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -2,7 +2,8 @@
 === Install Elasticsearch with Docker
 
 Elasticsearch is also available as a Docker image.
-The image is built with {xpack}/index.html[X-Pack].
+The image is built with {xpack}/index.html[X-Pack] and uses https://hub.docker.com/_/centos/[centos:7] as the base image.
+The source code can be found on https://github.com/elastic/elasticsearch-docker/tree/{branch}[github].
 
 ==== Security note
 
@@ -153,12 +154,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
     mem_limit: 1g
-    cap_add:
-      - IPC_LOCK
     volumes:
       - esdata1:/usr/share/elasticsearch/data
     ports:
@@ -176,12 +172,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
     mem_limit: 1g
-    cap_add:
-      - IPC_LOCK
     volumes:
       - esdata2:/usr/share/elasticsearch/data
     networks:
@@ -195,7 +186,6 @@ volumes:
 
 networks:
   esnet:
-    driver: bridge
 --------------------------------------------
 endif::[]
 
@@ -273,15 +263,19 @@ We have collected a number of best practices for production use.
 
 NOTE: Any Docker parameters mentioned below assume the use of `docker run`.
 
-. Elasticsearch inside the container runs as user `elasticsearch` using uid:gid `1000:1000`. If you are bind mounting a local directory or file, ensure it is readable by this user while the https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#path-settings[data and log dirs] additionally require write access.
-
-. It is important to correctly set capabilities and ulimits via the Docker CLI. As seen earlier in the example <<docker-prod-cluster-composefile,docker-compose.yml>>, the following options are required:
+. Elasticsearch inside the container runs as user `elasticsearch` using uid:gid `1000:1000`. If you are bind mounting a local directory or file, ensure it is readable by this user, while the <<path-settings,data and log dirs>> additionally require write access.
 +
-  --cap-add=IPC_LOCK --ulimit memlock=-1:-1 --ulimit nofile=65536:65536
+. It is important to ensure increased ulimits for <<setting-system-settings,nofile>> and https://www.elastic.co/guide/en/elasticsearch/reference/current/_maximum_number_of_threads_check.html[nproc] are available for the Elasticsearch containers. Verify the https://github.com/moby/moby/tree/ea4d1243953e6b652082305a9c3cda8656edab26/contrib/init[init system] for the Docker daemon is already setting those to acceptable values and, if needed, adjust them in the Daemon, or override them per container, for example using `docker run`:
 +
-. Ensure `bootstrap.memory_lock` is set to `true` as explained in "<<setup-configuration-memory,Disable swapping>>".
+  --ulimit nofile=65536:65536
 +
-This can be achieved through any of the <<docker-configuration-methods,configuration methods>>, e.g. by setting the appropriate environments variable with `-e "bootstrap.memory_lock=true"`.
+NOTE: One way of checking the Docker daemon defaults for the aforementioned ulimits is by running:
++
+  docker run --rm centos:7 /bin/bash -c 'ulimit -Hn && ulimit -Sn && ulimit -Hu && ulimit -Su'
++
+. Swapping needs to be disabled for performance and node stability. This can be achieved through any of the methods mentioned in the <<setup-configuration-memory,Elasticsearch docs>>. If you opt for the `boostrap.memory_lock: true` approach, apart from defining it through any of the <<docker-configuration-methods,configuration methods>>, you will additionally need the `memlock: true` ulimit, either defined in the https://docs.docker.com/engine/reference/commandline/dockerd/#default-ulimits[Docker Daemon] or specifically set for the container. This has been demonstrated earlier in the <<docker-prod-cluster-composefile,docker-compose.yml>>, or using `docker run`:
++
+  -e "bootstrap_memory_lock=true" --ulimit memlock=-1:-1
 +
 . The image https://docs.docker.com/engine/reference/builder/#/expose[exposes] TCP ports 9200 and 9300. For clusters it is recommended to randomize the published ports with `--publish-all`, unless you are pinning one container per host.
 +

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -3,7 +3,7 @@
 
 Elasticsearch is also available as a Docker image.
 The image is built with {xpack}/index.html[X-Pack] and uses https://hub.docker.com/_/centos/[centos:7] as the base image.
-The source code can be found on https://github.com/elastic/elasticsearch-docker/tree/{branch}[github].
+The source code can be found on https://github.com/elastic/elasticsearch-docker/tree/{branch}[GitHub].
 
 ==== Security note
 
@@ -263,7 +263,7 @@ We have collected a number of best practices for production use.
 
 NOTE: Any Docker parameters mentioned below assume the use of `docker run`.
 
-. Elasticsearch inside the container runs as user `elasticsearch` using uid:gid `1000:1000`. If you are bind mounting a local directory or file, ensure it is readable by this user, while the <<path-settings,data and log dirs>> additionally require write access.
+. Elasticsearch runs inside the container as user `elasticsearch` using uid:gid `1000:1000`. If you are bind-mounting a local directory or file, ensure it is readable by this user, while the <<path-settings,data and log dirs>> additionally require write access.
 +
 . It is important to ensure increased ulimits for <<setting-system-settings,nofile>> and https://www.elastic.co/guide/en/elasticsearch/reference/current/_maximum_number_of_threads_check.html[nproc] are available for the Elasticsearch containers. Verify the https://github.com/moby/moby/tree/ea4d1243953e6b652082305a9c3cda8656edab26/contrib/init[init system] for the Docker daemon is already setting those to acceptable values and, if needed, adjust them in the Daemon, or override them per container, for example using `docker run`:
 +

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -265,7 +265,7 @@ NOTE: Any Docker parameters mentioned below assume the use of `docker run`.
 
 . Elasticsearch runs inside the container as user `elasticsearch` using uid:gid `1000:1000`. If you are bind-mounting a local directory or file, ensure it is readable by this user, while the <<path-settings,data and log dirs>> additionally require write access.
 +
-. It is important to ensure increased ulimits for <<setting-system-settings,nofile>> and https://www.elastic.co/guide/en/elasticsearch/reference/current/_maximum_number_of_threads_check.html[nproc] are available for the Elasticsearch containers. Verify the https://github.com/moby/moby/tree/ea4d1243953e6b652082305a9c3cda8656edab26/contrib/init[init system] for the Docker daemon is already setting those to acceptable values and, if needed, adjust them in the Daemon, or override them per container, for example using `docker run`:
+. It is important to ensure increased ulimits for <<setting-system-settings,nofile>> and <<max-number-threads-check,nproc>> are available for the Elasticsearch containers. Verify the https://github.com/moby/moby/tree/ea4d1243953e6b652082305a9c3cda8656edab26/contrib/init[init system] for the Docker daemon is already setting those to acceptable values and, if needed, adjust them in the Daemon, or override them per container, for example using `docker run`:
 +
   --ulimit nofile=65536:65536
 +


### PR DESCRIPTION
Add info about the base image used and the github repo of elasticsearch-docker.

Clarify that setting `memlock=-1:-1` is only a requirement when `bootstrap_memory_lock=true` and the alternatives we document elsewhere in docs for disabling swap are valid for Docker as well.

Additionally, with latest versions of docker-ce shipping with unlimited (or high enough) defaults for `nofile` and `nproc`, clarify that explicitly setting those per ES container is not required, unless they are not defined in the Docker daemon.

Finally simplify production `docker-compose.yml` example by removing unneeded options. One such option is `cap_add: IPC_LOCK` which seems to be not required anymore in combination with `memlock=-1:-1`.