### PR TITLE
Log checkout so SHA is known

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -101,6 +101,7 @@ if (enabled) {
     commandLine = ['git', 'fetch', 'upstream']
   }
 
+  // this is an Exec task so that the SHA that is checked out is logged
   task checkoutBwcBranch(type: Exec) {
     dependsOn fetchLatest
     workingDir = checkoutDir

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -101,7 +101,7 @@ if (enabled) {
     commandLine = ['git', 'fetch', 'upstream']
   }
 
-  task checkoutBwcBranch(type: LoggedExec) {
+  task checkoutBwcBranch(type: Exec) {
     dependsOn fetchLatest
     workingDir = checkoutDir
     commandLine = ['git', 'checkout', "upstream/${bwcBranch}"]


### PR DESCRIPTION
This commit changes the task type of the checkoutBwcBranch task to Exec from LoggedExec so that the output of the checkout command is shown. This enables us to see the SHA used for the checkout which can be useful when debugging a BWC break.

