### PR TITLE
Scripting: Deprecate file scripts

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -542,6 +542,7 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
     }
 
     private class ScriptChangesListener implements FileChangesListener {
+        private boolean deprecationEmitted = false;
 
         private Tuple<String, String> getScriptNameExt(Path file) {
             Path scriptPath = scriptsDirectory.relativize(file);
@@ -574,6 +575,11 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
             if (engineService == null) {
                 logger.warn("No script engine found for [{}]", scriptNameExt.v2());
             } else {
+                if (deprecationEmitted == false) {
+                    deprecationLogger.deprecated("File scripts are deprecated. Use stored or inline scripts instead.");
+                    deprecationEmitted = true;
+                }
+
                 try {
                     //we don't know yet what the script will be used for, but if all of the operations for this lang
                     // with file scripts are disabled, it makes no sense to even compile it and cache it.

--- a/core/src/test/java/org/elasticsearch/script/FileScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/FileScriptTests.java
@@ -59,6 +59,7 @@ public class FileScriptTests extends ESTestCase {
         assertNotNull(compiledScript);
         MockCompiledScript executable = (MockCompiledScript) compiledScript.compiled();
         assertEquals("script1.mockscript", executable.getName());
+        assertWarnings("File scripts are deprecated. Use stored or inline scripts instead.");
     }
 
     public void testAllOpsDisabled() throws Exception {
@@ -78,5 +79,6 @@ public class FileScriptTests extends ESTestCase {
                 assertTrue(e.getMessage(), e.getMessage().contains("scripts of type [file], operation [" + context.getKey() + "] and lang [" + MockScriptEngine.NAME + "] are disabled"));
             }
         }
+        assertWarnings("File scripts are deprecated. Use stored or inline scripts instead.");
     }
 }

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -182,6 +182,7 @@ public class ScriptServiceTests extends ESTestCase {
         } catch (IllegalArgumentException ex) {
             assertThat(ex.getMessage(), containsString("unable to find file script [test_script] using lang [test]"));
         }
+        assertWarnings("File scripts are deprecated. Use stored or inline scripts instead.");
     }
 
     public void testScriptCompiledOnceHiddenFileDetected() throws IOException {
@@ -201,6 +202,7 @@ public class ScriptServiceTests extends ESTestCase {
         Files.delete(testHiddenFile);
         Files.delete(testFileScript);
         resourceWatcherService.notifyNow();
+        assertWarnings("File scripts are deprecated. Use stored or inline scripts instead.");
     }
 
     public void testInlineScriptCompiledOnceCache() throws IOException {
@@ -227,6 +229,7 @@ public class ScriptServiceTests extends ESTestCase {
             assertCompileRejected("dtest", "script", ScriptType.STORED, scriptContext);
             assertCompileAccepted("dtest", "file_script", ScriptType.FILE, scriptContext);
         }
+        assertWarnings("File scripts are deprecated. Use stored or inline scripts instead.");
     }
 
     public void testFineGrainedSettings() throws IOException {
@@ -317,6 +320,7 @@ public class ScriptServiceTests extends ESTestCase {
                 }
             }
         }
+        assertWarnings("File scripts are deprecated. Use stored or inline scripts instead.");
     }
 
     public void testCompileNonRegisteredContext() throws IOException {
@@ -384,6 +388,7 @@ public class ScriptServiceTests extends ESTestCase {
         createFileScripts("test");
         scriptService.compile(new Script(ScriptType.FILE, "test", "file_script", Collections.emptyMap()), randomFrom(scriptContexts));
         assertEquals(1L, scriptService.stats().getCompilations());
+        assertWarnings("File scripts are deprecated. Use stored or inline scripts instead.");
     }
 
     public void testIndexedScriptCountedInCompilationStats() throws IOException {


### PR DESCRIPTION
File scripts will be removed in 6.0. This commit adds a deprecation
warning for 5.5 when the first file script is loaded.

relates #21798