### PR TITLE
Higlighters: Fix MultiPhrasePrefixQuery rewriting

### DIFF
--- a/core/src/main/java/org/apache/lucene/search/uhighlight/CustomUnifiedHighlighter.java
+++ b/core/src/main/java/org/apache/lucene/search/uhighlight/CustomUnifiedHighlighter.java
@@ -182,13 +182,16 @@ public class CustomUnifiedHighlighter extends UnifiedHighlighter {
                     positionSpanQueries[i] = innerQueries[0];
                 }
             }
+
+            if (positionSpanQueries.length == 1) {
+                return Collections.singletonList(positionSpanQueries[0]);
+            }
             // sum position increments beyond 1
             int positionGaps = 0;
             if (positions.length >= 2) {
                 // positions are in increasing order.   max(0,...) is just a safeguard.
                 positionGaps = Math.max(0, positions[positions.length - 1] - positions[0] - positions.length + 1);
             }
-
             //if original slop is 0 then require inOrder
             boolean inorder = (mpq.getSlop() == 0);
             return Collections.singletonList(new SpanNearQuery(positionSpanQueries,

--- a/core/src/test/java/org/apache/lucene/search/uhighlight/CustomUnifiedHighlighterTests.java
+++ b/core/src/test/java/org/apache/lucene/search/uhighlight/CustomUnifiedHighlighterTests.java
@@ -121,6 +121,19 @@ public class CustomUnifiedHighlighterTests extends ESTestCase {
             BreakIterator.getSentenceInstance(Locale.ROOT), 100, inputs);
     }
 
+    public void testMultiPhrasePrefixQuerySingleTerm() throws Exception {
+        final String[] inputs = {
+            "The quick brown fox."
+        };
+        final String[] outputs = {
+            "The quick <b>brown</b> fox."
+        };
+        MultiPhrasePrefixQuery query = new MultiPhrasePrefixQuery();
+        query.add(new Term("text", "bro"));
+        assertHighlightOneDoc("text", inputs, new StandardAnalyzer(), query, Locale.ROOT,
+            BreakIterator.getSentenceInstance(Locale.ROOT), 0, outputs);
+    }
+
     public void testMultiPhrasePrefixQuery() throws Exception {
         final String[] inputs = {
             "The quick brown fox."

--- a/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -1455,10 +1455,19 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
         for (String type : UNIFIED_AND_NULL) {
             SearchSourceBuilder source = searchSource()
-                .query(matchPhrasePrefixQuery("field0", "quick bro"))
+                .query(matchPhrasePrefixQuery("field0", "bro"))
                 .highlighter(highlight().field("field0").order("score").preTags("<x>").postTags("</x>").highlighterType(type));
 
             SearchResponse searchResponse = client().search(searchRequest("test").source(source)).actionGet();
+
+            assertHighlight(searchResponse, 0, "field0", 0, 1, equalTo("The quick <x>brown</x> fox jumps over the lazy dog"));
+
+
+            source = searchSource()
+                .query(matchPhrasePrefixQuery("field0", "quick bro"))
+                .highlighter(highlight().field("field0").order("score").preTags("<x>").postTags("</x>").highlighterType(type));
+
+            searchResponse = client().search(searchRequest("test").source(source)).actionGet();
 
             assertHighlight(searchResponse, 0, "field0", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
 


### PR DESCRIPTION
The unified highlighter rewrites MultiPhrasePrefixQuery to SpanNearQuer even when there is a single term in the phrase.
Though SpanNearQuery throws an exception when the number of clauses is less than 2.
This change returns a simple PrefixQuery when there is a single term and builds the SpanNearQuery otherwise.

Relates #25088