### PR TITLE
[DOCS] Add XPack APIs to Elasticsearch Reference

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -26,10 +26,20 @@ release-state can be: released | prerelease | unreleased
 :plugin_url:      https://artifacts.elastic.co/downloads/elasticsearch-plugins
 
 :xpack:           X-Pack
+:security:        X-Pack security
+:monitoring:      X-Pack monitoring
+:watcher:         Watcher
+:reporting:       X-Pack reporting
+:graph:           X-Pack graph
+:searchprofiler:  X-Pack search profiler
 :xpackml:         X-Pack machine learning
 :ml:              machine learning
 :es:              Elasticsearch
 :kib:             Kibana
+:dfeed:           datafeed
+:dfeeds:          datafeeds
+:dfeed-cap:       Datafeed
+:dfeeds-cap:      Datafeeds
 
 :xes-repo-dir:    {docdir}/../../../elasticsearch-extra/x-pack-elasticsearch/docs/en
 

--- a/docs/reference/index-shared.asciidoc
+++ b/docs/reference/index-shared.asciidoc
@@ -22,6 +22,10 @@ include::cat.asciidoc[]
 
 include::cluster.asciidoc[]
 
+ifdef::include-xpack[]
+include::{xes-repo-dir}/rest-api/index.asciidoc[]
+endif::include-xpack[]
+
 include::query-dsl.asciidoc[]
 
 include::mapping.asciidoc[]


### PR DESCRIPTION
This pull request adds an X-Pack API section to the Elasticsearch Reference.  As discussed with @debadair, this section will appear after the Cluster APIs section.  For example:

![esapis](https://user-images.githubusercontent.com/26471269/27142791-0f50ebe4-50e1-11e7-888a-4b2d9aa53490.png)

It also adds some more attribute definitions to the Elasticsearch Reference (since they are required by the X-Pack content).

