### PR TITLE
Make PreConfiguredTokenFilter harder to misuse

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
@@ -96,6 +96,8 @@ public final class PreConfiguredTokenFilter implements AnalysisModule.AnalysisPr
         return useFilterForMultitermQueries;
     }
 
+    private interface MultiTermAwareTokenFilterFactory extends TokenFilterFactory, MultiTermAwareComponent {}
+
     private synchronized TokenFilterFactory getTokenFilterFactory(final Version version) {
         TokenFilterFactory factory = cache.get(version);
         if (factory == null) {
@@ -133,6 +135,4 @@ public final class PreConfiguredTokenFilter implements AnalysisModule.AnalysisPr
         }
         return factory;
     }
-
-    private interface MultiTermAwareTokenFilterFactory extends TokenFilterFactory, MultiTermAwareComponent {}
 }

--- a/core/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
@@ -38,7 +38,7 @@ import java.util.function.Function;
  */
 public final class PreConfiguredTokenFilter implements AnalysisModule.AnalysisProvider<TokenFilterFactory> {
     /**
-     * Set up a pre-configured token filter that may no vary at all.
+     * Create a pre-configured token filter that may not vary at all.
      */
     public static PreConfiguredTokenFilter singleton(String name, boolean useFilterForMultitermQueries,
             Function<TokenStream, TokenStream> create) {
@@ -47,7 +47,7 @@ public final class PreConfiguredTokenFilter implements AnalysisModule.AnalysisPr
     }
 
     /**
-     * Set up a pre-configured token filter that may vary based on the Lucene version.
+     * Create a pre-configured token filter that may vary based on the Lucene version.
      */
     public static PreConfiguredTokenFilter luceneVersion(String name, boolean useFilterForMultitermQueries,
             BiFunction<TokenStream, org.apache.lucene.util.Version, TokenStream> create) {
@@ -56,7 +56,7 @@ public final class PreConfiguredTokenFilter implements AnalysisModule.AnalysisPr
     }
 
     /**
-     * Set up a pre-configured token filter that may vary based on the Elasticsearch version.
+     * Create a pre-configured token filter that may vary based on the Elasticsearch version.
      */
     public static PreConfiguredTokenFilter elasticsearchVersion(String name, boolean useFilterForMultitermQueries,
             BiFunction<TokenStream, org.elasticsearch.Version, TokenStream> create) {

--- a/core/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
@@ -133,6 +133,7 @@ public final class PreConfiguredTokenFilter implements AnalysisModule.AnalysisPr
             }
             cache.put(version, factory);
         }
+
         return factory;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
@@ -27,6 +27,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory;
+import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 
 import java.io.IOException;
 import java.util.function.BiFunction;
