### PR TITLE
Keystore CLI should use the AddFileKeyStoreCommand for files

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/KeyStoreCli.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/KeyStoreCli.java
@@ -32,7 +32,7 @@ public class KeyStoreCli extends MultiCommand {
         subcommands.put("create", new CreateKeyStoreCommand());
         subcommands.put("list", new ListKeyStoreCommand());
         subcommands.put("add", new AddStringKeyStoreCommand());
-        subcommands.put("add-file", new AddStringKeyStoreCommand());
+        subcommands.put("add-file", new AddFileKeyStoreCommand());
         subcommands.put("remove", new RemoveSettingKeyStoreCommand());
     }
 


### PR DESCRIPTION
This commit fixes a typo in the KeyStoreCli class. The add-file command was incorrectly set to use
the AddStringKeyStoreCommand instead of the AddFileKeyStoreCommand.