### PR TITLE
Tests: Switch to Fedora-25 for packaging tests

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,8 +56,8 @@ Vagrant.configure(2) do |config|
     config.vm.box = "elastic/oraclelinux-7-x86_64"
     rpm_common config
   end
-  config.vm.define "fedora-24" do |config|
-    config.vm.box = "elastic/fedora-24-x86_64"
+  config.vm.define "fedora-25" do |config|
+    config.vm.box = "elastic/fedora-25-x86_64"
     dnf_common config
   end
   config.vm.define "opensuse-13" do |config|


### PR DESCRIPTION
With Fedora-25 available since 2016-11-22, it's time to switch to the corresponding Vagrant box for the packaging tests as well.