### PR TITLE
Add a specialized deferring collector for terms aggregator

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferringBucketCollector.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferringBucketCollector.java
@@ -33,18 +33,22 @@ import java.io.IOException;
  * allows to replay a subset of the collected buckets.
  */
 public abstract class DeferringBucketCollector extends BucketCollector {
+    protected final BucketCollector deferredCollector;
 
     /** Sole constructor. */
-    public DeferringBucketCollector() {}
-
-    /** Set the deferred collectors. */
-    public abstract void setDeferredCollector(Iterable<BucketCollector> deferredCollectors);
-
-    public final void replay(long... selectedBuckets) throws IOException {
-        prepareSelectedBuckets(selectedBuckets);
+    public DeferringBucketCollector(BucketCollector deferredCollector) {
+        this.deferredCollector = deferredCollector;
     }
 
-    public abstract void prepareSelectedBuckets(long... selectedBuckets) throws IOException;
+    public abstract void replaySelectedBuckets(long... selectedBuckets) throws IOException;
+
+    @Override
+    public void preCollection() throws IOException {
+        deferredCollector.preCollection();
+    }
+
+    @Override
+    public void postCollection() throws IOException {}
 
     /**
      * Wrap the provided aggregator so that it behaves (almost) as if it had
@@ -54,10 +58,10 @@ public abstract class DeferringBucketCollector extends BucketCollector {
         return new WrappedAggregator(in);
     }
 
-    protected class WrappedAggregator extends Aggregator {
+    public class WrappedAggregator extends Aggregator {
         private Aggregator in;
 
-        WrappedAggregator(Aggregator in) {
+        public WrappedAggregator(Aggregator in) {
             this.in = in;
         }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedBytesHashSamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedBytesHashSamplerAggregator.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.fielddata.AbstractNumericDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -58,8 +59,8 @@ public class DiversifiedBytesHashSamplerAggregator extends SamplerAggregator {
     }
 
     @Override
-    public DeferringBucketCollector getDeferringCollector() {
-        bdd = new DiverseDocsDeferringCollector();
+    protected DeferringBucketCollector getDeferringCollector(BucketCollector deferredCollector) {
+        bdd = new DiverseDocsDeferringCollector(deferredCollector);
         return bdd;
     }
 
@@ -70,10 +71,9 @@ public class DiversifiedBytesHashSamplerAggregator extends SamplerAggregator {
      */
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
 
-        DiverseDocsDeferringCollector() {
-            super(shardSize, context.bigArrays());
+        DiverseDocsDeferringCollector(BucketCollector deferredCollector) {
+            super(deferredCollector, shardSize, context.bigArrays());
         }
-
 
         @Override
         protected TopDocsCollector<ScoreDocKey> createTopDocsCollector(int size) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedMapSamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedMapSamplerAggregator.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.fielddata.AbstractNumericDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -64,8 +65,8 @@ public class DiversifiedMapSamplerAggregator extends SamplerAggregator {
     }
 
     @Override
-    public DeferringBucketCollector getDeferringCollector() {
-        bdd = new DiverseDocsDeferringCollector();
+    protected DeferringBucketCollector getDeferringCollector(BucketCollector deferredCollector) {
+        bdd = new DiverseDocsDeferringCollector(deferredCollector);
         return bdd;
     }
 
@@ -76,8 +77,8 @@ public class DiversifiedMapSamplerAggregator extends SamplerAggregator {
      */
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
 
-        DiverseDocsDeferringCollector() {
-            super(shardSize, context.bigArrays());
+        DiverseDocsDeferringCollector(BucketCollector deferredCollector) {
+            super(deferredCollector, shardSize, context.bigArrays());
         }
 
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedNumericSamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedNumericSamplerAggregator.java
@@ -29,6 +29,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.index.fielddata.AbstractNumericDocValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -52,8 +53,8 @@ public class DiversifiedNumericSamplerAggregator extends SamplerAggregator {
     }
 
     @Override
-    public DeferringBucketCollector getDeferringCollector() {
-        bdd = new DiverseDocsDeferringCollector();
+    protected DeferringBucketCollector getDeferringCollector(BucketCollector deferredCollector) {
+        bdd = new DiverseDocsDeferringCollector(deferredCollector);
         return bdd;
     }
 
@@ -63,8 +64,8 @@ public class DiversifiedNumericSamplerAggregator extends SamplerAggregator {
      * This implementation is only for use with a single bucket aggregation.
      */
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
-        DiverseDocsDeferringCollector() {
-            super(shardSize, context.bigArrays());
+        DiverseDocsDeferringCollector(BucketCollector deferredCollector) {
+            super(deferredCollector, shardSize, context.bigArrays());
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedOrdinalsSamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedOrdinalsSamplerAggregator.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.TopDocsCollector;
 import org.elasticsearch.index.fielddata.AbstractNumericDocValues;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -53,8 +54,8 @@ public class DiversifiedOrdinalsSamplerAggregator extends SamplerAggregator {
     }
 
     @Override
-    public DeferringBucketCollector getDeferringCollector() {
-        bdd = new DiverseDocsDeferringCollector();
+    protected DeferringBucketCollector getDeferringCollector(BucketCollector deferredCollector) {
+        bdd = new DiverseDocsDeferringCollector(deferredCollector);
         return bdd;
     }
 
@@ -65,8 +66,8 @@ public class DiversifiedOrdinalsSamplerAggregator extends SamplerAggregator {
      */
     class DiverseDocsDeferringCollector extends BestDocsDeferringCollector {
 
-        DiverseDocsDeferringCollector() {
-            super(shardSize, context.bigArrays());
+        DiverseDocsDeferringCollector(BucketCollector deferredCollector) {
+            super(deferredCollector, shardSize, context.bigArrays());
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregator.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
+import org.elasticsearch.search.aggregations.BucketCollector;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
@@ -152,8 +153,8 @@ public class SamplerAggregator extends SingleBucketAggregator {
     }
 
     @Override
-    public DeferringBucketCollector getDeferringCollector() {
-        bdd = new BestDocsDeferringCollector(shardSize, context.bigArrays());
+    protected DeferringBucketCollector getDeferringCollector(BucketCollector deferredCollector) {
+        bdd = new BestDocsDeferringCollector(deferredCollector, shardSize, context.bigArrays());
         return bdd;
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregator.java
@@ -59,7 +59,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyList;
 
 public class SignificantTextAggregator extends BucketsAggregator {
-    
+
     private final StringFilter includeExclude;
     protected final BucketCountThresholds bucketCountThresholds;
     protected long numCollectedDocs;
@@ -90,20 +90,17 @@ public class SignificantTextAggregator extends BucketsAggregator {
         this.sourceFieldNames = sourceFieldNames;
         bucketOrds = new BytesRefHash(1, context.bigArrays());
         if(filterDuplicateText){
-            dupSequenceSpotter = new DuplicateByteSequenceSpotter();        
+            dupSequenceSpotter = new DuplicateByteSequenceSpotter();
             lastTrieSize = dupSequenceSpotter.getEstimatedSizeInBytes();
         }
     }
-
-    
-    
 
     @Override
     public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
             final LeafBucketCollector sub) throws IOException {
         final BytesRefBuilder previous = new BytesRefBuilder();
         return new LeafBucketCollectorBase(sub, null) {
-            
+
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 collectFromSource(doc, bucket, fieldName, sourceFieldNames);
@@ -112,8 +109,7 @@ public class SignificantTextAggregator extends BucketsAggregator {
                     dupSequenceSpotter.startNewSequence();
                 }
             }
-            
-            private void processTokenStream(int doc, long bucket, TokenStream ts, BytesRefHash inDocTerms, String fieldText) 
+            private void processTokenStream(int doc, long bucket, TokenStream ts, BytesRefHash inDocTerms, String fieldText)
                     throws IOException{
                 if (dupSequenceSpotter != null) {
                     ts = new DeDuplicatingTokenFilter(ts, dupSequenceSpotter);
@@ -151,35 +147,35 @@ public class SignificantTextAggregator extends BucketsAggregator {
                     ts.close();
                 }
             }
-            
+
             private void collectFromSource(int doc, long bucket, String indexedFieldName, String[] sourceFieldNames) throws IOException {
                 MappedFieldType fieldType = context.getQueryShardContext().fieldMapper(indexedFieldName);
                 if(fieldType == null){
                     throw new IllegalArgumentException("Aggregation [" + name + "] cannot process field ["+indexedFieldName
-                            +"] since it is not present");                    
+                            +"] since it is not present");
                 }
 
                 SourceLookup sourceLookup = context.lookup().source();
                 sourceLookup.setSegmentAndDocument(ctx, doc);
                 BytesRefHash inDocTerms = new BytesRefHash(256, context.bigArrays());
-                
-                try {                
+
+                try {
                     for (String sourceField : sourceFieldNames) {
-                        List<Object> textsToHighlight = sourceLookup.extractRawValues(sourceField);    
+                        List<Object> textsToHighlight = sourceLookup.extractRawValues(sourceField);
                         textsToHighlight = textsToHighlight.stream().map(obj -> {
                             if (obj instanceof BytesRef) {
                                 return fieldType.valueForDisplay(obj).toString();
                             } else {
                                 return obj;
                             }
-                        }).collect(Collectors.toList());                
-                        
-                        Analyzer analyzer = fieldType.indexAnalyzer();                
+                        }).collect(Collectors.toList());
+
+                        Analyzer analyzer = fieldType.indexAnalyzer();
                         for (Object fieldValue : textsToHighlight) {
                             String fieldText = fieldValue.toString();
                             TokenStream ts = analyzer.tokenStream(indexedFieldName, fieldText);
-                            processTokenStream(doc, bucket, ts, inDocTerms, fieldText);                     
-                        }                    
+                            processTokenStream(doc, bucket, ts, inDocTerms, fieldText);
+                        }
                     }
                 } finally{
                     Releasables.close(inDocTerms);
@@ -220,7 +216,7 @@ public class SignificantTextAggregator extends BucketsAggregator {
             spare.updateScore(significanceHeuristic);
 
             spare.bucketOrd = i;
-            spare = ordered.insertWithOverflow(spare);            
+            spare = ordered.insertWithOverflow(spare);
         }
 
         final SignificantStringTerms.Bucket[] list = new SignificantStringTerms.Bucket[ordered.size()];

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BestTermsDeferringCollector.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/BestTermsDeferringCollector.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.terms;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.RoaringDocIdSet;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.LongHash;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.BucketCollector;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.bucket.DeferringBucketCollector;
+import org.elasticsearch.search.internal.SearchContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+/**
+ * A specialization of {@link DeferringBucketCollector} for {@link TermsAggregator} that
+ * first records all matches in a {@link RoaringDocIdSet} and then replay the best buckets
+ * selected by the aggregator that owns this collector.
+ * The second pass uses a {@link TermsAggregator.BucketSelectorValuesSource} to collect
+ * documents that belongs to the selected buckets.
+ */
+public final class BestTermsDeferringCollector extends DeferringBucketCollector {
+    private static class LeafEntry {
+        final LeafReaderContext context;
+        final RoaringDocIdSet.Builder builder;
+
+        private LeafEntry(LeafReaderContext context) {
+            this.context = context;
+            this.builder = new RoaringDocIdSet.Builder(context.reader().maxDoc());
+        }
+    }
+
+    private final SearchContext searchContext;
+    private final List<LeafEntry> leaves = new ArrayList<>();
+    private BucketValuesSourceProvider provider;
+    private LongHash bestBucketHash;
+
+    interface BucketValuesSourceProvider {
+        TermsAggregator.BucketSelectorValuesSource get(long... buckets);
+    }
+
+    public BestTermsDeferringCollector(BucketCollector deferredCollector,
+                                       SearchContext searchContext,
+                                       BucketValuesSourceProvider provider) {
+        super(deferredCollector);
+        this.searchContext = searchContext;
+        this.provider = provider;
+    }
+
+    @Override
+    public void replaySelectedBuckets(long... selectedBuckets) throws IOException {
+        final LongHash hash = new LongHash(selectedBuckets.length, BigArrays.NON_RECYCLING_INSTANCE);
+        for (long bucket : selectedBuckets) {
+            hash.add(bucket);
+        }
+        this.bestBucketHash = hash;
+        TermsAggregator.BucketSelectorValuesSource valuesSource = provider.get(selectedBuckets);
+
+        boolean needsScores = deferredCollector.needsScores();
+        Weight weight = null;
+        if (needsScores) {
+            weight = searchContext.searcher().createNormalizedWeight(searchContext.query(), true);
+        }
+        for (LeafEntry leafEntry : leaves) {
+            RoaringDocIdSet docIdSet = leafEntry.builder.build();
+            DocIdSetIterator it = docIdSet.iterator();
+            if (it == null) {
+                continue;
+            }
+            final LeafBucketCollector leafCollector = deferredCollector.getLeafCollector(leafEntry.context);
+            final SortedNumericDocValues dvs = valuesSource.get(leafEntry.context);
+            DocIdSetIterator docIt = null;
+            if (needsScores) {
+                Scorer scorer = weight.scorer(leafEntry.context);
+                // We don't need to check if the scorer is null
+                // since we are sure that there are documents to replay.
+                docIt = scorer.iterator();
+                leafCollector.setScorer(scorer);
+            }
+            int docId;
+            while ((docId = it.nextDoc()) != NO_MORE_DOCS) {
+                if (dvs.advanceExact(docId)) {
+                    if (needsScores) {
+                        if (docIt.docID() < docId) {
+                            docIt.advance(docId);
+                        }
+                        // aggregations should only be replayed on matching documents
+                        assert docIt.docID() == docId;
+                    }
+                    for (int i = 0; i < dvs.docValueCount(); i++) {
+                        long bucket = dvs.nextValue();
+                        leafCollector.collect(docId, bucket);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx) throws IOException {
+        final LeafEntry entry = new LeafEntry(ctx);
+        leaves.add(entry);
+        return new LeafBucketCollector() {
+            int lastDoc = -1;
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (doc != lastDoc) {
+                    entry.builder.add(doc);
+                    lastDoc = doc;
+                }
+            }
+        };
+    }
+
+    @Override
+    public boolean needsScores() {
+        return false;
+    }
+
+    /**
+     * Wrap the provided aggregator so that it behaves (almost) as if it had
+     * been collected directly.
+     */
+    @Override
+    public Aggregator wrap(final Aggregator in) {
+
+        return new WrappedAggregator(in) {
+
+            @Override
+            public InternalAggregation buildAggregation(long bucket) throws IOException {
+                if (bestBucketHash == null) {
+                    throw new IllegalStateException("Collection has not been replayed yet.");
+                }
+                final long rebasedBucket = bestBucketHash.find(bucket);
+                if (rebasedBucket == -1) {
+                    throw new IllegalStateException("Cannot build for a bucket which has not been collected");
+                }
+                return in.buildAggregation(rebasedBucket);
+            }
+        };
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -254,6 +254,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
     protected BucketSelectorValuesSource getBucketSelector(long... selectedBuckets) {
         final LongHash hash = new LongHash(selectedBuckets.length, BigArrays.NON_RECYCLING_INSTANCE);
         for (long bucket : selectedBuckets) {
+            // remap the global ord not the bucket
             hash.add(bucketOrds == null ? bucket : bucketOrds.get(bucket));
         }
         return context -> {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsAggregator.java
@@ -18,10 +18,14 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.LongHash;
+import org.elasticsearch.index.fielddata.AbstractSortedNumericDocValues;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -43,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
+import static org.apache.lucene.index.SortedSetDocValues.NO_MORE_ORDS;
 
 public class LongTermsAggregator extends TermsAggregator {
 
@@ -52,9 +57,9 @@ public class LongTermsAggregator extends TermsAggregator {
     private LongFilter longFilter;
 
     public LongTermsAggregator(String name, AggregatorFactories factories, ValuesSource.Numeric valuesSource, DocValueFormat format,
-            BucketOrder order, BucketCountThresholds bucketCountThresholds, SearchContext aggregationContext, Aggregator parent,
-            SubAggCollectionMode subAggCollectMode, boolean showTermDocCountError, IncludeExclude.LongFilter longFilter,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
+                               BucketOrder order, BucketCountThresholds bucketCountThresholds, SearchContext aggregationContext, Aggregator parent,
+                               SubAggCollectionMode subAggCollectMode, boolean showTermDocCountError, IncludeExclude.LongFilter longFilter,
+                               List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
         super(name, factories, aggregationContext, parent, bucketCountThresholds, order, format, subAggCollectMode, pipelineAggregators, metaData);
         this.valuesSource = valuesSource;
         this.showTermDocCountError = showTermDocCountError;
@@ -73,31 +78,48 @@ public class LongTermsAggregator extends TermsAggregator {
 
     @Override
     public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
-            final LeafBucketCollector sub) throws IOException {
+                                                final LeafBucketCollector sub) throws IOException {
         final SortedNumericDocValues values = getValues(valuesSource, ctx);
+        final NumericDocValues singleton = DocValues.unwrapSingleton(values);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long owningBucketOrdinal) throws IOException {
                 assert owningBucketOrdinal == 0;
-                if (values.advanceExact(doc)) {
-                    final int valuesCount = values.docValueCount();
+                if (singleton == null) {
+                    if (values.advanceExact(doc)) {
+                        final int valuesCount = values.docValueCount();
 
-                    long previous = Long.MAX_VALUE;
-                    for (int i = 0; i < valuesCount; ++i) {
-                        final long val = values.nextValue();
-                        if (previous != val || i == 0) {
-                            if ((longFilter == null) || (longFilter.accept(val))) {
-                                long bucketOrdinal = bucketOrds.add(val);
-                                if (bucketOrdinal < 0) { // already seen
-                                    bucketOrdinal = -1 - bucketOrdinal;
-                                    collectExistingBucket(sub, doc, bucketOrdinal);
-                                } else {
-                                    collectBucket(sub, doc, bucketOrdinal);
+                        long previous = Long.MAX_VALUE;
+                        for (int i = 0; i < valuesCount; ++i) {
+                            final long val = values.nextValue();
+                            if (previous != val || i == 0) {
+                                if ((longFilter == null) || (longFilter.accept(val))) {
+                                    long bucketOrdinal = bucketOrds.add(val);
+                                    if (bucketOrdinal < 0) { // already seen
+                                        bucketOrdinal = -1 - bucketOrdinal;
+                                        collectExistingBucket(sub, doc, bucketOrdinal);
+                                    } else {
+                                        collectBucket(sub, doc, bucketOrdinal);
+                                    }
                                 }
-                            }
 
-                            previous = val;
+                                previous = val;
+                            }
                         }
+                    }
+                } else {
+                    if (singleton.advanceExact(doc)) {
+                        final long val = singleton.longValue();
+                        if ((longFilter == null) || (longFilter.accept(val))) {
+                            long bucketOrdinal = bucketOrds.add(val);
+                            if (bucketOrdinal < 0) { // already seen
+                                bucketOrdinal = -1 - bucketOrdinal;
+                                collectExistingBucket(sub, doc, bucketOrdinal);
+                            } else {
+                                collectBucket(sub, doc, bucketOrdinal);
+                            }
+                        }
+
                     }
                 }
             }
@@ -140,7 +162,7 @@ public class LongTermsAggregator extends TermsAggregator {
             otherDocCount += spare.docCount;
             spare.bucketOrd = i;
             if (bucketCountThresholds.getShardMinDocCount() <= spare.docCount) {
-                spare = (LongTerms.Bucket) ordered.insertWithOverflow(spare);
+                spare = ordered.insertWithOverflow(spare);
             }
         }
 
@@ -148,7 +170,7 @@ public class LongTermsAggregator extends TermsAggregator {
         final LongTerms.Bucket[] list = new LongTerms.Bucket[ordered.size()];
         long survivingBucketOrds[] = new long[ordered.size()];
         for (int i = ordered.size() - 1; i >= 0; --i) {
-            final LongTerms.Bucket bucket = (LongTerms.Bucket) ordered.pop();
+            final LongTerms.Bucket bucket = ordered.pop();
             survivingBucketOrds[i] = bucket.bucketOrd;
             list[i] = bucket;
             otherDocCount -= bucket.docCount;
@@ -163,14 +185,14 @@ public class LongTermsAggregator extends TermsAggregator {
         }
 
         return new LongTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(),
-                pipelineAggregators(), metaData(), format, bucketCountThresholds.getShardSize(), showTermDocCountError, otherDocCount,
-                Arrays.asList(list), 0);
+            pipelineAggregators(), metaData(), format, bucketCountThresholds.getShardSize(), showTermDocCountError, otherDocCount,
+            Arrays.asList(list), 0);
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
         return new LongTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(),
-                pipelineAggregators(), metaData(), format, bucketCountThresholds.getShardSize(), showTermDocCountError, 0, emptyList(), 0);
+            pipelineAggregators(), metaData(), format, bucketCountThresholds.getShardSize(), showTermDocCountError, 0, emptyList(), 0);
     }
 
     @Override
@@ -178,4 +200,70 @@ public class LongTermsAggregator extends TermsAggregator {
         Releasables.close(bucketOrds);
     }
 
+    @Override
+    protected BucketSelectorValuesSource getBucketSelector(long... selectedBuckets) {
+        final LongHash hash = new LongHash(selectedBuckets.length, BigArrays.NON_RECYCLING_INSTANCE);
+        for (long bucket : selectedBuckets) {
+            // remap the value, not the bucket
+            hash.add(bucketOrds.get(bucket));
+        }
+        return context -> {
+            final SortedNumericDocValues values = getValues(valuesSource, context);
+            return new AbstractSortedNumericDocValues() {
+                long[] buckets = new long[1];
+                int offset;
+                int size;
+
+                @Override
+                public long nextValue() throws IOException {
+                    if (offset >= size) {
+                        return NO_MORE_ORDS;
+                    }
+                    return buckets[offset++];
+                }
+
+                @Override
+                public int docValueCount() {
+                    return size;
+                }
+
+                @Override
+                public boolean advanceExact(int target) throws IOException {
+                    if (values.advanceExact(target)) {
+                        return fillBuckets();
+                    }
+                    return false;
+                }
+
+                @Override
+                public int docID() {
+                    return values.docID();
+                }
+
+                boolean fillBuckets() throws IOException {
+                    offset = 0;
+                    int pos = 0;
+                    long previous = Long.MAX_VALUE;
+                    for (int i = 0; i < values.docValueCount(); i++) {
+                        long val = values.nextValue();
+                        if (val == previous && i > 0) {
+                            continue;
+                        }
+                        long bucket = hash.find(val);
+                        if (bucket != -1) {
+                            if (pos >= buckets.length) {
+                                long[] newBuckets = new long[buckets.length * 2];
+                                System.arraycopy(buckets, 0, newBuckets, 0, buckets.length);
+                                buckets = newBuckets;
+                            }
+                            buckets[pos++] = bucket;
+                        }
+                        previous = val;
+                    }
+                    size = pos;
+                    return size > 0;
+                }
+            };
+        };
+    }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
@@ -22,7 +22,9 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.index.fielddata.AbstractSortedNumericDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -53,13 +55,13 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
     private final IncludeExclude.StringFilter includeExclude;
 
     public StringTermsAggregator(String name, AggregatorFactories factories, ValuesSource valuesSource,
-            BucketOrder order, DocValueFormat format, BucketCountThresholds bucketCountThresholds,
-            IncludeExclude.StringFilter includeExclude, SearchContext context,
-            Aggregator parent, SubAggCollectionMode collectionMode, boolean showTermDocCountError,
-            List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
+                                 BucketOrder order, DocValueFormat format, BucketCountThresholds bucketCountThresholds,
+                                 IncludeExclude.StringFilter includeExclude, SearchContext context,
+                                 Aggregator parent, SubAggCollectionMode collectionMode, boolean showTermDocCountError,
+                                 List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) throws IOException {
 
         super(name, factories, context, parent, order, format, bucketCountThresholds, collectionMode, showTermDocCountError,
-                pipelineAggregators, metaData);
+            pipelineAggregators, metaData);
         this.valuesSource = valuesSource;
         this.includeExclude = includeExclude;
         bucketOrds = new BytesRefHash(1, context.bigArrays());
@@ -71,8 +73,7 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
     }
 
     @Override
-    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
-            final LeafBucketCollector sub) throws IOException {
+    public LeafBucketCollector getLeafCollector(LeafReaderContext ctx, final LeafBucketCollector sub) throws IOException {
         final SortedBinaryDocValues values = valuesSource.bytesValues(ctx);
         return new LeafBucketCollectorBase(sub, values) {
             final BytesRefBuilder previous = new BytesRefBuilder();
@@ -163,15 +164,15 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
 
         // Now build the aggs
         for (int i = 0; i < list.length; i++) {
-          final StringTerms.Bucket bucket = list[i];
-          bucket.termBytes = BytesRef.deepCopyOf(bucket.termBytes);
-          bucket.aggregations = bucketAggregations(bucket.bucketOrd);
-          bucket.docCountError = 0;
+            final StringTerms.Bucket bucket = list[i];
+            bucket.termBytes = BytesRef.deepCopyOf(bucket.termBytes);
+            bucket.aggregations = bucketAggregations(bucket.bucketOrd);
+            bucket.docCountError = 0;
         }
 
         return new StringTerms(name, order, bucketCountThresholds.getRequiredSize(), bucketCountThresholds.getMinDocCount(),
-                pipelineAggregators(), metaData(), format, bucketCountThresholds.getShardSize(), showTermDocCountError, otherDocCount,
-                Arrays.asList(list), 0);
+            pipelineAggregators(), metaData(), format, bucketCountThresholds.getShardSize(), showTermDocCountError, otherDocCount,
+            Arrays.asList(list), 0);
     }
 
     @Override
@@ -179,5 +180,69 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
         Releasables.close(bucketOrds);
     }
 
+    @Override
+    protected BucketSelectorValuesSource getBucketSelector(long... selectedBuckets) {
+        final BytesRefHash hash = new BytesRefHash(selectedBuckets.length, BigArrays.NON_RECYCLING_INSTANCE);
+        BytesRef rec = new BytesRef();
+        for (long bucket : selectedBuckets) {
+            hash.add(bucketOrds.get(bucket, rec));
+        }
+
+        return context -> {
+            final BytesRefBuilder previous = new BytesRefBuilder();
+            final SortedBinaryDocValues values = valuesSource.bytesValues(context);
+            return new AbstractSortedNumericDocValues() {
+                int offset;
+                int size;
+                long[] buckets = new long[1];
+
+
+                @Override
+                public long nextValue() throws IOException {
+                    if (offset >= size) {
+                        return -1;
+                    }
+                    return buckets[offset++];
+                }
+
+                @Override
+                public int docValueCount() {
+                    return values.docValueCount();
+                }
+
+                @Override
+                public boolean advanceExact(int target) throws IOException {
+                    if (values.advanceExact(target)) {
+                        return fillBuckets();
+                    }
+                    return false;
+                }
+
+                boolean fillBuckets() throws IOException {
+                    offset = 0;
+                    int pos = 0;
+                    previous.clear();
+                    for (int i = 0; i < values.docValueCount(); i++) {
+                        BytesRef value = values.nextValue();
+                        if (i > 0 && previous.get().equals(value)) {
+                            continue;
+                        }
+                        long bucket = hash.find(value);
+                        if (bucket != -1) {
+                            if (pos >= buckets.length) {
+                                long[] newBuckets = new long[buckets.length * 2];
+                                System.arraycopy(buckets, 0, newBuckets, 0, buckets.length);
+                                buckets = newBuckets;
+                            }
+                            buckets[pos++] = bucket;
+                        }
+                        previous.copyBytes(value);
+                    }
+                    size = pos;
+                    return size > 0;
+                }
+            };
+        };
+    }
 }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregator.java
@@ -185,6 +185,7 @@ public class StringTermsAggregator extends AbstractStringTermsAggregator {
         final BytesRefHash hash = new BytesRefHash(selectedBuckets.length, BigArrays.NON_RECYCLING_INSTANCE);
         BytesRef rec = new BytesRef();
         for (long bucket : selectedBuckets) {
+            // remap the value not the bucket
             hash.add(bucketOrds.get(bucket, rec));
         }
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollectorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollectorTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -62,13 +61,12 @@ public class BestBucketsDeferringCollectorTests extends AggregatorTestCase {
         TopDocs topDocs = indexSearcher.search(termQuery, numDocs);
 
         SearchContext searchContext = createSearchContext(indexSearcher, createIndexSettings());
-        BestBucketsDeferringCollector collector = new BestBucketsDeferringCollector(searchContext);
         Set<Integer> deferredCollectedDocIds = new HashSet<>();
-        collector.setDeferredCollector(Collections.singleton(bla(deferredCollectedDocIds)));
+        BestBucketsDeferringCollector collector = new BestBucketsDeferringCollector(bla(deferredCollectedDocIds), searchContext);
         collector.preCollection();
         indexSearcher.search(termQuery, collector);
         collector.postCollection();
-        collector.replay(0);
+        collector.replaySelectedBuckets(0);
 
         assertEquals(topDocs.scoreDocs.length, deferredCollectedDocIds.size());
         for (ScoreDoc scoreDoc : topDocs.scoreDocs) {


### PR DESCRIPTION
This change introduces a new deferring collector called `BestTermsDeferringCollector`.
Unlike the `BestBucketsDeferringCollector` this collector records only the matching docs during the first pass
and recomputes the buckets in the second pass using the parent terms aggregator.
This change also refactors/cleanups how the deferring collectors are handled in the base aggregator.

The savings in terms of memory can be significant. For instance a simple terms agg on 10M documents on a field with a cardinality of 1M needs 32MB per request using the `BestBucketsDeferringCollector` and only 1MB with the new `BestTermsDeferringCollector`.
The execution times are comparable when recomputing the buckets is cheap (from the doc_values) and can be slower otherwise (expensive scripts).