### PR TITLE
Fix GeoPoint FieldStats ternary logic bug

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/BaseGeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BaseGeoPointFieldMapper.java
@@ -661,8 +661,8 @@ public abstract class BaseGeoPointFieldMapper extends FieldMapper implements Arr
         return updated;
     }
 
-    private static GeoPoint prefixCodedToGeoPoint(BytesRef val, boolean isGeoCoded) {
-        final long encoded = isGeoCoded ? prefixCodedToGeoCoded(val) : LegacyNumericUtils.prefixCodedToLong(val);
+    private static GeoPoint prefixCodedToGeoPoint(BytesRef val, boolean numericEncoded) {
+        final long encoded = numericEncoded ? LegacyNumericUtils.prefixCodedToLong(val) : prefixCodedToGeoCoded(val);
         return new GeoPoint(MortonEncoder.decodeLatitude(encoded), MortonEncoder.decodeLongitude(encoded));
     }
 


### PR DESCRIPTION
The ternary logic in `prefixCodedToGeoPoint` was reversed such that numericEncoded GeoPoints were using the decoding logic for GeoCoded points and vice versa. This PR fixes that boneheaded bug.

closes #24275
