### PR TITLE
Add parsing for InternalAdjacencyMatrix aggregation

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/ParsedAdjacencyMatrix.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/ParsedAdjacencyMatrix.java
@@ -20,20 +20,15 @@
 package org.elasticsearch.search.aggregations.bucket.adjacency;
 
 import org.elasticsearch.common.xcontent.ObjectParser;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ParsedAdjecencyMatrix extends ParsedMultiBucketAggregation<ParsedAdjecencyMatrix.ParsedBucket> implements AdjacencyMatrix {
+public class ParsedAdjacencyMatrix extends ParsedMultiBucketAggregation<ParsedAdjacencyMatrix.ParsedBucket> implements AdjacencyMatrix {
 
     private Map<String, ParsedBucket> bucketMap;
 
@@ -58,16 +53,16 @@ public class ParsedAdjecencyMatrix extends ParsedMultiBucketAggregation<ParsedAd
         return bucketMap.get(key);
     }
 
-    private static ObjectParser<ParsedAdjecencyMatrix, Void> PARSER =
-            new ObjectParser<>(ParsedAdjecencyMatrix.class.getSimpleName(), true, ParsedAdjecencyMatrix::new);
+    private static ObjectParser<ParsedAdjacencyMatrix, Void> PARSER =
+            new ObjectParser<>(ParsedAdjacencyMatrix.class.getSimpleName(), true, ParsedAdjacencyMatrix::new);
     static {
         declareMultiBucketAggregationFields(PARSER,
                 parser -> ParsedBucket.fromXContent(parser),
                 parser -> ParsedBucket.fromXContent(parser));
     }
 
-    public static ParsedAdjecencyMatrix fromXContent(XContentParser parser, String name) throws IOException {
-        ParsedAdjecencyMatrix aggregation = PARSER.parse(parser, null);
+    public static ParsedAdjacencyMatrix fromXContent(XContentParser parser, String name) throws IOException {
+        ParsedAdjacencyMatrix aggregation = PARSER.parse(parser, null);
         aggregation.setName(name);
         return aggregation;
     }
@@ -86,38 +81,8 @@ public class ParsedAdjecencyMatrix extends ParsedMultiBucketAggregation<ParsedAd
             return key;
         }
 
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            builder.field(CommonFields.KEY.getPreferredName(), key);
-            builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
-            getAggregations().toXContentInternal(builder, params);
-            builder.endObject();
-            return builder;
-        }
-
-
         static ParsedBucket fromXContent(XContentParser parser) throws IOException {
-            final ParsedBucket bucket = new ParsedBucket();
-            XContentParser.Token token = parser.currentToken();
-            String currentFieldName = parser.currentName();
-
-            List<Aggregation> aggregations = new ArrayList<>();
-            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                if (token == XContentParser.Token.FIELD_NAME) {
-                    currentFieldName = parser.currentName();
-                } else if (token.isValue()) {
-                    if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
-                        bucket.setDocCount(parser.longValue());
-                    } else if (CommonFields.KEY.getPreferredName().equals(currentFieldName)) {
-                        bucket.key = parser.text();
-                    }
-                } else if (token == XContentParser.Token.START_OBJECT) {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
-                }
-            }
-            bucket.setAggregations(new Aggregations(aggregations));
-            return bucket;
+            return parseXContent(parser, false, ParsedBucket::new, (p, bucket) -> bucket.key = p.text());
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/ParsedAdjecencyMatrix.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/adjacency/ParsedAdjecencyMatrix.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.adjacency;
+
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ParsedAdjecencyMatrix extends ParsedMultiBucketAggregation<ParsedAdjecencyMatrix.ParsedBucket> implements AdjacencyMatrix {
+
+    private Map<String, ParsedBucket> bucketMap;
+
+    @Override
+    public String getType() {
+        return AdjacencyMatrixAggregationBuilder.NAME;
+    }
+
+    @Override
+    public List<? extends AdjacencyMatrix.Bucket> getBuckets() {
+        return buckets;
+    }
+
+    @Override
+    public ParsedBucket getBucketByKey(String key) {
+        if (bucketMap == null) {
+            bucketMap = new HashMap<>(buckets.size());
+            for (ParsedBucket bucket : buckets) {
+                bucketMap.put(bucket.getKey(), bucket);
+            }
+        }
+        return bucketMap.get(key);
+    }
+
+    private static ObjectParser<ParsedAdjecencyMatrix, Void> PARSER =
+            new ObjectParser<>(ParsedAdjecencyMatrix.class.getSimpleName(), true, ParsedAdjecencyMatrix::new);
+    static {
+        declareMultiBucketAggregationFields(PARSER,
+                parser -> ParsedBucket.fromXContent(parser),
+                parser -> ParsedBucket.fromXContent(parser));
+    }
+
+    public static ParsedAdjecencyMatrix fromXContent(XContentParser parser, String name) throws IOException {
+        ParsedAdjecencyMatrix aggregation = PARSER.parse(parser, null);
+        aggregation.setName(name);
+        return aggregation;
+    }
+
+    public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements AdjacencyMatrix.Bucket {
+
+        private String key;
+
+        @Override
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public String getKeyAsString() {
+            return key;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(CommonFields.KEY.getPreferredName(), key);
+            builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
+            getAggregations().toXContentInternal(builder, params);
+            builder.endObject();
+            return builder;
+        }
+
+
+        static ParsedBucket fromXContent(XContentParser parser) throws IOException {
+            final ParsedBucket bucket = new ParsedBucket();
+            XContentParser.Token token = parser.currentToken();
+            String currentFieldName = parser.currentName();
+
+            List<Aggregation> aggregations = new ArrayList<>();
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (token.isValue()) {
+                    if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
+                        bucket.setDocCount(parser.longValue());
+                    } else if (CommonFields.KEY.getPreferredName().equals(currentFieldName)) {
+                        bucket.key = parser.text();
+                    }
+                } else if (token == XContentParser.Token.START_OBJECT) {
+                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                }
+            }
+            bucket.setAggregations(new Aggregations(aggregations));
+            return bucket;
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.search.aggregations.bucket.adjacency.InternalAdjacencyMatrixTests;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilterTests;
 import org.elasticsearch.search.aggregations.bucket.filters.InternalFiltersTests;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoHashGridTests;
@@ -124,6 +125,7 @@ public class AggregationsTests extends ESTestCase {
         aggsTests.add(new InternalDateRangeTests());
         aggsTests.add(new InternalGeoDistanceTests());
         aggsTests.add(new InternalFiltersTests());
+        aggsTests.add(new InternalAdjacencyMatrixTests());
         return Collections.unmodifiableList(aggsTests);
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -21,8 +21,9 @@ package org.elasticsearch.search.aggregations.bucket.adjacency;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregationTestCase;
+import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
-import org.elasticsearch.test.InternalAggregationTestCase;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-public class InternalAdjacencyMatrixTests extends InternalAggregationTestCase<InternalAdjacencyMatrix> {
+public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregationTestCase<InternalAdjacencyMatrix> {
 
     private List<String> keys;
 
@@ -58,12 +59,12 @@ public class InternalAdjacencyMatrixTests extends InternalAggregationTestCase<In
 
     @Override
     protected InternalAdjacencyMatrix createTestInstance(String name, List<PipelineAggregator> pipelineAggregators,
-            Map<String, Object> metaData) {
+            Map<String, Object> metaData, InternalAggregations aggregations) {
         final List<InternalAdjacencyMatrix.InternalBucket> buckets = new ArrayList<>();
         for (int i = 0; i < keys.size(); ++i) {
             String key = keys.get(i);
             int docCount = randomIntBetween(0, 1000);
-            buckets.add(new InternalAdjacencyMatrix.InternalBucket(key, docCount, InternalAggregations.EMPTY));
+            buckets.add(new InternalAdjacencyMatrix.InternalBucket(key, docCount, aggregations));
         }
         return new InternalAdjacencyMatrix(name, buckets, pipelineAggregators, metaData);
     }
@@ -88,5 +89,10 @@ public class InternalAdjacencyMatrixTests extends InternalAggregationTestCase<In
     @Override
     protected Reader<InternalAdjacencyMatrix> instanceReader() {
         return InternalAdjacencyMatrix::new;
+    }
+
+    @Override
+    protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
+        return ParsedAdjecencyMatrix.class;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -93,6 +93,6 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
 
     @Override
     protected Class<? extends ParsedMultiBucketAggregation> implementationClass() {
-        return ParsedAdjecencyMatrix.class;
+        return ParsedAdjacencyMatrix.class;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -38,6 +38,8 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
+import org.elasticsearch.search.aggregations.bucket.adjacency.AdjacencyMatrixAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.adjacency.ParsedAdjecencyMatrix;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
 import org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregationBuilder;
@@ -173,6 +175,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         map.put(DateRangeAggregationBuilder.NAME, (p, c) -> ParsedDateRange.fromXContent(p, (String) c));
         map.put(GeoDistanceAggregationBuilder.NAME, (p, c) -> ParsedGeoDistance.fromXContent(p, (String) c));
         map.put(FiltersAggregationBuilder.NAME, (p, c) -> ParsedFilters.fromXContent(p, (String) c));
+        map.put(AdjacencyMatrixAggregationBuilder.NAME, (p, c) -> ParsedAdjecencyMatrix.fromXContent(p, (String) c));
 
         namedXContents = map.entrySet().stream()
                 .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue()))

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -39,7 +39,7 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.bucket.adjacency.AdjacencyMatrixAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.adjacency.ParsedAdjecencyMatrix;
+import org.elasticsearch.search.aggregations.bucket.adjacency.ParsedAdjacencyMatrix;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
 import org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregationBuilder;
@@ -175,7 +175,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         map.put(DateRangeAggregationBuilder.NAME, (p, c) -> ParsedDateRange.fromXContent(p, (String) c));
         map.put(GeoDistanceAggregationBuilder.NAME, (p, c) -> ParsedGeoDistance.fromXContent(p, (String) c));
         map.put(FiltersAggregationBuilder.NAME, (p, c) -> ParsedFilters.fromXContent(p, (String) c));
-        map.put(AdjacencyMatrixAggregationBuilder.NAME, (p, c) -> ParsedAdjecencyMatrix.fromXContent(p, (String) c));
+        map.put(AdjacencyMatrixAggregationBuilder.NAME, (p, c) -> ParsedAdjacencyMatrix.fromXContent(p, (String) c));
 
         namedXContents = map.entrySet().stream()
                 .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue()))


### PR DESCRIPTION
This adds parsing and related tests to the InternalAdjacencyMatrix aggregation.
Based on #24698 which should go into master first.
