### PR TITLE
[DOCS] Split index-shared.asciidoc into multiple smaller files

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -26,12 +26,8 @@ release-state can be: released | prerelease | unreleased
 :plugin_url:      https://artifacts.elastic.co/downloads/elasticsearch-plugins
 
 :xpack:           X-Pack
-:xpackml:         X-Pack machine learning
-:ml:              machine learning
 :es:              Elasticsearch
 :kib:             Kibana
-
-:xes-repo-dir:    {docdir}/../../../elasticsearch-extra/x-pack-elasticsearch/docs/en
 
 ///////
 Javadoc roots used to generate links from Painless's API reference

--- a/docs/reference/index-all.asciidoc
+++ b/docs/reference/index-all.asciidoc
@@ -1,6 +1,0 @@
-[[elasticsearch-reference]]
-= Elasticsearch Reference
-
-:include-xpack:             true
-
-include::index-shared.asciidoc[]

--- a/docs/reference/index-shared1.asciidoc
+++ b/docs/reference/index-shared1.asciidoc
@@ -1,0 +1,4 @@
+
+include::getting-started.asciidoc[]
+
+include::setup.asciidoc[]

--- a/docs/reference/index-shared2.asciidoc
+++ b/docs/reference/index-shared2.asciidoc
@@ -1,11 +1,4 @@
 
-include::../Versions.asciidoc[]
-
-
-include::getting-started.asciidoc[]
-
-include::setup.asciidoc[]
-
 include::migration/index.asciidoc[]
 
 include::api-conventions.asciidoc[]
@@ -33,13 +26,3 @@ include::modules.asciidoc[]
 include::index-modules.asciidoc[]
 
 include::ingest.asciidoc[]
-
-include::how-to.asciidoc[]
-
-include::testing.asciidoc[]
-
-include::glossary.asciidoc[]
-
-include::release-notes.asciidoc[]
-
-include::redirects.asciidoc[]

--- a/docs/reference/index-shared3.asciidoc
+++ b/docs/reference/index-shared3.asciidoc
@@ -1,0 +1,10 @@
+
+include::how-to.asciidoc[]
+
+include::testing.asciidoc[]
+
+include::glossary.asciidoc[]
+
+include::release-notes.asciidoc[]
+
+include::redirects.asciidoc[]

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -4,4 +4,7 @@
 :es-test-dir: {docdir}/../src/test
 :plugins-examples-dir: {docdir}/../../plugins/examples
 
-include::index-shared.asciidoc[]
+include::../Versions.asciidoc[]
+include::index-shared1.asciidoc[]
+include::index-shared2.asciidoc[]
+include::index-shared3.asciidoc[]


### PR DESCRIPTION
This pull request removes the index-all.asciidoc which is no longer required in this repository. 

It also splits the index-shared.asciidoc into files (index-shared1.asciidoc, index-shared2.asciidoc, and index-shared3.asciidoc), so that the table of contents can be re-used in smaller parts elsewhere. @debadair, if you prefer to use different names for those parts, please just let me know so I can make the same change where they're referenced elsewhere.

Finally, it removes some X-Pack attributes that are no longer required.  

NOTE: This PR should not be merged until corresponding changes are made in docs/conf.yaml since it currently references the index-all.asciidoc in this repo.