### PR TITLE
Move getType to Aggregation interface

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregation.java
@@ -40,6 +40,13 @@ public interface Aggregation extends ToXContent {
     String getName();
 
     /**
+     * @return a string representing the type of the aggregation. This type is added to
+     * the aggregation name in the response, so that it can later be used by clients
+     * to determine type of the aggregation and parse it into the proper object.
+     */
+    String getType();
+
+    /**
      * Get the optional byte array metadata that was set on the aggregation
      */
     Map<String, Object> getMetaData();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -169,11 +169,7 @@ public abstract class InternalAggregation implements Aggregation, ToXContent, Na
         return pipelineAggregators;
     }
 
-    /**
-     * Returns a string representing the type of the aggregation. This type is added to
-     * the aggregation name in the response, so that it can later be used by REST clients
-     * to determine the internal type of the aggregation.
-     */
+    @Override
     public String getType() {
         return getWriteableName();
     }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedAggregation.java
@@ -57,14 +57,6 @@ public abstract class ParsedAggregation implements Aggregation, ToXContent {
         return metadata;
     }
 
-    /**
-     * Returns a string representing the type of the aggregation. This type is added to
-     * the aggregation name in the response, so that it can later be used by REST clients
-     * to determine the internal type of the aggregation.
-     */
-    //TODO it may make sense to move getType to the Aggregation interface given that we are duplicating it in both implementations
-    public abstract String getType();
-
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         // Concatenates the type and the name of the aggregation (ex: top_hits#foo)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregationTestCase.java
@@ -122,7 +122,7 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
         assertTrue(expected instanceof InternalAggregation);
         assertEquals(expected.getName(), actual.getName());
         assertEquals(expected.getMetaData(), actual.getMetaData());
-        assertEquals(((InternalAggregation) expected).getType(), ((ParsedAggregation) actual).getType());
+        assertEquals(expected.getType(), actual.getType());
     }
 
     protected void assertBucket(MultiBucketsAggregation.Bucket expected, MultiBucketsAggregation.Bucket actual, boolean checkOrder) {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -333,7 +333,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
             assertEquals(aggregation.getMetaData(), parsedAggregation.getMetaData());
 
             assertTrue(parsedAggregation instanceof ParsedAggregation);
-            assertEquals(aggregation.getType(), ((ParsedAggregation) parsedAggregation).getType());
+            assertEquals(aggregation.getType(), parsedAggregation.getType());
         }
 
         BytesReference parsedBytes = toXContent(parsedAggregation, xContentType, params, humanReadable);


### PR DESCRIPTION
Given that both InternalAggregation and ParsedAggregation have this method, it makes sense to move it to the interface they both implement.