### PR TITLE
Remove assemble task when not used for publishing

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -34,6 +34,8 @@ apply plugin: 'com.github.johnrengelman.shadow'
 // have the shadow plugin provide the runShadow task
 apply plugin: 'application'
 
+tasks.remove(assemble)  // Not published so no need to assemble
+
 archivesBaseName = 'elasticsearch-benchmarks'
 mainClassName = 'org.openjdk.jmh.Main'
 

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 // have the shadow plugin provide the runShadow task
 apply plugin: 'application'
 
-tasks.remove(assemble)  // Not published so no need to assemble
+tasks.remove(assemble) // Not published so no need to assemble
 
 archivesBaseName = 'elasticsearch-benchmarks'
 mainClassName = 'org.openjdk.jmh.Main'

--- a/build.gradle
+++ b/build.gradle
@@ -402,3 +402,16 @@ task run(type: Run) {
   group = 'Verification'
   impliesSubProjects = true
 }
+
+/* Remove assemble on all qa projects because we don't need to publish
+ * artifacts for them. */
+gradle.projectsEvaluated {
+  subprojects {
+    if (project.path.startsWith(':qa')) {
+      Task assemble = project.tasks.findByName('assemble')
+      if (assemble) {
+        project.tasks.remove(assemble)
+      }
+    }
+  }
+}

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -394,8 +394,11 @@ class BuildPlugin implements Plugin<Project> {
             project.tasks.withType(GenerateMavenPom.class) { GenerateMavenPom t ->
                 // place the pom next to the jar it is for
                 t.destination = new File(project.buildDir, "distributions/${project.archivesBaseName}-${project.version}.pom")
-                // build poms with assemble
-                project.assemble.dependsOn(t)
+                // build poms with assemble (if the assemble task exists)
+                Task assemble = project.tasks.findByName('assemble')
+                if (assemble) {
+                    assemble.dependsOn(t)
+                }
             }
         }
     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/DocsTestPlugin.groovy
@@ -32,6 +32,8 @@ public class DocsTestPlugin extends RestTestPlugin {
     public void apply(Project project) {
         project.pluginManager.apply('elasticsearch.standalone-rest-test')
         super.apply(project)
+        // Docs are published separately so no need to assemble
+        project.tasks.remove(project.assemble)
         Map<String, String> defaultSubstitutions = [
             /* These match up with the asciidoc syntax for substitutions but
              * the values may differ. In particular {version} needs to resolve

--- a/client/benchmark/build.gradle
+++ b/client/benchmark/build.gradle
@@ -37,6 +37,8 @@ apply plugin: 'application'
 
 group = 'org.elasticsearch.client'
 
+tasks.remove(assemble)  // Not published so no need to assemble
+
 archivesBaseName = 'client-benchmarks'
 mainClassName = 'org.elasticsearch.client.benchmark.BenchmarkMain'
 

--- a/client/benchmark/build.gradle
+++ b/client/benchmark/build.gradle
@@ -37,7 +37,7 @@ apply plugin: 'application'
 
 group = 'org.elasticsearch.client'
 
-tasks.remove(assemble)  // Not published so no need to assemble
+tasks.remove(assemble) // Not published so no need to assemble
 
 archivesBaseName = 'client-benchmarks'
 mainClassName = 'org.elasticsearch.client.benchmark.BenchmarkMain'

--- a/client/client-benchmark-noop-api-plugin/build.gradle
+++ b/client/client-benchmark-noop-api-plugin/build.gradle
@@ -27,9 +27,10 @@ esplugin {
   classname 'org.elasticsearch.plugin.noop.NoopPlugin'
 }
 
+tasks.remove(assemble)  // Not published so no need to assemble
+
 compileJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-rawtypes,-try,-unchecked"
 
 // no unit tests
 test.enabled = false
 integTest.enabled = false
-

--- a/client/client-benchmark-noop-api-plugin/build.gradle
+++ b/client/client-benchmark-noop-api-plugin/build.gradle
@@ -27,7 +27,7 @@ esplugin {
   classname 'org.elasticsearch.plugin.noop.NoopPlugin'
 }
 
-tasks.remove(assemble)  // Not published so no need to assemble
+tasks.remove(assemble) // Not published so no need to assemble
 
 compileJava.options.compilerArgs << "-Xlint:-cast,-deprecation,-rawtypes,-try,-unchecked"
 

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -49,6 +49,7 @@ if (project.name == 'bwc-stable-snapshot') {
 
 if (enabled) {
   apply plugin: 'distribution'
+  tasks.remove(assemble)  // Not published so no need to assemble
 
   def (String major, String minor, String bugfix) = bwcVersion.split('\\.')
   def (String currentMajor, String currentMinor, String currentBugfix) = version.split('\\.')

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -49,7 +49,7 @@ if (project.name == 'bwc-stable-snapshot') {
 
 if (enabled) {
   apply plugin: 'distribution'
-  tasks.remove(assemble)  // Not published so no need to assemble
+  tasks.remove(assemble) // Not published so no need to assemble
 
   def (String major, String minor, String bugfix) = bwcVersion.split('\\.')
   def (String currentMajor, String currentMinor, String currentBugfix) = version.split('\\.')

--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -1,0 +1,9 @@
+// Subprojects aren't published so do not assemble
+gradle.projectsEvaluated {
+  subprojects {
+    Task assemble = project.tasks.findByName('assemble')
+    if (assemble) {
+      project.tasks.remove(assemble)
+    }
+  }
+}

--- a/plugins/jvm-example/build.gradle
+++ b/plugins/jvm-example/build.gradle
@@ -21,6 +21,7 @@ esplugin {
   description 'Demonstrates all the pluggable Java entry points in Elasticsearch'
   classname 'org.elasticsearch.plugin.example.JvmExamplePlugin'
 }
+tasks.remove(assemble)  // Not published so no need to assemble
 
 // no unit tests
 test.enabled = false
@@ -47,4 +48,3 @@ integTestCluster {
 integTestRunner {
   systemProperty 'external.address', "${ -> exampleFixture.addressAndPort }"
 }
-

--- a/plugins/jvm-example/build.gradle
+++ b/plugins/jvm-example/build.gradle
@@ -21,7 +21,7 @@ esplugin {
   description 'Demonstrates all the pluggable Java entry points in Elasticsearch'
   classname 'org.elasticsearch.plugin.example.JvmExamplePlugin'
 }
-tasks.remove(assemble)  // Not published so no need to assemble
+tasks.remove(assemble) // Not published so no need to assemble
 
 // no unit tests
 test.enabled = false

--- a/test/fixtures/example-fixture/build.gradle
+++ b/test/fixtures/example-fixture/build.gradle
@@ -19,3 +19,4 @@
 
 apply plugin: 'elasticsearch.build'
 test.enabled = false
+tasks.remove(assemble)  // Not published so no need to assemble

--- a/test/fixtures/example-fixture/build.gradle
+++ b/test/fixtures/example-fixture/build.gradle
@@ -19,4 +19,4 @@
 
 apply plugin: 'elasticsearch.build'
 test.enabled = false
-tasks.remove(assemble)  // Not published so no need to assemble
+tasks.remove(assemble) // Not published so no need to assemble


### PR DESCRIPTION
Removes the `assemble` task from projects that are not published.
This should speed up `gradle assemble` by skipping projects that
don't need to be built. Which is useful because `gradle assemble`
is how we cut releases.
