### PR TITLE
Fix broken build from stream with zero bytes

### DIFF
--- a/core/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
@@ -85,7 +85,7 @@ public class CompressibleBytesOutputStreamTests extends ESTestCase {
         BytesStream bStream = new ZeroOutOnCloseStream();
         CompressibleBytesOutputStream stream = new CompressibleBytesOutputStream(bStream, true);
 
-        byte[] expectedBytes = randomBytes(randomInt(30));
+        byte[] expectedBytes = randomBytes(randomInt(30) + 1);
         stream.write(expectedBytes);
 
 

--- a/core/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
@@ -85,7 +85,7 @@ public class CompressibleBytesOutputStreamTests extends ESTestCase {
         BytesStream bStream = new ZeroOutOnCloseStream();
         CompressibleBytesOutputStream stream = new CompressibleBytesOutputStream(bStream, true);
 
-        byte[] expectedBytes = randomBytes(randomInt(30) + 1);
+        byte[] expectedBytes = randomBytes(between(1, 30));
         stream.write(expectedBytes);
 
 


### PR DESCRIPTION
This is related to #24927. There was a small possibility that a test
was attempting to compress a stream with zero bytes. This was causing
a failure.

This test now requires at least one byte.