### PR TITLE
Avoid SecurityException in repository-S3 on DefaultS3OutputStream.flush()

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/DefaultS3OutputStream.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/DefaultS3OutputStream.java
@@ -78,6 +78,13 @@ class DefaultS3OutputStream extends S3OutputStream {
 
     @Override
     public void flush(byte[] bytes, int off, int len, boolean closing) throws IOException {
+        SocketAccess.doPrivilegedIOException(() -> {
+            flushPriveleged(bytes, off, len, closing);
+            return null;
+        });
+    }
+
+    private void flushPriveleged(byte[] bytes, int off, int len, boolean closing) throws IOException {
         if (len > MULTIPART_MAX_SIZE.getBytes()) {
             throw new IOException("Unable to upload files larger than " + MULTIPART_MAX_SIZE + " to Amazon S3");
         }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/DefaultS3OutputStream.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/DefaultS3OutputStream.java
@@ -79,12 +79,12 @@ class DefaultS3OutputStream extends S3OutputStream {
     @Override
     public void flush(byte[] bytes, int off, int len, boolean closing) throws IOException {
         SocketAccess.doPrivilegedIOException(() -> {
-            flushPriveleged(bytes, off, len, closing);
+            flushPrivileged(bytes, off, len, closing);
             return null;
         });
     }
 
-    private void flushPriveleged(byte[] bytes, int off, int len, boolean closing) throws IOException {
+    private void flushPrivileged(byte[] bytes, int off, int len, boolean closing) throws IOException {
         if (len > MULTIPART_MAX_SIZE.getBytes()) {
             throw new IOException("Unable to upload files larger than " + MULTIPART_MAX_SIZE + " to Amazon S3");
         }

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -92,7 +92,7 @@ class S3BlobContainer extends AbstractBlobContainer {
             throw new FileAlreadyExistsException("blob [" + blobName + "] already exists, cannot overwrite");
         }
         try (OutputStream stream = createOutput(blobName)) {
-            SocketAccess.doPrivilegedIOException(() -> Streams.copy(inputStream, stream));
+            Streams.copy(inputStream, stream);
         }
     }
 

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -40,6 +40,7 @@ import com.amazonaws.util.Base64;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.Socket;
 import java.security.DigestInputStream;
 import java.util.ArrayList;
@@ -58,7 +59,7 @@ class MockAmazonS3 extends AbstractAmazonS3 {
 
     private void openSocket() {
         try {
-            Socket socket = new Socket("localhost", 9200);
+            Socket socket = new Socket(InetAddress.getByName("127.0.0.1"), 9200);
             socket.close();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -40,6 +40,7 @@ import com.amazonaws.util.Base64;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.Socket;
 import java.security.DigestInputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +55,17 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     // length of the input data is 100 bytes
     private byte[] byteCounter = new byte[100];
 
+
+    private void openSocket() {
+        try {
+            Socket socket = new Socket("localhost", 9200);
+            socket.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
     @Override
     public boolean doesBucketExist(String bucket) {
         return true;
@@ -63,6 +75,7 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     public ObjectMetadata getObjectMetadata(
             GetObjectMetadataRequest getObjectMetadataRequest)
             throws AmazonClientException, AmazonServiceException {
+        openSocket();
         String blobName = getObjectMetadataRequest.getKey();
 
         if (!blobs.containsKey(blobName)) {
@@ -75,6 +88,7 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     @Override
     public PutObjectResult putObject(PutObjectRequest putObjectRequest)
             throws AmazonClientException, AmazonServiceException {
+        openSocket();
         String blobName = putObjectRequest.getKey();
         DigestInputStream stream = (DigestInputStream) putObjectRequest.getInputStream();
 
@@ -95,6 +109,7 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     @Override
     public S3Object getObject(GetObjectRequest getObjectRequest)
             throws AmazonClientException, AmazonServiceException {
+        openSocket();
         // in ESBlobStoreContainerTestCase.java, the prefix is empty,
         // so the key and blobName are equivalent to each other
         String blobName = getObjectRequest.getKey();
@@ -114,6 +129,7 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     @Override
     public ObjectListing listObjects(ListObjectsRequest listObjectsRequest)
             throws AmazonClientException, AmazonServiceException {
+        openSocket();
         MockObjectListing list = new MockObjectListing();
         list.setTruncated(false);
 
@@ -147,6 +163,7 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     @Override
     public CopyObjectResult copyObject(CopyObjectRequest copyObjectRequest)
             throws AmazonClientException, AmazonServiceException {
+        openSocket();
         String sourceBlobName = copyObjectRequest.getSourceKey();
         String targetBlobName = copyObjectRequest.getDestinationKey();
 
@@ -167,6 +184,7 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     @Override
     public void deleteObject(DeleteObjectRequest deleteObjectRequest)
             throws AmazonClientException, AmazonServiceException {
+        openSocket();
         String blobName = deleteObjectRequest.getKey();
 
         if (!blobs.containsKey(blobName)) {

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -37,7 +37,6 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.util.Base64;
-import org.junit.Assert;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,6 +48,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.assertTrue;
 
 class MockAmazonS3 extends AbstractAmazonS3 {
 
@@ -75,7 +76,7 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     // is able to to open a socket to the S3 Service without causing a SecurityException
     private void simulateS3SocketConnection() {
         try (Socket socket = new Socket(InetAddress.getByName("127.0.0.1"), mockSocketPort)) {
-            Assert.assertTrue(socket.isConnected()); // NOOP to keep static analysis happy
+            assertTrue(socket.isConnected()); // NOOP to keep static analysis happy
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -19,7 +19,10 @@
 
 package org.elasticsearch.repositories.s3;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -28,24 +31,25 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.Locale;
 
 public class S3BlobStoreContainerTests extends ESBlobStoreContainerTestCase {
 
+    private static final Logger logger = Loggers.getLogger(S3BlobStoreContainerTests.class);
+
     private static ServerSocket socket;
 
     @BeforeClass
     public static void openPort() throws IOException {
-        System.out.println("openPort()");
-        socket = new ServerSocket(9200);
+        socket = new ServerSocket(9200, 50, InetAddress.getByName("127.0.0.1"));
         new Thread(() -> {
             while (!socket.isClosed()) {
                 try {
                     socket.accept();
-                    System.out.println("accept!");
                 } catch (IOException e) {
-                    System.out.println(e);
+                    logger.log(Level.ERROR, e);
                 }
             }
         }).start();
@@ -61,7 +65,6 @@ public class S3BlobStoreContainerTests extends ESBlobStoreContainerTestCase {
 
     @AfterClass
     public static void closePort() throws IOException {
-        System.out.println("closePort()");
         socket.close();
     }
 }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreContainerTests.java
@@ -55,7 +55,6 @@ public class S3BlobStoreContainerTests extends ESBlobStoreContainerTestCase {
                     // Accept connections from MockAmazonS3.
                     mockS3ServerSocket.accept();
                 } catch (IOException e) {
-                    logger.log(Level.ERROR, e);
                 }
             }
         });

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -129,7 +129,7 @@ public class BootstrapForTesting {
                 // ... but tests are messy. like file permissions, just let them live in a fantasy for now.
                 // TODO: cut over all tests to bind to ephemeral ports
                 perms.add(new SocketPermission("localhost:1024-", "listen,resolve"));
-
+                perms.add(new SocketPermission("localhost:1024-", "accept,resolve"));
                 // read test-framework permissions
                 final Policy testFramework = Security.readPolicy(Bootstrap.class.getResource("test-framework.policy"), JarHell.parseClassPath());
                 final Policy esPolicy = new ESPolicy(perms, getPluginPermissions(), true);

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -129,7 +129,7 @@ public class BootstrapForTesting {
                 // ... but tests are messy. like file permissions, just let them live in a fantasy for now.
                 // TODO: cut over all tests to bind to ephemeral ports
                 perms.add(new SocketPermission("localhost:1024-", "listen,resolve"));
-                perms.add(new SocketPermission("localhost:1024-", "accept,resolve"));
+
                 // read test-framework permissions
                 final Policy testFramework = Security.readPolicy(Bootstrap.class.getResource("test-framework.policy"), JarHell.parseClassPath());
                 final Policy esPolicy = new ESPolicy(perms, getPluginPermissions(), true);


### PR DESCRIPTION
Moved SocketAccess.doPrivileged up the stack to DefaultS3OutputStream in repository-S3 plugin to avoid SecurityException by Streams.copy(). A plugin is only allowed to use its own jars when performing privileged operations. The S3 client might open a new Socket on close(). #25192
