### PR TITLE
Move IndicesAliasesRequest#concreteAliases to TransportIndicesAliasesAction

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -19,19 +19,15 @@
 
 package org.elasticsearch.action.admin.indices.alias;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.AliasesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.cluster.metadata.AliasAction;
-import org.elasticsearch.cluster.metadata.AliasMetaData;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -92,10 +88,10 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
 
             public static Type fromValue(byte value) {
                 switch (value) {
-                case 0: return ADD;
-                case 1: return REMOVE;
-                case 2: return REMOVE_INDEX;
-                default: throw new IllegalArgumentException("No type for action [" + value + "]");
+                    case 0: return ADD;
+                    case 1: return REMOVE;
+                    case 2: return REMOVE_INDEX;
+                    default: throw new IllegalArgumentException("No type for action [" + value + "]");
                 }
             }
         }
@@ -106,18 +102,21 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         public static AliasActions add() {
             return new AliasActions(AliasActions.Type.ADD);
         }
+
         /**
          * Build a new {@link AliasAction} to remove aliases.
          */
         public static AliasActions remove() {
             return new AliasActions(AliasActions.Type.REMOVE);
         }
+
         /**
-         * Build a new {@link AliasAction} to remove aliases.
+         * Build a new {@link AliasAction} to remove an index.
          */
         public static AliasActions removeIndex() {
             return new AliasActions(AliasActions.Type.REMOVE_INDEX);
         }
+
         private static ObjectParser<AliasActions, Void> parser(String name, Supplier<AliasActions> supplier) {
             ObjectParser<AliasActions, Void> parser = new ObjectParser<>(name, supplier);
             parser.declareString((action, index) -> {
@@ -400,24 +399,6 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         @Override
         public IndicesOptions indicesOptions() {
             return INDICES_OPTIONS;
-        }
-
-        public String[] concreteAliases(MetaData metaData, String concreteIndex) {
-            if (expandAliasesWildcards()) {
-                //for DELETE we expand the aliases
-                String[] indexAsArray = {concreteIndex};
-                ImmutableOpenMap<String, List<AliasMetaData>> aliasMetaData = metaData.findAliases(aliases, indexAsArray);
-                List<String> finalAliases = new ArrayList<>();
-                for (ObjectCursor<List<AliasMetaData>> curAliases : aliasMetaData.values()) {
-                    for (AliasMetaData aliasMeta: curAliases.value) {
-                        finalAliases.add(aliasMeta.alias());
-                    }
-                }
-                return finalAliases.toArray(new String[finalAliases.size()]);
-            } else {
-                //for add we just return the current aliases
-                return aliases;
-            }
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.alias;
 
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.support.ActionFilters;
@@ -28,9 +29,12 @@ import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasAction;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.MetaDataIndexAliasesService;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.action.admin.indices.AliasesNotFoundException;
@@ -97,12 +101,12 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeAction<Ind
             for (String index : concreteIndices) {
                 switch (action.actionType()) {
                 case ADD:
-                    for (String alias : action.concreteAliases(state.metaData(), index)) {
+                    for (String alias : concreteAliases(action, state.metaData(), index)) {
                         finalActions.add(new AliasAction.Add(index, alias, action.filter(), action.indexRouting(), action.searchRouting()));
                     }
                     break;
                 case REMOVE:
-                    for (String alias : action.concreteAliases(state.metaData(), index)) {
+                    for (String alias : concreteAliases(action, state.metaData(), index)) {
                         finalActions.add(new AliasAction.Remove(index, alias));
                     }
                     break;
@@ -133,5 +137,23 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeAction<Ind
                 listener.onFailure(t);
             }
         });
+    }
+
+    private static String[] concreteAliases(AliasActions action, MetaData metaData, String concreteIndex) {
+        if (action.expandAliasesWildcards()) {
+            //for DELETE we expand the aliases
+            String[] indexAsArray = {concreteIndex};
+            ImmutableOpenMap<String, List<AliasMetaData>> aliasMetaData = metaData.findAliases(action.aliases(), indexAsArray);
+            List<String> finalAliases = new ArrayList<>();
+            for (ObjectCursor<List<AliasMetaData>> curAliases : aliasMetaData.values()) {
+                for (AliasMetaData aliasMeta: curAliases.value) {
+                    finalAliases.add(aliasMeta.alias());
+                }
+            }
+            return finalAliases.toArray(new String[finalAliases.size()]);
+        } else {
+            //for ADD and REMOVE_INDEX we just return the current aliases
+            return action.aliases();
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -79,9 +79,7 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeAction<Ind
     protected ClusterBlockException checkBlock(IndicesAliasesRequest request, ClusterState state) {
         Set<String> indices = new HashSet<>();
         for (AliasActions aliasAction : request.aliasActions()) {
-            for (String index : aliasAction.indices()) {
-                indices.add(index);
-            }
+            Collections.addAll(indices, aliasAction.indices());
         }
         return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indices.toArray(new String[indices.size()]));
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/30_remove_index_and_replace_with_alias.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/30_remove_index_and_replace_with_alias.yaml
@@ -1,5 +1,5 @@
 ---
-"Remove and index and replace it with an alias":
+"Remove an index and replace it with an alias":
 
   - do:
       indices.create:


### PR DESCRIPTION
`IndicesAliasesRequest#concreteAliases` has to do with how the transport action may or may not resolve wildcards expressions to aliases names. It is only needed in `TransportIndicesAliasesAction` and for this reason it should be a private method in it rather than part of a request class which is also part of the Java API and later in the high level REST client.