### PR TITLE
Allow resetting settings that use an IP validator

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -48,7 +48,7 @@ public class DiscoveryNodeFilters {
         for (Map.Entry<String, String> entry : settingsMap.entrySet()) {
             String propertyKey = entry.getKey();
             if (entry.getValue() == null) {
-                continue; // this setting get's reset
+                continue; // this setting gets reset
             }
             if ("_ip".equals(propertyKey) || "_host_ip".equals(propertyKey) || "_publish_ip".equals(propertyKey)) {
                 for (String value : Strings.tokenizeToStringArray(entry.getValue(), ",")) {

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -47,6 +47,9 @@ public class DiscoveryNodeFilters {
         Map<String, String> settingsMap = settings.getAsMap();
         for (Map.Entry<String, String> entry : settingsMap.entrySet()) {
             String propertyKey = entry.getKey();
+            if (entry.getValue() == null) {
+                continue; // this setting get's reset
+            }
             if ("_ip".equals(propertyKey) || "_host_ip".equals(propertyKey) || "_publish_ip".equals(propertyKey)) {
                 for (String value : Strings.tokenizeToStringArray(entry.getValue(), ",")) {
                     if (InetAddresses.isInetAddress(value) == false) {

--- a/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -103,6 +103,30 @@ public class ScopedSettingsTests extends ESTestCase {
         assertNull(target.build().getAsInt("archived.foo.bar", null));
     }
 
+    public void testResetSettingWithIPValidator() {
+        Settings currentSettings = Settings.builder().put("index.routing.allocation.require._ip", "192.168.0.1,127.0.0.1")
+            .put("index.some.dyn.setting", 1)
+            .build();
+        Setting<Integer> dynamicSetting = Setting.intSetting("index.some.dyn.setting", 1, Property.Dynamic, Property.IndexScope);
+
+        IndexScopedSettings settings = new IndexScopedSettings(currentSettings,
+            new HashSet<>(Arrays.asList(dynamicSetting, IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING)));
+        Settings s = IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING.get(currentSettings);
+        assertEquals(1, s.size());
+        assertEquals("192.168.0.1,127.0.0.1", s.get("_ip"));
+        Settings.Builder builder = Settings.builder();
+        Settings updates = Settings.builder().putNull("index.routing.allocation.require._ip")
+            .put("index.some.dyn.setting", 1).build();
+        settings.validate(updates);
+        settings.updateDynamicSettings(updates,
+            Settings.builder().put(currentSettings), builder, "node");
+        currentSettings = builder.build();
+        s = IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING.get(currentSettings);
+        assertEquals(0, s.size());
+        assertEquals(1, dynamicSetting.get(currentSettings).intValue());
+        assertEquals(1, currentSettings.size());
+    }
+
     public void testAddConsumer() {
         Setting<Integer> testSetting = Setting.intSetting("foo.bar", 1, Property.Dynamic, Property.NodeScope);
         Setting<Integer> testSetting2 = Setting.intSetting("foo.bar.baz", 1, Property.Dynamic, Property.NodeScope);


### PR DESCRIPTION
The IP validator doesn't expect a null value for a setting that causes NPEs
if a user tries to reset a setting that uses this validator.

Closes #24709