### PR TITLE
ec2-discovery: set current region if no endpoint available

### DIFF
--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImpl.java
@@ -31,6 +31,8 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.http.IdleConnectionReaper;
 import com.amazonaws.internal.StaticCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
@@ -61,6 +63,12 @@ class AwsEc2ServiceImpl extends AbstractComponent implements AwsEc2Service, Clos
         String endpoint = findEndpoint(logger, settings);
         if (endpoint != null) {
             client.setEndpoint(endpoint);
+        } else {
+            Region currentRegion = Regions.getCurrentRegion();
+            if (currentRegion != null) {
+                logger.debug("using ec2 region [{}]", currentRegion);
+                client.setRegion(currentRegion);
+            }
         }
 
         return this.client;


### PR DESCRIPTION
The AwsEc2ServiceImpl instantiates a client and sets the endpoint which
can be specified explicitly by the ``ENDPOINT_SETTING`` or the
``REGION_SETTING``. If none of these settings are provided the client
would fall back to the endpoint of the ``us-east-1`` region.
This change however sets the client's region based on the region of the
running EC2 instance which can be obtained by an API call to the
instance metadata.