### PR TITLE
Add a dummy_index to upgrade tests to ensure we recover fine with replicas

### DIFF
--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -13,7 +13,7 @@
 
  - do:
      search:
-       index: dummy_index
+       index: index_with_replicas
 
  - match: { hits.total: 5 } # just check we recovered fine
 

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -12,6 +12,12 @@
  - match: { hits.total: 5 } # no new indexed data, so expect the original 5 documents from the old cluster
 
  - do:
+     search:
+       index: dummy_index
+
+ - match: { hits.total: 5 } # just check we recovered fine
+
+ - do:
      bulk:
         refresh: true
         body:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
@@ -10,7 +10,7 @@
 
   - do:
       indices.create:
-        index: dummy_index # dummy index to ensure we can recover indices with replicas just fine
+        index: index_with_replicas # dummy index to ensure we can recover indices with replicas just fine
 
   - do:
       bulk:
@@ -31,20 +31,20 @@
       bulk:
         refresh: true
         body:
-          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
           - '{"f1": "d_old"}'
-          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
           - '{"f1": "d_old"}'
-          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
           - '{"f1": "d_old"}'
-          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
           - '{"f1": "d_old"}'
-          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
           - '{"f1": "d_old"}'
 
   - do:
       indices.flush:
-        index: test_index,dummy_index
+        index: test_index,index_with_replicas
 
   - do:
       search:
@@ -54,7 +54,7 @@
 
   - do:
       search:
-        index: dummy_index
+        index: index_with_replicas
 
   - match: { hits.total: 5 }
 

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
@@ -9,27 +9,52 @@
               number_of_replicas: 0
 
   - do:
+      indices.create:
+        index: dummy_index # dummy index to ensure we can recover indices with replicas just fine
+
+  - do:
       bulk:
         refresh: true
         body:
-          - '{"index": {"_index": "test_index", "_type": "test_type"}}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
           - '{"f1": "v1_old", "f2": 0}'
-          - '{"index": {"_index": "test_index", "_type": "test_type"}}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
           - '{"f1": "v2_old", "f2": 1}'
-          - '{"index": {"_index": "test_index", "_type": "test_type"}}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
           - '{"f1": "v3_old", "f2": 2}'
-          - '{"index": {"_index": "test_index", "_type": "test_type"}}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
           - '{"f1": "v4_old", "f2": 3}'
-          - '{"index": {"_index": "test_index", "_type": "test_type"}}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
           - '{"f1": "v5_old", "f2": 4}'
 
   - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+          - '{"index": {"_index": "dummy_index", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+
+  - do:
       indices.flush:
-        index: test_index
+        index: test_index,dummy_index
 
   - do:
       search:
         index: test_index
+
+  - match: { hits.total: 5 }
+
+  - do:
+      search:
+        index: dummy_index
 
   - match: { hits.total: 5 }
 

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -12,6 +12,12 @@
  - match: { hits.total: 10 } # no new indexed data, so expect the original 10 documents from the old and mixed clusters
 
  - do:
+     search:
+       index: dummy_index
+
+ - match: { hits.total: 5 } # just check we recovered fine
+
+ - do:
      bulk:
         refresh: true
         body:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -13,7 +13,7 @@
 
  - do:
      search:
-       index: dummy_index
+       index: index_with_replicas
 
  - match: { hits.total: 5 } # just check we recovered fine
 


### PR DESCRIPTION
We default to 0 replicas in the rolling restart scenario already to ensure
we test against worst case. Yet, this adds a dummy index to ensure we also
recover and index with replicas just fine.
