### PR TITLE
String concatenation within a StringBuilder append chain

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -193,7 +193,7 @@ public class RoutingNode implements Iterable<ShardRouting> {
 
     public String prettyPrint() {
         StringBuilder sb = new StringBuilder();
-        sb.append("-----node_id[").append(nodeId).append("][" + (node == null ? "X" : "V") + "]\n");
+        sb.append("-----node_id[").append(nodeId).append("][").append(node == null ? "X" : "V").append("]\n");
         for (ShardRouting entry : shards.values()) {
             sb.append("--------").append(entry.shortSummary()).append('\n');
         }

--- a/core/src/main/java/org/elasticsearch/common/network/IfConfig.java
+++ b/core/src/main/java/org/elasticsearch/common/network/IfConfig.java
@@ -121,15 +121,15 @@ public final class IfConfig {
             sb.append("inet ");
             sb.append(NetworkAddress.format(address));
             int netmask = 0xFFFFFFFF << (32 - interfaceAddress.getNetworkPrefixLength());
-            sb.append(" netmask:" + NetworkAddress.format(InetAddress.getByAddress(new byte[] {
-                    (byte)(netmask >>> 24),
-                    (byte)(netmask >>> 16 & 0xFF),
-                    (byte)(netmask >>> 8 & 0xFF),
-                    (byte)(netmask & 0xFF)
+            sb.append(" netmask:").append(NetworkAddress.format(InetAddress.getByAddress(new byte[]{
+                (byte) (netmask >>> 24),
+                (byte) (netmask >>> 16 & 0xFF),
+                (byte) (netmask >>> 8 & 0xFF),
+                (byte) (netmask & 0xFF)
             })));
             InetAddress broadcast = interfaceAddress.getBroadcast();
             if (broadcast != null) {
-                sb.append(" broadcast:" + NetworkAddress.format(broadcast));
+                sb.append(" broadcast:").append(NetworkAddress.format(broadcast));
             }
         }
         if (address.isLoopbackAddress()) {
@@ -160,8 +160,8 @@ public final class IfConfig {
         if (nic.isVirtual()) {
             flags.append("VIRTUAL ");
         }
-        flags.append("mtu:" + nic.getMTU());
-        flags.append(" index:" + nic.getIndex());
+        flags.append("mtu:").append(nic.getMTU());
+        flags.append(" index:").append(nic.getIndex());
         return flags.toString();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/common/inject/ModuleTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/inject/ModuleTestCase.java
@@ -61,7 +61,7 @@ public abstract class ModuleTestCase extends ESTestCase {
         }
         StringBuilder s = new StringBuilder();
         for (Element element : elements) {
-            s.append(element + "\n");
+            s.append(element).append("\n");
         }
         fail("Did not find any binding to " + to.getName() + ". Found these bindings:\n" + s);
     }
@@ -93,7 +93,7 @@ public abstract class ModuleTestCase extends ESTestCase {
             List<Element> elements = Elements.getElements(module);
             StringBuilder s = new StringBuilder();
             for (Element element : elements) {
-                s.append(element + "\n");
+                s.append(element).append("\n");
             }
             fail("Expected exception from configuring module. Found these bindings:\n" + s);
         } catch (IllegalArgumentException e) {
@@ -220,7 +220,7 @@ public abstract class ModuleTestCase extends ESTestCase {
         }
         StringBuilder s = new StringBuilder();
         for (Element element : elements) {
-            s.append(element + "\n");
+            s.append(element).append("\n");
         }
         fail("Did not find any instance binding to " + to.getName() + ". Found these bindings:\n" + s);
     }


### PR DESCRIPTION
This very small PR is related to issue #24226 it is small exactly to keep it readable.

Doing a String concatenation inside an `.append()` call of a StringBuilder seemingly defeats the point of the effort of using a StringBuilder. It would be more logical to just continue using `.append()`. This PR fixes that.

===========

1. Contributor agreement: Has been signed

2. Contributor guidelines: I have read them.

3. Gradle check: **not done**

4. PR is against master

5. The PR is not OS specific.

6. I'm not part of a class.