### PR TITLE
Return index name and empty map for /{index}/_alias with no aliases

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -243,7 +243,8 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
      *
      * @param aliases         The names of the index aliases to find
      * @param concreteIndices The concrete indexes the index aliases must point to order to be returned.
-     * @return the found index aliases grouped by index
+     * @return a map of index to a list of alias metadata, the list corresponding to a concrete index will be empty if no aliases are
+     * present for that index
      */
     public ImmutableOpenMap<String, List<AliasMetaData>> findAliases(final String[] aliases, String[] concreteIndices) {
         assert aliases != null;
@@ -273,8 +274,8 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
                         return o1.alias().compareTo(o2.alias());
                     }
                 });
-                mapBuilder.put(index, Collections.unmodifiableList(filteredValues));
             }
+            mapBuilder.put(index, Collections.unmodifiableList(filteredValues));
         }
         return mapBuilder.build();
     }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.get;
 
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest.Feature;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
@@ -281,6 +282,8 @@ public class GetIndexIT extends ESIntegTestCase {
 
     private void assertEmptyAliases(GetIndexResponse response) {
         assertThat(response.aliases(), notNullValue());
-        assertThat(response.aliases().isEmpty(), equalTo(true));
+        for (final ObjectObjectCursor<String, List<AliasMetaData>> entry : response.getAliases()) {
+            assertTrue(entry.value.isEmpty());
+        }
     }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete_alias/all_path_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete_alias/all_path_options.yml
@@ -84,6 +84,10 @@ setup:
 
 ---
 "check delete with index list":
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
+
   - do:
       indices.delete_alias:
         index: "test_index1,test_index2"
@@ -106,6 +110,10 @@ setup:
 
 ---
 "check delete with prefix* index":
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
+
   - do:
       indices.delete_alias:
         index: "test_*"
@@ -129,6 +137,10 @@ setup:
 
 ---
 "check delete with index list and * aliases":
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
+
   - do:
       indices.delete_alias:
         index: "test_index1,test_index2"
@@ -152,6 +164,10 @@ setup:
 
 ---
 "check delete with index list and _all aliases":
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
+
   - do:
       indices.delete_alias:
         index: "test_index1,test_index2"
@@ -175,6 +191,10 @@ setup:
 
 ---
 "check delete with index list and wildcard aliases":
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
+
   - do:
       indices.delete_alias:
         index: "test_index1,test_index2"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -41,6 +41,62 @@ setup:
   - is_false: test_index_2
 
 ---
+"Get aliases via /_all/_alias/":
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
+
+  - do:
+      indices.create:
+        index: myindex
+
+  - do:
+      indices.get_alias:
+        index: _all
+
+  - match: {test_index.aliases.test_alias: {}}
+  - match: {test_index.aliases.test_blias: {}}
+  - match: {test_index_2.aliases.test_alias: {}}
+  - match: {test_index_2.aliases.test_blias: {}}
+  - match: {myindex.aliases: {}}
+
+---
+"Get aliases via /*/_alias/":
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
+
+  - do:
+      indices.create:
+        index: myindex
+
+  - do:
+      indices.get_alias:
+        index: "*"
+
+  - match: {test_index.aliases.test_alias: {}}
+  - match: {test_index.aliases.test_blias: {}}
+  - match: {test_index_2.aliases.test_alias: {}}
+  - match: {test_index_2.aliases.test_blias: {}}
+  - match: {myindex.aliases: {}}
+
+---
+"Get and index with no aliases via /{index}/_alias/":
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
+
+  - do:
+      indices.create:
+        index: myindex
+
+  - do:
+      indices.get_alias:
+        index: myindex
+
+  - match: {myindex.aliases: {}}
+
+---
 "Get specific alias via /{index}/_alias/{name}":
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/all_path_options.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_alias/all_path_options.yml
@@ -14,6 +14,9 @@ setup:
 
 ---
 "put alias per index":
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
 
   - do:
       indices.put_alias:
@@ -69,7 +72,9 @@ setup:
 
 ---
 "put alias prefix* index":
-
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
 
   - do:
       indices.put_alias:
@@ -86,7 +91,9 @@ setup:
 
 ---
 "put alias in list of indices":
-
+  - skip:
+      version: " - 5.99.99"
+      reason:  only requested indices are included in 6.x
 
   - do:
       indices.put_alias:


### PR DESCRIPTION
Previously in #24723 we changed the `_alias` API to not go through the
`RestGetIndicesAction` endpoint, instead creating a `RestGetAliasesAction` that
did the same thing.

This changes the formatting so that it matches the old formatting of the
endpoint, before:

```
GET /test-1/_alias

{ }
```

And after this change:

```
GET /test-1/_alias

{
  "test-1": {
    "aliases": {}
  }
}
```

This is related to #25090