### PR TITLE
Fix cache expire after access

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/cache/Cache.java
+++ b/core/src/main/java/org/elasticsearch/common/cache/Cache.java
@@ -194,7 +194,8 @@ public class Cache<K, V> {
         SegmentStats segmentStats = new SegmentStats();
 
         /**
-         * get an entry from the segment
+         * get an entry from the segment; expired entries will be returned as null but not removed from the cache until the LRU list is
+         * pruned or a manual {@link Cache#refresh()} is performed
          *
          * @param key       the key of the entry to get from the cache
          * @param now       the access time of this entry

--- a/core/src/main/java/org/elasticsearch/common/cache/Cache.java
+++ b/core/src/main/java/org/elasticsearch/common/cache/Cache.java
@@ -34,6 +34,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.function.ToLongBiFunction;
 
 /**
@@ -195,31 +196,32 @@ public class Cache<K, V> {
         /**
          * get an entry from the segment
          *
-         * @param key the key of the entry to get from the cache
-         * @param now the access time of this entry
+         * @param key       the key of the entry to get from the cache
+         * @param now       the access time of this entry
+         * @param isExpired test if the entry is expired
          * @return the entry if there was one, otherwise null
          */
-        Entry<K, V> get(K key, long now) {
+        Entry<K, V> get(K key, long now, Predicate<Entry<K, V>> isExpired) {
             CompletableFuture<Entry<K, V>> future;
             Entry<K, V> entry = null;
             try (ReleasableLock ignored = readLock.acquire()) {
                 future = map.get(key);
             }
             if (future != null) {
-              try {
-                  entry = future.handle((ok, ex) -> {
-                      if (ok != null) {
-                          segmentStats.hit();
-                          ok.accessTime = now;
-                          return ok;
-                      } else {
-                          segmentStats.miss();
-                          return null;
-                      }
-                  }).get();
-              } catch (ExecutionException | InterruptedException e) {
-                  throw new IllegalStateException(e);
-              }
+                try {
+                    entry = future.handle((ok, ex) -> {
+                        if (ok != null && !isExpired.test(ok)) {
+                            segmentStats.hit();
+                            ok.accessTime = now;
+                            return ok;
+                        } else {
+                            segmentStats.miss();
+                            return null;
+                        }
+                    }).get();
+                } catch (ExecutionException | InterruptedException e) {
+                    throw new IllegalStateException(e);
+                }
             }
             else {
                 segmentStats.miss();
@@ -332,8 +334,8 @@ public class Cache<K, V> {
 
     private V get(K key, long now) {
         CacheSegment<K, V> segment = getCacheSegment(key);
-        Entry<K, V> entry = segment.get(key, now);
-        if (entry == null || isExpired(entry, now)) {
+        Entry<K, V> entry = segment.get(key, now, e -> isExpired(e, now));
+        if (entry == null) {
             return null;
         } else {
             promote(entry, now);

--- a/core/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/core/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -257,6 +257,28 @@ public class CacheTests extends ESTestCase {
         }
     }
 
+    public void testSimpleExpireAfterAccess() {
+        AtomicLong now = new AtomicLong();
+        Cache<Integer, String> cache = new Cache<Integer, String>() {
+            @Override
+            protected long now() {
+                return now.get();
+            }
+        };
+        cache.setExpireAfterAccessNanos(1);
+        now.set(0);
+        for (int i = 0; i < numberOfEntries; i++) {
+            cache.put(i, Integer.toString(i));
+        }
+        for (int i = 0; i < numberOfEntries; i++) {
+            assertEquals(cache.get(i), Integer.toString(i));
+        }
+        now.set(2);
+        for(int i = 0; i < numberOfEntries; i++) {
+            assertNull(cache.get(i));
+        }
+    }
+
     public void testExpirationAfterWrite() {
         AtomicLong now = new AtomicLong();
         Cache<Integer, String> cache = new Cache<Integer, String>() {


### PR DESCRIPTION
This commit fixes a bug in the cache expire after access implementation. The bug is this: if you construct a cache with an expire after access of T, put a key, and then touch the key at some time t > T, the act of getting the key would update the access time for the entry before checking if the entry was expired. There are situations in which expire after access would be honored (e.g., if the cache needs to prune the LRU list to keep the cache under a certain weight, or a manual refresh was called) but this behavior is otherwise broken.