### PR TITLE
Build: Add master flag for disabling bwc tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,10 +152,28 @@ task verifyVersions {
   }
 }
 
+/*
+ * When adding backcompat behavior that spans major versions, temporarily
+ * disabling the backcompat tests is necessary. This flag controls
+ * the enabled state of every bwc task. It should be set back to true
+ * after the backport of the backcompat code is complete.
+ */
+allprojects {
+  ext.bwc_tests_enabled = true
+}
+
+task verifyBwcTestsEnabled {
+  doLast {
+    if (project.bwc_tests_enabled == false) {
+      throw new GradleException('Bwc tests are disabled. They must be re-enabled after completing backcompat behavior backporting.')
+    }
+  }
+}
+
 task branchConsistency {
   description 'Ensures this branch is internally consistent. For example, that versions constants match released versions.'
   group 'Verification'
-  dependsOn verifyVersions
+  dependsOn verifyVersions, verifyBwcTestsEnabled
 }
 
 subprojects {

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -30,9 +30,6 @@ task bwcTest {
 }
 
 for (Version version : indexCompatVersions) {
-  if (project.bwc_tests_enabled == false) {
-    continue
-  }
   String baseName = "v${version}"
 
   Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
@@ -82,7 +79,9 @@ for (Version version : indexCompatVersions) {
     dependsOn = [upgradedClusterTest]
   }
 
-  bwcTest.dependsOn(versionBwcTest)
+  if (project.bwc_tests_enabled == false) {
+    bwcTest.dependsOn(versionBwcTest)
+  }
 }
 
 test.enabled = false // no unit tests for rolling upgrades, only the rest integration test

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -30,6 +30,9 @@ task bwcTest {
 }
 
 for (Version version : indexCompatVersions) {
+  if (project.bwc_tests_enabled == false) {
+    continue
+  }
   String baseName = "v${version}"
 
   Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
@@ -86,7 +89,9 @@ test.enabled = false // no unit tests for rolling upgrades, only the rest integr
 
 // basic integ tests includes testing bwc against the most recent version
 task integTest {
-  dependsOn = ["v${indexCompatVersions[-1]}#bwcTest"]
+  if (project.bwc_tests_enabled) {
+    dependsOn = ["v${indexCompatVersions[-1]}#bwcTest"]
+  }
 }
 
 check.dependsOn(integTest)

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -30,6 +30,9 @@ task bwcTest {
 }
 
 for (Version version : wireCompatVersions) {
+  if (project.bwc_tests_enabled == false) {
+    continue
+  }
   String baseName = "v${version}"
 
   Task mixedClusterTest = tasks.create(name: "${baseName}#mixedClusterTest", type: RestIntegTestTask) {
@@ -58,7 +61,9 @@ test.enabled = false // no unit tests for rolling upgrades, only the rest integr
 
 // basic integ tests includes testing bwc against the most recent version
 task integTest {
-  dependsOn = ["v${wireCompatVersions[-1]}#bwcTest"]
+  if (project.bwc_tests_enabled) {
+    dependsOn = ["v${wireCompatVersions[-1]}#bwcTest"]
+  }
 }
 
 check.dependsOn(integTest)

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -30,9 +30,6 @@ task bwcTest {
 }
 
 for (Version version : wireCompatVersions) {
-  if (project.bwc_tests_enabled == false) {
-    continue
-  }
   String baseName = "v${version}"
 
   Task mixedClusterTest = tasks.create(name: "${baseName}#mixedClusterTest", type: RestIntegTestTask) {
@@ -54,7 +51,9 @@ for (Version version : wireCompatVersions) {
     dependsOn = [mixedClusterTest]
   }
 
-  bwcTest.dependsOn(versionBwcTest)
+  if (project.bwc_tests_enabled) {
+    bwcTest.dependsOn(versionBwcTest)
+  }
 }
 
 test.enabled = false // no unit tests for rolling upgrades, only the rest integration test

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -30,6 +30,9 @@ task bwcTest {
 }
 
 for (Version version : wireCompatVersions) {
+  if (project.bwc_tests_enabled == false) {
+    continue
+  }
   String baseName = "v${version}"
 
   Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
@@ -95,6 +98,7 @@ for (Version version : wireCompatVersions) {
   }
 
   Task versionBwcTest = tasks.create(name: "${baseName}#bwcTest") {
+    enabled = project.bwc_tests_enabled
     dependsOn = [upgradedClusterTest]
   }
 
@@ -105,7 +109,9 @@ test.enabled = false // no unit tests for rolling upgrades, only the rest integr
 
 // basic integ tests includes testing bwc against the most recent version
 task integTest {
-  dependsOn = ["v${wireCompatVersions[-1]}#bwcTest"]
+  if (project.bwc_tests_enabled) {
+    dependsOn = ["v${wireCompatVersions[-1]}#bwcTest"]
+  }
 }
 
 check.dependsOn(integTest)

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -30,9 +30,6 @@ task bwcTest {
 }
 
 for (Version version : wireCompatVersions) {
-  if (project.bwc_tests_enabled == false) {
-    continue
-  }
   String baseName = "v${version}"
 
   Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {
@@ -102,7 +99,9 @@ for (Version version : wireCompatVersions) {
     dependsOn = [upgradedClusterTest]
   }
 
-  bwcTest.dependsOn(versionBwcTest)
+  if (project.bwc_tests_enabled) {
+    bwcTest.dependsOn(versionBwcTest)
+  }
 }
 
 test.enabled = false // no unit tests for rolling upgrades, only the rest integration test


### PR DESCRIPTION
This commit adds a gradle project, set inside the root build.gradle,
which controls all our bwc tests. This allows for seamless (ie no errant
CI failures) backporting of bwc behavior.