@@ -36,29 +37,44 @@ import java.util.function.Function;
  * Provides pre-configured, shared {@link TokenFilter}s.
  */
 public final class PreConfiguredTokenFilter implements AnalysisModule.AnalysisProvider<TokenFilterFactory> {
+    /**
+     * Set up a pre-configured token filter that may no vary at all.
+     */
+    public static PreConfiguredTokenFilter singleton(String name, boolean useFilterForMultitermQueries,
+            Function<TokenStream, TokenStream> create) {
+        return new PreConfiguredTokenFilter(name, useFilterForMultitermQueries, CachingStrategy.ONE,
+                (tokenStream, version) -> create.apply(tokenStream));
+    }
+
+    /**
+     * Set up a pre-configured token filter that may vary based on the Lucene version.
+     */
+    public static PreConfiguredTokenFilter luceneVersion(String name, boolean useFilterForMultitermQueries,
+            BiFunction<TokenStream, org.apache.lucene.util.Version, TokenStream> create) {
+        return new PreConfiguredTokenFilter(name, useFilterForMultitermQueries, CachingStrategy.LUCENE,
+                (tokenStream, version) -> create.apply(tokenStream, version.luceneVersion));
+    }
+
+    /**
+     * Set up a pre-configured token filter that may vary based on the Elasticsearch version.
+     */
+    public static PreConfiguredTokenFilter elasticsearchVersion(String name, boolean useFilterForMultitermQueries,
+            BiFunction<TokenStream, org.elasticsearch.Version, TokenStream> create) {
+        return new PreConfiguredTokenFilter(name, useFilterForMultitermQueries, CachingStrategy.ELASTICSEARCH,
+                (tokenStream, version) -> create.apply(tokenStream, version));
+    }
+
     private final String name;
     private final boolean useFilterForMultitermQueries;
     private final PreBuiltCacheFactory.PreBuiltCache<TokenFilterFactory> cache;
     private final BiFunction<TokenStream, Version, TokenStream> create;
 
-    /**
-     * Standard ctor with all the power.
-     */
-    public PreConfiguredTokenFilter(String name, boolean useFilterForMultitermQueries,
-            PreBuiltCacheFactory.CachingStrategy cachingStrategy, BiFunction<TokenStream, Version, TokenStream> create) {
+    private PreConfiguredTokenFilter(String name, boolean useFilterForMultitermQueries,
+            PreBuiltCacheFactory.CachingStrategy cache, BiFunction<TokenStream, Version, TokenStream> create) {
         this.name = name;
         this.useFilterForMultitermQueries = useFilterForMultitermQueries;
-        cache = PreBuiltCacheFactory.getCache(cachingStrategy);
+        this.cache = PreBuiltCacheFactory.getCache(cache);
         this.create = create;
-    }
-
-    /**
-     * Convenience ctor for token streams that don't vary based on version.
-     */
-    public PreConfiguredTokenFilter(String name, boolean useFilterForMultitermQueries,
-            PreBuiltCacheFactory.CachingStrategy cachingStrategy, Function<TokenStream, TokenStream> create) {
-        this(name, useFilterForMultitermQueries, cachingStrategy, (input, version) -> create.apply(input));
-        // TODO why oh why aren't these all CachingStrategy.ONE? They *can't* vary based on version because they don't get it, right?!
     }
 
     @Override
@@ -79,8 +95,6 @@ public final class PreConfiguredTokenFilter implements AnalysisModule.AnalysisPr
     public boolean shouldUseFilterForMultitermQueries() {
         return useFilterForMultitermQueries;
     }
-
-    private interface MultiTermAwareTokenFilterFactory extends TokenFilterFactory, MultiTermAwareComponent {}
 
     private synchronized TokenFilterFactory getTokenFilterFactory(final Version version) {
         TokenFilterFactory factory = cache.get(version);
@@ -117,7 +131,8 @@ public final class PreConfiguredTokenFilter implements AnalysisModule.AnalysisPr
             }
             cache.put(version, factory);
         }
-
         return factory;
     }
+
+    private interface MultiTermAwareTokenFilterFactory extends TokenFilterFactory, MultiTermAwareComponent {}
 }

--- a/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenFilters.java
+++ b/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenFilters.java
@@ -30,7 +30,6 @@ import org.apache.lucene.analysis.core.DecimalDigitFilter;
 import org.apache.lucene.analysis.cz.CzechStemFilter;
 import org.apache.lucene.analysis.de.GermanNormalizationFilter;
 import org.apache.lucene.analysis.de.GermanStemFilter;
-import org.apache.lucene.analysis.en.PorterStemFilter;
 import org.apache.lucene.analysis.fa.PersianNormalizationFilter;
 import org.apache.lucene.analysis.fr.FrenchAnalyzer;
 import org.apache.lucene.analysis.hi.HindiNormalizationFilter;
@@ -70,20 +69,6 @@ public enum PreBuiltTokenFilters {
     },
 
     // Extended Token Filters
