### PR TITLE
Expand cross cluster search indices for search requests to the concrete index or to it's aliases

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/ArrayUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/util/ArrayUtils.java
@@ -84,5 +84,4 @@ public class ArrayUtils {
         System.arraycopy(other, 0, target, one.length, other.length);
         return target;
     }
-
 }


### PR DESCRIPTION
This change will expand the shard level request to the actual concrete index or to the aliases
that expanded to the concrete index to ensure shard level requests won't see wildcard expressions
as their original indices