### PR TITLE
newSearcher should not wrap again after wrap with ElasticsearchDirectoryReader

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
@@ -67,7 +67,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                         NumberFieldMapper.NumberType.LONG);
                 fieldType.setName(VALUE_FIELD_NAME);
 
-                Nested nested = search(newSearcher(indexReader, true, true),
+                Nested nested = search(newSearcher(indexReader, false, true),
                         new MatchAllDocsQuery(), nestedBuilder, fieldType);
                 ReverseNested reverseNested = (ReverseNested)
                         ((InternalAggregation)nested).getProperty(REVERSE_AGG_NAME);
@@ -130,7 +130,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                         NumberFieldMapper.NumberType.LONG);
                 fieldType.setName(VALUE_FIELD_NAME);
 
-                Nested nested = search(newSearcher(indexReader, true, true),
+                Nested nested = search(newSearcher(indexReader, false, true),
                         new MatchAllDocsQuery(), nestedBuilder, fieldType);
                 assertEquals(expectedNestedDocs, nested.getDocCount());
 


### PR DESCRIPTION
Try to Fix https://github.com/elastic/elasticsearch/issues/24554

`newSearcher` should not `wrap` again after wrap with `ElasticsearchDirectoryReader`, 

if random wrap again, this maybe will cause `maybeWrapReader` return:

1. ParallelLeafReader
2. ParallelCompositeReader
3. FCInvisibleMultiReader
...

and the above **readers** will cause: `ElasticsearchDirectoryReader.getElasticsearchDirectoryReader` return `null` and **NPE** in `getAndLoadIfNotPresent` method

