### PR TITLE
Postings highlighter deprecation

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.StringFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -68,13 +69,13 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
                 SourceFieldMapper sourceFieldMapper = context.mapperService().documentMapper(hitContext.hit().type()).sourceMapper();
                 if (!sourceFieldMapper.enabled()) {
                     throw new IllegalArgumentException("source is forced for fields " +  fieldNamesToHighlight
-                            + " but type [" + hitContext.hit().type() + "] has disabled _source");
+                        + " but type [" + hitContext.hit().type() + "] has disabled _source");
                 }
             }
 
             boolean fieldNameContainsWildcards = field.field().contains("*");
             for (String fieldName : fieldNamesToHighlight) {
-                FieldMapper fieldMapper = getMapperForField(fieldName, context, hitContext);
+                FieldMapper fieldMapper = getMapperForField(fieldName, context, hitContext.hit());
                 if (fieldMapper == null) {
                     continue;
                 }
@@ -107,7 +108,7 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
                 Highlighter highlighter = highlighters.get(highlighterType);
                 if (highlighter == null) {
                     throw new IllegalArgumentException("unknown highlighter type [" + highlighterType
-                            + "] for the field [" + fieldName + "]");
+                        + "] for the field [" + fieldName + "]");
                 }
 
                 Query highlightQuery = field.fieldOptions().highlightQuery();
@@ -115,7 +116,7 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
                     highlightQuery = context.parsedQuery().query();
                 }
                 HighlighterContext highlighterContext = new HighlighterContext(fieldName, field, fieldMapper, context,
-                        hitContext, highlightQuery);
+                    hitContext, highlightQuery);
 
                 if ((highlighter.canHighlight(fieldMapper) == false) && fieldNameContainsWildcards) {
                     // if several fieldnames matched the wildcard then we want to skip those that we cannot highlight
@@ -130,9 +131,85 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
         hitContext.hit().highlightFields(highlightFields);
     }
 
