### PR TITLE
Make contexts available to ScriptEngine construction

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/ScriptPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/ScriptPlugin.java
@@ -18,8 +18,10 @@
  */
 package org.elasticsearch.plugins;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.ScriptContext;
@@ -31,9 +33,11 @@ import org.elasticsearch.script.ScriptEngine;
 public interface ScriptPlugin {
 
     /**
-     * Returns a {@link ScriptEngine} instance or <code>null</code> if this plugin doesn't add a new script engine
+     * Returns a {@link ScriptEngine} instance or <code>null</code> if this plugin doesn't add a new script engine.
+     * @param settings Node settings
+     * @param contexts The contexts that {@link ScriptEngine#compile(String, String, ScriptContext, Map)} may be called with
      */
-    default ScriptEngine getScriptEngine(Settings settings) {
+    default ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
         return null;
     }
 

--- a/core/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -61,7 +61,9 @@ public class ScriptModule {
                     throw new IllegalArgumentException("Context name [" + context.name + "] defined twice");
                 }
             }
-            ScriptEngine engine = plugin.getScriptEngine(settings);
+        }
+        for (ScriptPlugin plugin : scriptPlugins) {
+            ScriptEngine engine = plugin.getScriptEngine(settings, contexts.values());
             if (engine != null) {
                 ScriptEngine existing = engines.put(engine.getType(), engine);
                 if (existing != null) {

--- a/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -70,7 +70,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
 
     public static class ExplainableScriptPlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngine(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
             return new ScriptEngine() {
                 @Override
                 public String getType() {

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestSearchIT.java
@@ -1009,7 +1009,7 @@ public class SuggestSearchIT extends ESIntegTestCase {
 
     public static class DummyTemplatePlugin extends Plugin implements ScriptPlugin {
         @Override
-        public ScriptEngine getScriptEngine(Settings settings) {
+        public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
             return new DummyTemplateScriptEngine();
         }
     }

--- a/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionPlugin.java
+++ b/modules/lang-expression/src/main/java/org/elasticsearch/script/expression/ExpressionPlugin.java
@@ -19,15 +19,18 @@
 
 package org.elasticsearch.script.expression;
 
+import java.util.Collection;
+
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 
 public class ExpressionPlugin extends Plugin implements ScriptPlugin {
 
     @Override
-    public ScriptEngine getScriptEngine(Settings settings) {
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
         return new ExpressionScriptEngine(settings);
     }
 }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
@@ -33,16 +33,18 @@ import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 
 public class MustachePlugin extends Plugin implements ScriptPlugin, ActionPlugin, SearchPlugin {
 
     @Override
-    public ScriptEngine getScriptEngine(Settings settings) {
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>>contexts) {
         return new MustacheScriptEngine();
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
@@ -24,9 +24,11 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -40,7 +42,7 @@ public final class PainlessPlugin extends Plugin implements ScriptPlugin {
     }
 
     @Override
-    public ScriptEngine getScriptEngine(Settings settings) {
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
         return new PainlessScriptEngine(settings);
     }
 

--- a/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
+++ b/plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java
@@ -21,6 +21,7 @@ package org.elasticsearch.example.expertscript;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -45,7 +46,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 public class ExpertScriptPlugin extends Plugin implements ScriptPlugin {
 
     @Override
-    public ScriptEngine getScriptEngine(Settings settings) {
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
         return new MyExpertScriptEngine();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptPlugin.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -34,7 +35,7 @@ public abstract class MockScriptPlugin extends Plugin implements ScriptPlugin {
     public static final String NAME = MockScriptEngine.NAME;
 
     @Override
-    public ScriptEngine getScriptEngine(Settings settings) {
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
         return new MockScriptEngine(pluginScriptLang(), pluginScripts());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -94,6 +94,7 @@ import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
@@ -1195,7 +1196,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     public static ScriptModule newTestScriptModule() {
         return new ScriptModule(Settings.EMPTY, singletonList(new ScriptPlugin() {
             @Override
-            public ScriptEngine getScriptEngine(Settings settings) {
+            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
                 return new MockScriptEngine(MockScriptEngine.NAME, Collections.singletonMap("1", script -> "1"));
             }
         }));


### PR DESCRIPTION
This commit adds collection of all contexts to the parameters of
getScriptEngine. This will allow script engines like painless to
precache extra information about the contexts.
