### PR TITLE
Add document count to Matrix Stats aggregation response

### DIFF
--- a/docs/reference/aggregations/matrix/stats-aggregation.asciidoc
+++ b/docs/reference/aggregations/matrix/stats-aggregation.asciidoc
@@ -37,6 +37,7 @@ the statistics. The above request returns the following response:
     ...
     "aggregations": {
         "matrixstats": {
+            "doc_count": 50,
             "fields": [{
                 "name": "income",
                 "count": 50,
@@ -72,6 +73,8 @@ the statistics. The above request returns the following response:
     }
 }
 --------------------------------------------------
+
+The `doc_count` field indicates the number of documents involved in the computation of the statistics.
 
 ==== Multi Value Fields
 

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
@@ -161,7 +161,7 @@ public class InternalMatrixStats extends InternalAggregation implements MatrixSt
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
-        if (results != null) {
+        if (results != null && results.getFieldCounts().keySet().isEmpty() == false) {
             builder.startArray(Fields.FIELDS);
             for (String fieldName : results.getFieldCounts().keySet()) {
                 builder.startObject();

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
@@ -73,6 +73,9 @@ public class InternalMatrixStats extends InternalAggregation implements MatrixSt
     /** get the number of documents */
     @Override
     public long getDocCount() {
+        if (stats == null) {
+            return 0;
+        }
         return stats.docCount;
     }
 
@@ -157,7 +160,8 @@ public class InternalMatrixStats extends InternalAggregation implements MatrixSt
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        if (results != null && results.getFieldCounts().keySet().isEmpty() == false) {
+        builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
+        if (results != null) {
             builder.startArray(Fields.FIELDS);
             for (String fieldName : results.getFieldCounts().keySet()) {
                 builder.startObject();

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yml
@@ -133,6 +133,7 @@ setup:
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"]} } } }
 
   - match: {hits.total: 0}
+  - match: {aggregations.mfs.doc_count: 0}
 
 ---
 "Single value field":
@@ -144,6 +145,7 @@ setup:
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val3"]} } } }
 
   - match: {hits.total: 15}
+  - match: {aggregations.mfs.doc_count: 15}
   - match: {aggregations.mfs.fields.0.count: 15}
 
 ---
@@ -156,6 +158,7 @@ setup:
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"]} } } }
 
   - match: {hits.total: 15}
+  - match: {aggregations.mfs.doc_count: 14}
   - match: {aggregations.mfs.fields.0.count: 14}
   - match: {aggregations.mfs.fields.2.correlation.val2: 0.9569513137793205}
 
@@ -169,6 +172,7 @@ setup:
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"], "missing" : {"val2" : 10} } } } }
 
   - match: {hits.total: 15}
+  - match: {aggregations.mfs.doc_count: 15}
   - match: {aggregations.mfs.fields.0.count: 15}
   - match: {aggregations.mfs.fields.2.correlation.val2: 0.9567970467908384}
 

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yml
@@ -133,6 +133,7 @@ setup:
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "vals"]} } } }
 
   - match: {hits.total: 0}
+  - match: {aggregations.mfs.doc_count: 0}
 
 ---
 "Multi value field Max":
@@ -144,6 +145,7 @@ setup:
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "vals"], "mode" : "max"} } } }
 
   - match: {hits.total: 15}
+  - match: {aggregations.mfs.doc_count: 14}
   - match: {aggregations.mfs.fields.0.count: 14}
   - match: {aggregations.mfs.fields.0.correlation.val1: 0.06838646533369998}
 
@@ -157,6 +159,7 @@ setup:
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "vals"], "mode" : "min"} } } }
 
   - match: {hits.total: 15}
+  - match: {aggregations.mfs.doc_count: 14}
   - match: {aggregations.mfs.fields.0.count: 14}
   - match: {aggregations.mfs.fields.0.correlation.val1: -0.09777682707831963}
 
@@ -170,6 +173,7 @@ setup:
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "vals"]} } } }
 
   - match: {hits.total: 15}
+  - match: {aggregations.mfs.doc_count: 13}
   - match: {aggregations.mfs.fields.0.count: 13}
   - match: {aggregations.mfs.fields.0.correlation.val1: -0.044997535185684244}
 
@@ -183,6 +187,7 @@ setup:
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "vals"], "missing" : {"val2" : 10, "vals" : 5 } } } } }
 
   - match: {hits.total: 15}
+  - match: {aggregations.mfs.doc_count: 15}
   - match: {aggregations.mfs.fields.0.count: 15}
   - match: {aggregations.mfs.fields.0.correlation.val2: 0.04028024709708195}
 


### PR DESCRIPTION
This commit adds a `doc_count` field to the response body of Matrix Stats aggregation. It exposes the number of documents involved in  the computation of statistics, a value that can already be retrieved using
the method `MatrixStats.getDocCount()` in the Java API.

This information will be useful for the Java High Level Rest Client in order to provide the same level of information as what a user can get using the Transport Client (see https://github.com/elastic/elasticsearch/pull/24746#discussion_r117244017).
