### PR TITLE
Add BWC packaging distributions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ if (currentVersion.bugfix == 0) {
   // If on a release branch, after the initial release of that branch, the bugfix version will
   // be bumped, and will be != 0. On master and N.x branches, we want to test against the
   // unreleased version of closest branch. So for those cases, the version includes -SNAPSHOT,
-  // and the bwc-zip distribution will checkout and build that version.
+  // and the bwc distribution will checkout and build that version.
   Version last = versions[-1]
   versions[-1] = new Version(last.major, last.minor, last.bugfix,
       true, last.unreleased)
@@ -173,8 +173,10 @@ subprojects {
   ]
   if (wireCompatVersions[-1].snapshot) {
     // if the most previous version is a snapshot, we need to connect that version to the
-    // bwc-zip project which will checkout and build that snapshot version
-    ext.projectSubstitutions["org.elasticsearch.distribution.zip:elasticsearch:${wireCompatVersions[-1]}"] = ':distribution:bwc-zip'
+    // bwc project which will checkout and build that snapshot version
+    ext.projectSubstitutions["org.elasticsearch.distribution.deb:elasticsearch:${wireCompatVersions[-1]}"] = ':distribution:bwc'
+    ext.projectSubstitutions["org.elasticsearch.distribution.rpm:elasticsearch:${wireCompatVersions[-1]}"] = ':distribution:bwc'
+    ext.projectSubstitutions["org.elasticsearch.distribution.zip:elasticsearch:${wireCompatVersions[-1]}"] = ':distribution:bwc'
   }
   project.afterEvaluate {
     configurations.all {

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -41,7 +41,7 @@ buildscript {
 }
 
 Collection distributions = project.subprojects.findAll {
-   it.path.contains(':tools') == false && it.name != 'bwc-zip' }
+   it.path.contains(':tools') == false && it.name != 'bwc' }
 
 /*****************************************************************************
  *                                Notice file                                *

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import java.util.regex.Matcher
+
 import org.elasticsearch.gradle.LoggedExec
 
 /**
@@ -81,14 +81,19 @@ if (bwcVersion.endsWith('-SNAPSHOT')) {
     commandLine = ['git', 'checkout', "upstream/${bwcBranch}"]
   }
 
+  File bwcDeb = file("${checkoutDir}/distribution/zip/build/distributions/elasticsearch-${bwcVersion}.deb")
+  File bwcRpm = file("${checkoutDir}/distribution/zip/build/distributions/elasticsearch-${bwcVersion}.rpm")
   File bwcZip = file("${checkoutDir}/distribution/zip/build/distributions/elasticsearch-${bwcVersion}.zip")
   task buildBwcVersion(type: GradleBuild) {
     dependsOn checkoutBwcBranch
     dir = checkoutDir
-    tasks = [':distribution:zip:assemble']
+    tasks = [':distribution:deb:assemble', ':distribution:rpm:assemble', ':distribution:zip:assemble']
   }
 
+
   artifacts {
+    'default' file: bwcDeb, name: 'elasticsearch', type: 'deb', builtBy: buildBwcVersion
+    'default' file: bwcRpm, name: 'elasticsearch', type: 'rpm', builtBy: buildBwcVersion
     'default' file: bwcZip, name: 'elasticsearch', type: 'zip', builtBy: buildBwcVersion
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ List projects = [
   'client:benchmark',
   'benchmarks',
   'distribution:integ-test-zip',
-  'distribution:bwc-zip',
+  'distribution:bwc',
   'distribution:zip',
   'distribution:tar',
   'distribution:deb',


### PR DESCRIPTION
Some packaging tests depend on snapshot versions of packaging distributions yet the build does not use a repository that includes such distributions. While we could add such a repository, a better strategy is to follow our approach for other BWC tests where we depend on a locally-compiled archive distribution. This commit adds a local compilation of packaging artifacts and substitutes these anywhere that we would otherwise depend on a snapshot of these artifacts.
