### PR TITLE
add ability to run scripts directly (without processors) within Ingest Pipelines

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -168,7 +168,8 @@ public class SimulatePipelineRequest extends ActionRequest {
 
     static Parsed parse(Map<String, Object> config, boolean verbose, PipelineStore pipelineStore) throws Exception {
         Map<String, Object> pipelineConfig = ConfigurationUtils.readMap(null, null, config, Fields.PIPELINE);
-        Pipeline pipeline = PIPELINE_FACTORY.create(SIMULATED_PIPELINE_ID, pipelineConfig, pipelineStore.getProcessorFactories());
+        Pipeline pipeline = PIPELINE_FACTORY.create(SIMULATED_PIPELINE_ID, pipelineConfig,
+            pipelineStore.getProcessorFactories(), pipelineStore.getScriptService());
         List<IngestDocument> ingestDocumentList = parseDocs(config, pipelineStore.isNewIngestDateFormat());
         return new Parsed(pipeline, ingestDocumentList, verbose);
     }

--- a/core/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/core/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -60,7 +60,7 @@ public class IngestService {
                 }
             }
         }
-        this.pipelineStore = new PipelineStore(clusterSettings, settings, Collections.unmodifiableMap(processorFactories));
+        this.pipelineStore = new PipelineStore(clusterSettings, settings, Collections.unmodifiableMap(processorFactories), scriptService);
         this.pipelineExecutionService = new PipelineExecutionService(pipelineStore, threadPool);
     }
 