-    private FieldMapper getMapperForField(String fieldName, SearchContext searchContext, HitContext hitContext) {
-        DocumentMapper documentMapper = searchContext.mapperService().documentMapper(hitContext.hit().type());
+    @Override
+    public void hitsExecute(SearchContext context, SearchHit[] hits) {
+        if (context.highlight() == null) {
+            return;
+        }
+
+        /**
+         * This is used to make sure that we log the deprecation of the {@link PostingsHighlighter}
+         * only once per request even though multiple documents/fields use the deprecated highlighter.
+         */
+        for (SearchHit hit : hits) {
+            for (SearchContextHighlight.Field field : context.highlight().fields()) {
+                for (String fieldName : getFieldsToHighlight(context, field, hit)) {
+                    FieldMapper fieldMapper = getMapperForField(fieldName, context, hit);
+                    if (fieldMapper == null) {
+                        continue;
+                    }
+
+                    String highlighterType = field.fieldOptions().highlighterType();
+                    Highlighter highlighter = getHighlighterForField(fieldMapper, highlighterType);
+                    if (highlighter instanceof PostingsHighlighter) {
+                        deprecationLogger.deprecated("[postings] highlighter is deprecated, please use [unified] instead");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the list of field names that match the provided field definition in the mapping of the {@link SearchHit}
+     */
+    private Collection<String> getFieldsToHighlight(SearchContext context, SearchContextHighlight.Field field, SearchHit hit) {
+        Collection<String> fieldNamesToHighlight;
+        if (Regex.isSimpleMatchPattern(field.field())) {
+            DocumentMapper documentMapper = context.mapperService().documentMapper(hit.type());
+            fieldNamesToHighlight = documentMapper.mappers().simpleMatchToFullName(field.field());
+        } else {
+            fieldNamesToHighlight = Collections.singletonList(field.field());
+        }
+
+        if (context.highlight().forceSource(field)) {
+            SourceFieldMapper sourceFieldMapper = context.mapperService().documentMapper(hit.type()).sourceMapper();
+            if (!sourceFieldMapper.enabled()) {
+                throw new IllegalArgumentException("source is forced for fields " + fieldNamesToHighlight
+                    + " but type [" + hit.type() + "] has disabled _source");
+            }
+        }
+        return fieldNamesToHighlight;
+    }
+
+    /**
+     * Returns the {@link FieldMapper} associated with the provided <code>fieldName</code>
+     */
+    private FieldMapper getMapperForField(String fieldName, SearchContext searchContext, SearchHit hit) {
+        DocumentMapper documentMapper = searchContext.mapperService().documentMapper(hit.getType());
         // TODO: no need to lookup the doc mapper with unambiguous field names? just look at the mapper service
         return documentMapper.mappers().smartNameFieldMapper(fieldName);
     }
+
+    /**
+     * Returns the {@link Highlighter} for the given {@link FieldMapper}
+     */
+    private Highlighter getHighlighterForField(FieldMapper fieldMapper, String name) {
+        if (name == null) {
+            for (String highlighterCandidate : STANDARD_HIGHLIGHTERS_BY_PRECEDENCE) {
+                if (highlighters.get(highlighterCandidate).canHighlight(fieldMapper)) {
+                    name = highlighterCandidate;
+                    break;
+                }
+            }
+            assert name != null;
+        }
+        Highlighter highlighter = highlighters.get(name);
+        if (highlighter == null) {
+            throw new IllegalArgumentException("unknown highlighter type [" + name
+                + "] for the field [" + fieldMapper.name() + "]");
+        }
+        return highlighter;
+    }
 }
+

--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PostingsHighlighter.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PostingsHighlighter.java
@@ -28,8 +28,6 @@ import org.apache.lucene.search.postingshighlight.CustomSeparatorBreakIterator;
 import org.apache.lucene.search.highlight.Snippet;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.fetch.FetchPhaseExecutionException;
@@ -48,13 +46,12 @@ import java.util.Map;
 
 @Deprecated
 public class PostingsHighlighter implements Highlighter {
-    private static DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(PostingsHighlighter.class));
 
     private static final String CACHE_KEY = "highlight-postings";
 
     @Override
     public HighlightField highlight(HighlighterContext highlighterContext) {
-        deprecationLogger.deprecated("[postings] highlighter is deprecated, please use [unified] instead");
+
         FieldMapper fieldMapper = highlighterContext.mapper;
         SearchContextHighlight.Field field = highlighterContext.field;
         if (canHighlight(fieldMapper) == false) {

--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PostingsHighlighter.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PostingsHighlighter.java
@@ -28,6 +28,8 @@ import org.apache.lucene.search.postingshighlight.CustomSeparatorBreakIterator;
 import org.apache.lucene.search.highlight.Snippet;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.search.fetch.FetchPhaseExecutionException;
@@ -44,13 +46,15 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+@Deprecated
 public class PostingsHighlighter implements Highlighter {
+    private static DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(PostingsHighlighter.class));
 
     private static final String CACHE_KEY = "highlight-postings";
 
     @Override
     public HighlightField highlight(HighlighterContext highlighterContext) {
-
+        deprecationLogger.deprecated("[postings] highlighter is deprecated, please use [unified] instead");
         FieldMapper fieldMapper = highlighterContext.mapper;
         SearchContextHighlight.Field field = highlighterContext.field;
         if (canHighlight(fieldMapper) == false) {

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -60,7 +60,7 @@ This is repeated for every field and every document that needs highlighting. If 
 [[postings-highlighter]]
 ==== Postings highlighter
 
-deprecated[5.5.0,This highlighter type is deprecated and will be removed. Please use the `unified` highlighter instead. ]
+deprecated[5.5.0,This highlighter type is deprecated and will be removed in 6.0. Please use the `unified` highlighter instead. ]
 
 
 If `index_options` is set to `offsets` in the mapping the postings highlighter

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -60,7 +60,7 @@ This is repeated for every field and every document that needs highlighting. If 
 [[postings-highlighter]]
 ==== Postings highlighter
 
-deprecated[5.5.0,This highlighter type is deprecated and will be removed in 6.0. Please use the `unified` highlighter instead. ]
+deprecated[5.6.0,This highlighter type is deprecated and will be removed in 6.0. Please use the `unified` highlighter instead. ]
 
 
 If `index_options` is set to `offsets` in the mapping the postings highlighter

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -60,8 +60,13 @@ This is repeated for every field and every document that needs highlighting. If 
 [[postings-highlighter]]
 ==== Postings highlighter
 
+deprecated[5.5.0,This highlighter type is deprecated and will be removed. Please use the `unified` highlighter instead. ]
+
+
 If `index_options` is set to `offsets` in the mapping the postings highlighter
-will be used instead of the plain highlighter. The postings highlighter:
+will be used instead of the plain highlighter.
+
+The postings highlighter:
 
 * Is faster since it doesn't require to reanalyze the text to be highlighted:
 the larger the documents the better the performance gain should be

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/20_postings.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/20_postings.yaml
@@ -4,7 +4,7 @@ setup:
           index: test
           body:
             mappings:
-              unified:
+              doc:
                 "properties":
                   "text":
                      "type": "text"
@@ -12,7 +12,7 @@ setup:
   - do:
       index:
         index: test
-        type:  unified
+        type:  doc
         id:    1
         body:
             "text" : "The quick brown fox is brown."
@@ -20,7 +20,7 @@ setup:
   - do:
       index:
         index: test
-        type:  unified
+        type:  doc
         id:    2
         body:
             "text" : "The quick brown fox is brown."
@@ -32,8 +32,8 @@ setup:
 "Postings highlighter should have deprecation warning":
   - skip:
       features: 'warnings'
-      version: ' - 5.4.99'
-      reason: deprecated in 5.5
+      version: ' - 5.5.99'
+      reason: deprecated in 5.6
   - do:
       warnings:
         - "[postings] highlighter is deprecated, please use [unified] instead"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/20_postings.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/20_postings.yaml
@@ -1,0 +1,42 @@
+setup:
+  - do:
+      indices.create:
+          index: test
+          body:
+            mappings:
+              unified:
+                "properties":
+                  "text":
+                     "type": "text"
+                     "index_options": "offsets"
+  - do:
+      index:
+        index: test
+        type:  unified
+        id:    1
+        body:
+            "text" : "The quick brown fox is brown."
+  - do:
+      indices.refresh: {}
+
+---
+"Postings highlighter should have deprecation warning":
+  - skip:
+      features: 'warnings'
+      version: ' - 5.4.99'
+      reason: deprecated in 5.5
+  - do:
+      warnings:
+        - "[postings] highlighter is deprecated, please use [unified] instead"
+      search:
+        body: { "query" : {"match" : { "text" : "quick brown fox" } }, "highlight" : { "fields" : { "*" : {} } } }
+
+  - match: {hits.hits.0.highlight.text.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is <em>brown</em>."}
+
+  - do:
+      warnings:
+        - "[postings] highlighter is deprecated, please use [unified] instead"
+      search:
+        body: { "query" : {"match" : { "text" : "quick brown fox" } }, "highlight" : { "type" : "postings", "fields" : { "*" : {} } } }
+
+  - match: {hits.hits.0.highlight.text.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is <em>brown</em>."}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/20_postings.yaml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/20_postings.yaml
@@ -16,6 +16,15 @@ setup:
         id:    1
         body:
             "text" : "The quick brown fox is brown."
+
+  - do:
+      index:
+        index: test
+        type:  unified
+        id:    2
+        body:
+            "text" : "The quick brown fox is brown."
+
   - do:
       indices.refresh: {}
 
@@ -32,6 +41,7 @@ setup:
         body: { "query" : {"match" : { "text" : "quick brown fox" } }, "highlight" : { "fields" : { "*" : {} } } }
 
   - match: {hits.hits.0.highlight.text.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is <em>brown</em>."}
+  - match: {hits.hits.1.highlight.text.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is <em>brown</em>."}
 
   - do:
       warnings:
@@ -40,3 +50,4 @@ setup:
         body: { "query" : {"match" : { "text" : "quick brown fox" } }, "highlight" : { "type" : "postings", "fields" : { "*" : {} } } }
 
   - match: {hits.hits.0.highlight.text.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is <em>brown</em>."}
+  - match: {hits.hits.1.highlight.text.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is <em>brown</em>."}


### PR DESCRIPTION
The `postings` highlighter is deprecated in Lucene and will be replaced by the `unified`.
This change adds a deprecation warning for removal in 6.0.

Relates https://github.com/elastic/elasticsearch/pull/25028
