### PR TITLE
Add helper methods to TransportActionProxy to identify proxy actions and requests

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -158,4 +158,18 @@ public final class TransportActionProxy {
         }
         return request;
     }
+
+    /**
+     * Returns <code>true</code> iff the given action is a proxy action
+     */
+    public static boolean isProxyAction(String action) {
+        return action.startsWith(PROXY_ACTION_PREFIX);
+    }
+
+    /**
+     * Returns <code>true</code> iff the given request is a proxy request
+     */
+    public static boolean isProxyRequest(TransportRequest request) {
+        return request instanceof ProxyRequest;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -258,4 +258,16 @@ public class TransportActionProxyTests extends ESTestCase {
         assertTrue(transportRequest instanceof TransportActionProxy.ProxyRequest);
         assertSame(TransportService.HandshakeRequest.INSTANCE, TransportActionProxy.unwrapRequest(transportRequest));
     }
+
+    public void testIsProxyAction() {
+        String action = "foo/bar";
+        String proxyAction = TransportActionProxy.getProxyAction(action);
+        assertTrue(TransportActionProxy.isProxyAction(proxyAction));
+        assertFalse(TransportActionProxy.isProxyAction(action));
+    }
+
+    public void testIsProxyRequest() {
+        assertTrue(TransportActionProxy.isProxyRequest(new TransportActionProxy.ProxyRequest<>(() -> null)));
+        assertFalse(TransportActionProxy.isProxyRequest(TransportRequest.Empty.INSTANCE));
+    }
 }


### PR DESCRIPTION
Downstream users of out network intercept infrastructure need this information which is
hidden due to member and class visibility.