### PR TITLE
Remove redundant and broken MD5 checksum from repository-s3

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/DefaultS3OutputStream.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/DefaultS3OutputStream.java
@@ -122,30 +122,11 @@ class DefaultS3OutputStream extends S3OutputStream {
         }
         md.setContentLength(length);
 
-        // We try to compute a MD5 while reading it
-        MessageDigest messageDigest;
-        InputStream inputStream;
-        try {
-            messageDigest = MessageDigest.getInstance("MD5");
-            inputStream = new DigestInputStream(is, messageDigest);
-        } catch (NoSuchAlgorithmException impossible) {
-            // Every implementation of the Java platform is required to support MD5 (see MessageDigest)
-            throw new RuntimeException(impossible);
-        }
-
-        PutObjectRequest putRequest = new PutObjectRequest(bucketName, blobName, inputStream, md)
+        PutObjectRequest putRequest = new PutObjectRequest(bucketName, blobName, is, md)
                 .withStorageClass(blobStore.getStorageClass())
                 .withCannedAcl(blobStore.getCannedACL());
-        PutObjectResult putObjectResult = blobStore.client().putObject(putRequest);
+        blobStore.client().putObject(putRequest);
 
-        String localMd5 = Base64.encodeAsString(messageDigest.digest());
-        String remoteMd5 = putObjectResult.getContentMd5();
-        if (!localMd5.equals(remoteMd5)) {
-            logger.debug("MD5 local [{}], remote [{}] are not equal...", localMd5, remoteMd5);
-            throw new AmazonS3Exception("MD5 local [" + localMd5 +
-                    "], remote [" + remoteMd5 +
-                    "] are not equal...");
-        }
     }
 
     private void initializeMultipart() {

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -76,20 +76,13 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     public PutObjectResult putObject(PutObjectRequest putObjectRequest)
             throws AmazonClientException, AmazonServiceException {
         String blobName = putObjectRequest.getKey();
-        DigestInputStream stream = (DigestInputStream) putObjectRequest.getInputStream();
 
         if (blobs.containsKey(blobName)) {
             throw new AmazonS3Exception("[" + blobName + "] already exists.");
         }
 
-        blobs.put(blobName, stream);
-
-        // input and output md5 hashes need to match to avoid an exception
-        String md5 = Base64.encodeAsString(stream.getMessageDigest().digest());
-        PutObjectResult result = new PutObjectResult();
-        result.setContentMd5(md5);
-
-        return result;
+        blobs.put(blobName, putObjectRequest.getInputStream());
+        return new PutObjectResult();
     }
 
     @Override


### PR DESCRIPTION
Remove redundant and not resettable (fails on retries) check-summing. Checksums are calculated and compared by the S3 client already. #25269

