### PR TITLE
[TEST] Rollback temporarily disabled field_caps test

### DIFF
--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/30_field_caps.yaml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/30_field_caps.yaml
@@ -1,8 +1,8 @@
 ---
 "Get simple field caps from remote cluster":
   - skip:
-      version: " - 5.99.99"
-      reason:  this uses a new API that has been added in 6.0.0
+      version: " - 5.4.99"
+      reason:  this uses a new API functionality that has been added in 5.5.0
 
   - do:
         indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/field_caps/10_basic.yaml
@@ -76,7 +76,7 @@ setup:
 ---
 "Get simple field caps":
   - skip:
-      version: " - 5.99.99" # temporarily disabled until bwc code is backported and propagated
+      version: " - 5.3.99"
       reason:  this uses a new API that has been added in 5.4.0
 
   - do:
@@ -117,7 +117,7 @@ setup:
 ---
 "Get nested field caps":
   - skip:
-      version: " - 5.99.99" # temporarily disabled until bwc code is backported and propagated
+      version: " - 5.3.99"
       reason:  this uses a new API that has been added in 5.4.0
 
   - do:
@@ -148,7 +148,7 @@ setup:
 ---
 "Get prefix field caps":
   - skip:
-      version: " - 5.99.99" # temporarily disabled until bwc code is backported and propagated
+      version: " - 5.3.99"
       reason:  this uses a new API that has been added in 5.4.0
 
   - do:


### PR DESCRIPTION
once a new snapshot is available we can reenable these tests again. I just open this PR to make sure I am not forgetting about it.