### PR TITLE
painless: Add tests for Java 9 features

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -112,8 +112,8 @@ public final class Def {
     private static final MethodHandle MAP_INDEX_NORMALIZE;
     /** pointer to {@link Def#listIndexNormalize}. */
     private static final MethodHandle LIST_INDEX_NORMALIZE;
-    /** factory for arraylength MethodHandle (intrinsic) from Java 9 */
-    private static final MethodHandle JAVA9_ARRAY_LENGTH_MH_FACTORY;
+    /** factory for arraylength MethodHandle (intrinsic) from Java 9 (pkg-private for tests) */
+    static final MethodHandle JAVA9_ARRAY_LENGTH_MH_FACTORY;
 
     static {
         final Lookup lookup = MethodHandles.publicLookup();

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless;
 
+import org.apache.lucene.util.Constants;
 import org.hamcrest.Matcher;
 
 import java.lang.invoke.MethodHandle;
@@ -44,6 +45,7 @@ public class ArrayTests extends ArrayLikeObjectTestCase {
     }
 
     public void testArrayLengthHelper() throws Throwable {
+        assertEquals(Constants.JRE_IS_MINIMUM_JAVA9, Def.JAVA9_ARRAY_LENGTH_MH_FACTORY != null);
         assertArrayLength(2, new int[2]);
         assertArrayLength(3, new long[3]);
         assertArrayLength(4, new byte[4]);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/StringTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/StringTests.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.painless;
 
+import org.apache.lucene.util.Constants;
+
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -248,5 +250,12 @@ public class StringTests extends ScriptTestCase {
 
         String rando = randomRealisticUnicodeOfLength(between(5, 1000));
         assertEquals(rando, exec("params.rando.encodeBase64().decodeBase64()", singletonMap("rando", rando), true));
+    }
+    
+    public void testJava9StringConcatBytecode() {
+        assumeTrue("Needs Java 9 to test indified String concat", Constants.JRE_IS_MINIMUM_JAVA9);
+        assertNotNull(WriterConstants.INDY_STRING_CONCAT_BOOTSTRAP_HANDLE);
+        assertBytecodeExists("String s = \"cat\"; return s + true + 'abc' + null;", 
+                "INVOKEDYNAMIC concat(Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Object;)Ljava/lang/String;");
     }
 }


### PR DESCRIPTION
Now that Java 9 is stable and method signatures should no longer change, we should add tests to check for existence and correct detection of the special Java 9 optimizations in painless:
- Indified String concat: This adds a test that only runs on java 9 to check the generated bytecode to have `INVOKEDYNAMIC`.
- `MethodHandles#arrayLength()` should be used. This makes the static constant in `Def` pkg private and adds a test for non-nullness on Java 9

This PR should not to test Java 9 compatibility at runtime (we always fallback to Java 8 behaviour if something breaks), it is intended to break the build instead if we are on Java 9 and painless does not use the better features. This may happen if somebody breaks the reflective lookups.