### PR TITLE
Fix legacy GeoPointField decoding in FieldStats

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -79,6 +79,7 @@ public class GeoPointFieldMapper extends BaseGeoPointFieldMapper  {
             if (context.indexCreatedVersion().before(Version.V_2_3_0)) {
                 fieldType.setNumericPrecisionStep(GeoPointField.PRECISION_STEP);
                 fieldType.setNumericType(FieldType.LegacyNumericType.LONG);
+                ((LegacyGeoPointFieldType)fieldType).numericEncoded = true;
             }
             setupFieldType(context);
             return new GeoPointFieldMapper(simpleName, fieldType, defaultFieldType, indexSettings, latMapper, lonMapper,


### PR DESCRIPTION
`LegacyGeoPointField` was using the wrong decoding for min/max prefix coded GeoPoint Terms. This PR applies the correct decoding. Note that the min/max values, though, are likely useless anyway since they map to a low resolution morton encoded version of the point; not something that is really of value for field stats.

closes #24275 