### PR TITLE
"shard started" should show index and shard ID

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -375,7 +375,7 @@ public class ShardStateAction extends AbstractComponent {
         public void messageReceived(ShardEntry request, TransportChannel channel) throws Exception {
             logger.debug("{} received shard started for [{}]", request.shardId, request);
             clusterService.submitStateUpdateTask(
-                "shard-started " + request.shardId,
+                "shard-started " + request,
                 request,
                 ClusterStateTaskConfig.build(Priority.URGENT),
                 shardStartedClusterStateTaskExecutor,

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -375,7 +375,7 @@ public class ShardStateAction extends AbstractComponent {
         public void messageReceived(ShardEntry request, TransportChannel channel) throws Exception {
             logger.debug("{} received shard started for [{}]", request.shardId, request);
             clusterService.submitStateUpdateTask(
-                "shard-started",
+                "shard-started " + request.shardId,
                 request,
                 ClusterStateTaskConfig.build(Priority.URGENT),
                 shardStartedClusterStateTaskExecutor,


### PR DESCRIPTION
When the cluster state is updated with Shard Started entries, it simply adds "shard-started" as the source of the change.

This adds the index name and shard ID so that we can see who/what is spamming the changes when the index creation step has already left the cluster state.

For example, while debugging this, it would have been helpful to know what shards these were because both indices only had a single shard, but there are three `shard-started` messages:

```
   > {time_in_queue=670ms, time_in_queue_millis=670, source=create-index [index1], cause [auto(bulk api)], executing=true, priority=URGENT, insert_order=209}
   > {time_in_queue=647ms, time_in_queue_millis=647, source=create-index [index2], cause [auto(bulk api)], executing=false, priority=URGENT, insert_order=210}
   > {time_in_queue=647ms, time_in_queue_millis=647, source=create-index [index2], cause [auto(bulk api)], executing=false, priority=URGENT, insert_order=211}
   > {time_in_queue=641ms, time_in_queue_millis=641, source=create-index [index2], cause [auto(bulk api)], executing=false, priority=URGENT, insert_order=212}
   > {time_in_queue=632ms, time_in_queue_millis=632, source=create-index-template [templateA], cause [api], executing=false, priority=URGENT, insert_order=214}
   > {time_in_queue=632ms, time_in_queue_millis=632, source=create-index-template [templateB], cause [api], executing=false, priority=URGENT, insert_order=216}
   > {time_in_queue=631ms, time_in_queue_millis=631, source=create-index-template [templateC], cause [api], executing=false, priority=URGENT, insert_order=218}
   > {time_in_queue=632ms, time_in_queue_millis=632, source=create-index [index2], cause [auto(bulk api)], executing=false, priority=URGENT, insert_order=213}
   > {time_in_queue=631ms, time_in_queue_millis=631, source=create-index-template [templateD], cause [api], executing=false, priority=URGENT, insert_order=219}
   > {time_in_queue=632ms, time_in_queue_millis=632, source=create-index-template [templateE], cause [api], executing=false, priority=URGENT, insert_order=215}
   > {time_in_queue=630ms, time_in_queue_millis=630, source=create-index-template [templateF], cause [api], executing=false, priority=URGENT, insert_order=220}
   > {time_in_queue=631ms, time_in_queue_millis=631, source=create-index-template [templateG], cause [api], executing=false, priority=URGENT, insert_order=217}
   > {time_in_queue=629ms, time_in_queue_millis=629, source=create-index-template [templateH], cause [api], executing=false, priority=URGENT, insert_order=221}
   > {time_in_queue=98ms, time_in_queue_millis=98, source=shard-started, executing=false, priority=URGENT, insert_order=222}
   > {time_in_queue=46ms, time_in_queue_millis=46, source=shard-started, executing=false, priority=URGENT, insert_order=223}
   > {time_in_queue=10ms, time_in_queue_millis=10, source=shard-started, executing=false, priority=URGENT, insert_order=224}
```