### PR TITLE
[Tests] Add unit test for InternalAdjecencyMatrix aggregation

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.adjacency;
+
+import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.test.InternalAggregationTestCase;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class InternalAdjacencyMatrixTests extends InternalAggregationTestCase<InternalAdjacencyMatrix> {
+
+    private List<String> keys;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        keys = new ArrayList<>();
+        int numFilters = randomIntBetween(2, 4);
+        String[] filters = new String[numFilters];
+        for (int i = 0; i < numFilters; i++) {
+            filters[i] = randomAlphaOfLength(5);
+        }
+        for (int i = 0; i < filters.length; i++) {
+            keys.add(filters[i]);
+            for (int j = i + 1; j < filters.length; j++) {
+                if (filters[i].compareTo(filters[j]) <= 0) {
+                    keys.add(filters[i] + "&" + filters[j]);
+                } else {
+                    keys.add(filters[j] + "&" + filters[i]);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected InternalAdjacencyMatrix createTestInstance(String name, List<PipelineAggregator> pipelineAggregators,
+            Map<String, Object> metaData) {
+        final List<InternalAdjacencyMatrix.InternalBucket> buckets = new ArrayList<>();
+        for (int i = 0; i < keys.size(); ++i) {
+            String key = keys.get(i);
+            int docCount = randomIntBetween(0, 1000);
+            buckets.add(new InternalAdjacencyMatrix.InternalBucket(key, docCount, InternalAggregations.EMPTY));
+        }
+        return new InternalAdjacencyMatrix(name, buckets, pipelineAggregators, metaData);
+    }
+
+    @Override
+    protected void assertReduced(InternalAdjacencyMatrix reduced, List<InternalAdjacencyMatrix> inputs) {
+        final Map<String, Long> expectedCounts = new TreeMap<>();
+        for (InternalAdjacencyMatrix input : inputs) {
+            for (InternalAdjacencyMatrix.InternalBucket bucket : input.getBuckets()) {
+                expectedCounts.compute(bucket.getKeyAsString(),
+                        (key, oldValue) -> (oldValue == null ? 0 : oldValue) + bucket.getDocCount());
+            }
+        }
+        final Map<String, Long> actualCounts = new TreeMap<>();
+        for (InternalAdjacencyMatrix.InternalBucket bucket : reduced.getBuckets()) {
+            actualCounts.compute(bucket.getKeyAsString(),
+                    (key, oldValue) -> (oldValue == null ? 0 : oldValue) + bucket.getDocCount());
+        }
+        assertEquals(expectedCounts, actualCounts);
+    }
+
+    @Override
+    protected Reader<InternalAdjacencyMatrix> instanceReader() {
+        return InternalAdjacencyMatrix::new;
+    }
+}


### PR DESCRIPTION
Adding a unit test to InternalAdjecencyMatrix that extends the shared InternalAggregationTestCase that we use for testing aggregations. 
Relates to #22278