### PR TITLE
Add more missing AggregationBuilder getters

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
@@ -116,6 +116,11 @@ public abstract class AbstractAggregationBuilder<AB extends AbstractAggregationB
     }
 
     @Override
+    public Map<String, Object> getMetaData() {
+        return metaData;
+    }
+
+    @Override
     public final String getWriteableName() {
         // We always use the type of the aggregation as the writeable name
         return getType();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.internal.SearchContext;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -117,7 +118,7 @@ public abstract class AbstractAggregationBuilder<AB extends AbstractAggregationB
 
     @Override
     public Map<String, Object> getMetaData() {
-        return metaData;
+        return Collections.unmodifiableMap(metaData);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -64,6 +64,9 @@ public abstract class AggregationBuilder
     @Override
     public abstract AggregationBuilder setMetaData(Map<String, Object> metaData);
 
+    /** Return any associated metadata with this {@link AggregationBuilder}. */
+    public abstract Map<String, Object> getMetaData();
+
     /** Add a sub aggregation to this builder. */
     public abstract AggregationBuilder subAggregation(AggregationBuilder aggregation);
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -149,6 +149,13 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Valu
     }
 
     /**
+     * Returns the number of term buckets currently configured
+     */
+    public int size() {
+        return bucketCountThresholds.getRequiredSize();
+    }
+
+    /**
      * Sets the shard_size - indicating the number of term buckets each shard
      * will return to the coordinating node (the node that coordinates the
      * search execution). The higher the shard size is, the more accurate the
@@ -161,6 +168,13 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Valu
         }
         bucketCountThresholds.setShardSize(shardSize);
         return this;
+    }
+
+    /**
+     * Returns the number of term buckets per shard that are currently configured
+     */
+    public int shardSize() {
+        return bucketCountThresholds.getShardSize();
     }
 
     /**
@@ -177,6 +191,13 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Valu
     }
 
     /**
+     * Returns the minimum document count required per term
+     */
+    public long minDocCount() {
+        return bucketCountThresholds.getMinDocCount();
+    }
+
+    /**
      * Set the minimum document count terms should have on the shard in order to
      * appear in the response.
      */
@@ -187,6 +208,13 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Valu
         }
         bucketCountThresholds.setShardMinDocCount(shardMinDocCount);
         return this;
+    }
+
+    /**
+     * Returns the minimum document count required per term, per shard
+     */
+    public long shardMinDocCount() {
+        return bucketCountThresholds.getShardMinDocCount();
     }
 
     /** Set a new order on this builder and return the builder so that calls

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/sum/InternalSum.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 public class InternalSum extends InternalNumericMetricsAggregation.SingleValue implements Sum {
     private final double sum;
 
-    InternalSum(String name, double sum, DocValueFormat formatter, List<PipelineAggregator> pipelineAggregators,
+    public InternalSum(String name, double sum, DocValueFormat formatter, List<PipelineAggregator> pipelineAggregators,
             Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.sum = sum;


### PR DESCRIPTION
Some more minor tweaks to make agg builders more consistent.

- getMetadata for all aggs
- various getters on TermsAggBuilder (without "get" prefix to maintain convention)
- Also makes InternalSum's ctor public, to follow suit of other metrics (min/max/avg/etc)

@cbuescher would you mind taking a look at this?  Want to make sure I'm not breaking anything related to the java client project. :)
