### PR TITLE
[DOCS] Defined es-test-dir in index.asciidoc. 

### DIFF
--- a/docs/reference/analysis/tokenfilters/stemmer-override-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stemmer-override-tokenfilter.asciidoc
@@ -46,7 +46,7 @@ Where the file looks like:
 
 [source,stemmer_override]
 --------------------------------------------------
-include::{docdir}/../src/test/cluster/config/analysis/stemmer_override.txt[]
+include::{es-test-dir}/cluster/config/analysis/stemmer_override.txt[]
 --------------------------------------------------
 
 You can also define the overrides rules inline:

--- a/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
@@ -65,7 +65,7 @@ The following is a sample format of the file:
 
 [source,synonyms]
 --------------------------------------------------
-include::{docdir}/../src/test/cluster/config/analysis/synonym.txt[]
+include::{es-test-dir}/cluster/config/analysis/synonym.txt[]
 --------------------------------------------------
 
 You can also define synonyms for the filter directly in the

--- a/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
@@ -49,7 +49,7 @@ The following is a sample format of the file:
 
 [source,synonyms]
 --------------------------------------------------
-include::{docdir}/../src/test/cluster/config/analysis/synonym.txt[]
+include::{es-test-dir}/cluster/config/analysis/synonym.txt[]
 --------------------------------------------------
 
 You can also define synonyms for the filter directly in the

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -1,4 +1,6 @@
 [[elasticsearch-reference]]
 = Elasticsearch Reference
 
+:es-test-dir: {docdir}/../src/test
+
 include::index-shared.asciidoc[]

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -2,5 +2,6 @@
 = Elasticsearch Reference
 
 :es-test-dir: {docdir}/../src/test
+:plugins-examples-dir: {docdir}/../../plugins/examples
 
 include::index-shared.asciidoc[]

--- a/docs/reference/modules/scripting/engine.asciidoc
+++ b/docs/reference/modules/scripting/engine.asciidoc
@@ -17,7 +17,7 @@ the document frequency of a provided term.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{docdir}/../../plugins/examples/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java[expert_engine]
+include-tagged::{plugins-examples-dir}/script-expert-scoring/src/main/java/org/elasticsearch/example/expertscript/ExpertScriptPlugin.java[expert_engine]
 --------------------------------------------------
 
 You can execute the script by specifying its `lang` as `expert_scripts`, and the name


### PR DESCRIPTION
Use this attribute when specifying the location of included tests. 

I also updated the existing test paths.

@nik9000 added you as a reviewer since you're the only one who's using test includes so far. Mostly just want you to know I'm adding the attribute. 
