### PR TITLE
Remove the unused SignificantTerms.compareTerm() method

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantLongTerms.java
@@ -77,11 +77,6 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
         }
 
         @Override
-        public int compareTerm(SignificantTerms.Bucket other) {
-            return Long.compare(term, ((Number) other.getKey()).longValue());
-        }
-
-        @Override
         public String getKeyAsString() {
             return format.format(term);
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantStringTerms.java
@@ -28,7 +28,6 @@ import org.elasticsearch.search.aggregations.bucket.significant.heuristics.Signi
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -80,11 +79,6 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
         public Number getKeyAsNumber() {
             // this method is needed for scripted numeric aggregations
             return Double.parseDouble(termBytes.utf8ToString());
-        }
-
-        @Override
-        public int compareTerm(SignificantTerms.Bucket other) {
-            return termBytes.compareTo(((Bucket) other).termBytes);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
@@ -40,8 +40,6 @@ public interface SignificantTerms extends MultiBucketsAggregation, Iterable<Sign
         long getSupersetSize();
 
         long getSubsetSize();
-
-        int compareTerm(SignificantTerms.Bucket other);
     }
 
     @Override


### PR DESCRIPTION
This method is not used and not tested. But it existence forces implementations of the interface to implement it even if it's unused.