### PR TITLE
Test: Convert rolling upgrade test to have task per wire compat version

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -449,6 +449,26 @@ Note: Starting vagrant VM outside of the elasticsearch folder requires to
 indicates the folder that contains the Vagrantfile using the VAGRANT_CWD
 environment variable.
 
+== Testing backwards compatibility
+
+Backwards compatibility tests exist to test upgrading from each supported version
+to the current version. To run all backcompat tests use:
+
+-------------------------------------------------
+gradle bwcTest
+-------------------------------------------------
+
+A specific version can be tested as well. For example, to test backcompat with
+version 5.3.2 run:
+
+-------------------------------------------------
+gradle v5.3.2#bwcTest
+-------------------------------------------------
+
+When running `gradle check`, some minimal backcompat checks are run. Which version
+is tested depends on the branch. On master, this will test against the current
+stable branch. On the stable branch, it will test against the latest release
+branch. Finally, on a release branch, it will test against the most recent release.
 
 == Coverage analysis
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ import org.eclipse.jgit.lib.RepositoryBuilder
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.Version
 
 // common maven publishing configuration
 subprojects {
@@ -62,11 +63,11 @@ configure(subprojects.findAll { it.projectDir.toPath().startsWith(rootPath) }) {
 }
 
 // introspect all versions of ES that may be tested agains for backwards compatibility
-String currentVersion = VersionProperties.elasticsearch.minus('-SNAPSHOT')
-int prevMajor = Integer.parseInt(currentVersion.split('\\.')[0]) - 1
+Version currentVersion = Version.fromString(VersionProperties.elasticsearch.minus('-SNAPSHOT'))
+int prevMajor = currentVersion.major - 1
 File versionFile = file('core/src/main/java/org/elasticsearch/Version.java')
 List<String> versionLines = versionFile.readLines('UTF-8')
-List<String> versions = []
+List<Version> versions = []
 // keep track of the previous major version's last minor, so we know where wire compat begins
 int prevMinorIndex = -1 // index in the versions list of the last minor from the prev major
 int lastPrevMinor = -1 // the minor version number from the prev major we most recently seen
@@ -76,9 +77,9 @@ for (String line : versionLines) {
     int major = Integer.parseInt(match.group(1))
     int minor = Integer.parseInt(match.group(2))
     int bugfix = Integer.parseInt(match.group(3))
-    String versionStr = "${major}.${minor}.${bugfix}"
-    if (currentVersion != versionStr) {
-      versions.add(versionStr)
+    Version foundVersion = new Version(major, minor, bugfix, false)
+    if (currentVersion != foundVersion) {
+      versions.add(foundVersion)
     }
     if (major == prevMajor && minor > lastPrevMinor) {
       prevMinorIndex = versions.size() - 1
@@ -86,16 +87,17 @@ for (String line : versionLines) {
     }
   }
 }
-if (versions.toSorted() != versions) {
-  throw new GradleException('Versions.java contains out of order version constants')
+if (versions.toSorted { it.id } != versions) {
+  println "Versions: ${versions}" 
+  throw new GradleException("Versions.java contains out of order version constants")
 }
-if (currentVersion.split('\\.')[2].split('-')[0] == '0') {
+if (currentVersion.bugfix == 0) {
   // If on a release branch, after the initial release of that branch, the bugfix version will
   // be bumped, and will be != 0. On master and N.x branches, we want to test against the
   // unreleased version of closest branch. So for those cases, the version includes -SNAPSHOT,
-  // and the bwc-zip distribution will checkout and build that version. The version parsing
-  // logic above pulls the bugfix version, and then strips off any prerelease version
-  versions[-1] += '-SNAPSHOT'
+  // and the bwc-zip distribution will checkout and build that version.
+  Version last = versions[-1]
+  versions[-1] = new Version(last.major, last.minor, last.bugfix, true)
 }
 
 // injecting groovy property variables into all projects
@@ -154,7 +156,6 @@ subprojects {
     "org.elasticsearch.client:transport:${version}": ':client:transport',
     "org.elasticsearch.test:framework:${version}": ':test:framework',
     "org.elasticsearch.distribution.integ-test-zip:elasticsearch:${version}": ':distribution:integ-test-zip',
-    "org.elasticsearch.distribution.zip:elasticsearch:${wireCompatVersions[-1]}": ':distribution:bwc-zip',
     "org.elasticsearch.distribution.zip:elasticsearch:${version}": ':distribution:zip',
     "org.elasticsearch.distribution.tar:elasticsearch:${version}": ':distribution:tar',
     "org.elasticsearch.distribution.rpm:elasticsearch:${version}": ':distribution:rpm',
@@ -167,6 +168,9 @@ subprojects {
     "org.elasticsearch.plugin:parent-join-client:${version}": ':modules:parent-join',
     "org.elasticsearch.plugin:percolator-client:${version}": ':modules:percolator',
   ]
+  if (wireCompatVersions[-1].snapshot) {
+    ext.projectSubstitutions["org.elasticsearch.distribution.zip:elasticsearch:${wireCompatVersions[-1]}"] = ':distribution:bwc-zip'
+  }
   project.afterEvaluate {
     configurations.all {
       resolutionStrategy.dependencySubstitution { DependencySubstitutions subs ->

--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,8 @@ subprojects {
     "org.elasticsearch.plugin:percolator-client:${version}": ':modules:percolator',
   ]
   if (wireCompatVersions[-1].snapshot) {
+    // if the most previous version is a snapshot, we need to connect that version to the
+    // bwc-zip project which will checkout and build that snapshot version
     ext.projectSubstitutions["org.elasticsearch.distribution.zip:elasticsearch:${wireCompatVersions[-1]}"] = ':distribution:bwc-zip'
   }
   project.afterEvaluate {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/Version.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/Version.groovy
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle
+
+/**
+ * Encapsulates comparison and printing logic for an x.y.z version.
+ */
+public class Version {
+
+    final int major
+    final int minor
+    final int bugfix
+    final int id
+    final boolean snapshot
+
+    public Version(int major, int minor, int bugfix, boolean snapshot) {
+        this.major = major
+        this.minor = minor
+        this.bugfix = bugfix
+        this.snapshot = snapshot
+        this.id = major * 100000 + minor * 1000 + bugfix * 10 + (snapshot ? 1 : 0)
+    }
+
+    public static Version fromString(String s) {
+        String[] parts = s.split('\\.')
+        String bugfix = parts[2]
+        boolean snapshot = false
+        if (bugfix.contains('-')) {
+            snapshot = bugfix.endsWith('-SNAPSHOT')
+            bugfix = bugfix.split('-')[0]
+        }
+        return new Version(parts[0] as int, parts[1] as int, bugfix as int, snapshot)
+    }
+
+    @Override
+    public String toString() {
+        String snapshotStr = snapshot ? '-SNAPSHOT' : ''
+        return "${major}.${minor}.${bugfix}${snapshotStr}"
+    }
+
+    public boolean equals(Version compareTo) {
+        return id == compareTo.id
+    }
+
+    public boolean before(String compareTo) {
+        return id < fromString(compareTo).id
+    }
+
+    public boolean onOrBefore(String compareTo) {
+        return id <= fromString(compareTo).id
+    }
+
+    public boolean onOrAfter(String compareTo) {
+        return id >= fromString(compareTo).id
+    }
+
+    public boolean after(String compareTo) {
+        return id > fromString(compareTo).id
+    }
+}

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -51,8 +51,6 @@ public class RestIntegTestTask extends DefaultTask {
     boolean includePackaged = false
 
     public RestIntegTestTask() {
-        description = 'Runs rest tests against an elasticsearch cluster.'
-        group = JavaBasePlugin.VERIFICATION_GROUP
         runner = project.tasks.create("${name}Runner", RandomizedTestingTask.class)
         super.dependsOn(runner)
         clusterInit = project.tasks.create(name: "${name}Cluster#init", dependsOn: project.testClasses)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestTestPlugin.groovy
@@ -22,6 +22,7 @@ import org.elasticsearch.gradle.BuildPlugin
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaBasePlugin
 
 /**
  * Adds support for starting an Elasticsearch cluster before running integration
@@ -43,6 +44,8 @@ public class RestTestPlugin implements Plugin<Project> {
         }
 
         RestIntegTestTask integTest = project.tasks.create('integTest', RestIntegTestTask.class)
+        integTest.description = 'Runs rest tests against an elasticsearch cluster.'
+        integTest.group = JavaBasePlugin.VERIFICATION_GROUP
         integTest.clusterConfig.distribution = 'zip' // rest tests should run with the real zip
         integTest.mustRunAfter(project.precommit)
         project.check.dependsOn(integTest)

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -18,6 +18,7 @@
  */
 
 import org.elasticsearch.gradle.test.RestIntegTestTask
+import org.elasticsearch.gradle.Version
 
 apply plugin: 'elasticsearch.standalone-test'
 
@@ -27,7 +28,7 @@ task bwcTest {
   group = 'verification'
 }
 
-for (String version : wireCompatVersions) {
+for (Version version : wireCompatVersions) {
   String baseName = "v${version}"
 
   Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
@@ -42,7 +43,9 @@ for (String version : wireCompatVersions) {
     numNodes = 2
     clusterName = 'rolling-upgrade'
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-    setting 'http.content_type.required', 'true'
+    if (version.onOrAfter('5.3.0')) {
+      setting 'http.content_type.required', 'true'
+    }
   }
 
   Task oldClusterTestRunner = tasks.getByName("${baseName}#oldClusterTestRunner")

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -30,7 +30,6 @@ task bwcTest {
 for (String version : wireCompatVersions) {
   String baseName = "v${version}"
 
-  println "creating rest integ test task"
   Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
     mustRunAfter(precommit)
   }
@@ -90,7 +89,6 @@ for (String version : wireCompatVersions) {
   Task versionBwcTest = tasks.create(name: "${baseName}#bwcTest") {
     dependsOn = [upgradedClusterTest]
   }
-  println "Created ${versionBwcTest.name}"
 
   bwcTest.dependsOn(versionBwcTest)
 }

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -22,7 +22,8 @@ import org.elasticsearch.gradle.Version
 
 apply plugin: 'elasticsearch.standalone-test'
 
-// dummy task for all bwc tests
+// This is a top level task which we will add dependencies to below.
+// It is a single task that can be used to backcompat tests against all versions.
 task bwcTest {
   description = 'Runs backwards compatibility tests.'
   group = 'verification'

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -103,10 +103,3 @@ task integTest {
 }
 
 check.dependsOn(integTest)
-
-/*repositories {
-  maven {
-    url "https://oss.sonatype.org/content/repositories/snapshots/"
-  }
-}
-*/

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -21,68 +21,92 @@ import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.standalone-test'
 
-task oldClusterTest(type: RestIntegTestTask) {
-  mustRunAfter(precommit)
+// dummy task for all bwc tests
+task bwcTest {
+  description = 'Runs backwards compatibility tests.'
+  group = 'verification'
 }
 
-oldClusterTestCluster {
-  distribution = 'zip'
-  bwcVersion = project.wireCompatVersions[-1] // TODO: either randomize, or make this settable with sysprop
-  numBwcNodes = 2
-  numNodes = 2
-  clusterName = 'rolling-upgrade'
-  setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-  setting 'http.content_type.required', 'true'
-}
+for (String version : wireCompatVersions) {
+  String baseName = "v${version}"
 
-oldClusterTestRunner {
-  systemProperty 'tests.rest.suite', 'old_cluster'
-}
+  println "creating rest integ test task"
+  Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
+    mustRunAfter(precommit)
+  }
 
-task mixedClusterTest(type: RestIntegTestTask) {}
+  Object extension = extensions.findByName("${baseName}#oldClusterTestCluster")
+  configure(extensions.findByName("${baseName}#oldClusterTestCluster")) {
+    distribution = 'zip'
+    bwcVersion = version
+    numBwcNodes = 2
+    numNodes = 2
+    clusterName = 'rolling-upgrade'
+    setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
+    setting 'http.content_type.required', 'true'
+  }
 
-mixedClusterTestCluster {
-  dependsOn oldClusterTestRunner, 'oldClusterTestCluster#node1.stop'
-  distribution = 'zip'
-  clusterName = 'rolling-upgrade'
-  unicastTransportUri = { seedNode, node, ant -> oldClusterTest.nodes.get(0).transportUri() }
-  dataDir = "${-> oldClusterTest.nodes[1].dataDir}"
-  setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-}
+  Task oldClusterTestRunner = tasks.getByName("${baseName}#oldClusterTestRunner")
+  oldClusterTestRunner.configure {
+    systemProperty 'tests.rest.suite', 'old_cluster'
+  }
 
-mixedClusterTestRunner {
-  systemProperty 'tests.rest.suite', 'mixed_cluster'
-  finalizedBy 'oldClusterTestCluster#node0.stop'
-}
+  Task mixedClusterTest = tasks.create(name: "${baseName}#mixedClusterTest", type: RestIntegTestTask)
 
-task upgradedClusterTest(type: RestIntegTestTask) {
-  dependsOn(mixedClusterTestRunner, 'oldClusterTestCluster#node0.stop')
-}
+  configure(extensions.findByName("${baseName}#mixedClusterTestCluster")) {
+    dependsOn oldClusterTestRunner, "${baseName}#oldClusterTestCluster#node1.stop"
+    distribution = 'zip'
+    clusterName = 'rolling-upgrade'
+    unicastTransportUri = { seedNode, node, ant -> oldClusterTest.nodes.get(0).transportUri() }
+    dataDir = "${-> oldClusterTest.nodes[1].dataDir}"
+    setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
+  }
 
-upgradedClusterTestCluster {
-  distribution = 'zip'
-  clusterName = 'rolling-upgrade'
-  unicastTransportUri = { seedNode, node, ant -> mixedClusterTest.nodes.get(0).transportUri() }
-  dataDir = "${-> oldClusterTest.nodes[0].dataDir}"
-  setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
-}
+  Task mixedClusterTestRunner = tasks.getByName("${baseName}#mixedClusterTestRunner")
+  mixedClusterTestRunner.configure {
+    systemProperty 'tests.rest.suite', 'mixed_cluster'
+    finalizedBy "${baseName}#oldClusterTestCluster#node0.stop"
+  }
 
-upgradedClusterTestRunner {
-  systemProperty 'tests.rest.suite', 'upgraded_cluster'
-  // only need to kill the mixed cluster tests node here because we explicitly told it to not stop nodes upon completion
-  finalizedBy 'mixedClusterTestCluster#stop'
-}
+  Task upgradedClusterTest = tasks.create(name: "${baseName}#upgradedClusterTest", type: RestIntegTestTask) {
+    dependsOn(mixedClusterTestRunner, "${baseName}#oldClusterTestCluster#node0.stop")
+  }
 
-task integTest {
-  dependsOn = [upgradedClusterTest]
+  configure(extensions.findByName("${baseName}#upgradedClusterTestCluster")) {
+    distribution = 'zip'
+    clusterName = 'rolling-upgrade'
+    unicastTransportUri = { seedNode, node, ant -> mixedClusterTest.nodes.get(0).transportUri() }
+    dataDir = "${-> oldClusterTest.nodes[0].dataDir}"
+    setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
+  }
+
+  Task upgradedClusterTestRunner = tasks.getByName("${baseName}#upgradedClusterTestRunner")
+  upgradedClusterTestRunner.configure {
+    systemProperty 'tests.rest.suite', 'upgraded_cluster'
+    // only need to kill the mixed cluster tests node here because we explicitly told it to not stop nodes upon completion
+    finalizedBy "${baseName}#mixedClusterTestCluster#stop"
+  }
+
+  Task versionBwcTest = tasks.create(name: "${baseName}#bwcTest") {
+    dependsOn = [upgradedClusterTest]
+  }
+  println "Created ${versionBwcTest.name}"
+
+  bwcTest.dependsOn(versionBwcTest)
 }
 
 test.enabled = false // no unit tests for rolling upgrades, only the rest integration test
 
+// basic integ tests includes testing bwc against the most recent version
+task integTest {
+  dependsOn = ["v${wireCompatVersions[-1]}#bwcTest"]
+}
+
 check.dependsOn(integTest)
 
-repositories {
+/*repositories {
   maven {
     url "https://oss.sonatype.org/content/repositories/snapshots/"
   }
 }
+*/


### PR DESCRIPTION
This commit changes the rolling upgrade test to create a set of rest
test tasks per wire compat version. The most recent wire compat version
is always tested with the `integTest` task, and all versions can be
tested with `bwcTest`.