### PR TITLE
Add deprecation logging for comma-separated feature parsing

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -75,6 +75,9 @@ public class RestGetIndicesAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         String[] featureParams = request.paramAsStringArray("type", null);
+        if (featureParams != null && featureParams.length > 1) {
+            deprecationLogger.deprecated("Requesting comma-separated features is deprecated and will be removed in 6.0+, retrieve all features instead.");
+        }
         // Work out if the indices is a list of features
         if (featureParams == null && indices.length > 0 && indices[0] != null && indices[0].startsWith("_") && !"_all".equals(indices[0])) {
             featureParams = indices;

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesAction.java
@@ -76,7 +76,8 @@ public class RestGetIndicesAction extends BaseRestHandler {
         String[] indices = Strings.splitStringByCommaToArray(request.param("index"));
         String[] featureParams = request.paramAsStringArray("type", null);
         if (featureParams != null && featureParams.length > 1) {
-            deprecationLogger.deprecated("Requesting comma-separated features is deprecated and will be removed in 6.0+, retrieve all features instead.");
+            deprecationLogger.deprecated("Requesting comma-separated features is deprecated and " +
+                            "will be removed in 6.0+, retrieve all features instead.");
         }
         // Work out if the indices is a list of features
         if (featureParams == null && indices.length > 0 && indices[0] != null && indices[0].startsWith("_") && !"_all".equals(indices[0])) {

--- a/docs/reference/indices/get-index.asciidoc
+++ b/docs/reference/indices/get-index.asciidoc
@@ -19,6 +19,8 @@ all indices by using `_all` or `*` as index.
 [float]
 === Filtering index information
 
+deprecated[5.5.0, This comma-separated format is deprecated and will be removed. You can retrieve either a single feature (ie _alias) or all features]
+
 The information returned by the get API can be filtered to include only specific features
 by specifying a comma delimited list of features in the URL:
 
@@ -27,7 +29,7 @@ by specifying a comma delimited list of features in the URL:
 GET twitter/_settings,_mappings
 --------------------------------------------------
 // CONSOLE
-// TEST[setup:twitter]
+// TEST[setup:twitter warning:Requesting comma-separated features is deprecated and will be removed in 6.0+, retrieve all features instead.]
 
 The above command will only return the settings and mappings for the index called `twitter`.
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get/10_basic.yaml
@@ -79,7 +79,13 @@ setup:
 ---
 "Get index infos should work for wildcards":
 
+  - skip:
+      features:
+        - warnings
+
   - do:
+      warnings:
+        - 'Requesting comma-separated features is deprecated and will be removed in 6.0+, retrieve all features instead.'
       indices.get:
         index: test_*
         feature: _mapping,_settings


### PR DESCRIPTION
This is the deprecation logging and documentation for 5.x related to #24723. It
logs when a user does a request like:

```
GET /index/_alias,_mapping
```
