### PR TITLE
Add Ability to Specify No Types/Contexts Allowed For Scripts

### DIFF
--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -261,7 +261,7 @@ public class ScriptServiceTests extends ESTestCase {
 
     public void testAllowNoScriptTypeSettings() throws IOException {
         Settings.Builder builder = Settings.builder();
-        builder.put("script.types_allowed", "");
+        builder.put("script.types_allowed", "none");
         buildScriptService(builder.build());
 
         assertCompileRejected("painless", "script", ScriptType.INLINE, ScriptContext.Standard.SEARCH);
@@ -270,7 +270,7 @@ public class ScriptServiceTests extends ESTestCase {
 
     public void testAllowNoScriptContextSettings() throws IOException {
         Settings.Builder builder = Settings.builder();
-        builder.put("script.contexts_allowed", "");
+        builder.put("script.contexts_allowed", "none");
         buildScriptService(builder.build());
 
         assertCompileRejected("painless", "script", ScriptType.INLINE, ScriptContext.Standard.SEARCH);

--- a/docs/reference/modules/scripting/security.asciidoc
+++ b/docs/reference/modules/scripting/security.asciidoc
@@ -110,7 +110,7 @@ script.allowed_types: inline <1>
 
 By default all script contexts are allowed to be executed.  This can be modified using the
 setting `script.allowed_contexts`.  Only the contexts specified as part of the setting will
-be allowed to be executed.  To specify no contexts are allowed, `set scripts.allowed_contexts`
+be allowed to be executed.  To specify no contexts are allowed, set `scripts.allowed_contexts`
 to be `none`.
 
 [source,yaml]

--- a/docs/reference/modules/scripting/security.asciidoc
+++ b/docs/reference/modules/scripting/security.asciidoc
@@ -94,7 +94,8 @@ security of the Elasticsearch deployment.
 
 By default all script types are allowed to be executed.  This can be modified using the
 setting `script.allowed_types`.  Only the types specified as part of the setting will be
-allowed to be executed.
+allowed to be executed.  To specify no types are allowed, set `scripts.allowed_types` to
+be `none`.
 
 [source,yaml]
 ----
@@ -109,7 +110,8 @@ script.allowed_types: inline <1>
 
 By default all script contexts are allowed to be executed.  This can be modified using the
 setting `script.allowed_contexts`.  Only the contexts specified as part of the setting will
-be allowed to be executed.
+be allowed to be executed.  To specify no contexts are allowed, `set scripts.allowed_contexts`
+to be `none`.
 
 [source,yaml]
 ----


### PR DESCRIPTION
Adds a special setting value of "none" for "script.allowed_types" and "script.allowed_contexts" to specify no types/contexts are allowed, respectively.