### PR TITLE
Support Multiple Inner Hits on a Field Collapse Request

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.collapse.CollapseBuilder;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -59,7 +60,8 @@ final class ExpandSearchPhase extends SearchPhase {
         final SearchRequest searchRequest = context.getRequest();
         return searchRequest.source() != null &&
             searchRequest.source().collapse() != null &&
-            searchRequest.source().collapse().getInnerHit() != null;
+            searchRequest.source().collapse().getInnerHits() != null &&
+            !searchRequest.source().collapse().getInnerHits().isEmpty();
     }
 
     @Override
@@ -67,6 +69,7 @@ final class ExpandSearchPhase extends SearchPhase {
         if (isCollapseRequest()) {
             SearchRequest searchRequest = context.getRequest();
             CollapseBuilder collapseBuilder = searchRequest.source().collapse();
+            final List<InnerHitBuilder> innerHitBuilders = collapseBuilder.getInnerHits();
             MultiSearchRequest multiRequest = new MultiSearchRequest();
             if (collapseBuilder.getMaxConcurrentGroupRequests() > 0) {
                 multiRequest.maxConcurrentSearchRequests(collapseBuilder.getMaxConcurrentGroupRequests());
@@ -83,27 +86,31 @@ final class ExpandSearchPhase extends SearchPhase {
                 if (origQuery != null) {
                     groupQuery.must(origQuery);
                 }
-                SearchSourceBuilder sourceBuilder = buildExpandSearchSourceBuilder(collapseBuilder.getInnerHit())
-                    .query(groupQuery);
-                SearchRequest groupRequest = new SearchRequest(searchRequest.indices())
-                    .types(searchRequest.types())
-                    .source(sourceBuilder);
-                multiRequest.add(groupRequest);
+                for (InnerHitBuilder innerHitBuilder : innerHitBuilders) {
+                    SearchSourceBuilder sourceBuilder = buildExpandSearchSourceBuilder(innerHitBuilder)
+                        .query(groupQuery);
+                    SearchRequest groupRequest = new SearchRequest(searchRequest.indices())
+                        .types(searchRequest.types())
+                        .source(sourceBuilder);
+                    multiRequest.add(groupRequest);
+                }
             }
             context.getSearchTransport().sendExecuteMultiSearch(multiRequest, context.getTask(),
                 ActionListener.wrap(response -> {
                     Iterator<MultiSearchResponse.Item> it = response.iterator();
                     for (SearchHit hit : searchResponse.getHits()) {
-                        MultiSearchResponse.Item item = it.next();
-                        if (item.isFailure()) {
-                            context.onPhaseFailure(this, "failed to expand hits", item.getFailure());
-                            return;
+                        for (InnerHitBuilder innerHitBuilder : innerHitBuilders) {
+                            MultiSearchResponse.Item item = it.next();
+                            if (item.isFailure()) {
+                                context.onPhaseFailure(this, "failed to expand hits", item.getFailure());
+                                return;
+                            }
+                            SearchHits innerHits = item.getResponse().getHits();
+                            if (hit.getInnerHits() == null) {
+                                hit.setInnerHits(new HashMap<>(innerHitBuilders.size()));
+                            }
+                            hit.getInnerHits().put(innerHitBuilder.getName(), innerHits);
                         }
-                        SearchHits innerHits = item.getResponse().getHits();
-                        if (hit.getInnerHits() == null) {
-                            hit.setInnerHits(new HashMap<>(1));
-                        }
-                        hit.getInnerHits().put(collapseBuilder.getInnerHit().getName(), innerHits);
                     }
                     context.executeNextPhase(this, nextPhaseFactory.apply(searchResponse));
                 }, context::onFailure)

--- a/core/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -205,6 +205,7 @@ public class CollapseBuilder extends ToXContentToBytes implements Writeable {
                 for (InnerHitBuilder innerHit : innerHits) {
                     innerHit.toXContent(builder, ToXContent.EMPTY_PARAMS);
                 }
+                builder.endArray();
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/search/collapse/CollapseContext.java
+++ b/core/src/main/java/org/elasticsearch/search/collapse/CollapseContext.java
@@ -26,17 +26,24 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.query.InnerHitBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Context used for field collapsing
  */
 public class CollapseContext {
     private final MappedFieldType fieldType;
-    private final InnerHitBuilder innerHit;
+    private final List<InnerHitBuilder> innerHits;
 
     public CollapseContext(MappedFieldType fieldType, InnerHitBuilder innerHit) {
         this.fieldType = fieldType;
-        this.innerHit = innerHit;
+        this.innerHits = Collections.singletonList(innerHit);
+    }
+
+    public CollapseContext(MappedFieldType fieldType, List<InnerHitBuilder> innerHits) {
+        this.fieldType = fieldType;
+        this.innerHits = innerHits;
     }
 
     /** The field type used for collapsing **/
@@ -44,10 +51,9 @@ public class CollapseContext {
         return fieldType;
     }
 
-
     /** The inner hit options to expand the collapsed results **/
-    public InnerHitBuilder getInnerHit() {
-        return innerHit;
+    public List<InnerHitBuilder> getInnerHit() {
+        return innerHits;
     }
 
     public CollapsingTopDocsCollector<?> createTopDocs(Sort sort, int topN, boolean trackMaxScore) throws IOException {

--- a/core/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
@@ -36,25 +36,38 @@ import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class ExpandSearchPhaseTests extends ESTestCase {
 
     public void testCollapseSingleHit() throws IOException {
         final int iters = randomIntBetween(5, 10);
         for (int i = 0; i < iters; i++) {
-            SearchHits collapsedHits = new SearchHits(new SearchHit[]{new SearchHit(2, "ID", new Text("type"),
-                Collections.emptyMap()), new SearchHit(3, "ID", new Text("type"),
-                Collections.emptyMap())}, 1, 1.0F);
+            final int numInnerHits = randomIntBetween(1, 5);
+            List<SearchHits> collapsedHits = new ArrayList<>(numInnerHits);
+            for (int innerHitNum = 0; innerHitNum < numInnerHits; innerHitNum++) {
+                SearchHits hits = new SearchHits(new SearchHit[]{new SearchHit(innerHitNum, "ID", new Text("type"),
+                    Collections.emptyMap()), new SearchHit(innerHitNum + 1, "ID", new Text("type"),
+                    Collections.emptyMap())}, 2, 1.0F);
+                collapsedHits.add(hits);
+            }
+
             AtomicBoolean executedMultiSearch = new AtomicBoolean(false);
             QueryBuilder originalQuery = randomBoolean() ? null : QueryBuilders.termQuery("foo", "bar");
 
-            MockSearchPhaseContext mockSearchPhaseContext = new MockSearchPhaseContext(1);
+            final MockSearchPhaseContext mockSearchPhaseContext = new MockSearchPhaseContext(1);
             String collapseValue = randomBoolean() ? null : "boom";
+
             mockSearchPhaseContext.getRequest().source(new SearchSourceBuilder()
-                .collapse(new CollapseBuilder("someField").setInnerHits(new InnerHitBuilder().setName("foobarbaz"))));
+                .collapse(new CollapseBuilder("someField")
+                    .setInnerHits(IntStream.range(0, numInnerHits).mapToObj(hitNum -> new InnerHitBuilder().setName("innerHit" + hitNum))
+                        .collect(Collectors.toList()))));
             mockSearchPhaseContext.getRequest().source().query(originalQuery);
             mockSearchPhaseContext.searchTransport = new SearchTransportService(
                 Settings.builder().put("search.remote.connect", false).build(), null) {
@@ -62,9 +75,10 @@ public class ExpandSearchPhaseTests extends ESTestCase {
                 @Override
                 void sendExecuteMultiSearch(MultiSearchRequest request, SearchTask task, ActionListener<MultiSearchResponse> listener) {
                     assertTrue(executedMultiSearch.compareAndSet(false, true));
-                    assertEquals(1, request.requests().size());
+                    assertEquals(numInnerHits, request.requests().size());
                     SearchRequest searchRequest = request.requests().get(0);
                     assertTrue(searchRequest.source().query() instanceof BoolQueryBuilder);
+
                     BoolQueryBuilder groupBuilder = (BoolQueryBuilder) searchRequest.source().query();
                     if (collapseValue == null) {
                         assertThat(groupBuilder.mustNot(), Matchers.contains(QueryBuilders.existsQuery("someField")));
@@ -78,13 +92,15 @@ public class ExpandSearchPhaseTests extends ESTestCase {
                     assertArrayEquals(mockSearchPhaseContext.getRequest().types(), searchRequest.types());
 
 
-                    InternalSearchResponse internalSearchResponse = new InternalSearchResponse(collapsedHits,
-                        null, null, null, false, null, 1);
-                    SearchResponse response = mockSearchPhaseContext.buildSearchResponse(internalSearchResponse, null);
-                    listener.onResponse(new MultiSearchResponse(new MultiSearchResponse.Item[]{
-                        new MultiSearchResponse.Item(response, null)
-                    }));
+                    List<MultiSearchResponse.Item> mSearchResponses = new ArrayList<>(numInnerHits);
+                    for (int innerHitNum = 0; innerHitNum < numInnerHits; innerHitNum++) {
+                        InternalSearchResponse internalSearchResponse = new InternalSearchResponse(collapsedHits.get(innerHitNum),
+                            null, null, null, false, null, 1);
+                        SearchResponse response = mockSearchPhaseContext.buildSearchResponse(internalSearchResponse, null);
+                        mSearchResponses.add(new MultiSearchResponse.Item(response, null));
+                    }
 
+                    listener.onResponse(new MultiSearchResponse(mSearchResponses.toArray(new MultiSearchResponse.Item[0])));
                 }
             };
 
@@ -108,8 +124,12 @@ public class ExpandSearchPhaseTests extends ESTestCase {
             assertNotNull(reference.get());
             SearchResponse theResponse = reference.get();
             assertSame(theResponse, response);
-            assertEquals(1, theResponse.getHits().getHits()[0].getInnerHits().size());
-            assertSame(theResponse.getHits().getHits()[0].getInnerHits().get("foobarbaz"), collapsedHits);
+            assertEquals(numInnerHits, theResponse.getHits().getHits()[0].getInnerHits().size());
+
+            for (int innerHitNum = 0; innerHitNum < numInnerHits; innerHitNum++) {
+                assertSame(theResponse.getHits().getHits()[0].getInnerHits().get("innerHit" + innerHitNum), collapsedHits.get(innerHitNum));
+            }
+
             assertTrue(executedMultiSearch.get());
             assertEquals(1, mockSearchPhaseContext.phasesExecuted.get());
         }

--- a/core/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -44,6 +44,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.mock;
@@ -69,10 +71,19 @@ public class CollapseBuilderTests extends AbstractWireSerializingTestCase {
     public static CollapseBuilder randomCollapseBuilder() {
         CollapseBuilder builder = new CollapseBuilder(randomAlphaOfLength(10));
         builder.setMaxConcurrentGroupRequests(randomIntBetween(1, 48));
-        if (randomBoolean()) {
+        int numInnerHits = randomIntBetween(0, 5);
+        if (numInnerHits == 1) {
             InnerHitBuilder innerHit = InnerHitBuilderTests.randomInnerHits(false, false);
             builder.setInnerHits(innerHit);
+        } else if (numInnerHits > 1) {
+            List<InnerHitBuilder> innerHits = new ArrayList<>(numInnerHits);
+            for (int i = 0; i < numInnerHits; i++) {
+                innerHits.add(InnerHitBuilderTests.randomInnerHits(false, false));
+            }
+
+            builder.setInnerHits(innerHits);
         }
+
         return builder;
     }
 

--- a/docs/reference/search/request/collapse.asciidoc
+++ b/docs/reference/search/request/collapse.asciidoc
@@ -76,5 +76,41 @@ The `max_concurrent_group_searches` request parameter can be used to control
 the maximum number of concurrent searches allowed in this phase.
 The default is based on the number of data nodes and the default search thread pool size.
 
+It is also possible to request multiple `inner_hits` for each collapsed hit.  This can be useful when you want to get
+multiple representations of the collapsed hits.
+
+[source,js]
+--------------------------------------------------
+GET /twitter/tweet/_search
+{
+    "query": {
+        "match": {
+            "message": "elasticsearch"
+        }
+    },
+    "collapse" : {
+        "field" : "user", <1>
+        "inner_hits": [
+            {
+                "name": "most_liked",  <2>
+                "size": 3,
+                "sort": ["likes"]
+            },
+            {
+                "name": "most_recent", <3>
+                "size": 3,
+                "sort": [{ "date": "asc" }]
+            }
+        ]
+    },
+    "sort": ["likes"]
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
+<1> collapse the result set using the "user" field
+<2> return the three most liked tweets for the user
+<3> return the three most recent tweets for the user
+
 WARNING: `collapse` cannot be used in conjunction with <<search-request-scroll, scroll>>,
 <<search-request-rescore, rescore>> or <<search-request-search-after, search after>>.

--- a/docs/reference/search/request/collapse.asciidoc
+++ b/docs/reference/search/request/collapse.asciidoc
@@ -70,12 +70,6 @@ GET /twitter/tweet/_search
 
 See <<search-request-inner-hits, inner hits>> for the complete list of supported options and the format of the response.
 
-The expansion of the group is done by sending an additional query for each
-collapsed hit returned in the response.
-The `max_concurrent_group_searches` request parameter can be used to control
-the maximum number of concurrent searches allowed in this phase.
-The default is based on the number of data nodes and the default search thread pool size.
-
 It is also possible to request multiple `inner_hits` for each collapsed hit.  This can be useful when you want to get
 multiple representations of the collapsed hits.
 
@@ -111,6 +105,14 @@ GET /twitter/tweet/_search
 <1> collapse the result set using the "user" field
 <2> return the three most liked tweets for the user
 <3> return the three most recent tweets for the user
+
+The expansion of the group is done by sending an additional query for each
+`inner_hit` request for each collapsed hit returned in the response.  This can significantly slow things down
+if you have too many groups and/or `inner_hit` requests.
+
+The `max_concurrent_group_searches` request parameter can be used to control
+the maximum number of concurrent searches allowed in this phase.
+The default is based on the number of data nodes and the default search thread pool size.
 
 WARNING: `collapse` cannot be used in conjunction with <<search-request-scroll, scroll>>,
 <<search-request-rescore, rescore>> or <<search-request-search-after, search after>>.


### PR DESCRIPTION
Support multiple named inner hits on a field collapsing request.  This change is backward compatible.