### PR TITLE
Add parsing for single bucket aggregations

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedAggregation.java
@@ -41,7 +41,7 @@ public abstract class ParsedAggregation implements Aggregation, ToXContent {
     }
 
     private String name;
-    Map<String, Object> metadata;
+    protected Map<String, Object> metadata;
 
     @Override
     public final String getName() {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.ParsedAggregation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+/**
+ * A base class for all the single bucket aggregations.
+ */
+public abstract class ParsedSingleBucketAggregation extends ParsedAggregation implements SingleBucketAggregation {
+
+    private long docCount;
+    protected Aggregations aggregations = new Aggregations(Collections.emptyList());
+
+    @Override
+    public long getDocCount() {
+        return docCount;
+    }
+
+    protected void setDocCount(long docCount) {
+        this.docCount = docCount;
+    }
+
+    @Override
+    public Aggregations getAggregations() {
+        return aggregations;
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
+        aggregations.toXContentInternal(builder, params);
+        return builder;
+    }
+
+    protected static <T extends ParsedSingleBucketAggregation> T parseXContent(final XContentParser parser, T aggregation, String name)
+            throws IOException {
+        aggregation.setName(name);
+        XContentParser.Token token = parser.currentToken();
+        String currentFieldName = parser.currentName();
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+
+        List<Aggregation> aggregations = new ArrayList<>();
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
+                    aggregation.setDocCount(parser.longValue());
+                }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if (CommonFields.META.getPreferredName().equals(currentFieldName)) {
+                    aggregation.metadata = parser.map();
+                } else {
+                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                }
+            }
+        }
+        aggregation.aggregations = new Aggregations(aggregations);
+        return aggregation;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
@@ -66,8 +66,10 @@ public abstract class ParsedSingleBucketAggregation extends ParsedAggregation im
         aggregation.setName(name);
         XContentParser.Token token = parser.currentToken();
         String currentFieldName = parser.currentName();
