### PR TITLE
[Test] Extend test for parsing SearchShardFailure

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -38,8 +38,6 @@ import org.elasticsearch.search.SearchShardTarget;
 import java.io.IOException;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownToken;
 
 /**
  * Represents a failure to search on a specific shard.
@@ -200,16 +198,16 @@ public class ShardSearchFailure implements ShardOperationFailedException {
                 } else if (NODE_FIELD.equals(currentFieldName)) {
                     nodeId  = parser.text();
                 } else {
-                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    parser.skipChildren();
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (REASON_FIELD.equals(currentFieldName)) {
                     exception = ElasticsearchException.fromXContent(parser);
                 } else {
-                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    parser.skipChildren();
                 }
             } else {
-                throwUnknownToken(token, parser.getTokenLocation());
+                parser.skipChildren();
             }
         }
         return new ShardSearchFailure(exception,


### PR DESCRIPTION
In a similar way as https://github.com/elastic/elasticsearch/pull/25132 or #25130 this change extends the testing of SearchShardFailure to make sure we don't fail on additional fields the parser doesn't know yet.
