### PR TITLE
Add fromXContent method to ClearScrollResponse

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/ClearScrollResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ClearScrollResponse.java
@@ -20,18 +20,33 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.StatusToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
 
 public class ClearScrollResponse extends ActionResponse implements StatusToXContentObject {
+
+    private static final ParseField SUCCEEDED = new ParseField("succeeded");
+    private static final ParseField NUMFREED = new ParseField("num_freed");
+
+    private static final ConstructingObjectParser<ClearScrollResponse, Void> PARSER = new ConstructingObjectParser<>("clear_scroll",
+            true, a -> new ClearScrollResponse((boolean)a[0], (int)a[1]));
+    static {
+        PARSER.declareField(constructorArg(), (parser, context) -> parser.booleanValue(), SUCCEEDED, ObjectParser.ValueType.BOOLEAN);
+        PARSER.declareField(constructorArg(), (parser, context) -> parser.intValue(), NUMFREED, ObjectParser.ValueType.INT);
+    }
 
     private boolean succeeded;
     private int numFreed;
@@ -67,10 +82,17 @@ public class ClearScrollResponse extends ActionResponse implements StatusToXCont
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(Fields.SUCCEEDED, succeeded);
-        builder.field(Fields.NUMFREED, numFreed);
+        builder.field(SUCCEEDED.getPreferredName(), succeeded);
+        builder.field(NUMFREED.getPreferredName(), numFreed);
         builder.endObject();
         return builder;
+    }
+
+    /**
+     * Parse the clear scroll response body into a new {@link ClearScrollResponse} object
+     */
+    public static ClearScrollResponse fromXContent(XContentParser parser) throws IOException {
+        return PARSER.apply(parser, null);
     }
 
     @Override
@@ -85,10 +107,5 @@ public class ClearScrollResponse extends ActionResponse implements StatusToXCont
         super.writeTo(out);
         out.writeBoolean(succeeded);
         out.writeVInt(numFreed);
-    }
-
-    static final class Fields {
-        static final String SUCCEEDED = "succeeded";
-        static final String NUMFREED = "num_freed";
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/ClearScrollResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/search/ClearScrollResponseTests.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search;
+
+import org.elasticsearch.action.search.ClearScrollResponse;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
+public class ClearScrollResponseTests extends ESTestCase {
+
+    public void testToXContent() throws IOException {
+        ClearScrollResponse clearScrollResponse = new ClearScrollResponse(true, 10);
+        try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+            clearScrollResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        }
+        assertEquals(true, clearScrollResponse.isSucceeded());
+        assertEquals(10, clearScrollResponse.getNumFreed());
+    }
+
+    public void testToAndFromXContent() throws IOException {
+        XContentType xContentType = randomFrom(XContentType.values());
+        ClearScrollResponse originalResponse = createTestItem();
+        BytesReference originalBytes = toShuffledXContent(originalResponse, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
+        ClearScrollResponse parsedResponse;
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            parsedResponse = ClearScrollResponse.fromXContent(parser);
+        }
+        assertEquals(originalResponse.isSucceeded(), parsedResponse.isSucceeded());
+        assertEquals(originalResponse.getNumFreed(), parsedResponse.getNumFreed());
+        BytesReference parsedBytes = XContentHelper.toXContent(parsedResponse, xContentType, randomBoolean());
+        assertToXContentEquivalent(originalBytes, parsedBytes, xContentType);
+    }
+
+    private static ClearScrollResponse createTestItem() {
+        return new ClearScrollResponse(randomBoolean(), randomIntBetween(0, Integer.MAX_VALUE));
+    }
+}


### PR DESCRIPTION
ClearScrollResponse can print out its content into an XContentBuilder as it implements ToXContentObject. This PR add a fromXContent method to it so that we are able to recreate the response object when parsing the response back. This will be used in the high level REST client.