### PR TITLE
Scripting: Deprecate native scripts

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/NativeScriptEngine.java
+++ b/core/src/main/java/org/elasticsearch/script/NativeScriptEngine.java
@@ -19,9 +19,12 @@
 
 package org.elasticsearch.script;
 
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.lookup.SearchLookup;
 
@@ -41,6 +44,11 @@ public class NativeScriptEngine extends AbstractComponent implements ScriptEngin
 
     public NativeScriptEngine(Settings settings, Map<String, NativeScriptFactory> scripts) {
         super(settings);
+        if (scripts.isEmpty() == false) {
+            Logger logger = Loggers.getLogger(ScriptModule.class);
+            DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
+            deprecationLogger.deprecated("Native scripts are deprecated. Use a custom ScriptEngine to write scripts in java.");
+        }
         this.scripts = unmodifiableMap(scripts);
     }
 

--- a/core/src/main/java/org/elasticsearch/script/NativeScriptFactory.java
+++ b/core/src/main/java/org/elasticsearch/script/NativeScriptFactory.java
@@ -31,7 +31,9 @@ import java.util.Map;
  * @see AbstractSearchScript
  * @see AbstractLongSearchScript
  * @see AbstractDoubleSearchScript
+ * @deprecated Create a {@link ScriptEngine} instead of using native scripts
  */
+@Deprecated
 public interface NativeScriptFactory {
 
     /**

--- a/core/src/test/java/org/elasticsearch/script/NativeScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/NativeScriptTests.java
@@ -55,6 +55,7 @@ public class NativeScriptTests extends ESTestCase {
         CompiledScript compiledScript = scriptModule.getScriptService().compile(script, ScriptContext.Standard.SEARCH);
         ExecutableScript executable = scriptModule.getScriptService().executable(compiledScript, script.getParams());
         assertThat(executable.run().toString(), equalTo("test"));
+        assertWarnings("Native scripts are deprecated. Use a custom ScriptEngine to write scripts in java.");
     }
 
     public void testFineGrainedSettingsDontAffectNativeScripts() throws IOException {
@@ -82,6 +83,7 @@ public class NativeScriptTests extends ESTestCase {
             assertThat(scriptService.compile(new Script(ScriptType.INLINE, NativeScriptEngine.NAME, "my", Collections.emptyMap()),
                 scriptContext), notNullValue());
         }
+        assertWarnings("Native scripts are deprecated. Use a custom ScriptEngine to write scripts in java.");
     }
 
     public static class MyNativeScriptFactory implements NativeScriptFactory {


### PR DESCRIPTION
Native scripts are no longer documented and instead using a ScriptEngine
is recommended. This change adds a deprecation warning for removal in
6.0.

relates #19966