### PR TITLE
[DOCS] Fixes the documentation on leading forward slashes in the base_path of S3 repositories

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -168,6 +168,9 @@ The following settings are supported:
 
     Specifies the path within bucket to repository data. Defaults to
     value of `repositories.s3.base_path` or to root directory if not set.
+    Previously, the base_path could take a leading `/` (forward slash).
+    However, this has been deprecated and setting the base_path now should
+    omit the leading `/`.
 
 `access_key`::
 


### PR DESCRIPTION
Closes #23435