### PR TITLE
Handle primary failure handling replica response

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -191,9 +191,9 @@ public class ReplicationOperation<
                 } catch (final AlreadyClosedException e) {
                     // okay, the index was deleted or this shard was never activated after a relocation; fallthrough and finish normally
                 } catch (final Exception e) {
+                    // fail the primary but fall through and let the rest of operation processing complete
                     final String message = String.format(Locale.ROOT, "primary failed updating local checkpoint for replica %s", shard);
                     primary.failShard(message, e);
-                    finishAsFailed(new RetryOnPrimaryException(primary.routingEntry().shardId(), message, e));
                 }
                 decPendingAndFinishIfNeeded();
             }

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -343,17 +343,14 @@ public class ReplicationOperationTests extends ESTestCase {
 
         if (fatal) {
             assertTrue(primaryFailed.get());
-            final ExecutionException e = expectThrows(ExecutionException.class, listener::get);
-            assertThat(e.getCause(), instanceOf(ReplicationOperation.RetryOnPrimaryException.class));
-            final ReplicationOperation.RetryOnPrimaryException rope = (ReplicationOperation.RetryOnPrimaryException) e.getCause();
-            assertThat(rope, hasToString(containsString("primary failed updating local checkpoint for replica")));
         } else {
             assertFalse(primaryFailed.get());
-            final ShardInfo shardInfo = listener.actionGet().getShardInfo();
-            assertThat(shardInfo.getFailed(), equalTo(0));
-            assertThat(shardInfo.getFailures(), arrayWithSize(0));
-            assertThat(shardInfo.getSuccessful(), equalTo(1 + getExpectedReplicas(shardId, state).size()));
         }
+        assertThat(primaryFailed.get(), equalTo(fatal));
+        final ShardInfo shardInfo = listener.actionGet().getShardInfo();
+        assertThat(shardInfo.getFailed(), equalTo(0));
+        assertThat(shardInfo.getFailures(), arrayWithSize(0));
+        assertThat(shardInfo.getSuccessful(), equalTo(1 + getExpectedReplicas(shardId, state).size()));
     }
 
     private Set<ShardRouting> getExpectedReplicas(ShardId shardId, ClusterState state) {

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.action.support.replication;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.UnavailableShardsException;
@@ -56,7 +57,9 @@ import java.util.function.Supplier;
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.state;
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.stateWithActivePrimary;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -191,8 +194,7 @@ public class ReplicationOperationTests extends ESTestCase {
                 assertTrue(primaryFailed.compareAndSet(false, true));
             }
         };
-        final TestReplicationOperation op = new TestReplicationOperation(request, primary, listener, replicasProxy,
-            () -> finalState);
+        final TestReplicationOperation op = new TestReplicationOperation(request, primary, listener, replicasProxy, () -> finalState);
         op.execute();
 
         assertThat("request was not processed on primary", request.processedOnPrimary.get(), equalTo(true));
@@ -297,6 +299,49 @@ public class ReplicationOperationTests extends ESTestCase {
                 request.processedOnPrimary.get());
             assertListenerThrows("should throw exception to trigger retry", listener, UnavailableShardsException.class);
         }
+    }
+
+    public void testPrimaryFailureHandlingReplicaResponse() throws Exception {
+        final String index = "test";
+        final ShardId shardId = new ShardId(index, "_na_", 0);
+
+        final Request request = new Request(shardId);
+
+        final ClusterState state = stateWithActivePrimary(index, true, 1, 0);
+        final IndexMetaData indexMetaData = state.getMetaData().index(index);
+        final long primaryTerm = indexMetaData.primaryTerm(0);
+        final ShardRouting primaryRouting = state.getRoutingTable().shardRoutingTable(shardId).primaryShard();
+
+        final AtomicBoolean primaryFailed = new AtomicBoolean();
+        final ReplicationOperation.Primary<Request, Request, TestPrimary.Result> primary = new TestPrimary(primaryRouting, primaryTerm) {
+
+            @Override
+            public void failShard(String message, Exception exception) {
+                primaryFailed.set(true);
+            }
+
+            @Override
+            public void updateLocalCheckpointForShard(String allocationId, long checkpoint) {
+                if (primaryRouting.allocationId().getId().equals(allocationId)) {
+                    super.updateLocalCheckpointForShard(allocationId, checkpoint);
+                } else {
+                    throw new AlreadyClosedException("closed");
+                }
+            }
+
+        };
+
+        final PlainActionFuture<TestPrimary.Result> listener = new PlainActionFuture<>();
+        final ReplicationOperation.Replicas<Request> replicas = new TestReplicaProxy(Collections.emptyMap());
+        TestReplicationOperation operation = new TestReplicationOperation(request, primary, listener, replicas, () -> state);
+        operation.execute();
+
+        assertTrue(primaryFailed.get());
+        final ExecutionException e = expectThrows(ExecutionException.class, listener::get);
+        assertThat(e.getCause(), instanceOf(ReplicationOperation.RetryOnPrimaryException.class));
+        final ReplicationOperation.RetryOnPrimaryException rope = (ReplicationOperation.RetryOnPrimaryException) e.getCause();
+        assertThat(rope, hasToString(containsString("primary failed updating local checkpoint for replica")));
+        // no need to assert that no replica was failed, the test replica proxy already ensures this since we passed an empty failure map
     }
 
     private Set<ShardRouting> getExpectedReplicas(ShardId shardId, ClusterState state) {

--- a/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -341,11 +341,6 @@ public class ReplicationOperationTests extends ESTestCase {
         TestReplicationOperation operation = new TestReplicationOperation(request, primary, listener, replicas, () -> state);
         operation.execute();
 
-        if (fatal) {
-            assertTrue(primaryFailed.get());
-        } else {
-            assertFalse(primaryFailed.get());
-        }
         assertThat(primaryFailed.get(), equalTo(fatal));
         final ShardInfo shardInfo = listener.actionGet().getShardInfo();
         assertThat(shardInfo.getFailed(), equalTo(0));


### PR DESCRIPTION
Today if the primary throws an exception while handling the replica response (e.g., because it is already closed while updating the local checkpoint for the replica), or because of a bug that causes an exception to be thrown in the replica operation listener, this exception is caught by the underlying transport handler plumbing and is translated into a response handler failure transport exception that is passed to the onFailure method of the replica operation listener. This causes the primary to turn around and fail the replica which is a disastrous and incorrect outcome as there's nothing wrong with the replica, it is the primary that is broken and deserves a paddlin'. This commit handles this situation by failing the primary.

Closes #24935