### PR TITLE
PatternAnalyzer should lowercase wildcard queries when `lowercase` is true.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzer.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/PatternAnalyzer.java
@@ -53,4 +53,13 @@ public final class PatternAnalyzer extends Analyzer {
         }
         return new TokenStreamComponents(tokenizer, stream);
     }
+
+    @Override
+    protected TokenStream normalize(String fieldName, TokenStream in) {
+        TokenStream stream = in;
+        if (lowercase) {
+            stream = new LowerCaseFilter(stream);
+        }
+        return stream;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/analysis/PatternAnalyzerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/analysis/PatternAnalyzerTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.StopAnalyzer;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.test.ESTokenStreamTestCase;
 
 import java.io.IOException;
@@ -110,5 +111,12 @@ public class PatternAnalyzerTests extends ESTokenStreamTestCase {
   public void testRandomStrings() throws Exception {
     Analyzer a = new PatternAnalyzer(Pattern.compile(","), true, StopAnalyzer.ENGLISH_STOP_WORDS_SET);
     checkRandomData(random(), a, 10000*RANDOM_MULTIPLIER);
+  }
+
+  public void testNormalize() {
+      PatternAnalyzer a = new PatternAnalyzer(Pattern.compile("\\s+"), false, null);
+      assertEquals(new BytesRef("FooBar"), a.normalize("dummy", "FooBar"));
+      a = new PatternAnalyzer(Pattern.compile("\\s+"), true, null);
+      assertEquals(new BytesRef("foobar"), a.normalize("dummy", "FooBar"));
   }
 }


### PR DESCRIPTION
It needs to override the `normalize` method.