### PR TITLE
Initialize primary term for shrunk indices

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -360,6 +360,11 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                             tmpImdBuilder.settings(actualIndexSettings);
 
                             if (shrinkFromIndex != null) {
+                                /*
+                                 * We need to arrange that the primary term on all the shards in the shrunken index is at least as large as
+                                 * the maximum primary term on all the shards in the source index. This ensures that we have correct
+                                 * document-level semantics regarding sequence numbers in the shrunken index.
+                                 */
                                 final IndexMetaData sourceMetaData = currentState.metaData().getIndexSafe(shrinkFromIndex);
                                 final long primaryTerm =
                                         IntStream


### PR DESCRIPTION
Today when an index is shrunk, the primary terms for its shards start from one. Yet, this is a problem as the index will already contain assigned sequence numbers across primary terms. To ensure document-level sequence number semantics, the primary terms of the target shards must start from the maximum of all the shards in the source index. This commit causes this to be the case.

Relates #10708

