### PR TITLE
Add rest test for sliced scroll

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/12_slices.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/scroll/12_slices.yaml
@@ -1,5 +1,5 @@
 ---
-"Sliced scroll":
+setup:
   - do:
       indices.create:
         index: test_sliced_scroll
@@ -8,31 +8,101 @@
       index:
         index:  test_sliced_scroll
         type:   test
-        id:     42
+        id:     1
         body:   { foo: 1 }
+
+  - do:
+      index:
+        index:  test_sliced_scroll
+        type:   test
+        id:     2
+        body:   { foo: 2 }
+
+  - do:
+      index:
+        index:  test_sliced_scroll
+        type:   test
+        id:     3
+        body:   { foo: 3 }
+
+  - do:
+      index:
+        index:  test_sliced_scroll
+        type:   test
+        id:     4
+        body:   { foo: 4 }
 
   - do:
       indices.refresh: {}
 
+---
+"Sliced scroll":
+  - skip:
+      version: " - 5.3.0"
+      reason: Prior version uses a random seed per node to compute the hash of the keys.
+
   - do:
       search:
         index: test_sliced_scroll
-        size: 1
         scroll: 1m
         sort: foo
         body:
           slice:
             id: 0
-            max: 3
+            max: 2
           query:
             match_all: {}
 
   - set: {_scroll_id: scroll_id}
+  - match: {hits.total:      3    }
+  - length: {hits.hits:      3    }
+  - match: {hits.hits.0._id: "2" }
+  - match: {hits.hits.1._id: "3" }
+  - match: {hits.hits.2._id: "4" }
+
+  - do:
+      scroll:
+        scroll_id: $scroll_id
+        scroll: 1m
+
+  - match: {hits.total:      3    }
+  - length: {hits.hits:      0    }
+
+  - do:
+      clear_scroll:
+        scroll_id: $scroll_id
+
+  - do:
+      search:
+        index: test_sliced_scroll
+        scroll: 1m
+        sort: foo
+        body:
+          slice:
+            id: 1
+            max: 2
+          query:
+            match_all: {}
+
+  - set: {_scroll_id: scroll_id}
+  - match: {hits.total:      1    }
+  - length: {hits.hits:      1    }
+  - match: {hits.hits.0._id: "1" }
+
+  - do:
+      scroll:
+        scroll_id: $scroll_id
+        scroll: 1m
+
+  - match: {hits.total:      1    }
+  - length: {hits.hits:      0    }
 
   - do:
         clear_scroll:
           scroll_id: $scroll_id
 
+---
+"Sliced scroll with invalid arguments":
   - do:
         catch:  /query_phase_execution_exception.*The number of slices.*index.max_slices_per_scroll/
         search:


### PR DESCRIPTION
This change adds a rest test for sliced scroll that checks that the hashing does not use a random seed for the partitioning.