### PR TITLE
Fix JVM test argline

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -468,8 +468,14 @@ class BuildPlugin implements Plugin<Project> {
             File heapdumpDir = new File(project.buildDir, 'heapdump')
             heapdumpDir.mkdirs()
             jvmArg '-XX:HeapDumpPath=' + heapdumpDir
-            argLine System.getProperty('tests.jvm.argline')
-            argLine '-XX:-OmitStackTraceInFastThrow'
+            final String testsJvmArgline = System.getProperty('tests.jvm.argline')
+            if (testsJvmArgline == null) {
+                argLine '-XX:-OmitStackTraceInFastThrow'
+            } else if (testsJvmArgline.indexOf("OmitStackTraceInFastThrow") < 0) {
+                argLine testsJvmArgline.trim() + ' ' + '-XX:-OmitStackTraceInFastThrow'
+            } else {
+                argLine testsJvmArgline.trim()
+            }
 
             // we use './temp' since this is per JVM and tests are forbidden from writing to CWD
             systemProperty 'java.io.tmpdir', './temp'

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -469,7 +469,10 @@ class BuildPlugin implements Plugin<Project> {
             heapdumpDir.mkdirs()
             jvmArg '-XX:HeapDumpPath=' + heapdumpDir
             final String testsJvmArgline = System.getProperty('tests.jvm.argline')
-            // only append -XX:-OmitStackTraceInFastThrow if it is not already included in tests.jvm.argline
+            /*
+             * We only want to append -XX:-OmitStackTraceInFastThrow if a flag for OmitStackTraceInFastThrow is not already included in
+             * tests.jvm.argline.
+             */
             if (testsJvmArgline == null) {
                 argLine '-XX:-OmitStackTraceInFastThrow'
             } else if (testsJvmArgline.indexOf("OmitStackTraceInFastThrow") < 0) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -469,7 +469,7 @@ class BuildPlugin implements Plugin<Project> {
             heapdumpDir.mkdirs()
             jvmArg '-XX:HeapDumpPath=' + heapdumpDir
             final String testsJvmArgline = System.getProperty('tests.jvm.argline')
-            // only append OmitStackTraceInFastThrow if it is not already included in tests.jvm.argline
+            // only append -XX:-OmitStackTraceInFastThrow if it is not already included in tests.jvm.argline
             if (testsJvmArgline == null) {
                 argLine '-XX:-OmitStackTraceInFastThrow'
             } else if (testsJvmArgline.indexOf("OmitStackTraceInFastThrow") < 0) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -469,6 +469,7 @@ class BuildPlugin implements Plugin<Project> {
             heapdumpDir.mkdirs()
             jvmArg '-XX:HeapDumpPath=' + heapdumpDir
             final String testsJvmArgline = System.getProperty('tests.jvm.argline')
+            // only append OmitStackTraceInFastThrow if it is not already included in tests.jvm.argline
             if (testsJvmArgline == null) {
                 argLine '-XX:-OmitStackTraceInFastThrow'
             } else if (testsJvmArgline.indexOf("OmitStackTraceInFastThrow") < 0) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -468,11 +468,11 @@ class BuildPlugin implements Plugin<Project> {
             File heapdumpDir = new File(project.buildDir, 'heapdump')
             heapdumpDir.mkdirs()
             jvmArg '-XX:HeapDumpPath=' + heapdumpDir
-            final String testsJvmArgline = System.getProperty('tests.jvm.argline')
             /*
              * We only want to append -XX:-OmitStackTraceInFastThrow if a flag for OmitStackTraceInFastThrow is not already included in
              * tests.jvm.argline.
              */
+            final String testsJvmArgline = System.getProperty('tests.jvm.argline')
             if (testsJvmArgline == null) {
                 argLine '-XX:-OmitStackTraceInFastThrow'
             } else if (testsJvmArgline.indexOf("OmitStackTraceInFastThrow") < 0) {


### PR DESCRIPTION
The argline was being overridden by '-XX:-OmitStackTraceInFastThrow' which led to test failures that were expecting the JVM to be in a certain state based on the value of tests.jvm.argline but they were not since these arguments were never passed to the JVM. Additionally, we need to respect the provided JVM argline if it is already provided with a flag for OmitStackTraceInFastThrow. This commit fixes this by only setting OmitStackTraceInFastThrow if it is not already set.

Relates #24426