### PR TITLE
[Tests] Check that parsing aggregations works in a forward compatible way

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
@@ -128,7 +128,7 @@ public final class XContentParserUtils {
      */
     public static <T> void parseTypedKeysObject(XContentParser parser, String delimiter, Class<T> objectClass, Consumer<T> consumer)
             throws IOException {
-        assert parser.currentToken() == XContentParser.Token.START_OBJECT;
+        assert parser.currentToken() == XContentParser.Token.START_OBJECT || parser.currentToken() == XContentParser.Token.START_ARRAY;
         String currentFieldName = parser.currentName();
         if (Strings.hasLength(currentFieldName)) {
             int position = currentFieldName.indexOf(delimiter);

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
@@ -139,7 +139,8 @@ public final class XContentParserUtils {
                 return;
             }
         }
-        // this will only happen when the field name is empty or we don't find a delimiter
+        // If the field name is empty or we didn't find a delimiter we ignore
+        // the object for forward compatibility instead of throwing an error
         parser.skipChildren();
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
@@ -134,7 +134,7 @@ public final class XContentParserUtils {
             throws IOException {
         if (parser.currentToken() != XContentParser.Token.START_OBJECT && parser.currentToken() != XContentParser.Token.START_ARRAY) {
             throwUnknownToken(parser.currentToken(), parser.getTokenLocation());
-        };
+        }
         String currentFieldName = parser.currentName();
         if (Strings.hasLength(currentFieldName)) {
             int position = currentFieldName.indexOf(delimiter);

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
@@ -25,8 +25,8 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Locale;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -121,13 +121,12 @@ public final class XContentParserUtils {
      * @param parser      the current {@link XContentParser}
      * @param delimiter   the delimiter to use to splits the field's name
      * @param objectClass the object class of the object to parse
-     * @param objects     a list of objects the parsed one will be added to
+     * @param consumer    something to consume the parsed object
      * @param <T>         the type of the object to parse
-     * @return the parsed object
      * @throws IOException if anything went wrong during parsing or if the type or name cannot be derived
      *                     from the field's name
      */
-    public static <T> void parseTypedKeysObject(XContentParser parser, String delimiter, Class<T> objectClass, List<T> objects)
+    public static <T> void parseTypedKeysObject(XContentParser parser, String delimiter, Class<T> objectClass, Consumer<T> consumer)
             throws IOException {
         assert parser.currentToken() == XContentParser.Token.START_OBJECT;
         String currentFieldName = parser.currentName();
@@ -136,7 +135,7 @@ public final class XContentParserUtils {
             if (position > 0) {
                 String type = currentFieldName.substring(0, position);
                 String name = currentFieldName.substring(position + 1);
-                objects.add(parser.namedObject(objectClass, type, name));
+                consumer.accept(parser.namedObject(objectClass, type, name));
                 return;
             }
         }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
@@ -27,6 +27,7 @@ import org.elasticsearch.rest.action.search.RestSearchAction;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -122,22 +123,29 @@ public final class XContentParserUtils {
      * @param delimiter   the delimiter to use to splits the field's name
      * @param objectClass the object class of the object to parse
      * @param <T>         the type of the object to parse
+     * @param lenient     set to <tt>true</tt> if the method should throw a ParsingException in no delimeter was found
      * @return the parsed object
      * @throws IOException if anything went wrong during parsing or if the type or name cannot be derived
      *                     from the field's name
      */
-    public static <T> T parseTypedKeysObject(XContentParser parser, String delimiter, Class<T> objectClass) throws IOException {
+    public static <T> Optional<T> parseTypedKeysObject(XContentParser parser, String delimiter, Class<T> objectClass, boolean lenient)
+            throws IOException {
         String currentFieldName = parser.currentName();
         if (Strings.hasLength(currentFieldName)) {
             int position = currentFieldName.indexOf(delimiter);
             if (position > 0) {
                 String type = currentFieldName.substring(0, position);
                 String name = currentFieldName.substring(position + 1);
-                return parser.namedObject(objectClass, type, name);
+                return Optional.of(parser.namedObject(objectClass, type, name));
             }
         }
-        throw new ParsingException(parser.getTokenLocation(), "Cannot parse object of class [" + objectClass.getSimpleName()
-                + "] without type information. Set [" + RestSearchAction.TYPED_KEYS_PARAM + "] parameter on the request to ensure the"
-                + " type information is added to the response output");
+        if (lenient) {
+            parser.skipChildren();
+            return Optional.empty();
+        }
+        throw new ParsingException(parser.getTokenLocation(),
+                "Cannot parse object of class [" + objectClass.getSimpleName() + "] without type information. Set ["
+                        + RestSearchAction.TYPED_KEYS_PARAM
+                        + "] parameter on the request to ensure the type information is added to the response output");
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
@@ -133,7 +133,7 @@ public class Aggregations implements Iterable<Aggregation>, ToXContent {
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.START_OBJECT) {
-                parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
+                parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations::add);
             }
         }
         return new Aggregations(aggregations);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static java.util.Collections.unmodifiableMap;
 
@@ -133,7 +134,11 @@ public class Aggregations implements Iterable<Aggregation>, ToXContent {
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.START_OBJECT) {
-                aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
+                        Aggregation.class, true);
+                if (aggregation.isPresent()) {
+                    aggregations.add(aggregation.get());
+                }
             }
         }
         return new Aggregations(aggregations);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/Aggregations.java
@@ -21,7 +21,6 @@ package org.elasticsearch.search.aggregations;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,9 +30,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import static java.util.Collections.unmodifiableMap;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.parseTypedKeysObject;
 
 /**
  * Represents a set of {@link Aggregation}s
@@ -134,11 +133,7 @@ public class Aggregations implements Iterable<Aggregation>, ToXContent {
         XContentParser.Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.START_OBJECT) {
-                Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
-                        Aggregation.class, true);
-                if (aggregation.isPresent()) {
-                    aggregations.add(aggregation.get());
-                }
+                parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
             }
         }
         return new Aggregations(aggregations);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -171,7 +171,8 @@ public abstract class ParsedMultiBucketAggregation<B extends ParsedMultiBucketAg
                         bucket.setDocCount(parser.longValue());
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class,
+                            aggregations::add);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -30,6 +30,7 @@ import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -171,7 +172,11 @@ public abstract class ParsedMultiBucketAggregation<B extends ParsedMultiBucketAg
                         bucket.setDocCount(parser.longValue());
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
+                            Aggregation.class, true);
+                    if (aggregation.isPresent()) {
+                        aggregations.add(aggregation.get());
+                    }
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/ParsedMultiBucketAggregation.java
@@ -30,7 +30,6 @@ import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -172,11 +171,7 @@ public abstract class ParsedMultiBucketAggregation<B extends ParsedMultiBucketAg
                         bucket.setDocCount(parser.longValue());
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
-                            Aggregation.class, true);
-                    if (aggregation.isPresent()) {
-                        aggregations.add(aggregation.get());
-                    }
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
@@ -83,7 +83,8 @@ public abstract class ParsedSingleBucketAggregation extends ParsedAggregation im
                 if (CommonFields.META.getPreferredName().equals(currentFieldName)) {
                     aggregation.metadata = parser.map();
                 } else {
-                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class,
+                            aggregations::add);
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -84,11 +83,7 @@ public abstract class ParsedSingleBucketAggregation extends ParsedAggregation im
                 if (CommonFields.META.getPreferredName().equals(currentFieldName)) {
                     aggregation.metadata = parser.map();
                 } else {
-                    Optional<Aggregation> innerAggregation = XContentParserUtils.parseTypedKeysObject(parser,
-                            Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, true);
-                    if (innerAggregation.isPresent()) {
-                        aggregations.add(innerAggregation.get());
-                    }
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/ParsedSingleBucketAggregation.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -83,7 +84,11 @@ public abstract class ParsedSingleBucketAggregation extends ParsedAggregation im
                 if (CommonFields.META.getPreferredName().equals(currentFieldName)) {
                     aggregation.metadata = parser.map();
                 } else {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                    Optional<Aggregation> innerAggregation = XContentParserUtils.parseTypedKeysObject(parser,
+                            Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, true);
+                    if (innerAggregation.isPresent()) {
+                        aggregations.add(innerAggregation.get());
+                    }
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/ParsedFilters.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/ParsedFilters.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -131,7 +132,11 @@ public class ParsedFilters extends ParsedMultiBucketAggregation<ParsedFilters.Pa
                         bucket.setDocCount(parser.longValue());
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
+                            Aggregation.class, true);
+                    if (aggregation.isPresent()) {
+                        aggregations.add(aggregation.get());
+                    }
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/ParsedFilters.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/ParsedFilters.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -132,11 +131,7 @@ public class ParsedFilters extends ParsedMultiBucketAggregation<ParsedFilters.Pa
                         bucket.setDocCount(parser.longValue());
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
-                            Aggregation.class, true);
-                    if (aggregation.isPresent()) {
-                        aggregations.add(aggregation.get());
-                    }
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/ParsedFilters.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filters/ParsedFilters.java
@@ -131,7 +131,8 @@ public class ParsedFilters extends ParsedMultiBucketAggregation<ParsedFilters.Pa
                         bucket.setDocCount(parser.longValue());
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class,
+                            aggregations::add);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.aggregations.bucket.range.ip.IpRangeAggregationB
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -147,11 +146,7 @@ public class ParsedBinaryRange extends ParsedMultiBucketAggregation<ParsedBinary
                         bucket.to = parser.text();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
-                            Aggregation.class, true);
-                    if (aggregation.isPresent()) {
-                        aggregations.add(aggregation.get());
-                    }
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
@@ -146,7 +146,7 @@ public class ParsedBinaryRange extends ParsedMultiBucketAggregation<ParsedBinary
                         bucket.to = parser.text();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations::add);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
@@ -31,6 +31,7 @@ import org.elasticsearch.search.aggregations.bucket.range.ip.IpRangeAggregationB
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -146,7 +147,11 @@ public class ParsedBinaryRange extends ParsedMultiBucketAggregation<ParsedBinary
                         bucket.to = parser.text();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
+                            Aggregation.class, true);
+                    if (aggregation.isPresent()) {
+                        aggregations.add(aggregation.get());
+                    }
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedBinaryRange.java
@@ -146,7 +146,8 @@ public class ParsedBinaryRange extends ParsedMultiBucketAggregation<ParsedBinary
                         bucket.to = parser.text();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations::add);
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class,
+                            aggregations::add);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedRange.java
@@ -179,7 +179,8 @@ public class ParsedRange extends ParsedMultiBucketAggregation<ParsedRange.Parsed
                         bucket.toAsString = parser.text();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class,
+                            aggregations::add);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedRange.java
@@ -31,6 +31,7 @@ import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -179,7 +180,11 @@ public class ParsedRange extends ParsedMultiBucketAggregation<ParsedRange.Parsed
                         bucket.toAsString = parser.text();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
+                            Aggregation.class, true);
+                    if (aggregation.isPresent()) {
+                        aggregations.add(aggregation.get());
+                    }
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedRange.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/ParsedRange.java
@@ -31,7 +31,6 @@ import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
@@ -180,11 +179,7 @@ public class ParsedRange extends ParsedMultiBucketAggregation<ParsedRange.Parsed
                         bucket.toAsString = parser.text();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
-                            Aggregation.class, true);
-                    if (aggregation.isPresent()) {
-                        aggregations.add(aggregation.get());
-                    }
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantTerms.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -153,6 +154,7 @@ public abstract class ParsedSignificantTerms extends ParsedMultiBucketAggregatio
             return builder;
         }
 
+        @Override
         protected abstract XContentBuilder keyToXContent(XContentBuilder builder) throws IOException;
 
         static <B extends ParsedBucket> B parseSignificantTermsBucketXContent(final XContentParser parser, final B bucket,
@@ -179,7 +181,11 @@ public abstract class ParsedSignificantTerms extends ParsedMultiBucketAggregatio
                         bucket.supersetDf = parser.longValue();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
+                            Aggregation.class, true);
+                    if (aggregation.isPresent()) {
+                        aggregations.add(aggregation.get());
+                    }
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantTerms.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -181,11 +180,7 @@ public abstract class ParsedSignificantTerms extends ParsedMultiBucketAggregatio
                         bucket.supersetDf = parser.longValue();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    Optional<Aggregation> aggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER,
-                            Aggregation.class, true);
-                    if (aggregation.isPresent()) {
-                        aggregations.add(aggregation.get());
-                    }
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/ParsedSignificantTerms.java
@@ -180,7 +180,8 @@ public abstract class ParsedSignificantTerms extends ParsedMultiBucketAggregatio
                         bucket.supersetDf = parser.longValue();
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class,
+                            aggregations::add);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
@@ -32,7 +32,6 @@ import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME;
@@ -137,11 +136,7 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation<ParsedTer
                         bucket.showDocCountError = true;
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    Optional<Aggregation> innerAggregation = XContentParserUtils.parseTypedKeysObject(parser,
-                            Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, true);
-                    if (innerAggregation.isPresent()) {
-                        aggregations.add(innerAggregation.get());
-                    }
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
@@ -136,7 +136,8 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation<ParsedTer
                         bucket.showDocCountError = true;
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
+                    XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class,
+                            aggregations::add);
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/ParsedTerms.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME;
@@ -136,7 +137,11 @@ public abstract class ParsedTerms extends ParsedMultiBucketAggregation<ParsedTer
                         bucket.showDocCountError = true;
                     }
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    aggregations.add(XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class));
+                    Optional<Aggregation> innerAggregation = XContentParserUtils.parseTypedKeysObject(parser,
+                            Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, true);
+                    if (innerAggregation.isPresent()) {
+                        aggregations.add(innerAggregation.get());
+                    }
                 }
             }
             bucket.setAggregations(new Aggregations(aggregations));

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/ParsedPercentiles.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/ParsedPercentiles.java
@@ -140,6 +140,8 @@ public abstract class ParsedPercentiles extends ParsedAggregation implements Ite
                         }
                     } else if (token == XContentParser.Token.VALUE_NULL) {
                         aggregation.addPercentile(Double.valueOf(parser.currentName()), Double.NaN);
+                    } else {
+                        parser.skipChildren(); // skip potential inner objects and arrays for forward compatibility
                     }
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
@@ -164,6 +166,8 @@ public abstract class ParsedPercentiles extends ParsedAggregation implements Ite
                             }
                         } else if (token == XContentParser.Token.VALUE_NULL) {
                             value = Double.NaN;
+                        } else {
+                            parser.skipChildren(); // skip potential inner objects and arrays for forward compatibility
                         }
                     }
                     if (key != null) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -387,7 +387,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         @SuppressWarnings("unchecked")
         public static Suggestion<? extends Entry<? extends Option>> fromXContent(XContentParser parser) throws IOException {
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
-            return XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggestion.class);
+            return XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggestion.class, true).get();
         }
 
         protected static <E extends Suggestion.Entry<?>> void parseEntries(XContentParser parser, Suggestion<E> suggestion,

--- a/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -177,7 +177,10 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         List<Suggestion<? extends Entry<? extends Option>>> suggestions = new ArrayList<>();
         while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            suggestions.add(Suggestion.fromXContent(parser));
+            Suggestion<? extends Entry<? extends Option>> suggestion = Suggestion.fromXContent(parser);
+            if (suggestion != null) {
+                suggestions.add(suggestion);
+            }
         }
         return new Suggest(suggestions);
     }
@@ -387,7 +390,13 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         @SuppressWarnings("unchecked")
         public static Suggestion<? extends Entry<? extends Option>> fromXContent(XContentParser parser) throws IOException {
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
-            return XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggestion.class, true).get();
+            List<Suggestion> suggestions = new ArrayList<>();
+            XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggestion.class, suggestions);
+            if (suggestions.isEmpty() == false) {
+                return suggestions.get(0);
+            } else {
+                return null;
+            }
         }
 
         protected static <E extends Suggestion.Entry<?>> void parseEntries(XContentParser parser, Suggestion<E> suggestion,

--- a/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -178,6 +178,8 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         List<Suggestion<? extends Entry<? extends Option>>> suggestions = new ArrayList<>();
         while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);
             Suggestion<? extends Entry<? extends Option>> suggestion = Suggestion.fromXContent(parser);
             if (suggestion != null) {
                 suggestions.add(suggestion);
@@ -390,7 +392,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
         @SuppressWarnings("unchecked")
         public static Suggestion<? extends Entry<? extends Option>> fromXContent(XContentParser parser) throws IOException {
-            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation);
             SetOnce<Suggestion> suggestion = new SetOnce<>();
             XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggestion.class, suggestion::set);
             return suggestion.get();
@@ -399,7 +401,7 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         protected static <E extends Suggestion.Entry<?>> void parseEntries(XContentParser parser, Suggestion<E> suggestion,
                                                                            CheckedFunction<XContentParser, E, IOException> entryParser)
                 throws IOException {
-            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation);
             while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                 suggestion.addTerm(entryParser.apply(parser));
             }

--- a/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.suggest;
 
 import org.apache.lucene.util.CollectionUtil;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -390,13 +391,9 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         @SuppressWarnings("unchecked")
         public static Suggestion<? extends Entry<? extends Option>> fromXContent(XContentParser parser) throws IOException {
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
-            List<Suggestion> suggestions = new ArrayList<>();
-            XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggestion.class, suggestions);
-            if (suggestions.isEmpty() == false) {
-                return suggestions.get(0);
-            } else {
-                return null;
-            }
+            SetOnce<Suggestion> suggestion = new SetOnce<>();
+            XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggestion.class, suggestion::set);
+            return suggestion.get();
         }
 
         protected static <E extends Suggestion.Entry<?>> void parseEntries(XContentParser parser, Suggestion<E> suggestion,

--- a/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -49,6 +50,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -179,10 +181,14 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
         List<Suggestion<? extends Entry<? extends Option>>> suggestions = new ArrayList<>();
         while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
+            String currentField = parser.currentName();
             ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);
             Suggestion<? extends Entry<? extends Option>> suggestion = Suggestion.fromXContent(parser);
             if (suggestion != null) {
                 suggestions.add(suggestion);
+            } else {
+                throw new ParsingException(parser.getTokenLocation(),
+                        String.format(Locale.ROOT, "Could not parse suggestion keyed as [%s]", currentField));
             }
         }
         return new Suggest(suggestions);

--- a/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.xcontent;
 
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -69,7 +70,7 @@ public class XContentParserUtilsTests extends ESTestCase {
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
 
             NamedXContentRegistry.UnknownNamedObjectException e = expectThrows(NamedXContentRegistry.UnknownNamedObjectException.class,
-                    () -> parseTypedKeysObject(parser, delimiter, Boolean.class, new ArrayList<>()));
+                    () -> parseTypedKeysObject(parser, delimiter, Boolean.class, a -> {}));
             assertEquals("Unknown Boolean [type]", e.getMessage());
             assertEquals("type", e.getName());
             assertEquals("java.lang.Boolean", e.getCategoryClass());
@@ -87,18 +88,16 @@ public class XContentParserUtilsTests extends ESTestCase {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
 
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
-            List<Long> parsedLong = new ArrayList<>();
-            parseTypedKeysObject(parser, delimiter, Long.class, parsedLong);
+            SetOnce<Long> parsedLong = new SetOnce<>();
+            parseTypedKeysObject(parser, delimiter, Long.class, parsedLong::set);
             assertNotNull(parsedLong);
-            assertEquals(1, parsedLong.size());
-            assertEquals(longValue, parsedLong.get(0).longValue());
+            assertEquals(longValue, parsedLong.get().longValue());
 
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
-            List<Boolean> parsedBoolean = new ArrayList<>();
-            parseTypedKeysObject(parser, delimiter, Boolean.class, parsedBoolean);
+            SetOnce<Boolean> parsedBoolean = new SetOnce<>();
+            parseTypedKeysObject(parser, delimiter, Boolean.class, parsedBoolean::set);
             assertNotNull(parsedBoolean);
-            assertEquals(1, parsedBoolean.size());
-            assertEquals(boolValue, parsedBoolean.get(0));
+            assertEquals(boolValue, parsedBoolean.get());
 
             ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser::getTokenLocation);
         }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
@@ -68,7 +68,7 @@ public class XContentParserUtilsTests extends ESTestCase {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
 
-            ParsingException e = expectThrows(ParsingException.class, () -> parseTypedKeysObject(parser, delimiter, Boolean.class));
+            ParsingException e = expectThrows(ParsingException.class, () -> parseTypedKeysObject(parser, delimiter, Boolean.class, false));
             assertEquals("Cannot parse object of class [Boolean] without type information. Set [typed_keys] parameter " +
                     "on the request to ensure the type information is added to the response output", e.getMessage());
         }
@@ -79,7 +79,7 @@ public class XContentParserUtilsTests extends ESTestCase {
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
 
             NamedXContentRegistry.UnknownNamedObjectException e = expectThrows(NamedXContentRegistry.UnknownNamedObjectException.class,
-                    () -> parseTypedKeysObject(parser, delimiter, Boolean.class));
+                    () -> parseTypedKeysObject(parser, delimiter, Boolean.class, false));
             assertEquals("Unknown Boolean [type]", e.getMessage());
             assertEquals("type", e.getName());
             assertEquals("java.lang.Boolean", e.getCategoryClass());
@@ -97,12 +97,12 @@ public class XContentParserUtilsTests extends ESTestCase {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
 
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
-            Long parsedLong = parseTypedKeysObject(parser, delimiter, Long.class);
+            Long parsedLong = parseTypedKeysObject(parser, delimiter, Long.class, false).get();
             assertNotNull(parsedLong);
             assertEquals(longValue, parsedLong.longValue());
 
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
-            Boolean parsedBoolean = parseTypedKeysObject(parser, delimiter, Boolean.class);
+            Boolean parsedBoolean = parseTypedKeysObject(parser, delimiter, Boolean.class, false).get();
             assertNotNull(parsedBoolean);
             assertEquals(boolValue, parsedBoolean);
 

--- a/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
@@ -53,22 +53,37 @@ public class XContentParserUtilsTests extends ESTestCase {
         final String delimiter = randomFrom("#", ":", "/", "-", "_", "|", "_delim_");
         final XContentType xContentType = randomFrom(XContentType.values());
 
+        final ObjectParser<SetOnce<Boolean>, Void> BOOLPARSER = new ObjectParser<>("bool", () -> new SetOnce<>());
+        BOOLPARSER.declareBoolean(SetOnce::set, new ParseField("field"));
+        final ObjectParser<SetOnce<Long>, Void> LONGPARSER = new ObjectParser<>("long", () -> new SetOnce<>());
+        LONGPARSER.declareLong(SetOnce::set, new ParseField("field"));
+
         List<NamedXContentRegistry.Entry> namedXContents = new ArrayList<>();
-        namedXContents.add(new NamedXContentRegistry.Entry(Boolean.class, new ParseField("bool"), parser -> {
-            ensureExpectedToken(XContentParser.Token.VALUE_BOOLEAN, parser.nextToken(), parser::getTokenLocation);
-            return parser.booleanValue();
-        }));
-        namedXContents.add(new NamedXContentRegistry.Entry(Long.class, new ParseField("long"), parser -> {
-            ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, parser.nextToken(), parser::getTokenLocation);
-            return parser.longValue();
-        }));
+        namedXContents.add(new NamedXContentRegistry.Entry(Boolean.class, new ParseField("bool"), p -> BOOLPARSER.parse(p, null).get()));
+        namedXContents.add(new NamedXContentRegistry.Entry(Long.class, new ParseField("long"), p -> LONGPARSER.parse(p, null).get()));
         final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(namedXContents);
 
-        BytesReference bytes = toXContent((builder, params) -> builder.field("type" + delimiter + "name", 0), xContentType, randomBoolean());
+        BytesReference bytes = toXContent((builder, params) -> builder.startObject("name").field("field", 0).endObject(), xContentType,
+                randomBoolean());
         try (XContentParser parser = xContentType.xContent().createParser(namedXContentRegistry, bytes)) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            SetOnce<Boolean> booleanConsumer = new SetOnce<>();
+            parseTypedKeysObject(parser, delimiter, Boolean.class, booleanConsumer::set);
+            // because of the missing type to identify the parser, we expect no return value, but also no exception
+            assertNull(booleanConsumer.get());
+            ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.currentToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            assertNull(parser.nextToken());
+        }
 
+        bytes = toXContent((builder, params) -> builder.startObject("type" + delimiter + "name").field("bool", true).endObject(),
+                xContentType, randomBoolean());
+        try (XContentParser parser = xContentType.xContent().createParser(namedXContentRegistry, bytes)) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             NamedXContentRegistry.UnknownNamedObjectException e = expectThrows(NamedXContentRegistry.UnknownNamedObjectException.class,
                     () -> parseTypedKeysObject(parser, delimiter, Boolean.class, a -> {}));
             assertEquals("Unknown Boolean [type]", e.getMessage());
@@ -79,8 +94,8 @@ public class XContentParserUtilsTests extends ESTestCase {
         final long longValue = randomLong();
         final boolean boolValue = randomBoolean();
         bytes = toXContent((builder, params) -> {
-            builder.field("long" + delimiter + "l", longValue);
-            builder.field("bool" + delimiter + "b", boolValue);
+            builder.startObject("long" + delimiter + "l").field("field", longValue).endObject();
+            builder.startObject("bool" + delimiter + "l").field("field", boolValue).endObject();
             return builder;
         }, xContentType, randomBoolean());
 
@@ -88,12 +103,14 @@ public class XContentParserUtilsTests extends ESTestCase {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
 
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             SetOnce<Long> parsedLong = new SetOnce<>();
             parseTypedKeysObject(parser, delimiter, Long.class, parsedLong::set);
             assertNotNull(parsedLong);
             assertEquals(longValue, parsedLong.get().longValue());
 
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             SetOnce<Boolean> parsedBoolean = new SetOnce<>();
             parseTypedKeysObject(parser, delimiter, Boolean.class, parsedBoolean::set);
             assertNotNull(parsedBoolean);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregationTestCase.java
@@ -90,7 +90,7 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
 
     public void testIterators() throws IOException {
         final T aggregation = createTestInstance();
-        assertMultiBucketsAggregations(aggregation, parseAndAssert(aggregation, false), true);
+        assertMultiBucketsAggregations(aggregation, parseAndAssert(aggregation, false, false), true);
     }
 
     private void assertMultiBucketsAggregations(Aggregation expected, Aggregation actual, boolean checkOrder) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/AbstractPercentilesTestCase.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.Aggregation.CommonFields;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -29,6 +30,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public abstract class AbstractPercentilesTestCase<T extends InternalAggregation & Iterable<Percentile>>
         extends InternalAggregationTestCase<T> {
@@ -62,7 +64,7 @@ public abstract class AbstractPercentilesTestCase<T extends InternalAggregation 
 
     public void testPercentilesIterators() throws IOException {
         final T aggregation = createTestInstance();
-        final Iterable<Percentile> parsedAggregation = parseAndAssert(aggregation, false);
+        final Iterable<Percentile> parsedAggregation = parseAndAssert(aggregation, false, false);
 
         Iterator<Percentile> it = aggregation.iterator();
         Iterator<Percentile> parsedIt = parsedAggregation.iterator();
@@ -81,5 +83,10 @@ public abstract class AbstractPercentilesTestCase<T extends InternalAggregation 
             Arrays.sort(percents);
         }
         return percents;
+    }
+
+    @Override
+    protected Predicate<String> excludePathsFromXContentInsertion() {
+        return path -> path.endsWith(CommonFields.VALUES.getPreferredName());
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentilesTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/InternalPercentilesTestCase.java
@@ -21,9 +21,6 @@ package org.elasticsearch.search.aggregations.metrics.percentiles;
 
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
-import org.elasticsearch.test.InternalAggregationTestCase;
-import org.junit.Before;
 
 import java.util.List;
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentilesRanksTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/percentiles/hdr/InternalHDRPercentilesRanksTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.metrics.percentiles.InternalPercentilesRanksTestCase;
 import org.elasticsearch.search.aggregations.metrics.percentiles.ParsedPercentiles;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
-import org.elasticsearch.test.InternalAggregationTestCase;
 
 import java.util.Arrays;
 import java.util.List;

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetricTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetricTests.java
@@ -189,6 +189,6 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
 
     @Override
     protected Predicate<String> excludePathsFromXContentInsertion() {
-        return path -> path.endsWith(CommonFields.VALUE.getPreferredName());
+        return path -> path.contains(CommonFields.VALUE.getPreferredName());
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetricTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetricTests.java
@@ -24,11 +24,11 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.aggregations.Aggregation.CommonFields;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public class InternalScriptedMetricTests extends InternalAggregationTestCase<InternalScriptedMetric> {
@@ -184,5 +185,10 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
         } else {
             assertEquals(expected, actual);
         }
+    }
+
+    @Override
+    protected Predicate<String> excludePathsFromXContentInsertion() {
+        return path -> path.endsWith(CommonFields.VALUE.getPreferredName());
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/percentile/InternalPercentilesBucketTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/bucketmetrics/percentile/InternalPercentilesBucketTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.pipeline.bucketmetrics.percentile;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.Aggregation.CommonFields;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.metrics.percentiles.Percentile;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
@@ -31,6 +32,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.search.aggregations.metrics.percentiles.InternalPercentilesTestCase.randomPercents;
 
@@ -110,11 +112,16 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
 
     public void testParsedAggregationIteratorOrder() throws IOException {
         final InternalPercentilesBucket aggregation = createTestInstance();
-        final Iterable<Percentile> parsedAggregation = parseAndAssert(aggregation, false);
+        final Iterable<Percentile> parsedAggregation = parseAndAssert(aggregation, false, false);
         Iterator<Percentile> it = aggregation.iterator();
         Iterator<Percentile> parsedIt = parsedAggregation.iterator();
         while (it.hasNext()) {
             assertEquals(it.next(), parsedIt.next());
         }
+    }
+
+    @Override
+    protected Predicate<String> excludePathsFromXContentInsertion() {
+        return path -> path.endsWith(CommonFields.VALUES.getPreferredName());
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
@@ -144,23 +144,6 @@ public class SuggestionTests extends ESTestCase {
         }
     }
 
-//    /**
-//     * test that we throw error if RestSearchAction.TYPED_KEYS_PARAM isn't set while rendering xContent
-//     */
-//    public void testFromXContentFailsWithoutTypeParam() throws IOException {
-//        XContentType xContentType = randomFrom(XContentType.values());
-//        BytesReference originalBytes = toXContent(createTestItem(), xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
-//        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
-//            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
-//            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
-//            ParsingException e = expectThrows(ParsingException.class, () -> Suggestion.fromXContent(parser));
-//            assertEquals(
-//                    "Cannot parse object of class [Suggestion] without type information. "
-//                    + "Set [typed_keys] parameter on the request to ensure the type information "
-//                    + "is added to the response output", e.getMessage());
-//        }
-//    }
-
     public void testUnknownSuggestionTypeThrows() throws IOException {
         XContent xContent = JsonXContent.jsonXContent;
         String suggestionString =

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
@@ -144,22 +144,22 @@ public class SuggestionTests extends ESTestCase {
         }
     }
 
-    /**
-     * test that we throw error if RestSearchAction.TYPED_KEYS_PARAM isn't set while rendering xContent
-     */
-    public void testFromXContentFailsWithoutTypeParam() throws IOException {
-        XContentType xContentType = randomFrom(XContentType.values());
-        BytesReference originalBytes = toXContent(createTestItem(), xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
-        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
-            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
-            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
-            ParsingException e = expectThrows(ParsingException.class, () -> Suggestion.fromXContent(parser));
-            assertEquals(
-                    "Cannot parse object of class [Suggestion] without type information. "
-                    + "Set [typed_keys] parameter on the request to ensure the type information "
-                    + "is added to the response output", e.getMessage());
-        }
-    }
+//    /**
+//     * test that we throw error if RestSearchAction.TYPED_KEYS_PARAM isn't set while rendering xContent
+//     */
+//    public void testFromXContentFailsWithoutTypeParam() throws IOException {
+//        XContentType xContentType = randomFrom(XContentType.values());
+//        BytesReference originalBytes = toXContent(createTestItem(), xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
+//        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+//            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+//            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
+//            ParsingException e = expectThrows(ParsingException.class, () -> Suggestion.fromXContent(parser));
+//            assertEquals(
+//                    "Cannot parse object of class [Suggestion] without type information. "
+//                    + "Set [typed_keys] parameter on the request to ensure the type information "
+//                    + "is added to the response output", e.getMessage());
+//        }
+//    }
 
     public void testUnknownSuggestionTypeThrows() throws IOException {
         XContent xContent = JsonXContent.jsonXContent;

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
@@ -132,6 +132,7 @@ public class SuggestionTests extends ESTestCase {
             try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
                 ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
+                ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);
                 parsed = Suggestion.fromXContent(parser);
                 assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
                 assertNull(parser.nextToken());
@@ -141,6 +142,22 @@ public class SuggestionTests extends ESTestCase {
             // We don't parse size via xContent, instead we set it to -1 on the client side
             assertEquals(-1, parsed.getSize());
             assertToXContentEquivalent(originalBytes, toXContent(parsed, xContentType, params, humanReadable), xContentType);
+        }
+    }
+
+    /**
+     * test that we parse nothing if RestSearchAction.TYPED_KEYS_PARAM isn't set while rendering xContent and we cannot find
+     * suggestion type information
+     */
+    public void testFromXContentWithoutTypeParam() throws IOException {
+        XContentType xContentType = randomFrom(XContentType.values());
+        BytesReference originalBytes = toXContent(createTestItem(), xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
+        try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);
+            assertNull(Suggestion.fromXContent(parser));
+            ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser::getTokenLocation);
         }
     }
 
@@ -160,6 +177,7 @@ public class SuggestionTests extends ESTestCase {
         try (XContentParser parser = xContent.createParser(xContentRegistry(), suggestionString)) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
+            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);
             ParsingException e = expectThrows(ParsingException.class, () -> Suggestion.fromXContent(parser));
             assertEquals("Unknown Suggestion [unknownType]", e.getMessage());
         }

--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStatsTests.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStatsTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
+import org.elasticsearch.search.aggregations.matrix.stats.InternalMatrixStats.Fields;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -38,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public class InternalMatrixStatsTests extends InternalAggregationTestCase<InternalMatrixStats> {
 
@@ -169,5 +171,10 @@ public class InternalMatrixStatsTests extends InternalAggregationTestCase<Intern
             expectThrows(IllegalArgumentException.class, () -> matrix.getCorrelation(unknownField, other));
             expectThrows(IllegalArgumentException.class, () -> matrix.getCorrelation(other, unknownField));
         }
+    }
+
+    @Override
+    protected Predicate<String> excludePathsFromXContentInsertion() {
+        return path -> path.endsWith(Fields.CORRELATION) || path.endsWith(Fields.COVARIANCE);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -328,11 +328,15 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         }
         BytesReference mutated;
         if (addRandomFields) {
-            /**
-             * - we don't add to the root object because it should only contain the named aggregation to test
-             * - we don't want to insert into the "meta" object, because we pass on everything we find there
-             * - we don't want to directly insert anything random into "buckets" objects, they are used with "keyed" aggregations and contain
-             *   named bucket objects. Any new named object on this level should also be a bucket and be parsed as such.
+            /*
+             * - we don't add to the root object because it should only contain
+             * the named aggregation to test - we don't want to insert into the
+             * "meta" object, because we pass on everything we find there
+             *
+             * - we don't want to directly insert anything random into "buckets"
+             * objects, they are used with "keyed" aggregations and contain
+             * named bucket objects. Any new named object on this level should
+             * also be a bucket and be parsed as such.
              */
             Predicate<String> basicExcludes = path -> path.isEmpty() || path.endsWith(Aggregation.CommonFields.META.getPreferredName())
                     || path.endsWith(Aggregation.CommonFields.BUCKETS.getPreferredName());
@@ -346,6 +350,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
             assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
             assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
             XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, parsedAggregation::set);
 
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -330,7 +330,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
             /**
              * - we don't add to the root object because it should only contain the named aggregation to test
              * - we don't want to insert into the "meta" object, because we pass on everything we find there
-             * - we don't want to directly insert anything ranodm into "buckets" objects, they are used with "keyed" aggregations and contain
+             * - we don't want to directly insert anything random into "buckets" objects, they are used with "keyed" aggregations and contain
              *   named bucket objects. Any new named object on this level should also be a bucket and be parsed as such.
              */
             Predicate<String> basicExcludes = path -> path.isEmpty() || path.endsWith(Aggregation.CommonFields.META.getPreferredName())
@@ -345,8 +345,9 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
             assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
             assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-
-            parsedAggregation = XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, false).get();
+            List<Aggregation> aggregations = new ArrayList<>();
+            XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, aggregations);
+            parsedAggregation = aggregations.get(0);
 
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
             assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());

