### PR TITLE
painless: Fix method references to ctor with the new LambdaBootstrap and cleanup code

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
@@ -30,6 +30,7 @@ import java.security.CodeSource;
 import java.security.SecureClassLoader;
 import java.security.cert.Certificate;
 import java.util.BitSet;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.painless.WriterConstants.CLASS_NAME;
 
@@ -66,6 +67,8 @@ final class Compiler {
      * A secure class loader used to define Painless scripts.
      */
     static final class Loader extends SecureClassLoader {
+        private final AtomicInteger lambdaCounter = new AtomicInteger(0);
+        
         /**
          * @param parent The parent ClassLoader.
          */
@@ -91,6 +94,14 @@ final class Compiler {
          */
         Class<?> defineLambda(String name, byte[] bytes) {
             return defineClass(name, bytes, 0, bytes.length);
+        }
+        
+        /**
+         * A counter used to generate a unique name for each lambda
+         * function/reference class in this classloader.
+         */
+        int newLambdaIdentifier() {
+            return lambdaCounter.getAndIncrement();
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Compiler.java
@@ -93,7 +93,7 @@ final class Compiler {
          * @return A Class object.
          */
         Class<?> defineLambda(String name, byte[] bytes) {
-            return defineClass(name, bytes, 0, bytes.length);
+            return defineClass(name, bytes, 0, bytes.length, CODESOURCE);
         }
         
         /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
@@ -33,7 +33,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.concurrent.atomic.AtomicLong;
@@ -473,9 +472,7 @@ public final class LambdaBootstrap {
         try {
             return new ConstantCallSite(MethodHandles.constant(
                 factoryMethodType.returnType(), constructor.newInstance()));
-        } catch (InstantiationException |
-            IllegalAccessException |
-            InvocationTargetException exception) {
+        } catch (ReflectiveOperationException exception) {
             throw new IllegalStateException("unable to create lambda class", exception);
         }
     }
@@ -492,7 +489,7 @@ public final class LambdaBootstrap {
             return new ConstantCallSite(
                 lookup.findConstructor(lambdaClass, factoryMethodType.changeReturnType(void.class))
                 .asType(factoryMethodType));
-        } catch (NoSuchMethodException | IllegalAccessException exception) {
+        } catch (ReflectiveOperationException exception) {
             throw new IllegalStateException("unable to create lambda factory class", exception);
         }
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
@@ -408,7 +408,7 @@ public final class LambdaBootstrap {
                 delegateInvokeType == H_INVOKEINTERFACE);
         iface.invokeDynamic(delegateMethodName, Type.getMethodType(interfaceMethodType
                 .toMethodDescriptorString()).getDescriptor(), DELEGATE_BOOTSTRAP_HANDLE,
-            delegateHandle);
+                delegateHandle);
 
         iface.returnValue();
         iface.endMethod();

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
@@ -313,7 +313,8 @@ public final class LambdaBootstrap {
     private static void generateStaticCtorDelegator(ClassWriter cw, Type delegateClassType, String delegateMethodName,
             MethodType delegateMethodType) {
         Method wrapperMethod = new Method(DELEGATED_CTOR_WRAPPER_NAME, delegateMethodType.toMethodDescriptorString());
-        Method constructorMethod = new Method(delegateMethodName, delegateMethodType.changeReturnType(void.class).toMethodDescriptorString());
+        Method constructorMethod = 
+            new Method(delegateMethodName, delegateMethodType.changeReturnType(void.class).toMethodDescriptorString());
         int modifiers = ACC_PRIVATE | ACC_STATIC;
 
         GeneratorAdapter factory = new GeneratorAdapter(modifiers, wrapperMethod,

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
@@ -194,14 +194,13 @@ public final class LambdaBootstrap {
             String delegateMethodName,
             MethodType delegateMethodType)
             throws LambdaConversionException {
-        String lambdaClassName = Type.getInternalName(lookup.lookupClass()) +"$$Lambda" + COUNTER.getAndIncrement();
+        String lambdaClassName = Type.getInternalName(lookup.lookupClass()) + "$$Lambda" + COUNTER.getAndIncrement();
         Type lambdaClassType = Type.getObjectType(lambdaClassName);
         Type delegateClassType = Type.getObjectType(delegateClassName.replace('.', '/'));
 
         validateTypes(interfaceMethodType, delegateMethodType);
 
-        ClassWriter cw =
-            beginLambdaClass(lambdaClassName, factoryMethodType.returnType());
+        ClassWriter cw = beginLambdaClass(lambdaClassName, factoryMethodType.returnType());
         Capture[] captures = generateCaptureFields(cw, factoryMethodType);
         generateLambdaConstructor(cw, lambdaClassType, factoryMethodType, captures);
         

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/LambdaBootstrap.java
@@ -247,7 +247,7 @@ public final class LambdaBootstrap {
      */
     private static ClassWriter beginLambdaClass(String lambdaClassName, Class<?> lambdaInterface) {
         String baseClass = Type.getInternalName(Object.class);
-        int modifiers = ACC_PUBLIC | ACC_STATIC | ACC_SUPER | ACC_FINAL | ACC_SYNTHETIC;
+        int modifiers = ACC_PUBLIC | ACC_SUPER | ACC_FINAL | ACC_SYNTHETIC;
 
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
         cw.visit(CLASS_VERSION,

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
@@ -27,7 +27,6 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Method;
 
 import java.lang.invoke.CallSite;
-import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionRefTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/FunctionRefTests.java
@@ -91,6 +91,13 @@ public class FunctionRefTests extends ScriptTestCase {
                  "return stats.getSum()"));
     }
 
+    public void testCtorWithParams() {
+        assertArrayEquals(new Object[] { "foo", "bar" },
+                (Object[]) exec("List l = new ArrayList(); l.add('foo'); l.add('bar'); " +
+                        "Stream stream = l.stream().map(StringBuilder::new);" +
+                        "return stream.map(Object::toString).toArray()"));
+    }
+
     public void testArrayCtorMethodRef() {
         assertEquals(1.0D,
                 exec("List l = new ArrayList(); l.add(1.0); l.add(2.0); " +


### PR DESCRIPTION
This PR fixes https://github.com/elastic/elasticsearch/pull/24070#issuecomment-298179537:

I figured out that the special handling of `H_NEWINVOKESPECIAL` is broken. The following test fails:

```java
    public void testCtorWithParams() {
        assertArrayEquals(new Object[] { "foo", "bar" },
                (Object[]) exec("List l = new ArrayList(); l.add('foo'); l.add('bar'); " +
                        "Stream stream = l.stream().map(StringBuilder::new);" +
                        "return stream.map(Object::toString).toArray()"));
    }
```

This code fails because the script returns a `Object[]` consisting only of 2 empty Strings. The reason for this is: `StringBuilder::new` points to the `StringBuilder(CharSequence)` ctor. The code in LambdaBootstrap ignores all parameters and calls the default ctor of `StringBuilder`. The result is mapped back to a String afterwards and is of course empty.

To fix this I changed the LamdaBootstrap to create a static proxy/delegator method around the ctor (`delegate$ctor`) with the same parameters as the ctor, returning the newly created instance (somehow similar like the factory for the captured lambda - which I removed, see below). When generating the `INVOKEDYNAMIC` to our type-adapting callsite, we change the `H_NEWINVOKESPECIAL` to a static method call to our proxy. I tried to fix this without using a static method, but although the JLS/class file format allows `H_NEWINVOKESPECIAL` for a handle, when passing this as a `Handle` (in constant pool) to `INVOKEDYNAMIC`, it causes a class format error. I am not sure if this is a bug in ASM or if `INVOKEDYNAMIC` does not support this. It has nothing to do with the fact of a `newinstance` bytecode may be needed - no it's not for MethodHandles!!!

In addition, the static factory as replacement for the constructor of the lambda (`get$lambda`) is not needed. If you use `lookup.findConstructor()` everything works as it should. So I also removed it. @jdconrad said (https://github.com/elastic/elasticsearch/pull/24070#discussion_r111591580) that its needed, but it isn't, because `lookup.findConstructor()` returns a MethodHandle that also does `newinstance` bytecode.

Documentation was updated accordingly.

The final TODO is to check why the direct MH in constant pool leads to a ClassFormatError. I will look into lambdas created by javac, maybe I see something that I was missing!