### PR TITLE
[Analysis] Support normalizer in request param

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequest.java
@@ -223,6 +223,9 @@ public class AnalyzeRequest extends SingleShardRequest<AnalyzeRequest> {
         if ((index == null || index.length() == 0) && normalizer != null) {
             validationException = addValidationError("index is required if normalizer is specified", validationException);
         }
+        if (normalizer != null && (tokenizer != null || analyzer != null)) {
+            validationException = addValidationError("tokenizer/analyze should be null if normalizer is specified", validationException);
+        }
         return validationException;
     }
 
@@ -237,7 +240,7 @@ public class AnalyzeRequest extends SingleShardRequest<AnalyzeRequest> {
         field = in.readOptionalString();
         explain = in.readBoolean();
         attributes = in.readStringArray();
-        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha3)) {
             normalizer = in.readOptionalString();
         }
     }
@@ -253,7 +256,7 @@ public class AnalyzeRequest extends SingleShardRequest<AnalyzeRequest> {
         out.writeOptionalString(field);
         out.writeBoolean(explain);
         out.writeStringArray(attributes);
-        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
+        if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha3)) {
             out.writeOptionalString(normalizer);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
@@ -125,4 +125,13 @@ public class AnalyzeRequestBuilder extends SingleShardOperationRequestBuilder<An
         request.text(texts);
         return this;
     }
+
+    /**
+     * Instead of setting the analyzer and tokenizer, sets the normalizer as name
+     */
+    public AnalyzeRequestBuilder setNormalizer(String normalizer) {
+        request.normalizer(normalizer);
+        return this;
+    }
+
 }

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
@@ -46,6 +46,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
         public static final ParseField CHAR_FILTERS = new ParseField("char_filter");
         public static final ParseField EXPLAIN = new ParseField("explain");
         public static final ParseField ATTRIBUTES = new ParseField("attributes");
