### PR TITLE
Remove Jython hacks

### DIFF
--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -77,7 +77,6 @@
 # log4j 2
 -Dlog4j.shutdownHookEnabled=false
 -Dlog4j2.disable.jmx=true
--Dlog4j.skipJansi=true
 
 ## heap dumps
 

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -101,18 +101,6 @@ public class BootstrapForTesting {
                 // initialize paths the same exact way as bootstrap
                 Permissions perms = new Permissions();
                 Security.addClasspathPermissions(perms);
-                // crazy jython
-                for (URL url : JarHell.parseClassPath()) {
-                    Path path = PathUtils.get(url.toURI());
-
-                    // crazy jython...
-                    String filename = path.getFileName().toString();
-                    if (filename.contains("jython") && filename.endsWith(".jar")) {
-                        // just enough so it won't fail when it does not exist
-                        perms.add(new FilePermission(path.getParent().toString(), "read,readlink"));
-                        perms.add(new FilePermission(path.getParent().resolve("Lib").toString(), "read,readlink"));
-                    }
-                }
                 // java.io.tmpdir
                 Security.addPath(perms, "java.io.tmpdir", javaTmpDir, "read,readlink,write,delete");
                 // custom test config file

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -177,7 +177,6 @@ public abstract class ESTestCase extends LuceneTestCase {
     static {
         System.setProperty("log4j.shutdownHookEnabled", "false");
         System.setProperty("log4j2.disable.jmx", "true");
-        System.setProperty("log4j.skipJansi", "true"); // jython has this crazy shaded Jansi version that log4j2 tries to load
 
         // shutdown hook so that when the test JVM exits, logging is shutdown too
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {


### PR DESCRIPTION
We had a hack in setting up permissions for tests to support testing the lang-python plugin. We also had a hack to prevent Log4j from loading a shaded version of Jansi provided by Jython. This plugin has been removed so these hacks are no longer necessary.

Relates #20334
