### PR TITLE
Explicitly reject duplicate data paths

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -273,8 +273,9 @@ final class Security {
              * on macOS).
              */
             try {
-                if (!dataFilesPaths.add(path.toRealPath())) {
-                    throw new IllegalStateException("path [" + path.toRealPath() + "] is duplicated by [" + path + "]");
+                final Path realPath = path.toRealPath();
+                if (!dataFilesPaths.add(realPath)) {
+                    throw new IllegalStateException("path [" + realPath + "] is duplicated by [" + path + "]");
                 }
             } catch (final IOException e) {
                 throw new IllegalStateException("unable to access [" + path + "]", e);

--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -269,7 +269,7 @@ final class Security {
             /*
              * We have to do this after adding the path because a side effect of that is that the directory is created; the Path#toRealPath
              * invocation will fail if the directory does not already exist. We use Path#toRealPath to follow symlinks and handle issues
-             * like unicode normalization or case-insensitivity on filesystems some filesystems (e.g., the case-insensitive variant of HFS+
+             * like unicode normalization or case-insensitivity on some filesystems (e.g., the case-insensitive variant of HFS+
              * on macOS).
              */
             try {

--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -46,6 +46,7 @@ import java.security.Policy;
 import java.security.URIParameter;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -262,8 +263,22 @@ final class Security {
         if (environment.sharedDataFile() != null) {
             addPath(policy, Environment.PATH_SHARED_DATA_SETTING.getKey(), environment.sharedDataFile(), "read,readlink,write,delete");
         }
+        final Set<Path> dataFilesPaths = new HashSet<>();
         for (Path path : environment.dataFiles()) {
             addPath(policy, Environment.PATH_DATA_SETTING.getKey(), path, "read,readlink,write,delete");
+            /*
+             * We have to do this after adding the path because a side effect of that is that the directory is created; the Path#toRealPath
+             * invocation will fail if the directory does not already exist. We use Path#toRealPath to follow symlinks and handle issues
+             * like unicode normalization or case-insensitivity on filesystems some filesystems (e.g., the case-insensitive variant of HFS+
+             * on macOS).
+             */
+            try {
+                if (!dataFilesPaths.add(path.toRealPath())) {
+                    throw new IllegalStateException("path [" + path.toRealPath() + "] is duplicated by [" + path + "]");
+                }
+            } catch (final IOException e) {
+                throw new IllegalStateException("unable to access [" + path + "]", e);
+            }
         }
         /*
          * If path.data and default.path.data are set, we need read access to the paths in default.path.data to check for the existence of
@@ -392,11 +407,12 @@ final class Security {
     }
 
     /**
-     * Add access to path (and all files underneath it)
-     * @param policy current policy to add permissions to
+     * Add access to path (and all files underneath it); this also creates the directory if it does not exist.
+     *
+     * @param policy            current policy to add permissions to
      * @param configurationName the configuration name associated with the path (for error messages only)
-     * @param path the path itself
-     * @param permissions set of file permissions to grant to the path
+     * @param path              the path itself
+     * @param permissions       set of file permissions to grant to the path
      */
     static void addPath(Permissions policy, String configurationName, Path path, String permissions) {
         // paths may not exist yet, this also checks accessibility

--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -269,8 +269,7 @@ final class Security {
             /*
              * We have to do this after adding the path because a side effect of that is that the directory is created; the Path#toRealPath
              * invocation will fail if the directory does not already exist. We use Path#toRealPath to follow symlinks and handle issues
-             * like unicode normalization or case-insensitivity on some filesystems (e.g., the case-insensitive variant of HFS+
-             * on macOS).
+             * like unicode normalization or case-insensitivity on some filesystems (e.g., the case-insensitive variant of HFS+ on macOS).
              */
             try {
                 final Path realPath = path.toRealPath();


### PR DESCRIPTION
Duplicate data paths already fail to work because we would attempt to take out a node lock on the directory a second time which will fail after the first lock attempt succeeds. However, how this failure manifests is not apparent at all and is quite difficult to debug. Instead, we should explicitly reject duplicate data paths to make the failure cause more obvious.

