### PR TITLE
[TEST] test that low level REST client leaves path untouched

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -553,7 +553,7 @@ public class RestClient implements Closeable {
         return httpRequest;
     }
 
-    private static URI buildUri(String pathPrefix, String path, Map<String, String> params) {
+    static URI buildUri(String pathPrefix, String path, Map<String, String> params) {
         Objects.requireNonNull(path, "path must not be null");
         try {
             String fullPath;

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
@@ -23,6 +23,9 @@ import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 
+import java.net.URI;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -74,6 +77,22 @@ public class RestClientTests extends RestClientTestCase {
             fail("should have failed because of wrong endpoint");
         } catch (IllegalArgumentException exception) {
             assertEquals("Expected scheme name at index 0: ::http:///", exception.getMessage());
+        }
+    }
+
+    public void testBuildUriLeavesPathUntouched() {
+        {
+            URI uri = RestClient.buildUri("/foo$bar", "/index/type/id", Collections.<String, String>emptyMap());
+            assertEquals("/foo$bar/index/type/id", uri.getPath());
+        }
+        {
+            URI uri = RestClient.buildUri(null, "/foo$bar/ty/pe/i/d", Collections.<String, String>emptyMap());
+            assertEquals("/foo$bar/ty/pe/i/d", uri.getPath());
+        }
+        {
+            URI uri = RestClient.buildUri(null, "/index/type/id", Collections.singletonMap("foo$bar", "x/y/z"));
+            assertEquals("/index/type/id", uri.getPath());
+            assertEquals("foo$bar=x/y/z", uri.getQuery());
         }
     }
 


### PR DESCRIPTION
It was brought up in #24987 that the low level REST client doesn't url encode the endpoint. This PR adds unit tests for this behaviour.

Relates to #24987 