### PR TITLE
Set available processors for Netty

### DIFF
--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -48,10 +48,18 @@ dependencyLicenses {
 }
 
 test {
+    /*
+     * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each
+     * other if we allow them to set the number of available processors as it's set-once in Netty.
+     */
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
 }
 
 integTestRunner {
+    /*
+     * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each
+     * other if we allow them to set the number of available processors as it's set-once in Netty.
+     */
     systemProperty 'es.set.netty.runtime.available.processors', 'false'
 }
 

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -47,6 +47,14 @@ dependencyLicenses {
   mapping from: /netty-.*/, to: 'netty'
 }
 
+test {
+    systemProperty 'es.set.netty.runtime.available.processors', 'false'
+}
+
+integTestRunner {
+    systemProperty 'es.set.netty.runtime.available.processors', 'false'
+}
+
 thirdPartyAudit.excludes = [
         // classes are missing
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -209,6 +209,7 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
     public Netty4HttpServerTransport(Settings settings, NetworkService networkService, BigArrays bigArrays, ThreadPool threadPool,
                                      NamedXContentRegistry xContentRegistry, Dispatcher dispatcher) {
         super(settings);
+        Netty4Utils.setAvailableProcessors(EsExecutors.PROCESSORS_SETTING.get(settings));
         this.networkService = networkService;
         this.bigArrays = bigArrays;
         this.threadPool = threadPool;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -134,6 +134,7 @@ public class Netty4Transport extends TcpTransport<Channel> {
     public Netty4Transport(Settings settings, ThreadPool threadPool, NetworkService networkService, BigArrays bigArrays,
                           NamedWriteableRegistry namedWriteableRegistry, CircuitBreakerService circuitBreakerService) {
         super("netty", settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService);
+        Netty4Utils.setAvailableProcessors(EsExecutors.PROCESSORS_SETTING.get(settings));
         this.workerCount = WORKER_COUNT.get(settings);
         this.maxCumulationBufferCapacity = NETTY_MAX_CUMULATION_BUFFER_CAPACITY.get(settings);
         this.maxCompositeBufferComponents = NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS.get(settings);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -65,8 +65,18 @@ public class Netty4Utils {
      * @param availableProcessors the number of available processors
      */
     public static void setAvailableProcessors(final int availableProcessors) {
+        /*
+         * This can be invoked twice, once from Netty4Transport and another time from Netty4HttpServerTransport; however,
+         * Netty4Runtime#availableProcessors forbids settings the number of processors twice so we prevent double invocation here.
+         */
         if (isAvailableProcessorsSet.compareAndSet(false, true)) {
             NettyRuntime.setAvailableProcessors(availableProcessors);
+        } else {
+            // we have already previously set the available processors so here we sanity check that we are setting to the same value
+            assert availableProcessors == NettyRuntime.availableProcessors()
+                    : "available processors value [" + availableProcessors + "] did not match current value ["
+                    + NettyRuntime.availableProcessors() + "]";
+
         }
     }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -68,7 +68,7 @@ public class Netty4Utils {
      * @throws IllegalStateException if available processors was set previously and the specified value does not match the already-set value
      */
     public static void setAvailableProcessors(final int availableProcessors) {
-        // we set this to false in tests to avoid tests that randomly set processors from stepping all over each other
+        // we set this to false in tests to avoid tests that randomly set processors from stepping on each other
         final boolean set = Booleans.parseBoolean(System.getProperty("es.set.netty.runtime.available.processors", "true"));
         if (!set) {
             return;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -24,6 +24,7 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.util.NettyRuntime;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.apache.lucene.util.BytesRef;
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 public class Netty4Utils {
@@ -53,6 +55,19 @@ public class Netty4Utils {
 
     public static void setup() {
 
+    }
+
+    private static AtomicBoolean isAvailableProcessorsSet = new AtomicBoolean();
+
+    /**
+     * Set the number of available processors that Netty uses for sizing various resources (e.g., thread pools).
+     *
+     * @param availableProcessors the number of available processors
+     */
+    public static void setAvailableProcessors(final int availableProcessors) {
+        if (isAvailableProcessorsSet.compareAndSet(false, true)) {
+            NettyRuntime.setAvailableProcessors(availableProcessors);
+        }
     }
 
     /**

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -29,6 +29,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 
@@ -67,6 +68,12 @@ public class Netty4Utils {
      * @throws IllegalStateException if available processors was set previously and the specified value does not match the already-set value
      */
     public static void setAvailableProcessors(final int availableProcessors) {
+        // we set this to false in tests to avoid tests that randomly set processors from stepping all over each other
+        final boolean set = Booleans.parseBoolean(System.getProperty("es.set.netty.runtime.available.processors", "true"));
+        if (!set) {
+            return;
+        }
+
         /*
          * This can be invoked twice, once from Netty4Transport and another time from Netty4HttpServerTransport; however,
          * Netty4Runtime#availableProcessors forbids settings the number of processors twice so we prevent double invocation here.

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Utils.java
@@ -72,7 +72,7 @@ public class Netty4Utils {
         if (isAvailableProcessorsSet.compareAndSet(false, true)) {
             NettyRuntime.setAvailableProcessors(availableProcessors);
         } else {
-            // we have already previously set the available processors so here we sanity check that we are setting to the same value
+            // we have previously set the available processors so here we sanity check that we are setting to the same value
             assert availableProcessors == NettyRuntime.availableProcessors()
                     : "available processors value [" + availableProcessors + "] did not match current value ["
                     + NettyRuntime.availableProcessors() + "]";

--- a/qa/smoke-test-http/build.gradle
+++ b/qa/smoke-test-http/build.gradle
@@ -24,3 +24,11 @@ apply plugin: 'elasticsearch.test-with-dependencies'
 dependencies {
     testCompile project(path: ':modules:transport-netty4', configuration: 'runtime') // for http
 }
+
+integTestRunner {
+    /*
+     * We have to disable setting the number of available processors as tests in the same JVM randomize processors and will step on each
+     * other if we allow them to set the number of available processors as it's set-once in Netty.
+     */
+    systemProperty 'es.set.netty.runtime.available.processors', 'false'
+}


### PR DESCRIPTION
Netty uses the number of processors for sizing various resources (e.g., thread pools, buffer pools, etc.). However, it uses the runtime number of available processors which might not match the configured number of processors as set in Elasticsearch to limit the number of threads (e.g., in Docker containers). A new feature was added to Netty that enables configuring the number of processors Netty should see for sizing this various resources. This commit takes advantage of this feature to set this number of available processors to be equal to the configured number of processors set in Elasticsearch.

Relates netty/netty#6224