### PR TITLE
Revert changing the InternalSampler type constant

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSampler.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSampler.java
@@ -29,6 +29,8 @@ import java.util.Map;
 
 public class InternalSampler extends InternalSingleBucketAggregation implements Sampler {
     public static final String NAME = "mapped_sampler";
+    // InternalSampler and UnmappedSampler share the same parser name, so we use this when identifying the aggregation type
+    public static final String PARSER_NAME = "sampler";
 
     InternalSampler(String name, long docCount, InternalAggregations subAggregations, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
@@ -49,7 +51,7 @@ public class InternalSampler extends InternalSingleBucketAggregation implements 
 
     @Override
     public String getType() {
-        return NAME;
+        return PARSER_NAME;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/ParsedSampler.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/ParsedSampler.java
@@ -27,7 +27,7 @@ public class ParsedSampler extends ParsedSingleBucketAggregation implements Samp
 
     @Override
     public String getType() {
-        return InternalSampler.NAME;
+        return InternalSampler.PARSER_NAME;
     }
 
     public static ParsedSampler fromXContent(XContentParser parser, final String name) throws IOException {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yaml
@@ -107,8 +107,8 @@ setup:
           - {query: {match_all: {} }, size: 0, aggs: {test_sterms: {terms: {field: name}, aggs: {test_umsignificant_terms: {significant_terms: {field:  surname} } } } } }
 
   - match:    { responses.0.hits.total: 5 }
-  - match:    { responses.0.aggregations.mapped_sampler#test_sampler.doc_count : 5 }
-  - match:    { responses.0.aggregations.mapped_sampler#test_sampler.sigsterms#test_significant_terms.doc_count : 5 }
+  - match:    { responses.0.aggregations.sampler#test_sampler.doc_count : 5 }
+  - match:    { responses.0.aggregations.sampler#test_sampler.sigsterms#test_significant_terms.doc_count : 5 }
   - match:    { responses.1.hits.total: 5 }
   - match:    { responses.1.aggregations.sterms#test_umterms.doc_count_error_upper_bound : 0 }
   - match:    { responses.2.hits.total: 5 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.test;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -43,10 +42,10 @@ import org.elasticsearch.search.aggregations.bucket.children.ChildrenAggregation
 import org.elasticsearch.search.aggregations.bucket.children.ParsedChildren;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
-import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.global.ParsedGlobal;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.geogrid.ParsedGeoHashGrid;
+import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.global.ParsedGlobal;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
@@ -57,14 +56,14 @@ import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuil
 import org.elasticsearch.search.aggregations.bucket.nested.ParsedNested;
 import org.elasticsearch.search.aggregations.bucket.nested.ParsedReverseNested;
 import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.sampler.InternalSampler;
-import org.elasticsearch.search.aggregations.bucket.sampler.ParsedSampler;
 import org.elasticsearch.search.aggregations.bucket.range.ParsedRange;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.date.ParsedDateRange;
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanceAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.ParsedGeoDistance;
+import org.elasticsearch.search.aggregations.bucket.sampler.InternalSampler;
+import org.elasticsearch.search.aggregations.bucket.sampler.ParsedSampler;
 import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedDoubleTerms;
@@ -168,7 +167,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         namedXContents.put(ChildrenAggregationBuilder.NAME, (p, c) -> ParsedChildren.fromXContent(p, (String) c));
         namedXContents.put(GlobalAggregationBuilder.NAME, (p, c) -> ParsedGlobal.fromXContent(p, (String) c));
         namedXContents.put(FilterAggregationBuilder.NAME, (p, c) -> ParsedFilter.fromXContent(p, (String) c));
-        namedXContents.put(InternalSampler.NAME, (p, c) -> ParsedSampler.fromXContent(p, (String) c));
+        namedXContents.put(InternalSampler.PARSER_NAME, (p, c) -> ParsedSampler.fromXContent(p, (String) c));
         namedXContents.put(GeoGridAggregationBuilder.NAME, (p, c) -> ParsedGeoHashGrid.fromXContent(p, (String) c));
         namedXContents.put(RangeAggregationBuilder.NAME, (p, c) -> ParsedRange.fromXContent(p, (String) c));
         namedXContents.put(DateRangeAggregationBuilder.NAME, (p, c) -> ParsedDateRange.fromXContent(p, (String) c));


### PR DESCRIPTION
Changing back the InternalSampler type constant that was changed with #24564.
This PR is against the feature branch used for adding parsing to the aggregations.
