### PR TITLE
[DOCS] Update XPack documentation version

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -15,7 +15,7 @@ release-state can be: released | prerelease | unreleased
 :defguide:        https://www.elastic.co/guide/en/elasticsearch/guide/2.x
 :plugins:         https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
 :javaclient:      https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
-:xpack:           https://www.elastic.co/guide/en/x-pack/5.3
+:xpack:           https://www.elastic.co/guide/en/x-pack/{branch}
 :logstash:        https://www.elastic.co/guide/en/logstash/{branch}
 :kibana:          https://www.elastic.co/guide/en/kibana/{branch}
 :issue:           https://github.com/elastic/elasticsearch/issues/
@@ -42,4 +42,3 @@ ifeval::["{release-state}"!="unreleased"]
 :elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}
 :painless-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/painless/lang-painless/{version}
 endif::[]
-


### PR DESCRIPTION
This PR updates the "xpack" attribute so that it points to {branch} (5.4) instead of 5.3
