### PR TITLE
Add doc_count to ParsedMatrixStats

### DIFF
--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/ParsedMatrixStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/ParsedMatrixStats.java
@@ -41,14 +41,20 @@ public class ParsedMatrixStats extends ParsedAggregation implements MatrixStats 
     private final Map<String, Map<String, Double>> covariances = new HashMap<>();
     private final Map<String, Map<String, Double>> correlations = new HashMap<>();
 
+    private long docCount;
+
     @Override
     public String getType() {
         return MatrixStatsAggregationBuilder.NAME;
     }
 
+    private void setDocCount(long docCount) {
+        this.docCount = docCount;
+    }
+
     @Override
     public long getDocCount() {
-        throw new UnsupportedOperationException();
+        return docCount;
     }
 
     @Override
@@ -97,6 +103,7 @@ public class ParsedMatrixStats extends ParsedAggregation implements MatrixStats 
 
     @Override
     protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
         if (counts != null && counts.isEmpty() == false) {
             builder.startArray(InternalMatrixStats.Fields.FIELDS);
             for (String fieldName : counts.keySet()) {
@@ -148,6 +155,7 @@ public class ParsedMatrixStats extends ParsedAggregation implements MatrixStats 
             new ObjectParser<>(ParsedMatrixStats.class.getSimpleName(), true, ParsedMatrixStats::new);
     static {
         declareAggregationFields(PARSER);
+        PARSER.declareLong(ParsedMatrixStats::setDocCount, CommonFields.DOC_COUNT);
         PARSER.declareObjectArray((matrixStats, results) -> {
             for (ParsedMatrixStatsResult result : results) {
                 final String fieldName = result.name;

--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStatsTests.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStatsTests.java
@@ -133,8 +133,7 @@ public class InternalMatrixStatsTests extends InternalAggregationTestCase<Intern
         assertTrue(parsedAggregation instanceof ParsedMatrixStats);
         ParsedMatrixStats actual = (ParsedMatrixStats) parsedAggregation;
 
-        //norelease add parsing logic for doc count and enable this test once elastic/elasticsearch#24776 is merged
-        //assertEquals(expected.getDocCount(), actual.getDocCount());
+        assertEquals(expected.getDocCount(), actual.getDocCount());
 
         for (String field : fields) {
             assertEquals(expected.getFieldCount(field), actual.getFieldCount(field));


### PR DESCRIPTION
This commit adds support in ParsedMatrixStats for parsing the doc_count
field now it has been added in #24776.