### PR TITLE
Docs: Add note about which secure settings are valid

### DIFF
--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -8,6 +8,9 @@ tool to manage the settings in the keystore.
 
 NOTE: All commands here should be run as the user which will run elasticsearch.
 
+NOTE: Only some settings are designed to be read from the keystore. See
+ documentation for each setting to see if it is supported as part of the keystore.
+
 [float]
 [[creating-keystore]]
 === Creating the keystore

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -9,7 +9,7 @@ tool to manage the settings in the keystore.
 NOTE: All commands here should be run as the user which will run elasticsearch.
 
 NOTE: Only some settings are designed to be read from the keystore. See
- documentation for each setting to see if it is supported as part of the keystore.
+documentation for each setting to see if it is supported as part of the keystore.
 
 [float]
 [[creating-keystore]]


### PR DESCRIPTION
This commit adds a note to the docs to clarify that only some settings
can be used with the keystore.