### PR TITLE
Handle parentheses in batch file path

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -37,7 +37,7 @@ SET HOSTNAME=%COMPUTERNAME%
 
 if "%ES_JVM_OPTIONS%" == "" (
 rem '0' is the batch file, '~dp' appends the drive and path
-set ES_JVM_OPTIONS=%~dp0\..\config\jvm.options
+set "ES_JVM_OPTIONS=%~dp0\..\config\jvm.options"
 )
 
 @setlocal


### PR DESCRIPTION
variable assignment needs to be quoted to correctly handle the scenario where the batch file path contains parentheses, for example, such as unzipping to a directory under `C:\Program Files (x86)\`.

If variable assignment is not quoted, the the following error is exhibited

```
<path after parentheses>\\..\config\jvm.options was unexpected at this time.
```

Is is not sufficient to just quote `%~dp0\..\config\jvm.options` because `%ES_JVM_OPTIONS%` will then contain quotes and thus be double quoted when performing the subsequent `findstr` operation, and in addition, the quotes cannot be removed from `"%ES_JVM_OPTIONS%"` in the `findstr` operation because they are needed to handle the case where the value is set from an environment variable (which may contain parentheses).

Quoting the whole assignment handles the case where the value assigned contains parentheses correctly.

Fixes #24712 