-    SNOWBALL(CachingStrategy.ONE) {
-        @Override
-        public TokenStream create(TokenStream tokenStream, Version version) {
-            return new SnowballFilter(tokenStream, "English");
-        }
-    },
-
-    STEMMER(CachingStrategy.ONE) {
-        @Override
-        public TokenStream create(TokenStream tokenStream, Version version) {
-            return new PorterStemFilter(tokenStream);
-        }
-    },
-
     ELISION(CachingStrategy.ONE) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {

--- a/core/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/AnalysisRegistryTests.java
@@ -34,7 +34,6 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.indices.analysis.AnalysisModule.AnalysisProvider;
 import org.elasticsearch.indices.analysis.PreBuiltAnalyzers;
-import org.elasticsearch.indices.analysis.PreBuiltCacheFactory;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
@@ -207,12 +206,11 @@ public class AnalysisRegistryTests extends ESTestCase {
 
     public void testPreConfiguredTokenFiltersAreCached() throws IOException {
         AtomicBoolean built = new AtomicBoolean(false);
-        PreConfiguredTokenFilter assertsBuiltOnce = new PreConfiguredTokenFilter("asserts_built_once", false,
-                PreBuiltCacheFactory.CachingStrategy.ONE, (tokens, version) -> {
+        PreConfiguredTokenFilter assertsBuiltOnce = PreConfiguredTokenFilter.singleton("asserts_built_once", false, tokenStream -> {
                     if (false == built.compareAndSet(false, true)) {
                         fail("Attempted to build the token filter twice when it should have been cached");
                     }
-                    return new MockTokenFilter(tokens, MockTokenFilter.EMPTY_STOPSET);
+                    return new MockTokenFilter(tokenStream, MockTokenFilter.EMPTY_STOPSET);
                 });
         try (AnalysisRegistry registryWithPreBuiltTokenFilter = new AnalysisRegistry(emptyEnvironment, emptyMap(), emptyMap(), emptyMap(),
                 emptyMap(), emptyMap(), singletonMap("asserts_built_once", assertsBuiltOnce))) {

--- a/core/src/test/java/org/elasticsearch/index/analysis/CustomNormalizerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/CustomNormalizerTests.java
@@ -24,7 +24,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.indices.analysis.AnalysisModule.AnalysisProvider;
-import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.ESTokenStreamTestCase;
@@ -113,7 +112,7 @@ public class CustomNormalizerTests extends ESTokenStreamTestCase {
     private static class MockAnalysisPlugin implements AnalysisPlugin {
         @Override
         public List<PreConfiguredTokenFilter> getPreConfiguredTokenFilters() {
-            return singletonList(new PreConfiguredTokenFilter("mock_forbidden", false, CachingStrategy.ONE, MockLowerCaseFilter::new));
+            return singletonList(PreConfiguredTokenFilter.singleton("mock_forbidden", false, MockLowerCaseFilter::new));
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.analysis.PreConfiguredTokenFilter;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
-import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -55,7 +54,7 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
     public static class MockAnalysisPlugin extends Plugin implements AnalysisPlugin {
         @Override
         public List<PreConfiguredTokenFilter> getPreConfiguredTokenFilters() {
-            return singletonList(new PreConfiguredTokenFilter("mock_other_lowercase", true, CachingStrategy.ONE, MockLowerCaseFilter::new));
+            return singletonList(PreConfiguredTokenFilter.singleton("mock_other_lowercase", true, MockLowerCaseFilter::new));
         }
     };
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -42,7 +42,6 @@ import org.elasticsearch.index.analysis.HtmlStripCharFilterFactory;
 import org.elasticsearch.index.analysis.PreConfiguredTokenFilter;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.indices.analysis.AnalysisModule.AnalysisProvider;
-import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.Plugin;
 
@@ -73,41 +72,38 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin {
 
     @Override
     public List<PreConfiguredTokenFilter> getPreConfiguredTokenFilters() {
-        // TODO we should revisit the caching strategies.
         List<PreConfiguredTokenFilter> filters = new ArrayList<>();
-        filters.add(new PreConfiguredTokenFilter("asciifolding", true, CachingStrategy.ONE, input -> new ASCIIFoldingFilter(input)));
-        filters.add(new PreConfiguredTokenFilter("classic", false, CachingStrategy.ONE, ClassicFilter::new));
-        filters.add(new PreConfiguredTokenFilter("common_grams", false, CachingStrategy.LUCENE, input ->
-                new CommonGramsFilter(input, CharArraySet.EMPTY_SET)));
-        filters.add(new PreConfiguredTokenFilter("edge_ngram", false, CachingStrategy.LUCENE, input ->
+        filters.add(PreConfiguredTokenFilter.singleton("asciifolding", true, input -> new ASCIIFoldingFilter(input)));
+        filters.add(PreConfiguredTokenFilter.singleton("classic", false, ClassicFilter::new));
+        filters.add(PreConfiguredTokenFilter.singleton("common_grams", false,
+                input -> new CommonGramsFilter(input, CharArraySet.EMPTY_SET)));
+        filters.add(PreConfiguredTokenFilter.singleton("edge_ngram", false, input ->
                 new EdgeNGramTokenFilter(input, EdgeNGramTokenFilter.DEFAULT_MIN_GRAM_SIZE, EdgeNGramTokenFilter.DEFAULT_MAX_GRAM_SIZE)));
         // TODO deprecate edgeNGram
-        filters.add(new PreConfiguredTokenFilter("edgeNGram", false, CachingStrategy.LUCENE, input ->
+        filters.add(PreConfiguredTokenFilter.singleton("edgeNGram", false, input ->
                 new EdgeNGramTokenFilter(input, EdgeNGramTokenFilter.DEFAULT_MIN_GRAM_SIZE, EdgeNGramTokenFilter.DEFAULT_MAX_GRAM_SIZE)));
-        filters.add(new PreConfiguredTokenFilter("kstem", false, CachingStrategy.ONE, KStemFilter::new));
-        filters.add(new PreConfiguredTokenFilter("length", false, CachingStrategy.LUCENE, input ->
+        filters.add(PreConfiguredTokenFilter.singleton("kstem", false, KStemFilter::new));
+        filters.add(PreConfiguredTokenFilter.singleton("length", false, input ->
                 new LengthFilter(input, 0, Integer.MAX_VALUE)));  // TODO this one seems useless
-        filters.add(new PreConfiguredTokenFilter("ngram", false, CachingStrategy.LUCENE, NGramTokenFilter::new));
+        filters.add(PreConfiguredTokenFilter.singleton("ngram", false, NGramTokenFilter::new));
         // TODO deprecate nGram
-        filters.add(new PreConfiguredTokenFilter("nGram", false, CachingStrategy.LUCENE, NGramTokenFilter::new));
-        filters.add(new PreConfiguredTokenFilter("porter_stem", false, CachingStrategy.ONE, PorterStemFilter::new));
-        filters.add(new PreConfiguredTokenFilter("reverse", false, CachingStrategy.LUCENE, input -> new ReverseStringFilter(input)));
+        filters.add(PreConfiguredTokenFilter.singleton("nGram", false, NGramTokenFilter::new));
+        filters.add(PreConfiguredTokenFilter.singleton("porter_stem", false, PorterStemFilter::new));
+        filters.add(PreConfiguredTokenFilter.singleton("reverse", false, input -> new ReverseStringFilter(input)));
         // The stop filter is in lucene-core but the English stop words set is in lucene-analyzers-common
-        filters.add(new PreConfiguredTokenFilter("stop", false, CachingStrategy.LUCENE, input ->
-                new StopFilter(input, StopAnalyzer.ENGLISH_STOP_WORDS_SET)));
-        filters.add(new PreConfiguredTokenFilter("trim", false, CachingStrategy.LUCENE, TrimFilter::new));
-        filters.add(new PreConfiguredTokenFilter("truncate", false, CachingStrategy.ONE, input ->
-                new TruncateTokenFilter(input, 10)));
-        filters.add(new PreConfiguredTokenFilter("unique", false, CachingStrategy.ONE, input -> new UniqueTokenFilter(input)));
-        filters.add(new PreConfiguredTokenFilter("uppercase", true, CachingStrategy.LUCENE, UpperCaseFilter::new));
-        filters.add(new PreConfiguredTokenFilter("word_delimiter", false, CachingStrategy.ONE, input ->
+        filters.add(PreConfiguredTokenFilter.singleton("stop", false, input -> new StopFilter(input, StopAnalyzer.ENGLISH_STOP_WORDS_SET)));
+        filters.add(PreConfiguredTokenFilter.singleton("trim", false, TrimFilter::new));
+        filters.add(PreConfiguredTokenFilter.singleton("truncate", false, input -> new TruncateTokenFilter(input, 10)));
+        filters.add(PreConfiguredTokenFilter.singleton("unique", false, input -> new UniqueTokenFilter(input)));
+        filters.add(PreConfiguredTokenFilter.singleton("uppercase", true, UpperCaseFilter::new));
+        filters.add(PreConfiguredTokenFilter.singleton("word_delimiter", false, input ->
                 new WordDelimiterFilter(input,
                         WordDelimiterFilter.GENERATE_WORD_PARTS
                       | WordDelimiterFilter.GENERATE_NUMBER_PARTS
                       | WordDelimiterFilter.SPLIT_ON_CASE_CHANGE
                       | WordDelimiterFilter.SPLIT_ON_NUMERICS
                       | WordDelimiterFilter.STEM_ENGLISH_POSSESSIVE, null)));
-        filters.add(new PreConfiguredTokenFilter("word_delimiter_graph", false, CachingStrategy.ONE, input ->
+        filters.add(PreConfiguredTokenFilter.singleton("word_delimiter_graph", false, input ->
                 new WordDelimiterGraphFilter(input,
                         WordDelimiterGraphFilter.GENERATE_WORD_PARTS
                       | WordDelimiterGraphFilter.GENERATE_NUMBER_PARTS

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -36,6 +36,7 @@ import org.apache.lucene.analysis.miscellaneous.WordDelimiterGraphFilter;
 import org.apache.lucene.analysis.ngram.EdgeNGramTokenFilter;
 import org.apache.lucene.analysis.ngram.NGramTokenFilter;
 import org.apache.lucene.analysis.reverse.ReverseStringFilter;
+import org.apache.lucene.analysis.snowball.SnowballFilter;
 import org.apache.lucene.analysis.standard.ClassicFilter;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.HtmlStripCharFilterFactory;
@@ -90,6 +91,8 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin {
         filters.add(PreConfiguredTokenFilter.singleton("nGram", false, NGramTokenFilter::new));
         filters.add(PreConfiguredTokenFilter.singleton("porter_stem", false, PorterStemFilter::new));
         filters.add(PreConfiguredTokenFilter.singleton("reverse", false, input -> new ReverseStringFilter(input)));
+        filters.add(PreConfiguredTokenFilter.singleton("snowball", false, input -> new SnowballFilter(input, "English")));
+        filters.add(PreConfiguredTokenFilter.singleton("stemmer", false, PorterStemFilter::new));
         // The stop filter is in lucene-core but the English stop words set is in lucene-analyzers-common
         filters.add(PreConfiguredTokenFilter.singleton("stop", false, input -> new StopFilter(input, StopAnalyzer.ENGLISH_STOP_WORDS_SET)));
         filters.add(PreConfiguredTokenFilter.singleton("trim", false, TrimFilter::new));

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisFactoryTests.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.analysis.common;
 
+import org.apache.lucene.analysis.en.PorterStemFilterFactory;
 import org.apache.lucene.analysis.reverse.ReverseStringFilterFactory;
+import org.apache.lucene.analysis.snowball.SnowballPorterFilterFactory;
 import org.elasticsearch.index.analysis.HtmlStripCharFilterFactory;
 import org.elasticsearch.indices.analysis.AnalysisFactoryTestCase;
 
@@ -77,6 +79,8 @@ public class CommonAnalysisFactoryTests extends AnalysisFactoryTestCase {
         filters.put("nGram", null);
         filters.put("porter_stem", null);
         filters.put("reverse", ReverseStringFilterFactory.class);
+        filters.put("snowball", SnowballPorterFilterFactory.class);
+        filters.put("stemmer", PorterStemFilterFactory.class);
         filters.put("stop", null);
         filters.put("trim", null);
         filters.put("truncate", null);

--- a/test/framework/src/main/java/org/elasticsearch/indices/analysis/AnalysisFactoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/analysis/AnalysisFactoryTestCase.java
@@ -350,14 +350,10 @@ public abstract class AnalysisFactoryTestCase extends ESTestCase {
             case LOWERCASE:
                 // This has been migrated but has to stick around until PreBuiltTokenizers is removed.
                 continue;
-            case SNOWBALL:
             case DUTCH_STEM:
             case FRENCH_STEM:
             case RUSSIAN_STEM:
                 luceneFactoryClass = SnowballPorterFilterFactory.class;
-                break;
-            case STEMMER:
-                luceneFactoryClass = PorterStemFilterFactory.class;
                 break;
             case DELIMITED_PAYLOAD_FILTER:
                 luceneFactoryClass = org.apache.lucene.analysis.payloads.DelimitedPayloadTokenFilterFactory.class;


### PR DESCRIPTION
There are now three public static method to build instances of
PreConfiguredTokenFilter and the ctor is private. I chose static
methods instead of constructors because those allow us to change
out the implementation returned if we so desire.

Also moves over two more pre-configured token filters. There still
a bunch to go!

Relates to #23658