### PR TITLE
Fix GeoDistance Ordinal for BWC

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoDistance.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.geo;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -40,7 +41,26 @@ public enum GeoDistance implements Writeable {
 
     /** Creates a GeoDistance instance from an input stream */
     public static GeoDistance readFromStream(StreamInput in) throws IOException {
+        Version clientVersion = in.getVersion();
         int ord = in.readVInt();
+        // bwc client deprecation for FACTOR and SLOPPY_ARC
+        if (clientVersion.before(Version.V_5_3_3)) {
+            switch (ord) {
+                case 0: return PLANE;
+                case 1: // FACTOR uses PLANE
+                    // bwc client deprecation for FACTOR
+                    DEPRECATION_LOGGER.deprecated("[factor] is deprecated. Using [plane] instead.");
+                    return PLANE;
+                case 2: return ARC;
+                case 3: // SLOPPY_ARC uses ARC
+                    // bwc client deprecation for SLOPPY_ARC
+                    DEPRECATION_LOGGER.deprecated("[sloppy_arc] is deprecated. Using [arc] instead.");
+                    return ARC;
+                default:
+                    throw new IOException("Unknown GeoDistance ordinal [" + ord + "]");
+            }
+        }
+
         if (ord < 0 || ord >= values().length) {
             throw new IOException("Unknown GeoDistance ordinal [" + ord + "]");
         }
@@ -50,6 +70,20 @@ public enum GeoDistance implements Writeable {
     /** Writes an instance of a GeoDistance object to an output stream */
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        Version clientVersion = out.getVersion();
+        int ord = this.ordinal();
+        if (clientVersion.before(Version.V_5_3_3)) {
+            switch (ord) {
+                case 0:
+                    out.write(0);  // write PLANE ordinal
+                    return;
+                case 1:
+                    out.write(2);  // write bwc ARC ordinal
+                    return;
+                default:
+                    throw new IOException("Unknown GeoDistance ordinal [" + ord + "]");
+            }
+        }
         out.writeVInt(this.ordinal());
     }
 


### PR DESCRIPTION
`GeoDistance` enum ordinals from 5.3+ are not backwards compatible with earlier client versions.. This PR adds backward compatibilty support in `GeoDistance` serialization.

closes #24816 