### PR TITLE
Use SPI in High Level Rest Client to load XContent parsers

### DIFF
--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -26,9 +26,9 @@ group = 'org.elasticsearch.client'
 dependencies {
   compile "org.elasticsearch:elasticsearch:${version}"
   compile "org.elasticsearch.client:rest:${version}"
-  compile "org.elasticsearch.plugin:parent-join-client:${version}"
-  compile "org.elasticsearch.plugin:aggs-matrix-stats-client:${version}"
 
+  testCompile "org.elasticsearch.plugin:parent-join-client:${version}"
+  testCompile "org.elasticsearch.plugin:aggs-matrix-stats-client:${version}"
   testCompile "org.elasticsearch.client:test:${version}"
   testCompile "org.elasticsearch.test:framework:${version}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -26,9 +26,9 @@ group = 'org.elasticsearch.client'
 dependencies {
   compile "org.elasticsearch:elasticsearch:${version}"
   compile "org.elasticsearch.client:rest:${version}"
+  compile "org.elasticsearch.plugin:parent-join-client:${version}"
+  compile "org.elasticsearch.plugin:aggs-matrix-stats-client:${version}"
 
-  testCompile "org.elasticsearch.plugin:parent-join-client:${version}"
-  testCompile "org.elasticsearch.plugin:aggs-matrix-stats-client:${version}"
   testCompile "org.elasticsearch.client:test:${version}"
   testCompile "org.elasticsearch.test:framework:${version}"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -56,10 +56,12 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.cbor.CborXContent;
 import org.elasticsearch.common.xcontent.smile.SmileXContent;
+import org.elasticsearch.join.aggregations.ChildrenAggregationBuilder;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsAggregationBuilder;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
@@ -69,6 +71,7 @@ import org.mockito.internal.matchers.VarargMatcher;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -613,9 +616,9 @@ public class RestHighLevelClientTests extends ESTestCase {
         assertEquals("Elasticsearch exception [type=exception, reason=test error message]", elasticsearchException.getMessage());
     }
 
-    public void testNamedXContents() {
+    public void testDefaultNamedXContents() {
         List<NamedXContentRegistry.Entry> namedXContents = RestHighLevelClient.getDefaultNamedXContents();
-        assertEquals(45, namedXContents.size());
+        assertEquals(43, namedXContents.size());
         Map<Class<?>, Integer> categories = new HashMap<>();
         for (NamedXContentRegistry.Entry namedXContent : namedXContents) {
             Integer counter = categories.putIfAbsent(namedXContent.categoryClass, 1);
@@ -624,8 +627,26 @@ public class RestHighLevelClientTests extends ESTestCase {
             }
         }
         assertEquals(2, categories.size());
-        assertEquals(Integer.valueOf(42), categories.get(Aggregation.class));
+        assertEquals(Integer.valueOf(40), categories.get(Aggregation.class));
         assertEquals(Integer.valueOf(3), categories.get(Suggest.Suggestion.class));
+    }
+
+    public void testProvidedNamedXContents() {
+        List<NamedXContentRegistry.Entry> namedXContents = RestHighLevelClient.getProvidedNamedXContents();
+        assertEquals(2, namedXContents.size());
+        Map<Class<?>, Integer> categories = new HashMap<>();
+        List<String> names = new ArrayList<>();
+        for (NamedXContentRegistry.Entry namedXContent : namedXContents) {
+            names.add(namedXContent.name.getPreferredName());
+            Integer counter = categories.putIfAbsent(namedXContent.categoryClass, 1);
+            if (counter != null) {
+                categories.put(namedXContent.categoryClass, counter + 1);
+            }
+        }
+        assertEquals(1, categories.size());
+        assertEquals(Integer.valueOf(2), categories.get(Aggregation.class));
+        assertTrue(names.contains(ChildrenAggregationBuilder.NAME));
+        assertTrue(names.contains(MatrixStatsAggregationBuilder.NAME));
     }
 
     private static class TrackingActionListener implements ActionListener<Integer> {

--- a/core/src/main/java/org/elasticsearch/plugins/spi/NamedXContentProvider.java
+++ b/core/src/main/java/org/elasticsearch/plugins/spi/NamedXContentProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins.spi;
+
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+
+import java.util.List;
+
+/**
+ * Provides named XContent parsers.
+ */
+public interface NamedXContentProvider {
+
+    /**
+     * @return a list of {@link NamedXContentRegistry.Entry} that this plugin provides.
+     */
+    List<NamedXContentRegistry.Entry> getNamedXContentParsers();
+}

--- a/core/src/main/java/org/elasticsearch/plugins/spi/package-info.java
+++ b/core/src/main/java/org/elasticsearch/plugins/spi/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This package contains interfaces for services provided by
+ * Elasticsearch plugins to external applications like the
+ * Java High Level Rest Client.
+ */
+package org.elasticsearch.plugins.spi;

--- a/core/src/test/java/org/elasticsearch/plugins/spi/NamedXContentProviderTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/spi/NamedXContentProviderTests.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plugins.spi;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.pipeline.ParsedSimpleValue;
+import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.search.suggest.term.TermSuggestion;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.function.Predicate;
+
+public class NamedXContentProviderTests extends ESTestCase {
+
+    public void testSpiFileExists() throws IOException {
+        String serviceFile = "/META-INF/services/" + NamedXContentProvider.class.getName();
+        List<String> implementations = new ArrayList<>();
+        try (InputStream input = NamedXContentProviderTests.class.getResourceAsStream(serviceFile)) {
+            Streams.readAllLines(input, implementations::add);
+        }
+
+        assertEquals(1, implementations.size());
+        assertEquals(TestNamedXContentProvider.class.getName(), implementations.get(0));
+    }
+
+    public void testNamedXContents() {
+        final List<NamedXContentRegistry.Entry> namedXContents = new ArrayList<>();
+        for (NamedXContentProvider service : ServiceLoader.load(NamedXContentProvider.class)) {
+            namedXContents.addAll(service.getNamedXContentParsers());
+        }
+
+        assertEquals(2, namedXContents.size());
+
+        List<Predicate<NamedXContentRegistry.Entry>> predicates = new ArrayList<>(2);
+        predicates.add(e -> Aggregation.class.equals(e.categoryClass) && "test_aggregation".equals(e.name.getPreferredName()));
+        predicates.add(e -> Suggest.Suggestion.class.equals(e.categoryClass) && "test_suggestion".equals(e.name.getPreferredName()));
+        predicates.forEach(predicate -> assertEquals(1, namedXContents.stream().filter(predicate).count()));
+    }
+
+    public static class TestNamedXContentProvider implements NamedXContentProvider {
+
+        public TestNamedXContentProvider() {
+        }
+
+        @Override
+        public List<NamedXContentRegistry.Entry> getNamedXContentParsers() {
+            return Arrays.asList(
+                    new NamedXContentRegistry.Entry(Aggregation.class, new ParseField("test_aggregation"),
+                            (parser, context) -> ParsedSimpleValue.fromXContent(parser, (String) context)),
+                    new NamedXContentRegistry.Entry(Suggest.Suggestion.class, new ParseField("test_suggestion"),
+                            (parser, context) -> TermSuggestion.fromXContent(parser, (String) context))
+            );
+        }
+    }
+}

--- a/core/src/test/resources/META-INF/services/org.elasticsearch.plugins.spi.NamedXContentProvider
+++ b/core/src/test/resources/META-INF/services/org.elasticsearch.plugins.spi.NamedXContentProvider
@@ -1,0 +1,1 @@
+org.elasticsearch.plugins.spi.NamedXContentProviderTests$TestNamedXContentProvider

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/spi/MatrixStatsNamedXContentProvider.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/spi/MatrixStatsNamedXContentProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.matrix.spi;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ContextParser;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.plugins.spi.NamedXContentProvider;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.matrix.stats.MatrixStatsAggregationBuilder;
+import org.elasticsearch.search.aggregations.matrix.stats.ParsedMatrixStats;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+public class MatrixStatsNamedXContentProvider implements NamedXContentProvider {
+
+    @Override
+    public List<NamedXContentRegistry.Entry> getNamedXContentParsers() {
+        ParseField parseField = new ParseField(MatrixStatsAggregationBuilder.NAME);
+        ContextParser<Object, Aggregation> contextParser = (p, name) -> ParsedMatrixStats.fromXContent(p, (String) name);
+        return singletonList(new NamedXContentRegistry.Entry(Aggregation.class, parseField, contextParser));
+    }
+}

--- a/modules/aggs-matrix-stats/src/main/resources/META-INF/services/org.elasticsearch.plugins.spi.NamedXContentProvider
+++ b/modules/aggs-matrix-stats/src/main/resources/META-INF/services/org.elasticsearch.plugins.spi.NamedXContentProvider
@@ -1,0 +1,1 @@
+org.elasticsearch.search.aggregations.matrix.spi.MatrixStatsNamedXContentProvider

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/spi/ParentJoinNamedXContentProvider.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/spi/ParentJoinNamedXContentProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.join.spi;
+
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ContextParser;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.join.aggregations.ChildrenAggregationBuilder;
+import org.elasticsearch.join.aggregations.ParsedChildren;
+import org.elasticsearch.plugins.spi.NamedXContentProvider;
+import org.elasticsearch.search.aggregations.Aggregation;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+public class ParentJoinNamedXContentProvider implements NamedXContentProvider {
+
+    @Override
+    public List<NamedXContentRegistry.Entry> getNamedXContentParsers() {
+        ParseField parseField = new ParseField(ChildrenAggregationBuilder.NAME);
+        ContextParser<Object, Aggregation> contextParser = (p, name) -> ParsedChildren.fromXContent(p, (String) name);
+        return singletonList(new NamedXContentRegistry.Entry(Aggregation.class, parseField, contextParser));
+    }
+}

--- a/modules/parent-join/src/main/resources/META-INF/services/org.elasticsearch.plugins.spi.NamedXContentProvider
+++ b/modules/parent-join/src/main/resources/META-INF/services/org.elasticsearch.plugins.spi.NamedXContentProvider
@@ -1,0 +1,1 @@
+org.elasticsearch.join.spi.ParentJoinNamedXContentProvider


### PR DESCRIPTION
The High Level REST Client can use Java's SPI to load named XContent parsers implementations provided by plugins or modules.

This pull request is an alternate solution for #25024 after [a suggestion](https://github.com/elastic/elasticsearch/pull/25024#issuecomment-305829768) from @rjernst and requires #25097 to be merged first.