--- a/test/framework/src/main/java/org/elasticsearch/test/XContentTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/XContentTestUtils.java
@@ -195,23 +195,20 @@ public final class XContentTestUtils {
             }
         }
 
-        try (XContentParser parser = createParser(NamedXContentRegistry.EMPTY, xContent, contentType)) {
-            Supplier<Object> value = () -> {
-                List<Object> randomValues = RandomObjects.randomStoredFieldValues(random, contentType).v1();
+        Supplier<Object> value = () -> {
+            List<Object> randomValues = RandomObjects.randomStoredFieldValues(random, contentType).v1();
+            if (random.nextBoolean()) {
+                return randomValues.get(0);
+            } else {
                 if (random.nextBoolean()) {
-                    return randomValues.get(0);
+                    return randomValues.stream().collect(Collectors.toMap(obj -> randomAsciiOfLength(random, 10), obj -> obj));
                 } else {
-                    if (random.nextBoolean()) {
-                        return randomValues.stream().collect(Collectors.toMap(obj -> randomAsciiOfLength(random, 10), obj -> obj));
-                    } else {
-                        return randomValues;
-                    }
+                    return randomValues;
                 }
-            };
-            return XContentTestUtils
-                    .insertIntoXContent(contentType.xContent(), xContent, insertPaths, () -> randomAsciiOfLength(random, 10), value)
-                    .bytes();
-        }
+            }
+        };
+        return XContentTestUtils
+                .insertIntoXContent(contentType.xContent(), xContent, insertPaths, () -> randomAsciiOfLength(random, 10), value).bytes();
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/XContentTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/XContentTestUtils.java
@@ -32,13 +32,13 @@ import org.elasticsearch.test.rest.yaml.ObjectPath;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Stack;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static com.carrotsearch.randomizedtesting.generators.RandomStrings.randomAsciiOfLength;
 import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
