### PR TITLE
Fix Fast Vector Highlighter NPE on match phrase prefix

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
@@ -164,6 +164,11 @@ public class MultiPhrasePrefixQuery extends Query {
             }
         }
         if (terms.isEmpty()) {
+            if (sizeMinus1 == 0) {
+                // no prefix and the phrase query is empty
+                return Queries.newMatchNoDocsQuery("No terms supplied for " + MultiPhrasePrefixQuery.class.getName());
+            }
+
             // if the terms does not exist we could return a MatchNoDocsQuery but this would break the unified highlighter
             // which rewrites query with an empty reader.
             return new BooleanQuery.Builder()

--- a/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -1462,7 +1462,6 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
             assertHighlight(searchResponse, 0, "field0", 0, 1, equalTo("The quick <x>brown</x> fox jumps over the lazy dog"));
 
-
             source = searchSource()
                 .query(matchPhrasePrefixQuery("field0", "quick bro"))
                 .highlighter(highlight().field("field0").order("score").preTags("<x>").postTags("</x>").highlighterType(type));
@@ -1472,6 +1471,21 @@ public class HighlighterSearchIT extends ESIntegTestCase {
             assertHighlight(searchResponse, 0, "field0", 0, 1, equalTo("The <x>quick</x> <x>brown</x> fox jumps over the lazy dog"));
 
             logger.info("--> highlighting and searching on field1");
+            source = searchSource()
+                .query(boolQuery()
+                    .should(matchPhrasePrefixQuery("field1", "test"))
+                    .should(matchPhrasePrefixQuery("field1", "bro"))
+                )
+                .highlighter(highlight().field("field1").order("score").preTags("<x>").postTags("</x>").highlighterType(type));
+
+            searchResponse = client().search(searchRequest("test").source(source)).actionGet();
+            assertThat(searchResponse.getHits().totalHits, equalTo(2L));
+            for (int i = 0; i < 2; i++) {
+                assertHighlight(searchResponse, i, "field1", 0, 1, anyOf(
+                    equalTo("The quick <x>browse</x> button is a fancy thing, right <x>bro</x>?"),
+                    equalTo("The quick <x>brown</x> fox jumps over the lazy dog")));
+            }
+
             source = searchSource()
                 .query(matchPhrasePrefixQuery("field1", "quick bro"))
                 .highlighter(highlight().field("field1").order("score").preTags("<x>").postTags("</x>").highlighterType(type));

--- a/core/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -280,9 +280,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
         assertExplanations(QueryBuilders.matchPhrasePrefixQuery("field", "ju"),
             Arrays.asList(
                 equalTo("field:jumps"),
-                equalTo("+MatchNoDocsQuery(\"empty MultiPhraseQuery\") +MatchNoDocsQuery(\"No " +
-                    "terms supplied for org.elasticsearch.common.lucene.search." +
-                    "MultiPhrasePrefixQuery\")")
+                equalTo("field:\"ju*\"")
             ), true, true);
     }
 


### PR DESCRIPTION
The FVH fails with an NPE when a match phrase prefix is rewritten in an empty phrase query.
This change makes sure that the multi match query rewrites to a MatchNoDocsQuery (instead of an empty phrase query) when there is
a single term and that term does not expand to any term in the index.

Fixes #25088