### PR TITLE
[Tests] Improve error message for failed xContentEquivalent() tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.test.hamcrest;
 
-import org.apache.logging.log4j.util.Strings;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchException;
@@ -805,13 +804,13 @@ public class ElasticsearchAssertions {
      * Compares two maps recursively, using arrays comparisons for byte[] through Arrays.equals(byte[], byte[])
      */
     private static void assertMapEquals(Map<String, Object> expected, Map<String, Object> actual, Stack<String> path) {
-        assertEquals("different field names at [" + Strings.join(path, '/') + "]: " + expected.keySet() + " vs. " + actual.keySet(),
-                expected.size(), actual.size());
+        assertEquals("different xContent at path [" + String.join("/", path) + "]. Expected " + expected.keySet() + ", but was "
+                + actual.keySet() + ". Number of fields", expected.size(), actual.size());
         for (Map.Entry<String, Object> expectedEntry : expected.entrySet()) {
             String expectedKey = expectedEntry.getKey();
             Object expectedValue = expectedEntry.getValue();
             if (expectedValue == null) {
-                assertTrue("different xContent at [" + Strings.join(path, '/') + "], [" + expectedValue + "] vs. ["
+                assertTrue("different xContent at [" + String.join("/", path) + "], [" + expectedValue + "] vs. ["
                         + actual.get(expectedKey) + "]", actual.get(expectedKey) == null && actual.containsKey(expectedKey));
             } else {
                 Object actualValue = actual.get(expectedKey);
@@ -826,7 +825,7 @@ public class ElasticsearchAssertions {
      * Compares two lists recursively, but using arrays comparisons for byte[] through Arrays.equals(byte[], byte[])
      */
     private static void assertListEquals(List<Object> expected, List<Object> actual, Stack<String> path) {
-        assertEquals("different list values at [" + Strings.join(path, '/') + "]: " + expected + " vs. " + actual, expected.size(),
+        assertEquals("different list values at [" + String.join("/", path) + "]: " + expected + " vs. " + actual, expected.size(),
                 actual.size());
         Iterator<Object> actualIterator = actual.iterator();
         int item = 0;
@@ -853,9 +852,9 @@ public class ElasticsearchAssertions {
         } else if (expected instanceof byte[]) {
             //byte[] is really a special case for binary values when comparing SMILE and CBOR, arrays of other types
             //don't need to be handled. Ordinary arrays get parsed as lists.
-            assertArrayEquals("different xContent at [" + Strings.join(path, '/') + "]", (byte[]) expected, (byte[]) actual);
+            assertArrayEquals("different xContent at [" + String.join("/", path) + "]", (byte[]) expected, (byte[]) actual);
         } else {
-            assertEquals("different xContent at [" + Strings.join(path, '/') + "]", expected, actual);
+            assertEquals("different xContent at [" + String.join("/", path) + "]", expected, actual);
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -797,12 +797,14 @@ public class ElasticsearchAssertions {
             actualMap = actualParser.map();
             try (XContentParser expectedParser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, expected)) {
                 expectedMap = expectedParser.map();
-                assertMapEquals(expectedMap, actualMap);
+                try {
+                    assertMapEquals(expectedMap, actualMap);
+                } catch (AssertionError error) {
+                    NotEqualMessageBuilder message = new NotEqualMessageBuilder();
+                    message.compareMaps(actualMap, expectedMap);
+                    throw new AssertionError("Error when comparing xContent.\n" + message.toString(), error);
+                }
             }
-        } catch (AssertionError error) {
-            NotEqualMessageBuilder message = new NotEqualMessageBuilder();
-            message.compareMaps(actualMap, expectedMap);
-            throw new AssertionError("Error when comparing xContent.\n" + message.toString(), error);
         }
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertionsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertionsTests.java
@@ -37,6 +37,7 @@ import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.VersionUtils.randomVersion;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertVersionSerializable;
+import static org.hamcrest.Matchers.containsString;
 
 public class ElasticsearchAssertionsTests extends ESTestCase {
     public void testAssertVersionSerializableIsOkWithIllegalArgumentException() {
@@ -96,8 +97,8 @@ public class ElasticsearchAssertionsTests extends ESTestCase {
             {
                 builder.startObject("foo");
                 {
-                    builder.field("field1", "value1");
-                    builder.field("field2", "value2");
+                    builder.field("f1", "value1");
+                    builder.field("f2", "value2");
                 }
                 builder.endObject();
             }
@@ -108,15 +109,14 @@ public class ElasticsearchAssertionsTests extends ESTestCase {
             {
                 otherBuilder.startObject("foo");
                 {
-                    otherBuilder.field("field1", "value1");
+                    otherBuilder.field("f1", "value1");
                 }
                 otherBuilder.endObject();
             }
             otherBuilder.endObject();
             AssertionError error = expectThrows(AssertionError.class,
                     () -> assertToXContentEquivalent(builder.bytes(), otherBuilder.bytes(), builder.contentType()));
-            assertEquals("different xContent at path [foo]. Expected [field1, field2], but was [field1]. "
-                    + "Number of fields expected:<2> but was:<1>", error.getMessage());
+            assertThat(error.getMessage(), containsString("f2: expected [value2] but not found"));
         }
         {
             XContentBuilder builder = JsonXContent.contentBuilder();
@@ -124,8 +124,8 @@ public class ElasticsearchAssertionsTests extends ESTestCase {
             {
                 builder.startObject("foo");
                 {
-                    builder.field("field1", "value1");
-                    builder.field("field2", "value2");
+                    builder.field("f1", "value1");
+                    builder.field("f2", "value2");
                 }
                 builder.endObject();
             }
@@ -136,15 +136,15 @@ public class ElasticsearchAssertionsTests extends ESTestCase {
             {
                 otherBuilder.startObject("foo");
                 {
-                    otherBuilder.field("field1", "value1");
-                    otherBuilder.field("field2", "differentValue2");
+                    otherBuilder.field("f1", "value1");
+                    otherBuilder.field("f2", "differentValue2");
                 }
                 otherBuilder.endObject();
             }
             otherBuilder.endObject();
             AssertionError error = expectThrows(AssertionError.class,
                     () -> assertToXContentEquivalent(builder.bytes(), otherBuilder.bytes(), builder.contentType()));
-            assertEquals("different xContent at [foo/field2] expected:<[v]alue2> but was:<[differentV]alue2>", error.getMessage());
+            assertThat(error.getMessage(), containsString("f2: expected [value2] but was [differentValue2]"));
         }
         {
             XContentBuilder builder = JsonXContent.contentBuilder();
@@ -158,6 +158,7 @@ public class ElasticsearchAssertionsTests extends ESTestCase {
                 }
                 builder.endArray();
             }
+            builder.field("f1", "value");
             builder.endObject();
 
             XContentBuilder otherBuilder = JsonXContent.contentBuilder();
@@ -171,10 +172,11 @@ public class ElasticsearchAssertionsTests extends ESTestCase {
                 }
                 otherBuilder.endArray();
             }
+            otherBuilder.field("f1", "value");
             otherBuilder.endObject();
             AssertionError error = expectThrows(AssertionError.class,
                     () -> assertToXContentEquivalent(builder.bytes(), otherBuilder.bytes(), builder.contentType()));
-            assertEquals("different xContent at [foo/2] expected:<[three]> but was:<[four]>", error.getMessage());
+            assertThat(error.getMessage(), containsString("2: expected [three] but was [four]"));
         }
         {
             XContentBuilder builder = JsonXContent.contentBuilder();
@@ -203,7 +205,7 @@ public class ElasticsearchAssertionsTests extends ESTestCase {
             otherBuilder.endObject();
             AssertionError error = expectThrows(AssertionError.class,
                     () -> assertToXContentEquivalent(builder.bytes(), otherBuilder.bytes(), builder.contentType()));
-            assertEquals("different list values at [foo]: [one, two, three] vs. [one, two] expected:<3> but was:<2>", error.getMessage());
+            assertThat(error.getMessage(), containsString("expected [1] more entries"));
         }
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertionsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertionsTests.java
@@ -24,12 +24,19 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.VersionUtils.randomVersion;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertVersionSerializable;
 
 public class ElasticsearchAssertionsTests extends ESTestCase {
@@ -50,6 +57,163 @@ public class ElasticsearchAssertionsTests extends ESTestCase {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             throw new IllegalArgumentException("Not supported.");
+        }
+    }
+
+    public void testAssertXContentEquivalent() throws IOException {
+        XContentBuilder original = JsonXContent.contentBuilder();
+        original.startObject();
+        addRandomNumberOfFields(original);
+        {
+            original.startObject(randomAlphaOfLength(10));
+            addRandomNumberOfFields(original);
+            original.endObject();
+        }
+        {
+            original.startArray(randomAlphaOfLength(10));
+            int elements = randomInt(5);
+            for (int i = 0; i < elements; i++) {
+                original.value(randomAlphaOfLength(10));
+            }
+            original.endArray();
+        }
+        original.endObject();
+
+        XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, original.bytes(), original.contentType());
+        XContentBuilder copy = JsonXContent.contentBuilder();
+        parser.nextToken();
+        XContentHelper.copyCurrentStructure(copy.generator(), parser);
+        assertToXContentEquivalent(original.bytes(), copy.bytes(), original.contentType());
+    }
+
+    public void testAssertXContentEquivalentErrors() throws IOException {
+        {
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            {
+                builder.startObject("foo");
+                {
+                    builder.field("field1", "value1");
+                    builder.field("field2", "value2");
+                }
+                builder.endObject();
+            }
+            builder.endObject();
+
+            XContentBuilder otherBuilder = JsonXContent.contentBuilder();
+            otherBuilder.startObject();
+            {
+                otherBuilder.startObject("foo");
+                {
+                    otherBuilder.field("field1", "value1");
+                }
+                otherBuilder.endObject();
+            }
+            otherBuilder.endObject();
+            AssertionError error = expectThrows(AssertionError.class,
+                    () -> assertToXContentEquivalent(builder.bytes(), otherBuilder.bytes(), builder.contentType()));
+            assertEquals("different field names at [foo]: [field1, field2] vs. [field1] expected:<2> but was:<1>",
+                    error.getMessage());
+        }
+        {
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            {
+                builder.startObject("foo");
+                {
+                    builder.field("field1", "value1");
+                    builder.field("field2", "value2");
+                }
+                builder.endObject();
+            }
+            builder.endObject();
+
+            XContentBuilder otherBuilder = JsonXContent.contentBuilder();
+            otherBuilder.startObject();
+            {
+                otherBuilder.startObject("foo");
+                {
+                    otherBuilder.field("field1", "value1");
+                    otherBuilder.field("field2", "differentValue2");
+                }
+                otherBuilder.endObject();
+            }
+            otherBuilder.endObject();
+            AssertionError error = expectThrows(AssertionError.class,
+                    () -> assertToXContentEquivalent(builder.bytes(), otherBuilder.bytes(), builder.contentType()));
+            assertEquals("different xContent at [foo/field2] expected:<[v]alue2> but was:<[differentV]alue2>", error.getMessage());
+        }
+        {
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            {
+                builder.startArray("foo");
+                {
+                    builder.value("one");
+                    builder.value("two");
+                    builder.value("three");
+                }
+                builder.endArray();
+            }
+            builder.endObject();
+
+            XContentBuilder otherBuilder = JsonXContent.contentBuilder();
+            otherBuilder.startObject();
+            {
+                otherBuilder.startArray("foo");
+                {
+                    otherBuilder.value("one");
+                    otherBuilder.value("two");
+                    otherBuilder.value("four");
+                }
+                otherBuilder.endArray();
+            }
+            otherBuilder.endObject();
+            AssertionError error = expectThrows(AssertionError.class,
+                    () -> assertToXContentEquivalent(builder.bytes(), otherBuilder.bytes(), builder.contentType()));
+            assertEquals("different xContent at [foo/2] expected:<[three]> but was:<[four]>", error.getMessage());
+        }
+        {
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            {
+                builder.startArray("foo");
+                {
+                    builder.value("one");
+                    builder.value("two");
+                    builder.value("three");
+                }
+                builder.endArray();
+            }
+            builder.endObject();
+
+            XContentBuilder otherBuilder = JsonXContent.contentBuilder();
+            otherBuilder.startObject();
+            {
+                otherBuilder.startArray("foo");
+                {
+                    otherBuilder.value("one");
+                    otherBuilder.value("two");
+                }
+                otherBuilder.endArray();
+            }
+            otherBuilder.endObject();
+            AssertionError error = expectThrows(AssertionError.class,
+                    () -> assertToXContentEquivalent(builder.bytes(), otherBuilder.bytes(), builder.contentType()));
+            assertEquals("different list values at [foo]: [one, two, three] vs. [one, two] expected:<3> but was:<2>", error.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void addRandomNumberOfFields(XContentBuilder builder) throws IOException {
+        int fields = randomInt(5);
+        for (int i = 0; i < fields; i++) {
+            Supplier<Object> sup = randomFrom(new Supplier[] {
+                () -> randomAlphaOfLength(10),
+                () -> randomInt(),
+                () -> randomBoolean()
+            });
+            builder.field(randomAlphaOfLength(10), sup.get());
         }
     }
 }


### PR DESCRIPTION
For comparing actual and parsed object equality for the response parsing we
currently rely heavily on comparing the original xContent and the output of the
parsed object. Currently we only have cryptic error messages if this comparison
fails which are hard to read also because we recursively compare lists and maps
of the xContent structures we compare.

This commits adds better error messages for these failures by e.g. keeping track
of the path to where differences in the two xContent structures occur and
printing out this information on failure.