### PR TITLE
Rewrite `exists` queries to a `match_all` query when all documents match.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/util/LocaleUtils.java
+++ b/core/src/main/java/org/elasticsearch/common/util/LocaleUtils.java
@@ -57,4 +57,8 @@ public class LocaleUtils {
         // JAVA7 - use .toLanguageTag instead of .toString()
         return locale.toString();
     }
+
+    public static void main(String[] args) {
+        System.out.println(parse("aar").getDisplayLanguage());
+    }
 }

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -143,8 +143,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         }
 
         if (fields.size() == 1) {
-            Query filter = fieldNamesFieldType.termQuery(fields.iterator().next(), context);
-            return new ConstantScoreQuery(filter);
+            return fieldNamesFieldType.termQuery(fields.iterator().next(), context);
         }
 
         BooleanQuery.Builder boolFilterBuilder = new BooleanQuery.Builder();

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -25,15 +25,18 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryUtils;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper.FieldExistsQuery;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.test.IndexSettingsModule;
@@ -59,15 +62,9 @@ public class FieldNamesFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testTermQuery() throws IOException {
-        Directory dir = newDirectory();
-        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
-        Document doc = new Document();
-        StringField fieldNames = new StringField(FieldNamesFieldMapper.CONTENT_TYPE, "field_name", Store.NO);
-        doc.add(fieldNames);
-        w.addDocument(doc);
-        IndexReader reader = DirectoryReader.open(w);
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAlphaOfLengthBetween(1, 10), Settings.EMPTY);
-        QueryShardContext context = new QueryShardContext(0, idxSettings, null, null, null, null, null, null, null, reader, null);
+        QueryShardContext context = new QueryShardContext(
+                0, idxSettings, null, null, null, null, null, null, null, null, null, null, null);
         
         FieldNamesFieldMapper.FieldNamesFieldType type = new FieldNamesFieldMapper.FieldNamesFieldType();
         type.setName(FieldNamesFieldMapper.CONTENT_TYPE);
@@ -75,22 +72,37 @@ public class FieldNamesFieldTypeTests extends FieldTypeTestCase {
 
         Query termQuery = type.termQuery("field_name", context);
         // all docs have the field
-        assertEquals(new MatchAllDocsQuery(), termQuery);
-
-        fieldNames.setStringValue("random_field_name");
-        w.addDocument(doc);
-        reader.close();
-        reader = DirectoryReader.open(w);
-        context = new QueryShardContext(0, idxSettings, null, null, null, null, null, null, null, reader, null);
-
-        termQuery = type.termQuery("field_name", context);
-        // not all docs have the field
-        assertEquals(new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name"))), termQuery);
+        assertEquals(new FieldExistsQuery(new BytesRef("field_name")), termQuery);
 
         type.setEnabled(false);
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> type.termQuery("field_name", null));
         assertEquals("Cannot run [exists] queries if the [_field_names] field is disabled", e.getMessage());
+    }
 
-        IOUtils.close(reader, w, dir);
+    public void testFieldExistsQueryEqualsAndHashcode() {
+        FieldExistsQuery q1 = new FieldExistsQuery(new BytesRef("foo"));
+        FieldExistsQuery q2 = new FieldExistsQuery(new BytesRef("foo"));
+        FieldExistsQuery q3 = new FieldExistsQuery(new BytesRef("bar"));
+        QueryUtils.checkEqual(q1, q2);
+        QueryUtils.checkUnequal(q1, q3);
+    }
+
+    public void testFieldExistsQuery() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+        Document doc = new Document();
+        doc.add(new StringField("_field_names", "foo", Store.NO));
+        w.addDocument(doc);
+        doc.add(new StringField("_field_names", "bar", Store.NO));
+        w.addDocument(doc);
+        w.forceMerge(1);
+        IndexReader reader = DirectoryReader.open(w);
+        w.close();
+        IndexSearcher searcher = new IndexSearcher(reader);
+        assertEquals(new MatchAllDocsQuery(), searcher.rewrite(new FieldExistsQuery(new BytesRef("foo"))));
+        assertEquals(new ConstantScoreQuery(new TermQuery(new Term("_field_names", "bar"))),
+                searcher.rewrite(new FieldExistsQuery(new BytesRef("bar"))));
+        assertEquals(new MatchNoDocsQuery(), searcher.rewrite(new FieldExistsQuery(new BytesRef("quux"))));
+        IOUtils.close(reader, dir);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -18,12 +18,28 @@
  */
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.ParseContext.Document;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.test.IndexSettingsModule;
 import org.junit.Before;
+
+import java.io.IOException;
 
 public class FieldNamesFieldTypeTests extends FieldTypeTestCase {
     @Override
@@ -42,14 +58,39 @@ public class FieldNamesFieldTypeTests extends FieldTypeTestCase {
         });
     }
 
-    public void testTermQuery() {
+    public void testTermQuery() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, newIndexWriterConfig());
+        Document doc = new Document();
+        StringField fieldNames = new StringField(FieldNamesFieldMapper.CONTENT_TYPE, "field_name", Store.NO);
+        doc.add(fieldNames);
+        w.addDocument(doc);
+        IndexReader reader = DirectoryReader.open(w);
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAlphaOfLengthBetween(1, 10), Settings.EMPTY);
+        QueryShardContext context = new QueryShardContext(0, idxSettings, null, null, null, null, null, null, null, reader, null);
+        
         FieldNamesFieldMapper.FieldNamesFieldType type = new FieldNamesFieldMapper.FieldNamesFieldType();
         type.setName(FieldNamesFieldMapper.CONTENT_TYPE);
         type.setEnabled(true);
