### PR TITLE
Checks the circuit breaker before allocating bytes for a new big array

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/AbstractArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/AbstractArray.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.Accountable;
-import org.elasticsearch.common.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -29,12 +28,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 abstract class AbstractArray implements BigArray {
 
-    @Nullable
     private final BigArrays bigArrays;
     public final boolean clearOnResize;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    AbstractArray(@Nullable BigArrays bigArrays, boolean clearOnResize) {
+    AbstractArray(BigArrays bigArrays, boolean clearOnResize) {
         this.bigArrays = bigArrays;
         this.clearOnResize = clearOnResize;
     }
@@ -43,9 +41,7 @@ abstract class AbstractArray implements BigArray {
     public final void close() {
         if (closed.compareAndSet(false, true)) {
             try {
-                if (bigArrays != null) {
-                    bigArrays.adjustBreaker(-ramBytesUsed(), true);
-                }
+                bigArrays.adjustBreaker(-ramBytesUsed(), true);
             } finally {
                 doClose();
             }

--- a/core/src/main/java/org/elasticsearch/common/util/AbstractArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/AbstractArray.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.Accountable;
+import org.elasticsearch.common.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -28,11 +29,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 abstract class AbstractArray implements BigArray {
 
+    @Nullable
     private final BigArrays bigArrays;
     public final boolean clearOnResize;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    AbstractArray(BigArrays bigArrays, boolean clearOnResize) {
+    AbstractArray(@Nullable BigArrays bigArrays, boolean clearOnResize) {
         this.bigArrays = bigArrays;
         this.clearOnResize = clearOnResize;
     }
@@ -41,7 +43,9 @@ abstract class AbstractArray implements BigArray {
     public final void close() {
         if (closed.compareAndSet(false, true)) {
             try {
-                bigArrays.adjustBreaker(-ramBytesUsed());
+                if (bigArrays != null) {
+                    bigArrays.adjustBreaker(-ramBytesUsed());
+                }
             } finally {
                 doClose();
             }

--- a/core/src/main/java/org/elasticsearch/common/util/AbstractArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/AbstractArray.java
@@ -44,7 +44,7 @@ abstract class AbstractArray implements BigArray {
         if (closed.compareAndSet(false, true)) {
             try {
                 if (bigArrays != null) {
-                    bigArrays.adjustBreaker(-ramBytesUsed());
+                    bigArrays.adjustBreaker(-ramBytesUsed(), true);
                 }
             } finally {
                 doClose();

--- a/core/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.recycler.Recycler;
 
@@ -38,9 +37,9 @@ abstract class AbstractBigArray extends AbstractArray {
     private final int pageMask;
     protected long size;
 
-    protected AbstractBigArray(int pageSize, @Nullable BigArrays bigArrays, boolean clearOnResize) {
+    protected AbstractBigArray(int pageSize, BigArrays bigArrays, boolean clearOnResize) {
         super(bigArrays, clearOnResize);
-        this.recycler = bigArrays != null ? bigArrays.recycler : null;
+        this.recycler = bigArrays.recycler;
         if (pageSize < 128) {
             throw new IllegalArgumentException("pageSize must be >= 128");
         }

--- a/core/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.recycler.Recycler;
 
@@ -37,9 +38,9 @@ abstract class AbstractBigArray extends AbstractArray {
     private final int pageMask;
     protected long size;
 
-    protected AbstractBigArray(int pageSize, BigArrays bigArrays, boolean clearOnResize) {
+    protected AbstractBigArray(int pageSize, @Nullable BigArrays bigArrays, boolean clearOnResize) {
         super(bigArrays, clearOnResize);
-        this.recycler = bigArrays.recycler;
+        this.recycler = bigArrays != null ? bigArrays.recycler : null;
         if (pageSize < 128) {
             throw new IllegalArgumentException("pageSize must be >= 128");
         }
@@ -87,6 +88,11 @@ abstract class AbstractBigArray extends AbstractArray {
 
     @Override
     public final long ramBytesUsed() {
+        return ramBytesEstimated(size);
+    }
+
+    /** Given the size of the array, estimate the number of bytes it will use. */
+    public final long ramBytesEstimated(final long size) {
         // rough approximate, we only take into account the size of the values, not the overhead of the array objects
         return ((long) pageIndex(size - 1) + 1) * pageSize() * numBytesPerElement();
     }

--- a/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -392,15 +392,6 @@ public class BigArrays implements Releasable {
     /**
      * Adjust the circuit breaker with the given delta, if the delta is
      * negative, or checkBreaker is false, the breaker will be adjusted
-     * without tripping.
-     */
-    void adjustBreaker(final long delta) {
-        adjustBreaker(delta, true);
-    }
-
-    /**
-     * Adjust the circuit breaker with the given delta, if the delta is
-     * negative, or checkBreaker is false, the breaker will be adjusted
      * without tripping.  If the data was already created before calling
      * this method, and the breaker trips, we add the delta without breaking
      * to account for the created data.  If the data has not been created yet,
@@ -458,7 +449,7 @@ public class BigArrays implements Releasable {
     private <T extends BigArray> T validate(T array) {
         boolean success = false;
         try {
-            adjustBreaker(array.ramBytesUsed());
+            adjustBreaker(array.ramBytesUsed(), true);
             success = true;
         } finally {
             if (!success) {

--- a/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -440,6 +440,8 @@ public class BigArrays implements Releasable {
 
     private <T extends AbstractBigArray> T resizeInPlace(T array, long newSize) {
         final long oldMemSize = array.ramBytesUsed();
+        assert oldMemSize == array.ramBytesEstimated(array.size) :
+            "ram bytes used should equal that which was previously estimated";
         final long estimatedIncreaseInBytes = array.ramBytesEstimated(newSize) - oldMemSize;
         adjustBreaker(estimatedIncreaseInBytes, false);
         array.resize(newSize);

--- a/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -25,7 +25,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.recycler.Recycler;
@@ -91,7 +90,7 @@ public class BigArrays implements Releasable {
 
     private abstract static class AbstractArrayWrapper extends AbstractArray implements BigArray {
 
-        protected static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ByteArrayWrapper.class);
+        static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ByteArrayWrapper.class);
 
         private final Releasable releasable;
         private final long size;
@@ -377,6 +376,7 @@ public class BigArrays implements Releasable {
         // Checking the breaker is disabled if not specified
         this(new PageCacheRecycler(settings), breakerService, false);
     }
+
     // public for tests
     public BigArrays(PageCacheRecycler recycler, @Nullable final CircuitBreakerService breakerService, boolean checkBreaker) {
         this.checkBreaker = checkBreaker;
@@ -392,9 +392,21 @@ public class BigArrays implements Releasable {
     /**
      * Adjust the circuit breaker with the given delta, if the delta is
      * negative, or checkBreaker is false, the breaker will be adjusted
-     * without tripping
+     * without tripping.
      */
-    void adjustBreaker(long delta) {
+    void adjustBreaker(final long delta) {
+        adjustBreaker(delta, true);
+    }
+
+    /**
+     * Adjust the circuit breaker with the given delta, if the delta is
+     * negative, or checkBreaker is false, the breaker will be adjusted
+     * without tripping.  If the data was already created before calling
+     * this method, and the breaker trips, we add the delta without breaking
+     * to account for the created data.  If the data has not been created yet,
+     * we do not add the delta to the breaker if it trips.
+     */
+    void adjustBreaker(final long delta, final boolean isDataAlreadyCreated) {
         if (this.breakerService != null) {
             CircuitBreaker breaker = this.breakerService.getBreaker(CircuitBreaker.REQUEST);
             if (this.checkBreaker) {
@@ -404,9 +416,11 @@ public class BigArrays implements Releasable {
                     try {
                         breaker.addEstimateBytesAndMaybeBreak(delta, "<reused_arrays>");
                     } catch (CircuitBreakingException e) {
-                        // since we've already created the data, we need to
-                        // add it so closing the stream re-adjusts properly
-                        breaker.addWithoutBreaking(delta);
+                        if (isDataAlreadyCreated) {
+                            // since we've already created the data, we need to
+                            // add it so closing the stream re-adjusts properly
+                            breaker.addWithoutBreaking(delta);
+                        }
                         // re-throw the original exception
                         throw e;
                     }
@@ -435,8 +449,9 @@ public class BigArrays implements Releasable {
 
     private <T extends AbstractBigArray> T resizeInPlace(T array, long newSize) {
         final long oldMemSize = array.ramBytesUsed();
+        final long estimatedIncreaseInBytes = array.ramBytesEstimated(newSize) - oldMemSize;
+        adjustBreaker(estimatedIncreaseInBytes, false);
         array.resize(newSize);
-        adjustBreaker(array.ramBytesUsed() - oldMemSize);
         return array;
     }
 
@@ -459,16 +474,17 @@ public class BigArrays implements Releasable {
      * @param clearOnResize whether values should be set to 0 on initialization and resize
      */
     public ByteArray newByteArray(long size, boolean clearOnResize) {
-        final ByteArray array;
         if (size > BYTE_PAGE_SIZE) {
-            array = new BigByteArray(size, this, clearOnResize);
+            // when allocating big arrays, we want to first ensure we have the capacity by
+            // checking with the circuit breaker before attempting to allocate
+            adjustBreaker(BigByteArray.estimateRamBytes(size), false);
+            return new BigByteArray(size, this, clearOnResize);
         } else if (size >= BYTE_PAGE_SIZE / 2 && recycler != null) {
             final Recycler.V<byte[]> page = recycler.bytePage(clearOnResize);
-            array = new ByteArrayWrapper(this, page.v(), size, page, clearOnResize);
+            return validate(new ByteArrayWrapper(this, page.v(), size, page, clearOnResize));
         } else {
-            array = new ByteArrayWrapper(this, new byte[(int) size], size, null, clearOnResize);
+            return validate(new ByteArrayWrapper(this, new byte[(int) size], size, null, clearOnResize));
         }
-        return validate(array);
     }
 
     /**
@@ -541,16 +557,17 @@ public class BigArrays implements Releasable {
      * @param clearOnResize whether values should be set to 0 on initialization and resize
      */
     public IntArray newIntArray(long size, boolean clearOnResize) {
-        final IntArray array;
         if (size > INT_PAGE_SIZE) {
-            array = new BigIntArray(size, this, clearOnResize);
+            // when allocating big arrays, we want to first ensure we have the capacity by
+            // checking with the circuit breaker before attempting to allocate
+            adjustBreaker(BigIntArray.estimateRamBytes(size), false);
+            return new BigIntArray(size, this, clearOnResize);
         } else if (size >= INT_PAGE_SIZE / 2 && recycler != null) {
             final Recycler.V<int[]> page = recycler.intPage(clearOnResize);
-            array = new IntArrayWrapper(this, page.v(), size, page, clearOnResize);
+            return validate(new IntArrayWrapper(this, page.v(), size, page, clearOnResize));
         } else {
-            array = new IntArrayWrapper(this, new int[(int) size], size, null, clearOnResize);
+            return validate(new IntArrayWrapper(this, new int[(int) size], size, null, clearOnResize));
         }
-        return validate(array);
     }
 
     /**
@@ -591,16 +608,17 @@ public class BigArrays implements Releasable {
      * @param clearOnResize whether values should be set to 0 on initialization and resize
      */
     public LongArray newLongArray(long size, boolean clearOnResize) {
-        final LongArray array;
         if (size > LONG_PAGE_SIZE) {
-            array = new BigLongArray(size, this, clearOnResize);
+            // when allocating big arrays, we want to first ensure we have the capacity by
+            // checking with the circuit breaker before attempting to allocate
+            adjustBreaker(BigLongArray.estimateRamBytes(size), false);
+            return new BigLongArray(size, this, clearOnResize);
         } else if (size >= LONG_PAGE_SIZE / 2 && recycler != null) {
             final Recycler.V<long[]> page = recycler.longPage(clearOnResize);
-            array = new LongArrayWrapper(this, page.v(), size, page, clearOnResize);
+            return validate(new LongArrayWrapper(this, page.v(), size, page, clearOnResize));
         } else {
-            array = new LongArrayWrapper(this, new long[(int) size], size, null, clearOnResize);
+            return validate(new LongArrayWrapper(this, new long[(int) size], size, null, clearOnResize));
         }
-        return validate(array);
     }
 
     /**
@@ -641,16 +659,17 @@ public class BigArrays implements Releasable {
      * @param clearOnResize whether values should be set to 0 on initialization and resize
      */
     public DoubleArray newDoubleArray(long size, boolean clearOnResize) {
-        final DoubleArray arr;
         if (size > LONG_PAGE_SIZE) {
-            arr = new BigDoubleArray(size, this, clearOnResize);
+            // when allocating big arrays, we want to first ensure we have the capacity by
+            // checking with the circuit breaker before attempting to allocate
+            adjustBreaker(BigDoubleArray.estimateRamBytes(size), false);
+            return new BigDoubleArray(size, this, clearOnResize);
         } else if (size >= LONG_PAGE_SIZE / 2 && recycler != null) {
             final Recycler.V<long[]> page = recycler.longPage(clearOnResize);
-            arr = new DoubleArrayWrapper(this, page.v(), size, page, clearOnResize);
+            return validate(new DoubleArrayWrapper(this, page.v(), size, page, clearOnResize));
         } else {
-            arr = new DoubleArrayWrapper(this, new long[(int) size], size, null, clearOnResize);
+            return validate(new DoubleArrayWrapper(this, new long[(int) size], size, null, clearOnResize));
         }
-        return validate(arr);
     }
 
     /** Allocate a new {@link DoubleArray} of the given capacity. */
@@ -688,16 +707,17 @@ public class BigArrays implements Releasable {
      * @param clearOnResize whether values should be set to 0 on initialization and resize
      */
     public FloatArray newFloatArray(long size, boolean clearOnResize) {
-        final FloatArray array;
         if (size > INT_PAGE_SIZE) {
-            array = new BigFloatArray(size, this, clearOnResize);
+            // when allocating big arrays, we want to first ensure we have the capacity by
+            // checking with the circuit breaker before attempting to allocate
+            adjustBreaker(BigFloatArray.estimateRamBytes(size), false);
+            return new BigFloatArray(size, this, clearOnResize);
         } else if (size >= INT_PAGE_SIZE / 2 && recycler != null) {
             final Recycler.V<int[]> page = recycler.intPage(clearOnResize);
-            array = new FloatArrayWrapper(this, page.v(), size, page, clearOnResize);
+            return validate(new FloatArrayWrapper(this, page.v(), size, page, clearOnResize));
         } else {
-            array = new FloatArrayWrapper(this, new int[(int) size], size, null, clearOnResize);
+            return validate(new FloatArrayWrapper(this, new int[(int) size], size, null, clearOnResize));
         }
-        return validate(array);
     }
 
     /** Allocate a new {@link FloatArray} of the given capacity. */
@@ -736,14 +756,16 @@ public class BigArrays implements Releasable {
     public <T> ObjectArray<T> newObjectArray(long size) {
         final ObjectArray<T> array;
         if (size > OBJECT_PAGE_SIZE) {
-            array = new BigObjectArray<>(size, this);
+            // when allocating big arrays, we want to first ensure we have the capacity by
+            // checking with the circuit breaker before attempting to allocate
+            adjustBreaker(BigObjectArray.estimateRamBytes(size), false);
+            return new BigObjectArray<>(size, this);
         } else if (size >= OBJECT_PAGE_SIZE / 2 && recycler != null) {
             final Recycler.V<Object[]> page = recycler.objectPage();
-            array = new ObjectArrayWrapper<>(this, page.v(), size, page);
+            return validate(new ObjectArrayWrapper<>(this, page.v(), size, page));
         } else {
-            array = new ObjectArrayWrapper<>(this, new Object[(int) size], size, null);
+            return validate(new ObjectArrayWrapper<>(this, new Object[(int) size], size, null));
         }
-        return validate(array);
     }
 
     /** Resize the array to the exact provided size. */

--- a/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -441,8 +441,11 @@ public class BigArrays implements Releasable {
     private <T extends AbstractBigArray> T resizeInPlace(T array, long newSize) {
         final long oldMemSize = array.ramBytesUsed();
         assert oldMemSize == array.ramBytesEstimated(array.size) :
-            "ram bytes used should equal that which was previously estimated";
+            "ram bytes used should equal that which was previously estimated: ramBytesUsed=" +
+                oldMemSize + ", ramBytesEstimated=" + array.ramBytesEstimated(array.size);
         final long estimatedIncreaseInBytes = array.ramBytesEstimated(newSize) - oldMemSize;
+        assert estimatedIncreaseInBytes >= 0 :
+            "estimated increase in bytes for resizing should not be negative: " + estimatedIncreaseInBytes;
         adjustBreaker(estimatedIncreaseInBytes, false);
         array.resize(newSize);
         return array;

--- a/core/src/main/java/org/elasticsearch/common/util/BigByteArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigByteArray.java
@@ -33,7 +33,7 @@ import static org.elasticsearch.common.util.BigArrays.BYTE_PAGE_SIZE;
  */
 final class BigByteArray extends AbstractBigArray implements ByteArray {
 
-    private static final BigByteArray ESTIMATOR = new BigByteArray(0, null, false);
+    private static final BigByteArray ESTIMATOR = new BigByteArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
     private byte[][] pages;
 

--- a/core/src/main/java/org/elasticsearch/common/util/BigByteArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigByteArray.java
@@ -33,6 +33,8 @@ import static org.elasticsearch.common.util.BigArrays.BYTE_PAGE_SIZE;
  */
 final class BigByteArray extends AbstractBigArray implements ByteArray {
 
+    private static final BigByteArray ESTIMATOR = new BigByteArray(0, null, false);
+
     private byte[][] pages;
 
     /** Constructor. */
@@ -44,7 +46,7 @@ final class BigByteArray extends AbstractBigArray implements ByteArray {
             pages[i] = newBytePage(i);
         }
     }
-    
+
     @Override
     public byte get(long index) {
         final int pageIndex = pageIndex(index);
@@ -145,6 +147,11 @@ final class BigByteArray extends AbstractBigArray implements ByteArray {
             releasePage(i);
         }
         this.size = newSize;
+    }
+
+    /** Estimates the number of bytes that would be consumed by an array of the given size. */
+    public static long estimateRamBytes(final long size) {
+        return ESTIMATOR.ramBytesEstimated(size);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
@@ -32,6 +32,8 @@ import static org.elasticsearch.common.util.BigArrays.LONG_PAGE_SIZE;
  */
 final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
 
+    private static final BigDoubleArray ESTIMATOR = new BigDoubleArray(0, null, false);
+
     private long[][] pages;
 
     /** Constructor. */
@@ -108,6 +110,11 @@ final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
             }
             Arrays.fill(pages[toPage], 0, indexInPage(toIndex - 1) + 1, longBits);
         }
+    }
+
+    /** Estimates the number of bytes that would be consumed by an array of the given size. */
+    public static long estimateRamBytes(final long size) {
+        return ESTIMATOR.ramBytesEstimated(size);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.common.util.BigArrays.LONG_PAGE_SIZE;
  */
 final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
 
-    private static final BigDoubleArray ESTIMATOR = new BigDoubleArray(0, null, false);
+    private static final BigDoubleArray ESTIMATOR = new BigDoubleArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
     private long[][] pages;
 

--- a/core/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.common.util.BigArrays.INT_PAGE_SIZE;
  */
 final class BigFloatArray extends AbstractBigArray implements FloatArray {
 
-    private static final BigFloatArray ESTIMATOR = new BigFloatArray(0, null, false);
+    private static final BigFloatArray ESTIMATOR = new BigFloatArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
     private int[][] pages;
 

--- a/core/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
@@ -32,6 +32,8 @@ import static org.elasticsearch.common.util.BigArrays.INT_PAGE_SIZE;
  */
 final class BigFloatArray extends AbstractBigArray implements FloatArray {
 
+    private static final BigFloatArray ESTIMATOR = new BigFloatArray(0, null, false);
+
     private int[][] pages;
 
     /** Constructor. */
@@ -108,6 +110,11 @@ final class BigFloatArray extends AbstractBigArray implements FloatArray {
             }
             Arrays.fill(pages[toPage], 0, indexInPage(toIndex - 1) + 1, intBits);
         }
+    }
+
+    /** Estimates the number of bytes that would be consumed by an array of the given size. */
+    public static long estimateRamBytes(final long size) {
+        return ESTIMATOR.ramBytesEstimated(size);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/common/util/BigIntArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigIntArray.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.common.util.BigArrays.INT_PAGE_SIZE;
  */
 final class BigIntArray extends AbstractBigArray implements IntArray {
 
-    private static final BigIntArray ESTIMATOR = new BigIntArray(0, null, false);
+    private static final BigIntArray ESTIMATOR = new BigIntArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
     private int[][] pages;
 

--- a/core/src/main/java/org/elasticsearch/common/util/BigIntArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigIntArray.java
@@ -32,6 +32,8 @@ import static org.elasticsearch.common.util.BigArrays.INT_PAGE_SIZE;
  */
 final class BigIntArray extends AbstractBigArray implements IntArray {
 
+    private static final BigIntArray ESTIMATOR = new BigIntArray(0, null, false);
+
     private int[][] pages;
 
     /** Constructor. */
@@ -106,6 +108,11 @@ final class BigIntArray extends AbstractBigArray implements IntArray {
             releasePage(i);
         }
         this.size = newSize;
+    }
+
+    /** Estimates the number of bytes that would be consumed by an array of the given size. */
+    public static long estimateRamBytes(final long size) {
+        return ESTIMATOR.ramBytesEstimated(size);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/common/util/BigLongArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigLongArray.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.common.util.BigArrays.LONG_PAGE_SIZE;
  */
 final class BigLongArray extends AbstractBigArray implements LongArray {
 
-    private static final BigLongArray ESTIMATOR = new BigLongArray(0, null, false);
+    private static final BigLongArray ESTIMATOR = new BigLongArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
     private long[][] pages;
 

--- a/core/src/main/java/org/elasticsearch/common/util/BigLongArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigLongArray.java
@@ -32,6 +32,8 @@ import static org.elasticsearch.common.util.BigArrays.LONG_PAGE_SIZE;
  */
 final class BigLongArray extends AbstractBigArray implements LongArray {
 
+    private static final BigLongArray ESTIMATOR = new BigLongArray(0, null, false);
+
     private long[][] pages;
 
     /** Constructor. */
@@ -109,6 +111,11 @@ final class BigLongArray extends AbstractBigArray implements LongArray {
             }
             Arrays.fill(pages[toPage], 0, indexInPage(toIndex - 1) + 1, value);
         }
+    }
+
+    /** Estimates the number of bytes that would be consumed by an array of the given size. */
+    public static long estimateRamBytes(final long size) {
+        return ESTIMATOR.ramBytesEstimated(size);
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.common.util.BigArrays.OBJECT_PAGE_SIZE;
  */
 final class BigObjectArray<T> extends AbstractBigArray implements ObjectArray<T> {
 
-    private static final BigObjectArray ESTIMATOR = new BigObjectArray(0, null);
+    private static final BigObjectArray ESTIMATOR = new BigObjectArray(0, BigArrays.NON_RECYCLING_INSTANCE);
 
     private Object[][] pages;
 

--- a/core/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
@@ -32,6 +32,8 @@ import static org.elasticsearch.common.util.BigArrays.OBJECT_PAGE_SIZE;
  */
 final class BigObjectArray<T> extends AbstractBigArray implements ObjectArray<T> {
 
+    private static final BigObjectArray ESTIMATOR = new BigObjectArray(0, null);
+
     private Object[][] pages;
 
     /** Constructor. */
@@ -83,6 +85,11 @@ final class BigObjectArray<T> extends AbstractBigArray implements ObjectArray<T>
             releasePage(i);
         }
         this.size = newSize;
+    }
+
+    /** Estimates the number of bytes that would be consumed by an array of the given size. */
+    public static long estimateRamBytes(final long size) {
+        return ESTIMATOR.ramBytesEstimated(size);
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -34,8 +34,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
-import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;


### PR DESCRIPTION
Previously, when allocating bytes for a BigArray, the array was created
(or attempted to be created) and only then would the array be checked
for the amount of RAM used to see if the circuit breaker should trip.

This is problematic because for very large arrays, if creating or
resizing the array, it is possible to attempt to create/resize and get
an OOM error before the circuit breaker trips, because the allocation
happens before checking with the circuit breaker.

This commit ensures that the circuit breaker is checked before all big
array allocations (note, this does not effect the array allocations that
are less than 16kb which use the [Type]ArrayWrapper classes found in
BigArrays.java).  If such an allocation or resizing would cause the
circuit breaker to trip, then the breaker trips before attempting to
allocate and potentially running into an OOM error from the JVM.

Closes #24790