### PR TITLE
Fix typo in example (grades_count -> types_count)

### DIFF
--- a/docs/reference/aggregations/metrics/valuecount-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/valuecount-aggregation.asciidoc
@@ -33,7 +33,7 @@ Response:
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
 
-The name of the aggregation (`grades_count` above) also serves as the key by which the aggregation result can be
+The name of the aggregation (`types_count` above) also serves as the key by which the aggregation result can be
 retrieved from the returned response.
 
 ==== Script
@@ -65,7 +65,7 @@ This will interpret the `script` parameter as an `inline` script with the `painl
 POST /sales/_search?size=0
 {
     "aggs" : {
-        "grades_count" : {
+        "types_count" : {
             "value_count" : {
                 "script" : {
                     "file": "my_script",


### PR DESCRIPTION
Looks like `doc.grade` was used for examples before. But not anymore - https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-aggregations-metrics-valuecount-aggregation.html
