### PR TITLE
[TEST] Move test skip/blacklist assumptions out of @Before method

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -139,6 +139,8 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
 
         // admin context must be available for @After always, regardless of whether the test was blacklisted
         adminExecutionContext.clear();
+
+        restTestExecutionContext.clear();
     }
 
     @Override
@@ -295,8 +297,6 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
             assumeFalse("[" + testCandidate.getTestPath() + "] skipped, reason: blacklisted", blacklistedPathMatcher
                 .isSuffixMatch(testPath));
         }
-
-        restTestExecutionContext.clear();
 
         //skip test if the whole suite (yaml file) is disabled
         assumeFalse(testCandidate.getSetupSection().getSkipSection().getSkipMessage(testCandidate.getSuitePath()),

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -139,25 +139,6 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
 
         // admin context must be available for @After always, regardless of whether the test was blacklisted
         adminExecutionContext.clear();
-
-        //skip test if it matches one of the blacklist globs
-        for (BlacklistedPathPatternMatcher blacklistedPathMatcher : blacklistPathMatchers) {
-            String testPath = testCandidate.getSuitePath() + "/" + testCandidate.getTestSection().getName();
-            assumeFalse("[" + testCandidate.getTestPath() + "] skipped, reason: blacklisted", blacklistedPathMatcher
-                    .isSuffixMatch(testPath));
-        }
-
-        restTestExecutionContext.clear();
-
-        //skip test if the whole suite (yaml file) is disabled
-        assumeFalse(testCandidate.getSetupSection().getSkipSection().getSkipMessage(testCandidate.getSuitePath()),
-                testCandidate.getSetupSection().getSkipSection().skip(restTestExecutionContext.esVersion()));
-        //skip test if the whole suite (yaml file) is disabled
-        assumeFalse(testCandidate.getTeardownSection().getSkipSection().getSkipMessage(testCandidate.getSuitePath()),
-                testCandidate.getTeardownSection().getSkipSection().skip(restTestExecutionContext.esVersion()));
-        //skip test if test section is disabled
-        assumeFalse(testCandidate.getTestSection().getSkipSection().getSkipMessage(testCandidate.getTestPath()),
-                testCandidate.getTestSection().getSkipSection().skip(restTestExecutionContext.esVersion()));
     }
 
     @Override
@@ -308,6 +289,25 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
     }
 
     public void test() throws IOException {
+        //skip test if it matches one of the blacklist globs
+        for (BlacklistedPathPatternMatcher blacklistedPathMatcher : blacklistPathMatchers) {
+            String testPath = testCandidate.getSuitePath() + "/" + testCandidate.getTestSection().getName();
+            assumeFalse("[" + testCandidate.getTestPath() + "] skipped, reason: blacklisted", blacklistedPathMatcher
+                .isSuffixMatch(testPath));
+        }
+
+        restTestExecutionContext.clear();
+
+        //skip test if the whole suite (yaml file) is disabled
+        assumeFalse(testCandidate.getSetupSection().getSkipSection().getSkipMessage(testCandidate.getSuitePath()),
+            testCandidate.getSetupSection().getSkipSection().skip(restTestExecutionContext.esVersion()));
+        //skip test if the whole suite (yaml file) is disabled
+        assumeFalse(testCandidate.getTeardownSection().getSkipSection().getSkipMessage(testCandidate.getSuitePath()),
+            testCandidate.getTeardownSection().getSkipSection().skip(restTestExecutionContext.esVersion()));
+        //skip test if test section is disabled
+        assumeFalse(testCandidate.getTestSection().getSkipSection().getSkipMessage(testCandidate.getTestPath()),
+            testCandidate.getTestSection().getSkipSection().skip(restTestExecutionContext.esVersion()));
+
         //let's check that there is something to run, otherwise there might be a problem with the test section
         if (testCandidate.getTestSection().getExecutableSections().size() == 0) {
             throw new IllegalArgumentException("No executable sections loaded for [" + testCandidate.getTestPath() + "]");


### PR DESCRIPTION
This commit moves the `assumeFalse()` calls that implement test skipping
and blacklisting out of the `@Before` method of `ESClientYamlSuiteTestCase`.
The problem with having them in the `@Before` method is that if an
assumption triggers then the `@Before` methods of classes that extend
`ESClientYamlSuiteTestCase` will not run, but their `@After` methods will.
This can lead to inconsistencies that cause assertions in the `@After`
methods and fail the test even though it was skipped/blacklisted.

Instead the `assumeFalse()` calls are now at the beginning of the `test()`
method, which runs after all `@Before` methods (including those in classes
that extend `ESClientYamlSuiteTestCase`) have completed.  The only side
effect is that overridden `test()` methods in classes that extend
`ESClientYamlSuiteTestCase` which call `super.test()` and also do other things
must now be designed not to consume any `InternalAssumptionViolatedException`
that may be thrown by the `super.test()` call.