### PR TITLE
Improves snapshot logging and snapshot deletion error handling

### DIFF
--- a/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.repositories;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.UUIDs;
@@ -189,8 +190,11 @@ public final class RepositoryData {
      */
     public RepositoryData removeSnapshot(final SnapshotId snapshotId) {
         Map<String, SnapshotId> newSnapshotIds = snapshotIds.values().stream()
-            .filter(id -> snapshotId.equals(id) == false)
+            .filter(id -> !snapshotId.equals(id))
             .collect(Collectors.toMap(SnapshotId::getUUID, Function.identity()));
+        if (newSnapshotIds.size() == snapshotIds.size()) {
+            throw new ElasticsearchException("Attempting to remove non-existent snapshot [{}] from repository data", snapshotId);
+        }
         Map<String, SnapshotState> newSnapshotStates = new HashMap<>(snapshotStates);
         newSnapshotStates.remove(snapshotId.getUUID());
         Map<IndexId, Set<SnapshotId>> indexSnapshots = new HashMap<>();

--- a/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -19,8 +19,8 @@
 
 package org.elasticsearch.repositories;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -193,7 +193,7 @@ public final class RepositoryData {
             .filter(id -> !snapshotId.equals(id))
             .collect(Collectors.toMap(SnapshotId::getUUID, Function.identity()));
         if (newSnapshotIds.size() == snapshotIds.size()) {
-            throw new ElasticsearchException("Attempting to remove non-existent snapshot [{}] from repository data", snapshotId);
+            throw new ResourceNotFoundException("Attempting to remove non-existent snapshot [{}] from repository data", snapshotId);
         }
         Map<String, SnapshotState> newSnapshotStates = new HashMap<>(snapshotStates);
         newSnapshotStates.remove(snapshotId.getUUID());

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -36,9 +36,9 @@ import org.apache.lucene.store.RateLimiter;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.IOUtils;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -413,7 +413,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                             "its index folder.", metadata.name(), indexId), ioe);
                 }
             }
-        } catch (IOException | ElasticsearchException ex) {
+        } catch (IOException | ResourceNotFoundException ex) {
             throw new RepositoryException(metadata.name(), "failed to delete snapshot [" + snapshotId + "]", ex);
         }
     }

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1180,7 +1180,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         @Override
                         public void onSnapshotCompletion(Snapshot completedSnapshot, SnapshotInfo snapshotInfo) {
                             if (completedSnapshot.equals(snapshot)) {
-                                logger.trace("deleted snapshot completed - deleting files");
+                                logger.debug("deleted snapshot completed - deleting files");
                                 removeListener(this);
                                 threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(() ->
                                     deleteSnapshot(completedSnapshot.getRepository(), completedSnapshot.getSnapshotId().getName(),
@@ -1214,7 +1214,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         }
                     });
                 } else {
-                    logger.trace("deleted snapshot is not running - deleting files");
+                    logger.debug("deleted snapshot is not running - deleting files");
                     deleteSnapshotFromRepository(snapshot, listener, repositoryStateId);
                 }
             }


### PR DESCRIPTION
This commit does two things:
  1. Adds logging at the DEBUG level for when the index-N blob is
  updated.
  2. When attempting to delete a snapshot, if the snapshot was not found
  in the repository data, an exception is now thrown instead of silently
  ignoring the lack of presence of the snapshot in the repository data.
