### PR TITLE
Add parsing for String/Long/Double Terms aggregations

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
@@ -47,7 +47,7 @@ public class Aggregations implements Iterable<Aggregation>, ToXContent {
     protected Aggregations() {
     }
 
-    protected Aggregations(List<? extends Aggregation> aggregations) {
+    public Aggregations(List<? extends Aggregation> aggregations) {
         this.aggregations = aggregations;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -34,9 +34,10 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
-public abstract class ParsedMultiBucketAggregation extends ParsedAggregation implements MultiBucketsAggregation {
+public abstract class ParsedMultiBucketAggregation<B extends ParsedMultiBucketAggregation.Bucket>
+        extends ParsedAggregation implements MultiBucketsAggregation {
 
-    protected final List<ParsedBucket> buckets = new ArrayList<>();
+    protected final List<B> buckets = new ArrayList<>();
     protected boolean keyed = false;
 
     @Override
@@ -46,7 +47,7 @@ public abstract class ParsedMultiBucketAggregation extends ParsedAggregation imp
         } else {
             builder.startArray(CommonFields.BUCKETS.getPreferredName());
         }
-        for (ParsedBucket bucket : buckets) {
+        for (B bucket : buckets) {
             bucket.toXContent(builder, params);
         }
         if (keyed) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations;
 
+import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -35,7 +36,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 
 public abstract class ParsedMultiBucketAggregation extends ParsedAggregation implements MultiBucketsAggregation {
 
-    protected final List<ParsedBucket<?>> buckets = new ArrayList<>();
+    protected final List<ParsedBucket> buckets = new ArrayList<>();
     protected boolean keyed = false;
 
     @Override
@@ -45,7 +46,7 @@ public abstract class ParsedMultiBucketAggregation extends ParsedAggregation imp
         } else {
             builder.startArray(CommonFields.BUCKETS.getPreferredName());
         }
-        for (ParsedBucket<?> bucket : buckets) {
+        for (ParsedBucket bucket : buckets) {
             bucket.toXContent(builder, params);
         }
         if (keyed) {
@@ -57,8 +58,8 @@ public abstract class ParsedMultiBucketAggregation extends ParsedAggregation imp
     }
 
     protected static void declareMultiBucketAggregationFields(final ObjectParser<? extends ParsedMultiBucketAggregation, Void> objectParser,
-                                                  final CheckedFunction<XContentParser, ParsedBucket<?>, IOException> bucketParser,
-                                                  final CheckedFunction<XContentParser, ParsedBucket<?>, IOException> keyedBucketParser) {
+                                                  final CheckedFunction<XContentParser, ParsedBucket, IOException> bucketParser,
+                                                  final CheckedFunction<XContentParser, ParsedBucket, IOException> keyedBucketParser) {
         declareAggregationFields(objectParser);
         objectParser.declareField((parser, aggregation, context) -> {
             XContentParser.Token token = parser.currentToken();
@@ -76,22 +77,12 @@ public abstract class ParsedMultiBucketAggregation extends ParsedAggregation imp
         }, CommonFields.BUCKETS, ObjectParser.ValueType.OBJECT_ARRAY);
     }
 
-    public static class ParsedBucket<T> implements MultiBucketsAggregation.Bucket {
+    public static abstract class ParsedBucket implements MultiBucketsAggregation.Bucket {
 
         private Aggregations aggregations;
-        private T key;
         private String keyAsString;
         private long docCount;
         private boolean keyed;
-
-        protected void setKey(T key) {
-            this.key = key;
-        }
-
-        @Override
-        public Object getKey() {
-            return key;
-        }
 
         protected void setKeyAsString(String keyAsString) {
             this.keyAsString = keyAsString;
@@ -137,17 +128,21 @@ public abstract class ParsedMultiBucketAggregation extends ParsedAggregation imp
             if (keyAsString != null) {
                 builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), getKeyAsString());
             }
-            builder.field(CommonFields.KEY.getPreferredName(), key);
+            keyToXContent(builder);
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             aggregations.toXContentInternal(builder, params);
             builder.endObject();
             return builder;
         }
 
-        protected static <T, B extends ParsedBucket<T>> B parseXContent(final XContentParser parser,
-                                                                        final boolean keyed,
-                                                                        final Supplier<B> bucketSupplier,
-                                                                        final CheckedFunction<XContentParser, T, IOException> keyParser)
+        protected XContentBuilder keyToXContent(XContentBuilder builder) throws IOException {
+            return builder.field(CommonFields.KEY.getPreferredName(), getKey());
+        }
+
+        protected static <B extends ParsedBucket> B parseXContent(final XContentParser parser,
+                                                                  final boolean keyed,
+                                                                  final Supplier<B> bucketSupplier,
+                                                                  final CheckedBiConsumer<XContentParser, B, IOException> keyConsumer)
                                                                         throws IOException {
             final B bucket = bucketSupplier.get();
             bucket.setKeyed(keyed);
@@ -166,7 +161,7 @@ public abstract class ParsedMultiBucketAggregation extends ParsedAggregation imp
                     if (CommonFields.KEY_AS_STRING.getPreferredName().equals(currentFieldName)) {
                         bucket.setKeyAsString(parser.text());
                     } else if (CommonFields.KEY.getPreferredName().equals(currentFieldName)) {
-                        bucket.setKey(keyParser.apply(parser));
+                        keyConsumer.accept(parser, bucket);
                     } else if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
                         bucket.setDocCount(parser.longValue());
                     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 public abstract class ParsedMultiBucketAggregation extends ParsedAggregation implements MultiBucketsAggregation {
 
     protected final List<ParsedBucket<?>> buckets = new ArrayList<>();
-    protected boolean keyed;
+    protected boolean keyed = false;
 
     @Override
     protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
@@ -73,7 +73,7 @@ public class ParsedDateHistogram extends ParsedMultiBucketAggregation<ParsedDate
             if (keyAsString != null) {
                 return keyAsString;
             }
-            if (key != null){
+            if (key != null) {
                 return Long.toString(key);
             }
             return null;

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedDateHistogram.java
@@ -28,9 +28,8 @@ import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
-public class ParsedDateHistogram extends ParsedMultiBucketAggregation implements Histogram {
+public class ParsedDateHistogram extends ParsedMultiBucketAggregation<ParsedDateHistogram.ParsedBucket> implements Histogram {
 
     @Override
     protected String getType() {
@@ -39,7 +38,7 @@ public class ParsedDateHistogram extends ParsedMultiBucketAggregation implements
 
     @Override
     public List<? extends Histogram.Bucket> getBuckets() {
-        return buckets.stream().map(bucket -> (Histogram.Bucket) bucket).collect(Collectors.toList());
+        return buckets;
     }
 
     private static ObjectParser<ParsedDateHistogram, Void> PARSER =

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
@@ -25,9 +25,8 @@ import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
-public class ParsedHistogram extends ParsedMultiBucketAggregation implements Histogram {
+public class ParsedHistogram extends ParsedMultiBucketAggregation<ParsedHistogram.ParsedBucket> implements Histogram {
 
     @Override
     protected String getType() {
@@ -36,7 +35,7 @@ public class ParsedHistogram extends ParsedMultiBucketAggregation implements His
 
     @Override
     public List<? extends Histogram.Bucket> getBuckets() {
-        return buckets.stream().map(bucket -> (Histogram.Bucket) bucket).collect(Collectors.toList());
+        return buckets;
     }
 
     private static ObjectParser<ParsedHistogram, Void> PARSER =

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedHistogram.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.io.IOException;
@@ -54,20 +53,29 @@ public class ParsedHistogram extends ParsedMultiBucketAggregation implements His
         return aggregation;
     }
 
-    static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket<Double> implements Histogram.Bucket {
+    static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Histogram.Bucket {
+
+        private Double key;
+
+        @Override
+        public Object getKey() {
+            return key;
+        }
 
         @Override
         public String getKeyAsString() {
             String keyAsString = super.getKeyAsString();
             if (keyAsString != null) {
                 return keyAsString;
-            } else {
-                return DocValueFormat.RAW.format((Double) getKey());
             }
+            if (key != null) {
+                return Double.toString(key);
+            }
+            return null;
         }
 
         static ParsedBucket fromXContent(XContentParser parser, boolean keyed) throws IOException {
-            return parseXContent(parser, keyed, ParsedBucket::new, XContentParser::doubleValue);
+            return parseXContent(parser, keyed, ParsedBucket::new, (p, bucket) -> bucket.key = p.doubleValue());
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedDoubleTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedDoubleTerms.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.DocValueFormat;
+
+import java.io.IOException;
+
+public class ParsedDoubleTerms extends ParsedTerms {
+
+    @Override
+    protected String getType() {
+        return DoubleTerms.NAME;
+    }
+
+    private static ObjectParser<ParsedDoubleTerms, Void> PARSER =
+            new ObjectParser<>(ParsedDoubleTerms.class.getSimpleName(), true, ParsedDoubleTerms::new);
+    static {
+        declareParsedTermsFields(PARSER, ParsedBucket::fromXContent);
+    }
+
+    public static ParsedDoubleTerms fromXContent(XContentParser parser, String name) throws IOException {
+        ParsedDoubleTerms aggregation = PARSER.parse(parser, null);
+        aggregation.setName(name);
+        return aggregation;
+    }
+
+    public static class ParsedBucket extends ParsedTerms.ParsedBucket<Double> {
+
+        @Override
+        public String getKeyAsString() {
+            String keyAsString = super.getKeyAsString();
+            if (keyAsString != null) {
+                return keyAsString;
+            }
+            return DocValueFormat.RAW.format((Double) getKey());
+        }
+
+        public Number getKeyAsNumber() {
+            return (Double) getKey();
+        }
+
+        @Override
+        protected XContentBuilder keyToXContent(XContentBuilder builder) throws IOException {
+            builder.field(CommonFields.KEY.getPreferredName(), getKey());
+            if (super.getKeyAsString() != null) {
+                builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), getKeyAsString());
+            }
+            return builder;
+        }
+
+        static ParsedBucket fromXContent(XContentParser parser) throws IOException {
+            return parseTermsBucketXContent(parser, ParsedBucket::new, XContentParser::doubleValue);
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedDoubleTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedDoubleTerms.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
 
@@ -45,7 +44,14 @@ public class ParsedDoubleTerms extends ParsedTerms {
         return aggregation;
     }
 
-    public static class ParsedBucket extends ParsedTerms.ParsedBucket<Double> {
+    public static class ParsedBucket extends ParsedTerms.ParsedBucket {
+
+        private Double key;
+
+        @Override
+        public Object getKey() {
+            return key;
+        }
 
         @Override
         public String getKeyAsString() {
@@ -53,16 +59,19 @@ public class ParsedDoubleTerms extends ParsedTerms {
             if (keyAsString != null) {
                 return keyAsString;
             }
-            return DocValueFormat.RAW.format((Double) getKey());
+            if (key != null) {
+                return Double.toString(key);
+            }
+            return null;
         }
 
         public Number getKeyAsNumber() {
-            return (Double) getKey();
+            return key;
         }
 
         @Override
         protected XContentBuilder keyToXContent(XContentBuilder builder) throws IOException {
-            builder.field(CommonFields.KEY.getPreferredName(), getKey());
+            builder.field(CommonFields.KEY.getPreferredName(), key);
             if (super.getKeyAsString() != null) {
                 builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), getKeyAsString());
             }
@@ -70,7 +79,7 @@ public class ParsedDoubleTerms extends ParsedTerms {
         }
 
         static ParsedBucket fromXContent(XContentParser parser) throws IOException {
-            return parseTermsBucketXContent(parser, ParsedBucket::new, XContentParser::doubleValue);
+            return parseTermsBucketXContent(parser, ParsedBucket::new, (p, bucket) -> bucket.key = p.doubleValue());
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedLongTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedLongTerms.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
 
@@ -45,7 +44,14 @@ public class ParsedLongTerms extends ParsedTerms {
         return aggregation;
     }
 
-    public static class ParsedBucket extends ParsedTerms.ParsedBucket<Long> {
+    public static class ParsedBucket extends ParsedTerms.ParsedBucket {
+
+        private Long key;
+
+        @Override
+        public Object getKey() {
+            return key;
+        }
 
         @Override
         public String getKeyAsString() {
@@ -53,16 +59,19 @@ public class ParsedLongTerms extends ParsedTerms {
             if (keyAsString != null) {
                 return keyAsString;
             }
-            return DocValueFormat.RAW.format((Long) getKey());
+            if (key != null) {
+                return Long.toString(key);
+            }
+            return null;
         }
 
         public Number getKeyAsNumber() {
-            return (Long) getKey();
+            return key;
         }
 
         @Override
         protected XContentBuilder keyToXContent(XContentBuilder builder) throws IOException {
-            builder.field(CommonFields.KEY.getPreferredName(), getKey());
+            builder.field(CommonFields.KEY.getPreferredName(), key);
             if (super.getKeyAsString() != null) {
                 builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), getKeyAsString());
             }
@@ -70,7 +79,7 @@ public class ParsedLongTerms extends ParsedTerms {
         }
 
         static ParsedBucket fromXContent(XContentParser parser) throws IOException {
-            return parseTermsBucketXContent(parser, ParsedBucket::new, XContentParser::longValue);
+            return parseTermsBucketXContent(parser, ParsedBucket::new, (p, bucket) -> bucket.key = p.longValue());
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedLongTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedLongTerms.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.DocValueFormat;
+
+import java.io.IOException;
+
+public class ParsedLongTerms extends ParsedTerms {
+
+    @Override
+    protected String getType() {
+        return LongTerms.NAME;
+    }
+
+    private static ObjectParser<ParsedLongTerms, Void> PARSER =
+            new ObjectParser<>(ParsedLongTerms.class.getSimpleName(), true, ParsedLongTerms::new);
+    static {
+        declareParsedTermsFields(PARSER, ParsedBucket::fromXContent);
+    }
+
+    public static ParsedLongTerms fromXContent(XContentParser parser, String name) throws IOException {
+        ParsedLongTerms aggregation = PARSER.parse(parser, null);
+        aggregation.setName(name);
+        return aggregation;
+    }
+
+    public static class ParsedBucket extends ParsedTerms.ParsedBucket<Long> {
+
+        @Override
+        public String getKeyAsString() {
+            String keyAsString = super.getKeyAsString();
+            if (keyAsString != null) {
+                return keyAsString;
+            }
+            return DocValueFormat.RAW.format((Long) getKey());
+        }
+
+        public Number getKeyAsNumber() {
+            return (Long) getKey();
+        }
+
+        @Override
+        protected XContentBuilder keyToXContent(XContentBuilder builder) throws IOException {
+            builder.field(CommonFields.KEY.getPreferredName(), getKey());
+            if (super.getKeyAsString() != null) {
+                builder.field(CommonFields.KEY_AS_STRING.getPreferredName(), getKeyAsString());
+            }
+            return builder;
+        }
+
+        static ParsedBucket fromXContent(XContentParser parser) throws IOException {
+            return parseTermsBucketXContent(parser, ParsedBucket::new, XContentParser::longValue);
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedStringTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedStringTerms.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.DocValueFormat;
+
+import java.io.IOException;
+
+public class ParsedStringTerms extends ParsedTerms {
+
+    @Override
+    protected String getType() {
+        return StringTerms.NAME;
+    }
+
+    private static ObjectParser<ParsedStringTerms, Void> PARSER =
+            new ObjectParser<>(ParsedStringTerms.class.getSimpleName(), true, ParsedStringTerms::new);
+    static {
+        declareParsedTermsFields(PARSER, ParsedBucket::fromXContent);
+    }
+
+    public static ParsedStringTerms fromXContent(XContentParser parser, String name) throws IOException {
+        ParsedStringTerms aggregation = PARSER.parse(parser, null);
+        aggregation.setName(name);
+        return aggregation;
+    }
+
+    public static class ParsedBucket extends ParsedTerms.ParsedBucket<BytesRef> {
+
+        @Override
+        public Object getKey() {
+            return getKeyAsString();
+        }
+
+        @Override
+        public String getKeyAsString() {
+            String keyAsString = super.getKeyAsString();
+            if (keyAsString != null) {
+                return keyAsString;
+            }
+            return DocValueFormat.RAW.format((BytesRef) super.getKey());
+        }
+
+        public Number getKeyAsNumber() {
+            return Double.parseDouble(((BytesRef) super.getKey()).utf8ToString());
+        }
+
+        @Override
+        protected XContentBuilder keyToXContent(XContentBuilder builder) throws IOException {
+            return builder.field(CommonFields.KEY.getPreferredName(), getKey());
+        }
+
+        static ParsedBucket fromXContent(XContentParser parser) throws IOException {
+            return parseTermsBucketXContent(parser, ParsedBucket::new, XContentParser::utf8BytesOrNull);
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -39,8 +40,8 @@ import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.S
 
 public abstract class ParsedTerms extends ParsedMultiBucketAggregation implements Terms {
 
-    private long docCountErrorUpperBound;
-    private long sumOtherDocCount;
+    protected long docCountErrorUpperBound;
+    protected  long sumOtherDocCount;
 
     @Override
     public long getDocCountError() {
@@ -50,14 +51,6 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation implement
     @Override
     public long getSumOfOtherDocCounts() {
         return sumOtherDocCount;
-    }
-
-    private void setDocCountErrorUpperBound(long docCountErrorUpperBound) {
-        this.docCountErrorUpperBound = docCountErrorUpperBound;
-    }
-
-    private void setSumOtherDocCount(long sumOtherDocCount) {
-        this.sumOtherDocCount = sumOtherDocCount;
     }
 
     @Override
@@ -88,16 +81,18 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation implement
     }
 
     static void declareParsedTermsFields(final ObjectParser<? extends ParsedTerms, Void> objectParser,
-                                         final CheckedFunction<XContentParser, ParsedBucket<?>, IOException> bucketParser) {
+                                         final CheckedFunction<XContentParser, ParsedBucket, IOException> bucketParser) {
         declareMultiBucketAggregationFields(objectParser, bucketParser::apply, bucketParser::apply);
-        objectParser.declareLong(ParsedTerms::setDocCountErrorUpperBound, DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME);
-        objectParser.declareLong(ParsedTerms::setSumOtherDocCount, SUM_OF_OTHER_DOC_COUNTS);
+        objectParser.declareLong((parsedTerms, value) -> parsedTerms.docCountErrorUpperBound = value ,
+                DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME);
+        objectParser.declareLong((parsedTerms, value) -> parsedTerms.sumOtherDocCount = value,
+                SUM_OF_OTHER_DOC_COUNTS);
     }
 
-    public abstract static class ParsedBucket<T> extends ParsedMultiBucketAggregation.ParsedBucket<T> implements Terms.Bucket {
+    public abstract static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements Terms.Bucket {
 
-        private boolean showDocCountError = false;
-        private long docCountError;
+        boolean showDocCountError = false;
+        protected long docCountError;
 
         @Override
         public int compareTerm(Terms.Bucket other) {
@@ -109,16 +104,8 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation implement
             return docCountError;
         }
 
-        void setShowDocCountError(boolean showDocCountError) {
-            this.showDocCountError = showDocCountError;
-        }
-
-        void setDocCountError(long docCountError) {
-            this.docCountError = docCountError;
-        }
-
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        public final XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             keyToXContent(builder);
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
@@ -130,10 +117,9 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation implement
             return builder;
         }
 
-        protected abstract XContentBuilder keyToXContent(XContentBuilder builder) throws IOException;
 
-        static <T, B extends ParsedBucket<T>> B parseTermsBucketXContent(final XContentParser parser, final Supplier<B> bucketSupplier,
-                                                                         final CheckedFunction<XContentParser, T, IOException> keyParser)
+        static <B extends ParsedBucket> B parseTermsBucketXContent(final XContentParser parser, final Supplier<B> bucketSupplier,
+                                                                   final CheckedBiConsumer<XContentParser, B, IOException> keyConsumer)
                 throws IOException {
 
             final B bucket = bucketSupplier.get();
@@ -148,12 +134,12 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation implement
                     if (CommonFields.KEY_AS_STRING.getPreferredName().equals(currentFieldName)) {
                         bucket.setKeyAsString(parser.text());
                     } else if (CommonFields.KEY.getPreferredName().equals(currentFieldName)) {
-                        bucket.setKey(keyParser.apply(parser));
+                        keyConsumer.accept(parser, bucket);
                     } else if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
                         bucket.setDocCount(parser.longValue());
                     } else if (DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME.getPreferredName().equals(currentFieldName)) {
-                        bucket.setDocCountError(parser.longValue());
-                        bucket.setShowDocCountError(true);
+                        bucket.docCountError = parser.longValue();
+                        bucket.showDocCountError = true;
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
                     aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
@@ -33,15 +33,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME;
 import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.SUM_OF_OTHER_DOC_COUNTS;
 
-public abstract class ParsedTerms extends ParsedMultiBucketAggregation implements Terms {
+public abstract class ParsedTerms extends ParsedMultiBucketAggregation<ParsedTerms.ParsedBucket> implements Terms {
 
     protected long docCountErrorUpperBound;
-    protected  long sumOtherDocCount;
+    protected long sumOtherDocCount;
 
     @Override
     public long getDocCountError() {
@@ -55,7 +54,7 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation implement
 
     @Override
     public List<? extends Terms.Bucket> getBuckets() {
-        return buckets.stream().map(bucket -> (Terms.Bucket) bucket).collect(Collectors.toList());
+        return buckets;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME;
+import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.SUM_OF_OTHER_DOC_COUNTS;
+
+public abstract class ParsedTerms extends ParsedMultiBucketAggregation implements Terms {
+
+    private long docCountErrorUpperBound;
+    private long sumOtherDocCount;
+
+    @Override
+    public long getDocCountError() {
+        return docCountErrorUpperBound;
+    }
+
+    @Override
+    public long getSumOfOtherDocCounts() {
+        return sumOtherDocCount;
+    }
+
+    private void setDocCountErrorUpperBound(long docCountErrorUpperBound) {
+        this.docCountErrorUpperBound = docCountErrorUpperBound;
+    }
+
+    private void setSumOtherDocCount(long sumOtherDocCount) {
+        this.sumOtherDocCount = sumOtherDocCount;
+    }
+
+    @Override
+    public List<? extends Terms.Bucket> getBuckets() {
+        return buckets.stream().map(bucket -> (Terms.Bucket) bucket).collect(Collectors.toList());
+    }
+
+    @Override
+    public Terms.Bucket getBucketByKey(String term) {
+        for (Terms.Bucket bucket : getBuckets()) {
+            if (bucket.getKeyAsString().equals(term)) {
+                return bucket;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        builder.field(DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME.getPreferredName(), getDocCountError());
+        builder.field(SUM_OF_OTHER_DOC_COUNTS.getPreferredName(), getSumOfOtherDocCounts());
+        builder.startArray(CommonFields.BUCKETS.getPreferredName());
+        for (Terms.Bucket bucket : getBuckets()) {
+            bucket.toXContent(builder, params);
+        }
+        builder.endArray();
+        return builder;
+    }
+
+    static void declareParsedTermsFields(final ObjectParser<? extends ParsedTerms, Void> objectParser,
+                                         final CheckedFunction<XContentParser, ParsedBucket<?>, IOException> bucketParser) {
+        declareMultiBucketAggregationFields(objectParser, bucketParser::apply, bucketParser::apply);
+        objectParser.declareLong(ParsedTerms::setDocCountErrorUpperBound, DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME);
+        objectParser.declareLong(ParsedTerms::setSumOtherDocCount, SUM_OF_OTHER_DOC_COUNTS);
+    }
+
+    public abstract static class ParsedBucket<T> extends ParsedMultiBucketAggregation.ParsedBucket<T> implements Terms.Bucket {
+
+        private boolean showDocCountError = false;
+        private long docCountError;
+
+        @Override
+        public int compareTerm(Terms.Bucket other) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getDocCountError() {
+            return docCountError;
+        }
+
+        void setShowDocCountError(boolean showDocCountError) {
+            this.showDocCountError = showDocCountError;
+        }
+
+        void setDocCountError(long docCountError) {
+            this.docCountError = docCountError;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            keyToXContent(builder);
+            builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
+            if (showDocCountError) {
+                builder.field(DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME.getPreferredName(), getDocCountError());
+            }
+            getAggregations().toXContentInternal(builder, params);
+            builder.endObject();
+            return builder;
+        }
+
+        protected abstract XContentBuilder keyToXContent(XContentBuilder builder) throws IOException;
+
+        static <T, B extends ParsedBucket<T>> B parseTermsBucketXContent(final XContentParser parser, final Supplier<B> bucketSupplier,
+                                                                         final CheckedFunction<XContentParser, T, IOException> keyParser)
+                throws IOException {
+
+            final B bucket = bucketSupplier.get();
+            final List<Aggregation> aggregations = new ArrayList<>();
+
+            XContentParser.Token token;
+            String currentFieldName = parser.currentName();
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (token.isValue()) {
+                    if (CommonFields.KEY_AS_STRING.getPreferredName().equals(currentFieldName)) {
+                        bucket.setKeyAsString(parser.text());
+                    } else if (CommonFields.KEY.getPreferredName().equals(currentFieldName)) {
+                        bucket.setKey(keyParser.apply(parser));
+                    } else if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
+                        bucket.setDocCount(parser.longValue());
+                    } else if (DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME.getPreferredName().equals(currentFieldName)) {
+                        bucket.setDocCountError(parser.longValue());
+                        bucket.setShowDocCountError(true);
+                    }
+                } else if (token == XContentParser.Token.START_OBJECT) {
+                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                }
+            }
+            bucket.setAggregations(new Aggregations(aggregations));
+            return bucket;
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/ParsedPercentiles.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/ParsedPercentiles.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.aggregations.metrics.percentiles;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 
 import java.io.IOException;
@@ -60,7 +59,7 @@ public abstract class ParsedPercentiles extends ParsedAggregation implements Ite
         }
         Double value = getPercentile(percent);
         if (value != null) {
-            return DocValueFormat.RAW.format(value);
+            return Double.toString(value);
         }
         return null;
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.ArrayList;
@@ -33,17 +34,17 @@ import java.util.Set;
 public class DoubleTermsTests extends InternalTermsTestCase {
 
     @Override
-    protected InternalTerms<?, ?> createTestInstance(
-            String name,
-            List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metaData) {
+    protected InternalTerms<?, ?> createTestInstance(String name,
+                                                     List<PipelineAggregator> pipelineAggregators,
+                                                     Map<String, Object> metaData,
+                                                     InternalAggregations aggregations,
+                                                     boolean showTermDocCountError,
+                                                     long docCountError) {
         Terms.Order order = Terms.Order.count(false);
         long minDocCount = 1;
         int requiredSize = 3;
         int shardSize = requiredSize + 2;
-        DocValueFormat format = DocValueFormat.RAW;
-        boolean showTermDocCountError = false;
-        long docCountError = -1;
+        DocValueFormat format = randomNumericDocValueFormat();
         long otherDocCount = 0;
         List<DoubleTerms.Bucket> buckets = new ArrayList<>();
         final int numBuckets = randomInt(shardSize);
@@ -51,8 +52,7 @@ public class DoubleTermsTests extends InternalTermsTestCase {
         for (int i = 0; i < numBuckets; ++i) {
             double term = randomValueOtherThanMany(d -> terms.add(d) == false, random()::nextDouble);
             int docCount = randomIntBetween(1, 100);
-            buckets.add(new DoubleTerms.Bucket(term, docCount, InternalAggregations.EMPTY,
-                    showTermDocCountError, docCountError, format));
+            buckets.add(new DoubleTerms.Bucket(term, docCount, aggregations, showTermDocCountError, docCountError, format));
         }
         return new DoubleTerms(name, order, requiredSize, minDocCount, pipelineAggregators,
                 metaData, format, shardSize, showTermDocCountError, otherDocCount, buckets, docCountError);
@@ -61,6 +61,11 @@ public class DoubleTermsTests extends InternalTermsTestCase {
     @Override
     protected Reader<InternalTerms<?, ?>> instanceReader() {
         return DoubleTerms::new;
+    }
+
+    @Override
+    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+        return ParsedDoubleTerms.class;
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTermsTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTermsTestCase.java
@@ -19,18 +19,44 @@
 
 package org.elasticsearch.search.aggregations.bucket.terms;
 
-import org.elasticsearch.search.aggregations.InternalAggregationTestCase;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.junit.Before;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public abstract class InternalTermsTestCase extends InternalAggregationTestCase<InternalTerms<?,?>> {
+public abstract class InternalTermsTestCase extends InternalMultiBucketAggregationTestCase<InternalTerms<?, ?>> {
+
+    private boolean showDocCount;
+    private long docCountError;
+
+    @Before
+    public void init() {
+        showDocCount = randomBoolean();
+        docCountError = showDocCount ? randomInt(1000) : -1;
+    }
+
+    @Override
+    protected InternalTerms<?, ?> createTestInstance(String name,
+                                                     List<PipelineAggregator> pipelineAggregators,
+                                                     Map<String, Object> metaData,
+                                                     InternalAggregations aggregations) {
+        return createTestInstance(name, pipelineAggregators, metaData, aggregations, showDocCount, docCountError);
+    }
+
+    protected abstract InternalTerms<?, ?> createTestInstance(String name,
+                                                              List<PipelineAggregator> pipelineAggregators,
+                                                              Map<String, Object> metaData,
+                                                              InternalAggregations aggregations,
+                                                              boolean showTermDocCountError,
+                                                              long docCountError);
 
     @Override
     protected InternalTerms<?, ?> createUnmappedInstance(


### PR DESCRIPTION
This pull request adds parsing methods for Long/Double/String terms aggregations