### PR TITLE
Remove comma-separated feature parsing for GetIndicesAction

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/core/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -253,6 +253,9 @@ import org.elasticsearch.rest.action.admin.indices.RestDeleteIndexTemplateAction
 import org.elasticsearch.rest.action.admin.indices.RestFlushAction;
 import org.elasticsearch.rest.action.admin.indices.RestForceMergeAction;
 import org.elasticsearch.rest.action.admin.indices.RestGetAliasesAction;
+import org.elasticsearch.rest.action.admin.indices.RestGetAllAliasesAction;
+import org.elasticsearch.rest.action.admin.indices.RestGetAllMappingsAction;
+import org.elasticsearch.rest.action.admin.indices.RestGetAllSettingsAction;
 import org.elasticsearch.rest.action.admin.indices.RestGetFieldMappingAction;
 import org.elasticsearch.rest.action.admin.indices.RestGetIndexTemplateAction;
 import org.elasticsearch.rest.action.admin.indices.RestGetIndicesAction;
@@ -541,6 +544,9 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestDeleteSnapshotAction(settings, restController));
         registerHandler.accept(new RestSnapshotsStatusAction(settings, restController));
 
+        registerHandler.accept(new RestGetAllAliasesAction(settings, restController));
+        registerHandler.accept(new RestGetAllMappingsAction(settings, restController));
+        registerHandler.accept(new RestGetAllSettingsAction(settings, restController, indexScopedSettings, settingsFilter));
         registerHandler.accept(new RestTypesExistsAction(settings, restController));
         registerHandler.accept(new RestGetIndicesAction(settings, restController, indexScopedSettings, settingsFilter));
         registerHandler.accept(new RestIndicesStatsAction(settings, restController));

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -57,6 +57,8 @@ public class RestGetAliasesAction extends BaseRestHandler {
         super(settings);
         controller.registerHandler(GET, "/_alias/{name}", this);
         controller.registerHandler(HEAD, "/_alias/{name}", this);
+        controller.registerHandler(GET, "/{index}/_alias", this);
+        controller.registerHandler(HEAD, "/{index}/_alias", this);
         controller.registerHandler(GET, "/{index}/_alias/{name}", this);
         controller.registerHandler(HEAD, "/{index}/_alias/{name}", this);
     }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAllAliasesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAllAliasesAction.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices;
