### PR TITLE
Allow RestHighLevelClient to use plugins

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
@@ -25,6 +25,7 @@ import org.apache.http.entity.StringEntity;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -36,7 +37,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.mockito.Mockito.mock;
 
 /**
- * This test works against a {@link RestHighLevelClient} subclass that simulats how custom response sections returned by
+ * This test works against a {@link RestHighLevelClient} subclass that simulates how custom response sections returned by
  * Elasticsearch plugins can be parsed using the high level client.
  */
 public class RestHighLevelClientExtTests extends ESTestCase {
@@ -46,7 +47,7 @@ public class RestHighLevelClientExtTests extends ESTestCase {
     @Before
     public void initClient() throws IOException {
         RestClient restClient = mock(RestClient.class);
-        restHighLevelClient = new RestHighLevelClientExt(restClient);
+        restHighLevelClient = new RestHighLevelClient(restClient, RestHighLevelClientExtPlugin.class);
     }
 
     public void testParseEntityCustomResponseSection() throws IOException {
@@ -66,13 +67,13 @@ public class RestHighLevelClientExtTests extends ESTestCase {
         }
     }
 
-    private static class RestHighLevelClientExt extends RestHighLevelClient {
+    public static class RestHighLevelClientExtPlugin extends Plugin {
 
-        private RestHighLevelClientExt(RestClient restClient) {
-            super(restClient, getNamedXContentsExt());
+        public RestHighLevelClientExtPlugin() {
         }
 
-        private static List<NamedXContentRegistry.Entry> getNamedXContentsExt() {
+        @Override
+        public List<NamedXContentRegistry.Entry> getNamedXContent() {
             List<NamedXContentRegistry.Entry> entries = new ArrayList<>();
             entries.add(new NamedXContentRegistry.Entry(BaseCustomResponseSection.class, new ParseField("custom1"),
                     CustomResponseSection1::fromXContent));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientWithCustomAggregationTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientWithCustomAggregationTests.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.HttpEntity;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchResponseSections;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
+import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Test usage of a custom aggregation provided by a plugin with the {@link RestHighLevelClient}.
+ */
+public class RestHighLevelClientWithCustomAggregationTests extends RestHighLevelClientWithPluginTestCase {
+
+    private static final String CUSTOM = "custom";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return singletonList(CustomPlugin.class);
+    }
+
+    public void testCustomAggregation() throws Exception {
+        String aggregationName = randomAlphaOfLengthBetween(5, 10);
+        CustomAggregationBuilder customAggregationBuilder = new CustomAggregationBuilder(aggregationName);
+        final int customNumber = randomIntBetween(1, 1000);
+        customAggregationBuilder.setCustomNumber(customNumber);
+
+        Map<String, Object> metaData = null;
+        if (randomBoolean()) {
+            metaData = new HashMap<>();
+            int metaDataCount = between(0, 10);
+            while (metaData.size() < metaDataCount) {
+                metaData.put(randomAlphaOfLength(5), randomAlphaOfLength(5));
+            }
+            customAggregationBuilder.setMetaData(metaData);
+        }
+
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(QueryBuilders.termQuery("field", "hello"));
+        searchSourceBuilder.aggregation(customAggregationBuilder);
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(searchSourceBuilder);
+
+        SearchResponse searchResponse = search(searchRequest);
+
+        Map<String, Aggregation> aggregations = searchResponse.getAggregations().getAsMap();
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.containsKey(aggregationName));
+
+        CustomAggregation customAggregation = (CustomAggregation) aggregations.get(aggregationName);
+        assertEquals(customNumber, customAggregation.getDocCount());
+        assertEquals(metaData, customAggregation.getMetaData());
+        assertEquals(customNumber % 2 == 1, customAggregation.isOdd());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Response performRequest(HttpEntity httpEntity) throws IOException {
+        try (XContentParser parser = createParser(Request.REQUEST_BODY_CONTENT_TYPE.xContent(), httpEntity.getContent())) {
+            Map<String, ?> requestAsMap = parser.map();
+            assertEquals(2, requestAsMap.size());
+            assertTrue("Search request does not contain the term query", requestAsMap.containsKey("query"));
+            assertTrue("Search request does not contain the aggregation", requestAsMap.containsKey("aggregations"));
+
+            Map<String, ?> queryAsMap = (Map<String, ?>) requestAsMap.get("query");
+            assertEquals(1, queryAsMap.size());
+            assertTrue("Query must be a term query", queryAsMap.containsKey("term"));
+
+            Map<String, ?> aggsAsMap = (Map<String, ?>) requestAsMap.get("aggregations");
+            assertEquals("Aggregations must contain the custom aggregation", 1, aggsAsMap.size());
+            String name = aggsAsMap.keySet().iterator().next();
+
+            Map<String, ?> customAggregationAsMap = (Map<String, ?>) aggsAsMap.get(name);
+            assertTrue("Custom aggregation must have the 'custom' type", customAggregationAsMap.containsKey(CUSTOM));
+            Map<String, Object> customMetadata = (Map<String, Object>) customAggregationAsMap.get("meta");
+
+            customAggregationAsMap = (Map<String, ?>) customAggregationAsMap.get(CUSTOM);
+            assertTrue("Custom aggregation must contain the random number", customAggregationAsMap.containsKey("number"));
+
+            int customNumber = ((Number) customAggregationAsMap.get("number")).intValue();
+            boolean isOdd = (customNumber % 2) != 0;
+
+            InternalCustom internal = new InternalCustom(name, isOdd, customNumber, InternalAggregations.EMPTY, null, customMetadata);
+            InternalAggregations internalAggregations = new InternalAggregations(singletonList(internal));
+            SearchResponse searchResponse =
+                    new SearchResponse(
+                            new SearchResponseSections(SearchHits.empty(), internalAggregations, null, false, false, null, 1),
+                            randomAlphaOfLengthBetween(5, 10), 5, 5, 100, ShardSearchFailure.EMPTY_ARRAY);
+            return createResponse(searchResponse);
+        }
+    }
+
+    /**
+     * A plugin that provides a custom aggregation.
+     */
+    public static class CustomPlugin extends Plugin implements SearchPlugin {
+
+        public CustomPlugin() {
+        }
+
+        @Override
+        public List<AggregationSpec> getAggregations() {
+            return singletonList(new AggregationSpec(CUSTOM, CustomAggregationBuilder::new, null)
+                    .addResultParser((p, c) -> ParsedCustom.fromXContent(p, (String) c)));
+        }
+    }
+
+    interface CustomAggregation extends SingleBucketAggregation {
+        boolean isOdd();
+    }
+
+    static class CustomAggregationBuilder extends AbstractAggregationBuilder<CustomAggregationBuilder> {
+
+        private int customNumber;
+
+        CustomAggregationBuilder(String name) {
+            super(name);
+        }
+
+        CustomAggregationBuilder(StreamInput in) throws IOException {
+            super(in);
+            this.customNumber = in.readInt();
+        }
+
+        @Override
+        public String getType() {
+            return CUSTOM;
+        }
+
+        void setCustomNumber(int value) {
+            this.customNumber = value;
+        }
+
+        @Override
+        protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("number", customNumber);
+            return builder.endObject();
+        }
+
+        @Override
+        protected void doWriteTo(StreamOutput out) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected AggregatorFactory<?> doBuild(SearchContext context,
+                                               AggregatorFactory<?> parent,
+                                               AggregatorFactories.Builder subFactories) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected int doHashCode() {
+            return Objects.hash(customNumber);
+        }
+
+        @Override
+        protected boolean doEquals(Object obj) {
+            CustomAggregationBuilder other = (CustomAggregationBuilder) obj;
+            return customNumber == other.customNumber;
+        }
+    }
+
+    static class InternalCustom extends InternalSingleBucketAggregation implements CustomAggregation {
+
+        private final boolean odd;
+
+        InternalCustom(String name, boolean odd, long docCount, InternalAggregations subAggregations,
+                       List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
+            super(name, docCount, subAggregations, pipelineAggregators, metaData);
+            this.odd = odd;
+        }
+
+        @Override
+        public String getWriteableName() {
+            return CUSTOM;
+        }
+
+        @Override
+        public boolean isOdd() {
+            return odd;
+        }
+
+        @Override
+        public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+            super.doXContentBody(builder, params);
+            return builder.field("is_odd", odd);
+        }
+
+        @Override
+        public InternalAggregation doReduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected InternalSingleBucketAggregation newAggregation(String name, long docCount, InternalAggregations subAggregations) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class ParsedCustom extends ParsedSingleBucketAggregation implements CustomAggregation {
+
+        private boolean odd;
+
+        @Override
+        public String getType() {
+            return CUSTOM;
+        }
+
+        @Override
+        public boolean isOdd() {
+            return odd;
+        }
+
+        void setOdd(boolean odd) {
+            this.odd = odd;
+        }
+
+        private static final ObjectParser<ParsedCustom, QueryParseContext> PARSER;
+        static {
+            PARSER = new ObjectParser<>(CUSTOM, ParsedCustom::new);
+            PARSER.declareBoolean(ParsedCustom::setOdd, new ParseField("is_odd"));
+            PARSER.declareLong(ParsedCustom::setDocCount, CommonFields.DOC_COUNT);
+            PARSER.declareObject(ParsedCustom::setMetadata, (p, c) -> p.mapOrdered(), CommonFields.META);
+        }
+
+        static ParsedCustom fromXContent(XContentParser parser, final String name) throws IOException {
+            ParsedCustom aggregation = PARSER.parse(parser, null);
+            aggregation.setName(name);
+            return aggregation;
+        }
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientWithCustomSuggesterTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientWithCustomSuggesterTests.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.HttpEntity;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchResponseSections;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.suggest.SortBy;
+import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.search.suggest.SuggestBuilder;
+import org.elasticsearch.search.suggest.term.TermSuggestion;
+import org.elasticsearch.search.suggest.term.TermSuggestionBuilder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Test usage of a custom suggester provided by a plugin with the {@link RestHighLevelClient}.
+ */
+public class RestHighLevelClientWithCustomSuggesterTests extends RestHighLevelClientWithPluginTestCase {
+
+    private static final String CUSTOM = "custom";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return singletonList(CustomPlugin.class);
+    }
+
+    public void testCustomSuggester() throws Exception {
+        final int numSuggestions = randomIntBetween(1, 5);
+        final int[] customNumbers = new int[numSuggestions];
+
+        SuggestBuilder suggestBuilder = new SuggestBuilder();
+        for (int i = 0; i < numSuggestions; i++) {
+            customNumbers[i] = randomIntBetween(0, 10);
+            suggestBuilder.addSuggestion("suggest_" + i,
+                    new CustomSuggestionBuilder("field", customNumbers[i]).text("custom number is " + customNumbers[i]));
+        }
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+        searchSourceBuilder.suggest(suggestBuilder);
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(searchSourceBuilder);
+
+        SearchResponse searchResponse = search(searchRequest);
+
+        Suggest suggest = searchResponse.getSuggest();
+        assertEquals(numSuggestions, suggest.size());
+        for (int i = 0; i < numSuggestions; i++) {
+            TermSuggestion suggestion = suggest.getSuggestion("suggest_" + i);
+            assertEquals(customNumbers[i], suggestion.getEntries().size());
+
+            for (int j = 0; j < customNumbers[i]; j++) {
+                assertEquals("term " + j, suggestion.getEntries().get(j).getText().string());
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Response performRequest(HttpEntity httpEntity) throws IOException {
+        try (XContentParser parser = createParser(Request.REQUEST_BODY_CONTENT_TYPE.xContent(), httpEntity.getContent())) {
+            Map<String, ?> requestAsMap = parser.map();
+            assertEquals(2, requestAsMap.size());
+            assertTrue("Search request does not contain the match all query", requestAsMap.containsKey("query"));
+            assertTrue("Search request does not contain any suggest", requestAsMap.containsKey("suggest"));
+
+            Map<String, ?> queryAsMap = (Map<String, ?>) requestAsMap.get("query");
+            assertEquals(1, queryAsMap.size());
+            assertTrue("Query must be a match query", queryAsMap.containsKey("match_all"));
+
+            Map<String, ?> suggestAsMap = (Map<String, ?>) requestAsMap.get("suggest");
+            assertThat(suggestAsMap.size(), greaterThan(0));
+
+            List<Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>>> suggestions =
+                    new ArrayList<>();
+
+            for (Map.Entry<String, ?> suggestEntry : suggestAsMap.entrySet()) {
+                assertTrue(suggestEntry.getKey().startsWith("suggest_"));
+
+                Map<String, ?> suggestEntryAsMap = (Map<String, ?>) suggestEntry.getValue();
+                assertTrue("Suggest must have 'custom' type", suggestEntryAsMap.containsKey(CUSTOM));
+                assertTrue("Suggest must have some text", suggestEntryAsMap.containsKey("text"));
+
+                Map<String, ?> customSuggestAsMap = (Map<String, ?>) suggestEntryAsMap.get(CUSTOM);
+                assertTrue("Custom suggest must contain the random number", customSuggestAsMap.containsKey("number"));
+
+                int customNumber = ((Number) customSuggestAsMap.get("number")).intValue();
+                assertEquals("custom number is " + customNumber, suggestEntryAsMap.get("text"));
+
+                TermSuggestion suggestion = new TermSuggestion(suggestEntry.getKey(), customNumber, SortBy.SCORE);
+                for (int i = 0; i < customNumber; i++) {
+                    suggestion.addTerm(new TermSuggestion.Entry(new Text("term " + i), i, customNumber));
+                }
+                suggestions.add(suggestion);
+            }
+
+            Suggest suggests = new Suggest(suggestions);
+            SearchResponse searchResponse =
+                    new SearchResponse(
+                            new SearchResponseSections(SearchHits.empty(), null, suggests, false, false, null, 1),
+                            randomAlphaOfLengthBetween(5, 10), 5, 5, 100, ShardSearchFailure.EMPTY_ARRAY);
+            return createResponse(searchResponse);
+        }
+    }
+
+    /**
+     * A plugin that provides a custom suggester.
+     */
+    public static class CustomPlugin extends Plugin implements SearchPlugin {
+
+        public CustomPlugin() {
+        }
+
+        @Override
+        public List<SuggesterSpec<?>> getSuggesters() {
+            return singletonList(new SuggesterSpec<>(CUSTOM, CustomSuggestionBuilder::new, CustomSuggestionBuilder::fromXContent));
+        }
+    }
+
+    static class CustomSuggestionBuilder extends TermSuggestionBuilder {
+
+        private final int customNumber;
+
+        CustomSuggestionBuilder(String field, int customNumber) {
+            super(field);
+            this.customNumber = customNumber;
+        }
+
+        CustomSuggestionBuilder(StreamInput in) throws IOException {
+            super(in);
+            this.customNumber = in.readInt();
+        }
+
+        @Override
+        public String getWriteableName() {
+            return CUSTOM;
+        }
+
+        @Override
+        public XContentBuilder innerToXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.field("number", customNumber);
+            return super.innerToXContent(builder, params);
+        }
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientWithPluginTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientWithPluginTestCase.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.RequestLine;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicRequestLine;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import static java.util.Collections.singletonMap;
+import static org.elasticsearch.client.ESRestHighLevelClientTestCase.execute;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test usage of search extensions provided by plugins with the {@link RestHighLevelClient}.
+ */
+public abstract class RestHighLevelClientWithPluginTestCase extends ESTestCase {
+
+    private static final String CUSTOM = "custom";
+
+    private RestClient restClient;
+    private RestHighLevelClient restHighLevelClient;
+
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.emptyList();
+    }
+
+    @Before
+    public void iniClients() throws IOException {
+        if (restHighLevelClient == null) {
+            restClient = mock(RestClient.class);
+            restHighLevelClient = new RestHighLevelClient(restClient, getPlugins());
+
+            doAnswer(mock -> performRequest((HttpEntity) mock.getArguments()[3]))
+                .when(restClient)
+                    .performRequest(eq(HttpGet.METHOD_NAME), eq("/_search"), anyMapOf(String.class, String.class),
+                            anyObject(), anyVararg());
+            doAnswer(mock -> performRequestAsync((HttpEntity) mock.getArguments()[3], (ResponseListener) mock.getArguments()[4]))
+                .when(restClient)
+                    .performRequestAsync(eq(HttpGet.METHOD_NAME), eq("/_search"), anyMapOf(String.class, String.class),
+                            any(HttpEntity.class), any(ResponseListener.class), anyVararg());
+        }
+    }
+
+    protected abstract Response performRequest(HttpEntity httpEntity) throws IOException;
+
+    protected Void performRequestAsync(HttpEntity httpEntity, ResponseListener responseListener) {
+        try {
+            responseListener.onSuccess(performRequest(httpEntity));
+        } catch (IOException e) {
+            responseListener.onFailure(e);
+        }
+        return null;
+    }
+
+    protected SearchResponse search(SearchRequest searchRequest) throws IOException {
+        return execute(searchRequest, restHighLevelClient::search, restHighLevelClient::searchAsync);
+    }
+
+    /**
+     * Creates a {@link Response} from a {@link SearchResponse}?
+     */
+    protected Response createResponse(SearchResponse searchResponse) throws IOException {
+        ProtocolVersion protocol = new ProtocolVersion("HTTP", 1, 1);
+        HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(protocol, 200, "OK"));
+
+        final ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
+        BytesRef bytesRef = XContentHelper.toXContent(searchResponse, XContentType.JSON, params, false).toBytesRef();
+        httpResponse.setEntity(new ByteArrayEntity(bytesRef.bytes, ContentType.APPLICATION_JSON));
+
+        RequestLine requestLine = new BasicRequestLine(HttpGet.METHOD_NAME, "/_search", protocol);
+        return new Response(requestLine, new HttpHost("localhost", 9200), httpResponse);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedAggregation.java
@@ -48,7 +48,7 @@ public abstract class ParsedAggregation implements Aggregation, ToXContent {
         return name;
     }
 
-    protected void setName(String name) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -71,6 +71,10 @@ public abstract class ParsedAggregation implements Aggregation, ToXContent {
     }
 
     protected abstract XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException;
+
+    protected void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
 
     /**
      * Parse a token of type XContentParser.Token.VALUE_NUMBER or XContentParser.Token.STRING to a double.

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/MatrixAggregationPlugin.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/MatrixAggregationPlugin.java
@@ -24,6 +24,7 @@ import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.matrix.stats.InternalMatrixStats;
 import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsAggregationBuilder;
 import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsParser;
+import org.elasticsearch.search.aggregations.matrix.stats.ParsedMatrixStats;
 
 import java.util.List;
 
@@ -32,7 +33,10 @@ import static java.util.Collections.singletonList;
 public class MatrixAggregationPlugin extends Plugin implements SearchPlugin {
     @Override
     public List<AggregationSpec> getAggregations() {
-        return singletonList(new AggregationSpec(MatrixStatsAggregationBuilder.NAME, MatrixStatsAggregationBuilder::new,
-                new MatrixStatsParser()).addResultReader(InternalMatrixStats::new));
+        return singletonList(
+                new AggregationSpec(MatrixStatsAggregationBuilder.NAME, MatrixStatsAggregationBuilder::new, new MatrixStatsParser())
+                        .addResultReader(InternalMatrixStats::new)
+                        .addResultParser((p, c) -> ParsedMatrixStats.fromXContent(p, (String) c))
+        );
     }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/ParentJoinPlugin.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/ParentJoinPlugin.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.join.aggregations.ChildrenAggregationBuilder;
 import org.elasticsearch.join.aggregations.InternalChildren;
+import org.elasticsearch.join.aggregations.ParsedChildren;
 import org.elasticsearch.join.fetch.ParentJoinFieldSubFetchPhase;
 import org.elasticsearch.join.mapper.ParentJoinFieldMapper;
 import org.elasticsearch.join.query.HasChildQueryBuilder;
@@ -52,7 +53,8 @@ public class ParentJoinPlugin extends Plugin implements SearchPlugin, MapperPlug
     public List<AggregationSpec> getAggregations() {
         return Collections.singletonList(
           new AggregationSpec(ChildrenAggregationBuilder.NAME, ChildrenAggregationBuilder::new, ChildrenAggregationBuilder::parse)
-              .addResultReader(InternalChildren::new)
+                .addResultReader(InternalChildren::new)
+                .addResultParser((p, c) -> ParsedChildren.fromXContent(p, (String) c))
         );
     }
 


### PR DESCRIPTION
This commit changes the `RestHighLevelClient` class so that it now accepts a list of plugin classes as a constructor parameter. Similarly to the `PreBuiltTransportClient`, the RestHighLevelClient uses the PluginService to load the plugins and then extracts their aggregations and suggesters specs. The aggregation specs have been changed in core in order to add a `addResultParser` method that allows to reference the parsing methods of an aggregation. This information is use in the RestHighLevelClient
 to register additional NamedXContent entries to parse back custom aggregations/suggesters.
