### PR TITLE
Fix branch logic for bwc tests in the same major version

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -32,7 +32,7 @@ if (bwcVersion.endsWith('-SNAPSHOT')) {
   apply plugin: 'distribution'
 
   def (String major, String minor, String bugfix) = bwcVersion.split('\\.')
-  String bwcBranch = bugfix == '0-SNAPSHOT' ? "${major}.x" : "${major}.${minor}"
+  String bwcBranch = "${major}.${minor}"
   File checkoutDir = file("${buildDir}/bwc/checkout-${bwcBranch}")
   task createClone(type: LoggedExec) {
     onlyIf { checkoutDir.exists() == false }

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -32,7 +32,8 @@ if (bwcVersion.endsWith('-SNAPSHOT')) {
   apply plugin: 'distribution'
 
   def (String major, String minor, String bugfix) = bwcVersion.split('\\.')
-  String bwcBranch = "${major}.${minor}"
+  def (String currentMajor, String currentMinor, String currentBugfix) = version.split('\\.')
+  String bwcBranch = currentMajor != major ? "${major}.x" : "${major}.${minor}"
   File checkoutDir = file("${buildDir}/bwc/checkout-${bwcBranch}")
   task createClone(type: LoggedExec) {
     onlyIf { checkoutDir.exists() == false }


### PR DESCRIPTION
When testing against the previous 5.x release, the bwc project incorrectly would checkout the 5.x
branch instead of the 5.5 branch as it still had the logic that applies for master. This changes the logic to always use the major and minor.