+        public static final ParseField NORMALIZER = new ParseField("normalizer");
     }
 
     public RestAnalyzeAction(Settings settings, RestController controller) {
@@ -147,6 +148,12 @@ public class RestAnalyzeAction extends BaseRestHandler {
                         attributes.add(parser.text());
                     }
                     analyzeRequest.attributes(attributes.toArray(new String[attributes.size()]));
+                } else if (Fields.NORMALIZER.match(currentFieldName)) {
+                    if (token == XContentParser.Token.VALUE_STRING) {
+                        analyzeRequest.normalizer(parser.text());
+                    } else {
+                        throw new IllegalArgumentException(currentFieldName + " should be normalizer's name");
+                    }
                 } else {
                     throw new IllegalArgumentException("Unknown parameter ["
                             + currentFieldName + "] in request body or parameter is of the wrong type[" + token + "] ");

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestTests.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.analyze;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.common.xcontent.yaml.YamlXContent;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Base64;
+
+
+public class AnalyzeRequestTests extends ESTestCase {
+
+    public void testValidation() throws Exception {
+        AnalyzeRequest request = new AnalyzeRequest();
+
+        ActionRequestValidationException e = request.validate();
+        assertNotNull("text validation should fail", e);
+        assertTrue(e.getMessage().contains("text is missing"));
+
+        request.text(new String[0]);
+        e = request.validate();
+        assertNotNull("text validation should fail", e);
+        assertTrue(e.getMessage().contains("text is missing"));
+
+        request.text("");
+        request.normalizer("some normalizer");
+        e = request.validate();
+        assertNotNull("normalizer validation should fail", e);
+        assertTrue(e.getMessage().contains("index is required if normalizer is specified"));
+
+        request.index("");
+        e = request.validate();
+        assertNotNull("normalizer validation should fail", e);
+        assertTrue(e.getMessage().contains("index is required if normalizer is specified"));
+
+        request.index("something");
+        e = request.validate();
+        assertNull("something wrong in validate", e);
+
+        request.tokenizer("tokenizer");
+        e = request.validate();
+        assertTrue(e.getMessage().contains("tokenizer/analyze should be null if normalizer is specified"));
+
+        AnalyzeRequest requestAnalyzer = new AnalyzeRequest("index");
+        requestAnalyzer.normalizer("some normalizer");
+        requestAnalyzer.text("something");
+        requestAnalyzer.analyzer("analyzer");
+        e = requestAnalyzer.validate();
+        assertTrue(e.getMessage().contains("tokenizer/analyze should be null if normalizer is specified"));
+    }
+
+    public void testSerialization() throws IOException {
+        AnalyzeRequest request = new AnalyzeRequest("foo");
+        request.text("a", "b");
+        request.tokenizer("tokenizer");
+        request.addTokenFilter("tokenfilter");
+        request.addCharFilter("charfilter");
+        request.normalizer("normalizer");
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            request.writeTo(output);
+            try (StreamInput in = output.bytes().streamInput()) {
+                AnalyzeRequest serialized = new AnalyzeRequest();
+                serialized.readFrom(in);
+                assertArrayEquals(request.text(), serialized.text());
+                assertEquals(request.tokenizer().name, serialized.tokenizer().name);
+                assertEquals(request.tokenFilters().get(0).name, serialized.tokenFilters().get(0).name);
+                assertEquals(request.charFilters().get(0).name, serialized.charFilters().get(0).name);
+                assertEquals(request.normalizer(), serialized.normalizer());
+            }
+        }
+    }
+
+    public void testSerializationBwc() throws IOException {
+        final byte[] data = Base64.getDecoder().decode("AAABA2ZvbwEEdGV4dAAAAAAAAAABCm5vcm1hbGl6ZXI=");
+        final Version version = randomFrom(Version.V_5_0_0, Version.V_5_0_1, Version.V_5_0_2,
+            Version.V_5_1_1, Version.V_5_1_2, Version.V_5_3_0, Version.V_5_3_1, Version.V_5_3_2,
+            Version.V_5_4_0);
+        try (StreamInput in = StreamInput.wrap(data)) {
+            in.setVersion(version);
+            AnalyzeRequest request = new AnalyzeRequest();
+            request.readFrom(in);
+            assertEquals("foo", request.index());
+            assertNull("normalizer support after 6.0.0", request.normalizer());
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestTests.java
@@ -23,11 +23,8 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.Base64;
@@ -98,9 +95,7 @@ public class AnalyzeRequestTests extends ESTestCase {
 
     public void testSerializationBwc() throws IOException {
         final byte[] data = Base64.getDecoder().decode("AAABA2ZvbwEEdGV4dAAAAAAAAAABCm5vcm1hbGl6ZXI=");
-        final Version version = randomFrom(Version.V_5_0_0, Version.V_5_0_1, Version.V_5_0_2,
-            Version.V_5_1_1, Version.V_5_1_2, Version.V_5_3_0, Version.V_5_3_1, Version.V_5_3_2,
-            Version.V_5_4_0);
+        final Version version = VersionUtils.randomVersionBetween(random(), Version.V_5_0_0, Version.V_5_4_0);
         try (StreamInput in = StreamInput.wrap(data)) {
             in.setVersion(version);
             AnalyzeRequest request = new AnalyzeRequest();

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestTests.java
@@ -94,6 +94,10 @@ public class AnalyzeRequestTests extends ESTestCase {
     }
 
     public void testSerializationBwc() throws IOException {
+        // AnalyzeRequest serializedRequest = new AnalyzeRequest("foo");
+        // serializedRequest.text("text");
+        // serializedRequest.normalizer("normalizer");
+        // Using Version.V_6_0_0_alpha3
         final byte[] data = Base64.getDecoder().decode("AAABA2ZvbwEEdGV4dAAAAAAAAAABCm5vcm1hbGl6ZXI=");
         final Version version = VersionUtils.randomVersionBetween(random(), Version.V_5_0_0, Version.V_5_4_0);
         try (StreamInput in = StreamInput.wrap(data)) {

--- a/core/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/analyze/AnalyzeActionIT.java
@@ -458,6 +458,7 @@ public class AnalyzeActionIT extends ESIntegTestCase {
         assertThat(token.getEndOffset(), equalTo(3));
         assertThat(token.getPosition(), equalTo(0));
         assertThat(token.getPositionLength(), equalTo(1));
-
     }
+
+
 }

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeActionTests.java
@@ -75,6 +75,7 @@ public class RestAnalyzeActionTests extends ESTestCase {
                         .array("mappings", "ph => f", "qu => q")
                     .endObject()
                 .endArray()
+                .field("normalizer", "normalizer")
             .endObject());
 
         AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
@@ -89,6 +90,7 @@ public class RestAnalyzeActionTests extends ESTestCase {
         assertThat(analyzeRequest.tokenFilters().get(1).definition, notNullValue());
         assertThat(analyzeRequest.charFilters().size(), equalTo(1));
         assertThat(analyzeRequest.charFilters().get(0).definition, notNullValue());
+        assertThat(analyzeRequest.normalizer(), equalTo("normalizer"));
     }
 
     public void testParseXContentForAnalyzeRequestWithInvalidJsonThrowsException() throws Exception {
@@ -120,6 +122,17 @@ public class RestAnalyzeActionTests extends ESTestCase {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
             () -> RestAnalyzeAction.buildFromContent(invalidExplain, analyzeRequest));
         assertThat(e.getMessage(), startsWith("explain must be either 'true' or 'false'"));
+    }
+
+    public void testParseXContentForAnalyzeRequestWithInvalidNromalizerThrowsException() throws Exception {
+        AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
+        XContentParser invalidExplain = createParser(XContentFactory.jsonBuilder()
+            .startObject()
+            .field("normalizer", true)
+            .endObject());
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> RestAnalyzeAction.buildFromContent(invalidExplain, analyzeRequest));
+        assertThat(e.getMessage(), startsWith("normalizer should be normalizer's name"));
     }
 
     public void testDeprecatedParamIn2xException() throws Exception {

--- a/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeActionTests.java
@@ -124,7 +124,7 @@ public class RestAnalyzeActionTests extends ESTestCase {
         assertThat(e.getMessage(), startsWith("explain must be either 'true' or 'false'"));
     }
 
-    public void testParseXContentForAnalyzeRequestWithInvalidNromalizerThrowsException() throws Exception {
+    public void testParseXContentForAnalyzeRequestWithInvalidNormalizerThrowsException() throws Exception {
         AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
         XContentParser invalidExplain = createParser(XContentFactory.jsonBuilder()
             .startObject()

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -457,3 +457,23 @@ buildRestTests.setups['stored_scripted_metric_script'] = '''
         body: { "script": { "lang": "painless", "source": "double profit = 0;for (a in params._aggs) { profit += a; } return profit" } }
   - match: { acknowledged: true }
 '''
+
+// Used by analyze api
+buildRestTests.setups['analyze_sample'] = '''
+  - do:
+        indices.create:
+          index: analyze_sample
+          body:
+            settings:
+              number_of_shards: 1
+              number_of_replicas: 0
+              analysis:
+                normalizer:
+                  my_normalizer:
+                    type: custom
+                    filter: [lowercase]
+            mappings:
+              tweet:
+                properties:
+                  obj1.field1:
+                    type: text'''

--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -84,7 +84,7 @@ GET analyze_sample/_analyze
 // TEST[setup:analyze_sample]
 
 The above will run an analysis on the "this is a test" text, using the
-default index analyzer associated with the `twitter` index. An `analyzer`
+default index analyzer associated with the `analyze_sample` index. An `analyzer`
 can also be provided to use a different analyzer:
 
 [source,js]
@@ -114,7 +114,7 @@ GET analyze_sample/_analyze
 Will cause the analysis to happen based on the analyzer configured in the
 mapping for `obj1.field1` (and if not, the default index analyzer).
 
-A `normalizer` can be provided for keyword field with normalizer associated with the `twitter` index.
+A `normalizer` can be provided for keyword field with normalizer associated with the `analyze_sample` index.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -75,44 +75,69 @@ It can also run against a specific index:
 
 [source,js]
 --------------------------------------------------
-GET twitter/_analyze
+GET analyze_sample/_analyze
 {
   "text" : "this is a test"
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[setup:twitter]
+// TEST[setup:analyze_sample]
 
 The above will run an analysis on the "this is a test" text, using the
-default index analyzer associated with the `test` index. An `analyzer`
+default index analyzer associated with the `twitter` index. An `analyzer`
 can also be provided to use a different analyzer:
 
 [source,js]
 --------------------------------------------------
-GET twitter/_analyze
+GET analyze_sample/_analyze
 {
   "analyzer" : "whitespace",
   "text" : "this is a test"
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[setup:twitter]
+// TEST[setup:analyze_sample]
 
 Also, the analyzer can be derived based on a field mapping, for example:
 
 [source,js]
 --------------------------------------------------
-GET twitter/_analyze
+GET analyze_sample/_analyze
 {
   "field" : "obj1.field1",
   "text" : "this is a test"
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[setup:twitter]
+// TEST[setup:analyze_sample]
 
 Will cause the analysis to happen based on the analyzer configured in the
 mapping for `obj1.field1` (and if not, the default index analyzer).
+
+A `normalizer` can be provided for keyword field with normalizer associated with the `twitter` index.
+
+[source,js]
+--------------------------------------------------
+GET analyze_sample/_analyze
+{
+  "normalizer" : "my_normalizer",
+  "text" : "BaR"
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:analyze_sample]
+
+Or by building a custom transient normalizer out of token filters and char filters.
+
+[source,js]
+--------------------------------------------------
+GET _analyze
+{
+  "filter" : ["lowercase"],
+  "text" : "BaR"
+}
+--------------------------------------------------
+// CONSOLE
 
 === Explain Analyze
 

--- a/docs/reference/migration/migrate_6_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_6_0/rest.asciidoc
@@ -31,6 +31,12 @@ value `false` and boolean "true" as the value `true`. All other values will rais
 
 The deprecated request parameters and plain text in request body has been removed. Define parameters in request body.
 
+==== Support custom normalizer in Analyze API
+
+Analyze API can analyze normalizer and custom normalizer.
+In previous versions of Elasticsearch, Analyze API is required `tokenizer` or `analyzer` parameter.
+In Elaticsearch 6.0.0, Analyze API analyze a text as a keyword field with custom normalizer if `char_filter`/`filter` without `tokenizer`/`analyzer`.
+
 ==== Indices exists API
 
 The `ignore_unavailable` and `allow_no_indices` options are no longer accepted

--- a/docs/reference/migration/migrate_6_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_6_0/rest.asciidoc
@@ -34,8 +34,9 @@ The deprecated request parameters and plain text in request body has been remove
 ==== Support custom normalizer in Analyze API
 
 Analyze API can analyze normalizer and custom normalizer.
-In previous versions of Elasticsearch, Analyze API is required `tokenizer` or `analyzer` parameter.
-In Elaticsearch 6.0.0, Analyze API analyze a text as a keyword field with custom normalizer if `char_filter`/`filter` without `tokenizer`/`analyzer`.
+In previous versions of Elasticsearch, Analyze API is requiring a `tokenizer` or `analyzer` parameter.
+In Elasticsearch 6.0.0, Analyze API can analyze a text as a keyword field with custom normalizer
+or if `char_filter`/`filter` is set and `tokenizer`/`analyzer` is not set.
 
 ==== Indices exists API
 

--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
@@ -1,0 +1,19 @@
+---
+"Custom normalizer with illegal filter in request":
+    # Tests analyze api with normalizer. This is in the analysis-common module
+    # because there are no filters that support multiTermAware
+    - skip:
+        version: " - 5.99.99"
+        reason:  normalizer support in 6.0.0
+    - do:
+        catch: request
+        indices.analyze:
+          body:
+            text: ABc
+            explain: true
+            filter: [word_delimiter]
+
+    - match: { status: 400 }
+    - match: { error.type: illegal_argument_exception }
+    - match: { error.reason: "Custom normalizer may not use filter [word_delimiter]" }
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
@@ -111,3 +111,40 @@
     - length: { tokens: 2 }
     - match:  { tokens.0.token: sha }
     - match:  { tokens.1.token: hay }
+
+---
+"Custom normalizer in request":
+    - skip:
+        version: " - 5.99.99"
+        reason:  normalizer support in 6.0.0
+    - do:
+        indices.analyze:
+          body:
+            text: ABc
+            explain: true
+            filter: ["lowercase"]
+
+    - length: { detail.tokenizer.tokens: 1 }
+    - length: { detail.tokenfilters.0.tokens: 1 }
+    - match:  { detail.tokenizer.name: keyword }
+    - match:  { detail.tokenizer.tokens.0.token: ABc }
+    - match:  { detail.tokenfilters.0.name: lowercase }
+    - match:  { detail.tokenfilters.0.tokens.0.token: abc }
+
+---
+"Custom normalizer with illegal char_filter in request":
+    - skip:
+        version: " - 5.99.99"
+        reason:  normalizer support in 6.0.0
+    - do:
+        catch: request
+        indices.analyze:
+          body:
+            text: ABc
+            explain: true
+            char_filter: ["html_strip"]
+
+    - match: { status: 400 }
+    - match: { error.type: illegal_argument_exception }
+    - match: { error.reason: "Custom normalizer may not use char filter [html_strip]" }
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
@@ -126,25 +126,7 @@
 
     - length: { detail.tokenizer.tokens: 1 }
     - length: { detail.tokenfilters.0.tokens: 1 }
-    - match:  { detail.tokenizer.name: keyword }
+    - match:  { detail.tokenizer.name: keyword_for_normalizer }
     - match:  { detail.tokenizer.tokens.0.token: ABc }
     - match:  { detail.tokenfilters.0.name: lowercase }
     - match:  { detail.tokenfilters.0.tokens.0.token: abc }
-
----
-"Custom normalizer with illegal char_filter in request":
-    - skip:
-        version: " - 5.99.99"
-        reason:  normalizer support in 6.0.0
-    - do:
-        catch: request
-        indices.analyze:
-          body:
-            text: ABc
-            explain: true
-            char_filter: ["html_strip"]
-
-    - match: { status: 400 }
-    - match: { error.type: illegal_argument_exception }
-    - match: { error.reason: "Custom normalizer may not use char filter [html_strip]" }
-


### PR DESCRIPTION
Support normalizer param and custom normalizer with char_filter/filter param.

In this PR, I didn't change a response.
If user send a request with keyword field name or normalizer name, analyze api display a response with tokenizer that is KeywordTokenizer.
Should we change a response format for normalizer?

Closes #23347