### PR TITLE
Add purge option to remove plugin CLI

### DIFF
--- a/core/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -132,8 +132,8 @@ public class PluginsServiceTests extends ESTestCase {
         final Path fake = home.resolve("plugins").resolve("fake");
         Files.createDirectories(fake);
         Files.createFile(fake.resolve("plugin.jar"));
-        final Path removing = fake.resolve(".removing-fake");
-        Files.createFile(fake.resolve(".removing-fake"));
+        final Path removing = home.resolve("plugins").resolve(".removing-fake");
+        Files.createFile(removing);
         PluginTestUtil.writeProperties(
                 fake,
                 "description", "fake",

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -481,6 +481,8 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
             throw new UserException(PLUGIN_EXISTS, message);
         }
 
+        PluginsService.checkForFailedPluginRemovals(env.pluginsFile());
+
         terminal.println(VERBOSE, info.toString());
 
         // don't let user install plugin as a module...

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/RemovePluginCommand.java
@@ -87,11 +87,13 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
 
         final Path pluginDir = env.pluginsFile().resolve(pluginName);
         final Path pluginConfigDir = env.configFile().resolve(pluginName);
+        final Path removing = env.pluginsFile().resolve(".removing-" + pluginName);
         /*
-         * If the plugin does not exist and the plugin config does not exist, fail to the user that the plugin is not found. Or, if the
-         * plugin does not exist, the plugin config does, and we are not purging, again fail to the user that the plugin is not found.
+         * If the plugin does not exist and the plugin config does not exist, fail to the user that the plugin is not found, unless there's
+         * a marker file left from a previously failed attempt in which case we proceed to clean up the marker file. Or, if the plugin does
+         * not exist, the plugin config does, and we are not purging, again fail to the user that the plugin is not found.
          */
-        if ((!Files.exists(pluginDir) && !Files.exists(pluginConfigDir))
+        if ((!Files.exists(pluginDir) && !Files.exists(pluginConfigDir) && !Files.exists(removing))
                 || (!Files.exists(pluginDir) && Files.exists(pluginConfigDir) && !purge)) {
             final String message = String.format(
                     Locale.ROOT, "plugin [%s] not found; run 'elasticsearch-plugin list' to get list of installed plugins", pluginName);
@@ -151,7 +153,6 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
          * marker file in the root plugin directory (not the specific plugin directory) so that we do not have to create the specific plugin
          * directory if it does not exist (we are purging configuration files).
          */
-        final Path removing = env.pluginsFile().resolve(".removing-" + pluginName);
         try {
             Files.createFile(removing);
         } catch (final FileAlreadyExistsException e) {

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -37,6 +37,8 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.PosixPermissionsResetter;
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -52,7 +54,6 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -64,6 +65,7 @@ import java.nio.file.attribute.UserPrincipal;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -73,18 +75,14 @@ import java.util.zip.ZipOutputStream;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.not;
 
 @LuceneTestCase.SuppressFileSystems("*")
 public class InstallPluginCommandTests extends ESTestCase {
 
-    private static InstallPluginCommand SKIP_JARHELL_COMMAND = new InstallPluginCommand() {
-        @Override
-        void jarHellCheck(Path candidate, Path pluginsDir) throws Exception {
-            // no jarhell check
-        }
-    };
-    private static InstallPluginCommand DEFAULT_COMMAND = new InstallPluginCommand();
+    private InstallPluginCommand skipJarHellCommand;
+    private InstallPluginCommand defaultCommand;
 
     private final Function<String, Path> temp;
 
@@ -104,9 +102,23 @@ public class InstallPluginCommandTests extends ESTestCase {
         System.setProperty("java.io.tmpdir", temp.apply("tmpdir").toString());
     }
 
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        skipJarHellCommand = new InstallPluginCommand() {
+            @Override
+            void jarHellCheck(Path candidate, Path pluginsDir) throws Exception {
+                // no jarhell check
+            }
+        };
+        defaultCommand = new InstallPluginCommand();
+    }
+
     @After
     @SuppressForbidden(reason = "resets java.io.tmpdir")
     public void tearDown() throws Exception {
+        defaultCommand.close();
+        skipJarHellCommand.close();
         System.setProperty("java.io.tmpdir", javaIoTmpdir);
         PathUtilsForTesting.teardown();
         super.tearDown();
@@ -210,11 +222,11 @@ public class InstallPluginCommandTests extends ESTestCase {
         return writeZip(structure, "elasticsearch");
     }
 
-    static MockTerminal installPlugin(String pluginUrl, Path home) throws Exception {
-        return installPlugin(pluginUrl, home, SKIP_JARHELL_COMMAND);
+    MockTerminal installPlugin(String pluginUrl, Path home) throws Exception {
+        return installPlugin(pluginUrl, home, skipJarHellCommand);
     }
 
-    static MockTerminal installPlugin(String pluginUrl, Path home, InstallPluginCommand command) throws Exception {
+    MockTerminal installPlugin(String pluginUrl, Path home, InstallPluginCommand command) throws Exception {
         Environment env = new Environment(Settings.builder().put("path.home", home).build());
         MockTerminal terminal = new MockTerminal();
         command.execute(terminal, pluginUrl, true, env);
@@ -322,6 +334,20 @@ public class InstallPluginCommandTests extends ESTestCase {
         assertPlugin("fake", pluginDir, env.v2());
     }
 
+    public void testInstallFailsIfPreviouslyRemovedPluginFailed() throws Exception {
+        Tuple<Path, Environment> env = createEnv(fs, temp);
+        Path pluginDir = createPluginDir(temp);
+        String pluginZip = createPluginUrl("fake", pluginDir);
+        final Path removing = env.v2().pluginsFile().resolve(".removing-failed");
+        Files.createDirectory(removing);
+        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> installPlugin(pluginZip, env.v1()));
+        final String expected = String.format(
+                Locale.ROOT,
+                "found file [%s] from a failed attempt to remove the plugin [failed]; execute [elasticsearch-plugin remove failed]",
+                removing);
+        assertThat(e, hasToString(containsString(expected)));
+    }
+
     public void testSpaceInUrl() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path pluginDir = createPluginDir(temp);
@@ -377,7 +403,7 @@ public class InstallPluginCommandTests extends ESTestCase {
         writeJar(pluginDirectory.resolve("other.jar"), "FakePlugin");
         String pluginZip = createPluginUrl("fake", pluginDirectory); // adds plugin.jar with FakePlugin
         IllegalStateException e = expectThrows(IllegalStateException.class,
-            () -> installPlugin(pluginZip, environment.v1(), DEFAULT_COMMAND));
+            () -> installPlugin(pluginZip, environment.v1(), defaultCommand));
         assertTrue(e.getMessage(), e.getMessage().contains("jar hell"));
         assertInstallCleaned(environment.v2());
     }
@@ -705,7 +731,7 @@ public class InstallPluginCommandTests extends ESTestCase {
         String pluginZip = createPluginUrl("fake", pluginDir);
         installPlugin(pluginZip, env.v1());
         final UserException e = expectThrows(UserException.class,
-            () -> installPlugin(pluginZip, env.v1(), randomFrom(SKIP_JARHELL_COMMAND, DEFAULT_COMMAND)));
+            () -> installPlugin(pluginZip, env.v1(), randomFrom(skipJarHellCommand, defaultCommand)));
         assertThat(
             e.getMessage(),
             equalTo("plugin directory [" + env.v2().pluginsFile().resolve("fake") + "] already exists; " +
@@ -717,7 +743,7 @@ public class InstallPluginCommandTests extends ESTestCase {
         Path pluginDir = createPluginDir(temp);
         // if batch is enabled, we also want to add a security policy
         String pluginZip = createPlugin("fake", pluginDir, isBatch).toUri().toURL().toString();
-        SKIP_JARHELL_COMMAND.execute(terminal, pluginZip, isBatch, env.v2());
+        skipJarHellCommand.execute(terminal, pluginZip, isBatch, env.v2());
     }
 
     public void assertInstallPluginFromUrl(String pluginId, String name, String url, String stagingHash) throws Exception {

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.hasToString;
 
 @LuceneTestCase.SuppressFileSystems("*")
 public class RemovePluginCommandTests extends ESTestCase {
@@ -58,10 +59,6 @@ public class RemovePluginCommandTests extends ESTestCase {
         env = new Environment(settings);
     }
 
-    static MockTerminal removePlugin(String name, Path home) throws Exception {
-        return removePlugin(name, home, false);
-    }
-
     static MockTerminal removePlugin(String name, Path home, boolean purge) throws Exception {
         Environment env = new Environment(Settings.builder().put("path.home", home).build());
         MockTerminal terminal = new MockTerminal();
@@ -80,7 +77,7 @@ public class RemovePluginCommandTests extends ESTestCase {
     }
 
     public void testMissing() throws Exception {
-        UserException e = expectThrows(UserException.class, () -> removePlugin("dne", home));
+        UserException e = expectThrows(UserException.class, () -> removePlugin("dne", home, randomBoolean()));
         assertTrue(e.getMessage(), e.getMessage().contains("plugin [dne] not found"));
         assertRemoveCleaned(env);
     }
@@ -90,7 +87,7 @@ public class RemovePluginCommandTests extends ESTestCase {
         Files.createFile(env.pluginsFile().resolve("fake").resolve("plugin.jar"));
         Files.createDirectory(env.pluginsFile().resolve("fake").resolve("subdir"));
         Files.createDirectory(env.pluginsFile().resolve("other"));
-        removePlugin("fake", home);
+        removePlugin("fake", home, randomBoolean());
         assertFalse(Files.exists(env.pluginsFile().resolve("fake")));
         assertTrue(Files.exists(env.pluginsFile().resolve("other")));
         assertRemoveCleaned(env);
@@ -101,7 +98,7 @@ public class RemovePluginCommandTests extends ESTestCase {
         Path binDir = env.binFile().resolve("fake");
         Files.createDirectories(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        removePlugin("fake", home);
+        removePlugin("fake", home, randomBoolean());
         assertFalse(Files.exists(env.pluginsFile().resolve("fake")));
         assertTrue(Files.exists(env.binFile().resolve("elasticsearch")));
         assertFalse(Files.exists(binDir));
@@ -110,7 +107,7 @@ public class RemovePluginCommandTests extends ESTestCase {
 
     public void testBinNotDir() throws Exception {
         Files.createDirectories(env.pluginsFile().resolve("elasticsearch"));
-        UserException e = expectThrows(UserException.class, () -> removePlugin("elasticsearch", home));
+        UserException e = expectThrows(UserException.class, () -> removePlugin("elasticsearch", home, randomBoolean()));
         assertTrue(e.getMessage(), e.getMessage().contains("not a directory"));
         assertTrue(Files.exists(env.pluginsFile().resolve("elasticsearch"))); // did not remove
         assertTrue(Files.exists(env.binFile().resolve("elasticsearch")));
@@ -122,14 +119,26 @@ public class RemovePluginCommandTests extends ESTestCase {
         final Path configDir = env.configFile().resolve("fake");
         Files.createDirectories(configDir);
         Files.createFile(configDir.resolve("fake.yml"));
-        final MockTerminal terminal = removePlugin("fake", home);
+        final MockTerminal terminal = removePlugin("fake", home, false);
         assertTrue(Files.exists(env.configFile().resolve("fake")));
         assertThat(terminal.getOutput(), containsString(expectedConfigDirPreservedMessage(configDir)));
         assertRemoveCleaned(env);
     }
 
-    public void testConfigDirPurged() throws Exception {
+    public void testPurgePluginExists() throws Exception {
         Files.createDirectories(env.pluginsFile().resolve("fake"));
+        final Path configDir = env.configFile().resolve("fake");
+        if (randomBoolean()) {
+            Files.createDirectories(configDir);
+            Files.createFile(configDir.resolve("fake.yml"));
+        }
+        final MockTerminal terminal = removePlugin("fake", home, true);
+        assertFalse(Files.exists(env.configFile().resolve("fake")));
+        assertThat(terminal.getOutput(), not(containsString(expectedConfigDirPreservedMessage(configDir))));
+        assertRemoveCleaned(env);
+    }
+
+    public void testPurgePluginDoesNotExist() throws Exception {
         final Path configDir = env.configFile().resolve("fake");
         Files.createDirectories(configDir);
         Files.createFile(configDir.resolve("fake.yml"));
@@ -139,15 +148,20 @@ public class RemovePluginCommandTests extends ESTestCase {
         assertRemoveCleaned(env);
     }
 
+    public void testPurgeNothingExists() throws Exception {
+        final UserException e = expectThrows(UserException.class, () -> removePlugin("fake", home, true));
+        assertThat(e, hasToString(containsString("plugin [fake] not found")));
+    }
+
     public void testNoConfigDirPreserved() throws Exception {
         Files.createDirectories(env.pluginsFile().resolve("fake"));
         final Path configDir = env.configFile().resolve("fake");
-        final MockTerminal terminal = removePlugin("fake", home);
+        final MockTerminal terminal = removePlugin("fake", home, randomBoolean());
         assertThat(terminal.getOutput(), not(containsString(expectedConfigDirPreservedMessage(configDir))));
     }
 
     public void testRemoveUninstalledPluginErrors() throws Exception {
-        UserException e = expectThrows(UserException.class, () -> removePlugin("fake", home));
+        UserException e = expectThrows(UserException.class, () -> removePlugin("fake", home, randomBoolean()));
         assertEquals(ExitCodes.CONFIG, e.exitCode);
         assertEquals("plugin [fake] not found; run 'elasticsearch-plugin list' to get list of installed plugins", e.getMessage());
 
@@ -167,7 +181,7 @@ public class RemovePluginCommandTests extends ESTestCase {
     }
 
     public void testMissingPluginName() throws Exception {
-        UserException e = expectThrows(UserException.class, () -> removePlugin(null, home));
+        UserException e = expectThrows(UserException.class, () -> removePlugin(null, home, randomBoolean()));
         assertEquals(ExitCodes.USAGE, e.exitCode);
         assertEquals("plugin name is required", e.getMessage());
     }
@@ -175,12 +189,12 @@ public class RemovePluginCommandTests extends ESTestCase {
     public void testRemoveWhenRemovingMarker() throws Exception {
         Files.createDirectory(env.pluginsFile().resolve("fake"));
         Files.createFile(env.pluginsFile().resolve("fake").resolve("plugin.jar"));
-        Files.createFile(env.pluginsFile().resolve("fake").resolve(".removing-fake"));
-        removePlugin("fake", home);
+        Files.createFile(env.pluginsFile().resolve(".removing-fake"));
+        removePlugin("fake", home, randomBoolean());
     }
 
     private String expectedConfigDirPreservedMessage(final Path configDir) {
-        return "-> preserving plugin config files [" + configDir + "] in case of upgrade; delete manually if not needed";
+        return "-> preserving plugin config files [" + configDir + "] in case of upgrade; use --purge if not needed";
     }
 
 }

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/RemovePluginCommandTests.java
@@ -153,6 +153,15 @@ public class RemovePluginCommandTests extends ESTestCase {
         assertThat(e, hasToString(containsString("plugin [fake] not found")));
     }
 
+    public void testPurgeOnlyMarkerFileExists() throws Exception {
+        final Path configDir = env.configFile().resolve("fake");
+        final Path removing = env.pluginsFile().resolve(".removing-fake");
+        Files.createFile(removing);
+        final MockTerminal terminal = removePlugin("fake", home, randomBoolean());
+        assertFalse(Files.exists(removing));
+        assertThat(terminal.getOutput(), not(containsString(expectedConfigDirPreservedMessage(configDir))));
+    }
+
     public void testNoConfigDirPreserved() throws Exception {
         Files.createDirectories(env.pluginsFile().resolve("fake"));
         final Path configDir = env.configFile().resolve("fake");

--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -107,7 +107,15 @@ Plugins can be removed manually, by deleting the appropriate directory under
 sudo bin/elasticsearch-plugin remove [pluginname]
 -----------------------------------
 
-After a Java plugin has been removed, you will need to restart the node to complete the removal process.
+After a Java plugin has been removed, you will need to restart the node to
+complete the removal process.
+
+By default, plugin configuration files (if any) are preserved on disk; this is
+so that configuration is not lost while upgrading a plugin. If you wish to
+purge the configuration files while removing a plugin, use `-p` or `--purge`.
+Note that this must be done when removing the plugin, attempting to later use
+the CLI tool to remove the configuration files will fail if the plugin does not
+exist (i.e., has already been removed).
 
 [float]
 === Updating plugins

--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -113,9 +113,8 @@ complete the removal process.
 By default, plugin configuration files (if any) are preserved on disk; this is
 so that configuration is not lost while upgrading a plugin. If you wish to
 purge the configuration files while removing a plugin, use `-p` or `--purge`.
-Note that this must be done when removing the plugin, attempting to later use
-the CLI tool to remove the configuration files will fail if the plugin does not
-exist (i.e., has already been removed).
+This can option can be used after a plugin is removed to remove any lingering
+configuration files.
 
 [float]
 === Updating plugins


### PR DESCRIPTION
By default, the remove plugin CLI command preserves configuration files. This is so that if a user is upgrading the plugin (which is done by first removing the old version and then installing the new version) they do not lose their configuration file. Yet, there are circumstances where preserving the configuration file is not desired. This commit adds a purge option to the remove plugin CLI command.

