### PR TITLE
Fix single shard scroll within a cluster with nodes in version `>= 5.3` and `<= 5.3`

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -121,6 +121,14 @@ public class SearchTransportService extends AbstractComponent {
         final boolean fetchDocuments = request.numberOfShards() == 1;
         Supplier<SearchPhaseResult> supplier = fetchDocuments ? QueryFetchSearchResult::new : QuerySearchResult::new;
         if (connection.getVersion().onOrBefore(Version.V_5_3_0_UNRELEASED) && fetchDocuments) {
+            if (connection.getVersion().before(Version.V_5_3_0_UNRELEASED) && request.scroll() != null) {
+                /**
+                 * This is needed for nodes pre 5.3 when the single shard optimization is used.
+                 * These nodes will set the last emitted doc only if the removed `query_and_fetch` search type is set
+                 * in the request. See {@link SearchType}.
+                 */
+                request.searchType(SearchType.fromId((byte) 3));
+            }
             // TODO this BWC layer can be removed once this is back-ported to 5.3
             transportService.sendChildRequest(connection, QUERY_FETCH_ACTION_NAME, request, task,
                 new ActionListenerResponseHandler<>(listener, supplier));

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -169,6 +169,10 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         return profile;
     }
 
+    void setSearchType(SearchType type) {
+        this.searchType = type;
+    }
+
     protected void innerReadFrom(StreamInput in) throws IOException {
         shardId = ShardId.readShardId(in);
         searchType = SearchType.fromId(in.readByte());

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -60,6 +60,10 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
         this.originalIndices = originalIndices;
     }
 
+    public void searchType(SearchType searchType) {
+        shardSearchLocalRequest.setSearchType(searchType);
+    }
+
     @Override
     public String[] indices() {
         if (originalIndices == null) {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/10_basic.yaml
@@ -66,6 +66,78 @@
         scroll_id: $scroll_id
 
 ---
+"Basic scroll with 1 shard":
+  - do:
+      indices.create:
+        index: test_scroll
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+
+  - do:
+      index:
+        index:  test_scroll
+        type:   test
+        id:     42
+        body:   { foo: 1 }
+
+  - do:
+      index:
+        index:  test_scroll
+        type:   test
+        id:     43
+        body:   { foo: 2 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test_scroll
+        size: 1
+        scroll: 1m
+        sort: foo
+        body:
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id}
+  - match: {hits.total:      2    }
+  - length: {hits.hits:      1    }
+  - match: {hits.hits.0._id: "42" }
+
+  - do:
+      index:
+        index:  test_scroll
+        type:   test
+        id:     44
+        body:   { foo: 3 }
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      scroll:
+        body: { "scroll_id": "$scroll_id", "scroll": "1m"}
+
+  - match: {hits.total:      2    }
+  - length: {hits.hits:      1    }
+  - match: {hits.hits.0._id: "43" }
+
+  - do:
+      scroll:
+        scroll_id: $scroll_id
+        scroll: 1m
+
+  - match: {hits.total:      2    }
+  - length: {hits.hits:      0    }
+
+  - do:
+      clear_scroll:
+        scroll_id: $scroll_id
+
+---
 "Body params override query string":
   - do:
       indices.create:


### PR DESCRIPTION
If a node in version >= 5.3 acts as a coordinating node during a scroll request that targets a single shard, the scroll may return the same documents over and over iff the targeted shard is hosted by a node with a version <= 5.3.
Nodes in this version will advance the scroll only if the search_type has been set to `query_and_fetch` though this search type has been removed in 5.3.
This change handles this situation by adding the removed `search_type` in the request that targets a node in version <= 5.3.