### PR TITLE
Initialise empty lists in BaseTaskResponse constructor

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksResponse.java
@@ -44,11 +44,6 @@ public class BaseTasksResponse extends ActionResponse {
     private List<TaskOperationFailure> taskFailures;
     private List<FailedNodeException> nodeFailures;
 
-    public BaseTasksResponse() {
-        taskFailures = Collections.emptyList();
-        nodeFailures = Collections.emptyList();
-    }
-
     public BaseTasksResponse(List<TaskOperationFailure> taskFailures, List<? extends FailedNodeException> nodeFailures) {
         this.taskFailures = taskFailures == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(taskFailures));
         this.nodeFailures = nodeFailures == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(nodeFailures));

--- a/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksResponse.java
@@ -45,6 +45,8 @@ public class BaseTasksResponse extends ActionResponse {
     private List<FailedNodeException> nodeFailures;
 
     public BaseTasksResponse() {
+        taskFailures = Collections.emptyList();
+        nodeFailures = Collections.emptyList();
     }
 
     public BaseTasksResponse(List<TaskOperationFailure> taskFailures, List<? extends FailedNodeException> nodeFailures) {

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TestTaskPlugin.java
@@ -386,7 +386,7 @@ public class TestTaskPlugin extends Plugin implements ActionPlugin {
         private List<UnblockTestTaskResponse> tasks;
 
         public UnblockTestTasksResponse() {
-
+            super(null, null);
         }
 
         public UnblockTestTasksResponse(List<UnblockTestTaskResponse> tasks, List<TaskOperationFailure> taskFailures, List<? extends

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -217,7 +217,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         private List<TestTaskResponse> tasks;
 
         TestTasksResponse() {
-
+            super(null, null);
         }
 
         TestTasksResponse(List<TestTaskResponse> tasks, List<TaskOperationFailure> taskFailures,


### PR DESCRIPTION
It's trivial to get `NullPointerException`s when using this class if as the default constructor does not initialise the members. 

