### PR TITLE
Do not swallow node lock failed exception

### DIFF
--- a/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/core/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -199,7 +199,6 @@ public final class NodeEnvironment  implements Closeable {
             int maxLocalStorageNodes = MAX_LOCAL_STORAGE_NODES_SETTING.get(settings);
             for (int possibleLockId = 0; possibleLockId < maxLocalStorageNodes; possibleLockId++) {
                 for (int dirIndex = 0; dirIndex < environment.dataFiles().length; dirIndex++) {
-                    Path dataDirWithClusterName = environment.dataWithClusterFiles()[dirIndex];
                     Path dataDir = environment.dataFiles()[dirIndex];
                     Path dir = resolveNodePath(dataDir, possibleLockId);
                     Files.createDirectories(dir);
@@ -211,7 +210,8 @@ public final class NodeEnvironment  implements Closeable {
                             nodePaths[dirIndex] = new NodePath(dir);
                             nodeLockId = possibleLockId;
                         } catch (LockObtainFailedException ex) {
-                            startupTraceLogger.trace("failed to obtain node lock on {}", dir.toAbsolutePath());
+                            startupTraceLogger.trace(
+                                    new ParameterizedMessage("failed to obtain node lock on {}", dir.toAbsolutePath()), ex);
                             // release all the ones that were obtained up until now
                             releaseAndNullLocks(locks);
                             break;


### PR DESCRIPTION
When attempting to obtain the node lock, if an exception is thrown it is not logged. This makes debugging difficult. This commit causes such an exception to be logged.
