### PR TITLE
[Test] Reduce number of buckets in SearchResponseTests and AggregationsTests

### DIFF
--- a/core/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
@@ -95,7 +95,6 @@ public class SearchResponseTests extends ESTestCase {
         return new SearchResponse(internalSearchResponse, null, totalShards, successfulShards, tookInMillis, shardSearchFailures);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/24891")
     public void testFromXContent() throws IOException {
         // the "_shard/total/failures" section makes if impossible to directly compare xContent, so we omit it here
         SearchResponse response = createTestItem();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
@@ -171,7 +171,6 @@ public class AggregationsTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/24891")
     public void testFromXContent() throws IOException {
         XContentType xContentType = randomFrom(XContentType.values());
         final ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
@@ -26,7 +26,48 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.search.aggregations.bucket.adjacency.InternalAdjacencyMatrixTests;
+import org.elasticsearch.search.aggregations.bucket.filter.InternalFilterTests;
+import org.elasticsearch.search.aggregations.bucket.filters.InternalFiltersTests;
+import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoHashGridTests;
+import org.elasticsearch.search.aggregations.bucket.global.InternalGlobalTests;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalDateHistogramTests;
+import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogramTests;
+import org.elasticsearch.search.aggregations.bucket.missing.InternalMissingTests;
+import org.elasticsearch.search.aggregations.bucket.nested.InternalNestedTests;
+import org.elasticsearch.search.aggregations.bucket.nested.InternalReverseNestedTests;
+import org.elasticsearch.search.aggregations.bucket.range.InternalBinaryRangeTests;
+import org.elasticsearch.search.aggregations.bucket.range.InternalRangeTests;
+import org.elasticsearch.search.aggregations.bucket.range.date.InternalDateRangeTests;
+import org.elasticsearch.search.aggregations.bucket.range.geodistance.InternalGeoDistanceTests;
+import org.elasticsearch.search.aggregations.bucket.sampler.InternalSamplerTests;
+import org.elasticsearch.search.aggregations.bucket.significant.SignificantLongTermsTests;
+import org.elasticsearch.search.aggregations.bucket.significant.SignificantStringTermsTests;
+import org.elasticsearch.search.aggregations.bucket.terms.DoubleTermsTests;
+import org.elasticsearch.search.aggregations.bucket.terms.LongTermsTests;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTermsTests;
+import org.elasticsearch.search.aggregations.metrics.InternalExtendedStatsTests;
+import org.elasticsearch.search.aggregations.metrics.InternalMaxTests;
+import org.elasticsearch.search.aggregations.metrics.InternalStatsBucketTests;
+import org.elasticsearch.search.aggregations.metrics.InternalStatsTests;
+import org.elasticsearch.search.aggregations.metrics.avg.InternalAvgTests;
+import org.elasticsearch.search.aggregations.metrics.cardinality.InternalCardinalityTests;
+import org.elasticsearch.search.aggregations.metrics.geobounds.InternalGeoBoundsTests;
+import org.elasticsearch.search.aggregations.metrics.geocentroid.InternalGeoCentroidTests;
+import org.elasticsearch.search.aggregations.metrics.min.InternalMinTests;
+import org.elasticsearch.search.aggregations.metrics.percentiles.hdr.InternalHDRPercentilesRanksTests;
+import org.elasticsearch.search.aggregations.metrics.percentiles.hdr.InternalHDRPercentilesTests;
+import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.InternalTDigestPercentilesRanksTests;
+import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.InternalTDigestPercentilesTests;
+import org.elasticsearch.search.aggregations.metrics.scripted.InternalScriptedMetricTests;
+import org.elasticsearch.search.aggregations.metrics.sum.InternalSumTests;
+import org.elasticsearch.search.aggregations.metrics.tophits.InternalTopHitsTests;
+import org.elasticsearch.search.aggregations.metrics.valuecount.InternalValueCountTests;
+import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValueTests;
+import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.InternalBucketMetricValueTests;
+import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.percentile.InternalPercentilesBucketTests;
+import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.extended.InternalExtendedStatsBucketTests;
+import org.elasticsearch.search.aggregations.pipeline.derivative.InternalDerivativeTests;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
@@ -52,7 +93,7 @@ public class AggregationsTests extends ESTestCase {
     private static final List<InternalAggregationTestCase> aggsTests = getAggsTests();
 
     private static List<InternalAggregationTestCase> getAggsTests() {
-        List<InternalAggregationTestCase> aggsTests = new ArrayList<>();/*
+        List<InternalAggregationTestCase> aggsTests = new ArrayList<>();
         aggsTests.add(new InternalCardinalityTests());
         aggsTests.add(new InternalTDigestPercentilesTests());
         aggsTests.add(new InternalTDigestPercentilesRanksTests());
@@ -73,8 +114,8 @@ public class AggregationsTests extends ESTestCase {
         aggsTests.add(new InternalExtendedStatsBucketTests());
         aggsTests.add(new InternalGeoBoundsTests());
         aggsTests.add(new InternalGeoCentroidTests());
-        aggsTests.add(new InternalHistogramTests());*/
-        aggsTests.add(new InternalDateHistogramTests());/*
+        aggsTests.add(new InternalHistogramTests());
+        aggsTests.add(new InternalDateHistogramTests());
         aggsTests.add(new LongTermsTests());
         aggsTests.add(new DoubleTermsTests());
         aggsTests.add(new StringTermsTests());
@@ -94,7 +135,7 @@ public class AggregationsTests extends ESTestCase {
         aggsTests.add(new SignificantStringTermsTests());
         aggsTests.add(new InternalScriptedMetricTests());
         aggsTests.add(new InternalBinaryRangeTests());
-        aggsTests.add(new InternalTopHitsTests());*/
+        aggsTests.add(new InternalTopHitsTests());
         return Collections.unmodifiableList(aggsTests);
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
@@ -26,48 +26,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.action.search.RestSearchAction;
-import org.elasticsearch.search.aggregations.bucket.adjacency.InternalAdjacencyMatrixTests;
-import org.elasticsearch.search.aggregations.bucket.filter.InternalFilterTests;
-import org.elasticsearch.search.aggregations.bucket.filters.InternalFiltersTests;
-import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoHashGridTests;
-import org.elasticsearch.search.aggregations.bucket.global.InternalGlobalTests;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalDateHistogramTests;
-import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogramTests;
-import org.elasticsearch.search.aggregations.bucket.missing.InternalMissingTests;
-import org.elasticsearch.search.aggregations.bucket.nested.InternalNestedTests;
-import org.elasticsearch.search.aggregations.bucket.nested.InternalReverseNestedTests;
-import org.elasticsearch.search.aggregations.bucket.range.InternalBinaryRangeTests;
-import org.elasticsearch.search.aggregations.bucket.range.InternalRangeTests;
-import org.elasticsearch.search.aggregations.bucket.range.date.InternalDateRangeTests;
-import org.elasticsearch.search.aggregations.bucket.range.geodistance.InternalGeoDistanceTests;
-import org.elasticsearch.search.aggregations.bucket.sampler.InternalSamplerTests;
-import org.elasticsearch.search.aggregations.bucket.significant.SignificantLongTermsTests;
-import org.elasticsearch.search.aggregations.bucket.significant.SignificantStringTermsTests;
-import org.elasticsearch.search.aggregations.bucket.terms.DoubleTermsTests;
-import org.elasticsearch.search.aggregations.bucket.terms.LongTermsTests;
-import org.elasticsearch.search.aggregations.bucket.terms.StringTermsTests;
-import org.elasticsearch.search.aggregations.metrics.InternalExtendedStatsTests;
-import org.elasticsearch.search.aggregations.metrics.InternalMaxTests;
-import org.elasticsearch.search.aggregations.metrics.InternalStatsBucketTests;
-import org.elasticsearch.search.aggregations.metrics.InternalStatsTests;
-import org.elasticsearch.search.aggregations.metrics.avg.InternalAvgTests;
-import org.elasticsearch.search.aggregations.metrics.cardinality.InternalCardinalityTests;
-import org.elasticsearch.search.aggregations.metrics.geobounds.InternalGeoBoundsTests;
-import org.elasticsearch.search.aggregations.metrics.geocentroid.InternalGeoCentroidTests;
-import org.elasticsearch.search.aggregations.metrics.min.InternalMinTests;
-import org.elasticsearch.search.aggregations.metrics.percentiles.hdr.InternalHDRPercentilesRanksTests;
-import org.elasticsearch.search.aggregations.metrics.percentiles.hdr.InternalHDRPercentilesTests;
-import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.InternalTDigestPercentilesRanksTests;
-import org.elasticsearch.search.aggregations.metrics.percentiles.tdigest.InternalTDigestPercentilesTests;
-import org.elasticsearch.search.aggregations.metrics.scripted.InternalScriptedMetricTests;
-import org.elasticsearch.search.aggregations.metrics.sum.InternalSumTests;
-import org.elasticsearch.search.aggregations.metrics.tophits.InternalTopHitsTests;
-import org.elasticsearch.search.aggregations.metrics.valuecount.InternalValueCountTests;
-import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValueTests;
-import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.InternalBucketMetricValueTests;
-import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.percentile.InternalPercentilesBucketTests;
-import org.elasticsearch.search.aggregations.pipeline.bucketmetrics.stats.extended.InternalExtendedStatsBucketTests;
-import org.elasticsearch.search.aggregations.pipeline.derivative.InternalDerivativeTests;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
@@ -93,7 +52,7 @@ public class AggregationsTests extends ESTestCase {
     private static final List<InternalAggregationTestCase> aggsTests = getAggsTests();
 
     private static List<InternalAggregationTestCase> getAggsTests() {
-        List<InternalAggregationTestCase> aggsTests = new ArrayList<>();
+        List<InternalAggregationTestCase> aggsTests = new ArrayList<>();/*
         aggsTests.add(new InternalCardinalityTests());
         aggsTests.add(new InternalTDigestPercentilesTests());
         aggsTests.add(new InternalTDigestPercentilesRanksTests());
@@ -114,8 +73,8 @@ public class AggregationsTests extends ESTestCase {
         aggsTests.add(new InternalExtendedStatsBucketTests());
         aggsTests.add(new InternalGeoBoundsTests());
         aggsTests.add(new InternalGeoCentroidTests());
-        aggsTests.add(new InternalHistogramTests());
-        aggsTests.add(new InternalDateHistogramTests());
+        aggsTests.add(new InternalHistogramTests());*/
+        aggsTests.add(new InternalDateHistogramTests());/*
         aggsTests.add(new LongTermsTests());
         aggsTests.add(new DoubleTermsTests());
         aggsTests.add(new StringTermsTests());
@@ -135,7 +94,7 @@ public class AggregationsTests extends ESTestCase {
         aggsTests.add(new SignificantStringTermsTests());
         aggsTests.add(new InternalScriptedMetricTests());
         aggsTests.add(new InternalBinaryRangeTests());
-        aggsTests.add(new InternalTopHitsTests());
+        aggsTests.add(new InternalTopHitsTests());*/
         return Collections.unmodifiableList(aggsTests);
     }
 
@@ -147,6 +106,11 @@ public class AggregationsTests extends ESTestCase {
     @Before
     public void init() throws Exception {
         for (InternalAggregationTestCase aggsTest : aggsTests) {
+            if (aggsTest instanceof InternalMultiBucketAggregationTestCase) {
+                // Lower down the number of buckets generated by multi bucket aggregation tests in
+                // order to avoid too many aggregations to be created.
+                ((InternalMultiBucketAggregationTestCase) aggsTest).maxNumberOfBuckets = 3;
+            }
             aggsTest.setUp();
         }
     }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregationTestCase.java
@@ -32,12 +32,11 @@ import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public abstract class InternalMultiBucketAggregationTestCase<T extends InternalAggregation & MultiBucketsAggregation>
         extends InternalAggregationTestCase<T> {
 
-    private static final int DEFAULT_MAX_NUMBER_OF_BUCKETS = 25;
+    private static final int DEFAULT_MAX_NUMBER_OF_BUCKETS = 10;
 
     Supplier<InternalAggregations> subAggregationsSupplier;
     int maxNumberOfBuckets = DEFAULT_MAX_NUMBER_OF_BUCKETS;
@@ -73,12 +72,9 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
 
     @Override
     protected final T createTestInstance(String name, List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
-        final int maxNumberOfBuckets = maxNumberOfBuckets();
         T instance = createTestInstance(name, pipelineAggregators, metaData, subAggregationsSupplier.get());
-
-        int numberOfBuckets = instance.getBuckets().size();
-        assertThat("Expecting a maximum number of "+ maxNumberOfBuckets + " buckets for " + instance.getClass().getSimpleName()
-                + " aggregation but got " + numberOfBuckets, numberOfBuckets, lessThanOrEqualTo(maxNumberOfBuckets));
+        assert instance.getBuckets().size() <= maxNumberOfBuckets() :
+                "Maximum number of buckets exceeded for " + instance.getClass().getSimpleName() + " aggregation";
         return instance;
     }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -35,6 +35,11 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
     private List<String> keys;
 
     @Override
+    protected int maxNumberOfBuckets() {
+        return 10;
+    }
+
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         keys = new ArrayList<>();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -57,7 +57,6 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
                 }
             }
         }
-        System.out.println("");
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -26,9 +26,11 @@ import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregationTestCase<InternalAdjacencyMatrix> {
 
@@ -37,22 +39,24 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        keys = new ArrayList<>();
+        List<String> listOfKeys = new ArrayList<>();
         int numFilters = randomIntBetween(2, 4);
         String[] filters = new String[numFilters];
         for (int i = 0; i < numFilters; i++) {
             filters[i] = randomAlphaOfLength(5);
         }
         for (int i = 0; i < filters.length; i++) {
-            keys.add(filters[i]);
+            listOfKeys.add(filters[i]);
             for (int j = i + 1; j < filters.length; j++) {
                 if (filters[i].compareTo(filters[j]) <= 0) {
-                    keys.add(filters[i] + "&" + filters[j]);
+                    listOfKeys.add(filters[i] + "&" + filters[j]);
                 } else {
-                    keys.add(filters[j] + "&" + filters[i]);
+                    listOfKeys.add(filters[j] + "&" + filters[i]);
                 }
             }
         }
+        Collections.shuffle(listOfKeys, random());
+        keys = Collections.unmodifiableList(listOfKeys.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -26,11 +26,9 @@ import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregationTestCase<InternalAdjacencyMatrix> {
 
@@ -39,24 +37,27 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        List<String> listOfKeys = new ArrayList<>();
+        keys = new ArrayList<>();
+        // InternalAdjacencyMatrix represents the upper triangular matrix:
+        // 2 filters (matrix of 2x2) generates 3 buckets
+        // 3 filters generates 6 buckets
+        // 4 filters generates 10 buckets
         int numFilters = randomIntBetween(2, 4);
         String[] filters = new String[numFilters];
         for (int i = 0; i < numFilters; i++) {
             filters[i] = randomAlphaOfLength(5);
         }
         for (int i = 0; i < filters.length; i++) {
-            listOfKeys.add(filters[i]);
+            keys.add(filters[i]);
             for (int j = i + 1; j < filters.length; j++) {
                 if (filters[i].compareTo(filters[j]) <= 0) {
-                    listOfKeys.add(filters[i] + "&" + filters[j]);
+                    keys.add(filters[i] + "&" + filters[j]);
                 } else {
-                    listOfKeys.add(filters[j] + "&" + filters[i]);
+                    keys.add(filters[j] + "&" + filters[i]);
                 }
             }
         }
-        Collections.shuffle(listOfKeys, random());
-        keys = Collections.unmodifiableList(listOfKeys.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
+        System.out.println("");
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filters/InternalFiltersTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/filters/InternalFiltersTests.java
@@ -40,7 +40,7 @@ public class InternalFiltersTests extends InternalMultiBucketAggregationTestCase
         super.setUp();
         keyed = randomBoolean();
         keys = new ArrayList<>();
-        int numBuckets = randomIntBetween(1, 5);
+        int numBuckets = randomNumberOfBuckets();
         for (int i = 0; i < numBuckets; i++) {
             if (keyed) {
                 keys.add(randomAlphaOfLength(5));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGridTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGridTests.java
@@ -34,11 +34,21 @@ import java.util.Map;
 public class InternalGeoHashGridTests extends InternalMultiBucketAggregationTestCase<InternalGeoHashGrid> {
 
     @Override
+    protected int minNumberOfBuckets() {
+        return 1;
+    }
+
+    @Override
+    protected int maxNumberOfBuckets() {
+        return 3;
+    }
+
+    @Override
     protected InternalGeoHashGrid createTestInstance(String name,
                                                      List<PipelineAggregator> pipelineAggregators,
                                                      Map<String, Object> metaData,
                                                      InternalAggregations aggregations) {
-        int size = randomIntBetween(1, 3);
+        int size = randomNumberOfBuckets();
         List<InternalGeoHashGrid.Bucket> buckets = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             double latitude = randomDoubleBetween(-90.0, 90.0, false);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
@@ -55,7 +55,7 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
                                                        List<PipelineAggregator> pipelineAggregators,
                                                        Map<String, Object> metaData,
                                                        InternalAggregations aggregations) {
-        int nbBuckets = randomInt(10);
+        int nbBuckets = randomNumberOfBuckets();
         List<InternalDateHistogram.Bucket> buckets = new ArrayList<>(nbBuckets);
         long startingDate = System.currentTimeMillis();
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
@@ -51,7 +51,7 @@ public class InternalHistogramTests extends InternalMultiBucketAggregationTestCa
                                                    Map<String, Object> metaData,
                                                    InternalAggregations aggregations) {
         final int base = randomInt(50) - 30;
-        final int numBuckets = randomInt(10);
+        final int numBuckets = randomNumberOfBuckets();
         final int interval = randomIntBetween(1, 3);
         List<InternalHistogram.Bucket> buckets = new ArrayList<>();
         for (int i = 0; i < numBuckets; ++i) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -57,7 +57,7 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
             listOfRanges.add(Tuple.tuple(null, null));
         }
 
-        final int numRanges = randomNumberOfBuckets() - listOfRanges.size();
+        final int numRanges = Math.max(0, randomNumberOfBuckets() - listOfRanges.size());
         for (int i = 0; i < numRanges; i++) {
             BytesRef[] values = new BytesRef[2];
             values[0] = new BytesRef(randomAlphaOfLength(15));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -32,27 +32,21 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBinaryRange> {
 
     private List<Tuple<BytesRef, BytesRef>> ranges;
 
     @Override
+    protected int minNumberOfBuckets() {
+        return 1;
+    }
+
+    @Override
     public void setUp() throws Exception {
         super.setUp();
 
-        final int numRanges = randomNumberOfBuckets();
-        List<Tuple<BytesRef, BytesRef>> listOfRanges = new ArrayList<>(numRanges);
-
-        for (int i = 0; i < numRanges; i++) {
-            BytesRef[] values = new BytesRef[2];
-            values[0] = new BytesRef(randomAlphaOfLength(15));
-            values[1] = new BytesRef(randomAlphaOfLength(15));
-            Arrays.sort(values);
-            listOfRanges.add(Tuple.tuple(values[0], values[1]));
-        }
-
+        List<Tuple<BytesRef, BytesRef>> listOfRanges = new ArrayList<>();
         if (randomBoolean()) {
             listOfRanges.add(Tuple.tuple(null, new BytesRef(randomAlphaOfLength(15))));
         }
@@ -62,8 +56,17 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
         if (randomBoolean()) {
             listOfRanges.add(Tuple.tuple(null, null));
         }
+
+        final int numRanges = randomNumberOfBuckets() - listOfRanges.size();
+        for (int i = 0; i < numRanges; i++) {
+            BytesRef[] values = new BytesRef[2];
+            values[0] = new BytesRef(randomAlphaOfLength(15));
+            values[1] = new BytesRef(randomAlphaOfLength(15));
+            Arrays.sort(values);
+            listOfRanges.add(Tuple.tuple(values[0], values[1]));
+        }
         Collections.shuffle(listOfRanges, random());
-        ranges = Collections.unmodifiableList(listOfRanges.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
+        ranges = Collections.unmodifiableList(listOfRanges);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -29,8 +29,10 @@ import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBinaryRange> {
 
@@ -40,26 +42,28 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
     public void setUp() throws Exception {
         super.setUp();
 
-        final int numRanges = randomIntBetween(1, 10);
-        ranges = new ArrayList<>(numRanges);
+        final int numRanges = randomNumberOfBuckets();
+        List<Tuple<BytesRef, BytesRef>> listOfRanges = new ArrayList<>(numRanges);
 
         for (int i = 0; i < numRanges; i++) {
             BytesRef[] values = new BytesRef[2];
             values[0] = new BytesRef(randomAlphaOfLength(15));
             values[1] = new BytesRef(randomAlphaOfLength(15));
             Arrays.sort(values);
-            ranges.add(Tuple.tuple(values[0], values[1]));
+            listOfRanges.add(Tuple.tuple(values[0], values[1]));
         }
 
         if (randomBoolean()) {
-            ranges.add(Tuple.tuple(null, new BytesRef(randomAlphaOfLength(15))));
+            listOfRanges.add(Tuple.tuple(null, new BytesRef(randomAlphaOfLength(15))));
         }
         if (randomBoolean()) {
-            ranges.add(Tuple.tuple(new BytesRef(randomAlphaOfLength(15)), null));
+            listOfRanges.add(Tuple.tuple(new BytesRef(randomAlphaOfLength(15)), null));
         }
         if (randomBoolean()) {
-            ranges.add(Tuple.tuple(null, null));
+            listOfRanges.add(Tuple.tuple(null, null));
         }
+        Collections.shuffle(listOfRanges, random());
+        ranges = Collections.unmodifiableList(listOfRanges.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class InternalRangeTests extends InternalRangeTestCase<InternalRange> {
 
@@ -43,22 +42,7 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange> {
         super.setUp();
         format = randomNumericDocValueFormat();
 
-        final int interval = randomFrom(1, 5, 10, 25, 50, 100);
-        final int numRanges = randomNumberOfBuckets();
-
-        List<Tuple<Double, Double>> listOfRanges = new ArrayList<>(numRanges);
-        for (int i = 0; i < numRanges; i++) {
-            double from = i * interval;
-            double to = from + interval;
-            listOfRanges.add(Tuple.tuple(from, to));
-        }
-        if (randomBoolean()) {
-            // Add some overlapping ranges
-            double max = (double) numRanges * interval;
-            listOfRanges.add(Tuple.tuple(0.0, max));
-            listOfRanges.add(Tuple.tuple(0.0, max / 2));
-            listOfRanges.add(Tuple.tuple(max / 3, max / 3 * 2));
-        }
+        List<Tuple<Double, Double>> listOfRanges = new ArrayList<>();
         if (rarely()) {
             listOfRanges.add(Tuple.tuple(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
         }
@@ -69,8 +53,25 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange> {
             listOfRanges.add(Tuple.tuple(randomDouble(), Double.POSITIVE_INFINITY));
         }
 
+        final int interval = randomFrom(1, 5, 10, 25, 50, 100);
+        final int numRanges = Math.max(0, randomNumberOfBuckets() - listOfRanges.size());
+        final double max = (double) numRanges * interval;
+
+        for (int i = 0; numRanges - listOfRanges.size() > 0; i++) {
+            double from = i * interval;
+            double to = from + interval;
+
+            Tuple<Double, Double> range;
+            if (randomBoolean()) {
+                range = Tuple.tuple(from, to);
+            } else {
+                // Add some overlapping range
+                range = Tuple.tuple(randomFrom(0.0, max / 3), randomFrom(max, max / 2, max / 3 * 2));
+            }
+            listOfRanges.add(range);
+        }
         Collections.shuffle(listOfRanges, random());
-        ranges = Collections.unmodifiableList(listOfRanges.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
+        ranges = Collections.unmodifiableList(listOfRanges);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class InternalRangeTests extends InternalRangeTestCase<InternalRange> {
 
@@ -43,7 +44,7 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange> {
         format = randomNumericDocValueFormat();
 
         final int interval = randomFrom(1, 5, 10, 25, 50, 100);
-        final int numRanges = randomIntBetween(1, 10);
+        final int numRanges = randomNumberOfBuckets();
 
         List<Tuple<Double, Double>> listOfRanges = new ArrayList<>(numRanges);
         for (int i = 0; i < numRanges; i++) {
@@ -67,7 +68,9 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange> {
         if (rarely()) {
             listOfRanges.add(Tuple.tuple(randomDouble(), Double.POSITIVE_INFINITY));
         }
-        ranges = Collections.unmodifiableList(listOfRanges);
+
+        Collections.shuffle(listOfRanges, random());
+        ranges = Collections.unmodifiableList(listOfRanges.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRangeTests.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRange> {
 
@@ -50,7 +51,7 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
                 dateTime -> dateTime.plusHours(1), dateTime -> dateTime.plusDays(1), dateTime -> dateTime.plusMonths(1), dateTime ->
                         dateTime.plusYears(1));
 
-        final int numRanges = randomIntBetween(1, 10);
+        final int numRanges = randomNumberOfBuckets();
         final List<Tuple<Double, Double>> listOfRanges = new ArrayList<>(numRanges);
 
         DateTime date = new DateTime(DateTimeZone.UTC);
@@ -71,7 +72,8 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
                 listOfRanges.add(Tuple.tuple(start, randomDoubleBetween(start, end, false)));
             }
         }
-        dateRanges = Collections.unmodifiableList(listOfRanges);
+        Collections.shuffle(listOfRanges, random());
+        dateRanges = Collections.unmodifiableList(listOfRanges.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/date/InternalDateRangeTests.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRange> {
 
@@ -61,19 +60,19 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
             double from = date.getMillis();
             date = interval.apply(date);
             double to = date.getMillis();
-            listOfRanges.add(Tuple.tuple(from, to));
             if (to > end) {
                 end = to;
             }
-        }
-        if (randomBoolean()) {
-            final int randomOverlaps = randomIntBetween(1, 5);
-            for (int i = 0; i < randomOverlaps; i++) {
+
+            if (randomBoolean()) {
+                listOfRanges.add(Tuple.tuple(from, to));
+            } else {
+                // Add some overlapping range
                 listOfRanges.add(Tuple.tuple(start, randomDoubleBetween(start, end, false)));
             }
         }
         Collections.shuffle(listOfRanges, random());
-        dateRanges = Collections.unmodifiableList(listOfRanges.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
+        dateRanges = Collections.unmodifiableList(listOfRanges);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistanceTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistanceTests.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoDistance> {
 
@@ -56,7 +57,8 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
             listOfRanges.add(Tuple.tuple(0.0, max / 2));
             listOfRanges.add(Tuple.tuple(max / 3, max / 3 * 2));
         }
-        geoDistanceRanges = Collections.unmodifiableList(listOfRanges);
+        Collections.shuffle(listOfRanges, random());
+        geoDistanceRanges = Collections.unmodifiableList(listOfRanges.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistanceTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/geodistance/InternalGeoDistanceTests.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoDistance> {
 
@@ -42,23 +41,25 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
         super.setUp();
 
         final int interval = randomFrom(1, 5, 10, 25, 50, 100);
-        final int numRanges = randomIntBetween(1, 10);
+        final int numRanges = randomNumberOfBuckets();
+        final double max = (double) numRanges * interval;
 
         List<Tuple<Double, Double>> listOfRanges = new ArrayList<>(numRanges);
         for (int i = 0; i < numRanges; i++) {
             double from = i * interval;
             double to = from + interval;
-            listOfRanges.add(Tuple.tuple(from, to));
-        }
-        if (randomBoolean()) {
-            // Add some overlapping ranges
-            double max = (double) numRanges * interval;
-            listOfRanges.add(Tuple.tuple(0.0, max));
-            listOfRanges.add(Tuple.tuple(0.0, max / 2));
-            listOfRanges.add(Tuple.tuple(max / 3, max / 3 * 2));
+
+            Tuple<Double, Double> range;
+            if (randomBoolean()) {
+                range = Tuple.tuple(from, to);
+            } else {
+                // Add some overlapping range
+                range = Tuple.tuple(randomFrom(0.0, max / 3), randomFrom(max, max / 2, max / 3 * 2));
+            }
+            listOfRanges.add(range);
         }
         Collections.shuffle(listOfRanges, random());
-        geoDistanceRanges = Collections.unmodifiableList(listOfRanges.stream().limit(maxNumberOfBuckets()).collect(Collectors.toList()));
+        geoDistanceRanges = Collections.unmodifiableList(listOfRanges);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTermsTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/InternalSignificantTermsTestCase.java
@@ -53,7 +53,7 @@ public abstract class InternalSignificantTermsTestCase extends InternalMultiBuck
                                                           Map<String, Object> metaData,
                                                           InternalAggregations aggregations) {
         final int requiredSize = randomIntBetween(1, 5);
-        final int numBuckets = randomInt(requiredSize + 2);
+        final int numBuckets = randomNumberOfBuckets();
 
         long subsetSize = 0;
         long supersetSize = 0;

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
@@ -48,7 +48,7 @@ public class DoubleTermsTests extends InternalTermsTestCase {
         DocValueFormat format = randomNumericDocValueFormat();
         long otherDocCount = 0;
         List<DoubleTerms.Bucket> buckets = new ArrayList<>();
-        final int numBuckets = randomInt(shardSize);
+        final int numBuckets = randomNumberOfBuckets();
         Set<Double> terms = new HashSet<>();
         for (int i = 0; i < numBuckets; ++i) {
             double term = randomValueOtherThanMany(d -> terms.add(d) == false, random()::nextDouble);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsTests.java
@@ -48,7 +48,7 @@ public class LongTermsTests extends InternalTermsTestCase {
         DocValueFormat format = randomNumericDocValueFormat();
         long otherDocCount = 0;
         List<LongTerms.Bucket> buckets = new ArrayList<>();
-        final int numBuckets = randomInt(shardSize);
+        final int numBuckets = randomNumberOfBuckets();
         Set<Long> terms = new HashSet<>();
         for (int i = 0; i < numBuckets; ++i) {
             long term = randomValueOtherThanMany(l -> terms.add(l) == false, random()::nextLong);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
@@ -49,7 +49,7 @@ public class StringTermsTests extends InternalTermsTestCase {
         DocValueFormat format = DocValueFormat.RAW;
         long otherDocCount = 0;
         List<StringTerms.Bucket> buckets = new ArrayList<>();
-        final int numBuckets = randomInt(shardSize);
+        final int numBuckets = randomNumberOfBuckets();
         Set<BytesRef> terms = new HashSet<>();
         for (int i = 0; i < numBuckets; ++i) {
             BytesRef term = randomValueOtherThanMany(b -> terms.add(b) == false, () -> new BytesRef(randomAlphaOfLength(10)));


### PR DESCRIPTION
`AggregationsTests.createTestInstance()` is used to generate a random aggregation that can contain multiple sub aggregations. The number of sub aggregation is limited (from 0 to 4) but sub aggregations can also have sub aggregations. This aggregation "tree" is limited in depth (only 5 levels of inner aggregations are allowed) but it can still get very big and cause OOM errors. This is mostly due to the way multi bucket aggregation are generated: each multi bucket aggregation is created with many buckets (up to 10 for histograms) and each bucket will be created with the same set of sub aggregations... It basically multiplies the number of aggregation for each bucket at each level of the aggregation tree, and it blows when printing out the XContent.

This pull request changes the InternalMultiBucketAggregationTestCase class so that it now has a `maxNumberOfBuckets` attribute with a default value of 25. When executed, up to 25 buckets can be generated by InternalMultiBucketAggregationTestCase sub classes. In specific cases like `AggregationsTests` and `SearchResponseTests`, where many aggregations are combined, the `maxNumberOfBuckets` is lowered down to 3. 

Closes #24891