### PR TITLE
Always use DisjunctionMaxQuery to build cross fields disjunction

### DIFF
--- a/core/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
+++ b/core/src/main/java/org/apache/lucene/queries/BlendedTermQuery.java
@@ -296,27 +296,6 @@ public abstract class BlendedTermQuery extends Query {
         return Objects.hash(classHash(), Arrays.hashCode(equalsTerms()));
     }
 
-    public static BlendedTermQuery booleanBlendedQuery(Term[] terms) {
-        return booleanBlendedQuery(terms, null);
-    }
-
-    public static BlendedTermQuery booleanBlendedQuery(Term[] terms, final float[] boosts) {
-        return new BlendedTermQuery(terms, boosts) {
-            @Override
-            protected Query topLevelQuery(Term[] terms, TermContext[] ctx, int[] docFreqs, int maxDoc) {
-                BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
-                for (int i = 0; i < terms.length; i++) {
-                    Query query = new TermQuery(terms[i], ctx[i]);
-                    if (boosts != null && boosts[i] != 1f) {
-                        query = new BoostQuery(query, boosts[i]);
-                    }
-                    booleanQueryBuilder.add(query, BooleanClause.Occur.SHOULD);
-                }
-                return booleanQueryBuilder.build();
-            }
-        };
-    }
-
     public static BlendedTermQuery commonTermsBlendedQuery(Term[] terms, final float[] boosts, final float maxTermFrequency) {
         return new BlendedTermQuery(terms, boosts) {
             @Override

--- a/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -56,7 +56,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Collections;

--- a/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
+++ b/core/src/main/java/org/apache/lucene/queryparser/classic/MapperQueryParser.java
@@ -26,6 +26,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.FuzzyQuery;
@@ -55,6 +56,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Collections;
@@ -155,31 +157,20 @@ public class MapperQueryParser extends QueryParser {
                 // if there is no match in the mappings.
                 return new MatchNoDocsQuery("empty fields");
             }
-            if (settings.useDisMax()) {
-                List<Query> queries = new ArrayList<>();
-                boolean added = false;
-                for (String mField : fields) {
-                    Query q = getFieldQuerySingle(mField, queryText, quoted);
-                    if (q != null) {
-                        added = true;
-                        queries.add(applyBoost(mField, q));
-                    }
+            float tiebreaker = settings.useDisMax() ? settings.tieBreaker() : 1.0f;
+            List<Query> queries = new ArrayList<>();
+            boolean added = false;
+            for (String mField : fields) {
+                Query q = getFieldQuerySingle(mField, queryText, quoted);
+                if (q != null) {
+                    added = true;
+                    queries.add(applyBoost(mField, q));
                 }
-                if (!added) {
-                    return null;
-                }
-                return new DisjunctionMaxQuery(queries, settings.tieBreaker());
-            } else {
-                List<BooleanClause> clauses = new ArrayList<>();
-                for (String mField : fields) {
-                    Query q = getFieldQuerySingle(mField, queryText, quoted);
-                    if (q != null) {
-                        clauses.add(new BooleanClause(applyBoost(mField, q), BooleanClause.Occur.SHOULD));
-                    }
-                }
-                if (clauses.isEmpty()) return null; // happens for stopwords
-                return getBooleanQuery(clauses);
             }
+            if (!added) {
+                return null;
+            }
+            return new DisjunctionMaxQuery(queries, tiebreaker);
         } else {
             return getFieldQuerySingle(field, queryText, quoted);
         }
@@ -255,33 +246,21 @@ public class MapperQueryParser extends QueryParser {
     protected Query getFieldQuery(String field, String queryText, int slop) throws ParseException {
         Collection<String> fields = extractMultiFields(field);
         if (fields != null) {
-            if (settings.useDisMax()) {
-                List<Query> queries = new ArrayList<>();
-                boolean added = false;
-                for (String mField : fields) {
-                    Query q = super.getFieldQuery(mField, queryText, slop);
-                    if (q != null) {
-                        added = true;
-                        q = applySlop(q, slop);
-                        queries.add(applyBoost(mField, q));
-                    }
+            float tiebreaker = settings.useDisMax() ? settings.tieBreaker() : 1.0f;
+            List<Query> queries = new ArrayList<>();
+            boolean added = false;
+            for (String mField : fields) {
+                Query q = super.getFieldQuery(mField, queryText, slop);
+                if (q != null) {
+                    added = true;
+                    q = applySlop(q, slop);
+                    queries.add(applyBoost(mField, q));
                 }
-                if (!added) {
-                    return null;
-                }
-                return new DisjunctionMaxQuery(queries, settings.tieBreaker());
-            } else {
-                List<BooleanClause> clauses = new ArrayList<>();
-                for (String mField : fields) {
-                    Query q = super.getFieldQuery(mField, queryText, slop);
-                    if (q != null) {
-                        q = applySlop(q, slop);
-                        clauses.add(new BooleanClause(applyBoost(mField, q), BooleanClause.Occur.SHOULD));
-                    }
-                }
-                if (clauses.isEmpty()) return null; // happens for stopwords
-                return getBooleanQuery(clauses);
             }
+            if (!added) {
+                return null;
+            }
+            return new DisjunctionMaxQuery(queries, tiebreaker);
         } else {
             return super.getFieldQuery(field, queryText, slop);
         }
@@ -308,31 +287,20 @@ public class MapperQueryParser extends QueryParser {
             return getRangeQuerySingle(fields.iterator().next(), part1, part2, startInclusive, endInclusive, context);
         }
 
-        if (settings.useDisMax()) {
-            List<Query> queries = new ArrayList<>();
-            boolean added = false;
-            for (String mField : fields) {
-                Query q = getRangeQuerySingle(mField, part1, part2, startInclusive, endInclusive, context);
-                if (q != null) {
-                    added = true;
-                    queries.add(applyBoost(mField, q));
-                }
+        float tiebreaker = settings.useDisMax() ? settings.tieBreaker() : 1.0f;
+        List<Query> queries = new ArrayList<>();
+        boolean added = false;
+        for (String mField : fields) {
+            Query q = getRangeQuerySingle(mField, part1, part2, startInclusive, endInclusive, context);
+            if (q != null) {
+                added = true;
+                queries.add(applyBoost(mField, q));
             }
-            if (!added) {
-                return null;
-            }
-            return new DisjunctionMaxQuery(queries, settings.tieBreaker());
-        } else {
-            List<BooleanClause> clauses = new ArrayList<>();
-            for (String mField : fields) {
-                Query q = getRangeQuerySingle(mField, part1, part2, startInclusive, endInclusive, context);
-                if (q != null) {
-                    clauses.add(new BooleanClause(applyBoost(mField, q), BooleanClause.Occur.SHOULD));
-                }
-            }
-            if (clauses.isEmpty()) return null; // happens for stopwords
-            return getBooleanQuery(clauses);
         }
+        if (!added) {
+            return null;
+        }
+        return new DisjunctionMaxQuery(queries, tiebreaker);
     }
 
     private Query getRangeQuerySingle(String field, String part1, String part2,
@@ -367,30 +335,20 @@ public class MapperQueryParser extends QueryParser {
             if (fields.size() == 1) {
                 return getFuzzyQuerySingle(fields.iterator().next(), termStr, minSimilarity);
             }
-            if (settings.useDisMax()) {
-                List<Query> queries = new ArrayList<>();
-                boolean added = false;
-                for (String mField : fields) {
-                    Query q = getFuzzyQuerySingle(mField, termStr, minSimilarity);
-                    if (q != null) {
-                        added = true;
-                        queries.add(applyBoost(mField, q));
-                    }
+            float tiebreaker = settings.useDisMax() ? settings.tieBreaker() : 1.0f;
+            List<Query> queries = new ArrayList<>();
+            boolean added = false;
+            for (String mField : fields) {
+                Query q = getFuzzyQuerySingle(mField, termStr, minSimilarity);
+                if (q != null) {
+                    added = true;
+                    queries.add(applyBoost(mField, q));
                 }
-                if (!added) {
-                    return null;
-                }
-                return new DisjunctionMaxQuery(queries, settings.tieBreaker());
-            } else {
-                List<BooleanClause> clauses = new ArrayList<>();
-                for (String mField : fields) {
-                    Query q = getFuzzyQuerySingle(mField, termStr, minSimilarity);
-                    if (q != null) {
-                        clauses.add(new BooleanClause(applyBoost(mField, q), BooleanClause.Occur.SHOULD));
-                    }
-                }
-                return getBooleanQuery(clauses);
             }
+            if (!added) {
+                return null;
+            }
+            return new DisjunctionMaxQuery(queries, tiebreaker);
         } else {
             return getFuzzyQuerySingle(field, termStr, minSimilarity);
         }
@@ -430,31 +388,20 @@ public class MapperQueryParser extends QueryParser {
             if (fields.size() == 1) {
                 return getPrefixQuerySingle(fields.iterator().next(), termStr);
             }
-            if (settings.useDisMax()) {
-                List<Query> queries = new ArrayList<>();
-                boolean added = false;
-                for (String mField : fields) {
-                    Query q = getPrefixQuerySingle(mField, termStr);
-                    if (q != null) {
-                        added = true;
-                        queries.add(applyBoost(mField, q));
-                    }
+            float tiebreaker = settings.useDisMax() ? settings.tieBreaker() : 1.0f;
+            List<Query> queries = new ArrayList<>();
+            boolean added = false;
+            for (String mField : fields) {
+                Query q = getPrefixQuerySingle(mField, termStr);
+                if (q != null) {
+                    added = true;
+                    queries.add(applyBoost(mField, q));
                 }
-                if (!added) {
-                    return null;
-                }
-                return new DisjunctionMaxQuery(queries, settings.tieBreaker());
-            } else {
-                List<BooleanClause> clauses = new ArrayList<>();
-                for (String mField : fields) {
-                    Query q = getPrefixQuerySingle(mField, termStr);
-                    if (q != null) {
-                        clauses.add(new BooleanClause(applyBoost(mField, q), BooleanClause.Occur.SHOULD));
-                    }
-                }
-                if (clauses.isEmpty()) return null; // happens for stopwords
-                return getBooleanQuery(clauses);
             }
+            if (!added) {
+                return null;
+            }
+            return new DisjunctionMaxQuery(queries, tiebreaker);
         } else {
             return getPrefixQuerySingle(field, termStr);
         }
@@ -592,31 +539,20 @@ public class MapperQueryParser extends QueryParser {
             if (fields.size() == 1) {
                 return getWildcardQuerySingle(fields.iterator().next(), termStr);
             }
-            if (settings.useDisMax()) {
-                List<Query> queries = new ArrayList<>();
-                boolean added = false;
-                for (String mField : fields) {
-                    Query q = getWildcardQuerySingle(mField, termStr);
-                    if (q != null) {
-                        added = true;
-                        queries.add(applyBoost(mField, q));
-                    }
+            float tiebreaker = settings.useDisMax() ? settings.tieBreaker() : 1.0f;
+            List<Query> queries = new ArrayList<>();
+            boolean added = false;
+            for (String mField : fields) {
+                Query q = getWildcardQuerySingle(mField, termStr);
+                if (q != null) {
+                    added = true;
+                    queries.add(applyBoost(mField, q));
                 }
-                if (!added) {
-                    return null;
-                }
-                return new DisjunctionMaxQuery(queries, settings.tieBreaker());
-            } else {
-                List<BooleanClause> clauses = new ArrayList<>();
-                for (String mField : fields) {
-                    Query q = getWildcardQuerySingle(mField, termStr);
-                    if (q != null) {
-                        clauses.add(new BooleanClause(applyBoost(mField, q), BooleanClause.Occur.SHOULD));
-                    }
-                }
-                if (clauses.isEmpty()) return null; // happens for stopwords
-                return getBooleanQuery(clauses);
             }
+            if (!added) {
+                return null;
+            }
+            return new DisjunctionMaxQuery(queries, tiebreaker);
         } else {
             return getWildcardQuerySingle(field, termStr);
         }
@@ -656,31 +592,20 @@ public class MapperQueryParser extends QueryParser {
             if (fields.size() == 1) {
                 return getRegexpQuerySingle(fields.iterator().next(), termStr);
             }
-            if (settings.useDisMax()) {
-                List<Query> queries = new ArrayList<>();
-                boolean added = false;
-                for (String mField : fields) {
-                    Query q = getRegexpQuerySingle(mField, termStr);
-                    if (q != null) {
-                        added = true;
-                        queries.add(applyBoost(mField, q));
-                    }
+            float tiebreaker = settings.useDisMax() ? settings.tieBreaker() : 1.0f;
+            List<Query> queries = new ArrayList<>();
+            boolean added = false;
+            for (String mField : fields) {
+                Query q = getRegexpQuerySingle(mField, termStr);
+                if (q != null) {
+                    added = true;
+                    queries.add(applyBoost(mField, q));
                 }
-                if (!added) {
-                    return null;
-                }
-                return new DisjunctionMaxQuery(queries, settings.tieBreaker());
-            } else {
-                List<BooleanClause> clauses = new ArrayList<>();
-                for (String mField : fields) {
-                    Query q = getRegexpQuerySingle(mField, termStr);
-                    if (q != null) {
-                        clauses.add(new BooleanClause(applyBoost(mField, q), BooleanClause.Occur.SHOULD));
-                    }
-                }
-                if (clauses.isEmpty()) return null; // happens for stopwords
-                return getBooleanQuery(clauses);
             }
+            if (!added) {
+                return null;
+            }
+            return new DisjunctionMaxQuery(queries, tiebreaker);
         } else {
             return getRegexpQuerySingle(field, termStr);
         }

--- a/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -22,9 +22,6 @@ package org.elasticsearch.index.search;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.BlendedTermQuery;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
@@ -84,7 +81,7 @@ public class MultiMatchQuery extends MatchQuery {
                     queryBuilder = new QueryBuilder(tieBreaker);
                     break;
                 case CROSS_FIELDS:
-                    queryBuilder = new CrossFieldsQueryBuilder(tieBreaker);
+                    queryBuilder = new CrossFieldsQueryBuilder();
                     break;
                 default:
                     throw new IllegalStateException("No such type: " + type);
@@ -99,15 +96,9 @@ public class MultiMatchQuery extends MatchQuery {
     private QueryBuilder queryBuilder;
 
     public class QueryBuilder {
-        protected final boolean groupDismax;
         protected final float tieBreaker;
 
         public QueryBuilder(float tieBreaker) {
-            this(tieBreaker != 1.0f, tieBreaker);
-        }
-
-        public QueryBuilder(boolean groupDismax, float tieBreaker) {
-            this.groupDismax = groupDismax;
             this.tieBreaker = tieBreaker;
         }
 
@@ -134,19 +125,11 @@ public class MultiMatchQuery extends MatchQuery {
             if (groupQuery.size() == 1) {
                 return groupQuery.get(0);
             }
-            if (groupDismax) {
-                List<Query> queries = new ArrayList<>();
-                for (Query query : groupQuery) {
-                    queries.add(query);
-                }
-                return new DisjunctionMaxQuery(queries, tieBreaker);
-            } else {
-                final BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
-                for (Query query : groupQuery) {
-                    booleanQuery.add(query, BooleanClause.Occur.SHOULD);
-                }
-                return booleanQuery.build();
+            List<Query> queries = new ArrayList<>();
+            for (Query query : groupQuery) {
+                queries.add(query);
             }
+            return new DisjunctionMaxQuery(queries, tieBreaker);
         }
 
         public Query blendTerm(Term term, MappedFieldType fieldType) {
@@ -165,8 +148,8 @@ public class MultiMatchQuery extends MatchQuery {
     final class CrossFieldsQueryBuilder extends QueryBuilder {
         private FieldAndFieldType[] blendedFields;
 
-        CrossFieldsQueryBuilder(float tieBreaker) {
-            super(false, tieBreaker);
+        CrossFieldsQueryBuilder() {
+            super(0.0f);
         }
 
         @Override
@@ -306,8 +289,6 @@ public class MultiMatchQuery extends MatchQuery {
             blendedBoost = Arrays.copyOf(blendedBoost, i);
             if (commonTermsCutoff != null) {
                 queries.add(BlendedTermQuery.commonTermsBlendedQuery(terms, blendedBoost, commonTermsCutoff));
-            } else if (tieBreaker == 1.0f) {
-                queries.add(BlendedTermQuery.booleanBlendedQuery(terms, blendedBoost));
             } else {
                 queries.add(BlendedTermQuery.dismaxBlendedQuery(terms, blendedBoost, tieBreaker));
             }
@@ -318,11 +299,7 @@ public class MultiMatchQuery extends MatchQuery {
             // best effort: add clauses that are not term queries so that they have an opportunity to match
             // however their score contribution will be different
             // TODO: can we improve this?
-            BooleanQuery.Builder bq = new BooleanQuery.Builder();
-            for (Query query : queries) {
-                bq.add(query, Occur.SHOULD);
-            }
-            return bq.build();
+            return new DisjunctionMaxQuery(queries, 1.0f);
         }
     }
 

--- a/core/src/test/java/org/apache/lucene/queries/BlendedTermQueryTests.java
+++ b/core/src/test/java/org/apache/lucene/queries/BlendedTermQueryTests.java
@@ -54,58 +54,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 public class BlendedTermQueryTests extends ESTestCase {
-    public void testBooleanQuery() throws IOException {
-        Directory dir = newDirectory();
-        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
-        String[] firstNames = new String[]{
-                "simon", "paul"
-        };
-        String[] surNames = new String[]{
-                "willnauer", "simon"
-        };
-        for (int i = 0; i < surNames.length; i++) {
-            Document d = new Document();
-            d.add(new TextField("id", Integer.toString(i), Field.Store.YES));
-            d.add(new TextField("firstname", firstNames[i], Field.Store.NO));
-            d.add(new TextField("surname", surNames[i], Field.Store.NO));
-            w.addDocument(d);
-        }
-        int iters = scaledRandomIntBetween(25, 100);
-        for (int j = 0; j < iters; j++) {
-            Document d = new Document();
-            d.add(new TextField("id", Integer.toString(firstNames.length + j), Field.Store.YES));
-            d.add(new TextField("firstname", rarely() ? "some_other_name" :
-                    "simon the sorcerer", Field.Store.NO)); // make sure length-norm is the tie-breaker
-            d.add(new TextField("surname", "bogus", Field.Store.NO));
-            w.addDocument(d);
-        }
-        w.commit();
-        DirectoryReader reader = DirectoryReader.open(w);
-        IndexSearcher searcher = setSimilarity(newSearcher(reader));
-
-        {
-            Term[] terms = new Term[]{new Term("firstname", "simon"), new Term("surname", "simon")};
-            BlendedTermQuery query = BlendedTermQuery.booleanBlendedQuery(terms);
-            TopDocs search = searcher.search(query, 3);
-            ScoreDoc[] scoreDocs = search.scoreDocs;
-            assertEquals(3, scoreDocs.length);
-            assertEquals(Integer.toString(0), reader.document(scoreDocs[0].doc).getField("id").stringValue());
-        }
-        {
-            BooleanQuery.Builder query = new BooleanQuery.Builder();
-            query.add(new TermQuery(new Term("firstname", "simon")), BooleanClause.Occur.SHOULD);
-            query.add(new TermQuery(new Term("surname", "simon")), BooleanClause.Occur.SHOULD);
-            TopDocs search = searcher.search(query.build(), 1);
-            ScoreDoc[] scoreDocs = search.scoreDocs;
-            assertEquals(Integer.toString(1), reader.document(scoreDocs[0].doc).getField("id").stringValue());
-
-        }
-        reader.close();
-        w.close();
-        dir.close();
-
-    }
-
     public void testDismaxQuery() throws IOException {
         Directory dir = newDirectory();
         IndexWriter w = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
@@ -183,12 +131,11 @@ public class BlendedTermQueryTests extends ESTestCase {
             }
             String term = TestUtil.randomRealisticUnicodeString(random(), 1, 10);
             Term[] terms = toTerms(fields, term);
-            boolean useBoolean = random().nextBoolean();
             float tieBreaker = random().nextFloat();
-            BlendedTermQuery query = useBoolean ? BlendedTermQuery.booleanBlendedQuery(terms) : BlendedTermQuery.dismaxBlendedQuery(terms, tieBreaker);
+            BlendedTermQuery query = BlendedTermQuery.dismaxBlendedQuery(terms, tieBreaker);
             QueryUtils.check(query);
             terms = toTerms(fields, term);
-            BlendedTermQuery query2 = useBoolean ? BlendedTermQuery.booleanBlendedQuery(terms) : BlendedTermQuery.dismaxBlendedQuery(terms, tieBreaker);
+            BlendedTermQuery query2 = BlendedTermQuery.dismaxBlendedQuery(terms, tieBreaker);
             assertEquals(query, query2);
         }
     }
@@ -217,8 +164,7 @@ public class BlendedTermQueryTests extends ESTestCase {
             terms.add(new Term(TestUtil.randomRealisticUnicodeString(random(), 1, 10), TestUtil.randomRealisticUnicodeString(random(), 1, 10)));
         }
 
-        BlendedTermQuery blendedTermQuery = random().nextBoolean() ? BlendedTermQuery.dismaxBlendedQuery(terms.toArray(new Term[0]), random().nextFloat()) :
-                BlendedTermQuery.booleanBlendedQuery(terms.toArray(new Term[0]));
+        BlendedTermQuery blendedTermQuery = BlendedTermQuery.dismaxBlendedQuery(terms.toArray(new Term[0]), random().nextFloat());
         Set<Term> extracted = new HashSet<>();
         IndexSearcher searcher = new IndexSearcher(new MultiReader());
         searcher.createNormalizedWeight(blendedTermQuery, false).extractTerms(extracted);

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -120,7 +120,6 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertSearchHits(searchResponse, "5", "6");
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/23966")
     public void testSimpleQueryStringMinimumShouldMatch() throws Exception {
         createIndex("test");
         ensureGreen("test");

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -244,8 +244,8 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         commonTermsQuery.add(new Term("field", "fox"));
         addQuery(commonTermsQuery, documents);
 
-        BlendedTermQuery blendedTermQuery = BlendedTermQuery.booleanBlendedQuery(new Term[]{new Term("field", "quick"),
-                new Term("field", "brown"), new Term("field", "fox")});
+        BlendedTermQuery blendedTermQuery = BlendedTermQuery.dismaxBlendedQuery(new Term[]{new Term("field", "quick"),
+                new Term("field", "brown"), new Term("field", "fox")}, 1.0f);
         addQuery(blendedTermQuery, documents);
 
         SpanNearQuery spanNearQuery = new SpanNearQuery.Builder("field", true)

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
@@ -276,7 +276,7 @@ public class QueryAnalyzerTests extends ESTestCase {
 
     public void testExtractQueryMetadata_blendedTermQuery() {
         Term[] termsArr = new Term[]{new Term("_field", "_term1"), new Term("_field", "_term2")};
-        BlendedTermQuery commonTermsQuery = BlendedTermQuery.booleanBlendedQuery(termsArr);
+        BlendedTermQuery commonTermsQuery = BlendedTermQuery.dismaxBlendedQuery(termsArr, 1.0f);
         Result result = analyze(commonTermsQuery);
         assertThat(result.verified, is(true));
         List<Term> terms = new ArrayList<>(result.terms);

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.test.hamcrest;
 
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
@@ -513,6 +514,14 @@ public class ElasticsearchAssertions {
         assertThat(q.clauses().size(), greaterThan(i));
         assertThat(q.clauses().get(i).getQuery(), instanceOf(subqueryType));
         return subqueryType.cast(q.clauses().get(i).getQuery());
+    }
+
+    public static <T extends Query> T assertDisjunctionSubQuery(Query query, Class<T> subqueryType, int i) {
+        assertThat(query, instanceOf(DisjunctionMaxQuery.class));
+        DisjunctionMaxQuery q = (DisjunctionMaxQuery) query;
+        assertThat(q.getDisjuncts().size(), greaterThan(i));
+        assertThat(q.getDisjuncts().get(i), instanceOf(subqueryType));
+        return subqueryType.cast(q.getDisjuncts().get(i));
     }
 
     /**


### PR DESCRIPTION
This PR modifies `query_string`, `simple_query_string` and `multi_match` queries to always use a DisjunctionMaxQuery when a disjunction over multiple fields is built. The tiebreaker is set to `1` in order to behave like the boolean query in terms of scoring. 
The removal of the coord factor in Lucene 7 made this change mandatory to correctly handle `minimum_should_match`. 
See https://github.com/elastic/elasticsearch/issues/23966#issuecomment-293578652

Closes #23966