### PR TITLE
Build: Move verifyVersions to new branchConsistency task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,43 +123,39 @@ allprojects {
   }
 }
 
-task('verifyVersions') {
-  description 'Verifies that all released versions that are indexed compatible are listed in Version.java.'
-  group 'Verification'
-  enabled = false == gradle.startParameter.isOffline()
+task verifyVersions {
   doLast {
+    if (gradle.startParameter.isOffline()) {
+      throw new GradleException("Must run in online mode to verify versions")
+    }
     // Read the list from maven central
     Node xml
     new URL('https://repo1.maven.org/maven2/org/elasticsearch/elasticsearch/maven-metadata.xml').openStream().withStream { s ->
         xml = new XmlParser().parse(s)
     }
-    Set<String> knownVersions = new TreeSet<>(xml.versioning.versions.version.collect { it.text() }.findAll { it ==~ /\d\.\d\.\d/ })
+    Set<Version> knownVersions = new TreeSet<>(xml.versioning.versions.version.collect { it.text() }.findAll { it ==~ /\d\.\d\.\d/ }.collect { Version.fromString(it) })
 
-    // Limit the known versions to those that should be index compatible
-    knownVersions = knownVersions.findAll { Integer.parseInt(it.split('\\.')[0]) >= prevMajor }
+    // Limit the known versions to those that should be index compatible, and are not future versions
+    knownVersions = knownVersions.findAll { it.major >= prevMajor && it.before(VersionProperties.elasticsearch) }
 
     /* Limit the listed versions to those that have been marked as released.
      * Versions not marked as released don't get the same testing and we want
      * to make sure that we flip all unreleased versions to released as soon
      * as possible after release. */
-    Set<String> actualVersions = new TreeSet<>(
-      indexCompatVersions
-        .findAll { false == it.snapshot }
-        .collect { it.toString() })
-
-    // TODO this is almost certainly going to fail on 5.4 when we release 5.5.0
+    Set<Version> actualVersions = new TreeSet<>(indexCompatVersions.findAll { false == it.snapshot })
 
     // Finally, compare!
-    if (!knownVersions.equals(actualVersions)) {
-      throw new GradleException("out-of-date released versions\nActual  :" +
-        actualVersions + "\nExpected:" + knownVersions +
-        "\nUpdate Version.java. Note that Version.CURRENT doesn't count " +
-        "because it is not released.")
+    if (knownVersions.equals(actualVersions) == false) {
+      throw new GradleException("out-of-date released versions\nActual  :" + actualVersions + "\nExpected:" + knownVersions +
+        "\nUpdate Version.java. Note that Version.CURRENT doesn't count because it is not released.")
     }
   }
 }
-task('precommit') {
-  dependsOn(verifyVersions)
+
+task branchConsistency {
+  description 'Ensures this branch is internally consistent. For example, that versions constants match released versions.'
+  group 'Verification'
+  dependsOn verifyVersions
 }
 
 subprojects {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/Version.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/Version.groovy
@@ -19,9 +19,12 @@
 
 package org.elasticsearch.gradle
 
+import groovy.transform.Sortable
+
 /**
  * Encapsulates comparison and printing logic for an x.y.z version.
  */
+@Sortable
 public class Version {
 
     final int major


### PR DESCRIPTION
This commit adds a new `branchConsistency` task which will run in CI
once a day, instead of on every commit. This allows `verifyVersions` to
not break immediately once a new version is released in maven.
