### PR TITLE
Add note regarding checking existence of indices

### DIFF
--- a/docs/reference/migration/migrate_5_4.asciidoc
+++ b/docs/reference/migration/migrate_5_4.asciidoc
@@ -23,7 +23,7 @@ users should stop relying on this functionality.
 [float]
 === Checking if indices exist
 
-The endpoint ``/{index}`` with the verb `HEAD` can be used to check if an index
+The endpoint `/{index}` with the verb `HEAD` can be used to check if an index
 matching `index` exists (`index` can be a comma-delimited list of index names or
 index patterns). This verb behaved differently than `GET` on the same endpoint
 in two ways. The first is that sending the same request to `GET` and `HEAD`

--- a/docs/reference/migration/migrate_5_4.asciidoc
+++ b/docs/reference/migration/migrate_5_4.asciidoc
@@ -22,7 +22,6 @@ users should stop relying on this functionality.
 [[breaking_54_rest_changes]]
 [float]
 === Checking if indices exist
-
 The endpoint `/{index}` with the verb `HEAD` can be used to check if an index
 matching `index` exists (`index` can be a comma-delimited list of index names or
 index patterns). This verb behaved differently than `GET` on the same endpoint
@@ -33,12 +32,11 @@ could in some cases return different status codes (e.g., `GET
 `content-length` header of zero). The second is that any `HEAD` request on this
 endpoint would return a `content-length` header of zero. Both of these are
 violations of the HTTP specification: if `HEAD` is supported, a `HEAD` request
-must return the same status code as a `GET` request on the same endpoint would,
-and it must return a `content-length` header that is equal to the
-`content-length` header as if a `GET` request. This behavior has been addressed
-so that `HEAD` always returns the same status code as a `GET` would have, and
-with the correct `content-length`. However, this means that `HEAD
-/pattern-that-has-no-matches*` which served as an index existence check no
-longer 404s, instead 200s as if it was a `GET` request. To obtain the previous
-behavior, you must add the parameter `?allow_no_indices=false` (this parameter
-defaults to true).
+must return the same status as the same `GET` request would, and it must return
+a `content-length` header that is equal to the `content-length` header as the
+same `GET` request would. This behavior has been addressed so that `HEAD` always
+returns the same status code as a `GET` would have, and with the correct
+`content-length`. However, this means that `HEAD /pattern-that-has-no-matches*`
+which served as an index existence check no longer 404s, instead 200s as if it
+was a `GET` request. To obtain the previous behavior, you must add the parameter
+`?allow_no_indices=false` (this parameter defaults to `true`).

--- a/docs/reference/migration/migrate_5_4.asciidoc
+++ b/docs/reference/migration/migrate_5_4.asciidoc
@@ -18,3 +18,27 @@ minor release to remove this feature with the exception of `default.path.conf`,
 `default.path.data`, and `default.path.logs` which remain to support packaging.
 A future version of Elasticsearch will remove support for these as well, so
 users should stop relying on this functionality.
+
+[[breaking_54_rest_changes]]
+[float]
+=== Checking if indices exist
+
+The endpoint ``/{index}`` with the verb `HEAD` can be used to check if an index
+matching `index` exists (`index` can be a comma-delimited list of index names or
+index patterns). This verb behaved differently than `GET` on the same endpoint
+in two ways. The first is that sending the same request to `GET` and `HEAD`
+could in some cases return different status codes (e.g., `GET
+/pattern-that-has-no-matches*` would 200 with an empty response and `HEAD
+/pattern-that-has-no-matches*` would 404 with an empty body (and a
+`content-length` header of zero). The second is that any `HEAD` request on this
+endpoint would return a `content-length` header of zero. Both of these are
+violations of the HTTP specification: if `HEAD` is supported, a `HEAD` request
+must return the same status code as a `GET` request on the same endpoint would,
+and it must return a `content-length` header that is equal to the
+`content-length` header as if a `GET` request. This behavior has been addressed
+so that `HEAD` always returns the same status code as a `GET` would have, and
+with the correct `content-length`. However, this means that `HEAD
+/pattern-that-has-no-matches*` which served as an index existence check no
+longer 404s, instead 200s as if it was a `GET` request. To obtain the previous
+behavior, you must add the parameter `?allow_no_indices=false` (this parameter
+defaults to true).


### PR DESCRIPTION
This commit adds a note to the migration docs regarding a change in behavior for HEAD /index used an index existence check versus GET /index.

Relates #21125, relates #23112, relates #25056, relates #25258
