### PR TITLE
Handle already closed while filling gaps

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -370,7 +370,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                         TimeUnit.MINUTES,
                         () -> {
                             latch.await();
-                            getEngine().fillSeqNoGaps(newPrimaryTerm);
+                            try {
+                                getEngine().fillSeqNoGaps(newPrimaryTerm);
+                            } catch (final AlreadyClosedException e) {
+                                // okay, the index was deleted or this shard was never activated after a relocation.
+                            }
                         },
                         e -> failShard("exception during primary term transition", e));
                 primaryTerm = newPrimaryTerm;

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -373,7 +373,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                             try {
                                 getEngine().fillSeqNoGaps(newPrimaryTerm);
                             } catch (final AlreadyClosedException e) {
-                                // okay, the index was deleted or this shard was never activated after a relocation.
+                                // okay, the index was deleted
                             }
                         },
                         e -> failShard("exception during primary term transition", e));


### PR DESCRIPTION
We can hit an already closed exception when filling the gaps after blocking operations when updating the primary term on a promoted replica shard. We should catch this and suppress it as it is an expected outcome instead of letting it bubble up which leads to trying to fail the shard which throws yet another already closed exception.

Relates #24925
