### PR TITLE
Update plugin-script.asciidoc

### DIFF
--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -153,7 +153,7 @@ can do this as follows:
 
 [source,sh]
 ---------------------
-sudo bin/elasticsearch-plugin -Epath.conf=/path/to/custom/config/dir install <plugin name>
+sudo bin/elasticsearch-plugin install -Epath.conf=/path/to/custom/config/dir <plugin name>
 ---------------------
 
 You can also set the `CONF_DIR` environment variable to the custom config


### PR DESCRIPTION
I get an error `ERROR: E is not a recognized option` when I pass the `-Epath.conf` after the `bin/elasticsearch-plugin` command, but it works if it's after the `install` parameter.
