### PR TITLE
Make ScriptEngine.compile generic on the script context

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/ScriptPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ScriptPlugin.java
@@ -20,7 +20,6 @@ package org.elasticsearch.plugins;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptContext;

--- a/core/src/main/java/org/elasticsearch/script/ScriptEngine.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptEngine.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.script;
 
-import org.elasticsearch.common.Nullable;
-import org.elasticsearch.search.lookup.SearchLookup;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
@@ -40,14 +37,12 @@ public interface ScriptEngine extends Closeable {
      * Compiles a script.
      * @param name the name of the script. {@code null} if it is anonymous (inline). For a stored script, its the identifier.
      * @param code actual source of the script
+     * @param context the context this script will be used for
      * @param params compile-time parameters (such as flags to the compiler)
-     * @return an opaque compiled script which may be cached and later passed to
+     * @return A compiled script of the CompiledType from {@link ScriptContext}
      */
-    Object compile(String name, String code, Map<String, String> params);
-
-    ExecutableScript executable(Object compiledScript, @Nullable Map<String, Object> vars);
-    
-    SearchScript search(Object compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars);
+    <InstanceType, CompiledType>
+    CompiledType compile(String name, String code, ScriptContext<InstanceType, CompiledType> context, Map<String, String> params);
 
     @Override
     default void close() throws IOException {}

--- a/core/src/main/java/org/elasticsearch/script/ScriptEngine.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptEngine.java
@@ -41,8 +41,7 @@ public interface ScriptEngine extends Closeable {
      * @param params compile-time parameters (such as flags to the compiler)
      * @return A compiled script of the CompiledType from {@link ScriptContext}
      */
-    <InstanceType, CompiledType>
-    CompiledType compile(String name, String code, ScriptContext<InstanceType, CompiledType> context, Map<String, String> params);
+    <CompiledType> CompiledType compile(String name, String code, ScriptContext<CompiledType> context, Map<String, String> params);
 
     @Override
     default void close() throws IOException {}

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -432,8 +432,8 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
                 throw new IllegalArgumentException(
                     "cannot put [" + ScriptType.STORED + "] script, no script contexts are enabled");
             } else {
-                // TODO: search context here is just a placeholder, replace with optional context name passed into PUT stored script req
-                Object compiled = scriptEngine.compile(request.id(), source.getCode(), ScriptContext.SEARCH, Collections.emptyMap());
+                // TODO: executable context here is just a placeholder, replace with optional context name passed into PUT stored script req
+                Object compiled = scriptEngine.compile(request.id(), source.getCode(), ScriptContext.EXECUTABLE, Collections.emptyMap());
 
                 if (compiled == null) {
                     throw new IllegalArgumentException("failed to parse/compile stored script [" + request.id() + "]" +

--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -312,14 +312,7 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
                     }
                     // Check whether too many compilations have happened
                     checkCompilationLimit();
-                    Object engineCompiled = scriptEngine.compile(id, idOrCode, options);
-                    if (context.instanceClazz == ExecutableScript.class) {
-                        compiledScript = (ExecutableScript.Compiled) params -> scriptEngine.executable(engineCompiled, params);
-                    } else if (context.instanceClazz == SearchScript.class) {
-                        compiledScript = (SearchScript.Compiled) (params, lookup) -> scriptEngine.search(engineCompiled, lookup, params);
-                    } else {
-                        throw new IllegalArgumentException("Script context [" + context.name + "] not supported");
-                    }
+                    compiledScript = scriptEngine.compile(id, idOrCode, context, options);
                 } catch (ScriptException good) {
                     // TODO: remove this try-catch completely, when all script engines have good exceptions!
                     throw good; // its already good
@@ -439,7 +432,8 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
                 throw new IllegalArgumentException(
                     "cannot put [" + ScriptType.STORED + "] script, no script contexts are enabled");
             } else {
-                Object compiled = scriptEngine.compile(request.id(), source.getCode(), Collections.emptyMap());
+                // TODO: search context here is just a placeholder, replace with optional context name passed into PUT stored script req
+                Object compiled = scriptEngine.compile(request.id(), source.getCode(), ScriptContext.SEARCH, Collections.emptyMap());
 
                 if (compiled == null) {
                     throw new IllegalArgumentException("failed to parse/compile stored script [" + request.id() + "]" +

--- a/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -78,7 +78,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
+                public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
                     assert scriptSource.equals("explainable_script");
                     assert context == ScriptContext.SEARCH;
                     SearchScript.Compiled compiled = (p, lookup) -> new SearchScript() {

--- a/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -34,6 +34,7 @@ import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.ExplainableSearchScript;
 import org.elasticsearch.script.LeafSearchScript;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.SearchScript;
@@ -77,19 +78,10 @@ public class ExplainableScriptIT extends ESIntegTestCase {
                 }
 
                 @Override
-                public Object compile(String scriptName, String scriptSource, Map<String, String> params) {
+                public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
                     assert scriptSource.equals("explainable_script");
-                    return null;
-                }
-
-                @Override
-                public ExecutableScript executable(Object compiledScript, @Nullable Map<String, Object> vars) {
-                    throw new UnsupportedOperationException();
-                }
-
-                @Override
-                public SearchScript search(Object compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars) {
-                    return new SearchScript() {
+                    assert context == ScriptContext.SEARCH;
+                    SearchScript.Compiled compiled = (p, lookup) -> new SearchScript() {
                         @Override
                         public LeafSearchScript getLeafSearchScript(LeafReaderContext context) throws IOException {
                             return new MyScript(lookup.doc().getLeafDocLookup(context));
@@ -99,6 +91,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
                             return false;
                         }
                     };
+                    return context.compiledClazz.cast(compiled);
                 }
             };
         }

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -1026,7 +1026,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
         }
 
         @Override
-        public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
+        public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
             if (context.instanceClazz != ExecutableScript.class) {
                 throw new UnsupportedOperationException();
             }

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -1025,33 +1026,29 @@ public class SuggestSearchIT extends ESIntegTestCase {
         }
 
         @Override
-        public Object compile(String scriptName, String scriptSource, Map<String, String> params) {
-            return scriptSource;
-        }
-
-        @Override
-        public ExecutableScript executable(Object compiledScript, Map<String, Object> params) {
-            String script = (String) compiledScript;
-            for (Entry<String, Object> entry : params.entrySet()) {
-                script = script.replace("{{" + entry.getKey() + "}}", String.valueOf(entry.getValue()));
+        public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
+            if (context.instanceClazz != ExecutableScript.class) {
+                throw new UnsupportedOperationException();
             }
-            String result = script;
-            return new ExecutableScript() {
-                @Override
-                public void setNextVar(String name, Object value) {
-                    throw new UnsupportedOperationException("setNextVar not supported");
+            ExecutableScript.Compiled compiled = p -> {
+                String script = scriptSource;
+                for (Entry<String, Object> entry : p.entrySet()) {
+                    script = script.replace("{{" + entry.getKey() + "}}", String.valueOf(entry.getValue()));
                 }
+                String result = script;
+                return new ExecutableScript() {
+                    @Override
+                    public void setNextVar(String name, Object value) {
+                        throw new UnsupportedOperationException("setNextVar not supported");
+                    }
 
-                @Override
-                public Object run() {
-                    return result;
-                }
+                    @Override
+                    public Object run() {
+                        return result;
+                    }
+                };
             };
-        }
-
-        @Override
-        public SearchScript search(Object compiledScript, SearchLookup lookup, Map<String, Object> vars) {
-            throw new UnsupportedOperationException("search script not supported");
+            return context.compiledClazz.cast(compiled);
         }
     }
 

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -73,7 +73,7 @@ public class ExpressionScriptEngine extends AbstractComponent implements ScriptE
     }
 
     @Override
-    public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
+    public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
         // classloader created here
         final SecurityManager sm = System.getSecurityManager();
         SpecialPermission.check();

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionScriptEngine.java
@@ -23,6 +23,7 @@ import org.apache.lucene.expressions.Expression;
 import org.apache.lucene.expressions.SimpleBindings;
 import org.apache.lucene.expressions.js.JavascriptCompiler;
 import org.apache.lucene.expressions.js.VariableContext;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.queries.function.valuesource.DoubleConstValueSource;
 import org.apache.lucene.search.SortField;
@@ -38,11 +39,14 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.script.ClassPermission;
 import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.LeafSearchScript;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.io.IOException;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -69,11 +73,11 @@ public class ExpressionScriptEngine extends AbstractComponent implements ScriptE
     }
 
     @Override
-    public Object compile(String scriptName, String scriptSource, Map<String, String> params) {
+    public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
         // classloader created here
         final SecurityManager sm = System.getSecurityManager();
         SpecialPermission.check();
-        return AccessController.doPrivileged(new PrivilegedAction<Expression>() {
+        Expression expr = AccessController.doPrivileged(new PrivilegedAction<Expression>() {
             @Override
             public Expression run() {
                 try {
@@ -100,11 +104,17 @@ public class ExpressionScriptEngine extends AbstractComponent implements ScriptE
                 }
             }
         });
+        if (context.instanceClazz.equals(SearchScript.class)) {
+            SearchScript.Compiled compiled = (p, lookup) -> newSearchScript(expr, lookup, p);
+            return context.compiledClazz.cast(compiled);
+        } else if (context.instanceClazz.equals(ExecutableScript.class)) {
+            ExecutableScript.Compiled compiled = (p) -> new ExpressionExecutableScript(expr, p);
+            return context.compiledClazz.cast(compiled);
+        }
+        throw new IllegalArgumentException("painless does not know how to handle context [" + context.name + "]");
     }
 
-    @Override
-    public SearchScript search(Object compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars) {
-        Expression expr = (Expression)compiledScript;
+    private SearchScript newSearchScript(Expression expr, SearchLookup lookup, @Nullable Map<String, Object> vars) {
         MapperService mapper = lookup.doc().mapperService();
         // NOTE: if we need to do anything complicated with bindings in the future, we can just extend Bindings,
         // instead of complicating SimpleBindings (which should stay simple)
@@ -245,10 +255,5 @@ public class ExpressionScriptEngine extends AbstractComponent implements ScriptE
         pointer.append("^---- HERE");
         stack.add(pointer.toString());
         throw new ScriptException(message, cause, stack, source, NAME);
-    }
-
-    @Override
-    public ExecutableScript executable(Object compiledScript, Map<String, Object> vars) {
-        return new ExpressionExecutableScript((Expression) compiledScript, vars);
     }
 }

--- a/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTests.java
+++ b/modules/lang-expression/src/test/java/org/elasticsearch/script/expression/ExpressionTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.script.expression;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -42,8 +43,8 @@ public class ExpressionTests extends ESSingleNodeTestCase {
     }
 
     private SearchScript compile(String expression) {
-        Object compiled = service.compile(null, expression, Collections.emptyMap());
-        return service.search(compiled, lookup, Collections.emptyMap());
+        SearchScript.Compiled compiled = service.compile(null, expression, ScriptContext.SEARCH, Collections.emptyMap());
+        return compiled.newInstance(Collections.emptyMap(), lookup);
     }
 
     public void testNeedsScores() {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.GeneralScriptException;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -63,10 +64,15 @@ public final class MustacheScriptEngine implements ScriptEngine {
      * @return a compiled template object for later execution.
      * */
     @Override
-    public Object compile(String templateName, String templateSource, Map<String, String> params) {
+    public <T, C> C compile(String templateName, String templateSource, ScriptContext<T, C> context, Map<String, String> params) {
+        if (context.instanceClazz.equals(ExecutableScript.class) == false) {
+            throw new IllegalArgumentException("mustache engine does not know how to handle context [" + context.name + "]");
+        }
         final MustacheFactory factory = createMustacheFactory(params);
         Reader reader = new FastStringReader(templateSource);
-        return factory.compile(reader, "query-template");
+        Mustache template = factory.compile(reader, "query-template");
+        ExecutableScript.Compiled compiled = p -> new MustacheExecutableScript(template, p);
+        return context.compiledClazz.cast(compiled);
     }
 
     private CustomMustacheFactory createMustacheFactory(Map<String, String> params) {
@@ -81,21 +87,11 @@ public final class MustacheScriptEngine implements ScriptEngine {
         return NAME;
     }
 
-    @Override
-    public ExecutableScript executable(Object compiledScript, @Nullable Map<String, Object> vars) {
-        return new MustacheExecutableScript((Mustache) compiledScript, vars);
-    }
-
-    @Override
-    public SearchScript search(Object compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars) {
-        throw new UnsupportedOperationException();
-    }
-
     /**
      * Used at query execution time by script service in order to execute a query template.
      * */
     private class MustacheExecutableScript implements ExecutableScript {
-        /** Compiled template object wrapper. */
+        /** Compiled template. */
         private Mustache template;
         /** Parameters to fill above object with. */
         private Map<String, Object> vars;

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
@@ -64,7 +64,7 @@ public final class MustacheScriptEngine implements ScriptEngine {
      * @return a compiled template object for later execution.
      * */
     @Override
-    public <T, C> C compile(String templateName, String templateSource, ScriptContext<T, C> context, Map<String, String> params) {
+    public <T> T compile(String templateName, String templateSource, ScriptContext<T> context, Map<String, String> params) {
         if (context.instanceClazz.equals(ExecutableScript.class) == false) {
             throw new IllegalArgumentException("mustache engine does not know how to handle context [" + context.name + "]");
         }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/CustomMustacheFactoryTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/CustomMustacheFactoryTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.script.mustache;
 import com.github.mustachejava.Mustache;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.test.ESTestCase;
 
@@ -61,9 +62,9 @@ public class CustomMustacheFactoryTests extends ESTestCase {
         final ScriptEngine engine = new MustacheScriptEngine();
         final Map<String, String> params = randomBoolean() ? singletonMap(Script.CONTENT_TYPE_OPTION, JSON_MIME_TYPE) : emptyMap();
 
-        Mustache script = (Mustache) engine.compile(null, "{\"field\": \"{{value}}\"}", params);
+        ExecutableScript.Compiled compiled = engine.compile(null, "{\"field\": \"{{value}}\"}", ScriptContext.EXECUTABLE, params);
 
-        ExecutableScript executable = engine.executable(script, singletonMap("value", "a \"value\""));
+        ExecutableScript executable = compiled.newInstance(singletonMap("value", "a \"value\""));
         assertThat(executable.run(), equalTo("{\"field\": \"a \\\"value\\\"\"}"));
     }
 
@@ -71,9 +72,9 @@ public class CustomMustacheFactoryTests extends ESTestCase {
         final ScriptEngine engine = new MustacheScriptEngine();
         final Map<String, String> params = singletonMap(Script.CONTENT_TYPE_OPTION, PLAIN_TEXT_MIME_TYPE);
 
-        Mustache script = (Mustache) engine.compile(null, "{\"field\": \"{{value}}\"}", params);
+        ExecutableScript.Compiled compiled = engine.compile(null, "{\"field\": \"{{value}}\"}", ScriptContext.EXECUTABLE, params);
 
-        ExecutableScript executable = engine.executable(script, singletonMap("value", "a \"value\""));
+        ExecutableScript executable = compiled.newInstance(singletonMap("value", "a \"value\""));
         assertThat(executable.run(), equalTo("{\"field\": \"a \"value\"\"}"));
     }
 
@@ -81,9 +82,9 @@ public class CustomMustacheFactoryTests extends ESTestCase {
         final ScriptEngine engine = new MustacheScriptEngine();
         final Map<String, String> params = singletonMap(Script.CONTENT_TYPE_OPTION, X_WWW_FORM_URLENCODED_MIME_TYPE);
 
-        Mustache script = (Mustache) engine.compile(null, "{\"field\": \"{{value}}\"}", params);
+        ExecutableScript.Compiled compiled = engine.compile(null, "{\"field\": \"{{value}}\"}", ScriptContext.EXECUTABLE, params);
 
-        ExecutableScript executable = engine.executable(script, singletonMap("value", "tilde~ AND date:[2016 FROM*]"));
+        ExecutableScript executable = compiled.newInstance(singletonMap("value", "tilde~ AND date:[2016 FROM*]"));
         assertThat(executable.run(), equalTo("{\"field\": \"tilde%7E+AND+date%3A%5B2016+FROM*%5D\"}"));
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -98,7 +98,7 @@ public final class PainlessScriptEngine extends AbstractComponent implements Scr
     static final String INLINE_NAME = "<inline>";
 
     @Override
-    public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
+    public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
         GenericElasticsearchScript painlessScript = compile(GenericElasticsearchScript.class, scriptName, scriptSource, params);
         if (context.instanceClazz.equals(SearchScript.class)) {
             SearchScript.Compiled compiled = (p, lookup) -> new SearchScript() {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -26,10 +26,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.painless.Compiler.Loader;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.SearchScript;
-import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.security.AccessControlContext;
@@ -98,8 +98,25 @@ public final class PainlessScriptEngine extends AbstractComponent implements Scr
     static final String INLINE_NAME = "<inline>";
 
     @Override
-    public Object compile(String scriptName, final String scriptSource, final Map<String, String> params) {
-        return compile(GenericElasticsearchScript.class, scriptName, scriptSource, params);
+    public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
+        GenericElasticsearchScript painlessScript = compile(GenericElasticsearchScript.class, scriptName, scriptSource, params);
+        if (context.instanceClazz.equals(SearchScript.class)) {
+            SearchScript.Compiled compiled = (p, lookup) -> new SearchScript() {
+                @Override
+                public LeafSearchScript getLeafSearchScript(final LeafReaderContext context) throws IOException {
+                    return new ScriptImpl(painlessScript, p, lookup.getLeafSearchLookup(context));
+                }
+                @Override
+                public boolean needsScores() {
+                    return painlessScript.uses$_score();
+                }
+            };
+            return context.compiledClazz.cast(compiled);
+        } else if (context.instanceClazz.equals(ExecutableScript.class)) {
+            ExecutableScript.Compiled compiled = (p) -> new ScriptImpl(painlessScript, p, null);
+            return context.compiledClazz.cast(compiled);
+        }
+        throw new IllegalArgumentException("painless does not know how to handle context [" + context.name + "]");
     }
 
     <T> T compile(Class<T> iface, String scriptName, final String scriptSource, final Map<String, String> params) {
@@ -166,47 +183,6 @@ public final class PainlessScriptEngine extends AbstractComponent implements Scr
         } catch (OutOfMemoryError | StackOverflowError | VerifyError | Exception e) {
             throw convertToScriptException(scriptName == null ? scriptSource : scriptName, scriptSource, e);
         }
-    }
-
-    /**
-     * Retrieve an {@link ExecutableScript} for later use.
-     * @param compiledScript A previously compiled script.
-     * @param vars The variables to be used in the script.
-     * @return An {@link ExecutableScript} with the currently specified variables.
-     */
-    @Override
-    public ExecutableScript executable(final Object compiledScript, final Map<String, Object> vars) {
-        return new ScriptImpl((GenericElasticsearchScript) compiledScript, vars, null);
-    }
-
-    /**
-     * Retrieve a {@link SearchScript} for later use.
-     * @param compiledScript A previously compiled script.
-     * @param lookup The object that ultimately allows access to search fields.
-     * @param vars The variables to be used in the script.
-     * @return An {@link SearchScript} with the currently specified variables.
-     */
-    @Override
-    public SearchScript search(final Object compiledScript, final SearchLookup lookup, final Map<String, Object> vars) {
-        return new SearchScript() {
-            /**
-             * Get the search script that will have access to search field values.
-             * @param context The LeafReaderContext to be used.
-             * @return A script that will have the search fields from the current context available for use.
-             */
-            @Override
-            public LeafSearchScript getLeafSearchScript(final LeafReaderContext context) throws IOException {
-                return new ScriptImpl((GenericElasticsearchScript) compiledScript, vars, lookup.getLeafSearchLookup(context));
-            }
-
-            /**
-             * Whether or not the score is needed.
-             */
-            @Override
-            public boolean needsScores() {
-                return ((GenericElasticsearchScript) compiledScript).uses$_score();
-            }
-        };
     }
 
     private ScriptException convertToScriptException(String scriptName, String scriptSource, Throwable t) {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/NeedsScoreTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/NeedsScoreTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.painless;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.SearchScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -39,20 +40,20 @@ public class NeedsScoreTests extends ESSingleNodeTestCase {
         PainlessScriptEngine service = new PainlessScriptEngine(Settings.EMPTY);
         SearchLookup lookup = new SearchLookup(index.mapperService(), index.fieldData(), null);
 
-        Object compiled = service.compile(null, "1.2", Collections.emptyMap());
-        SearchScript ss = service.search(compiled, lookup, Collections.emptyMap());
+        SearchScript.Compiled compiled = service.compile(null, "1.2", ScriptContext.SEARCH, Collections.emptyMap());
+        SearchScript ss = compiled.newInstance(Collections.emptyMap(), lookup);
         assertFalse(ss.needsScores());
 
-        compiled = service.compile(null, "doc['d'].value", Collections.emptyMap());
-        ss = service.search(compiled, lookup, Collections.emptyMap());
+        compiled = service.compile(null, "doc['d'].value", ScriptContext.SEARCH, Collections.emptyMap());
+        ss = compiled.newInstance(Collections.emptyMap(), lookup);
         assertFalse(ss.needsScores());
 
-        compiled = service.compile(null, "1/_score", Collections.emptyMap());
-        ss = service.search(compiled, lookup, Collections.emptyMap());
+        compiled = service.compile(null, "1/_score", ScriptContext.SEARCH, Collections.emptyMap());
+        ss = compiled.newInstance(Collections.emptyMap(), lookup);
         assertTrue(ss.needsScores());
 
-        compiled = service.compile(null, "doc['d'].value * _score", Collections.emptyMap());
-        ss = service.search(compiled, lookup, Collections.emptyMap());
+        compiled = service.compile(null, "doc['d'].value * _score", ScriptContext.SEARCH, Collections.emptyMap());
+        ss = compiled.newInstance(Collections.emptyMap(), lookup);
         assertTrue(ss.needsScores());
     }
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ScriptEngineTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ScriptEngineTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless;
 
 import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptContext;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -79,9 +80,9 @@ public class ScriptEngineTests extends ScriptTestCase {
         Map<String, Object> ctx = new HashMap<>();
         vars.put("ctx", ctx);
 
-        Object compiledScript = scriptEngine.compile(null,
-                "return ctx.value;", Collections.emptyMap());
-        ExecutableScript script = scriptEngine.executable(compiledScript, vars);
+        ExecutableScript.Compiled compiledScript =
+            scriptEngine.compile(null, "return ctx.value;", ScriptContext.EXECUTABLE, Collections.emptyMap());
+        ExecutableScript script = compiledScript.newInstance(vars);
 
         ctx.put("value", 1);
         Object o = script.run();
@@ -94,9 +95,9 @@ public class ScriptEngineTests extends ScriptTestCase {
 
     public void testChangingVarsCrossExecution2() {
         Map<String, Object> vars = new HashMap<>();
-        Object compiledScript = scriptEngine.compile(null, "return params['value'];", Collections.emptyMap());
-
-        ExecutableScript script = scriptEngine.executable(compiledScript, vars);
+        ExecutableScript.Compiled compiledScript =
+            scriptEngine.compile(null, "return params['value'];", ScriptContext.EXECUTABLE, Collections.emptyMap());
+        ExecutableScript script = compiledScript.newInstance(vars);
 
         script.setNextVar("value", 1);
         Object value = script.run();

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ScriptTestCase.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ScriptTestCase.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.lucene.ScorerAware;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.painless.antlr.Walker;
 import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
@@ -85,8 +86,8 @@ public abstract class ScriptTestCase extends ESTestCase {
                     definition, null);
         }
         // test actual script execution
-        Object compiled = scriptEngine.compile(null, script, compileParams);
-        ExecutableScript executableScript = scriptEngine.executable(compiled, vars);
+        ExecutableScript.Compiled compiled = scriptEngine.compile(null, script, ScriptContext.EXECUTABLE, compileParams);
+        ExecutableScript executableScript = compiled.newInstance(vars);
         if (scorer != null) {
             ((ScorerAware)executableScript).setScorer(scorer);
         }

--- a/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
+++ b/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
@@ -58,7 +58,7 @@ public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
         }
 
         @Override
-        public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
+        public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
             if (context.equals(ScriptContext.SEARCH) == false) {
                 throw new IllegalArgumentException(getType() + " scripts cannot be used for context [" + context.name + "]");
             }

--- a/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
+++ b/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
@@ -33,8 +33,10 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.LeafSearchScript;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.SearchScript;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 /**
@@ -56,10 +58,13 @@ public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
         }
 
         @Override
-        public Function<Map<String,Object>,SearchScript> compile(String scriptName, String scriptSource, Map<String, String> params) {
+        public <T, C> C compile(String scriptName, String scriptSource, ScriptContext<T, C> context, Map<String, String> params) {
+            if (context.equals(ScriptContext.SEARCH) == false) {
+                throw new IllegalArgumentException(getType() + " scripts cannot be used for context [" + context.name + "]");
+            }
             // we use the script "source" as the script identifier
             if ("pure_df".equals(scriptSource)) {
-                return p -> new SearchScript() {
+                SearchScript.Compiled compiled = (p, lookup) -> new SearchScript() {
                     final String field;
                     final String term;
                     {
@@ -114,20 +119,9 @@ public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
                         return false;
                     }
                 };
+                return context.compiledClazz.cast(compiled);
             }
             throw new IllegalArgumentException("Unknown script name " + scriptSource);
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public SearchScript search(Object compiledScript, SearchLookup lookup, @Nullable Map<String, Object> params) {
-          Function<Map<String,Object>,SearchScript> scriptFactory = (Function<Map<String,Object>,SearchScript>) compiledScript;
-          return scriptFactory.apply(params);
-        }
-
-        @Override
-        public ExecutableScript executable(Object compiledScript, @Nullable Map<String, Object> params) {
-            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -67,7 +67,7 @@ public class MockScriptEngine implements ScriptEngine {
     }
 
     @Override
-    public Object compile(String name, String source, Map<String, String> options) {
+    public <T, C> C compile(String name, String source, ScriptContext<T, C> context, Map<String, String> params) {
         // Scripts are always resolved using the script's source. For inline scripts, it's easy because they don't have names and the
         // source is always provided. For stored and file scripts, the source of the script must match the key of a predefined script.
         Function<Map<String, Object>, Object> script = scripts.get(source);
@@ -75,19 +75,15 @@ public class MockScriptEngine implements ScriptEngine {
             throw new IllegalArgumentException("No pre defined script matching [" + source + "] for script with name [" + name + "], " +
                     "did you declare the mocked script?");
         }
-        return new MockCompiledScript(name, options, source, script);
-    }
-
-    @Override
-    public ExecutableScript executable(Object compiledScript, @Nullable Map<String, Object> vars) {
-        MockCompiledScript compiled = (MockCompiledScript) compiledScript;
-        return compiled.createExecutableScript(vars);
-    }
-
-    @Override
-    public SearchScript search(Object compiledScript, SearchLookup lookup, @Nullable Map<String, Object> vars) {
-        MockCompiledScript compiled = (MockCompiledScript) compiledScript;
-        return compiled.createSearchScript(vars, lookup);
+        MockCompiledScript mockCompiled = new MockCompiledScript(name, params, source, script);
+        if (context.instanceClazz.equals(SearchScript.class)) {
+            SearchScript.Compiled compiled = mockCompiled::createSearchScript;
+            return context.compiledClazz.cast(compiled);
+        } else if (context.instanceClazz.equals(ExecutableScript.class)) {
+            ExecutableScript.Compiled compiled = mockCompiled::createExecutableScript;
+            return context.compiledClazz.cast(compiled);
+        }
+        throw new IllegalArgumentException("mock script engine does not know how to handle context [" + context.name + "]");
     }
 
     public class MockCompiledScript {

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -67,7 +67,7 @@ public class MockScriptEngine implements ScriptEngine {
     }
 
     @Override
-    public <T, C> C compile(String name, String source, ScriptContext<T, C> context, Map<String, String> params) {
+    public <T> T compile(String name, String source, ScriptContext<T> context, Map<String, String> params) {
         // Scripts are always resolved using the script's source. For inline scripts, it's easy because they don't have names and the
         // source is always provided. For stored and file scripts, the source of the script must match the key of a predefined script.
         Function<Map<String, Object>, Object> script = scripts.get(source);


### PR DESCRIPTION
This commit changes the compile method of ScriptEngine to be generic in
the same way it is on ScriptService. This moves the shim of handling the
two existing context classes into each script engine, so that each
engine can be worked on independently to convert to real handling of
contexts.