### PR TITLE
Add support for early termination of search request

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -127,6 +127,15 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
+     * Indicates whether the search should early terminate based on the index sorting.
+     * The search sort must not be set since documents will be returned sorted by the index sorting criteria.
+     */
+    public SearchRequestBuilder setEarlyTerminate(boolean value) {
+        sourceBuilder().earlyTerminate(value);
+        return this;
+    }
+
+    /**
      * A comma separated list of routing values to control the shards the search will be executed on.
      */
     public SearchRequestBuilder setRouting(String routing) {

--- a/core/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -42,6 +42,7 @@ import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.EarlyTerminatingSortingCollector;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.IndexSearcher;
@@ -50,6 +51,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SimpleCollector;
+import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSortField;
@@ -258,6 +260,14 @@ public class Lucene {
     public static final TimeLimitingCollector wrapTimeLimitingCollector(final Collector delegate, final Counter counter, long timeoutInMillis) {
         return new TimeLimitingCollector(delegate, counter, timeoutInMillis);
     }
+
+    /**
+     * Wraps <code>delegate</code> with segment count based early termination sorting collector with a threshold of <code>maxHitsPerSegment</code>
+     */
+    public static final EarlyTerminatingSortingCollector wrapCountBasedEarlyTerminatingSortingCollector(final Collector delegate, final Sort sort, int maxHitsPerSegment) {
+        return new EarlyTerminatingSortingCollector(delegate, sort, maxHitsPerSegment);
+    }
+
 
     /**
      * Check whether there is one or more documents matching the provided query.

--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -67,6 +67,7 @@ import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
@@ -120,7 +121,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final ScriptService scriptService;
     private final ClusterService clusterService;
     private final Client client;
-    private Supplier<Sort> indexSortSupplier;
+    private Supplier<SortAndFormats> indexSortSupplier;
 
     public IndexService(IndexSettings indexSettings, NodeEnvironment nodeEnv,
                         NamedXContentRegistry xContentRegistry,
@@ -255,7 +256,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         return similarityService;
     }
 
-    public Supplier<Sort> getIndexSortSupplier() {
+    public Supplier<SortAndFormats> getIndexSortSupplier() {
         return indexSortSupplier;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -46,6 +46,7 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.search.sort.SortAndFormats;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -110,12 +111,13 @@ final class StoreRecovery {
             }
             indexShard.mapperService().merge(indexMetaData, MapperService.MergeReason.MAPPING_RECOVERY, true);
             // now that the mapping is merged we can validate the index sort configuration.
-            Sort indexSort = indexShard.getIndexSort();
+            SortAndFormats indexSort = indexShard.getIndexSort();
             return executeRecovery(indexShard, () -> {
                 logger.debug("starting recovery from local shards {}", shards);
                 try {
                     final Directory directory = indexShard.store().directory(); // don't close this directory!!
-                    addIndices(indexShard.recoveryState().getIndex(), directory, indexSort,
+                    addIndices(indexShard.recoveryState().getIndex(), directory,
+                        indexSort == null ? null : indexSort.sort,
                         shards.stream().map(s -> s.getSnapshotDirectory())
                         .collect(Collectors.toList()).toArray(new Directory[shards.size()]));
                     internalRecoverFromStore(indexShard);

--- a/core/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -100,6 +100,7 @@ final class DefaultSearchContext extends SearchContext {
     private TimeValue timeout;
     // terminate after count
     private int terminateAfter = DEFAULT_TERMINATE_AFTER;
+    private boolean earlyTerminate = false;
     private List<String> groupStats;
     private ScrollContext scrollContext;
     private boolean explain;
@@ -512,6 +513,16 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public void terminateAfter(int terminateAfter) {
         this.terminateAfter = terminateAfter;
+    }
+
+    @Override
+    public boolean earlyTerminate() {
+        return earlyTerminate;
+    }
+
+    @Override
+    public void earlyTerminate(boolean value) {
+        this.earlyTerminate = value;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -287,6 +287,16 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
+    public boolean earlyTerminate() {
+        return in.earlyTerminate();
+    }
+
+    @Override
+    public void earlyTerminate(boolean value) {
+        in.earlyTerminate(value);
+    }
+
+    @Override
     public boolean lowLevelCancellation() {
         return in.lowLevelCancellation();
     }

--- a/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -220,6 +220,10 @@ public abstract class SearchContext extends AbstractRefCounted implements Releas
 
     public abstract void terminateAfter(int terminateAfter);
 
+    public abstract boolean earlyTerminate();
+
+    public abstract void earlyTerminate(boolean value);
+
     /**
      * Indicates if the current index should perform frequent low level search cancellation check.
      *

--- a/core/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
@@ -47,6 +47,7 @@ public class CollectorResult implements ToXContentObject, Writeable {
     public static final String REASON_SEARCH_COUNT = "search_count";
     public static final String REASON_SEARCH_TOP_HITS = "search_top_hits";
     public static final String REASON_SEARCH_TERMINATE_AFTER_COUNT = "search_terminate_after_count";
+    public static final String REASON_SEARCH_SORTING_EARLY_TERMINATION = "search_sorting_early_terminate";
     public static final String REASON_SEARCH_POST_FILTER = "search_post_filter";
     public static final String REASON_SEARCH_MIN_SCORE = "search_min_score";
     public static final String REASON_SEARCH_MULTI = "search_multi";

--- a/docs/reference/index-modules/index-sorting.asciidoc
+++ b/docs/reference/index-modules/index-sorting.asciidoc
@@ -104,4 +104,82 @@ Index sorting supports the following settings:
 
 [WARNING]
 Index sorting can be defined only once at index creation. It is not allowed to add or update
-a sort on an existing index.
+a sort on an existing index. Index sorting also has a cost in terms of indexing throughput since
+documents must be sorted at flush and merge time. You should test the impact on your application
+before activating this feature.
+
+[float]
+[[early-terminate]]
+=== Early termination of search request
+
+By default in elasticsearch a search request must visit every document that match a query to
+retrieve the top documents sorted by a specified sort.
+Though when the index sort and the search sort are the same it is possible to limit
+the number of documents that should be visited per segment to retrieve the N top ranked documents.
+Since each segment is sorted in the index we only need to visit the N first documents per segment
+to retrieve the final N documents of that shard.
+For example, let's say we have an index that contains events sorted by a timestamp field:
+
+[source,js]
+--------------------------------------------------
+PUT events
+{
+    "settings" : {
+        "index" : {
+            "sort.field" : "timestamp",
+            "sort.order" : "desc" <2>
+        }
+    },
+    "mappings": {
+        "doc": {
+            "properties": {
+                "timestamp": {
+                    "type": "date"
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+<1> This index is sorted by timestamp in descending order (most recent first)
+
+You can search for the last 10 events with:
+
+[source,js]
+--------------------------------------------------
+GET /events/_search
+{
+    "size": 10,
+    "sort": [
+        { "timestamp": "desc" }
+    ]
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+... but this will search the entire index.
+If you're only looking for the last 10 events and have no interest in
+the total number of documents that match the query you can use `early_terminate`
+to restrict the search to the first 10 documents per segment:
+
+[source,js]
+--------------------------------------------------
+GET /events/_search
+{
+    "size": 10,
+    "early_terminate": true  <1>
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+<1> The index sort will be used to rank the top documents and each segment will early terminate the collection after the first 10 matches.
+
+[WARNING]
+Aggregations should not be used when `early_terminate` is set because only the top ranked documents are going
+to be collected resulting in partial results in the buckets. Similarly the total number of documents returned by
+a request with `early_terminate` set to true does not take all the documents into account.
+

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -93,6 +93,14 @@ And here is a sample response:
     the query execution has actually terminated_early. Defaults to no
     terminate_after.
 
+`early_terminate`::
+
+    Set to `true` to limit the search to the first `size` documents per segment.
+    This option can only be used when the index is sorted using the same sort than
+    the request. It is also possible to omit `sort` in the request which will cause
+    the documents to be sorted by the index sort automatically in the response.
+    See <<index-modules-index-sorting,`index-sorting`>> for more.
+
 
 Out of the above, the `search_type` and the `request_cache` must be passed as
 query-string parameters. The rest of the search request should be passed

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.sort/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.sort/10_basic.yaml
@@ -56,28 +56,28 @@
         index: test
         type:  test
         id:    "5"
-        body:  { "rank": 7 }
+        body:  { "rank": 8 }
 
   - do:
       index:
         index: test
         type:  test
         id:    "6"
-        body:  { "rank": 5 }
+        body:  { "rank": 6 }
 
   - do:
       index:
         index: test
         type:  test
         id:    "7"
-        body:  { "rank": 4 }
+        body:  { "rank": 5 }
 
   - do:
       index:
         index: test
         type:  test
         id:    "8"
-        body:  { "rank": 6 }
+        body:  { "rank": 7 }
 
   - do:
       indices.refresh:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.sort/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.sort/10_basic.yaml
@@ -52,6 +52,62 @@
         index: test
 
   - do:
+      index:
+        index: test
+        type:  test
+        id:    "5"
+        body:  { "rank": 7 }
+
+  - do:
+      index:
+        index: test
+        type:  test
+        id:    "6"
+        body:  { "rank": 5 }
+
+  - do:
+      index:
+        index: test
+        type:  test
+        id:    "7"
+        body:  { "rank": 4 }
+
+  - do:
+      index:
+        index: test
+        type:  test
+        id:    "8"
+        body:  { "rank": 6 }
+
+  - do:
+      indices.refresh:
+        index: test
+
+  - do:
+      search:
+        index: test
+        type: test
+        body:
+          early_terminate: true
+          size: 1
+
+  - length: {hits.hits: 1 }
+  - match: {hits.hits.0._id: "2" }
+
+  - do:
+      search:
+        index: test
+        type: test
+        body:
+          early_terminate: true
+          size: 3
+
+  - length: {hits.hits: 3 }
+  - match: {hits.hits.0._id: "2" }
+  - match: {hits.hits.1._id: "4" }
+  - match: {hits.hits.2._id: "3" }
+
+  - do:
       indices.forcemerge:
         index: test
         max_num_segments: 1
@@ -67,9 +123,38 @@
         body:
           sort: _doc
 
-  - match: {hits.total: 4 }
-  - length: {hits.hits: 4 }
+  - match: {hits.total: 8 }
+  - length: {hits.hits: 8 }
   - match: {hits.hits.0._id: "2" }
   - match: {hits.hits.1._id: "4" }
   - match: {hits.hits.2._id: "3" }
   - match: {hits.hits.3._id: "1" }
+  - match: {hits.hits.4._id: "7" }
+  - match: {hits.hits.5._id: "6" }
+  - match: {hits.hits.6._id: "8" }
+  - match: {hits.hits.7._id: "5" }
+
+  - do:
+      search:
+        index: test
+        type: test
+        body:
+          size: 3
+          early_terminate: true
+
+  - match: {hits.total: 3 }
+  - length: {hits.hits: 3 }
+  - match: {hits.hits.0._id: "2" }
+  - match: {hits.hits.1._id: "4" }
+  - match: {hits.hits.2._id: "3" }
+
+  - do:
+      catch: /cannot use `early_terminate` when the search sort.+/
+      search:
+        index: test
+        type: test
+        body:
+          size: 3
+          sort: _doc
+          early_terminate: true
+

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -85,6 +85,7 @@ public class TestSearchContext extends SearchContext {
     ContextIndexSearcher searcher;
     int size;
     private int terminateAfter = DEFAULT_TERMINATE_AFTER;
+    private boolean earlyTerminate = false;
     private SearchContextAggregations aggregations;
 
     private final long originNanoTime = System.nanoTime();
@@ -316,6 +317,16 @@ public class TestSearchContext extends SearchContext {
     @Override
     public void terminateAfter(int terminateAfter) {
         this.terminateAfter = terminateAfter;
+    }
+
+    @Override
+    public boolean earlyTerminate() {
+        return earlyTerminate;
+    }
+
+    @Override
+    public void earlyTerminate(boolean value) {
+        this.earlyTerminate = value;
     }
 
     @Override


### PR DESCRIPTION
Relates #6720
This change introduce early termination of search request for indices sorted by specific fields.
When the index is sorted, the option called `early_terminate` indicates that top documents must be sorted by the index sort criteria
and that only the top N documents per segment should be visited.
Let's say for example that we have an index sorted by timestamp:

```
PUT events
{
    "settings" : {
        "index" : {
            "sort.field" : "timestamp",
            "sort.order" : "desc" <2>
        }
    },
    "mappings": {
        "doc": {
            "properties": {
                "timestamp": {
                    "type": "date"
                }
            }
        }
    }
}
```

... it is then possible to retrieve the N last events without visiting all the documents in the index with the following query:

```
GET /events/_search
{
    "size": 10,
    "early_terminate": true
}
```

The `sort` of this search request is automatically set to the index sort and each segment will visit the first 10 matching documents at most.

Setting this option on an index that is not sorted by any criteria will throw an exception.