### PR TITLE
Adding _field_names to META_FIELDS to fix issue #24422

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -111,7 +111,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
     private static ObjectHashSet<String> META_FIELDS = ObjectHashSet.from(
             "_uid", "_id", "_type", "_all", "_parent", "_routing", "_index",
-            "_size", "_timestamp", "_ttl"
+            "_size", "_timestamp", "_ttl", "_field_names"
     );
 
     private final IndexAnalyzers indexAnalyzers;


### PR DESCRIPTION
Fix for #24422 

Unit tests already goes through this code path (in `DocumentParserTests.testDocumentContainsMetadataField()`, thus I did not add any new one as it seems a bit of an overkill