### PR TITLE
Removes the 5.3.3 version constant

### DIFF
--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -120,8 +120,6 @@ public class Version {
     public static final Version V_5_3_1 = new Version(V_5_3_1_ID, org.apache.lucene.util.Version.LUCENE_6_4_2);
     public static final int V_5_3_2_ID = 5030299;
     public static final Version V_5_3_2 = new Version(V_5_3_2_ID, org.apache.lucene.util.Version.LUCENE_6_4_2);
-    public static final int V_5_3_3_ID_UNRELEASED = 5030399;
-    public static final Version V_5_3_3_UNRELEASED = new Version(V_5_3_3_ID_UNRELEASED, org.apache.lucene.util.Version.LUCENE_6_4_2);
     public static final int V_5_4_0_ID = 5040099;
     public static final Version V_5_4_0 = new Version(V_5_4_0_ID, org.apache.lucene.util.Version.LUCENE_6_5_0);
     public static final int V_5_4_1_ID_UNRELEASED = 5040199;
@@ -149,8 +147,6 @@ public class Version {
                 return V_5_4_1_UNRELEASED;
             case V_5_4_0_ID:
                 return V_5_4_0;
-            case V_5_3_3_ID_UNRELEASED:
-                return V_5_3_3_UNRELEASED;
             case V_5_3_2_ID:
                 return V_5_3_2;
             case V_5_3_1_ID:


### PR DESCRIPTION
After releasing 5.3.2, the 5.3.3 version constant was created.  However,
this causes issues for the rolling upgrade tests, which expect to have
all older versions artifacts published and no point releases created off
of the older versions (older meaning more than one version behind the
current version).  This commit removes the 5.3.3 version constant,
assuming we will not need it anywhere.