### PR TITLE
Change manual collection copies to use builtin methods instead.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/inject/ModulesBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/inject/ModulesBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.inject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -28,9 +29,7 @@ public class ModulesBuilder implements Iterable<Module> {
     private final List<Module> modules = new ArrayList<>();
 
     public ModulesBuilder add(Module... newModules) {
-        for (Module module : newModules) {
-            modules.add(module);
-        }
+        Collections.addAll(modules, newModules);
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
@@ -124,9 +124,7 @@ public class MultiPhrasePrefixQuery extends Query {
         Term[][] terms = new Term[termArrays.size()][];
         for (int i = 0; i < termArrays.size(); i++) {
             terms[i] = new Term[termArrays.get(i).length];
-            for (int j = 0; j < termArrays.get(i).length; j++) {
-                terms[i][j] = termArrays.get(i)[j];
-            }
+            System.arraycopy(termArrays.get(i), 0, terms[i], 0, termArrays.get(i).length);
         }
         return terms;
     }

--- a/core/src/main/java/org/elasticsearch/index/IndexWarmer.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexWarmer.java
@@ -54,9 +54,8 @@ public final class IndexWarmer extends AbstractComponent {
         ArrayList<Listener> list = new ArrayList<>();
         final Executor executor = threadPool.executor(ThreadPool.Names.WARMER);
         list.add(new FieldDataWarmer(executor));
-        for (Listener listener : listeners) {
-            list.add(listener);
-        }
+
+        Collections.addAll(list, listeners);
         this.listeners = Collections.unmodifiableList(list);
     }
 

--- a/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.indices.fielddata.cache;
 
+import java.util.Collections;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -134,9 +135,7 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
             //noinspection unchecked
             final Accountable accountable = cache.computeIfAbsent(key, k -> {
                 cacheHelper.addClosedListener(IndexFieldCache.this);
-                for (Listener listener : this.listeners) {
-                    k.listeners.add(listener);
-                }
+                Collections.addAll(k.listeners, this.listeners);
                 final AtomicFieldData fieldData = indexFieldData.loadDirect(context);
                 for (Listener listener : k.listeners) {
                     try {
@@ -162,9 +161,7 @@ public class IndicesFieldDataCache extends AbstractComponent implements RemovalL
             //noinspection unchecked
             final Accountable accountable = cache.computeIfAbsent(key, k -> {
                 ElasticsearchDirectoryReader.addReaderCloseListener(indexReader, IndexFieldCache.this);
-                for (Listener listener : this.listeners) {
-                    k.listeners.add(listener);
-                }
+                Collections.addAll(k.listeners, this.listeners);
                 final Accountable ifd = (Accountable) indexFieldData.localGlobalDirect(indexReader);
                 for (Listener listener : k.listeners) {
                     try {

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGenerator.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGenerator.java
@@ -229,9 +229,8 @@ public final class DirectCandidateGenerator extends CandidateGenerator {
             // Merge new candidates into existing ones,
             // deduping:
             final Set<Candidate> set = new HashSet<>(candidates);
-            for (int i = 0; i < this.candidates.length; i++) {
-                set.add(this.candidates[i]);
-            }
+            Collections.addAll(set, this.candidates);
+
             this.candidates = set.toArray(new Candidate[set.size()]);
             // Sort strongest to weakest:
             Arrays.sort(this.candidates, Collections.reverseOrder());

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefCall.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubDefCall.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
+import java.util.Collections;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Globals;
@@ -97,10 +98,7 @@ final class PSubDefCall extends AExpression {
 
             if (argument instanceof ILambda) {
                 ILambda lambda = (ILambda) argument;
-
-                for (Type capture : lambda.getCaptures()) {
-                    parameterTypes.add(capture);
-                }
+                Collections.addAll(parameterTypes, lambda.getCaptures());
             }
 
             argument.write(writer, globals);


### PR DESCRIPTION
This very small PR is related to issue #24226 it is small exactly to keep it readable.

This PR focusses on cases in the code where a collection is iterated for the sole purpose of adding each item in it to another collection.

Java has its own methods for this, this PR introduces them where useable.

===========

1. Contributor agreement: Has been signed

2. Contributor guidelines: I have read them.

3. Gradle check: build successful.

4. PR is against master

5. The PR is not OS specific.

6. I'm not part of a class.