### PR TITLE
Test fix - removed superfluous assertion in SignificantTextAggregatorTests

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorTests.java
@@ -65,10 +65,6 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
         textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
         IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
-        indexWriterConfig.setMaxBufferedDocs(100);
-        indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a
-                                                   // single segment with
-                                                   // predictable docIds
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
             for (int i = 0; i < 10; i++) {
                 Document doc = new Document();
@@ -95,7 +91,6 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                     .subAggregation(sigAgg);
             
             try (IndexReader reader = DirectoryReader.open(w)) {
-                assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);
                                 
                 // Search "odd" which should have no duplication
@@ -145,7 +140,6 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
             SignificantTextAggregationBuilder sigAgg = new SignificantTextAggregationBuilder("sig_text", "text");
             sigAgg.sourceFieldNames(Arrays.asList(new String [] {"title", "text"}));
             try (IndexReader reader = DirectoryReader.open(w)) {
-                assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);                                
                 searchAndReduce(searcher, new TermQuery(new Term("text", "foo")), sigAgg, textFieldType);
                 // No significant results to be found in this test - only checking we don't end up


### PR DESCRIPTION
This assertion was failing due to lack of IndexWriterConfig setup. Actually the assertion was from a copy/paste of terms agg tests and is irrelevant to this test and so was removed.

Closes #25245
