### PR TITLE
Avoid race when shutting down controller processes

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -180,8 +180,8 @@ final class Bootstrap {
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 @Override
                 public void run() {
-                    try (Spawner spawnerToClose = spawner) {
-                        IOUtils.close(node);
+                    try {
+                        IOUtils.close(node, spawner);
                         LoggerContext context = (LoggerContext) LogManager.getContext(false);
                         Configurator.shutdown(context);
                     } catch (IOException ex) {
@@ -258,8 +258,8 @@ final class Bootstrap {
     }
 
     static void stop() throws IOException {
-        try (Spawner spawnerToClose = INSTANCE.spawner) {
-            IOUtils.close(INSTANCE.node);
+        try {
+            IOUtils.close(INSTANCE.node, INSTANCE.spawner);
         } finally {
             INSTANCE.keepAliveLatch.countDown();
         }


### PR DESCRIPTION
This commit terminates any controller processes plugins might have after
the node has been closed.  This gives the plugins a chance to shut down their
controllers gracefully.

Previously there was a race condition where controller processes could be shut
down gracefully and terminated by two threads running in parallel, leading to
non-deterministic outcomes.

Additionally, controller processes that failed to shut down gracefully were
not forcibly terminated when running as a Windows service; there was a reliance
on the plugin to shut down its controller gracefully in this situation.
This commit also fixes this problem.