### PR TITLE
[WIP] update DateFormat to use same year heuristic as Logstash

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateIndexNameProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateIndexNameProcessor.java
@@ -143,7 +143,7 @@ public final class DateIndexNameProcessor extends AbstractProcessor {
             List<Function<String, DateTime>> dateFormats = new ArrayList<>(dateFormatStrings.size());
             for (String format : dateFormatStrings) {
                 DateFormat dateFormat = DateFormat.fromString(format);
-                dateFormats.add(dateFormat.getFunction(format, timezone, locale));
+                dateFormats.add(dateFormat.getFunction(() -> new DateTime(DateTimeZone.UTC), format, timezone, locale));
             }
 
             String field = ConfigurationUtils.readStringProperty(TYPE, tag, config, "field");

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -28,12 +28,14 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.IllformedLocaleException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public final class DateProcessor extends AbstractProcessor {
 
@@ -47,7 +49,8 @@ public final class DateProcessor extends AbstractProcessor {
     private final List<String> formats;
     private final List<Function<String, DateTime>> dateParsers;
 
-    DateProcessor(String tag, DateTimeZone timezone, Locale locale, String field, List<String> formats, String targetField) {
+    DateProcessor(Supplier<DateTime> currentTimeSupplier, String tag, DateTimeZone timezone, Locale locale,
+                  String field, List<String> formats, String targetField) {
         super(tag);
         this.timezone = timezone;
         this.locale = locale;
@@ -57,7 +60,7 @@ public final class DateProcessor extends AbstractProcessor {
         this.dateParsers = new ArrayList<>(this.formats.size());
         for (String format : formats) {
             DateFormat dateFormat = DateFormat.fromString(format);
-            dateParsers.add(dateFormat.getFunction(format, timezone, locale));
+            dateParsers.add(dateFormat.getFunction(currentTimeSupplier, format, timezone, locale));
         }
     }
 
@@ -127,7 +130,8 @@ public final class DateProcessor extends AbstractProcessor {
                 }
             }
             List<String> formats = ConfigurationUtils.readList(TYPE, processorTag, config, "formats");
-            return new DateProcessor(processorTag, timezone, locale, field, formats, targetField);
+            return new DateProcessor(() -> (new DateTime(DateTimeZone.UTC)), processorTag, timezone,
+                locale, field, formats, targetField);
         }
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
@@ -28,13 +28,15 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class DateFormatTests extends ESTestCase {
 
     public void testParseJoda() {
-        Function<String, DateTime> jodaFunction = DateFormat.Joda.getFunction("MMM dd HH:mm:ss Z",
+        Supplier<DateTime> currentTimeSupplier = () -> new DateTime(2019, 10, 23, 8, 40);
+        Function<String, DateTime> jodaFunction = DateFormat.Joda.getFunction(currentTimeSupplier, "MMM dd HH:mm:ss Z",
                 DateTimeZone.forOffsetHours(-8), Locale.ENGLISH);
         assertThat(Instant.ofEpochMilli(jodaFunction.apply("Nov 24 01:29:01 -0800").getMillis())
                         .atZone(ZoneId.of("GMT-8"))
@@ -43,24 +45,27 @@ public class DateFormatTests extends ESTestCase {
     }
 
     public void testParseUnixMs() {
-        assertThat(DateFormat.UnixMs.getFunction(null, DateTimeZone.UTC, null).apply("1000500").getMillis(), equalTo(1000500L));
+        assertThat(DateFormat.UnixMs.getFunction(null, null, DateTimeZone.UTC, null)
+            .apply("1000500").getMillis(), equalTo(1000500L));
     }
 
     public void testParseUnix() {
-        assertThat(DateFormat.Unix.getFunction(null, DateTimeZone.UTC, null).apply("1000.5").getMillis(), equalTo(1000500L));
+        assertThat(DateFormat.Unix.getFunction(null, null, DateTimeZone.UTC, null)
+            .apply("1000.5").getMillis(), equalTo(1000500L));
     }
 
     public void testParseUnixWithMsPrecision() {
-        assertThat(DateFormat.Unix.getFunction(null, DateTimeZone.UTC, null).apply("1495718015").getMillis(), equalTo(1495718015000L));
+        assertThat(DateFormat.Unix.getFunction(null, null, DateTimeZone.UTC, null)
+            .apply("1495718015").getMillis(), equalTo(1495718015000L));
     }
 
     public void testParseISO8601() {
-        assertThat(DateFormat.Iso8601.getFunction(null, DateTimeZone.UTC, null).apply("2001-01-01T00:00:00-0800").getMillis(),
-                equalTo(978336000000L));
+        assertThat(DateFormat.Iso8601.getFunction(null, null, DateTimeZone.UTC, null)
+                .apply("2001-01-01T00:00:00-0800").getMillis(), equalTo(978336000000L));
     }
 
     public void testParseISO8601Failure() {
-        Function<String, DateTime> function = DateFormat.Iso8601.getFunction(null, DateTimeZone.UTC, null);
+        Function<String, DateTime> function = DateFormat.Iso8601.getFunction(null, null, DateTimeZone.UTC, null);
         try {
             function.apply("2001-01-0:00-0800");
             fail("parse should have failed");
@@ -72,7 +77,7 @@ public class DateFormatTests extends ESTestCase {
     public void testTAI64NParse() {
         String input = "4000000050d506482dbdf024";
         String expected = "2012-12-22T03:00:46.767+02:00";
-        assertThat(DateFormat.Tai64n.getFunction(null, DateTimeZone.forOffsetHours(2), null)
+        assertThat(DateFormat.Tai64n.getFunction(null, null, DateTimeZone.forOffsetHours(2), null)
                 .apply((randomBoolean() ? "@" : "") + input).toString(), equalTo(expected));
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameProcessorTests.java
@@ -32,7 +32,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class DateIndexNameProcessorTests extends ESTestCase {
 
     public void testJodaPattern() throws Exception {
-        Function<String, DateTime> function = DateFormat.Joda.getFunction("yyyy-MM-dd'T'HH:mm:ss.SSSZ", DateTimeZone.UTC, Locale.ROOT);
+        Function<String, DateTime> function = DateFormat.Joda.getFunction(DateTime::new, "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+            DateTimeZone.UTC, Locale.ROOT);
         DateIndexNameProcessor processor = new DateIndexNameProcessor(
                 "_tag", "_field", Collections.singletonList(function), DateTimeZone.UTC,
                 "events-", "y", "yyyyMMdd"
@@ -45,7 +46,7 @@ public class DateIndexNameProcessorTests extends ESTestCase {
     }
 
     public void testTAI64N()throws Exception {
-        Function<String, DateTime> function = DateFormat.Tai64n.getFunction(null, DateTimeZone.UTC, null);
+        Function<String, DateTime> function = DateFormat.Tai64n.getFunction(null, null, DateTimeZone.UTC, null);
         DateIndexNameProcessor dateProcessor = new DateIndexNameProcessor("_tag", "_field", Collections.singletonList(function),
                 DateTimeZone.UTC, "events-", "m", "yyyyMMdd");
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null,
@@ -55,7 +56,7 @@ public class DateIndexNameProcessorTests extends ESTestCase {
     }
 
     public void testUnixMs()throws Exception {
-        Function<String, DateTime> function = DateFormat.UnixMs.getFunction(null, DateTimeZone.UTC, null);
+        Function<String, DateTime> function = DateFormat.UnixMs.getFunction(null, null, DateTimeZone.UTC, null);
         DateIndexNameProcessor dateProcessor = new DateIndexNameProcessor("_tag", "_field", Collections.singletonList(function),
                 DateTimeZone.UTC, "events-", "m", "yyyyMMdd");
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null,
@@ -65,7 +66,7 @@ public class DateIndexNameProcessorTests extends ESTestCase {
     }
 
     public void testUnix()throws Exception {
-        Function<String, DateTime> function = DateFormat.Unix.getFunction(null, DateTimeZone.UTC, null);
+        Function<String, DateTime> function = DateFormat.Unix.getFunction(null, null, DateTimeZone.UTC, null);
         DateIndexNameProcessor dateProcessor = new DateIndexNameProcessor("_tag", "_field", Collections.singletonList(function),
                 DateTimeZone.UTC, "events-", "m", "yyyyMMdd");
         IngestDocument document = new IngestDocument("_index", "_type", "_id", null, null,


### PR DESCRIPTION
This is intended to keep parity of behavior between Logstash and Elasticsearch

here was the original PR: https://github.com/logstash-plugins/logstash-filter-date/pull/4

TODO:
- add proper parity tests using the smoke test framework
- add more edge-case test scenarios