### PR TITLE
In case of addAll/putAll to List/Map, use constructor that accepts an existing List/Map instead.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldstats/FieldStatsShardRequest.java
@@ -39,8 +39,7 @@ public class FieldStatsShardRequest extends BroadcastShardRequest {
 
     public FieldStatsShardRequest(ShardId shardId, FieldStatsRequest request) {
         super(shardId, request);
-        Set<String> fields = new HashSet<>();
-        fields.addAll(Arrays.asList(request.getFields()));
+        Set<String> fields = new HashSet<>(Arrays.asList(request.getFields()));
         for (IndexConstraint indexConstraint : request.getIndexConstraints()) {
             fields.add(indexConstraint.getField());
         }

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -129,10 +129,8 @@ public abstract class TransportClient extends AbstractClient {
         resourcesToClose.add(() -> ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
         final NetworkService networkService = new NetworkService(settings, Collections.emptyList());
         try {
-            final List<Setting<?>> additionalSettings = new ArrayList<>();
-            final List<String> additionalSettingsFilter = new ArrayList<>();
-            additionalSettings.addAll(pluginsService.getPluginSettings());
-            additionalSettingsFilter.addAll(pluginsService.getPluginSettingsFilter());
+            final List<Setting<?>> additionalSettings = new ArrayList<>(pluginsService.getPluginSettings());
+            final List<String> additionalSettingsFilter = new ArrayList<>(pluginsService.getPluginSettingsFilter());
             for (final ExecutorBuilder<?> builder : threadPool.builders()) {
                 additionalSettings.addAll(builder.getRegisteredSettings());
             }
@@ -194,8 +192,7 @@ public abstract class TransportClient extends AbstractClient {
             final TransportProxyClient proxy = new TransportProxyClient(settings, transportService, nodesService,
                 actionModule.getActions().values().stream().map(x -> x.getAction()).collect(Collectors.toList()));
 
-            List<LifecycleComponent> pluginLifecycleComponents = new ArrayList<>();
-            pluginLifecycleComponents.addAll(pluginsService.getGuiceServiceClasses().stream()
+            List<LifecycleComponent> pluginLifecycleComponents = new ArrayList<>(pluginsService.getGuiceServiceClasses().stream()
                 .map(injector::getInstance).collect(Collectors.toList()));
             resourcesToClose.addAll(pluginLifecycleComponents);
 

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -187,8 +187,7 @@ final class TransportClientNodesService extends AbstractComponent implements Clo
             if (filtered.isEmpty()) {
                 return this;
             }
-            List<DiscoveryNode> builder = new ArrayList<>();
-            builder.addAll(listedNodes());
+            List<DiscoveryNode> builder = new ArrayList<>(listedNodes);
             for (TransportAddress transportAddress : filtered) {
                 DiscoveryNode node = new DiscoveryNode("#transport#-" + tempNodeIdGenerator.incrementAndGet(),
                         transportAddress, Collections.emptyMap(), Collections.emptySet(), minCompatibilityVersion);

--- a/core/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
+++ b/core/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
@@ -193,8 +193,7 @@ public final class DiffableUtils {
 
         @Override
         public Map<K, T> apply(Map<K, T> map) {
-            Map<K, T> builder = new HashMap<>();
-            builder.putAll(map);
+            Map<K, T> builder = new HashMap<>(map);
 
             for (K part : deletes) {
                 builder.remove(part);

--- a/core/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
+++ b/core/src/main/java/org/elasticsearch/common/blobstore/BlobPath.java
@@ -55,8 +55,7 @@ public class BlobPath implements Iterable<String> {
     }
 
     public BlobPath add(String path) {
-        List<String> paths = new ArrayList<>();
-        paths.addAll(this.paths);
+        List<String> paths = new ArrayList<>(this.paths);
         paths.add(path);
         return new BlobPath(Collections.unmodifiableList(paths));
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -741,8 +741,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
             // There is no need to synchronize writes here. In the case of concurrent access, we could just
             // compute some mappers several times, which is not a big deal
-            Map<String, MappedFieldType> newUnmappedFieldTypes = new HashMap<>();
-            newUnmappedFieldTypes.putAll(unmappedFieldTypes);
+            Map<String, MappedFieldType> newUnmappedFieldTypes = new HashMap<>(unmappedFieldTypes);
             newUnmappedFieldTypes.put(type, fieldType);
             unmappedFieldTypes = unmodifiableMap(newUnmappedFieldTypes);
         }

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -316,10 +316,8 @@ public class Node implements Closeable {
             DeprecationLogger.setThreadContext(threadPool.getThreadContext());
             resourcesToClose.add(() -> DeprecationLogger.removeThreadContext(threadPool.getThreadContext()));
 
-            final List<Setting<?>> additionalSettings = new ArrayList<>();
-            final List<String> additionalSettingsFilter = new ArrayList<>();
-            additionalSettings.addAll(pluginsService.getPluginSettings());
-            additionalSettingsFilter.addAll(pluginsService.getPluginSettingsFilter());
+            final List<Setting<?>> additionalSettings = new ArrayList<>(pluginsService.getPluginSettings());
+            final List<String> additionalSettingsFilter = new ArrayList<>(pluginsService.getPluginSettingsFilter());
             for (final ExecutorBuilder<?> builder : threadPool.builders()) {
                 additionalSettings.addAll(builder.getRegisteredSettings());
             }

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -95,8 +95,7 @@ public class RestThreadPoolAction extends AbstractCatAction {
     private static final Set<String> RESPONSE_PARAMS;
 
     static {
-        final Set<String> responseParams = new HashSet<>();
-        responseParams.addAll(AbstractCatAction.RESPONSE_PARAMS);
+        final Set<String> responseParams = new HashSet<>(AbstractCatAction.RESPONSE_PARAMS);
         responseParams.add("thread_pool_patterns");
         RESPONSE_PARAMS = Collections.unmodifiableSet(responseParams);
     }

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotUtils.java
@@ -82,8 +82,7 @@ public class SnapshotUtils {
                     } else {
                         if (result == null) {
                             // add all the previous ones...
-                            result = new HashSet<>();
-                            result.addAll(availableIndices.subList(0, i));
+                            result = new HashSet<>(availableIndices.subList(0, i));
                         }
                     }
                 } else {
@@ -99,8 +98,7 @@ public class SnapshotUtils {
             }
             if (result == null) {
                 // add all the previous ones...
-                result = new HashSet<>();
-                result.addAll(availableIndices.subList(0, i));
+                result = new HashSet<>(availableIndices.subList(0, i));
             }
             boolean found = false;
             for (String index : availableIndices) {

--- a/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/phonetic/KoelnerPhonetik.java
+++ b/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/phonetic/KoelnerPhonetik.java
@@ -142,7 +142,7 @@ public class KoelnerPhonetik implements StringEncoder {
         List<String> parts = new ArrayList<>();
         parts.add(primaryForm.replaceAll("[^\\p{L}\\p{N}]", ""));
         if (!primary) {
-            List<String> tmpParts = new ArrayList<>((Arrays.asList(str.split("[\\p{Z}\\p{C}\\p{P}]"))));
+            List<String> tmpParts = new ArrayList<>(Arrays.asList(str.split("[\\p{Z}\\p{C}\\p{P}]")));
             int numberOfParts = tmpParts.size();
             while (tmpParts.size() > 0) {
                 StringBuilder part = new StringBuilder();

--- a/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/phonetic/KoelnerPhonetik.java
+++ b/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/phonetic/KoelnerPhonetik.java
@@ -142,8 +142,7 @@ public class KoelnerPhonetik implements StringEncoder {
         List<String> parts = new ArrayList<>();
         parts.add(primaryForm.replaceAll("[^\\p{L}\\p{N}]", ""));
         if (!primary) {
-            List<String> tmpParts = new ArrayList<>();
-            tmpParts.addAll((Arrays.asList(str.split("[\\p{Z}\\p{C}\\p{P}]"))));
+            List<String> tmpParts = new ArrayList<>((Arrays.asList(str.split("[\\p{Z}\\p{C}\\p{P}]"))));
             int numberOfParts = tmpParts.size();
             while (tmpParts.size() > 0) {
                 StringBuilder part = new StringBuilder();

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -184,8 +184,7 @@ public class MockScriptEngine implements ScriptEngineService {
         public LeafSearchScript getLeafSearchScript(LeafReaderContext context) throws IOException {
             LeafSearchLookup leafLookup = lookup.getLeafSearchLookup(context);
 
-            Map<String, Object> ctx = new HashMap<>();
-            ctx.putAll(leafLookup.asMap());
+            Map<String, Object> ctx = new HashMap<>(leafLookup.asMap());
             if (vars != null) {
                 ctx.putAll(vars);
             }


### PR DESCRIPTION
This very small PR is related to issue #24226 it is small exactly to keep it readable.

This PR focusses on lists/maps that get instantiated with the default constructor, only have them be filled up with `addAll`/`putAll` the very next line. Most List/Map classes have a constructor where they accept an existing List/Map.

This avoids creating a list with default size, only to have it expand immediately afterward.

===========

1. Contributor agreement: Has been signed

2. Contributor guidelines: I have read them.

3. Gradle check: build successful.

4. PR is against master

5. The PR is not OS specific.

6. I'm not part of a class.