### PR TITLE
Get short path name for native controllers

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/JNAKernel32Library.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JNAKernel32Library.java
@@ -24,6 +24,7 @@ import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import com.sun.jna.WString;
 import com.sun.jna.win32.StdCallLibrary;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
@@ -222,6 +223,18 @@ final class JNAKernel32Library {
      * @return true if the function succeeds.
      */
     native boolean CloseHandle(Pointer handle);
+
+    /**
+     * Retrieves the short path form of the specified path. See
+     * <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa364989.aspx">{@code GetShortPathName}</a>.
+     *
+     * @param lpszLongPath  the path string
+     * @param lpszShortPath a pointer to a buffer to receive the null-terminated short form of the path that {@code lpszLongPath} specifies;
+     *                      passing null and zero for the size of the buffer returns the required buffer size
+     * @param cchBuffer     the size of the buffer that {@code lpszShortPath} points to (zero if {@code lpszShortPath} is null)
+     * @return the length of the string copied into {@code lpszShortPath}, otherwise zero for failure
+     */
+    native int GetShortPathNameW(WString lpszLongPath, char[] lpszShortPath, int cchBuffer);
 
     /**
      * Creates or opens a new job object

--- a/core/src/main/java/org/elasticsearch/bootstrap/JNAKernel32Library.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JNAKernel32Library.java
@@ -229,9 +229,8 @@ final class JNAKernel32Library {
      * <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa364989.aspx">{@code GetShortPathName}</a>.
      *
      * @param lpszLongPath  the path string
-     * @param lpszShortPath a pointer to a buffer to receive the null-terminated short form of the path that {@code lpszLongPath} specifies;
-     *                      passing null and zero for the size of the buffer returns the required buffer size
-     * @param cchBuffer     the size of the buffer that {@code lpszShortPath} points to (zero if {@code lpszShortPath} is null)
+     * @param lpszShortPath a buffer to receive the short name
+     * @param cchBuffer     the size of the buffer
      * @return the length of the string copied into {@code lpszShortPath}, otherwise zero for failure
      */
     native int GetShortPathNameW(WString lpszLongPath, char[] lpszShortPath, int cchBuffer);

--- a/core/src/main/java/org/elasticsearch/bootstrap/Natives.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Natives.java
@@ -76,6 +76,20 @@ final class Natives {
         JNANatives.tryVirtualLock();
     }
 
+    /**
+     * Retrieves the short path form of the specified path.
+     *
+     * @param path the path
+     * @return the short path name (or the original path if getting the short path name fails for any reason)
+     */
+    static String getShortPathName(final String path) {
+        if (!JNA_AVAILABLE) {
+            logger.warn("cannot obtain short path for [{}] because JNA is not avilable", path);
+            return path;
+        }
+        return JNANatives.getShortPathName(path);
+    }
+
     static void addConsoleCtrlHandler(ConsoleCtrlHandler handler) {
         if (!JNA_AVAILABLE) {
             logger.warn("cannot register console handler because JNA is not available");

--- a/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -108,7 +108,7 @@ final class Spawner implements Closeable {
              * if its first argument (the application name) is null, then its second argument (the command line for the process to start) is
              * restricted in length to 260 characters (cf. https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425.aspx). Since
              * this is exactly how the JDK starts the process on Windows (cf.
-             * http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/windows/native/java/lang/ProcessImpl_md.c#l3190), this
+             * http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/windows/native/java/lang/ProcessImpl_md.c#l319), this
              * limitation is in force. As such, we use the short name to avoid any such problems.
              */
             command = Natives.getShortPathName(spawnPath.toString());

--- a/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -102,7 +102,15 @@ final class Spawner implements Closeable {
             final Path tmpPath) throws IOException {
         final String command;
         if (Constants.WINDOWS) {
-            // we have to get the short path name or CreateProcessW will fail due to MAX_PATH limitations
+            /*
+             * We have to get the short path name or starting the process could fail due to max path limitations. The underlying issue here
+             * is that starting the process on Windows ultimately involves the use of CreateProcessW. CreateProcessW has a limitation that
+             * if its first argument (the application name) is null, then its second argument (the command line for the process to start) is
+             * restricted in length to 260 characters (cf. https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425.aspx). Since
+             * this is exactly how the JDK starts the process on Windows (cf.
+             * http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/windows/native/java/lang/ProcessImpl_md.c#l3190), this
+             * limitation is in force. As such, we use the short name to avoid any such problems.
+             */
             command = Natives.getShortPathName(spawnPath.toString());
         } else {
             command = spawnPath.toString();

--- a/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.bootstrap;
 
+import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Platforms;
@@ -99,7 +100,14 @@ final class Spawner implements Closeable {
     private Process spawnNativePluginController(
             final Path spawnPath,
             final Path tmpPath) throws IOException {
-        final ProcessBuilder pb = new ProcessBuilder(spawnPath.toString());
+        final String command;
+        if (Constants.WINDOWS) {
+            // we have to get the short path name or CreateProcessW will fail due to MAX_PATH limitations
+            command = Natives.getShortPathName(spawnPath.toString());
+        } else {
+            command = spawnPath.toString();
+        }
+        final ProcessBuilder pb = new ProcessBuilder(command);
 
         // the only environment variable passes on the path to the temporary directory
         pb.environment().clear();


### PR DESCRIPTION
Due to limitations with CreateProcessW on Windows (ultimately used by ProcessBuilder) with respect to maximum path lengths, we need to get the short path name for any native controllers before trying to start them in case the absolute path exceeds the maximum path length. This commit uses JNA to invoke the necessary Windows API for this to start the native controller using the short path.

To be precise about the limitation here, the MSDN docs for CreateProcessW say for the command line parameter:

>The command line to be executed. The maximum length of this string is 32,768 characters, including the Unicode terminating null character. If lpApplicationName is NULL, the module name portionof lpCommandLine is limited to MAX_PATH characters.

This is exactly how the Windows implementation of Process in the JDK invokes CreateProcessW: with the executable name (lpApplicationName) set to NULL.

