### PR TITLE
Scripting: Remove "service" from ScriptEngine interface name

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/ScriptPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ScriptPlugin.java
@@ -34,7 +34,7 @@ public interface ScriptPlugin {
     /**
      * Returns a {@link ScriptEngine} instance or <code>null</code> if this plugin doesn't add a new script engine
      */
-    default ScriptEngine getScriptEngineService(Settings settings) {
+    default ScriptEngine getScriptEngine(Settings settings) {
         return null;
     }
 

--- a/core/src/main/java/org/elasticsearch/plugins/ScriptPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ScriptPlugin.java
@@ -21,7 +21,7 @@ package org.elasticsearch.plugins;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.NativeScriptFactory;
 import org.elasticsearch.script.ScriptContext;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,9 +32,9 @@ import java.util.List;
 public interface ScriptPlugin {
 
     /**
-     * Returns a {@link ScriptEngineService} instance or <code>null</code> if this plugin doesn't add a new script engine
+     * Returns a {@link ScriptEngine} instance or <code>null</code> if this plugin doesn't add a new script engine
      */
-    default ScriptEngineService getScriptEngineService(Settings settings) {
+    default ScriptEngine getScriptEngineService(Settings settings) {
         return null;
     }
 

--- a/core/src/main/java/org/elasticsearch/script/NativeScriptEngine.java
+++ b/core/src/main/java/org/elasticsearch/script/NativeScriptEngine.java
@@ -33,13 +33,13 @@ import static java.util.Collections.unmodifiableMap;
 /**
  * A native script engine service.
  */
-public class NativeScriptEngineService extends AbstractComponent implements ScriptEngineService {
+public class NativeScriptEngine extends AbstractComponent implements ScriptEngine {
 
     public static final String NAME = "native";
 
     private final Map<String, NativeScriptFactory> scripts;
 
-    public NativeScriptEngineService(Settings settings, Map<String, NativeScriptFactory> scripts) {
+    public NativeScriptEngine(Settings settings, Map<String, NativeScriptFactory> scripts) {
         super(settings);
         this.scripts = unmodifiableMap(scripts);
     }

--- a/core/src/main/java/org/elasticsearch/script/ScriptEngine.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptEngine.java
@@ -25,10 +25,19 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import java.io.Closeable;
 import java.util.Map;
 
-public interface ScriptEngineService extends Closeable {
+/**
+ * A script language implementation.
+ */
+public interface ScriptEngine extends Closeable {
 
+    /**
+     * The language name used in the script APIs to refer to this scripting backend.
+     */
     String getType();
 
+    /**
+     * The extension for file scripts in this language.
+     */
     String getExtension();
 
     /**

--- a/core/src/main/java/org/elasticsearch/script/ScriptEngineRegistry.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptEngineRegistry.java
@@ -21,23 +21,21 @@ package org.elasticsearch.script;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.elasticsearch.common.Strings;
 
 public class ScriptEngineRegistry {
 
-    private final Map<Class<? extends ScriptEngineService>, String> registeredScriptEngineServices;
-    private final Map<String, ScriptEngineService> registeredLanguages;
+    private final Map<Class<? extends ScriptEngine>, String> registeredScriptEngineServices;
+    private final Map<String, ScriptEngine> registeredLanguages;
     private final Map<String, Boolean> defaultInlineScriptEnableds;
 
-    public ScriptEngineRegistry(Iterable<ScriptEngineService> registrations) {
+    public ScriptEngineRegistry(Iterable<ScriptEngine> registrations) {
         Objects.requireNonNull(registrations);
-        Map<Class<? extends ScriptEngineService>, String> registeredScriptEngineServices = new HashMap<>();
-        Map<String, ScriptEngineService> registeredLanguages = new HashMap<>();
+        Map<Class<? extends ScriptEngine>, String> registeredScriptEngineServices = new HashMap<>();
+        Map<String, ScriptEngine> registeredLanguages = new HashMap<>();
         Map<String, Boolean> inlineScriptEnableds = new HashMap<>();
-        for (ScriptEngineService service : registrations) {
+        for (ScriptEngine service : registrations) {
             String oldLanguage = registeredScriptEngineServices.putIfAbsent(service.getClass(),
                     service.getType());
             if (oldLanguage != null) {
@@ -45,11 +43,11 @@ public class ScriptEngineRegistry {
                                 "] already registered for language [" + oldLanguage + "]");
             }
             String language = service.getType();
-            ScriptEngineService scriptEngineService =
+            ScriptEngine scriptEngine =
                     registeredLanguages.putIfAbsent(language, service);
-            if (scriptEngineService != null) {
+            if (scriptEngine != null) {
                 throw new IllegalArgumentException("scripting language [" + language + "] already registered for script engine service [" +
-                    scriptEngineService.getClass().getCanonicalName() + "]");
+                    scriptEngine.getClass().getCanonicalName() + "]");
             }
             inlineScriptEnableds.put(language, service.isInlineScriptEnabled());
         }
@@ -59,16 +57,16 @@ public class ScriptEngineRegistry {
         this.defaultInlineScriptEnableds = Collections.unmodifiableMap(inlineScriptEnableds);
     }
 
-    Iterable<Class<? extends ScriptEngineService>> getRegisteredScriptEngineServices() {
+    Iterable<Class<? extends ScriptEngine>> getRegisteredScriptEngineServices() {
         return registeredScriptEngineServices.keySet();
     }
 
-    String getLanguage(Class<? extends ScriptEngineService> scriptEngineService) {
+    String getLanguage(Class<? extends ScriptEngine> scriptEngineService) {
         Objects.requireNonNull(scriptEngineService);
         return registeredScriptEngineServices.get(scriptEngineService);
     }
 
-    public Map<String, ScriptEngineService> getRegisteredLanguages() {
+    public Map<String, ScriptEngine> getRegisteredLanguages() {
         return registeredLanguages;
     }
 

--- a/core/src/main/java/org/elasticsearch/script/ScriptModes.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptModes.java
@@ -57,7 +57,7 @@ public class ScriptModes {
      */
     public boolean getScriptEnabled(String lang, ScriptType scriptType, ScriptContext scriptContext) {
         //native scripts are always enabled as they are static by definition
-        if (NativeScriptEngineService.NAME.equals(lang)) {
+        if (NativeScriptEngine.NAME.equals(lang)) {
             return true;
         }
         Boolean scriptMode = scriptEnabled.get(getKey(lang, scriptType, scriptContext));

--- a/core/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -49,7 +49,7 @@ public class ScriptModule {
         Map<String, NativeScriptFactory> factoryMap = scriptPlugins.stream().flatMap(x -> x.getNativeScripts().stream())
             .collect(Collectors.toMap(NativeScriptFactory::getName, Function.identity()));
         NativeScriptEngine nativeScriptEngineService = new NativeScriptEngine(settings, factoryMap);
-        List<ScriptEngine> scriptEngines = scriptPlugins.stream().map(x -> x.getScriptEngineService(settings))
+        List<ScriptEngine> scriptEngines = scriptPlugins.stream().map(x -> x.getScriptEngine(settings))
             .filter(Objects::nonNull).collect(Collectors.toList());
         scriptEngines.add(nativeScriptEngineService);
         List<ScriptContext.Plugin> plugins = scriptPlugins.stream().map(x -> x.getCustomScriptContexts()).filter(Objects::nonNull)

--- a/core/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -27,8 +27,6 @@ import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,23 +48,23 @@ public class ScriptModule {
                                       ResourceWatcherService resourceWatcherService, List<ScriptPlugin> scriptPlugins) {
         Map<String, NativeScriptFactory> factoryMap = scriptPlugins.stream().flatMap(x -> x.getNativeScripts().stream())
             .collect(Collectors.toMap(NativeScriptFactory::getName, Function.identity()));
-        NativeScriptEngineService nativeScriptEngineService = new NativeScriptEngineService(settings, factoryMap);
-        List<ScriptEngineService> scriptEngineServices = scriptPlugins.stream().map(x -> x.getScriptEngineService(settings))
+        NativeScriptEngine nativeScriptEngineService = new NativeScriptEngine(settings, factoryMap);
+        List<ScriptEngine> scriptEngines = scriptPlugins.stream().map(x -> x.getScriptEngineService(settings))
             .filter(Objects::nonNull).collect(Collectors.toList());
-        scriptEngineServices.add(nativeScriptEngineService);
+        scriptEngines.add(nativeScriptEngineService);
         List<ScriptContext.Plugin> plugins = scriptPlugins.stream().map(x -> x.getCustomScriptContexts()).filter(Objects::nonNull)
                 .collect(Collectors.toList());
-        return new ScriptModule(settings, environment, resourceWatcherService, scriptEngineServices, plugins);
+        return new ScriptModule(settings, environment, resourceWatcherService, scriptEngines, plugins);
     }
 
     /**
-     * Build {@linkplain ScriptEngineService} and {@linkplain ScriptContext.Plugin}.
+     * Build {@linkplain ScriptEngine} and {@linkplain ScriptContext.Plugin}.
      */
     public ScriptModule(Settings settings, Environment environment,
-                        ResourceWatcherService resourceWatcherService, List<ScriptEngineService> scriptEngineServices,
+                        ResourceWatcherService resourceWatcherService, List<ScriptEngine> scriptEngines,
                         List<ScriptContext.Plugin> customScriptContexts) {
         ScriptContextRegistry scriptContextRegistry = new ScriptContextRegistry(customScriptContexts);
-        ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(scriptEngineServices);
+        ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(scriptEngines);
         scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
         try {
             scriptService = new ScriptService(settings, environment, resourceWatcherService, scriptEngineRegistry, scriptContextRegistry,

--- a/core/src/main/java/org/elasticsearch/script/ScriptSettings.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptSettings.java
@@ -72,8 +72,8 @@ public class ScriptSettings {
                                                               ScriptContextRegistry scriptContextRegistry) {
         final List<Setting<Boolean>> scriptModeSettings = new ArrayList<>();
 
-        for (final Class<? extends ScriptEngineService> scriptEngineService : scriptEngineRegistry.getRegisteredScriptEngineServices()) {
-            if (scriptEngineService == NativeScriptEngineService.class) {
+        for (final Class<? extends ScriptEngine> scriptEngineService : scriptEngineRegistry.getRegisteredScriptEngineServices()) {
+            if (scriptEngineService == NativeScriptEngine.class) {
                 // native scripts are always enabled, and their settings can not be changed
                 continue;
             }

--- a/core/src/main/java/org/elasticsearch/script/ScriptType.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptType.java
@@ -37,7 +37,7 @@ public enum ScriptType implements Writeable {
      * INLINE scripts are specified in numerous queries and compiled on-the-fly.
      * They will be cached based on the lang and code of the script.
      * They are turned off by default because most languages are insecure
-     * (Groovy and others), but can be overridden by the specific {@link ScriptEngineService}
+     * (Groovy and others), but can be overridden by the specific {@link ScriptEngine}
      * if the language is naturally secure (Painless, Mustache, and Expressions).
      */
     INLINE ( 0 , new ParseField("inline") , false ),
@@ -46,7 +46,7 @@ public enum ScriptType implements Writeable {
      * STORED scripts are saved as part of the {@link org.elasticsearch.cluster.ClusterState}
      * based on user requests.  They will be cached when they are first used in a query.
      * They are turned off by default because most languages are insecure
-     * (Groovy and others), but can be overridden by the specific {@link ScriptEngineService}
+     * (Groovy and others), but can be overridden by the specific {@link ScriptEngine}
      * if the language is naturally secure (Painless, Mustache, and Expressions).
      */
     STORED ( 1 , new ParseField("stored", "id") , false ),
@@ -123,7 +123,7 @@ public enum ScriptType implements Writeable {
 
     /**
      * @return Whether or not a {@link ScriptType} can be run by default.  Note
-     * this can be potentially overridden by any {@link ScriptEngineService}.
+     * this can be potentially overridden by any {@link ScriptEngine}.
      */
     public boolean isDefaultEnabled() {
         return defaultEnabled;

--- a/core/src/test/java/org/elasticsearch/script/NativeScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/NativeScriptTests.java
@@ -47,11 +47,11 @@ public class NativeScriptTests extends ESTestCase {
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .build();
         ScriptModule scriptModule = new ScriptModule(settings, new Environment(settings), null,
-                singletonList(new NativeScriptEngineService(settings, singletonMap("my", new MyNativeScriptFactory()))), emptyList());
+                singletonList(new NativeScriptEngine(settings, singletonMap("my", new MyNativeScriptFactory()))), emptyList());
         List<Setting<?>> scriptSettings = scriptModule.getSettings();
         scriptSettings.add(InternalSettingsPlugin.VERSION_CREATED);
 
-        Script script = new Script(ScriptType.INLINE, NativeScriptEngineService.NAME, "my", Collections.emptyMap());
+        Script script = new Script(ScriptType.INLINE, NativeScriptEngine.NAME, "my", Collections.emptyMap());
         CompiledScript compiledScript = scriptModule.getScriptService().compile(script, ScriptContext.Standard.SEARCH);
         ExecutableScript executable = scriptModule.getScriptService().executable(compiledScript, script.getParams());
         assertThat(executable.run().toString(), equalTo("test"));
@@ -71,7 +71,7 @@ public class NativeScriptTests extends ESTestCase {
         ResourceWatcherService resourceWatcherService = new ResourceWatcherService(settings, null);
         Map<String, NativeScriptFactory> nativeScriptFactoryMap = new HashMap<>();
         nativeScriptFactoryMap.put("my", new MyNativeScriptFactory());
-        ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(Collections.singleton(new NativeScriptEngineService(settings,
+        ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(Collections.singleton(new NativeScriptEngine(settings,
             nativeScriptFactoryMap)));
         ScriptContextRegistry scriptContextRegistry = new ScriptContextRegistry(new ArrayList<>());
         ScriptSettings scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
@@ -79,7 +79,7 @@ public class NativeScriptTests extends ESTestCase {
             scriptContextRegistry, scriptSettings);
 
         for (ScriptContext scriptContext : scriptContextRegistry.scriptContexts()) {
-            assertThat(scriptService.compile(new Script(ScriptType.INLINE, NativeScriptEngineService.NAME, "my", Collections.emptyMap()),
+            assertThat(scriptService.compile(new Script(ScriptType.INLINE, NativeScriptEngine.NAME, "my", Collections.emptyMap()),
                 scriptContext), notNullValue());
         }
     }

--- a/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptModesTests.java
@@ -43,7 +43,7 @@ public class ScriptModesTests extends ESTestCase {
     ScriptSettings scriptSettings;
     ScriptContextRegistry scriptContextRegistry;
     private ScriptContext[] scriptContexts;
-    private Map<String, ScriptEngineService> scriptEngines;
+    private Map<String, ScriptEngine> scriptEngines;
     private ScriptModes scriptModes;
     private Set<String> checkedSettings;
     private boolean assertAllSettingsWereChecked;
@@ -65,8 +65,8 @@ public class ScriptModesTests extends ESTestCase {
         scriptContexts = scriptContextRegistry.scriptContexts().toArray(new ScriptContext[scriptContextRegistry.scriptContexts().size()]);
         scriptEngines = buildScriptEnginesByLangMap(newHashSet(
                 //add the native engine just to make sure it gets filtered out
-                new NativeScriptEngineService(Settings.EMPTY, Collections.<String, NativeScriptFactory>emptyMap()),
-                new CustomScriptEngineService()));
+                new NativeScriptEngine(Settings.EMPTY, Collections.<String, NativeScriptFactory>emptyMap()),
+                new CustomScriptEngine()));
         ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(scriptEngines.values());
         scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
         checkedSettings = new HashSet<>();
@@ -77,7 +77,7 @@ public class ScriptModesTests extends ESTestCase {
     @After
     public void assertNativeScriptsAreAlwaysAllowed() {
         if (assertScriptModesNonNull) {
-            assertThat(scriptModes.getScriptEnabled(NativeScriptEngineService.NAME, randomFrom(ScriptType.values()), randomFrom(scriptContexts)), equalTo(true));
+            assertThat(scriptModes.getScriptEnabled(NativeScriptEngine.NAME, randomFrom(ScriptType.values()), randomFrom(scriptContexts)), equalTo(true));
         }
     }
 
@@ -216,16 +216,16 @@ public class ScriptModesTests extends ESTestCase {
         return copy.values().toArray(new ScriptContext[copy.size()]);
     }
 
-    static Map<String, ScriptEngineService> buildScriptEnginesByLangMap(Set<ScriptEngineService> scriptEngines) {
-        Map<String, ScriptEngineService> builder = new HashMap<>();
-        for (ScriptEngineService scriptEngine : scriptEngines) {
+    static Map<String, ScriptEngine> buildScriptEnginesByLangMap(Set<ScriptEngine> scriptEngines) {
+        Map<String, ScriptEngine> builder = new HashMap<>();
+        for (ScriptEngine scriptEngine : scriptEngines) {
             String type = scriptEngine.getType();
             builder.put(type, scriptEngine);
         }
         return unmodifiableMap(builder);
     }
 
-    private static class CustomScriptEngineService implements ScriptEngineService {
+    private static class CustomScriptEngine implements ScriptEngine {
 
         public static final String NAME = "custom";
 

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -55,9 +55,9 @@ import static org.hamcrest.Matchers.sameInstance;
 public class ScriptServiceTests extends ESTestCase {
 
     private ResourceWatcherService resourceWatcherService;
-    private ScriptEngineService scriptEngineService;
-    private ScriptEngineService dangerousScriptEngineService;
-    private Map<String, ScriptEngineService> scriptEnginesByLangMap;
+    private ScriptEngine scriptEngine;
+    private ScriptEngine dangerousScriptEngine;
+    private Map<String, ScriptEngine> scriptEnginesByLangMap;
     private ScriptEngineRegistry scriptEngineRegistry;
     private ScriptContextRegistry scriptContextRegistry;
     private ScriptSettings scriptSettings;
@@ -83,11 +83,11 @@ public class ScriptServiceTests extends ESTestCase {
                 .put(ScriptService.SCRIPT_MAX_COMPILATIONS_PER_MINUTE.getKey(), 10000)
                 .build();
         resourceWatcherService = new ResourceWatcherService(baseSettings, null);
-        scriptEngineService = new TestEngineService();
-        dangerousScriptEngineService = new TestDangerousEngineService();
-        TestEngineService defaultScriptServiceEngine = new TestEngineService(Script.DEFAULT_SCRIPT_LANG) {};
+        scriptEngine = new TestEngine();
+        dangerousScriptEngine = new TestDangerousEngine();
+        TestEngine defaultScriptServiceEngine = new TestEngine(Script.DEFAULT_SCRIPT_LANG) {};
         scriptEnginesByLangMap = ScriptModesTests.buildScriptEnginesByLangMap(
-                new HashSet<>(Arrays.asList(scriptEngineService, defaultScriptServiceEngine)));
+                new HashSet<>(Arrays.asList(scriptEngine, defaultScriptServiceEngine)));
         //randomly register custom script contexts
         int randomInt = randomIntBetween(0, 3);
         //prevent duplicates using map
@@ -104,7 +104,7 @@ public class ScriptServiceTests extends ESTestCase {
             String context = plugin + "_" + operation;
             contexts.put(context, new ScriptContext.Plugin(plugin, operation));
         }
-        scriptEngineRegistry = new ScriptEngineRegistry(Arrays.asList(scriptEngineService, dangerousScriptEngineService,
+        scriptEngineRegistry = new ScriptEngineRegistry(Arrays.asList(scriptEngine, dangerousScriptEngine,
                 defaultScriptServiceEngine));
         scriptContextRegistry = new ScriptContextRegistry(contexts.values());
         scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
@@ -259,7 +259,7 @@ public class ScriptServiceTests extends ESTestCase {
             do {
                 ScriptType scriptType = randomFrom(ScriptType.values());
                 ScriptContext scriptContext = randomFrom(this.scriptContexts);
-                settingKey = scriptEngineService.getType() + "." + scriptType + "." + scriptContext.getKey();
+                settingKey = scriptEngine.getType() + "." + scriptType + "." + scriptContext.getKey();
             } while (engineSettings.containsKey(settingKey));
             engineSettings.put(settingKey, randomBoolean());
         }
@@ -301,7 +301,7 @@ public class ScriptServiceTests extends ESTestCase {
             String script = scriptType == ScriptType.FILE ? "file_script" : "script";
             for (ScriptContext scriptContext : this.scriptContexts) {
                 //fallback mechanism: 1) engine specific settings 2) op based settings 3) source based settings
-                Boolean scriptEnabled = engineSettings.get(dangerousScriptEngineService.getType() + "." + scriptType + "." + scriptContext.getKey());
+                Boolean scriptEnabled = engineSettings.get(dangerousScriptEngine.getType() + "." + scriptType + "." + scriptContext.getKey());
                 if (scriptEnabled == null) {
                     scriptEnabled = scriptContextSettings.get(scriptContext);
                 }
@@ -312,7 +312,7 @@ public class ScriptServiceTests extends ESTestCase {
                     scriptEnabled = DEFAULT_SCRIPT_ENABLED.get(scriptType);
                 }
 
-                String lang = dangerousScriptEngineService.getType();
+                String lang = dangerousScriptEngine.getType();
                 if (scriptEnabled) {
                     assertCompileAccepted(lang, script, scriptType, scriptContext);
                 } else {
@@ -332,7 +332,7 @@ public class ScriptServiceTests extends ESTestCase {
             unknownContext = randomAlphaOfLength(randomIntBetween(1, 30));
         } while(scriptContextRegistry.isSupportedContext(new ScriptContext.Plugin(pluginName, unknownContext)));
 
-        String type = scriptEngineService.getType();
+        String type = scriptEngine.getType();
         try {
             scriptService.compile(new Script(randomFrom(ScriptType.values()), type, "test", Collections.emptyMap()),
                 new ScriptContext.Plugin(pluginName, unknownContext));
@@ -482,17 +482,17 @@ public class ScriptServiceTests extends ESTestCase {
         );
     }
 
-    public static class TestEngineService implements ScriptEngineService {
+    public static class TestEngine implements ScriptEngine {
 
         public static final String NAME = "test";
 
         private final String name;
 
-        public TestEngineService() {
+        public TestEngine() {
             this(NAME);
         }
 
-        public TestEngineService(String name) {
+        public TestEngine(String name) {
             this.name = name;
         }
 
@@ -532,7 +532,7 @@ public class ScriptServiceTests extends ESTestCase {
         }
     }
 
-    public static class TestDangerousEngineService implements ScriptEngineService {
+    public static class TestDangerousEngine implements ScriptEngine {
 
         public static final String NAME = "dtest";
 

--- a/core/src/test/java/org/elasticsearch/script/ScriptSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptSettingsTests.java
@@ -29,14 +29,13 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ScriptSettingsTests extends ESTestCase {
 
     public void testSettingsAreProperlyPropogated() {
         ScriptEngineRegistry scriptEngineRegistry =
-            new ScriptEngineRegistry(Collections.singletonList(new CustomScriptEngineService()));
+            new ScriptEngineRegistry(Collections.singletonList(new CustomScriptEngine()));
         ScriptContextRegistry scriptContextRegistry = new ScriptContextRegistry(Collections.emptyList());
         ScriptSettings scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
         boolean enabled = randomBoolean();
@@ -50,7 +49,7 @@ public class ScriptSettingsTests extends ESTestCase {
         }
     }
 
-    private static class CustomScriptEngineService implements ScriptEngineService {
+    private static class CustomScriptEngine implements ScriptEngine {
 
         public static final String NAME = "custom";
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
@@ -28,7 +28,7 @@ import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -397,7 +397,7 @@ public class AvgIT extends AbstractNumericTestCase {
      */
     public static class ExtractFieldScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new ExtractFieldScriptEngine();
         }
     }
@@ -405,7 +405,7 @@ public class AvgIT extends AbstractNumericTestCase {
     /**
      * This mock script returns the field that is specified by name in the script body
      */
-    public static class ExtractFieldScriptEngine implements ScriptEngineService {
+    public static class ExtractFieldScriptEngine implements ScriptEngine {
 
         public static final String NAME = "extract_field";
 
@@ -502,7 +502,7 @@ public class AvgIT extends AbstractNumericTestCase {
      */
     public static class FieldValueScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new FieldValueScriptEngine();
         }
     }
@@ -510,7 +510,7 @@ public class AvgIT extends AbstractNumericTestCase {
     /**
      * This mock script returns the field value and adds one month to the returned date
      */
-    public static class FieldValueScriptEngine implements ScriptEngineService {
+    public static class FieldValueScriptEngine implements ScriptEngine {
 
         public static final String NAME = "field_value";
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
@@ -397,7 +397,7 @@ public class AvgIT extends AbstractNumericTestCase {
      */
     public static class ExtractFieldScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new ExtractFieldScriptEngine();
         }
     }
@@ -502,7 +502,7 @@ public class AvgIT extends AbstractNumericTestCase {
      */
     public static class FieldValueScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new FieldValueScriptEngine();
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -28,7 +28,7 @@ import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -396,7 +396,7 @@ public class SumIT extends AbstractNumericTestCase {
      */
     public static class ExtractFieldScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new ExtractFieldScriptEngine();
         }
     }
@@ -405,7 +405,7 @@ public class SumIT extends AbstractNumericTestCase {
      * This mock script returns the field that is specified by name in the
      * script body
      */
-    public static class ExtractFieldScriptEngine implements ScriptEngineService {
+    public static class ExtractFieldScriptEngine implements ScriptEngine {
 
         public static final String NAME = "extract_field";
 
@@ -508,7 +508,7 @@ public class SumIT extends AbstractNumericTestCase {
      */
     public static class FieldValueScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new FieldValueScriptEngine();
         }
     }
@@ -517,7 +517,7 @@ public class SumIT extends AbstractNumericTestCase {
      * This mock script returns the field value and adds one to the returned
      * value
      */
-    public static class FieldValueScriptEngine implements ScriptEngineService {
+    public static class FieldValueScriptEngine implements ScriptEngine {
 
         public static final String NAME = "field_value";
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -396,7 +396,7 @@ public class SumIT extends AbstractNumericTestCase {
      */
     public static class ExtractFieldScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new ExtractFieldScriptEngine();
         }
     }
@@ -508,7 +508,7 @@ public class SumIT extends AbstractNumericTestCase {
      */
     public static class FieldValueScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new FieldValueScriptEngine();
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
@@ -251,7 +251,7 @@ public class ValueCountIT extends ESIntegTestCase {
      */
     public static class FieldValueScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new FieldValueScriptEngine();
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
@@ -28,7 +28,7 @@ import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -251,7 +251,7 @@ public class ValueCountIT extends ESIntegTestCase {
      */
     public static class FieldValueScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new FieldValueScriptEngine();
         }
     }
@@ -259,7 +259,7 @@ public class ValueCountIT extends ESIntegTestCase {
     /**
      * This mock script returns the field value. If the parameter map contains a parameter "s", the corresponding is used as field name.
      */
-    public static class FieldValueScriptEngine implements ScriptEngineService {
+    public static class FieldValueScriptEngine implements ScriptEngine {
 
         public static final String NAME = "field_value";
 

--- a/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -56,7 +56,7 @@ import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptContextRegistry;
 import org.elasticsearch.script.ScriptEngineRegistry;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.ScriptServiceTests.TestEngineService;
+import org.elasticsearch.script.ScriptServiceTests.TestEngine;
 import org.elasticsearch.script.ScriptSettings;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.DocValueFormat;
@@ -91,7 +91,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
                 .build();
         Environment environment = new Environment(baseSettings);
         ScriptContextRegistry scriptContextRegistry = new ScriptContextRegistry(Collections.emptyList());
-        ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(Collections.singletonList(new TestEngineService()));
+        ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(Collections.singletonList(new TestEngine()));
         ScriptSettings scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
         scriptService = new ScriptService(baseSettings, environment,
                 new ResourceWatcherService(baseSettings, null), scriptEngineRegistry, scriptContextRegistry, scriptSettings) {

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -1111,7 +1111,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
 
     public static class DummyTemplatePlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new DummyTemplateScriptEngine();
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -22,7 +22,6 @@ package org.elasticsearch.search.suggest;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.ReduceSearchPhaseException;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -34,7 +33,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.suggest.phrase.DirectCandidateGeneratorBuilder;
@@ -1112,12 +1111,12 @@ public class SuggestSearchIT extends ESIntegTestCase {
 
     public static class DummyTemplatePlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new DummyTemplateScriptEngine();
         }
     }
 
-    public static class DummyTemplateScriptEngine implements ScriptEngineService {
+    public static class DummyTemplateScriptEngine implements ScriptEngine {
 
         // The collate query setter is hard coded to use mustache, so lets lie in this test about the script plugin,
         // which makes the collate code thinks mustache is evaluating the query.

--- a/core/src/test/java/org/elasticsearch/update/UpdateByNativeScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateByNativeScriptIT.java
@@ -23,7 +23,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.AbstractExecutableScript;
 import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.NativeScriptEngineService;
+import org.elasticsearch.script.NativeScriptEngine;
 import org.elasticsearch.script.NativeScriptFactory;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
@@ -57,7 +57,7 @@ public class UpdateByNativeScriptIT extends ESIntegTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("foo", "SETVALUE");
         client().prepareUpdate("test", "type", "1")
-                .setScript(new Script(ScriptType.INLINE, NativeScriptEngineService.NAME, "custom", params)).get();
+                .setScript(new Script(ScriptType.INLINE, NativeScriptEngine.NAME, "custom", params)).get();
 
         Map<String, Object> data = client().prepareGet("test", "type", "1").get().getSource();
         assertThat(data, hasKey("foo"));

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -34,17 +34,14 @@ import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.MergePolicyConfig;
-import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.engine.DocumentMissingException;
-import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -76,12 +73,12 @@ public class UpdateIT extends ESIntegTestCase {
 
     public static class PutFieldValuesScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new PutFieldValuesScriptEngine();
         }
     }
 
-    public static class PutFieldValuesScriptEngine implements ScriptEngineService {
+    public static class PutFieldValuesScriptEngine implements ScriptEngine {
 
         public static final String NAME = "put_values";
 
@@ -149,12 +146,12 @@ public class UpdateIT extends ESIntegTestCase {
 
     public static class FieldIncrementScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new FieldIncrementScriptEngine();
         }
     }
 
-    public static class FieldIncrementScriptEngine implements ScriptEngineService {
+    public static class FieldIncrementScriptEngine implements ScriptEngine {
 
         public static final String NAME = "field_inc";
 
@@ -215,12 +212,12 @@ public class UpdateIT extends ESIntegTestCase {
 
     public static class ScriptedUpsertScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new ScriptedUpsertScriptEngine();
         }
     }
 
-    public static class ScriptedUpsertScriptEngine implements ScriptEngineService {
+    public static class ScriptedUpsertScriptEngine implements ScriptEngine {
 
         public static final String NAME = "scripted_upsert";
 
@@ -282,12 +279,12 @@ public class UpdateIT extends ESIntegTestCase {
 
     public static class ExtractContextInSourceScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngineService getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngineService(Settings settings) {
             return new ExtractContextInSourceScriptEngine();
         }
     }
 
-    public static class ExtractContextInSourceScriptEngine implements ScriptEngineService {
+    public static class ExtractContextInSourceScriptEngine implements ScriptEngine {
 
         public static final String NAME = "extract_ctx";
 

--- a/core/src/test/java/org/elasticsearch/update/UpdateIT.java
+++ b/core/src/test/java/org/elasticsearch/update/UpdateIT.java
@@ -73,7 +73,7 @@ public class UpdateIT extends ESIntegTestCase {
 
     public static class PutFieldValuesScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new PutFieldValuesScriptEngine();
         }
     }
@@ -146,7 +146,7 @@ public class UpdateIT extends ESIntegTestCase {
 
     public static class FieldIncrementScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new FieldIncrementScriptEngine();
         }
     }
@@ -212,7 +212,7 @@ public class UpdateIT extends ESIntegTestCase {
 
     public static class ScriptedUpsertScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new ScriptedUpsertScriptEngine();
         }
     }
@@ -279,7 +279,7 @@ public class UpdateIT extends ESIntegTestCase {
 
     public static class ExtractContextInSourceScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngineService(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings) {
             return new ExtractContextInSourceScriptEngine();
         }
     }

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionPlugin.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionPlugin.java
@@ -22,14 +22,12 @@ package org.elasticsearch.script.expression;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
-import org.elasticsearch.script.ScriptEngineRegistry;
-import org.elasticsearch.script.ScriptEngineService;
-import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.script.ScriptEngine;
 
 public class ExpressionPlugin extends Plugin implements ScriptPlugin {
 
     @Override
-    public ScriptEngineService getScriptEngineService(Settings settings) {
-        return new ExpressionScriptEngineService(settings);
+    public ScriptEngine getScriptEngineService(Settings settings) {
+        return new ExpressionScriptEngine(settings);
     }
 }

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionPlugin.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionPlugin.java
@@ -27,7 +27,7 @@ import org.elasticsearch.script.ScriptEngine;
 public class ExpressionPlugin extends Plugin implements ScriptPlugin {
 
     @Override
-    public ScriptEngine getScriptEngineService(Settings settings) {
+    public ScriptEngine getScriptEngine(Settings settings) {
         return new ExpressionScriptEngine(settings);
     }
 }

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.script.ClassPermission;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -56,11 +56,11 @@ import java.util.Map;
  * Provides the infrastructure for Lucene expressions as a scripting language for Elasticsearch.  Only
  * {@link SearchScript}s are supported.
  */
-public class ExpressionScriptEngineService extends AbstractComponent implements ScriptEngineService {
+public class ExpressionScriptEngine extends AbstractComponent implements ScriptEngine {
 
     public static final String NAME = "expression";
 
-    public ExpressionScriptEngineService(Settings settings) {
+    public ExpressionScriptEngine(Settings settings) {
         super(settings);
     }
 

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTests.java
@@ -32,14 +32,14 @@ import java.text.ParseException;
 import java.util.Collections;
 
 public class ExpressionTests extends ESSingleNodeTestCase {
-    ExpressionScriptEngineService service;
+    ExpressionScriptEngine service;
     SearchLookup lookup;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         IndexService index = createIndex("test", Settings.EMPTY, "type", "d", "type=double");
-        service = new ExpressionScriptEngineService(Settings.EMPTY);
+        service = new ExpressionScriptEngine(Settings.EMPTY);
         lookup = new SearchLookup(index.mapperService(), index.fieldData(), null);
     }
 

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/MoreExpressionTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/MoreExpressionTests.java
@@ -444,15 +444,15 @@ public class MoreExpressionTests extends ESIntegTestCase {
                 .addAggregation(
                         AggregationBuilders.stats("int_agg").field("x")
                                 .script(new Script(ScriptType.INLINE,
-                                    ExpressionScriptEngineService.NAME, "_value * 3", Collections.emptyMap())))
+                                    ExpressionScriptEngine.NAME, "_value * 3", Collections.emptyMap())))
                 .addAggregation(
                         AggregationBuilders.stats("double_agg").field("y")
                                 .script(new Script(ScriptType.INLINE,
-                                    ExpressionScriptEngineService.NAME, "_value - 1.1", Collections.emptyMap())))
+                                    ExpressionScriptEngine.NAME, "_value - 1.1", Collections.emptyMap())))
                 .addAggregation(
                         AggregationBuilders.stats("const_agg").field("x") // specifically to test a script w/o _value
                                 .script(new Script(ScriptType.INLINE,
-                                    ExpressionScriptEngineService.NAME, "3.0", Collections.emptyMap()))
+                                    ExpressionScriptEngine.NAME, "3.0", Collections.emptyMap()))
                 );
 
         SearchResponse rsp = req.get();
@@ -487,7 +487,7 @@ public class MoreExpressionTests extends ESIntegTestCase {
                 .addAggregation(
                         AggregationBuilders.terms("term_agg").field("text")
                                 .script(
-                                    new Script(ScriptType.INLINE, ExpressionScriptEngineService.NAME, "_value", Collections.emptyMap())));
+                                    new Script(ScriptType.INLINE, ExpressionScriptEngine.NAME, "_value", Collections.emptyMap())));
 
         String message;
         try {
@@ -577,7 +577,7 @@ public class MoreExpressionTests extends ESIntegTestCase {
             UpdateRequestBuilder urb = client().prepareUpdate().setIndex("test_index");
             urb.setType("doc");
             urb.setId("1");
-            urb.setScript(new Script(ScriptType.INLINE, ExpressionScriptEngineService.NAME, "0", Collections.emptyMap()));
+            urb.setScript(new Script(ScriptType.INLINE, ExpressionScriptEngine.NAME, "0", Collections.emptyMap()));
             urb.get();
             fail("Expression scripts should not be allowed to run as update scripts.");
         } catch (Exception e) {
@@ -609,7 +609,7 @@ public class MoreExpressionTests extends ESIntegTestCase {
                                 .subAggregation(sum("fourSum").field("four"))
                                 .subAggregation(bucketScript("totalSum",
                                     new Script(ScriptType.INLINE,
-                                        ExpressionScriptEngineService.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
+                                        ExpressionScriptEngine.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
                                     "twoSum", "threeSum", "fourSum")))
                 .execute().actionGet();
 

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/StoredExpressionTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/StoredExpressionTests.java
@@ -52,14 +52,14 @@ public class StoredExpressionTests extends ESIntegTestCase {
 
     public void testAllOpsDisabledIndexedScripts() throws IOException {
         client().admin().cluster().preparePutStoredScript()
-                .setLang(ExpressionScriptEngineService.NAME)
+                .setLang(ExpressionScriptEngine.NAME)
                 .setId("script1")
                 .setContent(new BytesArray("{\"script\":\"2\"}"), XContentType.JSON)
                 .get();
         client().prepareIndex("test", "scriptTest", "1").setSource("{\"theField\":\"foo\"}", XContentType.JSON).get();
         try {
             client().prepareUpdate("test", "scriptTest", "1")
-                    .setScript(new Script(ScriptType.STORED, ExpressionScriptEngineService.NAME, "script1", Collections.emptyMap())).get();
+                    .setScript(new Script(ScriptType.STORED, ExpressionScriptEngine.NAME, "script1", Collections.emptyMap())).get();
             fail("update script should have been rejected");
         } catch(Exception e) {
             assertThat(e.getMessage(), containsString("failed to execute script"));

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
@@ -44,7 +44,7 @@ import static java.util.Collections.singletonList;
 public class MustachePlugin extends Plugin implements ScriptPlugin, ActionPlugin, SearchPlugin {
 
     @Override
-    public ScriptEngine getScriptEngineService(Settings settings) {
+    public ScriptEngine getScriptEngine(Settings settings) {
         return new MustacheScriptEngine();
     }
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
@@ -33,7 +33,7 @@ import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 
 import java.util.Arrays;
 import java.util.List;
@@ -44,8 +44,8 @@ import static java.util.Collections.singletonList;
 public class MustachePlugin extends Plugin implements ScriptPlugin, ActionPlugin, SearchPlugin {
 
     @Override
-    public ScriptEngineService getScriptEngineService(Settings settings) {
-        return new MustacheScriptEngineService();
+    public ScriptEngine getScriptEngineService(Settings settings) {
+        return new MustacheScriptEngine();
     }
 
     @Override

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
@@ -34,7 +34,7 @@ import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.GeneralScriptException;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -53,8 +53,8 @@ import java.util.Map;
  * process: First compile the string representing the template, the resulting
  * {@link Mustache} object can then be re-used for subsequent executions.
  */
-public final class MustacheScriptEngineService implements ScriptEngineService {
-    private static final Logger logger = ESLoggerFactory.getLogger(MustacheScriptEngineService.class);
+public final class MustacheScriptEngine implements ScriptEngine {
+    private static final Logger logger = ESLoggerFactory.getLogger(MustacheScriptEngine.class);
 
     public static final String NAME = "mustache";
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.script.mustache;
 
-import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -35,8 +34,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryParseContext;
-import org.elasticsearch.script.CompiledScript;
-import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -50,7 +47,7 @@ import static org.elasticsearch.script.ScriptContext.Standard.SEARCH;
 
 public class TransportSearchTemplateAction extends HandledTransportAction<SearchTemplateRequest, SearchTemplateResponse> {
 
-    private static final String TEMPLATE_LANG = MustacheScriptEngineService.NAME;
+    private static final String TEMPLATE_LANG = MustacheScriptEngine.NAME;
 
     private final ScriptService scriptService;
     private final TransportSearchAction searchAction;

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/CustomMustacheFactoryTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/CustomMustacheFactoryTests.java
@@ -21,11 +21,10 @@ package org.elasticsearch.script.mustache;
 
 import com.github.mustachejava.Mustache;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Map;
@@ -62,11 +61,11 @@ public class CustomMustacheFactoryTests extends ESTestCase {
     }
 
     public void testJsonEscapeEncoder() {
-        final ScriptEngineService engine = new MustacheScriptEngineService();
+        final ScriptEngine engine = new MustacheScriptEngine();
         final Map<String, String> params = randomBoolean() ? singletonMap(Script.CONTENT_TYPE_OPTION, JSON_MIME_TYPE) : emptyMap();
 
         Mustache script = (Mustache) engine.compile(null, "{\"field\": \"{{value}}\"}", params);
-        CompiledScript compiled = new CompiledScript(INLINE, null, MustacheScriptEngineService.NAME, script);
+        CompiledScript compiled = new CompiledScript(INLINE, null, MustacheScriptEngine.NAME, script);
 
         ExecutableScript executable = engine.executable(compiled, singletonMap("value", "a \"value\""));
         BytesReference result = (BytesReference) executable.run();
@@ -74,11 +73,11 @@ public class CustomMustacheFactoryTests extends ESTestCase {
     }
 
     public void testDefaultEncoder() {
-        final ScriptEngineService engine = new MustacheScriptEngineService();
+        final ScriptEngine engine = new MustacheScriptEngine();
         final Map<String, String> params = singletonMap(Script.CONTENT_TYPE_OPTION, PLAIN_TEXT_MIME_TYPE);
 
         Mustache script = (Mustache) engine.compile(null, "{\"field\": \"{{value}}\"}", params);
-        CompiledScript compiled = new CompiledScript(INLINE, null, MustacheScriptEngineService.NAME, script);
+        CompiledScript compiled = new CompiledScript(INLINE, null, MustacheScriptEngine.NAME, script);
 
         ExecutableScript executable = engine.executable(compiled, singletonMap("value", "a \"value\""));
         BytesReference result = (BytesReference) executable.run();
@@ -86,11 +85,11 @@ public class CustomMustacheFactoryTests extends ESTestCase {
     }
 
     public void testUrlEncoder() {
-        final ScriptEngineService engine = new MustacheScriptEngineService();
+        final ScriptEngine engine = new MustacheScriptEngine();
         final Map<String, String> params = singletonMap(Script.CONTENT_TYPE_OPTION, X_WWW_FORM_URLENCODED_MIME_TYPE);
 
         Mustache script = (Mustache) engine.compile(null, "{\"field\": \"{{value}}\"}", params);
-        CompiledScript compiled = new CompiledScript(INLINE, null, MustacheScriptEngineService.NAME, script);
+        CompiledScript compiled = new CompiledScript(INLINE, null, MustacheScriptEngine.NAME, script);
 
         ExecutableScript executable = engine.executable(compiled, singletonMap("value", "tilde~ AND date:[2016 FROM*]"));
         BytesReference result = (BytesReference) executable.run();

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
@@ -42,12 +42,12 @@ import static org.hamcrest.Matchers.equalTo;
  * Mustache based templating test
  */
 public class MustacheScriptEngineTests extends ESTestCase {
-    private MustacheScriptEngineService qe;
+    private MustacheScriptEngine qe;
     private MustacheFactory factory;
 
     @Before
     public void setup() {
-        qe = new MustacheScriptEngineService();
+        qe = new MustacheScriptEngine();
         factory = new CustomMustacheFactory();
     }
 

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matcher;
 
@@ -55,7 +55,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class MustacheTests extends ESTestCase {
 
-    private ScriptEngineService engine = new MustacheScriptEngineService();
+    private ScriptEngine engine = new MustacheScriptEngine();
 
     public void testBasics() {
         String template = "GET _search {\"query\": " + "{\"boosting\": {"

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateIT.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateIT.java
@@ -151,7 +151,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
 
     public void testIndexedTemplateClient() throws Exception {
         assertAcked(client().admin().cluster().preparePutStoredScript()
-                .setLang(MustacheScriptEngineService.NAME)
+                .setLang(MustacheScriptEngine.NAME)
                 .setId("testTemplate")
                 .setContent(new BytesArray("{" +
                         "\"template\":{" +
@@ -164,7 +164,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
 
 
         assertAcked(client().admin().cluster().preparePutStoredScript()
-                .setLang(MustacheScriptEngineService.NAME)
+                .setLang(MustacheScriptEngine.NAME)
                 .setId("testTemplate").setContent(new BytesArray("{" +
                         "\"template\":{" +
                         "                \"query\":{" +
@@ -175,7 +175,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
                         "}"), XContentType.JSON));
 
         GetStoredScriptResponse getResponse = client().admin().cluster()
-                .prepareGetStoredScript(MustacheScriptEngineService.NAME, "testTemplate").get();
+                .prepareGetStoredScript(MustacheScriptEngine.NAME, "testTemplate").get();
         assertNotNull(getResponse.getSource());
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
@@ -197,10 +197,10 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         assertHitCount(searchResponse.getResponse(), 4);
 
         assertAcked(client().admin().cluster()
-                .prepareDeleteStoredScript(MustacheScriptEngineService.NAME, "testTemplate"));
+                .prepareDeleteStoredScript(MustacheScriptEngine.NAME, "testTemplate"));
 
         getResponse = client().admin().cluster()
-                .prepareGetStoredScript(MustacheScriptEngineService.NAME, "testTemplate").get();
+                .prepareGetStoredScript(MustacheScriptEngine.NAME, "testTemplate").get();
         assertNull(getResponse.getSource());
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new SearchTemplateRequestBuilder(client())
@@ -212,7 +212,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
 
     public void testIndexedTemplate() throws Exception {
         assertAcked(client().admin().cluster().preparePutStoredScript()
-                .setLang(MustacheScriptEngineService.NAME)
+                .setLang(MustacheScriptEngine.NAME)
                 .setId("1a")
                 .setContent(new BytesArray("{" +
                         "\"template\":{" +
@@ -225,7 +225,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
                 ), XContentType.JSON)
         );
         assertAcked(client().admin().cluster().preparePutStoredScript()
-                .setLang(MustacheScriptEngineService.NAME)
+                .setLang(MustacheScriptEngine.NAME)
                 .setId("2")
                 .setContent(new BytesArray("{" +
                         "\"template\":{" +
@@ -237,7 +237,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
                         "}"), XContentType.JSON)
         );
         assertAcked(client().admin().cluster().preparePutStoredScript()
-                .setLang(MustacheScriptEngineService.NAME)
+                .setLang(MustacheScriptEngine.NAME)
                 .setId("3")
                 .setContent(new BytesArray("{" +
                         "\"template\":{" +
@@ -313,13 +313,13 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         int iterations = randomIntBetween(2, 11);
         for (int i = 1; i < iterations; i++) {
             assertAcked(client().admin().cluster().preparePutStoredScript()
-                    .setLang(MustacheScriptEngineService.NAME)
+                    .setLang(MustacheScriptEngine.NAME)
                     .setId("git01")
                     .setContent(new BytesArray("{\"template\":{\"query\": {\"match\": {\"searchtext\": {\"query\": \"{{P_Keyword1}}\"," +
                             "\"type\": \"ooophrase_prefix\"}}}}}"), XContentType.JSON));
 
             GetStoredScriptResponse getResponse = client().admin().cluster()
-                    .prepareGetStoredScript(MustacheScriptEngineService.NAME, "git01").get();
+                    .prepareGetStoredScript(MustacheScriptEngine.NAME, "git01").get();
             assertNotNull(getResponse.getSource());
 
             Map<String, Object> templateParams = new HashMap<>();
@@ -333,7 +333,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
             assertWarnings("Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]");
 
             assertAcked(client().admin().cluster().preparePutStoredScript()
-                    .setLang(MustacheScriptEngineService.NAME)
+                    .setLang(MustacheScriptEngine.NAME)
                     .setId("git01")
                     .setContent(new BytesArray("{\"query\": {\"match\": {\"searchtext\": {\"query\": \"{{P_Keyword1}}\"," +
                             "\"type\": \"phrase_prefix\"}}}}"), XContentType.JSON));
@@ -351,7 +351,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         String multiQuery = "{\"query\":{\"terms\":{\"theField\":[\"{{#fieldParam}}\",\"{{.}}\",\"{{/fieldParam}}\"]}}}";
         assertAcked(
                 client().admin().cluster().preparePutStoredScript()
-                        .setLang(MustacheScriptEngineService.NAME)
+                        .setLang(MustacheScriptEngine.NAME)
                         .setId("4")
                         .setContent(jsonBuilder().startObject().field("template", multiQuery).endObject().bytes(), XContentType.JSON)
         );

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Location.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Location.java
@@ -72,7 +72,7 @@ public final class Location {
     /** Computes the file name (mostly important for stacktraces) */
     public static String computeSourceName(String scriptName, String source) {
         StringBuilder fileName = new StringBuilder();
-        if (scriptName.equals(PainlessScriptEngineService.INLINE_NAME)) {
+        if (scriptName.equals(PainlessScriptEngine.INLINE_NAME)) {
             // its an anonymous script, include at least a portion of the source to help identify which one it is
             // but don't create stacktraces with filenames that contain newlines or huge names.
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 
 import java.util.Arrays;
 import java.util.List;
@@ -40,8 +40,8 @@ public final class PainlessPlugin extends Plugin implements ScriptPlugin {
     }
 
     @Override
-    public ScriptEngineService getScriptEngineService(Settings settings) {
-        return new PainlessScriptEngineService(settings);
+    public ScriptEngine getScriptEngineService(Settings settings) {
+        return new PainlessScriptEngine(settings);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
@@ -40,7 +40,7 @@ public final class PainlessPlugin extends Plugin implements ScriptPlugin {
     }
 
     @Override
-    public ScriptEngine getScriptEngineService(Settings settings) {
+    public ScriptEngine getScriptEngine(Settings settings) {
         return new PainlessScriptEngine(settings);
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScript.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScript.java
@@ -93,12 +93,12 @@ public abstract class PainlessScript {
         }
         // build a name for the script:
         final String name;
-        if (PainlessScriptEngineService.INLINE_NAME.equals(this.name)) {
+        if (PainlessScriptEngine.INLINE_NAME.equals(this.name)) {
             name = source;
         } else {
             name = this.name;
         }
-        ScriptException scriptException = new ScriptException("runtime error", t, scriptStack, name, PainlessScriptEngineService.NAME);
+        ScriptException scriptException = new ScriptException("runtime error", t, scriptStack, name, PainlessScriptEngine.NAME);
         for (Map.Entry<String, List<String>> entry : extraMetadata.entrySet()) {
             scriptException.addMetadata(entry.getKey(), entry.getValue());
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -27,7 +27,7 @@ import org.elasticsearch.painless.Compiler.Loader;
 import org.elasticsearch.script.CompiledScript;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
-import org.elasticsearch.script.ScriptEngineService;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -46,7 +46,7 @@ import java.util.Map;
 /**
  * Implementation of a ScriptEngine for the Painless language.
  */
-public final class PainlessScriptEngineService extends AbstractComponent implements ScriptEngineService {
+public final class PainlessScriptEngine extends AbstractComponent implements ScriptEngine {
 
     /**
      * Standard name of the Painless language.
@@ -71,7 +71,7 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
 
     /**
      * Default compiler settings to be used. Note that {@link CompilerSettings} is mutable but this instance shouldn't be mutated outside
-     * of {@link PainlessScriptEngineService#PainlessScriptEngineService(Settings)}.
+     * of {@link PainlessScriptEngine#PainlessScriptEngine(Settings)}.
      */
     private final CompilerSettings defaultCompilerSettings = new CompilerSettings();
 
@@ -79,7 +79,7 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
      * Constructor.
      * @param settings The settings to initialize the engine with.
      */
-    public PainlessScriptEngineService(final Settings settings) {
+    public PainlessScriptEngine(final Settings settings) {
         super(settings);
         defaultCompilerSettings.setRegexesEnabled(CompilerSettings.REGEX_ENABLED.get(settings));
     }
@@ -262,7 +262,7 @@ public final class PainlessScriptEngineService extends AbstractComponent impleme
                 break;
             }
         }
-        throw new ScriptException("compile error", t, scriptStack, scriptSource, PainlessScriptEngineService.NAME);
+        throw new ScriptException("compile error", t, scriptStack, scriptSource, PainlessScriptEngine.NAME);
     }
 
     // very simple heuristic: +/- 25 chars. can be improved later.

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/NeedsScoreTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/NeedsScoreTests.java
@@ -38,7 +38,7 @@ public class NeedsScoreTests extends ESSingleNodeTestCase {
     public void testNeedsScores() {
         IndexService index = createIndex("test", Settings.EMPTY, "type", "d", "type=double");
 
-        PainlessScriptEngineService service = new PainlessScriptEngineService(Settings.EMPTY);
+        PainlessScriptEngine service = new PainlessScriptEngine(Settings.EMPTY);
         SearchLookup lookup = new SearchLookup(index.mapperService(), index.fieldData(), null);
 
         Object compiled = service.compile(null, "1.2", Collections.emptyMap());

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ScriptTestCase.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ScriptTestCase.java
@@ -43,11 +43,11 @@ import static org.hamcrest.Matchers.hasSize;
  * Typically just asserts the output of {@code exec()}
  */
 public abstract class ScriptTestCase extends ESTestCase {
-    protected PainlessScriptEngineService scriptEngine;
+    protected PainlessScriptEngine scriptEngine;
 
     @Before
     public void setup() {
-        scriptEngine = new PainlessScriptEngineService(scriptEngineSettings());
+        scriptEngine = new PainlessScriptEngine(scriptEngineSettings());
     }
 
     /**

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/AbstractScriptTestCase.java
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/java/org/elasticsearch/ingest/AbstractScriptTestCase.java
@@ -25,7 +25,7 @@ import org.elasticsearch.script.ScriptContextRegistry;
 import org.elasticsearch.script.ScriptEngineRegistry;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptSettings;
-import org.elasticsearch.script.mustache.MustacheScriptEngineService;
+import org.elasticsearch.script.mustache.MustacheScriptEngine;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -41,7 +41,7 @@ public abstract class AbstractScriptTestCase extends ESTestCase {
         Settings settings = Settings.builder()
             .put("path.home", createTempDir())
             .build();
-        ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(Arrays.asList(new MustacheScriptEngineService()));
+        ScriptEngineRegistry scriptEngineRegistry = new ScriptEngineRegistry(Arrays.asList(new MustacheScriptEngine()));
         ScriptContextRegistry scriptContextRegistry = new ScriptContextRegistry(Collections.emptyList());
         ScriptSettings scriptSettings = new ScriptSettings(scriptEngineRegistry, scriptContextRegistry);
 

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -46,7 +46,7 @@ import static java.util.Collections.emptyMap;
  *
  * The function is used to provide the result of the script execution and can return anything.
  */
-public class MockScriptEngine implements ScriptEngineService {
+public class MockScriptEngine implements ScriptEngine {
 
     public static final String NAME = "mockscript";
 

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptPlugin.java
@@ -34,7 +34,7 @@ public abstract class MockScriptPlugin extends Plugin implements ScriptPlugin {
     public static final String NAME = MockScriptEngine.NAME;
 
     @Override
-    public ScriptEngine getScriptEngineService(Settings settings) {
+    public ScriptEngine getScriptEngine(Settings settings) {
         return new MockScriptEngine(pluginScriptLang(), pluginScripts());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptPlugin.java
@@ -34,7 +34,7 @@ public abstract class MockScriptPlugin extends Plugin implements ScriptPlugin {
     public static final String NAME = MockScriptEngine.NAME;
 
     @Override
-    public ScriptEngineService getScriptEngineService(Settings settings) {
+    public ScriptEngine getScriptEngineService(Settings settings) {
         return new MockScriptEngine(pluginScriptLang(), pluginScripts());
     }
 


### PR DESCRIPTION
This commit renames ScriptEngineService to ScriptEngine.  It is often
confusing because we have the ScriptService, and then
ScriptEngineService implementations, but the latter are not services as
we see in other places in elasticsearch.