### PR TITLE
remove remaining references to scripts directory

### DIFF
--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -110,7 +110,6 @@ chown -R elasticsearch:elasticsearch /var/lib/elasticsearch
 chown -R elasticsearch:elasticsearch /var/log/elasticsearch
 chown -R root:elasticsearch /etc/elasticsearch
 chmod 0750 /etc/elasticsearch
-chmod 0750 /etc/elasticsearch/scripts
 
 if [ -f /etc/sysconfig/elasticsearch ]; then
    chmod 0660 /etc/sysconfig/elasticsearch

--- a/distribution/src/main/packaging/scripts/prerm
+++ b/distribution/src/main/packaging/scripts/prerm
@@ -79,12 +79,6 @@ if [ "$REMOVE_SERVICE" = "true" ]; then
     if command -v update-rc.d >/dev/null; then
         update-rc.d elasticsearch remove >/dev/null || true
     fi
-
-    SCRIPTS_DIR="/etc/elasticsearch/scripts"
-    # delete the scripts directory if and only if empty
-    if [ -d "$SCRIPTS_DIR" ]; then
-        rmdir --ignore-fail-on-non-empty "$SCRIPTS_DIR"
-    fi
 fi
 
 


### PR DESCRIPTION
The packaging scripts still referenced the scripts directory which is now removed.

