### PR TITLE
Fix typo in terms-query

### DIFF
--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -68,7 +68,7 @@ possible, reducing the need for networking.
 [float]
 ===== Terms lookup twitter example
 At first we index the information for user with id 2, specifically, its
-followers, than index a tweet from user with id 1. Finally we search on
+followers, then index a tweet from user with id 1. Finally we search on
 all the tweets that match the followers of user 2.
 
 [source,js]


### PR DESCRIPTION
Found a typo. You don't have to merge this if you don't want to, just tracking it here.