### PR TITLE
add `exclude_keys` option to KeyValueProcessor

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1621,6 +1621,7 @@ For example, if you have a log message which contains `ip=1.2.3.4 error=REFUSED`
 | `value_split`    | yes       | -        | Regex pattern to use for splitting the key from the value within a key-value pair
 | `target_field`   | no        | `null`   | The field to insert the extracted keys into. Defaults to the root of the document
 | `include_keys`   | no        | `null`   | List of keys to filter and insert into document. Defaults to including all keys
+| `exclude_keys`   | no        | `null`   | List of keys to exclude from document
 | `ignore_missing` | no        | `false`  | If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document
 |======
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/KeyValueProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/KeyValueProcessorFactoryTests.java
@@ -21,9 +21,11 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -58,6 +60,7 @@ public class KeyValueProcessorFactoryTests extends ESTestCase {
         config.put("value_split", "=");
         config.put("target_field", "target");
         config.put("include_keys", Arrays.asList("a", "b"));
+        config.put("exclude_keys", Collections.emptyList());
         config.put("ignore_missing", true);
         String processorTag = randomAlphaOfLength(10);
         KeyValueProcessor processor = factory.create(null, processorTag, config);
@@ -65,7 +68,8 @@ public class KeyValueProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getField(), equalTo("field1"));
         assertThat(processor.getFieldSplit(), equalTo("&"));
         assertThat(processor.getValueSplit(), equalTo("="));
-        assertThat(processor.getIncludeKeys(), equalTo(Arrays.asList("a", "b")));
+        assertThat(processor.getIncludeKeys(), equalTo(Sets.newHashSet("a", "b")));
+        assertThat(processor.getExcludeKeys(), equalTo(Collections.emptySet()));
         assertThat(processor.getTargetField(), equalTo("target"));
         assertTrue(processor.isIgnoreMissing());
     }


### PR DESCRIPTION
adds `exclude_keys` option, just like Logstash allows. Where, if included, a field will not show up in the resulting document. Attempts to preserve exact behavior.

Closes #23856