### PR TITLE
[DOCS] Add references to X-Pack installation and overview

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -18,7 +18,9 @@ release-state can be: released | prerelease | unreleased
 :javaclient:      https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
 :xpack-ref:       https://www.elastic.co/guide/en/x-pack/{branch}
 :logstash:        https://www.elastic.co/guide/en/logstash/{branch}
+:logstash-ref:    https://www.elastic.co/guide/en/logstash/{branch}
 :kibana:          https://www.elastic.co/guide/en/kibana/{branch}
+:kibana-ref:      https://www.elastic.co/guide/en/kibana/{branch}
 :issue:           https://github.com/elastic/elasticsearch/issues/
 :pull:            https://github.com/elastic/elasticsearch/pull/
 
@@ -31,7 +33,7 @@ release-state can be: released | prerelease | unreleased
 :es:              Elasticsearch
 :kib:             Kibana
 
-:xes-repo-dir:    {docdir}/../../elasticsearch-extra/x-pack-elasticsearch/docs/en
+:xes-repo-dir:    {docdir}/../../../elasticsearch-extra/x-pack-elasticsearch/docs/en
 
 ///////
 Javadoc roots used to generate links from Painless's API reference

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -1203,3 +1203,7 @@ There are many other aggregations capabilities that we won't go into detail here
 == Conclusion
 
 Elasticsearch is both a simple and complex product. We've so far learned the basics of what it is, how to look inside of it, and how to work with it using some of the REST APIs. I hope that this tutorial has given you a better understanding of what Elasticsearch is and more importantly, inspired you to further experiment with the rest of its great features!
+
+ifdef::include-xpack[]
+include::{xes-repo-dir}/introduction.asciidoc[]
+endif::include-xpack[]

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -55,3 +55,7 @@ include::setup/sysconfig.asciidoc[]
 include::setup/upgrade.asciidoc[]
 
 include::setup/stopping.asciidoc[]
+
+ifdef::include-xpack[]
+include::{xes-repo-dir}/installing.asciidoc[]
+endif::include-xpack[]


### PR DESCRIPTION
This PR adds references to X-Pack content in the setup and getting started sections of the Elasticsearch Reference. 

This content arose from discussions about X-Pack content in the Kibana Guide: https://github.com/elastic/kibana/pull/12062 and we thought it was a good idea to add similar content in the Elasticsearch Reference too.