### PR TITLE
Reuse inner hit query weight

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsFetchSubPhase.java
@@ -22,12 +22,11 @@ package org.elasticsearch.search.fetch.subphase;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
 import org.elasticsearch.search.fetch.FetchSubPhase;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
@@ -43,39 +42,42 @@ public final class InnerHitsFetchSubPhase implements FetchSubPhase {
     }
 
     @Override
-    public void hitExecute(SearchContext context, HitContext hitContext) {
+    public void hitsExecute(SearchContext context, SearchHit[] hits) throws IOException {
         if ((context.innerHits() != null && context.innerHits().getInnerHits().size() > 0) == false) {
             return;
         }
-        Map<String, SearchHits> results = new HashMap<>();
+
         for (Map.Entry<String, InnerHitsContext.BaseInnerHits> entry : context.innerHits().getInnerHits().entrySet()) {
             InnerHitsContext.BaseInnerHits innerHits = entry.getValue();
-            TopDocs topDocs;
-            try {
-                topDocs = innerHits.topDocs(context, hitContext);
-            } catch (IOException e) {
-                throw ExceptionsHelper.convertToElastic(e);
-            }
-            innerHits.queryResult().topDocs(topDocs, innerHits.sort() == null ? null : innerHits.sort().formats);
-            int[] docIdsToLoad = new int[topDocs.scoreDocs.length];
-            for (int i = 0; i < topDocs.scoreDocs.length; i++) {
-                docIdsToLoad[i] = topDocs.scoreDocs[i].doc;
-            }
-            innerHits.docIdsToLoad(docIdsToLoad, 0, docIdsToLoad.length);
-            fetchPhase.execute(innerHits);
-            FetchSearchResult fetchResult = innerHits.fetchResult();
-            SearchHit[] internalHits = fetchResult.fetchResult().hits().internalHits();
-            for (int i = 0; i < internalHits.length; i++) {
-                ScoreDoc scoreDoc = topDocs.scoreDocs[i];
-                SearchHit searchHitFields = internalHits[i];
-                searchHitFields.score(scoreDoc.score);
-                if (scoreDoc instanceof FieldDoc) {
-                    FieldDoc fieldDoc = (FieldDoc) scoreDoc;
-                    searchHitFields.sortValues(fieldDoc.fields, innerHits.sort().formats);
+            TopDocs[] topDocs = innerHits.topDocs(hits);
+            for (int i = 0; i < hits.length; i++) {
+                SearchHit hit = hits[i];
+                TopDocs topDoc = topDocs[i];
+
+                Map<String, SearchHits> results = hit.getInnerHits();
+                if (results == null) {
+                    hit.setInnerHits(results = new HashMap<>());
                 }
+                innerHits.queryResult().topDocs(topDoc, innerHits.sort() == null ? null : innerHits.sort().formats);
+                int[] docIdsToLoad = new int[topDoc.scoreDocs.length];
+                for (int j = 0; j < topDoc.scoreDocs.length; j++) {
+                    docIdsToLoad[j] = topDoc.scoreDocs[j].doc;
+                }
+                innerHits.docIdsToLoad(docIdsToLoad, 0, docIdsToLoad.length);
+                fetchPhase.execute(innerHits);
+                FetchSearchResult fetchResult = innerHits.fetchResult();
+                SearchHit[] internalHits = fetchResult.fetchResult().hits().internalHits();
+                for (int j = 0; j < internalHits.length; j++) {
+                    ScoreDoc scoreDoc = topDoc.scoreDocs[j];
+                    SearchHit searchHitFields = internalHits[j];
+                    searchHitFields.score(scoreDoc.score);
+                    if (scoreDoc instanceof FieldDoc) {
+                        FieldDoc fieldDoc = (FieldDoc) scoreDoc;
+                        searchHitFields.sortValues(fieldDoc.fields, innerHits.sort().formats);
+                    }
+                }
+                results.put(entry.getKey(), fetchResult.hits());
             }
-            results.put(entry.getKey(), fetchResult.hits());
         }
-        hitContext.hit().setInnerHits(results);
     }
 }


### PR DESCRIPTION
Previously query weight was created for each search hit that needed to compute inner hits,
 with this change the weight of the inner hit query is computed once for all search hits.

Depending on how expensive it is to rewrite and create the weight for the `nested`  query's (or `has_child` and `has_parent`) inner query, this optimization can yield quite a nice improvement in the overall query time. For example the rewrite and weight creation of range queries is cheap, while for bool with many term based clauses, phrase query or phrase prefix query this is not, and when these queries will benefit from this change. 

PR for #23917