@@ -197,13 +197,14 @@ public final class XContentTestUtils {
 
         try (XContentParser parser = createParser(NamedXContentRegistry.EMPTY, xContent, contentType)) {
             Supplier<Object> value = () -> {
+                List<Object> randomValues = RandomObjects.randomStoredFieldValues(random, contentType).v1();
                 if (random.nextBoolean()) {
-                    return RandomObjects.randomStoredFieldValues(random, contentType);
+                    return randomValues.get(0);
                 } else {
                     if (random.nextBoolean()) {
-                        return Collections.singletonMap(randomAsciiOfLength(random, 10), randomAsciiOfLength(random, 10));
+                        return randomValues.stream().collect(Collectors.toMap(obj -> randomAsciiOfLength(random, 10), obj -> obj));
                     } else {
-                        return Collections.singletonList(randomAsciiOfLength(random, 10));
+                        return randomValues;
                     }
                 }
             };

--- a/test/framework/src/main/java/org/elasticsearch/test/XContentTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/XContentTestUtils.java
@@ -249,7 +249,8 @@ public final class XContentTestUtils {
         List<String> validPaths = new ArrayList<>();
         // parser.currentName() can be null for root object and unnamed objects in arrays
         if (parser.currentName() != null) {
-            currentPath.push(parser.currentName());
+            // dots in randomized field names need to be escaped, we use that character as the path separator
+            currentPath.push(parser.currentName().replaceAll("\\.", "\\\\."));
         }
         if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
             validPaths.add(String.join(".", currentPath.toArray(new String[currentPath.size()])));

--- a/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
@@ -61,7 +61,7 @@ public class XContentTestUtilsTests extends ESTestCase {
             builder.startObject("inner1");
             {
                 builder.field("inner1field1", "value");
-                builder.startObject("inner2");
+                builder.startObject("inn.er2");
                 {
                     builder.field("inner2field1", "value");
                 }
@@ -79,7 +79,7 @@ public class XContentTestUtilsTests extends ESTestCase {
             assertThat(insertPaths, hasItem(equalTo("list1.2")));
             assertThat(insertPaths, hasItem(equalTo("list1.4")));
             assertThat(insertPaths, hasItem(equalTo("inner1")));
-            assertThat(insertPaths, hasItem(equalTo("inner1.inner2")));
+            assertThat(insertPaths, hasItem(equalTo("inner1.inn\\.er2")));
         }
     }
 
@@ -89,19 +89,19 @@ public class XContentTestUtilsTests extends ESTestCase {
         builder.startObject();
         builder.endObject();
         builder = XContentTestUtils.insertIntoXContent(XContentType.JSON.xContent(), builder.bytes(), Collections.singletonList(""),
-                () -> "inner1", () -> new HashMap<>());
+                () -> "inn.er1", () -> new HashMap<>());
         builder = XContentTestUtils.insertIntoXContent(XContentType.JSON.xContent(), builder.bytes(), Collections.singletonList(""),
                 () -> "field1", () -> "value1");
-        builder = XContentTestUtils.insertIntoXContent(XContentType.JSON.xContent(), builder.bytes(), Collections.singletonList("inner1"),
-                () -> "inner2", () -> new HashMap<>());
-        builder = XContentTestUtils.insertIntoXContent(XContentType.JSON.xContent(), builder.bytes(), Collections.singletonList("inner1"),
-                () -> "field2", () -> "value2");
+        builder = XContentTestUtils.insertIntoXContent(XContentType.JSON.xContent(), builder.bytes(),
+                Collections.singletonList("inn\\.er1"), () -> "inner2", () -> new HashMap<>());
+        builder = XContentTestUtils.insertIntoXContent(XContentType.JSON.xContent(), builder.bytes(),
+                Collections.singletonList("inn\\.er1"), () -> "field2", () -> "value2");
         try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, builder.bytes(), builder.contentType())) {
             Map<String, Object> map = parser.map();
             assertEquals(2, map.size());
             assertEquals("value1", map.get("field1"));
-            assertThat(map.get("inner1"), instanceOf(Map.class));
-            Map<String, Object> innerMap = (Map<String, Object>) map.get("inner1");
+            assertThat(map.get("inn.er1"), instanceOf(Map.class));
+            Map<String, Object> innerMap = (Map<String, Object>) map.get("inn.er1");
             assertEquals(2, innerMap.size());
             assertEquals("value2", innerMap.get("field2"));
             assertThat(innerMap.get("inner2"), instanceOf(Map.class));


### PR DESCRIPTION
This change adds tests for the aggregation parsing that try to simulate that we can parse existing aggregations in a forward compatible way in the future, ignoring potential newly added fields or substructures to the xContent response. 

Marked as WIP because expect some discussions around how we want to handle parsing inner objects where we now expect only inner aggregations, e.g. in cases like this:

```
{
	"filter#myFilterAgg": {
                "meta": {},
		"doc_count": 524513125,
		"max#myMaxAgg": {
			"meta": {},
			"value": 0.14740193438495786
		},		
		"someNewInnerObject": {
			"foo": "bar"
		}
	}
}
```

Currently we would throw an Exception because we only parse the meta data objects and treat all other objects as if they were named inner aggregations. We need to decide if adding any other inner object in the future is likely and how we should parse this in clients that don't understand this yet. The current solution in this PR is to have a "lenient" flag `parseTypedKeysObject()` and skip over things that don't contain a type delimiter.

The next question would be what we do to handle future aggregation types, e.g. the response is:

```
{
	"filter#myFilterAgg": {
                "meta": {},
		"doc_count": 524513125,
		"max#myMaxAgg": {
			"meta": {},
			"value": 0.14740193438495786
		},		
		"futureAggType#myName": {
			"foo": "bar"
		}
	}
}
```

If a client who doesn't undestand this new type yet is receiving above response, we currently will throw an exception. Maybe we should also be lenient in this case, but it would at least be good to notify the user that there are some parts missing from the response object that couldn't be parsed. I don't know if we have decided on logging etc... for such cases.