### PR TITLE
Add the ability to set eager_global_ordinals in the new parent-join field

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
@@ -65,6 +65,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
             FIELD_TYPE.setIndexOptions(IndexOptions.NONE);
             FIELD_TYPE.setHasDocValues(true);
             FIELD_TYPE.setDocValuesType(DocValuesType.SORTED);
+            FIELD_TYPE.setEagerGlobalOrdinals(true);
             FIELD_TYPE.freeze();
         }
     }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -73,6 +73,11 @@ public final class ParentIdFieldMapper extends FieldMapper {
             return children;
         }
 
+        public Builder eagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
+            fieldType().setEagerGlobalOrdinals(eagerGlobalOrdinals);
+            return builder;
+        }
+
         @Override
         public ParentIdFieldMapper build(BuilderContext context) {
             fieldType.setName(name);

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -119,7 +119,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
     static class Builder extends FieldMapper.Builder<Builder, ParentJoinFieldMapper> {
         final List<ParentIdFieldMapper.Builder> parentIdFieldBuilders = new ArrayList<>();
-        boolean eagerGlobalOrdinals = false;
+        boolean eagerGlobalOrdinals = true;
 
         Builder(String name) {
             super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
@@ -38,11 +39,13 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParentFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -116,6 +119,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
     static class Builder extends FieldMapper.Builder<Builder, ParentJoinFieldMapper> {
         final List<ParentIdFieldMapper.Builder> parentIdFieldBuilders = new ArrayList<>();
+        boolean eagerGlobalOrdinals = false;
 
         Builder(String name) {
             super(name, Defaults.FIELD_TYPE, Defaults.FIELD_TYPE);
@@ -130,7 +134,12 @@ public final class ParentJoinFieldMapper extends FieldMapper {
         public Builder addParent(String parent, Set<String> children) {
             String parentIdFieldName = getParentIdFieldName(name, parent);
             parentIdFieldBuilders.add(new ParentIdFieldMapper.Builder(parentIdFieldName, parent, children));
-            return this;
+            return builder;
+        }
+
+        public Builder eagerGlobalOrdinals(boolean eagerGlobalOrdinals) {
+            this.eagerGlobalOrdinals = eagerGlobalOrdinals;
+            return builder;
         }
 
         @Override
@@ -138,7 +147,14 @@ public final class ParentJoinFieldMapper extends FieldMapper {
             checkPreConditions(context.indexCreatedVersion(), context.path(), name);
             fieldType.setName(name);
             final List<ParentIdFieldMapper> parentIdFields = new ArrayList<>();
-            parentIdFieldBuilders.stream().map((e) -> e.build(context)).forEach(parentIdFields::add);
+            parentIdFieldBuilders.stream()
+                .map((parentBuilder) -> {
+                    if (eagerGlobalOrdinals) {
+                        parentBuilder.eagerGlobalOrdinals(true);
+                    }
+                    return parentBuilder.build(context);
+                })
+                .forEach(parentIdFields::add);
             checkParentFields(name(), parentIdFields);
             MetaJoinFieldMapper unique = new MetaJoinFieldMapper.Builder().build(context);
             return new ParentJoinFieldMapper(name, fieldType, context.indexSettings(),
@@ -161,25 +177,17 @@ public final class ParentJoinFieldMapper extends FieldMapper {
                 if ("type".equals(entry.getKey())) {
                     continue;
                 }
-
+                if ("eager_global_ordinals".equals(entry.getKey())) {
+                    builder.eagerGlobalOrdinals(XContentMapValues.nodeBooleanValue(entry.getValue(), "eager_global_ordinals"));
+                    iterator.remove();
+                    continue;
+                }
                 final String parent = entry.getKey();
                 Set<String> children;
-                if (entry.getValue() instanceof List) {
-                    children = new HashSet<>();
-                    for (Object childObj : (List) entry.getValue()) {
-                        if (childObj instanceof String) {
-                           children.add(childObj.toString());
-                        } else {
-                            throw new MapperParsingException("[" + parent + "] expected an array of strings but was:" +
-                                childObj.getClass().getSimpleName());
-                        }
-                    }
-                    children = Collections.unmodifiableSet(children);
-                } else if (entry.getValue() instanceof String) {
-                    children = Collections.singleton(entry.getValue().toString());
+                if (XContentMapValues.isArray(entry.getValue())) {
+                    children = new HashSet<>(Arrays.asList(XContentMapValues.nodeStringArrayValue(entry.getValue())));
                 } else {
-                    throw new MapperParsingException("[" + parent + "] expected string but was:" +
-                        entry.getValue().getClass().getSimpleName());
+                    children = Collections.singleton(entry.getValue().toString());
                 }
                 builder.addParent(parent, children);
                 iterator.remove();

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -383,15 +383,15 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
         assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
         assertNotNull(service.mapperService().fullName("join_field#parent"));
-        assertFalse(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());
+        assertTrue(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());
         assertNotNull(service.mapperService().fullName("join_field#child"));
-        assertFalse(service.mapperService().fullName("join_field#child").eagerGlobalOrdinals());
+        assertTrue(service.mapperService().fullName("join_field#child").eagerGlobalOrdinals());
 
         mapping = XContentFactory.jsonBuilder().startObject()
             .startObject("properties")
                 .startObject("join_field")
                     .field("type", "join")
-                    .field("eager_global_ordinals", true)
+                    .field("eager_global_ordinals", false)
                     .field("parent", "child")
                     .field("child", "grand_child")
                 .endObject()
@@ -401,8 +401,8 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
             MapperService.MergeReason.MAPPING_UPDATE, false);
         assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
         assertNotNull(service.mapperService().fullName("join_field#parent"));
-        assertTrue(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());
+        assertFalse(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());
         assertNotNull(service.mapperService().fullName("join_field#child"));
-        assertTrue(service.mapperService().fullName("join_field#child").eagerGlobalOrdinals());
+        assertFalse(service.mapperService().fullName("join_field#child").eagerGlobalOrdinals());
     }
 }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -366,4 +366,43 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
             assertThat(exc.getMessage(), containsString("Field [_parent_join] is defined twice in [type]"));
         }
     }
+
+    public void testEagerGlobalOrdinals() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject()
+            .startObject("properties")
+                .startObject("join_field")
+                    .field("type", "join")
+                    .field("parent", "child")
+                    .field("child", "grand_child")
+                .endObject()
+            .endObject()
+            .endObject().string();
+        IndexService service = createIndex("test");
+        DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
+            MapperService.MergeReason.MAPPING_UPDATE, false);
+        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
+        assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
+        assertNotNull(service.mapperService().fullName("join_field#parent"));
+        assertFalse(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());
+        assertNotNull(service.mapperService().fullName("join_field#child"));
+        assertFalse(service.mapperService().fullName("join_field#child").eagerGlobalOrdinals());
+
+        mapping = XContentFactory.jsonBuilder().startObject()
+            .startObject("properties")
+                .startObject("join_field")
+                    .field("type", "join")
+                    .field("eager_global_ordinals", true)
+                    .field("parent", "child")
+                    .field("child", "grand_child")
+                .endObject()
+            .endObject()
+            .endObject().string();
+        docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
+            MapperService.MergeReason.MAPPING_UPDATE, false);
+        assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
+        assertNotNull(service.mapperService().fullName("join_field#parent"));
+        assertTrue(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());
+        assertNotNull(service.mapperService().fullName("join_field#child"));
+        assertTrue(service.mapperService().fullName("join_field#child").eagerGlobalOrdinals());
+    }
 }


### PR DESCRIPTION
This change allows `eager_global_ordinals` to be set globally for the `parent-join` field.
Defaults to `true`.