### PR TITLE
You had one job Netty logging guard

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4InternalESLogger.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4InternalESLogger.java
@@ -101,7 +101,11 @@ class Netty4InternalESLogger extends AbstractInternalLogger {
 
     @Override
     public void info(String msg) {
-        logger.info(msg);
+        if (!("Your platform does not provide complete low-level API for accessing direct buffers reliably. " +
+                "Unless explicitly requested, heap buffer will always be preferred to avoid potential system " +
+                "instability.").equals(msg)) {
+            logger.info(msg);
+        }
     }
 
     @Override


### PR DESCRIPTION
In pre-release versions of Elasticsearch 5.0.0, users were subject to log messages of the form "your platform does not.*reliably.*potential system instability". This is because we disable Netty from being unsafe, and Netty throws up this scary info-level message when unsafe is unavailable, even if it was unavailable because the user requested that it be unavailabe. Users were rightly confused, and concerned. So, we contributed a guard to Netty to prevent this log message from showing up when unsafe was explicitly disabled. This guard shipped with all versions of Netty that shipped starting with Elasticsearch 5.0.0. Unfortunately, this guard was lost in an unrelated refactoring and now with the 4.1.10.Final upgrade, users will again see this message. This commit is a hack around this until we can get a fix upstream again.

Relates netty/netty#5624, netty/netty#6568
