### PR TITLE
Eliminate array access in tight loops when profiling is enabled.

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.Weight;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.search.dfs.AggregatedDfs;
+import org.elasticsearch.search.profile.Timer;
 import org.elasticsearch.search.profile.query.ProfileWeight;
 import org.elasticsearch.search.profile.query.QueryProfileBreakdown;
 import org.elasticsearch.search.profile.query.QueryProfiler;
@@ -116,12 +117,13 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             // each invocation so that it can build an internal representation of the query
             // tree
             QueryProfileBreakdown profile = profiler.getQueryBreakdown(query);
-            profile.startTime(QueryTimingType.CREATE_WEIGHT);
+            Timer timer = profile.getTimer(QueryTimingType.CREATE_WEIGHT);
+            timer.start();
             final Weight weight;
             try {
                 weight = super.createWeight(query, needsScores, boost);
             } finally {
-                profile.stopAndRecordTime();
+                timer.stop();
                 profiler.pollLastElement();
             }
             return new ProfileWeight(query, weight, profile);

--- a/core/src/main/java/org/elasticsearch/search/profile/Timer.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/Timer.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.profile;
+
+/** Helps measure how much time is spent running some methods.
+ *  The {@link #start()} and {@link #stop()} methods should typically be called
+ *  in a try/finally clause with {@link #start()} being called right before the
+ *  try block and {@link #stop()} being called at the beginning of the finally
+ *  block:
+ *  <pre>
+ *  timer.start();
+ *  try {
+ *    // code to time
+ *  } finally {
+ *    timer.stop();
+ *  }
+ *  </pre>
+ */
+// TODO: do not time every single call as discussed in https://github.com/elastic/elasticsearch/issues/24799
+public final class Timer {
+
+    private long timing, count, start;
+
+    /** Start the timer. */
+    public void start() {
+        assert start == 0 : "#start call misses a matching #stop call";
+        count++;
+        start = System.nanoTime();
+    }
+
+    /** Stop the timer. */
+    public void stop() {
+        timing += Math.max(System.nanoTime() - start, 1L);
+        start = 0;
+    }
+
+    /** Return the number of times that {@link #start()} has been called. */
+    public long getCount() {
+        if (start != 0) {
+            throw new IllegalStateException("#start call misses a matching #stop call");
+        }
+        return count;
+    }
+
+    /** Return an approximation of the total time spend between consecutive calls of #start and #stop. */
+    public long getTiming() {
+        if (start != 0) {
+            throw new IllegalStateException("#start call misses a matching #stop call");
+        }
+        return timing;
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/search/profile/aggregation/AggregationProfileBreakdown.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/aggregation/AggregationProfileBreakdown.java
@@ -24,7 +24,7 @@ import org.elasticsearch.search.profile.AbstractProfileBreakdown;
 public class AggregationProfileBreakdown extends AbstractProfileBreakdown<AggregationTimingType> {
 
     public AggregationProfileBreakdown() {
-        super(AggregationTimingType.values());
+        super(AggregationTimingType.class);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingAggregator.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.profile.Timer;
 
 import java.io.IOException;
 
@@ -70,9 +71,14 @@ public class ProfilingAggregator extends Aggregator {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) throws IOException {
-        profileBreakdown.startTime(AggregationTimingType.BUILD_AGGREGATION);
-        InternalAggregation result = delegate.buildAggregation(bucket);
-        profileBreakdown.stopAndRecordTime();
+        Timer timer = profileBreakdown.getTimer(AggregationTimingType.BUILD_AGGREGATION);
+        timer.start();
+        InternalAggregation result;
+        try {
+            result = delegate.buildAggregation(bucket);
+        } finally {
+            timer.stop();
+        }
         return result;
     }
 
@@ -89,9 +95,13 @@ public class ProfilingAggregator extends Aggregator {
     @Override
     public void preCollection() throws IOException {
         this.profileBreakdown = profiler.getQueryBreakdown(delegate);
-        profileBreakdown.startTime(AggregationTimingType.INITIALIZE);
-        delegate.preCollection();
-        profileBreakdown.stopAndRecordTime();
+        Timer timer = profileBreakdown.getTimer(AggregationTimingType.INITIALIZE);
+        timer.start();
+        try {
+            delegate.preCollection();
+        } finally {
+            timer.stop();
+        }
         profiler.pollLastElement();
     }
 

--- a/core/src/main/java/org/elasticsearch/search/profile/query/ProfileWeight.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/ProfileWeight.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
+import org.elasticsearch.search.profile.Timer;
 
 import java.io.IOException;
 import java.util.Set;
@@ -48,12 +49,13 @@ public final class ProfileWeight extends Weight {
 
     @Override
     public Scorer scorer(LeafReaderContext context) throws IOException {
-        profile.startTime(QueryTimingType.BUILD_SCORER);
+        Timer timer = profile.getTimer(QueryTimingType.BUILD_SCORER);
+        timer.start();
         final Scorer subQueryScorer;
         try {
             subQueryScorer = subQueryWeight.scorer(context);
         } finally {
-            profile.stopAndRecordTime();
+            timer.stop();
         }
         if (subQueryScorer == null) {
             return null;

--- a/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileBreakdown.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/QueryProfileBreakdown.java
@@ -30,6 +30,6 @@ public final class QueryProfileBreakdown extends AbstractProfileBreakdown<QueryT
 
     /** Sole constructor. */
     public QueryProfileBreakdown() {
-        super(QueryTimingType.values());
+        super(QueryTimingType.class);
     }
 }


### PR DESCRIPTION
This makes profiling classes acquire a timer up-front that can be then reused
across all calls, in order to save bound checks for methods that are called in
tight loops.