### PR TITLE
[DOCS] Clarify expected availability of HDFS for the HDFS Repository

### DIFF
--- a/docs/plugins/repository-hdfs.asciidoc
+++ b/docs/plugins/repository-hdfs.asciidoc
@@ -81,8 +81,9 @@ The following settings are supported:
 ===== A Note on HDFS Availablility
 When you initialize a repository, its settings are persisted in the cluster state. When a node comes online, it will
 attempt to create all repositories for which it has settings. If your cluster has an HDFS repository configured, then
-all nodes in the cluster must be able to reach HDFS when starting. If not, then the node may fail to create the
-repository at start up. If this happens, you may need to remove and re-add the repository or restart the offending node.
+all nodes in the cluster must be able to reach HDFS when starting. If not, then the node will fail to initialize the
+repository at start up and the repository will be unusable. If this happens, you will need to remove and re-add the
+repository or restart the offending node.
 
 [[repository-hdfs-security]]
 ==== Hadoop Security

--- a/docs/plugins/repository-hdfs.asciidoc
+++ b/docs/plugins/repository-hdfs.asciidoc
@@ -76,6 +76,14 @@ The following settings are supported:
     the pattern with the hostname of the node at runtime (see
     link:repository-hdfs-security-runtime[Creating the Secure Repository]).
 
+[[repository-hdfs-availability]]
+[float]
+===== A Note on HDFS Availablility
+When you create a repository, its settings are persisted in the cluster state. When a node comes online, it will
+attempt to create all repositories for which it has settings. If your cluster has an HDFS repository configured, then
+all nodes in the cluster must be able to reach HDFS, even when starting. If not, then the node may fail to create the
+repository at start up. If this happens, you may need to remove and re-add the repository or restart the offending node.
+
 [[repository-hdfs-security]]
 ==== Hadoop Security
 

--- a/docs/plugins/repository-hdfs.asciidoc
+++ b/docs/plugins/repository-hdfs.asciidoc
@@ -79,7 +79,7 @@ The following settings are supported:
 [[repository-hdfs-availability]]
 [float]
 ===== A Note on HDFS Availablility
-When you create a repository, its settings are persisted in the cluster state. When a node comes online, it will
+When you initialize a repository, its settings are persisted in the cluster state. When a node comes online, it will
 attempt to create all repositories for which it has settings. If your cluster has an HDFS repository configured, then
 all nodes in the cluster must be able to reach HDFS, even when starting. If not, then the node may fail to create the
 repository at start up. If this happens, you may need to remove and re-add the repository or restart the offending node.

--- a/docs/plugins/repository-hdfs.asciidoc
+++ b/docs/plugins/repository-hdfs.asciidoc
@@ -80,7 +80,7 @@ The following settings are supported:
 [float]
 ===== A Note on HDFS Availablility
 When you initialize a repository, its settings are persisted in the cluster state. When a node comes online, it will
-attempt to create all repositories for which it has settings. If your cluster has an HDFS repository configured, then
+attempt to initialize all repositories for which it has settings. If your cluster has an HDFS repository configured, then
 all nodes in the cluster must be able to reach HDFS when starting. If not, then the node will fail to initialize the
 repository at start up and the repository will be unusable. If this happens, you will need to remove and re-add the
 repository or restart the offending node.

--- a/docs/plugins/repository-hdfs.asciidoc
+++ b/docs/plugins/repository-hdfs.asciidoc
@@ -81,7 +81,7 @@ The following settings are supported:
 ===== A Note on HDFS Availablility
 When you initialize a repository, its settings are persisted in the cluster state. When a node comes online, it will
 attempt to create all repositories for which it has settings. If your cluster has an HDFS repository configured, then
-all nodes in the cluster must be able to reach HDFS, even when starting. If not, then the node may fail to create the
+all nodes in the cluster must be able to reach HDFS when starting. If not, then the node may fail to create the
 repository at start up. If this happens, you may need to remove and re-add the repository or restart the offending node.
 
 [[repository-hdfs-security]]


### PR DESCRIPTION
If a cluster is configured with an HDFS repository and a node is started, that node must be able to
reach HDFS, or else when it attempts to add the repository from the cluster state at start up it will
fail to connect and the repository will be left in an inconsistent state. Adding a blurb in the docs to
outline the expected availability for HDFS when using the repository plugin.