### PR TITLE
Include empty mappings in GET /{index}/_mappings requests

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -89,9 +89,6 @@ public class RestGetMappingAction extends BaseRestHandler {
 
                 builder.startObject();
                 for (ObjectObjectCursor<String, ImmutableOpenMap<String, MappingMetaData>> indexEntry : mappingsByIndex) {
-                    if (indexEntry.value.isEmpty()) {
-                        continue;
-                    }
                     builder.startObject(indexEntry.key);
                     builder.startObject(Fields.MAPPINGS);
                     for (ObjectObjectCursor<String, MappingMetaData> typeEntry : indexEntry.value) {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/10_basic.yml
@@ -20,6 +20,19 @@ setup:
                 type_3: {}
 
 ---
+"Get /{index}/_mapping with empty mappings":
+
+ - do:
+     indices.create:
+       index: t
+
+ - do:
+     indices.get_mapping:
+       index: t
+
+ - match: { t.mappings: {}}
+
+---
 "Get /_mapping":
 
  - skip:


### PR DESCRIPTION
Previously this would output:

```
GET /test-1/_mappings

{ }
```

And after this change:

```
GET /test-1/_mappings

{
  "test-1": {
    "mappings": {}
  }
}
```

To bring parity back to the REST output after #24723.

Relates to #25090
