### PR TITLE
[TEST] Never use local=true in ensureStableCluster method

### DIFF
--- a/core/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -190,7 +190,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                 disruptionScheme.stopDisrupting();
                 for (String node : internalCluster().getNodeNames()) {
                     ensureStableCluster(nodes.size(), TimeValue.timeValueMillis(disruptionScheme.expectedTimeToHeal().millis() +
-                        DISRUPTION_HEALING_OVERHEAD.millis()), true, node);
+                        DISRUPTION_HEALING_OVERHEAD.millis()), node);
                 }
                 // in case of a bridge partition, shard allocation can fail "index.allocation.max_retries" times if the master
                 // is the super-connected node and recovery source and target are on opposite sides of the bridge

--- a/core/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/MasterDisruptionIT.java
@@ -288,7 +288,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         // restore GC
         masterNodeDisruption.stopDisrupting();
         final TimeValue waitTime = new TimeValue(DISRUPTION_HEALING_OVERHEAD.millis() + masterNodeDisruption.expectedTimeToHeal().millis());
-        ensureStableCluster(3, waitTime, false, oldNonMasterNodes.get(0));
+        ensureStableCluster(3, waitTime, oldNonMasterNodes.get(0));
 
         // make sure all nodes agree on master
         String newMaster = internalCluster().getMasterName();
@@ -333,7 +333,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
 
         for (String node : nodes) {
             ensureStableCluster(3, new TimeValue(DISRUPTION_HEALING_OVERHEAD.millis() + networkDisruption.expectedTimeToHeal().millis()),
-                    true, node);
+                node);
         }
 
         logger.info("issue a reroute");

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1151,14 +1151,14 @@ public abstract class ESIntegTestCase extends ESTestCase {
     }
 
     protected void ensureStableCluster(int nodeCount, TimeValue timeValue) {
-        ensureStableCluster(nodeCount, timeValue, false, null);
+        ensureStableCluster(nodeCount, timeValue, null);
     }
 
     protected void ensureStableCluster(int nodeCount, @Nullable String viaNode) {
-        ensureStableCluster(nodeCount, TimeValue.timeValueSeconds(30), false, viaNode);
+        ensureStableCluster(nodeCount, TimeValue.timeValueSeconds(30), viaNode);
     }
 
-    protected void ensureStableCluster(int nodeCount, TimeValue timeValue, boolean local, @Nullable String viaNode) {
+    protected void ensureStableCluster(int nodeCount, TimeValue timeValue, @Nullable String viaNode) {
         if (viaNode == null) {
             viaNode = randomFrom(internalCluster().getNodeNames());
         }
@@ -1167,7 +1167,6 @@ public abstract class ESIntegTestCase extends ESTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes(Integer.toString(nodeCount))
             .setTimeout(timeValue)
-            .setLocal(local)
             .setWaitForNoRelocatingShards(true)
             .get();
         if (clusterHealthResponse.isTimedOut()) {


### PR DESCRIPTION
The test infrastructure method `ensureStableCluster` with local flag set to true internally issues a cluster health request. Cluster health requests with local flag set to true are trappy, however, as they will happily the right number of nodes even if the node is not part of an actual cluster but has a NO_MASTER_BLOCK up (see https://github.com/elastic/elasticsearch/issues/24457#issuecomment-298882617).

This commit removes the "local" parameter from `ensureStableCluster` and changes the few callers that were using the flag.