### PR TITLE
[Test] Extend parsing checks for DocWriteResponses

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -395,6 +395,10 @@ public class RestHighLevelClient {
                 try {
                     return responseConverter.apply(e.getResponse());
                 } catch (Exception innerException) {
+                    //the exception is ignored as we now try to parse the response as an error.
+                    //this covers cases like get where 404 can either be a valid document not found response,
+                    //or an error for which parsing is completely different. We try to consider the 404 response as a valid one
+                    //first. If parsing of the response breaks, we fall back to parsing it as an error.
                     throw parseResponseException(e);
                 }
             }

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -356,7 +356,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
             } else {
                 parser.skipChildren(); // skip potential inner objects for forward compatibility
             }
-        } else {
+        } else if (token == XContentParser.Token.START_ARRAY) {
             parser.skipChildren(); // skip potential inner arrays for forward compatibility
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -43,8 +43,6 @@ import java.net.URLEncoder;
 import java.util.Locale;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownToken;
 
 /**
  * A base class for the response of a write operation that involves a single doc
@@ -351,17 +349,15 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
                 context.setSeqNo(parser.longValue());
             } else if (_PRIMARY_TERM.equals(currentFieldName)) {
                 context.setPrimaryTerm(parser.longValue());
-            } else {
-                throwUnknownField(currentFieldName, parser.getTokenLocation());
             }
         } else if (token == XContentParser.Token.START_OBJECT) {
             if (_SHARDS.equals(currentFieldName)) {
                 context.setShardInfo(ShardInfo.fromXContent(parser));
             } else {
-                throwUnknownField(currentFieldName, parser.getTokenLocation());
+                parser.skipChildren(); // skip potential inner objects for forward compatibility
             }
         } else {
-            throwUnknownToken(token, parser.getTokenLocation());
+            parser.skipChildren(); // skip potential inner arrays for forward compatibility
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknownField;
 
 /**
  * Base class for write action responses.
@@ -187,8 +186,8 @@ public class ReplicationResponse extends ActionResponse {
                         total = parser.intValue();
                     } else if (SUCCESSFUL.equals(currentFieldName)) {
                         successful = parser.intValue();
-                    } else if (FAILED.equals(currentFieldName) == false) {
-                        throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    } else {
+                        parser.skipChildren();
                     }
                 } else if (token == XContentParser.Token.START_ARRAY) {
                     if (FAILURES.equals(currentFieldName)) {
@@ -197,8 +196,10 @@ public class ReplicationResponse extends ActionResponse {
                             failuresList.add(Failure.fromXContent(parser));
                         }
                     } else {
-                        throwUnknownField(currentFieldName, parser.getTokenLocation());
+                        parser.skipChildren();
                     }
+                } else {
+                    parser.skipChildren();
                 }
             }
             Failure[] failures = EMPTY;
@@ -365,15 +366,15 @@ public class ReplicationResponse extends ActionResponse {
                             status = RestStatus.valueOf(parser.text());
                         } else if (PRIMARY.equals(currentFieldName)) {
                             primary = parser.booleanValue();
-                        } else {
-                            throwUnknownField(currentFieldName, parser.getTokenLocation());
                         }
                     } else if (token == XContentParser.Token.START_OBJECT) {
                         if (REASON.equals(currentFieldName)) {
                             reason = ElasticsearchException.fromXContent(parser);
                         } else {
-                            throwUnknownField(currentFieldName, parser.getTokenLocation());
+                            parser.skipChildren(); // skip potential inner objects for forward compatibility
                         }
+                    } else {
+                        parser.skipChildren(); // skip potential inner arrays for forward compatibility
                     }
                 }
                 return new Failure(new ShardId(shardIndex, IndexMetaData.INDEX_UUID_NA_VALUE, shardId), nodeId, reason, status, primary);

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -196,10 +196,10 @@ public class ReplicationResponse extends ActionResponse {
                             failuresList.add(Failure.fromXContent(parser));
                         }
                     } else {
-                        parser.skipChildren();
+                        parser.skipChildren(); // skip potential inner arrays for forward compatibility
                     }
-                } else {
-                    parser.skipChildren();
+                } else if (token == XContentParser.Token.START_OBJECT) {
+                    parser.skipChildren(); // skip potential inner arrays for forward compatibility
                 }
             }
             Failure[] failures = EMPTY;
@@ -373,7 +373,7 @@ public class ReplicationResponse extends ActionResponse {
                         } else {
                             parser.skipChildren(); // skip potential inner objects for forward compatibility
                         }
-                    } else {
+                    } else if (token == XContentParser.Token.START_ARRAY) {
                         parser.skipChildren(); // skip potential inner arrays for forward compatibility
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/index/get/GetField.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetField.java
@@ -115,16 +115,17 @@ public class GetField implements Streamable, ToXContent, Iterable<Object> {
         ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
         String fieldName = parser.currentName();
         XContentParser.Token token = parser.nextToken();
-        if (token == XContentParser.Token.START_ARRAY) {
-            List<Object> values = new ArrayList<>();
-            while((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+        ensureExpectedToken(XContentParser.Token.START_ARRAY, token, parser::getTokenLocation);
+
+        List<Object> values = new ArrayList<>();
+        while((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            if (token.isValue()) {
                 values.add(parseStoredFieldsValue(parser));
+            } else {
+                parser.skipChildren();
             }
-            return new GetField(fieldName, values);
-        } else {
-            parser.skipChildren();
         }
-        return null;
+        return new GetField(fieldName, values);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/get/GetField.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetField.java
@@ -116,14 +116,9 @@ public class GetField implements Streamable, ToXContent, Iterable<Object> {
         String fieldName = parser.currentName();
         XContentParser.Token token = parser.nextToken();
         ensureExpectedToken(XContentParser.Token.START_ARRAY, token, parser::getTokenLocation);
-
         List<Object> values = new ArrayList<>();
         while((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-            if (token.isValue()) {
-                values.add(parseStoredFieldsValue(parser));
-            } else {
-                parser.skipChildren();
-            }
+            values.add(parseStoredFieldsValue(parser));
         }
         return new GetField(fieldName, values);
     }

--- a/core/src/main/java/org/elasticsearch/index/get/GetField.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetField.java
@@ -115,12 +115,16 @@ public class GetField implements Streamable, ToXContent, Iterable<Object> {
         ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser::getTokenLocation);
         String fieldName = parser.currentName();
         XContentParser.Token token = parser.nextToken();
-        ensureExpectedToken(XContentParser.Token.START_ARRAY, token, parser::getTokenLocation);
-        List<Object> values = new ArrayList<>();
-        while((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-            values.add(parseStoredFieldsValue(parser));
+        if (token == XContentParser.Token.START_ARRAY) {
+            List<Object> values = new ArrayList<>();
+            while((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                values.add(parseStoredFieldsValue(parser));
+            }
+            return new GetField(fieldName, values);
+        } else {
+            parser.skipChildren();
         }
-        return new GetField(fieldName, values);
+        return null;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -48,9 +48,9 @@ import static org.elasticsearch.index.get.GetField.readGetField;
 
 public class GetResult implements Streamable, Iterable<GetField>, ToXContentObject {
 
-    private static final String _INDEX = "_index";
-    private static final String _TYPE = "_type";
-    private static final String _ID = "_id";
+    public static final String _INDEX = "_index";
+    public static final String _TYPE = "_type";
+    public static final String _ID = "_id";
     private static final String _VERSION = "_version";
     private static final String FOUND = "found";
     private static final String FIELDS = "fields";
@@ -312,16 +312,6 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContentObje
             } else if (token == XContentParser.Token.START_ARRAY) {
                 parser.skipChildren(); // skip potential inner arrays for forward compatibility
             }
-        }
-
-        // At this stage we ensure that we parsed enough information to return
-        // a valid GetResult instance. If it's not the case, we throw an
-        // exception so that callers know it and can handle it correctly.
-        // This is typically the case when one wants to parse the result of
-        // a get request and uses this method, but the xcontent to parse is
-        // not a valid get result but an exception instead.
-        if (found == null) {
-            throw new ParsingException(parser.getTokenLocation(), "Missing required field [found]");
         }
         return new GetResult(index, type, id, version, found, source, fields);
     }

--- a/core/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -314,6 +314,12 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContentObje
             }
         }
 
+        // At this stage we ensure that we parsed enough information to return
+        // a valid GetResult instance. If it's not the case, we throw an
+        // exception so that callers know it and can handle it correctly.
+        // This is typically the case when one wants to parse the result of
+        // a get request and uses this method, but the xcontent to parse is
+        // not a valid get result but an exception instead.
         if (found == null) {
             throw new ParsingException(parser.getTokenLocation(), "Missing required field [found]");
         }

--- a/core/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/core/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -304,11 +304,15 @@ public class GetResult implements Streamable, Iterable<GetField>, ToXContentObje
                 } else if (FIELDS.equals(currentFieldName)) {
                     while(parser.nextToken() != XContentParser.Token.END_OBJECT) {
                         GetField getField = GetField.fromXContent(parser);
-                        fields.put(getField.getName(), getField);
+                        if (getField != null) {
+                            fields.put(getField.getName(), getField);
+                        }
                     }
                 } else {
-                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    parser.skipChildren(); // skip potential inner objects for forward compatibility
                 }
+            } else {
+                parser.skipChildren(); // skip potential inner arrays for forward compatibility
             }
         }
         return new GetResult(index, type, id, version, found, source, fields);

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse.Failure;
 import org.elasticsearch.action.delete.DeleteResponseTests;
 import org.elasticsearch.action.index.IndexResponseTests;
+import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.action.update.UpdateResponseTests;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
@@ -137,11 +138,12 @@ public class BulkItemResponseTests extends ESTestCase {
 
             assertDeepEquals((ElasticsearchException) expectedFailure.getCause(), (ElasticsearchException) actualFailure.getCause());
         } else {
+            DocWriteResponse expectedDocResponse = expected.getResponse();
+            DocWriteResponse actualDocResponse = expected.getResponse();
+
+            IndexResponseTests.assertDocWriteResponse(expectedDocResponse, actualDocResponse);
             if (expected.getOpType() == DocWriteRequest.OpType.UPDATE) {
-                UpdateResponseTests.assertUpdateResponse(expected.getResponse(), actual.getResponse());
-            } else {
-                // assertDocWriteResponse check the result for INDEX/CREATE and DELETE operations
-                IndexResponseTests.assertDocWriteResponse(expected.getResponse(), actual.getResponse());
+                assertEquals(((UpdateResponse) expectedDocResponse).getGetResult(), ((UpdateResponse)actualDocResponse).getGetResult());
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
@@ -32,9 +32,11 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.RandomObjects;
 
 import java.io.IOException;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.action.index.IndexResponseTests.assertDocWriteResponse;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_UUID_NA_VALUE;
+import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
 
 public class DeleteResponseTests extends ESTestCase {
 
@@ -56,16 +58,40 @@ public class DeleteResponseTests extends ESTestCase {
     }
 
     public void testToAndFromXContent() throws IOException {
+        doFromXContentTestWithRandomFields(false);
+    }
+
+    /**
+     * This test adds random fields and objects to the xContent rendered out to
+     * ensure we can parse it back to be forward compatible with additions to
+     * the xContent
+     */
+    public void testFromXContentWithRandomFields() throws IOException {
+        doFromXContentTestWithRandomFields(true);
+    }
+
+    private void doFromXContentTestWithRandomFields(boolean addRandomFields) throws IOException {
         final Tuple<DeleteResponse, DeleteResponse> tuple = randomDeleteResponse();
         DeleteResponse deleteResponse = tuple.v1();
         DeleteResponse expectedDeleteResponse = tuple.v2();
 
         boolean humanReadable = randomBoolean();
         final XContentType xContentType = randomFrom(XContentType.values());
-        BytesReference deleteResponseBytes = toShuffledXContent(deleteResponse, xContentType, ToXContent.EMPTY_PARAMS, humanReadable);
+        BytesReference originalBytes = toShuffledXContent(deleteResponse, xContentType, ToXContent.EMPTY_PARAMS, humanReadable);
 
+        BytesReference mutated;
+        if (addRandomFields) {
+            // The ShardInfo.Failure's exception is rendered out in a "reason" object. We shouldn't add anything random there
+            // because exception rendering and parsing are very permissive: any extra object or field would be rendered as
+            // a exception custom metadata and be parsed back as a custom header, making it impossible to compare the results
+            // in this test.
+            Predicate<String> excludeFilter = path -> path.contains("reason");
+            mutated = insertRandomFields(xContentType, originalBytes, excludeFilter, random());
+        } else {
+            mutated = originalBytes;
+        }
         DeleteResponse parsedDeleteResponse;
-        try (XContentParser parser = createParser(xContentType.xContent(), deleteResponseBytes)) {
+        try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
             parsedDeleteResponse = DeleteResponse.fromXContent(parser);
             assertNull(parser.nextToken());
         }

--- a/core/src/test/java/org/elasticsearch/action/get/GetResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/get/GetResponseTests.java
@@ -68,8 +68,8 @@ public class GetResponseTests extends ESTestCase {
         BytesReference mutated;
         if (addRandomFields) {
             // "_source" and "fields" just consists of key/value pairs, we shouldn't add anything random there. It is already
-            // randomized in the randomGetResult() method anyway. Metadata fields are rendered out in the root object while
-            // other fields are rendered out in a "fields" object.
+            // randomized in the randomGetResult() method anyway. Also, we cannot add anything in the root object since this is
+            // where GetResult's metadata fields are rendered out while other fields are rendered out in a "fields" object.
             Predicate<String> excludeFilter = (s) -> s.isEmpty() || s.contains("fields") || s.contains("_source");
             mutated = insertRandomFields(xContentType, originalBytes, excludeFilter, random());
         } else {

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
@@ -110,8 +110,10 @@ public class UpdateResponseTests extends ESTestCase {
             // because exception rendering and parsing are very permissive: any extra object or field would be rendered as
             // a exception custom metadata and be parsed back as a custom header, making it impossible to compare the results
             // in this test.
-            // - Thet GetResult's "_source" and "fields" just consists of key/value pairs, we shouldn't add anything random there.
-            // It is already randomized in the randomGetResult() method anyway.
+            // - The GetResult's "_source" and "fields" just consists of key/value pairs, we shouldn't add anything random there.
+            // It is already randomized in the randomGetResult() method anyway. Also, we cannot add anything within the "get"
+            // object since this is where GetResult's metadata fields are rendered out and they would be parsed back as
+            // extra metadata fields.
             Predicate<String> excludeFilter = path -> path.contains("reason") || path.contains("get.fields")
                     || path.contains("get._source") || path.endsWith("get");
             mutated = insertRandomFields(xContentType, originalBytes, excludeFilter, random());


### PR DESCRIPTION
This commit changes the parsing logic of DocWriteResponse, ReplicationResponse and GetResult so that it skips any unknown additional fields (for forward compatibility reasons). This affects the IndexResponse, UpdateResponse, DeleteResponse and GetResponse objects.