### PR TITLE
GET _tasks/taskId:1 doesn't work to get task info

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -664,7 +664,7 @@ With the task id you can look up the task directly:
 
 [source,js]
 --------------------------------------------------
-GET /_tasks/taskId:1
+GET /_tasks/nodeId:taskId
 --------------------------------------------------
 // CONSOLE
 // TEST[catch:missing]
@@ -685,7 +685,7 @@ Any Reindex can be canceled using the <<tasks,Task Cancel API>>:
 
 [source,js]
 --------------------------------------------------
-POST _tasks/task_id:1/_cancel
+POST _tasks/node_id:task_id/_cancel
 --------------------------------------------------
 // CONSOLE
 
@@ -704,7 +704,7 @@ the `_rethrottle` API:
 
 [source,js]
 --------------------------------------------------
-POST _reindex/task_id:1/_rethrottle?requests_per_second=-1
+POST _reindex/node_id:task_id/_rethrottle?requests_per_second=-1
 --------------------------------------------------
 // CONSOLE
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -668,6 +668,7 @@ GET /_tasks/nodeId:taskId
 --------------------------------------------------
 // CONSOLE
 // TEST[catch:missing]
+// TEST[s/:taskId/1/]
 
 The advantage of this API is that it integrates with `wait_for_completion=false`
 to transparently return the status of completed tasks. If the task is completed
@@ -688,6 +689,7 @@ Any Reindex can be canceled using the <<tasks,Task Cancel API>>:
 POST _tasks/node_id:task_id/_cancel
 --------------------------------------------------
 // CONSOLE
+// TEST[s/:taskId/1/]
 
 The `task_id` can be found using the tasks API above.
 
@@ -707,6 +709,7 @@ the `_rethrottle` API:
 POST _reindex/node_id:task_id/_rethrottle?requests_per_second=-1
 --------------------------------------------------
 // CONSOLE
+// TEST[s/:taskId/1/]
 
 The `task_id` can be found using the tasks API above.
 


### PR DESCRIPTION
The proposed API doesn't work.
Instead, the one suggested in the Tasks API page works.
Like GET _tasks/node_id:task_id works.
Similarly for cancelling and re-throttling

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
