### PR TITLE
Provide the TransportRequest during validation of a search context

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/SearchOperationListener.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/SearchOperationListener.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.transport.TransportRequest;
 
 import java.util.List;
 
@@ -110,8 +111,9 @@ public interface SearchOperationListener {
      * from the active contexts. If the context is deemed invalid a runtime
      * exception can be thrown, which will prevent the context from being used.
      * @param context the context retrieved from the active contexts
+     * @param transportRequest the request that is going to use the search context
      */
-    default void validateSearchContext(SearchContext context) {}
+    default void validateSearchContext(SearchContext context, TransportRequest transportRequest) {}
 
     /**
      * A Composite listener that multiplexes calls to each of the listeners methods.
@@ -236,11 +238,11 @@ public interface SearchOperationListener {
         }
 
         @Override
-        public void validateSearchContext(SearchContext context) {
+        public void validateSearchContext(SearchContext context, TransportRequest request) {
             Exception exception = null;
             for (SearchOperationListener listener : listeners) {
                 try {
-                    listener.validateSearchContext(context);
+                    listener.validateSearchContext(context, request);
                 } catch (Exception e) {
                     exception = ExceptionsHelper.useOrSuppress(exception, e);
                 }

--- a/core/src/test/java/org/elasticsearch/index/shard/SearchOperationListenerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/SearchOperationListenerTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.index.shard;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestSearchContext;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequest.Empty;
 
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
@@ -112,7 +114,7 @@ public class SearchOperationListenerTests extends ESTestCase {
             }
 
             @Override
-            public void validateSearchContext(SearchContext context) {
+            public void validateSearchContext(SearchContext context, TransportRequest request) {
                 assertNotNull(context);
                 validateSearchContext.incrementAndGet();
             }
@@ -267,9 +269,10 @@ public class SearchOperationListenerTests extends ESTestCase {
         assertEquals(0, validateSearchContext.get());
 
         if (throwingListeners == 0) {
-            compositeListener.validateSearchContext(ctx);
+            compositeListener.validateSearchContext(ctx, Empty.INSTANCE);
         } else {
-            RuntimeException expected = expectThrows(RuntimeException.class, () -> compositeListener.validateSearchContext(ctx));
+            RuntimeException expected =
+                expectThrows(RuntimeException.class, () -> compositeListener.validateSearchContext(ctx, Empty.INSTANCE));
             assertNull(expected.getMessage());
             assertEquals(throwingListeners - 1, expected.getSuppressed().length);
             if (throwingListeners > 1) {


### PR DESCRIPTION
This commit provides the TransportRequest that caused the retrieval of a search context to the
SearchOperationListener#validateSearchContext method so that implementers have access to the
request.