--- a/core/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/core/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -21,11 +21,20 @@ package org.elasticsearch.ingest;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.script.IngestScript;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A pipeline is a list of {@link Processor} instances grouped under a unique id.
@@ -36,6 +45,7 @@ public final class Pipeline {
     static final String PROCESSORS_KEY = "processors";
     static final String VERSION_KEY = "version";
     static final String ON_FAILURE_KEY = "on_failure";
+    private static final CompoundProcessor EMPTY_PROCESSOR = new CompoundProcessor();
 
     private final String id;
     @Nullable
@@ -43,19 +53,33 @@ public final class Pipeline {
     @Nullable
     private final Integer version;
     private final CompoundProcessor compoundProcessor;
+    private final Optional<IngestScript> script;
 
     public Pipeline(String id, @Nullable String description, @Nullable Integer version, CompoundProcessor compoundProcessor) {
         this.id = id;
         this.description = description;
-        this.compoundProcessor = compoundProcessor;
         this.version = version;
+        this.compoundProcessor = compoundProcessor;
+        this.script = Optional.empty();
+    }
+
+    public Pipeline(String id, @Nullable String description, @Nullable Integer version, IngestScript script) {
+        this.id = id;
+        this.description = description;
+        this.version = version;
+        this.script = Optional.of(script);
+        this.compoundProcessor = EMPTY_PROCESSOR;
     }
 
     /**
      * Modifies the data of a document to be indexed based on the processor this pipeline holds
      */
     public void execute(IngestDocument ingestDocument) throws Exception {
-        compoundProcessor.execute(ingestDocument);
+        if (script.isPresent()) {
+            script.get().execute(ingestDocument.getSourceAndMetadata());
+        } else {
+            compoundProcessor.execute(ingestDocument);
+        }
     }
 
     /**
@@ -115,18 +139,34 @@ public final class Pipeline {
 
     public static final class Factory {
 
-        public Pipeline create(String id, Map<String, Object> config, Map<String, Processor.Factory> processorFactories) throws Exception {
+        private void assertConfigIsEmpty(Map<String, Object> config, String pipelineId) {
+            if (config.isEmpty() == false) {
+                throw new ElasticsearchParseException("pipeline [" + pipelineId +
+                    "] doesn't support one or more provided configuration parameters " + Arrays.toString(config.keySet().toArray()));
+            }
+        }
+        public Pipeline create(String id, Map<String, Object> config, Map<String, Processor.Factory> processorFactories,
+                               ScriptService scriptService) throws Exception {
             String description = ConfigurationUtils.readOptionalStringProperty(null, null, config, DESCRIPTION_KEY);
             Integer version = ConfigurationUtils.readIntProperty(null, null, config, VERSION_KEY, null);
-            List<Map<String, Map<String, Object>>> processorConfigs = ConfigurationUtils.readList(null, null, config, PROCESSORS_KEY);
+            Script script = ConfigurationUtils.readOptionalScript(null, null,
+                config, Script.SCRIPT_PARSE_FIELD.getPreferredName());
+            if (script != null && (config.containsKey(PROCESSORS_KEY) || config.containsKey(ON_FAILURE_KEY))) {
+                throw new ElasticsearchParseException("pipeline [" + id + "]: cannot have both `script` and `processors` defined");
+            } else if (script != null) {
+                // Skip processor extraction
+                IngestScript.Factory factory = scriptService.compile(script, IngestScript.CONTEXT);
+                IngestScript ingestScript = factory.newInstance(script.getParams());
+                assertConfigIsEmpty(config, id);
+                return new Pipeline(id, description, version, ingestScript);
+            }
+            List<Map<String, Map<String, Object>>> processorConfigs = ConfigurationUtils.readOptionalList(null,
+                null,config, PROCESSORS_KEY);
             List<Processor> processors = ConfigurationUtils.readProcessorConfigs(processorConfigs, processorFactories);
             List<Map<String, Map<String, Object>>> onFailureProcessorConfigs =
                     ConfigurationUtils.readOptionalList(null, null, config, ON_FAILURE_KEY);
             List<Processor> onFailureProcessors = ConfigurationUtils.readProcessorConfigs(onFailureProcessorConfigs, processorFactories);
-            if (config.isEmpty() == false) {
-                throw new ElasticsearchParseException("pipeline [" + id +
-                        "] doesn't support one or more provided configuration parameters " + Arrays.toString(config.keySet().toArray()));
-            }
+            assertConfigIsEmpty(config, id);
             if (onFailureProcessorConfigs != null && onFailureProcessors.isEmpty()) {
                 throw new ElasticsearchParseException("pipeline [" + id + "] cannot have an empty on_failure option defined");
             }

--- a/core/src/main/java/org/elasticsearch/script/ExecutableScript.java
+++ b/core/src/main/java/org/elasticsearch/script/ExecutableScript.java
@@ -50,5 +50,4 @@ public interface ExecutableScript {
     // TODO: remove these once each has its own script interface
     ScriptContext<Factory> AGGS_CONTEXT = new ScriptContext<>("aggs_executable", Factory.class);
     ScriptContext<Factory> UPDATE_CONTEXT = new ScriptContext<>("update", Factory.class);
-    ScriptContext<Factory> INGEST_CONTEXT = new ScriptContext<>("ingest", Factory.class);
 }

--- a/core/src/main/java/org/elasticsearch/script/IngestScript.java
+++ b/core/src/main/java/org/elasticsearch/script/IngestScript.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.script;
+
+import java.util.Map;
+
+public abstract class IngestScript {
+    public static final String[] PARAMETERS = new String[] { "ctx" };
+
+    /** The generic runtime parameters for the script. */
+    private final Map<String, Object> params;
+
+    public IngestScript(Map<String, Object> params) {
+        this.params = params;
+    }
+
+    /** Return the parameters for this script. */
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    public abstract void execute(Map<String, Object> ctx);
+
+    public interface Factory {
+        IngestScript newInstance(Map<String, Object> params);
+    }
+
+    /** The context used to compile {@link IngestScript} factories. */
+    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("ingest", Factory.class);
+}

--- a/core/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -44,7 +44,7 @@ public class ScriptModule {
             ExecutableScript.CONTEXT,
             ExecutableScript.AGGS_CONTEXT,
             ExecutableScript.UPDATE_CONTEXT,
-            ExecutableScript.INGEST_CONTEXT,
+            IngestScript.CONTEXT,
             TemplateScript.CONTEXT
         ).collect(Collectors.toMap(c -> c.name, Function.identity()));
     }

