### PR TITLE
Mark Log4j API dependency as non-optional

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,7 +81,7 @@ dependencies {
   compile "com.vividsolutions:jts:${versions.jts}", optional
 
   // logging
-  compile "org.apache.logging.log4j:log4j-api:${versions.log4j}", optional
+  compile "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   compile "org.apache.logging.log4j:log4j-core:${versions.log4j}", optional
   // to bridge dependencies that are still on Log4j 1 to Log4j 2
   compile "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}", optional

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -43,11 +43,6 @@ You need to also include Log4j 2 dependencies:
 --------------------------------------------------
 <dependency>
     <groupId>org.apache.logging.log4j</groupId>
-    <artifactId>log4j-api</artifactId>
-    <version>2.8.2</version>
-</dependency>
-<dependency>
-    <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-core</artifactId>
     <version>2.8.2</version>
 </dependency>


### PR DESCRIPTION
The Log4j dependency is separated into two artifacts, the API and the core implementation. This is to enable replacing Log4j on the backend through the SLF4J bridge with another logging implementation. For this reason, the dependencies are marked as optional. This causes confusion amongst users as to use the bridge, the API should be non-optional since it is needed for the bridge to function correctly. While they could pull it into their application directly, it would be clearer if we simply marked this depdendency as non-optional. Note that this does not mean that users have to use Log4j for logging in their application, so we are not marking core as required, it only clarifies what they need to be able to plug in a different logging implementation.

Relates #22671
