### PR TITLE
Open/Close index api to allow_no_indices by default

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequest.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class CloseIndexRequest extends AcknowledgedRequest<CloseIndexRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, true, false);
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandOpen();
 
     public CloseIndexRequest() {
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequest.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class OpenIndexRequest extends AcknowledgedRequest<OpenIndexRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, false, false, true);
+    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, false, true);
 
     public OpenIndexRequest() {
     }

--- a/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -491,8 +491,8 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(client().admin().indices().prepareOpen("_all"), false);
 
         // if there are no indices to open/close throw an exception
-        IndicesOptions openIndicesOptions = IndicesOptions.fromOptions(false, false, true, false);
-        IndicesOptions closeIndicesOptions = IndicesOptions.fromOptions(false, false, false, true);
+        IndicesOptions openIndicesOptions = IndicesOptions.fromOptions(false, false, false, true);
+        IndicesOptions closeIndicesOptions = IndicesOptions.fromOptions(false, false, true, false);
 
         verify(client().admin().indices().prepareClose("bar*").setIndicesOptions(closeIndicesOptions), false);
         verify(client().admin().indices().prepareClose("bar*").setIndicesOptions(closeIndicesOptions), true);

--- a/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -474,20 +474,36 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         verify(search("t*"), false);
     }
 
-    public void testCloseApiWildcards() throws Exception {
+    public void testOpenCloseApiWildcards() throws Exception {
         createIndex("foo", "foobar", "bar", "barbaz");
         ensureGreen();
 
+        // if there are no indices to open/close and allow_no_indices=true (default), the open/close is a no-op
         verify(client().admin().indices().prepareClose("bar*"), false);
-        verify(client().admin().indices().prepareClose("bar*"), true);
+        verify(client().admin().indices().prepareClose("bar*"), false);
 
         verify(client().admin().indices().prepareClose("foo*"), false);
-        verify(client().admin().indices().prepareClose("foo*"), true);
-        verify(client().admin().indices().prepareClose("_all"), true);
+        verify(client().admin().indices().prepareClose("foo*"), false);
+        verify(client().admin().indices().prepareClose("_all"), false);
 
         verify(client().admin().indices().prepareOpen("bar*"), false);
         verify(client().admin().indices().prepareOpen("_all"), false);
-        verify(client().admin().indices().prepareOpen("_all"), true);
+        verify(client().admin().indices().prepareOpen("_all"), false);
+
+        // if there are no indices to open/close throw an exception
+        IndicesOptions openIndicesOptions = IndicesOptions.fromOptions(false, false, true, false);
+        IndicesOptions closeIndicesOptions = IndicesOptions.fromOptions(false, false, false, true);
+
+        verify(client().admin().indices().prepareClose("bar*").setIndicesOptions(closeIndicesOptions), false);
+        verify(client().admin().indices().prepareClose("bar*").setIndicesOptions(closeIndicesOptions), true);
+
+        verify(client().admin().indices().prepareClose("foo*").setIndicesOptions(closeIndicesOptions), false);
+        verify(client().admin().indices().prepareClose("foo*").setIndicesOptions(closeIndicesOptions), true);
+        verify(client().admin().indices().prepareClose("_all").setIndicesOptions(closeIndicesOptions), true);
+
+        verify(client().admin().indices().prepareOpen("bar*").setIndicesOptions(openIndicesOptions), false);
+        verify(client().admin().indices().prepareOpen("_all").setIndicesOptions(openIndicesOptions), false);
+        verify(client().admin().indices().prepareOpen("_all").setIndicesOptions(openIndicesOptions), true);
     }
 
     public void testDeleteIndex() throws Exception {

--- a/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -191,41 +191,6 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         assertIndexIsOpened("test1", "test2", "test3");
     }
     
-    // if there are no indices to open/close throw an exception
-    public void testOpenCloseWildCardsNoIndicesDefault() {
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("test").execute().actionGet());
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("test").execute().actionGet());
-        
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("test*").execute().actionGet());
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("test*").execute().actionGet());
-        
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("*").execute().actionGet());
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("*").execute().actionGet());
-        
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareOpen("_all").execute().actionGet());
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareClose("_all").execute().actionGet());
-    }
-    
-    // if there are no indices to open/close and allow_no_indices=true, the open/close is a no-op
-    public void testOpenCloseWildCardsNoIndicesAllowNoIndices() throws InterruptedException, ExecutionException {
-        IndicesOptions openIndicesOptions = IndicesOptions.fromOptions(false, true, false, true);
-        IndicesOptions closeIndicesOptions = IndicesOptions.fromOptions(false, true, true, false);
-
-        expectThrows(IndexNotFoundException.class,
-                () -> client().admin().indices().prepareOpen("test").setIndicesOptions(openIndicesOptions).execute().actionGet());
-        expectThrows(IndexNotFoundException.class,
-                () -> client().admin().indices().prepareClose("test").setIndicesOptions(closeIndicesOptions).execute().actionGet());
-
-        assertAcked(client().admin().indices().prepareOpen("test*").setIndicesOptions(openIndicesOptions).execute().get());
-        assertAcked(client().admin().indices().prepareClose("test*").setIndicesOptions(closeIndicesOptions).execute().get());
-        
-        assertAcked(client().admin().indices().prepareOpen("*").setIndicesOptions(openIndicesOptions).execute().get());
-        assertAcked(client().admin().indices().prepareClose("*").setIndicesOptions(closeIndicesOptions).execute().get());
-        
-        assertAcked(client().admin().indices().prepareOpen("_all").setIndicesOptions(openIndicesOptions).execute().get());
-        assertAcked(client().admin().indices().prepareClose("_all").setIndicesOptions(closeIndicesOptions).execute().get());
-    }
-
     public void testCloseNoIndex() {
         Client client = client();
         Exception e = expectThrows(ActionRequestValidationException.class, () ->

--- a/docs/reference/migration/migrate_6_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_6_0/indices.asciidoc
@@ -37,3 +37,10 @@ following settings:
 - `index.shared_filesystem`
 - `index.shadow_replicas`
 - `node.add_lock_id_to_custom_path`
+
+=== Open/Close index API allows wildcard expressions that match no indices by default
+
+The default value of the `allow_no_indices` option for the Open/Close index API
+has been changed from `false` to `true` so it is aligned with the behaviour of the
+Delete index API. As a result, Open/Close index API don't return an error by
+default when a provided wildcard expression doesn't match any closed/open index.


### PR DESCRIPTION
Open/Close index api have allow_no_indices set to false by default, while delete index has it set to true. The flag controls whether a wildcard expression that matches no indices will be ignored or an error will be thrown instead. This commit aligns open/close default behaviour to that of delete index.

This is a followup to #24031. Also related to #24341.