### PR TITLE
Fix compilation in Eclipse

### DIFF
--- a/core/src/main/java/org/elasticsearch/discovery/TribeDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/TribeDiscovery.java
@@ -24,7 +24,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.service.ClusterApplier;;
+import org.elasticsearch.cluster.service.ClusterApplier;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.single.SingleNodeDiscovery;


### PR DESCRIPTION
Eclipse doesn't allow extra semicolons after an import statement:
```
import foo.Bar;;   // <-- syntax error!
```

Here is the Eclipse bug:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=425140
which the Eclipse folks closed as "the spec doesn't allow these
semicolons so why should we?" Which is fair. Here is the bug
against javac for allowing them:
https://bugs.openjdk.java.net/browse/JDK-8027682
which hasn't been touched since 2013 without explanation. There
is, however, a rather educations mailing list thread:
http://mail.openjdk.java.net/pipermail/compiler-dev/2013-August/006956.html

which contains gems like, "In general, it is better/simpler to
change javac to conform to the spec. (Except when it is not.)"

I suspect the reason this hasn't been fixed is:
```
FWIW, if we change javac such that the set of programs accepted by javac
is changed, we have an process (currently Oracle internal) to get
approval for such a change.   So, we would not simply change javac on a
whim to meet the spec; we would at least have other eyes looking at the
behavioral change to determine if it is "acceptable".
```
from http://mail.openjdk.java.net/pipermail/compiler-dev/2013-August/006973.html
