### PR TITLE
Fix handling of exceptions thrown on HEAD requests

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
+++ b/core/src/main/java/org/elasticsearch/rest/BytesRestResponse.java
@@ -93,14 +93,9 @@ public class BytesRestResponse extends RestResponse {
 
     public BytesRestResponse(RestChannel channel, RestStatus status, Exception e) throws IOException {
         this.status = status;
-        if (channel.request().method() == RestRequest.Method.HEAD) {
-            this.content = BytesArray.EMPTY;
-            this.contentType = TEXT_CONTENT_TYPE;
-        } else {
-            try (XContentBuilder builder = build(channel, status, e)) {
-                this.content = builder.bytes();
-                this.contentType = builder.contentType().mediaType();
-            }
+        try (XContentBuilder builder = build(channel, status, e)) {
+            this.content = builder.bytes();
+            this.contentType = builder.contentType().mediaType();
         }
         if (e instanceof ElasticsearchException) {
             copyHeaders(((ElasticsearchException) e));

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -162,6 +162,14 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
         }
     }
 
+    public void testException() throws IOException {
+        /*
+         * This will throw an index not found exception which will be sent on the channel; previously when handling HEAD requests that would
+         * throw an exception, the content was swallowed and a content length header of zero was returned.
+         */
+        headTestCase("/index-not-found-exception", emptyMap(), NOT_FOUND.getStatus(), greaterThan(0));
+    }
+
     private void headTestCase(final String url, final Map<String, String> params, final Matcher<Integer> matcher) throws IOException {
         headTestCase(url, params, OK.getStatus(), matcher);
     }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -165,7 +165,9 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
     public void testException() throws IOException {
         /*
          * This will throw an index not found exception which will be sent on the channel; previously when handling HEAD requests that would
-         * throw an exception, the content was swallowed and a content length header of zero was returned.
+         * throw an exception, the content was swallowed and a content length header of zero was returned. Instead of swallowing the content
+         * we now let it rise up to the upstream channel so that it can compute the content length that would be returned. This test case is
+         * a test for this situation.
          */
         headTestCase("/index-not-found-exception", emptyMap(), NOT_FOUND.getStatus(), greaterThan(0));
     }


### PR DESCRIPTION
Today when an exception is thrown handling a HEAD request, the body is swallowed before the channel has a chance to see it. Yet, the channel is where we compute the content length that would be returned as a header in the response. This is a violation of the HTTP specification. This commit addresses the issue. To address this issue, we remove the special handling in bytes rest response for HEAD requests when an exception is thrown. Instead, we let the upstream channel handle the special case, as we already do today for the non-exceptional case.

Relates #21125
