### PR TITLE
Promote replica on the highest version node

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -24,6 +24,7 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.Assertions;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -67,6 +68,8 @@ public class RoutingNodes implements Iterable<RoutingNode> {
 
     private final Map<String, RoutingNode> nodesToShards = new HashMap<>();
 
+    private final Map<String, Version> nodesToVersions = new HashMap<>();
+
     private final UnassignedShards unassignedShards = new UnassignedShards(this);
 
     private final Map<ShardId, List<ShardRouting>> assignedShards = new HashMap<>();
@@ -94,6 +97,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         // fill in the nodeToShards with the "live" nodes
         for (ObjectCursor<DiscoveryNode> cursor : clusterState.nodes().getDataNodes().values()) {
             nodesToShards.put(cursor.value.getId(), new LinkedHashMap<>()); // LinkedHashMap to preserve order
+            nodesToVersions.put(cursor.value.getId(), cursor.value.getVersion());
         }
 
         // fill in the inverse of node -> shards allocated
@@ -320,14 +324,32 @@ public class RoutingNodes implements Iterable<RoutingNode> {
     /**
      * Returns one active replica shard for the given shard id or <code>null</code> if
      * no active replica is found.
+     *
+     * Since replicas could possibly be on nodes with a older version of ES than
+     * the primary is, this will return replicas on the highest version of ES.
+     *
      */
-    public ShardRouting activeReplica(ShardId shardId) {
+    public ShardRouting activeReplicaWithHighestVersion(ShardId shardId) {
+        Version highestVersionSeen = null;
+        ShardRouting candidate = null;
         for (ShardRouting shardRouting : assignedShards(shardId)) {
             if (!shardRouting.primary() && shardRouting.active()) {
-                return shardRouting;
+                // It's possible for replicaNodeVersion to be null, when deassociating dead nodes
+                // that have been removed, the shards are failed, and part of the shard failing
+                // calls this method with an out-of-date RoutingNodes, where the version might not
+                // be accessible. Therefore, we need to protect against the version being null
+                // (meaning the node will be going away).
+                Version replicaNodeVersion = nodesToVersions.get(shardRouting.currentNodeId());
+                if (replicaNodeVersion == null && candidate == null) {
+                    // Only use this replica if there are no other candidates
+                    candidate = shardRouting;
+                } else if (highestVersionSeen == null || (replicaNodeVersion != null && replicaNodeVersion.after(highestVersionSeen))) {
+                    highestVersionSeen = replicaNodeVersion;
+                    candidate = shardRouting;
+                }
             }
         }
-        return null;
+        return candidate;
     }
 
     /**
@@ -567,7 +589,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             if (failedShard.relocatingNodeId() == null) {
                 if (failedShard.primary()) {
                     // promote active replica to primary if active replica exists (only the case for shadow replicas)
-                    ShardRouting activeReplica = activeReplica(failedShard.shardId());
+                    ShardRouting activeReplica = activeReplicaWithHighestVersion(failedShard.shardId());
                     if (activeReplica == null) {
                         moveToUnassigned(failedShard, unassignedInfo);
                     } else {
@@ -596,7 +618,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             assert failedShard.active();
             if (failedShard.primary()) {
                 // promote active replica to primary if active replica exists
-                ShardRouting activeReplica = activeReplica(failedShard.shardId());
+                ShardRouting activeReplica = activeReplicaWithHighestVersion(failedShard.shardId());
                 if (activeReplica == null) {
                     moveToUnassigned(failedShard, unassignedInfo);
                 } else {

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -339,11 +339,11 @@ public class RoutingNodes implements Iterable<RoutingNode> {
                 RoutingNode replicaNode = node(shardRouting.currentNodeId());
                 if (replicaNode != null && replicaNode.node() != null) {
                     Version replicaNodeVersion = replicaNode.node().getVersion();
-                    if (replicaNodeVersion == null && candidate == null) {
-                        // Only use this replica if there are no other candidates
-                        candidate = shardRouting;
-                    } else if (highestVersionSeen == null || (replicaNodeVersion != null && replicaNodeVersion.after(highestVersionSeen))) {
+                    if (highestVersionSeen == null || replicaNodeVersion.after(highestVersionSeen)) {
                         highestVersionSeen = replicaNodeVersion;
+                        candidate = shardRouting;
+                    } else if (candidate == null) {
+                        // Only use this replica if there are no other candidates
                         candidate = shardRouting;
                     }
                 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedNodeRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedNodeRoutingTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.routing.allocation;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
@@ -57,6 +58,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
@@ -143,10 +145,10 @@ public class FailedNodeRoutingTests extends ESAllocationTestCase {
         // randomly create some indices
         logger.info("--> creating some indices");
         for (int i = 0; i < randomIntBetween(2, 5); i++) {
-            String name = "index_" + randomAlphaOfLength(15).toLowerCase(Locale.ROOT);
+            String name = "index_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
             Settings.Builder settingsBuilder = Settings.builder()
-                .put(SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 3))
-                .put(SETTING_NUMBER_OF_REPLICAS, randomIntBetween(1, 3));
+                .put(SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 4))
+                .put(SETTING_NUMBER_OF_REPLICAS, randomIntBetween(2, 4));
             CreateIndexRequest request = new CreateIndexRequest(name, settingsBuilder.build()).waitForActiveShards(ActiveShardCount.NONE);
             state = cluster.createIndex(state, request);
             assertTrue(state.metaData().hasIndex(name));
@@ -158,35 +160,64 @@ public class FailedNodeRoutingTests extends ESAllocationTestCase {
         logger.info("--> starting shards");
         state = cluster.applyStartedShards(state, state.getRoutingNodes().shardsWithState(INITIALIZING));
         logger.info("--> starting replicas a random number of times");
-        for (int i = 0; i < randomIntBetween(1,4); i++) {
+        for (int i = 0; i < randomIntBetween(1,10); i++) {
             state = cluster.applyStartedShards(state, state.getRoutingNodes().shardsWithState(INITIALIZING));
         }
 
         logger.info("--> state before failing shards: {}", state);
-        for (int i = 0; i < randomIntBetween(5, 10); i++) {
-            for (ShardRouting shardRouting : state.getRoutingNodes().shardsWithState(STARTED)) {
-                if (shardRouting.primary() && randomBoolean()) {
-                    ShardRouting replicaToBePromoted = state.getRoutingNodes()
-                        .activeReplicaWithHighestVersion(shardRouting.shardId());
-                    if (replicaToBePromoted != null) {
-                        Version replicaNodeVersion = state.nodes().getDataNodes()
-                            .get(replicaToBePromoted.currentNodeId()).getVersion();
-                        List<FailedShard> shardsToFail = new ArrayList<>();
-                        logger.info("--> found replica that should be promoted: {}", replicaToBePromoted);
-                        logger.info("--> failing shard {}", shardRouting);
-                        shardsToFail.add(new FailedShard(shardRouting, "failed primary", new Exception()));
-                        state = cluster.applyFailedShards(state, shardsToFail);
-                        ShardRouting newPrimary = state.routingTable().index(shardRouting.index())
-                            .shard(shardRouting.id()).primaryShard();
+        for (ShardRouting shardRouting : state.getRoutingNodes().shardsWithState(STARTED)) {
+            if (shardRouting.primary() && randomBoolean()) {
+                ShardRouting replicaToBePromoted = state.getRoutingNodes()
+                    .activeReplicaWithHighestVersion(shardRouting.shardId());
+                final ClusterState currentState = state;
+                // List of potential candidate replicas for promotion
+                Set<ShardRouting> candidates = state.getRoutingNodes().shardsWithState(STARTED)
+                    .stream()
+                    .filter(s -> !s.primary() && s.active())
+                    .filter(s -> s.shardId().equals(shardRouting.shardId()))
+                    .filter(s -> !s.equals(replicaToBePromoted))
+                    .filter(s -> currentState.getRoutingNodes().node(s.currentNodeId()) != null)
+                    .collect(Collectors.toSet());
+                // If we find a replica and at least another candidate
+                if (replicaToBePromoted != null && candidates.size() > 0) {
+                    logger.info("--> found replica that should be promoted: {}", replicaToBePromoted);
+                    logger.info("--> other candidates: {}", candidates);
 
-                        assertThat(newPrimary.allocationId().getId(),
-                            equalTo(replicaToBePromoted.allocationId().getId()));
+                    List<FailedShard> shardsToFail = new ArrayList<>();
+                    logger.info("--> failing shard {}", shardRouting);
+                    shardsToFail.add(new FailedShard(shardRouting, "failed primary", new Exception()));
+                    state = cluster.applyFailedShards(state, shardsToFail);
+                    ShardRouting newPrimary = state.routingTable().index(shardRouting.index())
+                        .shard(shardRouting.id()).primaryShard();
+                    Version newPrimaryVersion = getNodeVersion(newPrimary, state);
+
+                    final ClusterState compareState = state;
+                    logger.info("--> new primary is on version {}: {}", newPrimaryVersion, newPrimary);
+                    List<Version> candidateVersions = candidates.stream().map(sr -> {
+                        Version version = getNodeVersion(sr, compareState);
+                        logger.info("--> candidate on {} node; shard routing: {}", version, sr);
+                        return version;
+                    }).collect(Collectors.toList());
+                    for (Version candidateVer : candidateVersions) {
+                        assertTrue("candidate was not on the newest version, new primary is on " +
+                                newPrimaryVersion + " and there is a candidate on " + candidateVer,
+                            candidateVer.onOrBefore(newPrimaryVersion));
                     }
                 }
-                state = cluster.reroute(state, new ClusterRerouteRequest());
             }
+            state = cluster.applyStartedShards(state, state.getRoutingNodes().shardsWithState(INITIALIZING));
         }
         terminate(threadPool);
+    }
+
+    private static Version getNodeVersion(ShardRouting shardRouting, ClusterState state) {
+        for (ObjectObjectCursor<String, DiscoveryNode> entry : state.getNodes().getDataNodes()) {
+            if (entry.key.equals(shardRouting.currentNodeId())) {
+                return state.getRoutingNodes().node(entry.key).node().getVersion();
+            }
+        }
+        fail("shard is not assigned to a node");
+        return null;
     }
 
     private static final AtomicInteger nodeIdGenerator = new AtomicInteger();

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedShardsRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedShardsRoutingTests.java
@@ -19,12 +19,14 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -499,7 +501,7 @@ public class FailedShardsRoutingTests extends ESAllocationTestCase {
             Collections.singletonList(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).get(0)));
         assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(2));
         assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(1));
-        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplica(shardId);
+        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
 
 
         // fail the primary shard, check replicas get removed as well...
@@ -555,5 +557,119 @@ public class FailedShardsRoutingTests extends ESAllocationTestCase {
 
         ShardRouting newPrimaryShard = clusterState.routingTable().index("test").shard(0).primaryShard();
         assertThat(newPrimaryShard, not(equalTo(primaryShardToFail)));
+    }
+
+    public void testReplicaOnNewestVersionIsPromoted() {
+        AllocationService allocation = createAllocationService(Settings.builder().build());
+
+        MetaData metaData = MetaData.builder().put(IndexMetaData.builder("test")
+                .settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(3)) .build();
+
+        RoutingTable initialRoutingTable = RoutingTable.builder().addAsNew(metaData.index("test")).build();
+
+        ClusterState clusterState = ClusterState.builder(CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+                .metaData(metaData).routingTable(initialRoutingTable).build();
+
+        ShardId shardId = new ShardId(metaData.index("test").getIndex(), 0);
+
+        // add a single node
+        clusterState = ClusterState.builder(clusterState).nodes(
+                DiscoveryNodes.builder()
+                .add(newNode("node1-5.x", Version.V_5_6_0)))
+                .build();
+        clusterState = ClusterState.builder(clusterState).routingTable(allocation.reroute(clusterState, "reroute").routingTable()).build();
+        assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(3));
+
+        // start primary shard
+        clusterState = allocation.applyStartedShards(clusterState, clusterState.getRoutingNodes().shardsWithState(INITIALIZING));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(3));
+
+        // add another 5.6 node
+        clusterState = ClusterState.builder(clusterState).nodes(
+                DiscoveryNodes.builder(clusterState.nodes())
+                .add(newNode("node2-5.x", Version.V_5_6_0)))
+                .build();
+
+        // start the shards, should have 1 primary and 1 replica available
+        clusterState = allocation.reroute(clusterState, "reroute");
+        assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(1));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(1));
+        clusterState = allocation.applyStartedShards(clusterState, clusterState.getRoutingNodes().shardsWithState(INITIALIZING));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(2));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(2));
+
+        clusterState = ClusterState.builder(clusterState).nodes(
+                DiscoveryNodes.builder(clusterState.nodes())
+                .add(newNode("node3-6.x", Version.V_6_0_0_alpha3))
+                .add(newNode("node4-6.x", Version.V_6_0_0_alpha3)))
+                .build();
+
+        // start all the replicas
+        clusterState = allocation.reroute(clusterState, "reroute");
+        assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(2));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(INITIALIZING).size(), equalTo(2));
+        clusterState = allocation.applyStartedShards(clusterState, clusterState.getRoutingNodes().shardsWithState(INITIALIZING));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(4));
+        assertThat(clusterState.getRoutingNodes().shardsWithState(UNASSIGNED).size(), equalTo(0));
+
+        ShardRouting startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
+        logger.info("--> all shards allocated, replica that should be promoted: {}", startedReplica);
+
+        // fail the primary shard, check replicas get removed as well...
+        ShardRouting primaryShardToFail = clusterState.routingTable().index("test").shard(0).primaryShard();
+        ClusterState newState = allocation.applyFailedShard(clusterState, primaryShardToFail);
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        // the primary gets allocated on another node
+        assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(3));
+
+        ShardRouting newPrimaryShard = clusterState.routingTable().index("test").shard(0).primaryShard();
+        assertThat(newPrimaryShard, not(equalTo(primaryShardToFail)));
+        assertThat(newPrimaryShard.allocationId(), equalTo(startedReplica.allocationId()));
+
+        Version replicaNodeVersion = clusterState.nodes().getDataNodes().get(startedReplica.currentNodeId()).getVersion();
+        assertNotNull(replicaNodeVersion);
+        logger.info("--> shard {} got assigned to node with version {}", startedReplica, replicaNodeVersion);
+
+        for (ObjectCursor<DiscoveryNode> cursor : clusterState.nodes().getDataNodes().values()) {
+            if ("node1".equals(cursor.value.getId())) {
+                // Skip the node that the primary was on, it doesn't have a replica so doesn't need a version check
+                continue;
+            }
+            Version nodeVer = cursor.value.getVersion();
+            assertTrue("expected node [" + cursor.value.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
+                    replicaNodeVersion.onOrAfter(nodeVer));
+        }
+
+        startedReplica = clusterState.getRoutingNodes().activeReplicaWithHighestVersion(shardId);
+        logger.info("--> failing primary shard a second time, should select: {}", startedReplica);
+
+        // fail the primary shard again, and ensure the same thing happens
+        primaryShardToFail = clusterState.routingTable().index("test").shard(0).primaryShard();
+        newState = allocation.applyFailedShard(clusterState, primaryShardToFail);
+        assertThat(newState, not(equalTo(clusterState)));
+        clusterState = newState;
+        // the primary gets allocated on another node
+        assertThat(clusterState.getRoutingNodes().shardsWithState(STARTED).size(), equalTo(2));
+
+        newPrimaryShard = clusterState.routingTable().index("test").shard(0).primaryShard();
+        assertThat(newPrimaryShard, not(equalTo(primaryShardToFail)));
+        assertThat(newPrimaryShard.allocationId(), equalTo(startedReplica.allocationId()));
+
+        replicaNodeVersion = clusterState.nodes().getDataNodes().get(startedReplica.currentNodeId()).getVersion();
+        assertNotNull(replicaNodeVersion);
+        logger.info("--> shard {} got assigned to node with version {}", startedReplica, replicaNodeVersion);
+
+        for (ObjectCursor<DiscoveryNode> cursor : clusterState.nodes().getDataNodes().values()) {
+            if ("node1".equals(cursor.value.getId())) {
+                // Skip the node that the primary was on, it doesn't have a replica so doesn't need a version check
+                continue;
+            }
+            Version nodeVer = cursor.value.getVersion();
+            assertTrue("expected node [" + cursor.value.getId() + "] with version " + nodeVer + " to be before " + replicaNodeVersion,
+                    replicaNodeVersion.onOrAfter(nodeVer));
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.indices.cluster;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
@@ -51,7 +50,6 @@ import org.elasticsearch.discovery.DiscoverySettings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.repositories.RepositoriesService;
-import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -74,8 +72,6 @@ import java.util.function.Supplier;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
-import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
-import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -141,74 +137,6 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
 
         // TODO: check if we can go to green by starting all shards and finishing all iterations
         logger.info("Final cluster state: {}", state);
-    }
-
-    public void testRandomClusterPromotesNewestReplica() {
-        // we have an IndicesClusterStateService per node in the cluster
-        final Map<DiscoveryNode, IndicesClusterStateService> clusterStateServiceMap = new HashMap<>();
-        ClusterState state = randomInitialClusterState(clusterStateServiceMap, MockIndicesService::new);
-
-        // randomly add nodes of mixed versions
-        logger.info("--> adding random nodes");
-        for (int i = 0; i < randomIntBetween(4, 8); i++) {
-            DiscoveryNodes newNodes = DiscoveryNodes.builder(state.nodes())
-                    .add(createRandomVersionNode()).build();
-            state = ClusterState.builder(state).nodes(newNodes).build();
-            state = cluster.reroute(state, new ClusterRerouteRequest()); // always reroute after node leave
-        }
-
-        // Log the shard versions (for debugging if necessary)
-        for (ObjectCursor<DiscoveryNode> cursor : state.nodes().getDataNodes().values()) {
-            Version nodeVer = cursor.value.getVersion();
-            logger.info("--> node [{}] has version [{}]", cursor.value.getId(), nodeVer);
-        }
-
-        // randomly create some indices
-        logger.info("--> creating some indices");
-        for (int i = 0; i < randomIntBetween(2, 5); i++) {
-            String name = "index_" + randomAlphaOfLength(15).toLowerCase(Locale.ROOT);
-            Settings.Builder settingsBuilder = Settings.builder()
-                    .put(SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 3))
-                    .put(SETTING_NUMBER_OF_REPLICAS, randomIntBetween(1, 3));
-            CreateIndexRequest request = new CreateIndexRequest(name, settingsBuilder.build()).waitForActiveShards(ActiveShardCount.NONE);
-            state = cluster.createIndex(state, request);
-            assertTrue(state.metaData().hasIndex(name));
-        }
-        state = cluster.reroute(state, new ClusterRerouteRequest());
-
-        ClusterState previousState = state;
-
-        logger.info("--> starting shards");
-        state = cluster.applyStartedShards(state, state.getRoutingNodes().shardsWithState(INITIALIZING));
-        logger.info("--> starting replicas a random number of times");
-        for (int i = 0; i < randomIntBetween(1,4); i++) {
-            state = cluster.applyStartedShards(state, state.getRoutingNodes().shardsWithState(INITIALIZING));
-        }
-
-        logger.info("--> state before failing shards: {}", state);
-        for (int i = 0; i < randomIntBetween(5, 10); i++) {
-            for (ShardRouting shardRouting : state.getRoutingNodes().shardsWithState(STARTED)) {
-                if (shardRouting.primary() && randomBoolean()) {
-                    ShardRouting replicaToBePromoted = state.getRoutingNodes()
-                        .activeReplicaWithHighestVersion(shardRouting.shardId());
-                    if (replicaToBePromoted != null) {
-                        Version replicaNodeVersion = state.nodes().getDataNodes()
-                            .get(replicaToBePromoted.currentNodeId()).getVersion();
-                        List<FailedShard> shardsToFail = new ArrayList<>();
-                        logger.info("--> found replica that should be promoted: {}", replicaToBePromoted);
-                        logger.info("--> failing shard {}", shardRouting);
-                        shardsToFail.add(new FailedShard(shardRouting, "failed primary", new Exception()));
-                        state = cluster.applyFailedShards(state, shardsToFail);
-                        ShardRouting newPrimary = state.routingTable().index(shardRouting.index())
-                            .shard(shardRouting.id()).primaryShard();
-
-                        assertThat(newPrimary.allocationId().getId(),
-                            equalTo(replicaToBePromoted.allocationId().getId()));
-                    }
-                }
-                state = cluster.reroute(state, new ClusterRerouteRequest());
-            }
-        }
     }
 
     /**
@@ -458,16 +386,6 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
         final String id = String.format(Locale.ROOT, "node_%03d", nodeIdGenerator.incrementAndGet());
         return new DiscoveryNode(id, id, buildNewFakeTransportAddress(), Collections.emptyMap(), roles,
             Version.CURRENT);
-    }
-
-    protected DiscoveryNode createRandomVersionNode(DiscoveryNode.Role... mustHaveRoles) {
-        Set<DiscoveryNode.Role> roles = new HashSet<>(randomSubsetOf(Sets.newHashSet(DiscoveryNode.Role.values())));
-        for (DiscoveryNode.Role mustHaveRole : mustHaveRoles) {
-            roles.add(mustHaveRole);
-        }
-        final String id = String.format(Locale.ROOT, "node_%03d", nodeIdGenerator.incrementAndGet());
-        return new DiscoveryNode(id, id, buildNewFakeTransportAddress(), Collections.emptyMap(), roles,
-                VersionUtils.randomVersionBetween(random(), Version.V_5_6_0, null));
     }
 
     private static ClusterState adaptClusterStateToLocalNode(ClusterState state, DiscoveryNode node) {


### PR DESCRIPTION
This changes the replica selection to prefer to return replicas on the highest
version when choosing a replacement to promote when the primary shard fails.

Consider this situation:

- A replica on a 5.6 node
- Another replica on a 6.0 node
- The primary on a 6.0 node

The primary shard is sending sequence numbers to the replica on the 6.0 node and
skipping sending them for the 5.6 node. Now assume that the primary shard fails
and (prior to this change) the replica on 5.6 node gets promoted to primary, it
now has no knowledge of sequence numbers and the replica on the 6.0 node will be
expecting sequence numbers but will never receive them.

Relates to #10708
