### PR TITLE
Remove Netty logging hack

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4InternalESLogger.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4InternalESLogger.java
@@ -101,11 +101,7 @@ class Netty4InternalESLogger extends AbstractInternalLogger {
 
     @Override
     public void info(String msg) {
-        if (!("Your platform does not provide complete low-level API for accessing direct buffers reliably. " +
-                "Unless explicitly requested, heap buffer will always be preferred to avoid potential system " +
-                "instability.").equals(msg)) {
-            logger.info(msg);
-        }
+        logger.info(msg);
     }
 
     @Override


### PR DESCRIPTION
Netty removed a logging guarded we added to prevent a scary logging message. We added a hack to work around this. They've added the guard back, so we can remove the hack now.

Relates #24469, relates netty/netty#5624, netty/netty#6568, netty/netty#6696