### PR TITLE
Elasticsearch 5.6.0 uses Lucene 6.6.0

### DIFF
--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -81,7 +81,7 @@ public class Version implements Comparable<Version> {
     public static final int V_5_5_0_ID = 5050099;
     public static final Version V_5_5_0 = new Version(V_5_5_0_ID, org.apache.lucene.util.Version.LUCENE_6_5_1);
     public static final int V_5_6_0_ID = 5060099;
-    public static final Version V_5_6_0 = new Version(V_5_6_0_ID, org.apache.lucene.util.Version.LUCENE_6_5_1);
+    public static final Version V_5_6_0 = new Version(V_5_6_0_ID, org.apache.lucene.util.Version.LUCENE_6_6_0);
     public static final int V_6_0_0_alpha1_ID = 6000001;
     public static final Version V_6_0_0_alpha1 =
             new Version(V_6_0_0_alpha1_ID, org.apache.lucene.util.Version.LUCENE_7_0_0);


### PR DESCRIPTION
This version uses Lucene 6.6.0.

Closes #25111 