--- a/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptServiceTests.java
@@ -139,7 +139,7 @@ public class ScriptServiceTests extends ESTestCase {
         assertCompileAccepted("painless", "script", ScriptType.INLINE, SearchScript.CONTEXT);
         assertCompileAccepted("painless", "script", ScriptType.INLINE, SearchScript.AGGS_CONTEXT);
         assertCompileAccepted("painless", "script", ScriptType.INLINE, ExecutableScript.UPDATE_CONTEXT);
-        assertCompileAccepted("painless", "script", ScriptType.INLINE, ExecutableScript.INGEST_CONTEXT);
+        assertCompileAccepted("painless", "script", ScriptType.INLINE, IngestScript.CONTEXT);
     }
 
     public void testAllowSomeScriptTypeSettings() throws IOException {
@@ -180,13 +180,13 @@ public class ScriptServiceTests extends ESTestCase {
     }
 
     public void testCompileNonRegisteredContext() throws IOException {
-        contexts.remove(ExecutableScript.INGEST_CONTEXT.name);
+        contexts.remove(IngestScript.CONTEXT.name);
         buildScriptService(Settings.EMPTY);
 
         String type = scriptEngine.getType();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
-            scriptService.compile(new Script(randomFrom(ScriptType.values()), type, "test", Collections.emptyMap()), ExecutableScript.INGEST_CONTEXT));
-        assertThat(e.getMessage(), containsString("script context [" + ExecutableScript.INGEST_CONTEXT.name + "] not supported"));
+            scriptService.compile(new Script(randomFrom(ScriptType.values()), type, "test", Collections.emptyMap()), IngestScript.CONTEXT));
+        assertThat(e.getMessage(), containsString("script context [" + IngestScript.CONTEXT.name + "] not supported"));
     }
 
     public void testCompileCountedInCompilationStats() throws IOException {

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
-import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.IngestScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.ScriptService;
@@ -71,10 +71,10 @@ public final class ScriptProcessor extends AbstractProcessor {
      */
     @Override
     public void execute(IngestDocument document) {
-        ExecutableScript.Factory factory = scriptService.compile(script, ExecutableScript.INGEST_CONTEXT);
-        ExecutableScript executableScript = factory.newInstance(script.getParams());
-        executableScript.setNextVar("ctx",  document.getSourceAndMetadata());
-        executableScript.run();
+        IngestScript.Factory factory = scriptService.compile(script, IngestScript.CONTEXT);
+        IngestScript ingestScript = factory.newInstance(script.getParams());
+        ingestScript.execute(document.getSourceAndMetadata());
+
     }
 
     @Override
@@ -144,7 +144,7 @@ public final class ScriptProcessor extends AbstractProcessor {
 
             // verify script is able to be compiled before successfully creating processor.
             try {
-                scriptService.compile(script, ExecutableScript.INGEST_CONTEXT);
+                scriptService.compile(script, IngestScript.CONTEXT);
             } catch (ScriptException e) {
                 throw newConfigurationException(TYPE, processorTag, scriptPropertyUsed, e);
             }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorTests.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.RandomDocumentPicks;
-import org.elasticsearch.script.ExecutableScript;
+import org.elasticsearch.script.IngestScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTestCase;
@@ -45,10 +45,10 @@ public class ScriptProcessorTests extends ESTestCase {
 
         ScriptService scriptService = mock(ScriptService.class);
         Script script = mockScript("_script");
-        ExecutableScript.Factory factory = mock(ExecutableScript.Factory.class);
-        ExecutableScript executableScript = mock(ExecutableScript.class);
-        when(scriptService.compile(script, ExecutableScript.INGEST_CONTEXT)).thenReturn(factory);
-        when(factory.newInstance(any())).thenReturn(executableScript);
+        IngestScript.Factory factory = mock(IngestScript.Factory.class);
+        IngestScript ingestScript = mock(IngestScript.class);
+        when(scriptService.compile(script, IngestScript.CONTEXT)).thenReturn(factory);
+        when(factory.newInstance(any())).thenReturn(ingestScript);
 
         Map<String, Object> document = new HashMap<>();
         document.put("bytes_in", randomInt());
@@ -58,7 +58,7 @@ public class ScriptProcessorTests extends ESTestCase {
         doAnswer(invocationOnMock ->  {
             ingestDocument.setFieldValue("bytes_total", randomBytesTotal);
             return null;
-        }).when(executableScript).run();
+        }).when(ingestScript).execute(any());
 
         ScriptProcessor processor = new ScriptProcessor(randomAlphaOfLength(10), script, scriptService);
 


### PR DESCRIPTION
- add `script` field to pipelines as a replacement to executing processors
- introduce a specific IngestContext script context for executing within pipelines