### PR TITLE
Move flag to painless tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -468,18 +468,7 @@ class BuildPlugin implements Plugin<Project> {
             File heapdumpDir = new File(project.buildDir, 'heapdump')
             heapdumpDir.mkdirs()
             jvmArg '-XX:HeapDumpPath=' + heapdumpDir
-            /*
-             * We only want to append -XX:-OmitStackTraceInFastThrow if a flag for OmitStackTraceInFastThrow is not already included in
-             * tests.jvm.argline.
-             */
             final String testsJvmArgline = System.getProperty('tests.jvm.argline')
-            if (testsJvmArgline == null) {
-                argLine '-XX:-OmitStackTraceInFastThrow'
-            } else if (testsJvmArgline.indexOf("OmitStackTraceInFastThrow") < 0) {
-                argLine testsJvmArgline.trim() + ' ' + '-XX:-OmitStackTraceInFastThrow'
-            } else {
-                argLine testsJvmArgline.trim()
-            }
 
             // we use './temp' since this is per JVM and tests are forbidden from writing to CWD
             systemProperty 'java.io.tmpdir', './temp'

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -468,7 +468,7 @@ class BuildPlugin implements Plugin<Project> {
             File heapdumpDir = new File(project.buildDir, 'heapdump')
             heapdumpDir.mkdirs()
             jvmArg '-XX:HeapDumpPath=' + heapdumpDir
-            final String testsJvmArgline = System.getProperty('tests.jvm.argline')
+            argLine System.getProperty('tests.jvm.argline')
 
             // we use './temp' since this is per JVM and tests are forbidden from writing to CWD
             systemProperty 'java.io.tmpdir', './temp'

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -33,6 +33,10 @@ dependencyLicenses {
   mapping from: /asm-.*/, to: 'asm'
 }
 
+test {
+  jvmArg '-XX:-OmitStackTraceInFastThrow'
+}
+
 integTestCluster {
   setting 'script.max_compilations_per_minute', '1000'
 }
@@ -146,5 +150,3 @@ task regen {
     }
   }
 }
-
-


### PR DESCRIPTION
The `-XX:-OmitStackTraceInFastThrow` flag is only required by Painless's
tests so we'll only set it there. This is much simpler.