-        Query termQuery = type.termQuery("field_name", null);
-        assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name")), termQuery);
+
+        Query termQuery = type.termQuery("field_name", context);
+        // all docs have the field
+        assertEquals(new MatchAllDocsQuery(), termQuery);
+
+        fieldNames.setStringValue("random_field_name");
+        w.addDocument(doc);
+        reader.close();
+        reader = DirectoryReader.open(w);
+        context = new QueryShardContext(0, idxSettings, null, null, null, null, null, null, null, reader, null);
+
+        termQuery = type.termQuery("field_name", context);
+        // not all docs have the field
+        assertEquals(new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name"))), termQuery);
+
         type.setEnabled(false);
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> type.termQuery("field_name", null));
         assertEquals("Cannot run [exists] queries if the [_field_names] field is disabled", e.getMessage());
+
+        IOUtils.close(reader, w, dir);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -65,9 +65,8 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
             MatchNoDocsQuery matchNoDocsQuery = (MatchNoDocsQuery) query;
             assertThat(matchNoDocsQuery.toString(null), containsString("Missing types in \"exists\" query."));
         } else if (fields.size() == 1) {
-            assertThat(query, instanceOf(ConstantScoreQuery.class));
-            ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
-            assertThat(constantScoreQuery.getQuery(), instanceOf(MatchAllDocsQuery.class));
+            assertEquals(context.getQueryShardContext().fieldMapper("_field_names")
+                    .termQuery(fields.iterator().next(), context.getQueryShardContext()), query);
         } else {
             assertThat(query, instanceOf(ConstantScoreQuery.class));
             ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -22,9 +22,9 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
@@ -67,9 +67,7 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
         } else if (fields.size() == 1) {
             assertThat(query, instanceOf(ConstantScoreQuery.class));
             ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
-            assertThat(constantScoreQuery.getQuery(), instanceOf(TermQuery.class));
-            TermQuery termQuery = (TermQuery) constantScoreQuery.getQuery();
-            assertEquals(fields.iterator().next(), termQuery.getTerm().text());
+            assertThat(constantScoreQuery.getQuery(), instanceOf(MatchAllDocsQuery.class));
         } else {
             assertThat(query, instanceOf(ConstantScoreQuery.class));
             ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -804,7 +804,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         Query query = queryBuilder.toQuery(context);
         Query expected;
         if (getCurrentTypes().length > 0) {
-            expected = new ConstantScoreQuery(new TermQuery(new Term("_field_names", "foo")));
+            expected = context.fieldMapper("_field_names").termQuery("foo", context);
         } else {
             expected = new MatchNoDocsQuery();
         }

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -54,6 +54,7 @@ import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.search.QueryStringQueryParser;
 import org.elasticsearch.search.internal.SearchContext;

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -23,20 +23,16 @@ import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.index.Term;
-import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.mapper.DateFieldMapper;
-import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.mapper.MapperService;
@@ -129,7 +125,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         if (queryBuilder.from() == null && queryBuilder.to() == null) {
             final Query expectedQuery;
             if (getCurrentTypes().length > 0) {
-                expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, queryBuilder.fieldName())));
+                expectedQuery = context.getQueryShardContext().fieldMapper("_field_names")
+                        .termQuery(queryBuilder.fieldName(), context.getQueryShardContext());
             } else {
                 expectedQuery = new MatchNoDocsQuery("no mappings yet");
             }
@@ -443,7 +440,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         final Query luceneQuery = rewrittenRange.toQuery(queryShardContext);
         final Query expectedQuery;
         if (getCurrentTypes().length > 0) {
-            expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, query.fieldName())));
+            expectedQuery = queryShardContext.fieldMapper("_field_names").termQuery(fieldName, queryShardContext);
         } else {
             expectedQuery = new MatchNoDocsQuery("no mappings yet");
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -21,8 +21,6 @@ package org.elasticsearch.test;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -1102,12 +1100,6 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         }
 
         QueryShardContext createShardContext() {
-            IndexReader reader;
-            try {
-                reader = new MultiReader();
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
             return new QueryShardContext(0, idxSettings, bitsetFilterCache, indexFieldDataService::getForField, mapperService,
                 similarityService, scriptService, xContentRegistry, namedWriteableRegistry, this.client, null, () -> nowInMillis, null);
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -21,6 +21,8 @@ package org.elasticsearch.test;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -1100,6 +1102,12 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
         }
 
         QueryShardContext createShardContext() {
+            IndexReader reader;
+            try {
+                reader = new MultiReader();
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
             return new QueryShardContext(0, idxSettings, bitsetFilterCache, indexFieldDataService::getForField, mapperService,
                 similarityService, scriptService, xContentRegistry, namedWriteableRegistry, this.client, null, () -> nowInMillis, null);
         }


### PR DESCRIPTION
Since `BooleanQuery` has special rewrite rules in case some clauses are
instances of `MatchAllDocsQuery` this can help simplify queries. I think this
change will be especially helpful when #22640 is implemented.