### PR TITLE
[Tests] Harden InternalExtendedStatsTests

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
@@ -79,10 +79,13 @@ public class InternalExtendedStatsTests extends InternalAggregationTestCase<Inte
         }
         assertEquals(sigma, reduced.getSigma(), 0);
         assertEquals(expectedCount, reduced.getCount());
-        assertEquals(expectedSum, reduced.getSum(), 1e-07);
+        // The order in which you add double values in java can give different results. The difference can
+        // be larger for large sum values, so we make the delta in the assertion depend on the values magnitude
+        assertEquals(expectedSum, reduced.getSum(), Math.abs(expectedSum) * 1e-12);
         assertEquals(expectedMin, reduced.getMin(), 0d);
         assertEquals(expectedMax, reduced.getMax(), 0d);
-        assertEquals(expectedSumOfSquare, reduced.getSumOfSquares(), 1e-07);
+        // summing squared values, see reason for delta above
+        assertEquals(expectedSumOfSquare, reduced.getSumOfSquares(), expectedSumOfSquare * 1e-14);
     }
 
     @Override


### PR DESCRIPTION
The order in which double values are added in Java can give different results,
so in testing the sum and sumOfSquares we need to allow some delta for testing
equality. The difference can be larger for large sum values, so we should
account for this by making the delta in the assertion depend on the values
magnitude.

Closes #24931