+
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.xcontent.ToXContent.Params;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.action.RestBuilderListener;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.HEAD;
+import static org.elasticsearch.rest.RestStatus.OK;
+
+/**
+ * The REST handler for retrieving all aliases
+ */
+public class RestGetAllAliasesAction extends BaseRestHandler {
+
+    public RestGetAllAliasesAction(final Settings settings, final RestController controller) {
+        super(settings);
+        controller.registerHandler(GET, "/_alias", this);
+        controller.registerHandler(GET, "/_aliases", this);
+    }
+
+    @Override
+    public String getName() {
+        return "get_all_aliases_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        final GetIndexRequest getIndexRequest = new GetIndexRequest();
+        getIndexRequest.indices(Strings.EMPTY_ARRAY);
+        getIndexRequest.features(Feature.ALIASES);
+        getIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, getIndexRequest.indicesOptions()));
+        getIndexRequest.local(request.paramAsBoolean("local", getIndexRequest.local()));
+        getIndexRequest.humanReadable(request.paramAsBoolean("human", false));
+        return channel -> client.admin().indices().getIndex(getIndexRequest, new RestBuilderListener<GetIndexResponse>(channel) {
+
+            @Override
+            public RestResponse buildResponse(final GetIndexResponse response, final XContentBuilder builder) throws Exception {
+                builder.startObject();
+                {
+                    for (final String index : response.indices()) {
+                        builder.startObject(index);
+                        {
+                            writeAliases(response.aliases().get(index), builder, request);
+                        }
+                        builder.endObject();
+                    }
+                }
+                builder.endObject();
+
+                return new BytesRestResponse(OK, builder);
+            }
+
+            private void writeAliases(final List<AliasMetaData> aliases, final XContentBuilder builder,
+                                      final Params params) throws IOException {
+                builder.startObject("aliases");
+                {
+                    if (aliases != null) {
+                        for (final AliasMetaData alias : aliases) {
+                            AliasMetaData.Builder.toXContent(alias, builder, params);
+                        }
+                    }
+                }
+                builder.endObject();
+            }
+        });
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAllMappingsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAllMappingsAction.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices;
+
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.xcontent.ToXContent.Params;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.action.RestBuilderListener;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.HEAD;
+import static org.elasticsearch.rest.RestStatus.OK;
+
+/**
+ * The REST handler for retrieving all mappings
+ */
+public class RestGetAllMappingsAction extends BaseRestHandler {
+
+    public RestGetAllMappingsAction(final Settings settings, final RestController controller) {
+        super(settings);
+        controller.registerHandler(GET, "/_mapping", this);
+        controller.registerHandler(GET, "/_mappings", this);
+    }
+
+    @Override
+    public String getName() {
+        return "get_all_mappings_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        final GetIndexRequest getIndexRequest = new GetIndexRequest();
+        getIndexRequest.indices(Strings.EMPTY_ARRAY);
+        getIndexRequest.features(Feature.MAPPINGS);
+        getIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, getIndexRequest.indicesOptions()));
+        getIndexRequest.local(request.paramAsBoolean("local", getIndexRequest.local()));
+        getIndexRequest.humanReadable(request.paramAsBoolean("human", false));
+        return channel -> client.admin().indices().getIndex(getIndexRequest, new RestBuilderListener<GetIndexResponse>(channel) {
+
+            @Override
+            public RestResponse buildResponse(final GetIndexResponse response, final XContentBuilder builder) throws Exception {
+                builder.startObject();
+                {
+                    for (final String index : response.indices()) {
+                        builder.startObject(index);
+                        {
+                            writeMappings(response.mappings().get(index), builder);
+                        }
+                        builder.endObject();
+                    }
+                }
+                builder.endObject();
+
+                return new BytesRestResponse(OK, builder);
+            }
+
+            private void writeMappings(final ImmutableOpenMap<String, MappingMetaData> mappings,
+                                       final XContentBuilder builder) throws IOException {
+                builder.startObject("mappings");
+                {
+                    for (final ObjectObjectCursor<String, MappingMetaData> typeEntry : mappings) {
+                        builder.field(typeEntry.key);
+                        builder.map(typeEntry.value.sourceAsMap());
+                    }
+                }
+                builder.endObject();
+            }
+        });
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAllSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAllSettingsAction.java
@@ -19,17 +19,13 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
-import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
@@ -51,38 +47,36 @@ import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
- * The REST handler for get index and head index APIs.
+ * The REST handler for retrieving all settings
  */
