### PR TITLE
Makes the index alias cluster state updates method public for testing

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -88,12 +88,13 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
 
                 @Override
                 public ClusterState execute(ClusterState currentState) {
-                    return innerExecute(currentState, request.actions());
+                    return updateAliasesInClusterState(currentState, request.actions());
                 }
             });
     }
 
-    ClusterState innerExecute(ClusterState currentState, Iterable<AliasAction> actions) {
+    // public for use in tests
+    public ClusterState updateAliasesInClusterState(ClusterState currentState, Iterable<AliasAction> actions) {
         List<Index> indicesToClose = new ArrayList<>();
         Map<String, IndexService> indices = new HashMap<>();
         try {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -93,8 +93,11 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
             });
     }
 
-    // public for use in tests
-    public ClusterState updateAliasesInClusterState(ClusterState currentState, Iterable<AliasAction> actions) {
+    /**
+     * Updates the given cluster state with the requested {@link AliasAction}s to perform
+     * and returns a new cluster state.
+     */
+    public final ClusterState updateAliasesInClusterState(ClusterState currentState, Iterable<AliasAction> actions) {
         List<Index> indicesToClose = new ArrayList<>();
         Map<String, IndexService> indices = new HashMap<>();
         try {


### PR DESCRIPTION
This commit changes the name of the method that updates the cluster 
state with index aliases to make it more meaningful and makes the 
method public for use in tests.