### PR TITLE
fix(docs): Correct example label

### DIFF
--- a/docs/reference/aggregations/pipeline/extended-stats-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/extended-stats-bucket-aggregation.asciidoc
@@ -33,7 +33,7 @@ A `extended_stats_bucket` aggregation looks like this in isolation:
 |`sigma` |The number of standard deviations above/below the mean to display |Optional | 2
 |===
 
-The following snippet calculates the sum of all the total monthly `sales` buckets:
+The following snippet calculates the extended stats for monthly `sales` bucket:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/aggregations/pipeline/percentiles-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/percentiles-bucket-aggregation.asciidoc
@@ -31,7 +31,7 @@ A `percentiles_bucket` aggregation looks like this in isolation:
 |`percents` |The list of percentiles to calculate |Optional | `[ 1, 5, 25, 50, 75, 95, 99 ]`
 |===
 
-The following snippet calculates the sum of all the total monthly `sales` buckets:
+The following snippet calculates the percentiles for the total monthly `sales` buckets:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/aggregations/pipeline/stats-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/stats-bucket-aggregation.asciidoc
@@ -30,7 +30,7 @@ A `stats_bucket` aggregation looks like this in isolation:
 |`format` |format to apply to the output value of this aggregation |Optional | `null`
 |===
 
-The following snippet calculates the sum of all the total monthly `sales` buckets:
+The following snippet calculates the stats for monthly `sales`:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Very minor correction. Label for Stats Bucket Aggregation and Extended Stats Aggregation wrongly mentions sum.