### PR TITLE
Search: Fairer balancing when routing searches by session ID

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.routing;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -177,10 +178,17 @@ public class OperationRouting extends AbstractComponent {
             }
         }
         // if not, then use it as the index
+        int routingHash = Murmur3HashFunction.hash(preference);
+        if (nodes.getMinNodeVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
+            // Better overall balancing can be achieved if each shardId opts
+            // for a different selection from the elements in the list
+            // given the same user-supplied preference key.
+            routingHash = 31 * routingHash + indexShard.shardId.id();
+        }
         if (awarenessAttributes.length == 0) {
-            return indexShard.activeInitializingShardsIt(Murmur3HashFunction.hash(preference));
+            return indexShard.activeInitializingShardsIt(routingHash);
         } else {
-            return indexShard.preferAttributesActiveInitializingShardsIt(awarenessAttributes, nodes, Murmur3HashFunction.hash(preference));
+            return indexShard.preferAttributesActiveInitializingShardsIt(awarenessAttributes, nodes, routingHash);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -180,10 +180,13 @@ public class OperationRouting extends AbstractComponent {
         // if not, then use it as the index
         int routingHash = Murmur3HashFunction.hash(preference);
         if (nodes.getMinNodeVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
+            // The AllocationService lists shards in a fixed order based on nodes
+            // so earlier versions of this class would have a tendency to
+            // select the same node across different shardIds.
             // Better overall balancing can be achieved if each shardId opts
-            // for a different selection from the elements in the list
-            // given the same user-supplied preference key.
-            routingHash = 31 * routingHash + indexShard.shardId.id();
+            // for a different element in the list by also incorporating the
+            // shard ID into the hash of the user-supplied preference key.
+            routingHash = 31 * routingHash + indexShard.shardId.hashCode();
         }
         if (awarenessAttributes.length == 0) {
             return indexShard.activeInitializingShardsIt(routingHash);

--- a/core/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
@@ -395,14 +395,14 @@ public class OperationRoutingTests extends ESTestCase{
             Set<String> selectedNodes = new HashSet<>(numShards);
             final GroupShardsIterator<ShardIterator> groupIterator = opRouting.searchShards(state, indexNames, null, sessionKey);
 
-            assertEquals("One group per index shard", numIndices * numShards, groupIterator.size());
+            assertThat("One group per index shard", groupIterator.size(), equalTo(numIndices * numShards));
             for (ShardIterator shardIterator : groupIterator) {
-                assertEquals(numReplicas + 1, shardIterator.size());
+                assertThat(shardIterator.size(), equalTo(numReplicas + 1));
 
                 ShardRouting firstChoice = shardIterator.nextOrNull();
                 assertNotNull(firstChoice);
                 ShardRouting duelFirst = duelGetShards(state, firstChoice.shardId(), sessionKey).nextOrNull();
-                assertEquals("Regression test failure", duelFirst, firstChoice);
+                assertThat("Regression test failure", duelFirst, equalTo(firstChoice));
 
                 searchedShards.add(firstChoice);
                 selectedNodes.add(firstChoice.currentNodeId());
@@ -410,7 +410,7 @@ public class OperationRoutingTests extends ESTestCase{
             if (sessionsfirstSearch == null) {
                 sessionsfirstSearch = searchedShards;
             } else {
-                assertEquals("Sessions must reuse same replica choices", sessionsfirstSearch, searchedShards);
+                assertThat("Sessions must reuse same replica choices", searchedShards, equalTo(sessionsfirstSearch));
             }
 
             // 2 is the bare minimum number of nodes we can reliably expect from


### PR DESCRIPTION
A user reported uneven balancing of load on nodes handling search requests from Kibana which supplies a session ID in a routing preference. Each shardId was selecting the same node for a given session ID from the list of allocations (in their case 2 data nodes with all primaries on one node and replicas on the other).
This change counteracts the tendency to opt for the same node given the same user-supplied preference by incorporating shard ID in the hash of the preference key. This will help randomise node choices across shards.

Closes #24642