### PR TITLE
Deprecate percolate query's document_type parameter.

### DIFF
--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -53,6 +53,9 @@
 
 * The `template` query has been removed. This query was deprecated since 5.0
 
+* The `percolate` query's `document_type` has been deprecated. From 6.0 and later
+  it is no longer required to specify the `document_type` parameter.
+
 ==== Search shards API
 
 The search shards API no longer accepts the `type` url parameter, which didn't

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -65,7 +65,6 @@ GET /my-index/_search
     "query" : {
         "percolate" : {
             "field" : "query",
-            "document_type" : "doc",
             "document" : {
                 "message" : "A new bonsai tree in the office"
             }
@@ -190,7 +189,6 @@ GET /my-index/_search
     "query" : {
         "percolate" : {
             "field": "query",
-            "document_type" : "doc",
             "index" : "my-index",
             "type" : "doc",
             "id" : "2",
@@ -261,7 +259,6 @@ GET /my-index/_search
     "query" : {
         "percolate" : {
             "field": "query",
-            "document_type" : "doc",
             "document" : {
                 "message" : "The quick brown fox jumps over the lazy dog"
             }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQuery.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQuery.java
@@ -46,16 +46,14 @@ final class PercolateQuery extends Query implements Accountable {
     // cost of matching the query against the document, arbitrary as it would be really complex to estimate
     public static final float MATCH_COST = 1000;
 
-    private final String documentType;
     private final QueryStore queryStore;
     private final BytesReference documentSource;
     private final Query candidateMatchesQuery;
     private final Query verifiedMatchesQuery;
     private final IndexSearcher percolatorIndexSearcher;
 
-    PercolateQuery(String documentType, QueryStore queryStore, BytesReference documentSource,
-                          Query candidateMatchesQuery, IndexSearcher percolatorIndexSearcher, Query verifiedMatchesQuery) {
-        this.documentType = Objects.requireNonNull(documentType);
+    PercolateQuery(QueryStore queryStore, BytesReference documentSource,
+                   Query candidateMatchesQuery, IndexSearcher percolatorIndexSearcher, Query verifiedMatchesQuery) {
         this.documentSource = Objects.requireNonNull(documentSource);
         this.candidateMatchesQuery = Objects.requireNonNull(candidateMatchesQuery);
         this.queryStore = Objects.requireNonNull(queryStore);
@@ -67,8 +65,7 @@ final class PercolateQuery extends Query implements Accountable {
     public Query rewrite(IndexReader reader) throws IOException {
         Query rewritten = candidateMatchesQuery.rewrite(reader);
         if (rewritten != candidateMatchesQuery) {
-            return new PercolateQuery(documentType, queryStore, documentSource, rewritten, percolatorIndexSearcher,
-                    verifiedMatchesQuery);
+            return new PercolateQuery(queryStore, documentSource, rewritten, percolatorIndexSearcher, verifiedMatchesQuery);
         } else {
             return this;
         }
@@ -171,10 +168,6 @@ final class PercolateQuery extends Query implements Accountable {
         return percolatorIndexSearcher;
     }
 
-    public String getDocumentType() {
-        return documentType;
-    }
-
     public BytesReference getDocumentSource() {
         return documentSource;
     }
@@ -200,8 +193,8 @@ final class PercolateQuery extends Query implements Accountable {
 
     @Override
     public String toString(String s) {
-        return "PercolateQuery{document_type={" + documentType + "},document_source={" + documentSource.utf8ToString() +
-                "},inner={" + candidateMatchesQuery.toString(s)  + "}}";
+        return "PercolateQuery{document_source={" + documentSource.utf8ToString() + "},inner={" +
+            candidateMatchesQuery.toString(s)  + "}}";
     }
 
     @Override

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -50,6 +50,8 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -74,6 +76,7 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Objects;
 
 import static org.elasticsearch.index.mapper.SourceToParse.source;
@@ -81,6 +84,8 @@ import static org.elasticsearch.percolator.PercolatorFieldMapper.parseQuery;
 
 public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBuilder> {
     public static final String NAME = "percolate";
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(ParseField.class));
 
     static final ParseField DOCUMENT_FIELD = new ParseField("document");
     private static final ParseField QUERY_FIELD = new ParseField("field");
@@ -93,6 +98,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
     private static final ParseField INDEXED_DOCUMENT_FIELD_VERSION = new ParseField("version");
 
     private final String field;
+    @Deprecated
     private final String documentType;
     private final BytesReference document;
     private final XContentType documentXContentType;
@@ -105,20 +111,29 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
     private final Long indexedDocumentVersion;
 
     /**
-     * @deprecated use {@link #PercolateQueryBuilder(String, String, BytesReference, XContentType)} with the document content type to avoid
-     * autodetection
+     * @deprecated use {@link #PercolateQueryBuilder(String, BytesReference, XContentType)} with the document content
+     * type to avoid autodetection.
      */
     @Deprecated
     public PercolateQueryBuilder(String field, String documentType, BytesReference document) {
         this(field, documentType, document, XContentFactory.xContentType(document));
     }
 
+    /**
+     * Creates a percolator query builder instance for percolating a provided document.
+     *
+     * @param field                     The field that contains the percolator query
+     * @param document                  The binary blob containing document to percolate
+     * @param documentXContentType      The content type of the binary blob containing the document to percolate
+     */
+    public PercolateQueryBuilder(String field, BytesReference document, XContentType documentXContentType) {
+        this(field, null, document, documentXContentType);
+    }
+
+    @Deprecated
     public PercolateQueryBuilder(String field, String documentType, BytesReference document, XContentType documentXContentType) {
         if (field == null) {
             throw new IllegalArgumentException("[field] is a required argument");
-        }
-        if (documentType == null) {
-            throw new IllegalArgumentException("[document_type] is a required argument");
         }
         if (document == null) {
             throw new IllegalArgumentException("[document] is a required argument");
@@ -135,14 +150,29 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         indexedDocumentVersion = null;
     }
 
-    public PercolateQueryBuilder(String field, String documentType, String indexedDocumentIndex, String indexedDocumentType,
-                                 String indexedDocumentId, String indexedDocumentRouting, String indexedDocumentPreference,
-                                 Long indexedDocumentVersion) {
+    /**
+     * Creates a percolator query builder instance for percolating a document in a remote index.
+     *
+     * @param field                     The field that contains the percolator query
+     * @param indexedDocumentIndex      The index containing the document to percolate
+     * @param indexedDocumentType       The type containing the document to percolate
+     * @param indexedDocumentId         The id of the document to percolate
+     * @param indexedDocumentRouting    The routing value for the document to percolate
+     * @param indexedDocumentPreference The preference to use when fetching the document to percolate
+     * @param indexedDocumentVersion    The expected version of the document to percolate
+     */
+    public PercolateQueryBuilder(String field, String indexedDocumentIndex, String indexedDocumentType, String indexedDocumentId,
+                                 String indexedDocumentRouting, String indexedDocumentPreference, Long indexedDocumentVersion) {
+        this(field, null, indexedDocumentIndex, indexedDocumentType, indexedDocumentId, indexedDocumentRouting,
+            indexedDocumentPreference, indexedDocumentVersion);
+    }
+
+    @Deprecated
+    public PercolateQueryBuilder(String field, String documentType, String indexedDocumentIndex,
+                                 String indexedDocumentType, String indexedDocumentId, String indexedDocumentRouting,
+                                 String indexedDocumentPreference, Long indexedDocumentVersion) {
         if (field == null) {
             throw new IllegalArgumentException("[field] is a required argument");
-        }
-        if (documentType == null) {
-            throw new IllegalArgumentException("[document_type] is a required argument");
         }
         if (indexedDocumentIndex == null) {
             throw new IllegalArgumentException("[index] is a required argument");
@@ -171,7 +201,11 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
     PercolateQueryBuilder(StreamInput in) throws IOException {
         super(in);
         field = in.readString();
-        documentType = in.readString();
+        if (in.getVersion().before(Version.V_6_0_0_alpha3)) {
+            documentType = in.readString();
+        } else {
+            documentType = in.readOptionalString();
+        }
         indexedDocumentIndex = in.readOptionalString();
         indexedDocumentType = in.readOptionalString();
         indexedDocumentId = in.readOptionalString();
@@ -197,7 +231,11 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(field);
-        out.writeString(documentType);
+        if (out.getVersion().before(Version.V_6_0_0_alpha3)) {
+            out.writeString(documentType);
+        } else {
+            out.writeOptionalString(documentType);
+        }
         out.writeOptionalString(indexedDocumentIndex);
         out.writeOptionalString(indexedDocumentType);
         out.writeOptionalString(indexedDocumentId);
@@ -281,11 +319,11 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
                     throw new ParsingException(parser.getTokenLocation(), "[" + PercolateQueryBuilder.NAME +
                             "] query does not support [" + token + "]");
                 }
-            } else if (token.isValue()) {
+            } else if (token.isValue() || token == XContentParser.Token.VALUE_NULL) {
                 if (QUERY_FIELD.match(currentFieldName)) {
                     field = parser.text();
                 } else if (DOCUMENT_TYPE_FIELD.match(currentFieldName)) {
-                    documentType = parser.text();
+                    documentType = parser.textOrNull();
                 } else if (INDEXED_DOCUMENT_FIELD_INDEX.match(currentFieldName)) {
                     indexedDocumentIndex = parser.text();
                 } else if (INDEXED_DOCUMENT_FIELD_TYPE.match(currentFieldName)) {
@@ -310,11 +348,6 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
                 throw new ParsingException(parser.getTokenLocation(), "[" + PercolateQueryBuilder.NAME +
                         "] query does not support [" + token + "]");
             }
-        }
-
-        if (documentType == null) {
-            throw new IllegalArgumentException("[" + PercolateQueryBuilder.NAME + "] query is missing required [" +
-                    DOCUMENT_TYPE_FIELD.getPreferredName() + "] parameter");
         }
 
         PercolateQueryBuilder queryBuilder;
@@ -392,11 +425,42 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
             throw new IllegalStateException("no document to percolate");
         }
 
-        MapperService mapperService = context.getMapperService();
-        DocumentMapperForType docMapperForType = mapperService.documentMapperWithAutoCreate(documentType);
-        DocumentMapper docMapper = docMapperForType.getDocumentMapper();
+        MappedFieldType fieldType = context.fieldMapper(field);
+        if (fieldType == null) {
+            throw new QueryShardException(context, "field [" + field + "] does not exist");
+        }
 
-        ParsedDocument doc = docMapper.parse(source(context.index().getName(), documentType, "_temp_id", document, documentXContentType));
+        if (!(fieldType instanceof PercolatorFieldMapper.FieldType)) {
+            throw new QueryShardException(context, "expected field [" + field +
+                "] to be of type [percolator], but is of type [" + fieldType.typeName() + "]");
+        }
+
+        final ParsedDocument doc;
+        final DocumentMapper docMapper;
+        final MapperService mapperService = context.getMapperService();
+        if (context.getIndexSettings().isSingleType()) {
+            Collection<String> types = mapperService.types();
+            if (types.size() != 1) {
+                throw new IllegalStateException("Only a single type should exist, but [" + types.size() + " types exists");
+            }
+            String type = types.iterator().next();
+            if (documentType != null) {
+                DEPRECATION_LOGGER.deprecated("[document_type] parameter has been deprecated because types have been deprecated");
+                if (documentType.equals(type) == false) {
+                    throw new IllegalArgumentException("specified document_type [" + documentType +
+                        "] is not equal to the actual type [" + type + "]");
+                }
+            }
+            docMapper = mapperService.documentMapper(type);
+            doc = docMapper.parse(source(context.index().getName(), type, "_temp_id", document, documentXContentType));
+        } else {
+            if (documentType == null) {
+                throw new IllegalArgumentException("[percolate] query is missing required [document_type] parameter");
+            }
+            DocumentMapperForType docMapperForType = mapperService.documentMapperWithAutoCreate(documentType);
+            docMapper = docMapperForType.getDocumentMapper();
+            doc = docMapper.parse(source(context.index().getName(), documentType, "_temp_id", document, documentXContentType));
+        }
 
         FieldNameAnalyzer fieldNameAnalyzer = (FieldNameAnalyzer) docMapper.mappers().indexAnalyzer();
         // Need to this custom impl because FieldNameAnalyzer is strict and the percolator sometimes isn't when
@@ -425,18 +489,10 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         boolean mapUnmappedFieldsAsString = context.getIndexSettings()
                 .getValue(PercolatorFieldMapper.INDEX_MAP_UNMAPPED_FIELDS_AS_STRING_SETTING);
         QueryShardContext percolateShardContext = wrap(context);
-        MappedFieldType fieldType = context.fieldMapper(field);
-        if (fieldType == null) {
-            throw new QueryShardException(context, "field [" + field + "] does not exist");
-        }
 
-        if (!(fieldType instanceof PercolatorFieldMapper.FieldType)) {
-            throw new QueryShardException(context, "expected field [" + field +
-                "] to be of type [percolator], but is of type [" + fieldType.typeName() + "]");
-        }
         PercolatorFieldMapper.FieldType pft = (PercolatorFieldMapper.FieldType) fieldType;
         PercolateQuery.QueryStore queryStore = createStore(pft, percolateShardContext, mapUnmappedFieldsAsString);
-        return pft.percolateQuery(documentType, queryStore, document, docSearcher);
+        return pft.percolateQuery(queryStore, document, docSearcher);
     }
 
     public String getField() {

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -176,8 +176,8 @@ public class PercolatorFieldMapper extends FieldMapper {
             throw new QueryShardException(context, "Percolator fields are not searchable directly, use a percolate query instead");
         }
 
-        public Query percolateQuery(String documentType, PercolateQuery.QueryStore queryStore, BytesReference documentSource,
-                                    IndexSearcher searcher) throws IOException {
+        Query percolateQuery(PercolateQuery.QueryStore queryStore, BytesReference documentSource,
+                             IndexSearcher searcher) throws IOException {
             IndexReader indexReader = searcher.getIndexReader();
             Query candidateMatchesQuery = createCandidateQuery(indexReader);
             Query verifiedMatchesQuery;
@@ -190,7 +190,7 @@ public class PercolatorFieldMapper extends FieldMapper {
             } else {
                 verifiedMatchesQuery = new MatchNoDocsQuery("nested docs, so no verified matches");
             }
-            return new PercolateQuery(documentType, queryStore, documentSource, candidateMatchesQuery, searcher, verifiedMatchesQuery);
+            return new PercolateQuery(queryStore, documentSource, candidateMatchesQuery, searcher, verifiedMatchesQuery);
         }
 
         Query createCandidateQuery(IndexReader indexReader) throws IOException {

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
@@ -33,11 +33,11 @@ import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightPhase;
 import org.elasticsearch.search.fetch.subphase.highlight.Highlighter;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchContextHighlight;
-import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.SubSearchContext;
 
@@ -52,7 +52,7 @@ import java.util.Map;
  */
 public final class PercolatorHighlightSubFetchPhase extends HighlightPhase {
 
-    public PercolatorHighlightSubFetchPhase(Settings settings, Map<String, Highlighter> highlighters) {
+    PercolatorHighlightSubFetchPhase(Settings settings, Map<String, Highlighter> highlighters) {
         super(settings, highlighters);
     }
 
@@ -93,7 +93,7 @@ public final class PercolatorHighlightSubFetchPhase extends HighlightPhase {
             if (query != null) {
                 subSearchContext.parsedQuery(new ParsedQuery(query));
                 hitContext.reset(
-                        new SearchHit(0, "unknown", new Text(percolateQuery.getDocumentType()), Collections.emptyMap()),
+                        new SearchHit(0, "unknown", new Text(hit.getType()), Collections.emptyMap()),
                         percolatorLeafReaderContext, 0, percolatorIndexSearcher
                 );
                 hitContext.cache().clear();

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -40,7 +40,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.ConstantScoreScorer;
-import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.FilterScorer;
@@ -291,7 +290,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
     private void duelRun(PercolateQuery.QueryStore queryStore, MemoryIndex memoryIndex, IndexSearcher shardSearcher) throws IOException {
         boolean requireScore = randomBoolean();
         IndexSearcher percolateSearcher = memoryIndex.createSearcher();
-        Query percolateQuery = fieldType.percolateQuery("type", queryStore, new BytesArray("{}"), percolateSearcher);
+        Query percolateQuery = fieldType.percolateQuery(queryStore, new BytesArray("{}"), percolateSearcher);
         Query query = requireScore ? percolateQuery : new ConstantScoreQuery(percolateQuery);
         TopDocs topDocs = shardSearcher.search(query, 10);
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.internal.SearchContext;
@@ -86,13 +87,16 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         queryField = randomAlphaOfLength(4);
-        docType = "doc";
-        mapperService.merge("doc", new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef("doc",
+        String docType = "doc";
+        mapperService.merge(docType, new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef(docType,
                 queryField, "type=percolator"
         ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
         mapperService.merge(docType, new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef(docType,
                 STRING_FIELD_NAME, "type=text"
         ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        if (mapperService.getIndexSettings().isSingleType() == false) {
+            PercolateQueryBuilderTests.docType = docType;
+        }
     }
 
     @Override
@@ -150,7 +154,7 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     protected void doAssertLuceneQuery(PercolateQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {
         assertThat(query, Matchers.instanceOf(PercolateQuery.class));
         PercolateQuery percolateQuery = (PercolateQuery) query;
-        assertThat(percolateQuery.getDocumentType(), Matchers.equalTo(queryBuilder.getDocumentType()));
+        assertThat(docType, Matchers.equalTo(queryBuilder.getDocumentType()));
         assertThat(percolateQuery.getDocumentSource(), Matchers.equalTo(documentSource));
     }
 
@@ -187,10 +191,6 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
         assertThat(e.getMessage(), equalTo("[field] is a required argument"));
 
         e = expectThrows(IllegalArgumentException.class,
-            () -> new PercolateQueryBuilder("_field", null, new BytesArray("{}"), XContentType.JSON));
-        assertThat(e.getMessage(), equalTo("[document_type] is a required argument"));
-
-        e = expectThrows(IllegalArgumentException.class,
             () -> new PercolateQueryBuilder("_field", "_document_type", null, null));
         assertThat(e.getMessage(), equalTo("[document] is a required argument"));
 
@@ -198,11 +198,6 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
             new PercolateQueryBuilder(null, null, "_index", "_type", "_id", null, null, null);
         });
         assertThat(e.getMessage(), equalTo("[field] is a required argument"));
-
-        e = expectThrows(IllegalArgumentException.class, () -> {
-            new PercolateQueryBuilder("_field", null, "_index", "_type", "_id", null, null, null);
-        });
-        assertThat(e.getMessage(), equalTo("[document_type] is a required argument"));
 
         e = expectThrows(IllegalArgumentException.class, () -> {
             new PercolateQueryBuilder("_field", "_document_type", null, "_type", "_id", null, null, null);
@@ -221,9 +216,15 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
     }
 
     public void testFromJsonNoDocumentType() throws IOException {
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> parseQuery("{\"percolate\" : { \"document\": {}}"));
-        assertThat(e.getMessage(), equalTo("[percolate] query is missing required [document_type] parameter"));
+        QueryShardContext queryShardContext = createShardContext();
+        QueryBuilder queryBuilder = parseQuery("{\"percolate\" : { \"document\": {}, \"field\":\"" + queryField + "\"}}");
+        if (indexVersionCreated.before(Version.V_6_0_0_alpha3)) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> queryBuilder.toQuery(queryShardContext));
+            assertThat(e.getMessage(), equalTo("[percolate] query is missing required [document_type] parameter"));
+        } else {
+            queryBuilder.toQuery(queryShardContext);
+        }
     }
 
     public void testCreateMultiDocumentSearcher() throws Exception {

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryTests.java
@@ -116,7 +116,7 @@ public class PercolateQueryTests extends ESTestCase {
         memoryIndex.addField("field", "the quick brown fox jumps over the lazy dog", new WhitespaceAnalyzer());
         IndexSearcher percolateSearcher = memoryIndex.createSearcher();
         // no scoring, wrapping it in a constant score query:
-        Query query = new ConstantScoreQuery(new PercolateQuery("type", queryStore, new BytesArray("a"),
+        Query query = new ConstantScoreQuery(new PercolateQuery(queryStore, new BytesArray("a"),
                 new TermQuery(new Term("select", "a")), percolateSearcher, new MatchNoDocsQuery("")));
         TopDocs topDocs = shardSearcher.search(query, 10);
         assertThat(topDocs.totalHits, equalTo(1));
@@ -126,7 +126,7 @@ public class PercolateQueryTests extends ESTestCase {
         assertThat(explanation.isMatch(), is(true));
         assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[0].score));
 
-        query = new ConstantScoreQuery(new PercolateQuery("type", queryStore, new BytesArray("b"),
+        query = new ConstantScoreQuery(new PercolateQuery(queryStore, new BytesArray("b"),
                 new TermQuery(new Term("select", "b")), percolateSearcher, new MatchNoDocsQuery("")));
         topDocs = shardSearcher.search(query, 10);
         assertThat(topDocs.totalHits, equalTo(3));
@@ -146,12 +146,12 @@ public class PercolateQueryTests extends ESTestCase {
         assertThat(explanation.isMatch(), is(true));
         assertThat(explanation.getValue(), equalTo(topDocs.scoreDocs[2].score));
 
-        query = new ConstantScoreQuery(new PercolateQuery("type", queryStore, new BytesArray("c"),
+        query = new ConstantScoreQuery(new PercolateQuery(queryStore, new BytesArray("c"),
                 new MatchAllDocsQuery(), percolateSearcher, new MatchAllDocsQuery()));
         topDocs = shardSearcher.search(query, 10);
         assertThat(topDocs.totalHits, equalTo(4));
 
-        query = new PercolateQuery("type", queryStore, new BytesArray("{}"), new TermQuery(new Term("select", "b")),
+        query = new PercolateQuery(queryStore, new BytesArray("{}"), new TermQuery(new Term("select", "b")),
                 percolateSearcher, new MatchNoDocsQuery(""));
         topDocs = shardSearcher.search(query, 10);
         assertThat(topDocs.totalHits, equalTo(3));

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhaseTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhaseTests.java
@@ -46,7 +46,7 @@ public class PercolatorHighlightSubFetchPhaseTests extends ESTestCase {
 
     public void testHitsExecutionNeeded() {
         PercolateQuery percolateQuery = new PercolateQuery(
-                "", ctx -> null, new BytesArray("{}"), new MatchAllDocsQuery(), Mockito.mock(IndexSearcher.class), new MatchAllDocsQuery()
+                ctx -> null, new BytesArray("{}"), new MatchAllDocsQuery(), Mockito.mock(IndexSearcher.class), new MatchAllDocsQuery()
         );
         PercolatorHighlightSubFetchPhase subFetchPhase = new PercolatorHighlightSubFetchPhase(Settings.EMPTY,
             emptyMap());
@@ -61,7 +61,7 @@ public class PercolatorHighlightSubFetchPhaseTests extends ESTestCase {
 
     public void testLocatePercolatorQuery() {
         PercolateQuery percolateQuery = new PercolateQuery(
-                "", ctx -> null, new BytesArray("{}"), new MatchAllDocsQuery(), Mockito.mock(IndexSearcher.class), new MatchAllDocsQuery()
+                ctx -> null, new BytesArray("{}"), new MatchAllDocsQuery(), Mockito.mock(IndexSearcher.class), new MatchAllDocsQuery()
         );
         assertThat(PercolatorHighlightSubFetchPhase.locatePercolatorQuery(new MatchAllDocsQuery()), nullValue());
         BooleanQuery.Builder bq = new BooleanQuery.Builder();

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
@@ -104,7 +104,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .execute().actionGet();
         SearchResponse response = client().prepareSearch("index")
-            .setQuery(new PercolateQueryBuilder("query", "type", jsonBuilder().startObject().field("field1", "b").endObject().bytes(),
+            .setQuery(new PercolateQueryBuilder("query", jsonBuilder().startObject().field("field1", "b").endObject().bytes(),
                 XContentType.JSON))
             .get();
         assertHitCount(response, 1);
@@ -132,7 +132,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         BytesReference source = jsonBuilder().startObject().endObject().bytes();
         logger.info("percolating empty doc");
         SearchResponse response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .get();
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
@@ -140,7 +140,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         source = jsonBuilder().startObject().field("field1", "value").endObject().bytes();
         logger.info("percolating doc with 1 field");
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .addSort("_uid", SortOrder.ASC)
                 .get();
         assertHitCount(response, 2);
@@ -150,7 +150,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         source = jsonBuilder().startObject().field("field1", "value").field("field2", "value").endObject().bytes();
         logger.info("percolating doc with 2 fields");
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .addSort("_uid", SortOrder.ASC)
                 .get();
         assertHitCount(response, 3);
@@ -214,7 +214,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         // Test long range:
         BytesReference source = jsonBuilder().startObject().field("field1", 12).endObject().bytes();
         SearchResponse response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .get();
         assertHitCount(response, 2);
         assertThat(response.getHits().getAt(0).getId(), equalTo("3"));
@@ -222,7 +222,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
 
         source = jsonBuilder().startObject().field("field1", 11).endObject().bytes();
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .get();
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
@@ -230,7 +230,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         // Test double range:
         source = jsonBuilder().startObject().field("field2", 12).endObject().bytes();
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .get();
         assertHitCount(response, 2);
         assertThat(response.getHits().getAt(0).getId(), equalTo("6"));
@@ -238,7 +238,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
 
         source = jsonBuilder().startObject().field("field2", 11).endObject().bytes();
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .get();
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).getId(), equalTo("4"));
@@ -246,7 +246,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         // Test IP range:
         source = jsonBuilder().startObject().field("field3", "192.168.1.5").endObject().bytes();
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .get();
         assertHitCount(response, 2);
         assertThat(response.getHits().getAt(0).getId(), equalTo("9"));
@@ -254,7 +254,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
 
         source = jsonBuilder().startObject().field("field3", "192.168.1.4").endObject().bytes();
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .get();
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).getId(), equalTo("7"));
@@ -262,7 +262,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         // Test date range:
         source = jsonBuilder().startObject().field("field4", "2016-05-15").endObject().bytes();
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .get();
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).getId(), equalTo("10"));
@@ -292,14 +292,14 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
 
         logger.info("percolating empty doc");
         SearchResponse response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", "test", "type", "1", null, null, null))
+                .setQuery(new PercolateQueryBuilder("query", "test", "type", "1", null, null, null))
                 .get();
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
 
         logger.info("percolating doc with 1 field");
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", "test", "type", "5", null, null, null))
+                .setQuery(new PercolateQueryBuilder("query", "test", "type", "5", null, null, null))
                 .addSort("_uid", SortOrder.ASC)
                 .get();
         assertHitCount(response, 2);
@@ -308,7 +308,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
 
         logger.info("percolating doc with 2 fields");
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", "test", "type", "6", null, null, null))
+                .setQuery(new PercolateQueryBuilder("query", "test", "type", "6", null, null, null))
                 .addSort("_uid", SortOrder.ASC)
                 .get();
         assertHitCount(response, 3);
@@ -332,7 +332,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         logger.info("percolating empty doc with source disabled");
         Throwable e = expectThrows(SearchPhaseExecutionException.class, () -> {
             client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", "test", "type", "1", null, null, null))
+                .setQuery(new PercolateQueryBuilder("query", "test", "type", "1", null, null, null))
                 .get();
         }).getRootCause();
         assertThat(e, instanceOf(IllegalArgumentException.class));
@@ -396,7 +396,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
                 .field("field2", "the quick brown fox falls down into the well")
                 .endObject().bytes();
         SearchResponse response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", source, XContentType.JSON))
                 .addSort("_uid", SortOrder.ASC)
                 .get();
         assertHitCount(response, 4);
@@ -442,7 +442,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
                 .field("field1", "The quick brown fox jumps over the lazy dog")
                 .endObject().bytes();
         SearchResponse searchResponse = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "type", document, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", document, XContentType.JSON))
                 .highlighter(new HighlightBuilder().field("field1"))
                 .addSort("_uid", SortOrder.ASC)
                 .get();
@@ -475,7 +475,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         client().admin().indices().prepareRefresh().get();
 
         SearchResponse response = client().prepareSearch().setQuery(
-                new PercolateQueryBuilder("query", "type", new BytesArray("{\"field\" : [\"brown\", \"fox\"]}"), XContentType.JSON)
+                new PercolateQueryBuilder("query", null, new BytesArray("{\"field\" : [\"brown\", \"fox\"]}"), XContentType.JSON)
         ).get();
         assertHitCount(response, 1);
         assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
@@ -542,7 +542,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
 
         BytesReference source = jsonBuilder().startObject().field("field", "value").endObject().bytes();
         SearchResponse response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder(queryFieldName, "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder(queryFieldName, source, XContentType.JSON))
                 .setIndices("test1")
                 .get();
         assertHitCount(response, 1);
@@ -551,7 +551,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         assertThat(response.getHits().getAt(0).getIndex(), equalTo("test1"));
 
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("object_field." + queryFieldName, "type", source, XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("object_field." + queryFieldName, source, XContentType.JSON))
                 .setIndices("test2")
                 .get();
         assertHitCount(response, 1);
@@ -593,7 +593,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         client().admin().indices().prepareRefresh().get();
 
         SearchResponse response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "employee",
+                .setQuery(new PercolateQueryBuilder("query",
                         XContentFactory.jsonBuilder()
                             .startObject().field("companyname", "stark")
                                 .startArray("employee")
@@ -607,7 +607,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         assertThat(response.getHits().getAt(0).getId(), equalTo("q1"));
 
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "employee",
+                .setQuery(new PercolateQueryBuilder("query",
                         XContentFactory.jsonBuilder()
                             .startObject().field("companyname", "notstark")
                                 .startArray("employee")
@@ -620,7 +620,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         assertHitCount(response, 0);
 
         response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "employee",
+                .setQuery(new PercolateQueryBuilder("query",
                         XContentFactory.jsonBuilder().startObject().field("companyname", "notstark").endObject().bytes(),
                     XContentType.JSON))
                 .addSort("_doc", SortOrder.ASC)
@@ -649,7 +649,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
 
         for (int i = 0; i < 32; i++) {
             SearchResponse response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "employee",
+                .setQuery(new PercolateQueryBuilder("query",
                     XContentFactory.jsonBuilder()
                         .startObject().field("companyname", "stark")
                         .startArray("employee")
@@ -734,7 +734,7 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
         doc.endObject();
         for (int i = 0; i < 32; i++) {
             SearchResponse response = client().prepareSearch()
-                .setQuery(new PercolateQueryBuilder("query", "employee", doc.bytes(), XContentType.JSON))
+                .setQuery(new PercolateQueryBuilder("query", doc.bytes(), XContentType.JSON))
                 .addSort("_doc", SortOrder.ASC)
                 .get();
             assertHitCount(response, 1);
@@ -772,21 +772,21 @@ public class PercolatorQuerySearchIT extends ESSingleNodeTestCase {
 
         MultiSearchResponse response = client().prepareMultiSearch()
             .add(client().prepareSearch("test")
-                .setQuery(new PercolateQueryBuilder("query", "type",
+                .setQuery(new PercolateQueryBuilder("query",
                     jsonBuilder().startObject().field("field1", "b").endObject().bytes(), XContentType.JSON)))
             .add(client().prepareSearch("test")
-                .setQuery(new PercolateQueryBuilder("query", "type",
+                .setQuery(new PercolateQueryBuilder("query",
                     yamlBuilder().startObject().field("field1", "c").endObject().bytes(), XContentType.JSON)))
             .add(client().prepareSearch("test")
-                .setQuery(new PercolateQueryBuilder("query", "type",
+                .setQuery(new PercolateQueryBuilder("query",
                     smileBuilder().startObject().field("field1", "b c").endObject().bytes(), XContentType.JSON)))
             .add(client().prepareSearch("test")
-                .setQuery(new PercolateQueryBuilder("query", "type",
+                .setQuery(new PercolateQueryBuilder("query",
                     jsonBuilder().startObject().field("field1", "d").endObject().bytes(), XContentType.JSON)))
             .add(client().prepareSearch("test")
-                .setQuery(new PercolateQueryBuilder("query", "type", "test", "type", "5", null, null, null)))
+                .setQuery(new PercolateQueryBuilder("query", "test", "type", "5", null, null, null)))
             .add(client().prepareSearch("test") // non existing doc, so error element
-                .setQuery(new PercolateQueryBuilder("query", "type", "test", "type", "6", null, null, null)))
+                .setQuery(new PercolateQueryBuilder("query", "test", "type", "6", null, null, null)))
             .get();
 
         MultiSearchResponse.Item item = response.getResponses()[0];

--- a/modules/percolator/src/test/resources/rest-api-spec/test/10_basic.yml
+++ b/modules/percolator/src/test/resources/rest-api-spec/test/10_basic.yml
@@ -5,7 +5,7 @@
         index: queries_index
         body:
           mappings:
-            type:
+            doc:
               properties:
                 query:
                   type: percolator
@@ -15,7 +15,7 @@
   - do:
       index:
         index: queries_index
-        type: type
+        type: doc
         id:   test_percolator
         body:
           query:
@@ -29,7 +29,6 @@
         body:
           - query:
               percolate:
-                document_type: type
                 field: query
                 document:
                   foo: bar
@@ -41,7 +40,6 @@
           - index: queries_index
           - query:
               percolate:
-                document_type: type
                 field: query
                 document:
                   foo: bar


### PR DESCRIPTION
The `document_type` parameter is no longer required to be specified,
because by default from 6.0 only a single type is allowed. (`index.mapping.single_type` defaults to `true`)