### PR TITLE
Make randomVersionBetween work with unreleased versions

### DIFF
--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -254,7 +254,7 @@ public class VersionTests extends ESTestCase {
         final Set<Version> unreleasedVersions = new HashSet<>(VersionUtils.allUnreleasedVersions());
         Map<String, Version> maxBranchVersions = new HashMap<>();
         for (java.lang.reflect.Field field : Version.class.getFields()) {
-            if (field.getName().matches("_ID(_UNRELEASED)?")) {
+            if (field.getName().matches("_ID")) {
                 assertTrue(field.getName() + " should be static", Modifier.isStatic(field.getModifiers()));
                 assertTrue(field.getName() + " should be final", Modifier.isFinal(field.getModifiers()));
                 int versionId = (Integer)field.get(Version.class);
@@ -293,7 +293,12 @@ public class VersionTests extends ESTestCase {
                 if (maxBranchVersion == null) {
                     maxBranchVersions.put(branchName, v);
                 } else if (v.after(maxBranchVersion)) {
-                    assertFalse("Version " + maxBranchVersion + " cannot be a snapshot because version " + v + " exists", VersionUtils.isSnapshot(maxBranchVersion));
+                    if (v == Version.CURRENT) {
+                        // Current is weird - it counts as released even though it shouldn't.
+                        continue;
+                    }
+                    assertFalse("Version " + maxBranchVersion + " cannot be a snapshot because version " + v + " exists",
+                            VersionUtils.allUnreleasedVersions().contains(maxBranchVersion));
                     maxBranchVersions.put(branchName, v);
                 }
             }

--- a/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/OldIndexBackwardsCompatibilityIT.java
@@ -176,7 +176,8 @@ public class OldIndexBackwardsCompatibilityIT extends ESIntegTestCase {
     public void testAllVersionsTested() throws Exception {
         SortedSet<String> expectedVersions = new TreeSet<>();
         for (Version v : VersionUtils.allReleasedVersions()) {
-            if (VersionUtils.isSnapshot(v)) continue;  // snapshots are unreleased, so there is no backcompat yet
+            // The current version is in the "released" list even though it isn't released for historical reasons
+            if (v == Version.CURRENT) continue;
             if (v.isRelease() == false) continue; // no guarantees for prereleases
             if (v.before(Version.CURRENT.minimumIndexCompatibilityVersion())) continue; // we can only support one major version backward
             if (v.equals(Version.CURRENT)) continue; // the current version is always compatible with itself

--- a/core/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatIT.java
+++ b/core/src/test/java/org/elasticsearch/bwcompat/RestoreBackwardsCompatIT.java
@@ -89,7 +89,8 @@ public class RestoreBackwardsCompatIT extends AbstractSnapshotIntegTestCase {
 
         SortedSet<String> expectedVersions = new TreeSet<>();
         for (Version v : VersionUtils.allReleasedVersions()) {
-            if (VersionUtils.isSnapshot(v)) continue;  // snapshots are unreleased, so there is no backcompat yet
+            // The current version is in the "released" list even though it isn't released for historical reasons
+            if (v == Version.CURRENT) continue;
             if (v.isRelease() == false) continue; // no guarantees for prereleases
             if (v.before(Version.CURRENT.minimumIndexCompatibilityVersion())) continue; // we only support versions N and N-1
             if (v.equals(Version.CURRENT)) continue; // the current version is always compatible with itself

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -126,8 +126,6 @@ public class VersionUtils {
 
     /**
      * Returns an immutable, sorted list containing all released versions.
-     *
-     * @return all released versions
      */
     public static List<Version> allReleasedVersions() {
         return RELEASED_VERSIONS;
@@ -135,8 +133,6 @@ public class VersionUtils {
 
     /**
      * Returns an immutable, sorted list containing all unreleased versions.
-     *
-     * @return all unreleased versions
      */
     public static List<Version> allUnreleasedVersions() {
         return UNRELEASED_VERSIONS;
@@ -144,7 +140,6 @@ public class VersionUtils {
 
     /**
      * Returns an immutable, sorted list containing all versions, both released and unreleased.
-     * @return
      */
     public static List<Version> allVersions() {
         return ALL_VERSIONS;
@@ -212,12 +207,5 @@ public class VersionUtils {
             int range = maxVersionIndex + 1 - minVersionIndex;
             return ALL_VERSIONS.get(minVersionIndex + random.nextInt(range));
         }
-    }
-
-    public static boolean isSnapshot(Version version) { // TODO this seems wrong - we keep unreleased versions in 
-        if (Version.CURRENT.equals(version)) {
-            return true;
-        }
-        return false;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.test;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 
 import java.lang.reflect.Field;
@@ -110,11 +111,17 @@ public class VersionUtils {
 
     private static final List<Version> RELEASED_VERSIONS;
     private static final List<Version> UNRELEASED_VERSIONS;
+    private static final List<Version> ALL_VERSIONS;
 
     static {
         Tuple<List<Version>, List<Version>> versions = resolveReleasedVersions(Version.CURRENT, Version.class);
         RELEASED_VERSIONS = versions.v1();
         UNRELEASED_VERSIONS = versions.v2();
+        List<Version> allVersions = new ArrayList<>(RELEASED_VERSIONS.size() + UNRELEASED_VERSIONS.size());
+        allVersions.addAll(RELEASED_VERSIONS);
+        allVersions.addAll(UNRELEASED_VERSIONS);
+        Collections.sort(allVersions);
+        ALL_VERSIONS = unmodifiableList(allVersions);
     }
 
     /**
@@ -135,20 +142,36 @@ public class VersionUtils {
         return UNRELEASED_VERSIONS;
     }
 
+    /**
+     * Returns an immutable, sorted list containing all versions, both released and unreleased.
+     * @return
+     */
+    public static List<Version> allVersions() {
+        return ALL_VERSIONS;
+    }
+
+    /**
+     * Get the released version before {@code version}.
+     */
     public static Version getPreviousVersion(Version version) {
         int index = RELEASED_VERSIONS.indexOf(version);
         assert index > 0;
         return RELEASED_VERSIONS.get(index - 1);
     }
 
-    /** Returns the {@link Version} before the {@link Version#CURRENT} */
+    /**
+     * Get the released version before {@link Version#CURRENT}.
+     */
     public static Version getPreviousVersion() {
         Version version = getPreviousVersion(Version.CURRENT);
         assert version.before(Version.CURRENT);
         return version;
     }
 
-    /** Returns the {@link Version} before the {@link Version#CURRENT} where the minor version is less than the currents minor version. */
+    /**
+     * Returns the released {@link Version} before the {@link Version#CURRENT}
+     * where the minor version is less than the currents minor version.
+     */
     public static Version getPreviousMinorVersion() {
         Version version = Version.CURRENT;
         do {
@@ -158,25 +181,25 @@ public class VersionUtils {
         return version;
     }
 
-    /** Returns the oldest {@link Version} */
+    /** Returns the oldest released {@link Version} */
     public static Version getFirstVersion() {
         return RELEASED_VERSIONS.get(0);
     }
 
     /** Returns a random {@link Version} from all available versions. */
     public static Version randomVersion(Random random) {
-        return RELEASED_VERSIONS.get(random.nextInt(RELEASED_VERSIONS.size()));
+        return ALL_VERSIONS.get(random.nextInt(ALL_VERSIONS.size()));
     }
 
     /** Returns a random {@link Version} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
-    public static Version randomVersionBetween(Random random, Version minVersion, Version maxVersion) {
+    public static Version randomVersionBetween(Random random, @Nullable Version minVersion, @Nullable Version maxVersion) {
         int minVersionIndex = 0;
         if (minVersion != null) {
-            minVersionIndex = RELEASED_VERSIONS.indexOf(minVersion);
+            minVersionIndex = ALL_VERSIONS.indexOf(minVersion);
         }
-        int maxVersionIndex = RELEASED_VERSIONS.size() - 1;
+        int maxVersionIndex = ALL_VERSIONS.size() - 1;
         if (maxVersion != null) {
-            maxVersionIndex = RELEASED_VERSIONS.indexOf(maxVersion);
+            maxVersionIndex = ALL_VERSIONS.indexOf(maxVersion);
         }
         if (minVersionIndex == -1) {
             throw new IllegalArgumentException("minVersion [" + minVersion + "] does not exist.");
@@ -187,11 +210,11 @@ public class VersionUtils {
         } else {
             // minVersionIndex is inclusive so need to add 1 to this index
             int range = maxVersionIndex + 1 - minVersionIndex;
-            return RELEASED_VERSIONS.get(minVersionIndex + random.nextInt(range));
+            return ALL_VERSIONS.get(minVersionIndex + random.nextInt(range));
         }
     }
 
-    public static boolean isSnapshot(Version version) {
+    public static boolean isSnapshot(Version version) { // TODO this seems wrong - we keep unreleased versions in 
         if (Version.CURRENT.equals(version)) {
             return true;
         }

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -28,6 +28,8 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class VersionUtilsTests extends ESTestCase {
 
@@ -86,6 +88,11 @@ public class VersionUtilsTests extends ESTestCase {
         assertEquals(got, VersionUtils.getFirstVersion());
         got = VersionUtils.randomVersionBetween(random(), Version.CURRENT, null);
         assertEquals(got, Version.CURRENT);
+
+        // max or min can be an unreleased version
+        Version unreleased = randomFrom(VersionUtils.allUnreleasedVersions());
+        assertThat(VersionUtils.randomVersionBetween(random(), null, unreleased), lessThanOrEqualTo(unreleased));
+        assertThat(VersionUtils.randomVersionBetween(random(), unreleased, null), greaterThanOrEqualTo(unreleased));
     }
 
     static class TestReleaseBranch {

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -93,6 +93,7 @@ public class VersionUtilsTests extends ESTestCase {
         Version unreleased = randomFrom(VersionUtils.allUnreleasedVersions());
         assertThat(VersionUtils.randomVersionBetween(random(), null, unreleased), lessThanOrEqualTo(unreleased));
         assertThat(VersionUtils.randomVersionBetween(random(), unreleased, null), greaterThanOrEqualTo(unreleased));
+        assertEquals(unreleased, VersionUtils.randomVersionBetween(random(), unreleased, unreleased));
     }
 
     static class TestReleaseBranch {


### PR DESCRIPTION
Modifies randomVersionBetween so that it works with unreleased
versions. This should make switching a version from unreleased
to released much simpler.