### PR TITLE
[TEST] Temporarily disable the secure fixture for hdfs tests

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -180,7 +180,7 @@ if (fixtureSupported) {
 }
 
 // Create a Integration Test suite just for security based tests
-if (secureFixtureSupported) {
+if (secureFixtureSupported && false) { // This fails due to a vagrant configuration issue - remove the false check to re-enable
   // This must execute before the afterEvaluate block from integTestSecure
   project.afterEvaluate {
     Path elasticsearchKT = project(':test:fixtures:krb5kdc-fixture').buildDir.toPath().resolve("keytabs").resolve("elasticsearch.keytab").toAbsolutePath()


### PR DESCRIPTION
This keeps failing the build so I am temporarily disabling it
until #24636 gets merged.