-        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+        if (token == XContentParser.Token.FIELD_NAME) {
+            token = parser.nextToken();
+        }
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser::getTokenLocation);
 
         List<Aggregation> aggregations = new ArrayList<>();
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ParsedChildren.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/children/ParsedChildren.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.children;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
+
+import java.io.IOException;
+
+public class ParsedChildren extends ParsedSingleBucketAggregation implements Children {
+
+    @Override
+    public String getType() {
+        return ChildrenAggregationBuilder.NAME;
+    }
+
+    public static ParsedChildren fromXContent(XContentParser parser, final String name) throws IOException {
+        return parseXContent(parser, new ParsedChildren(), name);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/ParsedFilter.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/ParsedFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.filter;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
+
+import java.io.IOException;
+
+public class ParsedFilter extends ParsedSingleBucketAggregation implements Filter {
+
+    @Override
+    public String getType() {
+        return FilterAggregationBuilder.NAME;
+    }
+
+    public static ParsedFilter fromXContent(XContentParser parser, final String name) throws IOException {
+        return parseXContent(parser, new ParsedFilter(), name);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/global/ParsedGlobal.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/global/ParsedGlobal.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.global;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
+
+import java.io.IOException;
+
+public class ParsedGlobal extends ParsedSingleBucketAggregation implements Global {
+
+    @Override
+    public String getType() {
+        return GlobalAggregationBuilder.NAME;
+    }
+
+    public static ParsedGlobal fromXContent(XContentParser parser, final String name) throws IOException {
+        return parseXContent(parser, new ParsedGlobal(), name);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/ParsedMissing.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/missing/ParsedMissing.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.missing;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
+
+import java.io.IOException;
+
+public class ParsedMissing extends ParsedSingleBucketAggregation implements Missing {
+
+    @Override
+    public String getType() {
+        return MissingAggregationBuilder.NAME;
+    }
+
+    public static ParsedMissing fromXContent(XContentParser parser, final String name) throws IOException {
+        return parseXContent(parser, new ParsedMissing(), name);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ParsedNested.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ParsedNested.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.nested;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
+
+import java.io.IOException;
+
+public class ParsedNested extends ParsedSingleBucketAggregation implements Nested {
+
+    @Override
+    public String getType() {
+        return NestedAggregationBuilder.NAME;
+    }
+
+    public static ParsedNested fromXContent(XContentParser parser, final String name) throws IOException {
+        return parseXContent(parser, new ParsedNested(), name);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ParsedReverseNested.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/ParsedReverseNested.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.nested;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
+
+import java.io.IOException;
+
+public class ParsedReverseNested extends ParsedSingleBucketAggregation implements Nested {
+
+    @Override
+    public String getType() {
+        return ReverseNestedAggregationBuilder.NAME;
+    }
+
+    public static ParsedReverseNested fromXContent(XContentParser parser, final String name) throws IOException {
+        return parseXContent(parser, new ParsedReverseNested(), name);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSampler.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSampler.java
@@ -49,7 +49,7 @@ public class InternalSampler extends InternalSingleBucketAggregation implements 
 
     @Override
     public String getType() {
-        return "sampler";
+        return NAME;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/ParsedSampler.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/ParsedSampler.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.search.aggregations.bucket.sampler;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
+
+import java.io.IOException;
+
+public class ParsedSampler extends ParsedSingleBucketAggregation implements Sampler {
+
+    @Override
+    public String getType() {
+        return InternalSampler.NAME;
+    }
+
+    public static ParsedSampler fromXContent(XContentParser parser, final String name) throws IOException {
+        return parseXContent(parser, new ParsedSampler(), name);
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
@@ -27,8 +27,15 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.bucket.children.InternalChildrenTests;
+import org.elasticsearch.search.aggregations.bucket.filter.InternalFilterTests;
+import org.elasticsearch.search.aggregations.bucket.global.InternalGlobalTests;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalDateHistogramTests;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogramTests;
+import org.elasticsearch.search.aggregations.bucket.missing.InternalMissingTests;
+import org.elasticsearch.search.aggregations.bucket.nested.InternalNestedTests;
+import org.elasticsearch.search.aggregations.bucket.nested.InternalReverseNestedTests;
+import org.elasticsearch.search.aggregations.bucket.sampler.InternalSamplerTests;
 import org.elasticsearch.search.aggregations.bucket.terms.DoubleTermsTests;
 import org.elasticsearch.search.aggregations.bucket.terms.LongTermsTests;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTermsTests;
@@ -103,6 +110,13 @@ public class AggregationsTests extends ESTestCase {
         aggsTests.add(new LongTermsTests());
         aggsTests.add(new DoubleTermsTests());
         aggsTests.add(new StringTermsTests());
+        aggsTests.add(new InternalMissingTests());
+        aggsTests.add(new InternalNestedTests());
+        aggsTests.add(new InternalReverseNestedTests());
+        aggsTests.add(new InternalChildrenTests());
+        aggsTests.add(new InternalGlobalTests());
+        aggsTests.add(new InternalFilterTests());
+        aggsTests.add(new InternalSamplerTests());
         return Collections.unmodifiableList(aggsTests);
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregationTestCase.java
@@ -48,14 +48,16 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 public abstract class InternalSingleBucketAggregationTestCase<T extends InternalSingleBucketAggregation>
         extends InternalAggregationTestCase<T> {
 
-    private final boolean hasInternalMax = randomBoolean();
-    private final boolean hasInternalMin = randomBoolean();
+    private boolean hasInternalMax;
+    private boolean hasInternalMin;
 
     public Supplier<InternalAggregations> subAggregationsSupplier;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        hasInternalMax = randomBoolean();
+        hasInternalMin = randomBoolean();
         subAggregationsSupplier = () -> {
             List<InternalAggregation> aggs = new ArrayList<>();
             if (hasInternalMax) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/children/InternalChildrenTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/children/InternalChildrenTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.children;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
@@ -44,4 +45,8 @@ public class InternalChildrenTests extends InternalSingleBucketAggregationTestCa
         return InternalChildren::new;
     }
 
+    @Override
+    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
+        return ParsedChildren.class;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilterTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilterTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.filter;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
@@ -42,5 +43,10 @@ public class InternalFilterTests extends InternalSingleBucketAggregationTestCase
     @Override
     protected Reader<InternalFilter> instanceReader() {
         return InternalFilter::new;
+    }
+
+    @Override
+    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
+        return ParsedFilter.class;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobalTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobalTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.global;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
@@ -44,4 +45,8 @@ public class InternalGlobalTests extends InternalSingleBucketAggregationTestCase
         return InternalGlobal::new;
     }
 
+    @Override
+    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
+        return ParsedGlobal.class;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissingTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissingTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.missing;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
@@ -44,4 +45,8 @@ public class InternalMissingTests extends InternalSingleBucketAggregationTestCas
         return InternalMissing::new;
     }
 
+    @Override
+    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
+        return ParsedMissing.class;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNestedTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNestedTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.nested;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
@@ -42,5 +43,10 @@ public class InternalNestedTests extends InternalSingleBucketAggregationTestCase
     @Override
     protected Reader<InternalNested> instanceReader() {
         return InternalNested::new;
+    }
+
+    @Override
+    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
+        return ParsedNested.class;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNestedTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNestedTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search.aggregations.bucket.nested;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
@@ -42,5 +43,10 @@ public class InternalReverseNestedTests extends InternalSingleBucketAggregationT
     @Override
     protected Reader<InternalReverseNested> instanceReader() {
         return InternalReverseNested::new;
+    }
+
+    @Override
+    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
+        return ParsedReverseNested.class;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSamplerTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSamplerTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.bucket.sampler;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.List;
@@ -41,5 +42,10 @@ public class InternalSamplerTests extends InternalSingleBucketAggregationTestCas
     @Override
     protected Writeable.Reader<InternalSampler> instanceReader() {
         return InternalSampler::new;
+    }
+
+    @Override
+    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
+        return ParsedSampler.class;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -38,10 +38,24 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
+import org.elasticsearch.search.aggregations.bucket.children.ChildrenAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.children.ParsedChildren;
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
+import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.global.ParsedGlobal;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.ParsedHistogram;
+import org.elasticsearch.search.aggregations.bucket.missing.MissingAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.missing.ParsedMissing;
+import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.nested.ParsedNested;
+import org.elasticsearch.search.aggregations.bucket.nested.ParsedReverseNested;
+import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.sampler.InternalSampler;
+import org.elasticsearch.search.aggregations.bucket.sampler.ParsedSampler;
 import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedDoubleTerms;
@@ -139,6 +153,13 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         namedXContents.put(StringTerms.NAME, (p, c) -> ParsedStringTerms.fromXContent(p, (String) c));
         namedXContents.put(LongTerms.NAME, (p, c) -> ParsedLongTerms.fromXContent(p, (String) c));
         namedXContents.put(DoubleTerms.NAME, (p, c) -> ParsedDoubleTerms.fromXContent(p, (String) c));
+        namedXContents.put(MissingAggregationBuilder.NAME, (p, c) -> ParsedMissing.fromXContent(p, (String) c));
+        namedXContents.put(NestedAggregationBuilder.NAME, (p, c) -> ParsedNested.fromXContent(p, (String) c));
+        namedXContents.put(ReverseNestedAggregationBuilder.NAME, (p, c) -> ParsedReverseNested.fromXContent(p, (String) c));
+        namedXContents.put(ChildrenAggregationBuilder.NAME, (p, c) -> ParsedChildren.fromXContent(p, (String) c));
+        namedXContents.put(GlobalAggregationBuilder.NAME, (p, c) -> ParsedGlobal.fromXContent(p, (String) c));
+        namedXContents.put(FilterAggregationBuilder.NAME, (p, c) -> ParsedFilter.fromXContent(p, (String) c));
+        namedXContents.put(InternalSampler.NAME, (p, c) -> ParsedSampler.fromXContent(p, (String) c));
 
         return namedXContents.entrySet().stream()
                 .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue()))

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -269,7 +269,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
     }
 
     //norelease TODO make abstract
-    protected void assertFromXContent(T aggregation, ParsedAggregation parsedAggregation) {
+    protected void assertFromXContent(T aggregation, ParsedAggregation parsedAggregation) throws IOException {
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This is an alternative approach to #24386 that doesn't rely on extending ObjectParsers capabilities and uses manual parsing instead.