### PR TITLE
Add assertions enabled helper

### DIFF
--- a/core/src/main/java/org/elasticsearch/Assertions.java
+++ b/core/src/main/java/org/elasticsearch/Assertions.java
@@ -19,7 +19,16 @@
 
 package org.elasticsearch;
 
-public class Assertions {
+/**
+ * Provides a static final field that can be used to check if assertions are enabled. Since this field might be used elsewhere to check if
+ * assertions are enabled, if you are running with assertions enabled for specific packages or classes, you should enable assertions on this
+ * class too (e.g., {@code -ea org.elasticsearch.Assertions -ea org.elasticsearch.cluster.service.MasterService}).
+ */
+public final class Assertions {
+
+    private Assertions() {
+
+    }
 
     public static final boolean ENABLED;
 
@@ -27,9 +36,7 @@ public class Assertions {
         boolean enabled = false;
         /*
          * If assertions are enabled, the following line will be evaluated and enabled will have the value true, otherwise when assertions
-         * are disabled enabled will have the value false. The class field ENABLED can then be checked elsewhere to see if assertions are
-         * enabled. Note that this means that if you wish to enable assertions on specific packages or classes, you should enable assertions
-         * on this class too (e.g., -ea org.elasticsearch.Assertions -ea org.elasticsearch.cluster.service.MasterService).
+         * are disabled enabled will have the value false.
          */
         assert enabled = true;
         ENABLED = enabled;

--- a/core/src/main/java/org/elasticsearch/Assertions.java
+++ b/core/src/main/java/org/elasticsearch/Assertions.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch;
+
+public class Assertions {
+
+    public static final boolean ENABLED;
+
+    static {
+        boolean enabled = false;
+        /*
+         * If assertions are enabled, the following line will be evaluated and enabled will have the value true, otherwise when assertions
+         * are disabled enabled will have the value false. The class field ENABLED can then be checked elsewhere to see if assertions are
+         * enabled. Note that this means that if you wish to enable assertions on specific packages or classes, you should enable assertions
+         * on this class too (e.g., -ea org.elasticsearch.Assertions -ea org.elasticsearch.cluster.service.MasterService).
+         */
+        assert enabled = true;
+        ENABLED = enabled;
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -23,6 +23,7 @@ import com.carrotsearch.hppc.ObjectIntHashMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.CollectionUtil;
+import org.elasticsearch.Assertions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -1018,9 +1019,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
      *         this method does nothing.
      */
     public static boolean assertShardStats(RoutingNodes routingNodes) {
-        boolean run = false;
-        assert (run = true); // only run if assertions are enabled!
-        if (!run) {
+        if (!Assertions.ENABLED) {
             return true;
         }
         int unassignedPrimaryCount = 0;

--- a/core/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cluster.service;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
+import org.elasticsearch.Assertions;
 import org.elasticsearch.cluster.AckedClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
@@ -666,9 +667,7 @@ public class MasterService extends AbstractLifecycleComponent {
         assert clusterTasksResult.executionResults.size() == taskInputs.updateTasks.size()
             : String.format(Locale.ROOT, "expected [%d] task result%s but was [%d]", taskInputs.updateTasks.size(),
             taskInputs.updateTasks.size() == 1 ? "" : "s", clusterTasksResult.executionResults.size());
-        boolean assertsEnabled = false;
-        assert (assertsEnabled = true);
-        if (assertsEnabled) {
+        if (Assertions.ENABLED) {
             ClusterTasksResult<Object> finalClusterTasksResult = clusterTasksResult;
             taskInputs.updateTasks.forEach(updateTask -> {
                 assert finalClusterTasksResult.executionResults.containsKey(updateTask.task) :

--- a/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/builders/ShapeBuilder.java
@@ -23,6 +23,7 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Assertions;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.ToXContentToBytes;
 import org.elasticsearch.common.io.stream.NamedWriteable;
@@ -58,9 +59,7 @@ public abstract class ShapeBuilder extends ToXContentToBytes implements NamedWri
     static {
         // if asserts are enabled we run the debug statements even if they are not logged
         // to prevent exceptions only present if debug enabled
-        boolean debug = false;
-        assert debug = true;
-        DEBUG = debug;
+        DEBUG = Assertions.ENABLED;
     }
 
     public static final double DATELINE = 180;

--- a/core/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/ShardCoreKeyMap.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.lucene;
 
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
+import org.elasticsearch.Assertions;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardUtils;
 
@@ -152,10 +153,7 @@ public final class ShardCoreKeyMap {
     }
 
     private synchronized boolean assertSize() {
-        // this is heavy and should only used in assertions
-        boolean assertionsEnabled = false;
-        assert assertionsEnabled = true;
-        if (assertionsEnabled == false) {
+        if (!Assertions.ENABLED) {
             throw new AssertionError("only run this if assertions are enabled");
         }
         Collection<Set<IndexReader.CacheKey>> values = indexToCoreKey.values();

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/ReleasableLock.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/ReleasableLock.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.util.concurrent;
 
+import org.elasticsearch.Assertions;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.index.engine.EngineException;
 
@@ -35,9 +36,7 @@ public class ReleasableLock implements Releasable {
 
     public ReleasableLock(Lock lock) {
         this.lock = lock;
-        boolean useHoldingThreads = false;
-        assert (useHoldingThreads = true);
-        if (useHoldingThreads) {
+        if (Assertions.ENABLED) {
             holdingThreads = new ThreadLocal<>();
         } else {
             holdingThreads = null;

--- a/core/src/test/java/org/elasticsearch/common/hppc/HppcMapsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/hppc/HppcMapsTests.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.common.hppc;
 
 import com.carrotsearch.hppc.ObjectHashSet;
+import org.elasticsearch.Assertions;
 import org.elasticsearch.common.collect.HppcMaps;
 import org.elasticsearch.test.ESTestCase;
 
@@ -29,9 +30,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class HppcMapsTests extends ESTestCase {
     public void testIntersection() throws Exception {
-        boolean enabled = false;
-        assert enabled = true;
-        assumeTrue("assertions enabled", enabled);
+        assumeTrue("assertions enabled", Assertions.ENABLED);
         ObjectHashSet<String> set1 = ObjectHashSet.from("1", "2", "3");
         ObjectHashSet<String> set2 = ObjectHashSet.from("1", "2", "3");
         List<String> values = toList(HppcMaps.intersection(set1, set2));


### PR DESCRIPTION
Today in the code base we have lots of ugly code blocks like:

```java
  boolean assertionsEnabled = false;
  assert assertionsEnabled = true;
  if (assertionsEnabled) {
    // something
  }
```

These are a nuisance. Instead, we can do this in exactly one place and replace these blocks with

```java
  if (Assertions.ENABLED) {
    // something
  }
```

The cool thing here is that since this is a static final field, the JIT can optimize away the check at runtime if assertions are disabled.

