### PR TITLE
Tests: Switch to openSUSE 42 (Leap) for packaging tests

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -354,7 +354,7 @@ These are the linux flavors the Vagrantfile currently supports:
 * oel-6 aka Oracle Enterprise Linux 6
 * oel-7 aka Oracle Enterprise Linux 7
 * sles-12
-* opensuse-13
+* opensuse-42 aka Leap
 
 We're missing the following from the support matrix because there aren't high
 quality boxes available in vagrant atlas:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,8 +60,8 @@ Vagrant.configure(2) do |config|
     config.vm.box = "elastic/fedora-25-x86_64"
     dnf_common config
   end
-  config.vm.define "opensuse-13" do |config|
-    config.vm.box = "elastic/opensuse-13-x86_64"
+  config.vm.define "opensuse-42" do |config|
+    config.vm.box = "elastic/opensuse-42-x86_64"
     opensuse_common config
   end
   config.vm.define "sles-12" do |config|

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -20,7 +20,7 @@ class VagrantTestPlugin implements Plugin<Project> {
             'fedora-25',
             'oel-6',
             'oel-7',
-            'opensuse-13',
+            'opensuse-42',
             'sles-12',
             'ubuntu-1404',
             'ubuntu-1604'


### PR DESCRIPTION
openSUSE-13 has reached [EOL](https://en.opensuse.org/Lifetime).

Replace openSUSE-13 with openSUSE-42 (Leap) for packaging tests and
update docs.
