### PR TITLE
fix grok's pattern parsing to validate pattern names in expression

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Grok.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/Grok.java
@@ -29,7 +29,6 @@ import org.joni.Syntax;
 import org.joni.exception.ValueException;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
@@ -107,7 +106,12 @@ final class Grok {
             // TODO(tal): Support definitions
             String definition = groupMatch(DEFINITION_GROUP, region, grokPattern);
             String patternName = groupMatch(PATTERN_GROUP, region, grokPattern);
+
             String pattern = patternBank.get(patternName);
+
+            if (pattern == null) {
+                throw new IllegalArgumentException("Unable to find pattern [" + patternName + "] in Grok's pattern dictionary");
+            }
 
             String grokPart;
             if (namedCaptures && subName != null) {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorTests.java
@@ -54,6 +54,16 @@ public class GrokProcessorTests extends ESTestCase {
         assertThat(e.getMessage(), equalTo("Provided Grok expressions do not match field value: [23]"));
     }
 
+    public void testNoMatchingPatternName() {
+        String fieldName = RandomDocumentPicks.randomFieldName(random());
+        IngestDocument doc = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        doc.setFieldValue(fieldName, "23");
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new GrokProcessor(randomAlphaOfLength(10),
+            Collections.singletonMap("ONE", "1"), Collections.singletonList("%{NOTONE:not_one}"), fieldName,
+            false, false));
+        assertThat(e.getMessage(), equalTo("Unable to find pattern [NOTONE] in Grok's pattern dictionary"));
+    }
+
     public void testMatchWithoutCaptures() throws Exception {
         String fieldName = "value";
         IngestDocument originalDoc = new IngestDocument(new HashMap<>(), new HashMap<>());

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokTests.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +47,11 @@ public class GrokTests extends ESTestCase {
         Grok grok = new Grok(basePatterns, "value");
         Map<String, Object> matches = grok.captures(line);
         assertEquals(0, matches.size());
+    }
+
+    public void testNoMatchingPatternInDictionary() {
+        Exception e = expectThrows(IllegalArgumentException.class, () -> new Grok(Collections.emptyMap(), "%{NOTFOUND}"));
+        assertThat(e.getMessage(), equalTo("Unable to find pattern [NOTFOUND] in Grok's pattern dictionary"));
     }
 
     public void testSimpleSyslogLine() {


### PR DESCRIPTION
Unknown patterns used to silently be ignored. This was a problem because users did not know they were providing an invalid pattern name, and maybe thought the rest of their regexes were invalid.

Fixes #22831.