### PR TITLE
[docs] include two cluster doc pages missing from index

### DIFF
--- a/docs/reference/cluster.asciidoc
+++ b/docs/reference/cluster.asciidoc
@@ -46,6 +46,10 @@ include::cluster/nodes-stats.asciidoc[]
 
 include::cluster/nodes-info.asciidoc[]
 
+include::cluster/nodes-usage.asciidoc[]
+
+include::cluster/remote-info.asciidoc[]
+
 include::cluster/tasks.asciidoc[]
 
 include::cluster/nodes-hot-threads.asciidoc[]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/remote.info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/remote.info.json
@@ -1,6 +1,6 @@
 {
   "remote.info": {
-    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/remote-info.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-remote-info.html",
     "methods": ["GET"],
     "url": {
       "path": "/_remote/info",


### PR DESCRIPTION
Doc build errors indicated that the remote-info api docs were not online anymore, while adding them I notice that the `nodes-usage` doc file also wasn't being included.

@debadair do you know how far I should backport this?