-public class RestGetIndicesAction extends BaseRestHandler {
+public class RestGetAllSettingsAction extends BaseRestHandler {
 
     private final IndexScopedSettings indexScopedSettings;
     private final SettingsFilter settingsFilter;
 
-    public RestGetIndicesAction(
-            final Settings settings,
-            final RestController controller,
-            final IndexScopedSettings indexScopedSettings,
-            final SettingsFilter settingsFilter) {
+    public RestGetAllSettingsAction(final Settings settings, final RestController controller,
+                                    final IndexScopedSettings indexScopedSettings, final SettingsFilter settingsFilter) {
         super(settings);
         this.indexScopedSettings = indexScopedSettings;
-        controller.registerHandler(GET, "/{index}", this);
-        controller.registerHandler(HEAD, "/{index}", this);
+        controller.registerHandler(GET, "/_settings", this);
         this.settingsFilter = settingsFilter;
     }
 
     @Override
     public String getName() {
-        return "get_indices_action";
+        return "get_all_settings_action";
     }
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         final GetIndexRequest getIndexRequest = new GetIndexRequest();
-        getIndexRequest.indices(indices);
+        getIndexRequest.indices(Strings.EMPTY_ARRAY);
+        getIndexRequest.features(Feature.SETTINGS);
         getIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, getIndexRequest.indicesOptions()));
         getIndexRequest.local(request.paramAsBoolean("local", getIndexRequest.local()));
         getIndexRequest.humanReadable(request.paramAsBoolean("human", false));
+        // This is required so the "flat_settings" parameter counts as consumed
+        request.paramAsBoolean("flat_settings", false);
         final boolean defaults = request.paramAsBoolean("include_defaults", false);
         return channel -> client.admin().indices().getIndex(getIndexRequest, new RestBuilderListener<GetIndexResponse>(channel) {
 
@@ -93,24 +87,9 @@ public class RestGetIndicesAction extends BaseRestHandler {
                     for (final String index : response.indices()) {
                         builder.startObject(index);
                         {
-                            for (final Feature feature : getIndexRequest.features()) {
-                                switch (feature) {
-                                    case ALIASES:
-                                        writeAliases(response.aliases().get(index), builder, request);
-                                        break;
-                                    case MAPPINGS:
-                                        writeMappings(response.mappings().get(index), builder);
-                                        break;
-                                    case SETTINGS:
-                                        writeSettings(response.settings().get(index), builder, request, defaults);
-                                        break;
-                                    default:
-                                        throw new IllegalStateException("feature [" + feature + "] is not valid");
-                                }
-                            }
+                            writeSettings(response.settings().get(index), builder, request, defaults);
                         }
                         builder.endObject();
-
                     }
                 }
                 builder.endObject();
@@ -118,40 +97,9 @@ public class RestGetIndicesAction extends BaseRestHandler {
                 return new BytesRestResponse(OK, builder);
             }
 
-            private void writeAliases(
-                    final List<AliasMetaData> aliases,
-                    final XContentBuilder builder,
-                    final Params params) throws IOException {
-                builder.startObject("aliases");
-                {
-                    if (aliases != null) {
-                        for (final AliasMetaData alias : aliases) {
-                            AliasMetaData.Builder.toXContent(alias, builder, params);
-                        }
-                    }
-                }
-                builder.endObject();
-            }
 
-            private void writeMappings(final ImmutableOpenMap<String, MappingMetaData> mappings, final XContentBuilder builder)
-                    throws IOException {
-                builder.startObject("mappings");
-                {
-                    if (mappings != null) {
-                        for (final ObjectObjectCursor<String, MappingMetaData> typeEntry : mappings) {
-                            builder.field(typeEntry.key);
-                            builder.map(typeEntry.value.sourceAsMap());
-                        }
-                    }
-                }
-                builder.endObject();
-            }
-
-            private void writeSettings(
-                    final Settings settings,
-                    final XContentBuilder builder,
-                    final Params params,
-                    final boolean defaults) throws IOException {
+            private void writeSettings(final Settings settings, final XContentBuilder builder,
+                                       final Params params, final boolean defaults) throws IOException {
                 builder.startObject("settings");
                 {
                     settings.toXContent(builder, params);
@@ -161,19 +109,13 @@ public class RestGetIndicesAction extends BaseRestHandler {
                     builder.startObject("defaults");
                     {
                         settingsFilter
-                                .filter(indexScopedSettings.diff(settings, RestGetIndicesAction.this.settings))
+                                .filter(indexScopedSettings.diff(settings, RestGetAllSettingsAction.this.settings))
                                 .toXContent(builder, request);
                     }
                     builder.endObject();
                 }
             }
-
         });
-    }
-
-    @Override
-    protected Set<String> responseParams() {
-        return Settings.FORMAT_PARAMS;
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -48,6 +48,8 @@ public class RestGetMappingAction extends BaseRestHandler {
     public RestGetMappingAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(GET, "/{index}/{type}/_mapping", this);
+        controller.registerHandler(GET, "/{index}/_mappings", this);
+        controller.registerHandler(GET, "/{index}/_mapping", this);
         controller.registerHandler(GET, "/{index}/_mappings/{type}", this);
         controller.registerHandler(GET, "/{index}/_mapping/{type}", this);
         controller.registerHandler(GET, "/_mapping/{type}", this);

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetSettingsAction.java
@@ -51,8 +51,9 @@ public class RestGetSettingsAction extends BaseRestHandler {
             final SettingsFilter settingsFilter) {
         super(settings);
         this.indexScopedSettings = indexScopedSettings;
-        controller.registerHandler(GET, "/{index}/_settings/{name}", this);
         controller.registerHandler(GET, "/_settings/{name}", this);
+        controller.registerHandler(GET, "/{index}/_settings", this);
+        controller.registerHandler(GET, "/{index}/_settings/{name}", this);
         controller.registerHandler(GET, "/{index}/_setting/{name}", this);
         this.settingsFilter = settingsFilter;
     }
@@ -66,6 +67,8 @@ public class RestGetSettingsAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         final String[] names = request.paramAsStringArrayOrEmptyIfAll("name");
         final boolean renderDefaults = request.paramAsBoolean("include_defaults", false);
+        // This is required so the "flat_settings" parameter counts as consumed
+        request.paramAsBoolean("flat_settings", false);
         GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
                 .indices(Strings.splitStringByCommaToArray(request.param("index")))
                 .indicesOptions(IndicesOptions.fromRequest(request, IndicesOptions.strictExpandOpen()))

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -15,20 +15,3 @@ alias or wildcard expression is required.
 
 The get index API can also be applied to more than one index, or on
 all indices by using `_all` or `*` as index.
-
-[float]
-=== Filtering index information
-
-The information returned by the get API can be filtered to include only specific features
-by specifying a comma delimited list of features in the URL:
-
-[source,js]
---------------------------------------------------
-GET twitter/_settings,_mappings
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
-
-The above command will only return the settings and mappings for the index called `twitter`.
-
-The available features are `_settings`, `_mappings` and `_aliases`.

--- a/docs/reference/migration/migrate_6_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_6_0/rest.asciidoc
@@ -58,3 +58,13 @@ as a result. From version 6.0.0, delete by query requests require an explicit qu
 
 Running `DELETE index/type/id` now implicitly creates `type` with a default
 mapping if it did not exist yet.
+
+==== Indices information APIs
+
+Previously it was possible to execute `GET /_aliases,_mappings` or `GET
+/myindex/_settings,_alias` by separating mulitple types of requests with commas
+in order to retrieve multiple types of information about one or more indices.
+This comma-separation for retrieving multiple pieces of information has been
+removed.. `GET /_all` can be used to retrieve all aliases, settings, and
+mappings for all indices. In order to retrieve only the mappings for an index,
+`GET /myindex/_mappings` (or `_aliases`, or `_settings`).

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -4,17 +4,12 @@
     "methods":[ "GET" ],
     "url":{
       "path":"/{index}",
-      "paths":[ "/{index}", "/{index}/{feature}" ],
+      "paths":[ "/{index}" ],
       "parts":{
         "index":{
           "type":"list",
           "required" : true,
           "description":"A comma-separated list of index names"
-        },
-        "feature":{
-          "type":"list",
-          "description":"A comma-separated list of features",
-          "options": ["_settings", "_mappings", "_aliases"]
         }
       },
       "params":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yml
@@ -53,41 +53,18 @@ setup:
   - is_true: test_index.mappings
 
 ---
-"Get index infos for mappings only":
-
-  - do:
-      indices.get:
-        index: test_index
-        feature: _mapping
-
-  - is_true: test_index.mappings
-  - is_false: test_index.aliases
-  - is_false: test_index.settings
-
----
-"Get index infos should work on aliases":
-
-  - do:
-      indices.get:
-        index: test_blias
-        feature: _mapping
-
-  - is_true: test_index.mappings
-  - is_false: test_index.aliases
-  - is_false: test_index.settings
-
----
 "Get index infos should work for wildcards":
 
   - do:
       indices.get:
         index: test_*
-        feature: _mapping,_settings
 
   - is_true: test_index.mappings
+  - is_true: test_index.aliases
   - is_true: test_index.settings
   - is_true: test_index_2.settings
-  - is_false: test_index.aliases
+  - is_true: test_index_2.mappings
+  - is_true: test_index_2.aliases
 
 ---
 "Get index infos with human settings should return index creation date and version in readable format":
@@ -95,7 +72,6 @@ setup:
   - do:
       indices.get:
         index: test_index
-        feature: _settings
         human: true
 
   - is_true: test_index.settings.index.creation_date_string
@@ -107,7 +83,6 @@ setup:
   - do:
       indices.get:
         index: test_index
-        feature: _settings
 
   - is_false: test_index.settings.index.creation_date_string
   - is_false: test_index.settings.index.version.created_string
@@ -169,7 +144,6 @@ setup:
   - do:
       indices.get:
         index: test_index_*
-        feature: _settings
         expand_wildcards: closed
 
   - is_false: test_index_2.settings
@@ -181,7 +155,6 @@ setup:
   - do:
       indices.get:
         index: test_index_*
-        feature: _settings
         expand_wildcards: open,closed
 
   - is_true: test_index_2.settings

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
@@ -96,11 +96,10 @@ setup:
 "Get test-* with wildcard_expansion=none":
 
  - do:
+    catch: missing
     indices.get_mapping:
         index: test-x*
         expand_wildcards: none
-
- - match: { $body: {} }
 
 ---
 "Get test-* with wildcard_expansion=open,closed":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/30_remove_index_and_replace_with_alias.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/30_remove_index_and_replace_with_alias.yml
@@ -29,7 +29,7 @@
   - is_true: ''
 
   - do:
-      indices.get_mapping:
+      indices.get:
         index: test
     # the name of the index that the alias points to, would be `test` if the index were still there
   - is_true: test_2


### PR DESCRIPTION
This removes the parsing of things like `GET /idx/_aliases,_mappings`, instead,
a user must choose between retriving all index metadata with `GET /idx`, or only
a specific form such as `GET /idx/_settings`.

Relates to (and is a prerequisite of) #24437
