### PR TITLE
Adjust available and free bytes to be non-negative on huge FSes

### DIFF
--- a/core/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
+++ b/core/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
@@ -155,8 +155,8 @@ public class FsProbe extends AbstractComponent {
         // since recomputing these once per second (default) could be costly,
         // and they should not change:
         fsPath.total = adjustForHugeFilesystems(nodePath.fileStore.getTotalSpace());
-        fsPath.free = nodePath.fileStore.getUnallocatedSpace();
-        fsPath.available = nodePath.fileStore.getUsableSpace();
+        fsPath.free = adjustForHugeFilesystems(nodePath.fileStore.getUnallocatedSpace());
+        fsPath.available = adjustForHugeFilesystems(nodePath.fileStore.getUsableSpace());
         fsPath.type = nodePath.fileStore.type();
         fsPath.mount = nodePath.fileStore.toString();
         return fsPath;

--- a/core/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
@@ -246,6 +246,8 @@ public class FsProbeTests extends ESTestCase {
     public void testAdjustForHugeFilesystems() throws Exception {
         NodePath np = new FakeNodePath(createTempDir());
         assertThat(FsProbe.getFSInfo(np).total, greaterThanOrEqualTo(0L));
+        assertThat(FsProbe.getFSInfo(np).free, greaterThanOrEqualTo(0L));
+        assertThat(FsProbe.getFSInfo(np).available, greaterThanOrEqualTo(0L));
     }
 
     static class FakeNodePath extends NodeEnvironment.NodePath {
@@ -284,12 +286,12 @@ public class FsProbeTests extends ESTestCase {
 
         @Override
         public long getUsableSpace() throws IOException {
-            return 10;
+            return randomIntBetween(-1000, 1000);
         }
 
         @Override
         public long getUnallocatedSpace() throws IOException {
-            return 10;
+            return randomIntBetween(-1000, 1000);
         }
 
         @Override


### PR DESCRIPTION
In #23093 we made a change so that total bytes for a filesystem would not be a
negative value when the total bytes were > Long.MAX_VALUE.

This fixes #24453 which had a related issue where `available` and `free` bytes
could also be so large that they were negative. These will now return
`Long.MAX_VALUE` for the bytes if the JDK returns a negative value.
