### PR TITLE
Fix indentation for mem_limit

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -154,7 +154,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-    mem_limit: 1g
+      mem_limit: 1g
     volumes:
       - esdata1:/usr/share/elasticsearch/data
     ports:
@@ -172,7 +172,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-    mem_limit: 1g
+      mem_limit: 1g
     volumes:
       - esdata2:/usr/share/elasticsearch/data
     networks:


### PR DESCRIPTION
When running the docker-compose example the following error is shown:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services.elasticsearch1: 'mem_limit'.
```

The fix sets the `mem_limit` option below the `ulimits`.
