### PR TITLE
Machine Permission update on Google Compute

### DIFF
--- a/docs/plugins/discovery-gce.asciidoc
+++ b/docs/plugins/discovery-gce.asciidoc
@@ -433,8 +433,7 @@ gcloud config set project es-cloud
 [[discovery-gce-usage-tips-permissions]]
 ===== Machine Permissions
 
-If you have created a machine without the correct permissions, you will see `403 unauthorized` error messages. The only
-way to alter these permissions is to delete the instance (NOT THE DISK). Then create another with the correct permissions.
+If you have created a machine without the correct permissions, you will see `403 unauthorized` error messages. To change machine permission on an existing instance, first stop the instance then Edit. Scroll down to `Access Scopes` to change permission.  The other way to alter these permissions is to delete the instance (NOT THE DISK). Then create another with the correct permissions.
 
 Creating machines with gcloud::
 +


### PR DESCRIPTION
Machine permission can be updated without deleting instances.