### PR TITLE
Fix typo in GeoUtils#isValidLongitude

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
@@ -82,7 +82,7 @@ public class GeoUtils {
 
     /** Returns true if longitude is actually a valid longitude value. */
     public static boolean isValidLongitude(double longitude) {
-        if (Double.isNaN(longitude) || Double.isNaN(longitude) || longitude < GeoUtils.MIN_LON || longitude > GeoUtils.MAX_LON) {
+        if (Double.isNaN(longitude) || Double.isInfinite(longitude) || longitude < GeoUtils.MIN_LON || longitude > GeoUtils.MAX_LON) {
             return false;
         }
         return true;


### PR DESCRIPTION
I noticed that `isValidLongitude` is inconsistent with `isValidLatitude`. Neither technically need the `isInfinite` check because they then compare against min and max values.