### PR TITLE
Support 'AND' operation for context query in context suggester

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionContext.java
@@ -25,25 +25,24 @@ import org.elasticsearch.index.mapper.CompletionFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.search.suggest.SuggestionSearchContext;
 import org.elasticsearch.search.suggest.completion.context.ContextMapping;
+import org.elasticsearch.search.suggest.completion.context.ContextMapping.InternalQueryContext.Operation;
 import org.elasticsearch.search.suggest.completion.context.ContextMappings;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
-public class CompletionSuggestionContext extends SuggestionSearchContext.SuggestionContext {
-
-    protected CompletionSuggestionContext(QueryShardContext shardContext) {
-        super(CompletionSuggester.INSTANCE, shardContext);
-    }
-
+class CompletionSuggestionContext extends SuggestionSearchContext.SuggestionContext {
     private CompletionFieldMapper.CompletionFieldType fieldType;
     private FuzzyOptions fuzzyOptions;
     private RegexOptions regexOptions;
     private Map<String, List<ContextMapping.InternalQueryContext>> queryContexts = Collections.emptyMap();
 
-    CompletionFieldMapper.CompletionFieldType getFieldType() {
-        return this.fieldType;
+    CompletionSuggestionContext(QueryShardContext shardContext) {
+        super(CompletionSuggester.INSTANCE, shardContext);
     }
 
     void setFieldType(CompletionFieldMapper.CompletionFieldType fieldType) {
@@ -62,16 +61,67 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
         this.queryContexts = queryContexts;
     }
 
-    public FuzzyOptions getFuzzyOptions() {
-        return fuzzyOptions;
+    CompletionFieldMapper.CompletionFieldType getFieldType() {
+        return this.fieldType;
     }
 
-    public RegexOptions getRegexOptions() {
-        return regexOptions;
+    /**
+     * When context is enabled for a completion field,
+     * we factor in the number of indexed context mappings (when no query context is provided)
+     * or the number of query context values into the maximum number of suggestion to traverse
+     * for a lucene segment, to ensure search admissibility.
+     *
+     * NOTE: a suggestion with N context values are represented as N suggestions, at the lucene level.
+     * Completion suggester will early-terminate when {@link #getSize()} acceptable results are collected
+     * for each lucene segment.
+     */
+    int getMaxSize() {
+        if (fieldType.hasContextMappings()) {
+            if (queryContexts.isEmpty() == false) {
+                // multiply the size with # of query context values
+                int nQueryContexts = queryContexts.values().stream().mapToInt(List::size).sum();
+                return nQueryContexts * getSize();
+            } else {
+                // multiply the size with # of indexed context types
+                int nIndexedContextTypes = fieldType.getContextMappings().size();
+                return nIndexedContextTypes * getSize();
+            }
+        } else {
+            return getSize();
+        }
     }
 
-    public Map<String, List<ContextMapping.InternalQueryContext>> getQueryContexts() {
-        return queryContexts;
+    /**
+     * Predicate to test if a suggestion is acceptable given it's collected contexts,
+     * to ensure suggestions that doesn't have all the required (AND'ed) contexts
+     * are filtered out at query time.
+     */
+    Predicate<List<CharSequence>> suggestContextsPredicate() {
+        return suggestDocContexts -> {
+            if (fieldType.hasContextMappings() == false) {
+                return true;
+            }
+            final Set<String> requiredContextTypes = getRequiredContextTypes();
+            if (requiredContextTypes.isEmpty()) {
+                return true;
+            }
+            final Map<String, Set<CharSequence>> documentContexts = fieldType.getContextMappings()
+                    .getNamedContexts(suggestDocContexts);
+            final Set<String> documentContextTypes = documentContexts.keySet();
+            boolean hasAllRequiredContextTypes = requiredContextTypes.stream().allMatch(documentContextTypes::contains);
+            if (hasAllRequiredContextTypes) {
+                for (String requiredContextType : requiredContextTypes) {
+                    final List<String> requiredContextValues = getContexts(requiredContextType, Operation.AND);
+                    final Set<CharSequence> documentContextValues = documentContexts.get(requiredContextType);
+                    boolean hasAllRequiredContextValues = requiredContextValues.stream().allMatch(documentContextValues::contains);
+                    if (hasAllRequiredContextValues == false) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        };
     }
 
     CompletionQuery toQuery() {
@@ -112,6 +162,19 @@ public class CompletionSuggestionContext extends SuggestionSearchContext.Suggest
             query = fieldType.prefixQuery(prefix);
         }
         return query;
+    }
+
+    private List<String> getContexts(final String type, final Operation operation) {
+        return queryContexts.get(type).stream()
+                .filter(context -> context.operation == operation)
+                .map(context -> context.context)
+                .collect(Collectors.toList());
+    }
+
+    private Set<String> getRequiredContextTypes() {
+        return queryContexts.keySet().stream()
+                .filter(context -> getContexts(context, Operation.AND).size() > 0)
+                .collect(Collectors.toSet());
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
@@ -53,6 +53,7 @@ public class CategoryContextMapping extends ContextMapping<CategoryQueryContext>
     static final String CONTEXT_VALUE = "context";
     static final String CONTEXT_BOOST = "boost";
     static final String CONTEXT_PREFIX = "prefix";
+    static final String CONTEXT_OPERATION = "operation";
 
     private final String fieldName;
 
@@ -168,7 +169,7 @@ public class CategoryContextMapping extends ContextMapping<CategoryQueryContext>
         List<InternalQueryContext> internalInternalQueryContexts = new ArrayList<>(queryContexts.size());
         internalInternalQueryContexts.addAll(
             queryContexts.stream()
-                .map(queryContext -> new InternalQueryContext(queryContext.getCategory(), queryContext.getBoost(), queryContext.isPrefix()))
+                .map(queryContext -> new InternalQueryContext(queryContext.getCategory(), queryContext.getBoost(), queryContext.isPrefix(), queryContext.getOperation()))
                 .collect(Collectors.toList()));
         return internalInternalQueryContexts;
     }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/ContextMapping.java
@@ -163,14 +163,29 @@ public abstract class ContextMapping<T extends ToXContent> implements ToXContent
     }
 
     public static class InternalQueryContext {
+        public enum Operation {
+            AND, OR;
+
+            public static Operation fromString(String operation) {
+                if (operation.equalsIgnoreCase("and")) {
+                    return AND;
+                } else if (operation.equalsIgnoreCase("or")) {
+                    return OR;
+                } else {
+                    throw new IllegalArgumentException("No context operation for [" + operation + "]");
+                }
+            }
+        }
         public final String context;
         public final int boost;
         public final boolean isPrefix;
+        public final Operation operation;
 
-        public InternalQueryContext(String context, int boost, boolean isPrefix) {
+        public InternalQueryContext(String context, int boost, boolean isPrefix, Operation operation) {
             this.context = context;
             this.boost = boost;
             this.isPrefix = isPrefix;
+            this.operation = operation;
         }
 
         @Override
@@ -182,6 +197,7 @@ public abstract class ContextMapping<T extends ToXContent> implements ToXContent
 
             if (boost != that.boost) return false;
             if (isPrefix != that.isPrefix) return false;
+            if (operation != that.operation) return false;
             return context != null ? context.equals(that.context) : that.context == null;
 
         }
@@ -191,6 +207,7 @@ public abstract class ContextMapping<T extends ToXContent> implements ToXContent
             int result = context != null ? context.hashCode() : 0;
             result = 31 * result + boost;
             result = 31 * result + (isPrefix ? 1 : 0);
+            result = 31 * result + operation.ordinal();
             return result;
         }
 
@@ -200,6 +217,7 @@ public abstract class ContextMapping<T extends ToXContent> implements ToXContent
                     "context='" + context + '\'' +
                     ", boost=" + boost +
                     ", isPrefix=" + isPrefix +
+                    ", operation=" + operation.name() +
                     '}';
         }
     }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -274,7 +274,14 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
             }
             internalQueryContextList.addAll(
                 locations.stream()
-                    .map(location -> new InternalQueryContext(location, queryContext.getBoost(), location.length() < this.precision))
+                    .map(location ->
+                            new InternalQueryContext(
+                                location,
+                                queryContext.getBoost(),
+                               location.length() < this.precision,
+                                queryContext.getOperation()
+                            )
+                    )
                     .collect(Collectors.toList()));
         }
         return internalQueryContextList;

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoQueryContext.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoQueryContext.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.search.suggest.completion.context.ContextMapping.InternalQueryContext.Operation;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -49,12 +50,14 @@ public final class GeoQueryContext implements ToXContent {
     private final int boost;
     private final int precision;
     private final List<Integer> neighbours;
+    private Operation operation;
 
-    private GeoQueryContext(GeoPoint geoPoint, int boost, int precision, List<Integer> neighbours) {
+    private GeoQueryContext(GeoPoint geoPoint, int boost, int precision, List<Integer> neighbours, Operation operation) {
         this.geoPoint = geoPoint;
         this.boost = boost;
         this.precision = precision;
         this.neighbours = neighbours;
+        this.operation = operation;
     }
 
     /**
@@ -85,6 +88,10 @@ public final class GeoQueryContext implements ToXContent {
         return neighbours;
     }
 
+    public Operation getOperation() {
+        return operation;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -95,6 +102,7 @@ public final class GeoQueryContext implements ToXContent {
         if (boost != that.boost) return false;
         if (precision != that.precision) return false;
         if (geoPoint != null ? !geoPoint.equals(that.geoPoint) : that.geoPoint != null) return false;
+        if (operation != that.operation) return false;
         return neighbours != null ? neighbours.equals(that.neighbours) : that.neighbours == null;
 
     }
@@ -105,6 +113,7 @@ public final class GeoQueryContext implements ToXContent {
         result = 31 * result + boost;
         result = 31 * result + precision;
         result = 31 * result + (neighbours != null ? neighbours.hashCode() : 0);
+        result = 31 * result + operation.ordinal();
         return result;
     }
 
@@ -157,6 +166,7 @@ public final class GeoQueryContext implements ToXContent {
         private int boost = 1;
         private int precision = 12;
         private List<Integer> neighbours = Collections.emptyList();
+        private Operation operation = Operation.OR;
 
         public Builder() {
         }
@@ -209,6 +219,11 @@ public final class GeoQueryContext implements ToXContent {
             return this;
         }
 
+        public Builder setOperation(Operation operation) {
+            this.operation = operation;
+            return this;
+        }
+
         private double lat = Double.NaN;
         void setLat(double lat) {
             this.lat = lat;
@@ -226,7 +241,7 @@ public final class GeoQueryContext implements ToXContent {
                 }
             }
             Objects.requireNonNull(geoPoint, "geoPoint must not be null");
-            return new GeoQueryContext(geoPoint, boost, precision, neighbours);
+            return new GeoQueryContext(geoPoint, boost, precision, neighbours, operation);
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
@@ -37,6 +37,7 @@ import org.elasticsearch.search.suggest.completion.context.CategoryContextMappin
 import org.elasticsearch.search.suggest.completion.context.CategoryQueryContext;
 import org.elasticsearch.search.suggest.completion.context.ContextBuilder;
 import org.elasticsearch.search.suggest.completion.context.ContextMapping;
+import org.elasticsearch.search.suggest.completion.context.ContextMapping.InternalQueryContext.Operation;
 import org.elasticsearch.search.suggest.completion.context.GeoContextMapping;
 import org.elasticsearch.search.suggest.completion.context.GeoQueryContext;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -303,6 +304,76 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
         contextMap.put("cat", Collections.singletonList(CategoryQueryContext.builder().setCategory("cat2").build()));
         multiContextFilterSuggest.contexts(contextMap);
         assertSuggestions("foo", multiContextFilterSuggest, "suggestion6", "suggestion2");
+    }
+
+    public void testMultipleContextTypeFiltering() throws Exception {
+        LinkedHashMap<String, ContextMapping> map = new LinkedHashMap<>();
+        map.put("cat", ContextBuilder.category("cat").field("cat").build());
+        map.put("type", ContextBuilder.category("type").field("type").build());
+        final CompletionMappingBuilder mapping = new CompletionMappingBuilder().context(map);
+        createIndexAndMapping(mapping);
+        int numDocs = 40;
+        List<IndexRequestBuilder> indexRequestBuilders = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            XContentBuilder source = jsonBuilder()
+                    .startObject()
+                    .startObject(FIELD)
+                    .field("input", "suggestion" + i)
+                    .field("weight", i + 1)
+                    .endObject()
+                    .field("cat", "cat" + i % 2)
+                    .field("type", "type" + i % 4)
+                    .endObject();
+            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i)
+                    .setSource(source));
+        }
+        indexRandom(true, indexRequestBuilders);
+        CompletionSuggestionBuilder multiContextFilterSuggest = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
+        // query context order should never matter
+        Map<String, List<? extends ToXContent>> contextMap = new HashMap<>();
+        contextMap.put("type", Collections.singletonList(CategoryQueryContext.builder().setCategory("type0").setOperation(Operation.AND).build()));
+        contextMap.put("cat", Collections.singletonList(CategoryQueryContext.builder().setCategory("cat0").setOperation(Operation.AND).build()));
+        multiContextFilterSuggest.contexts(contextMap);
+        assertSuggestions("foo", multiContextFilterSuggest,
+                "suggestion36", "suggestion32", "suggestion28", "suggestion24", "suggestion20");
+    }
+
+    public void testSingleContextTypeFiltering() throws Exception {
+        LinkedHashMap<String, ContextMapping> map = new LinkedHashMap<>();
+        map.put("type", ContextBuilder.category("type").field("type").build());
+        final CompletionMappingBuilder mapping = new CompletionMappingBuilder().context(map);
+        createIndexAndMapping(mapping);
+        int numDocs = 40;
+        List<IndexRequestBuilder> indexRequestBuilders = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            String[] contexts = new String[2];
+            contexts[0] = "type" + i % 4;
+            contexts[1] = "type" + (i + 1) % 4;
+            XContentBuilder source = jsonBuilder()
+                    .startObject()
+                    .startObject(FIELD)
+                    .field("input", "suggestion" + i)
+                    .field("weight", i + 1)
+                    .endObject()
+                    .field("type", contexts)
+                    .endObject();
+            indexRequestBuilders.add(client().prepareIndex(INDEX, TYPE, "" + i)
+                    .setSource(source));
+        }
+        indexRandom(true, indexRequestBuilders);
+        CompletionSuggestionBuilder multiContextFilterSuggest = SuggestBuilders.completionSuggestion(FIELD).prefix("sugg");
+        // query context order should never matter
+        Map<String, List<? extends ToXContent>> contextMap = new HashMap<>();
+        contextMap.put("type",
+                Arrays.asList(
+                        CategoryQueryContext.builder().setCategory("type0").setOperation(Operation.AND).build(),
+                        CategoryQueryContext.builder().setCategory("type1").setOperation(Operation.AND).build()
+                )
+        );
+        multiContextFilterSuggest.contexts(contextMap);
+        assertSuggestions("foo", multiContextFilterSuggest,
+                "suggestion36", "suggestion32", "suggestion28", "suggestion24", "suggestion20");
+
     }
 
     @AwaitsFix(bugUrl = "multiple context boosting is broken, as a suggestion, contexts pair is treated as (num(context) entries)")


### PR DESCRIPTION
Currently, when multiple contexts are provided for a context
suggester query, the contexts are 'OR'ed. This commit adds
support for specifying 'AND' operation for contexts, allowing
querying suggestions that have all the contexts.

WIP: add documentation

Closes https://github.com/elastic/elasticsearch/issues/24421

