### PR TITLE
Remove gap skipping when opening engine

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1421,7 +1421,7 @@ public abstract class Engine implements Closeable {
      * @param primaryTerm the shards primary term this engine was created for
      * @return the number of no-ops added
      */
-    public abstract int fillSequenceNumberHistory(long primaryTerm) throws IOException;
+    public abstract int fillSeqNoGaps(long primaryTerm) throws IOException;
 
     /**
      * Performs recovery from the transaction log.

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -223,7 +223,10 @@ public class InternalEngine extends Engine {
             final long localCheckpoint = seqNoService().getLocalCheckpoint();
             final long maxSeqNo = seqNoService().getMaxSeqNo();
             int numNoOpsAdded = 0;
-            for (long seqNo = localCheckpoint + 1; seqNo <= maxSeqNo; seqNo = seqNoService().getLocalCheckpoint() + 1) {
+            for (
+                    long seqNo = localCheckpoint + 1;
+                    seqNo <= maxSeqNo;
+                    seqNo = seqNoService().getLocalCheckpoint() + 1 /* the local checkpoint might have advanced so we leap-frog */) {
                 innerNoOp(new NoOp(seqNo, primaryTerm, Operation.Origin.PRIMARY, System.nanoTime(), "filling gaps"));
                 numNoOpsAdded++;
                 assert seqNo <= seqNoService().getLocalCheckpoint()

--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -177,15 +177,6 @@ public class InternalEngine extends Engine {
                 logger.trace("recovered [{}]", seqNoStats);
                 seqNoService = sequenceNumberService(shardId, engineConfig.getIndexSettings(), seqNoStats);
                 updateMaxUnsafeAutoIdTimestampFromWriter(writer);
-                // norelease
-                /*
-                 * We have no guarantees that all operations above the local checkpoint are in the Lucene commit or the translog. This means
-                 * that we there might be operations greater than the local checkpoint that will not be replayed. Here we force the local
-                 * checkpoint to the maximum sequence number in the commit (at the potential expense of correctness).
-                 */
-                while (seqNoService().getLocalCheckpoint() < seqNoService().getMaxSeqNo()) {
-                    seqNoService().markSeqNoAsCompleted(seqNoService().getLocalCheckpoint() + 1);
-                }
                 indexWriter = writer;
                 translog = openTranslog(engineConfig, writer, () -> seqNoService().getGlobalCheckpoint());
                 assert translog.getGeneration() != null;
@@ -226,21 +217,17 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    public int fillSequenceNumberHistory(long primaryTerm) throws IOException {
-        try (ReleasableLock lock = writeLock.acquire()) {
+    public int fillSeqNoGaps(long primaryTerm) throws IOException {
+        try (ReleasableLock ignored = writeLock.acquire()) {
             ensureOpen();
-            final long localCheckpoint = seqNoService.getLocalCheckpoint();
-            final long maxSeqId = seqNoService.getMaxSeqNo();
+            final long localCheckpoint = seqNoService().getLocalCheckpoint();
+            final long maxSeqNo = seqNoService().getMaxSeqNo();
             int numNoOpsAdded = 0;
-            for (long seqNo = localCheckpoint + 1; seqNo <= maxSeqId;
-                 // the local checkpoint might have been advanced so we are leap-frogging
-                 // to the next seq ID we need to process and create a noop for
-                 seqNo = seqNoService.getLocalCheckpoint()+1) {
-                final NoOp noOp = new NoOp(seqNo, primaryTerm, Operation.Origin.PRIMARY, System.nanoTime(), "filling up seqNo history");
-                innerNoOp(noOp);
+            for (long seqNo = localCheckpoint + 1; seqNo <= maxSeqNo; seqNo = seqNoService().getLocalCheckpoint() + 1) {
+                innerNoOp(new NoOp(seqNo, primaryTerm, Operation.Origin.PRIMARY, System.nanoTime(), "filling gaps"));
                 numNoOpsAdded++;
-                assert seqNo <= seqNoService.getLocalCheckpoint() : "localCheckpoint didn't advanced used to be " + seqNo + " now it's on:"
-                     + seqNoService.getLocalCheckpoint();
+                assert seqNo <= seqNoService().getLocalCheckpoint()
+                        : "local checkpoint did not advance; was [" + seqNo + "], now [" + seqNoService().getLocalCheckpoint() + "]";
 
             }
             return numNoOpsAdded;

--- a/core/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -365,7 +365,7 @@ final class StoreRecovery {
                 }
                 indexShard.performTranslogRecovery(indexShouldExists);
                 assert indexShard.shardRouting.primary() : "only primary shards can recover from store";
-                indexShard.getEngine().fillSequenceNumberHistory(indexShard.getPrimaryTerm());
+                indexShard.getEngine().fillSeqNoGaps(indexShard.getPrimaryTerm());
             }
             indexShard.finalizeRecovery();
             indexShard.postRecovery("post recovery from shard_store");


### PR DESCRIPTION
Today when opening the engine we skip gaps in the history, advancing the local checkpoint until it is equal to the maximum sequence number contained in the commit. This allows history to advance, but it leaves gaps. A previous change filled these gaps when recovering from store, but since we were skipping the gaps while opening the engine, this change had no effect. This commit removes the gap skipping when opening the engine allowing the gap filling to do its job.

Relates #10708, relates #24238
