### PR TITLE
Add superset size to Significant Term REST response

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalMappedSignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/InternalMappedSignificantTerms.java
@@ -128,6 +128,7 @@ public abstract class InternalMappedSignificantTerms<
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.field(CommonFields.DOC_COUNT.getPreferredName(), subsetSize);
+        builder.field(BG_COUNT, supersetSize);
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (Bucket bucket : buckets) {
             //There is a condition (presumably when only one shard has a bucket?) where reduce is not called

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantLongTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantLongTerms.java
@@ -39,9 +39,7 @@ public class ParsedSignificantLongTerms extends ParsedSignificantTerms {
     }
 
     public static ParsedSignificantLongTerms fromXContent(XContentParser parser, String name) throws IOException {
-        ParsedSignificantLongTerms aggregation = PARSER.parse(parser, null);
-        aggregation.setName(name);
-        return aggregation;
+        return parseSignificantTermsXContent(() -> PARSER.parse(parser, null), name);
     }
 
     public static class ParsedBucket extends ParsedSignificantTerms.ParsedBucket {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantStringTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantStringTerms.java
@@ -40,9 +40,7 @@ public class ParsedSignificantStringTerms extends ParsedSignificantTerms {
     }
 
     public static ParsedSignificantStringTerms fromXContent(XContentParser parser, String name) throws IOException {
-        ParsedSignificantStringTerms aggregation = PARSER.parse(parser, null);
-        aggregation.setName(name);
-        return aggregation;
+        return parseSignificantTermsXContent(() -> PARSER.parse(parser, null), name);
     }
 
     public static class ParsedBucket extends ParsedSignificantTerms.ParsedBucket {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
@@ -53,7 +53,7 @@ public interface SignificantTerms extends MultiBucketsAggregation, Iterable<Sign
         long getSupersetDf();
 
         /**
-         * @return The numbers of docs in the superset (also known as the background count
+         * @return The numbers of docs in the superset (ordinarily the background count
          * of the containing aggregation).
          */
         long getSupersetSize();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTerms.java
@@ -29,17 +29,39 @@ public interface SignificantTerms extends MultiBucketsAggregation, Iterable<Sign
 
     interface Bucket extends MultiBucketsAggregation.Bucket {
 
+        /**
+         * @return The significant score for the subset
+         */
         double getSignificanceScore();
 
-        Number getKeyAsNumber();
-
+        /**
+         * @return The number of docs in the subset containing a particular term.
+         * This number is equal to the document count of the bucket.
+         */
         long getSubsetDf();
 
+        /**
+         * @return The numbers of docs in the subset (also known as "foreground set").
+         * This number is equal to the document count of the containing aggregation.
+         */
+        long getSubsetSize();
+
+        /**
+         * @return The number of docs in the superset containing a particular term (also
+         * known as the "background count" of the bucket)
+         */
         long getSupersetDf();
 
+        /**
+         * @return The numbers of docs in the superset (also known as the background count
+         * of the containing aggregation).
+         */
         long getSupersetSize();
 
-        long getSubsetSize();
+        /**
+         * @return The key, expressed as a number
+         */
+        Number getKeyAsNumber();
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -310,6 +310,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 + "\"doc_count\":4,"
                 + "\"sig_terms\":{"
                 + "\"doc_count\":4,"
+                + "\"bg_count\":7,"
                 + "\"buckets\":["
                 + "{"
                 + "\"key\":" + (type.equals("long") ? "0," : "\"0\",")
@@ -325,6 +326,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 + "\"doc_count\":3,"
                 + "\"sig_terms\":{"
                 + "\"doc_count\":3,"
+                + "\"bg_count\":7,"
                 + "\"buckets\":["
                 + "{"
                 + "\"key\":" + (type.equals("long") ? "1," : "\"1\",")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTermsTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTermsTestCase.java
@@ -19,8 +19,14 @@
 
 package org.elasticsearch.search.aggregations.bucket.significant;
 
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.ChiSquare;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.GND;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.JLHScore;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.MutualInformation;
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.Arrays;
@@ -32,6 +38,51 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class InternalSignificantTermsTestCase extends InternalMultiBucketAggregationTestCase<InternalSignificantTerms<?, ?>> {
+
+    private SignificanceHeuristic significanceHeuristic;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        significanceHeuristic = randomSignificanceHeuristic();
+    }
+
+    @Override
+    protected final InternalSignificantTerms createTestInstance(String name,
+                                                          List<PipelineAggregator> pipelineAggregators,
+                                                          Map<String, Object> metaData,
+                                                          InternalAggregations aggregations) {
+        final int requiredSize = randomIntBetween(1, 5);
+        final int numBuckets = randomInt(requiredSize + 2);
+
+        long subsetSize = 0;
+        long supersetSize = 0;
+
+        int[] subsetDfs = new int[numBuckets];
+        int[] supersetDfs = new int[numBuckets];
+
+        for (int i = 0; i < numBuckets; ++i) {
+            int subsetDf = randomIntBetween(1, 10);
+            subsetDfs[i] = subsetDf;
+
+            int supersetDf = randomIntBetween(subsetDf, 20);
+            supersetDfs[i] = supersetDf;
+
+            subsetSize += subsetDf;
+            supersetSize += supersetDf;
+        }
+        return createTestInstance(name, pipelineAggregators, metaData, aggregations, requiredSize, numBuckets, subsetSize, subsetDfs,
+                supersetSize, supersetDfs, significanceHeuristic);
+    }
+
+    protected abstract InternalSignificantTerms createTestInstance(String name,
+                                                                   List<PipelineAggregator> pipelineAggregators,
+                                                                   Map<String, Object> metaData,
+                                                                   InternalAggregations aggregations,
+                                                                   int requiredSize, int numBuckets,
+                                                                   long subsetSize, int[] subsetDfs,
+                                                                   long supersetSize, int[] supersetDfs,
+                                                                   SignificanceHeuristic significanceHeuristic);
 
     @Override
     protected InternalSignificantTerms createUnmappedInstance(String name,
@@ -72,6 +123,7 @@ public abstract class InternalSignificantTermsTestCase extends InternalMultiBuck
         InternalSignificantTerms expectedSigTerms = (InternalSignificantTerms) expected;
         ParsedSignificantTerms actualSigTerms = (ParsedSignificantTerms) actual;
         assertEquals(expectedSigTerms.getSubsetSize(), actualSigTerms.getSubsetSize());
+        assertEquals(expectedSigTerms.getSupersetSize(), actualSigTerms.getSupersetSize());
 
         for (SignificantTerms.Bucket bucket : (SignificantTerms) expected) {
             String key = bucket.getKeyAsString();
@@ -91,14 +143,22 @@ public abstract class InternalSignificantTermsTestCase extends InternalMultiBuck
 
         assertEquals(expectedSigTerm.getSignificanceScore(), actualSigTerm.getSignificanceScore(), 0.0);
         assertEquals(expectedSigTerm.getSubsetDf(), actualSigTerm.getSubsetDf());
+        assertEquals(actualSigTerm.getDocCount(), actualSigTerm.getSubsetDf());
         assertEquals(expectedSigTerm.getSupersetDf(), actualSigTerm.getSupersetDf());
-
-        expectThrows(UnsupportedOperationException.class, actualSigTerm::getSubsetSize);
-        expectThrows(UnsupportedOperationException.class, actualSigTerm::getSupersetSize);
+        assertEquals(expectedSigTerm.getSubsetSize(), actualSigTerm.getSubsetSize());
+        assertEquals(expectedSigTerm.getSupersetSize(), actualSigTerm.getSupersetSize());
     }
 
     private static Map<Object, Long> toCounts(Stream<? extends SignificantTerms.Bucket> buckets,
                                               Function<SignificantTerms.Bucket, Long> fn) {
         return buckets.collect(Collectors.toMap(SignificantTerms.Bucket::getKey, fn, Long::sum));
+    }
+
+    private static SignificanceHeuristic randomSignificanceHeuristic() {
+        return randomFrom(
+                new JLHScore(),
+                new MutualInformation(randomBoolean(), randomBoolean()),
+                new GND(randomBoolean()),
+                new ChiSquare(randomBoolean(), randomBoolean()));
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTermsTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTermsTestCase.java
@@ -143,7 +143,7 @@ public abstract class InternalSignificantTermsTestCase extends InternalMultiBuck
 
         assertEquals(expectedSigTerm.getSignificanceScore(), actualSigTerm.getSignificanceScore(), 0.0);
         assertEquals(expectedSigTerm.getSubsetDf(), actualSigTerm.getSubsetDf());
-        assertEquals(actualSigTerm.getDocCount(), actualSigTerm.getSubsetDf());
+        assertEquals(expectedSigTerm.getDocCount(), actualSigTerm.getSubsetDf());
         assertEquals(expectedSigTerm.getSupersetDf(), actualSigTerm.getSupersetDf());
         assertEquals(expectedSigTerm.getSubsetSize(), actualSigTerm.getSubsetSize());
         assertEquals(expectedSigTerm.getSupersetSize(), actualSigTerm.getSupersetSize());

--- a/docs/reference/aggregations/bucket/diversified-sampler-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/diversified-sampler-aggregation.asciidoc
@@ -86,8 +86,7 @@ Response:
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
 // TESTRESPONSE[s/2.213/$body.aggregations.my_unbiased_sample.keywords.buckets.0.score/]
 
-<1> 151 documents were sampled in total because we asked for a maximum of 200 from an index with 5 shards. The cost of performing the
-nested significant_terms aggregation was therefore limited rather than unbounded.
+<1> 151 documents were sampled in total.
 <2> The results of the significant_terms aggregation are not skewed by any single author's quirks because we asked for a maximum of one post from any one author in our sample.
 
 ==== Scripted example:

--- a/docs/reference/aggregations/bucket/diversified-sampler-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/diversified-sampler-aggregation.asciidoc
@@ -66,9 +66,10 @@ Response:
     ...
     "aggregations": {
         "my_unbiased_sample": {
-            "doc_count": 1000,<1>
+            "doc_count": 151,<1>
             "keywords": {<2>
-                "doc_count": 1000,
+                "doc_count": 151,
+                "bg_count": 650,
                 "buckets": [
                     {
                         "key": "kibana",
@@ -83,10 +84,10 @@ Response:
 }
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
-// TESTRESPONSE[s/1000/151/]
 // TESTRESPONSE[s/2.213/$body.aggregations.my_unbiased_sample.keywords.buckets.0.score/]
 
-<1> 1000 documents were sampled in total because we asked for a maximum of 200 from an index with 5 shards. The cost of performing the nested significant_terms aggregation was therefore limited rather than unbounded.
+<1> 151 documents were sampled in total because we asked for a maximum of 200 from an index with 5 shards. The cost of performing the
+nested significant_terms aggregation was therefore limited rather than unbounded.
 <2> The results of the significant_terms aggregation are not skewed by any single author's quirks because we asked for a maximum of one post from any one author in our sample.
 
 ==== Scripted example:
@@ -136,9 +137,10 @@ Response:
     ...
     "aggregations": {
         "my_unbiased_sample": {
-            "doc_count": 1000,
+            "doc_count": 6,
             "keywords": {
-                "doc_count": 1000,
+                "doc_count": 6,
+                "bg_count": 650,
                 "buckets": [
                     {
                         "key": "logstash",
@@ -159,7 +161,6 @@ Response:
 }
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
-// TESTRESPONSE[s/1000/6/]
 // TESTRESPONSE[s/2.213/$body.aggregations.my_unbiased_sample.keywords.buckets.0.score/]
 // TESTRESPONSE[s/1.34/$body.aggregations.my_unbiased_sample.keywords.buckets.1.score/]
 

--- a/docs/reference/aggregations/bucket/sampler-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/sampler-aggregation.asciidoc
@@ -54,9 +54,10 @@ Response:
     ...
     "aggregations": {
         "sample": {
-            "doc_count": 1000,<1>
+            "doc_count": 200,<1>
             "keywords": {
-                "doc_count": 1000,
+                "doc_count": 200,
+                "bg_count": 650,
                 "buckets": [
                     {
                         "key": "elasticsearch",
@@ -77,9 +78,9 @@ Response:
 }
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
-// TESTRESPONSE[s/1000/200/]
 
-<1> 1000 documents were sampled in total because we asked for a maximum of 200 from an index with 5 shards. The cost of performing the nested significant_terms aggregation was therefore limited rather than unbounded.
+<1> 200 documents were sampled in total. The cost of performing the nested significant_terms aggregation was
+therefore limited rather than unbounded.
 
 
 Without the `sampler` aggregation the request query considers the full "long tail" of low-quality matches and therefore identifies
@@ -117,13 +118,14 @@ Response:
     ...
     "aggregations": {
         "low_quality_keywords": {
-            "doc_count": 1000,
+            "doc_count": 600,
+            "bg_count": 650,
             "buckets": [
                 {
                     "key": "angular",
                     "doc_count": 200,
                     "score": 0.02777,
-                   "bg_count": 200
+                    "bg_count": 200
                 },
                 {
                     "key": "jquery",
@@ -143,7 +145,6 @@ Response:
 }
 --------------------------------------------------
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
-// TESTRESPONSE[s/1000/600/]
 // TESTRESPONSE[s/0.02777/$body.aggregations.low_quality_keywords.buckets.0.score/]
 // TESTRESPONSE[s/0.0069/$body.aggregations.low_quality_keywords.buckets.2.score/]
 

--- a/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -48,6 +48,7 @@ Response:
     "aggregations" : {
         "significantCrimeTypes" : {
             "doc_count": 47347,
+            "bg_count": 5064554,
             "buckets" : [
                 {
                     "key": "Bicycle theft",
@@ -111,6 +112,7 @@ Response:
                 "doc_count": 894038,
                 "significantCrimeTypes": {
                     "doc_count": 894038,
+                    "bg_count": 5064554,
                     "buckets": [
                         {
                             "key": "Robbery",
@@ -127,6 +129,7 @@ Response:
                 "doc_count": 47347,
                 "significantCrimeTypes": {
                     "doc_count": 47347,
+                    "bg_count": 5064554,
                     "buckets": [
                         {
                             "key": "Bicycle theft",


### PR DESCRIPTION
This commit adds a new `bg_count` field to the REST response of `SignificantTerms` aggregations. Similarly to the `bg_count ` that already exists in significant terms buckets, this new `bg_count` field is set at the aggregation level and is populated with the superset size value.

The addition of this field allows the High Level REST client to provide implementations of `SignificantTerms`and `SignificantTerms.Bucket` with the exact same behavior as the internal implementations. Before this pull request, a significant term aggregation didn't know about the superset size at all. Same thing for the aggregation's buckets that throw unsupported operation exceptions because the aggregation's superset size and subset size were unkown. This PR fixes that and adds support for both fields that are now populated at parsing time.

Note that the subset size field at the bucket could have been implemented before but I didn't know much about how to do that. Thanks to @markharwood it is now supported.

There's a bit of history around these fields (see https://github.com/elastic/elasticsearch/pull/5146#r9862823) and the superset size information was not added to the aggregation at the first place. I think the main argument was that it could be retrieved at query time using a Global aggregation. This argument is still valid, but adding this new field provides a better support of Significant Terms aggregation in the High Level REST Client and it might also be useful in the future for a new chart type in Kibana.