### PR TITLE
Remove remaining `index.mapping.single_type=false`

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/mapper/TypeFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/TypeFieldMapperTests.java
@@ -62,8 +62,8 @@ public class TypeFieldMapperTests extends ESSingleNodeTestCase {
     }
 
     public void testDocValues(boolean singleType) throws IOException {
-        Settings indexSettings = Settings.builder()
-                .put("index.mapping.single_type", singleType)
+        Settings indexSettings = singleType ? Settings.EMPTY : Settings.builder()
+                .put("index.version.created", Version.V_5_6_0)
                 .build();
         MapperService mapperService = createIndex("test", indexSettings).mapperService();
         DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE, false);

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenIT.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenIT.java
@@ -26,9 +26,7 @@ import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.join.query.ParentChildTestCase;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -36,12 +34,9 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.search.aggregations.metrics.tophits.TopHits;
 import org.elasticsearch.search.sort.SortOrder;
-import org.elasticsearch.test.InternalSettingsPlugin;
 import org.junit.Before;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -68,11 +63,7 @@ public class ChildrenIT extends ParentChildTestCase {
 
 
     private static final Map<String, Control> categoryToControl = new HashMap<>();
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
-        plugins.add(InternalSettingsPlugin.class);
-        return plugins;
-    }
+
 
     @Before
     public void setupCluster() throws Exception {

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/InnerHitsIT.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/InnerHitsIT.java
@@ -72,7 +72,9 @@ public class InnerHitsIT extends ParentChildTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(ParentJoinPlugin.class, CustomScriptPlugin.class);
+        ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(CustomScriptPlugin.class);
+        return plugins;
     }
 
     public static class CustomScriptPlugin extends MockScriptPlugin {

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyHasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyHasChildQueryBuilderTests.java
@@ -114,7 +114,7 @@ public class LegacyHasChildQueryBuilderTests extends AbstractQueryTestCase<HasCh
     protected Settings indexSettings() {
         return Settings.builder()
             .put(super.indexSettings())
-            .put("index.mapping.single_type", false)
+            .put("index.version.created", Version.V_5_6_0) // multi type
             .build();
     }
 

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyHasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyHasParentQueryBuilderTests.java
@@ -75,7 +75,7 @@ public class LegacyHasParentQueryBuilderTests extends AbstractQueryTestCase<HasP
     protected Settings indexSettings() {
         return Settings.builder()
             .put(super.indexSettings())
-            .put("index.mapping.single_type", false)
+            .put("index.version.created", Version.V_5_6_0) // legacy needs multi types
             .build();
     }
 

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyParentIdQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyParentIdQueryBuilderTests.java
@@ -24,6 +24,7 @@ import org.apache.lucene.search.DocValuesTermsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -58,7 +59,7 @@ public class LegacyParentIdQueryBuilderTests extends AbstractQueryTestCase<Paren
     protected Settings indexSettings() {
         return Settings.builder()
             .put(super.indexSettings())
-            .put("index.mapping.single_type", false)
+            .put("index.version.created", Version.V_5_6_0) // legacy needs multi type
             .build();
     }
 

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentChildTestCase.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentChildTestCase.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.join.query;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -27,8 +28,10 @@ import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,7 +47,7 @@ public abstract class ParentChildTestCase extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Collections.singleton(ParentJoinPlugin.class);
+        return Arrays.asList(InternalSettingsPlugin.class, ParentJoinPlugin.class);
     }
 
     @Override
@@ -60,7 +63,7 @@ public abstract class ParentChildTestCase extends ESIntegTestCase {
             .put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true);
 
         if (legacy()) {
-            builder.put("index.mapping.single_type", false);
+            builder.put("index.version.created", Version.V_5_6_0);
         }
 
         return builder.build();

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexParentChildTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/ReindexParentChildTests.java
@@ -19,11 +19,13 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.InternalSettingsPlugin;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -56,6 +58,7 @@ public class ReindexParentChildTests extends ReindexTestCase {
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         final List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
         plugins.add(ParentJoinPlugin.class);
+        plugins.add(InternalSettingsPlugin.class);
         return Collections.unmodifiableList(plugins);
     }
 
@@ -116,7 +119,7 @@ public class ReindexParentChildTests extends ReindexTestCase {
      */
     private void createParentChildIndex(String indexName) throws Exception {
         CreateIndexRequestBuilder create = client().admin().indices().prepareCreate(indexName);
-        create.setSettings("index.mapping.single_type", false);
+        create.setSettings("index.version.created", Version.V_5_6_0.id);
         create.addMapping("city", "{\"_parent\": {\"type\": \"country\"}}", XContentType.JSON);
         create.addMapping("neighborhood", "{\"_parent\": {\"type\": \"city\"}}", XContentType.JSON);
         assertAcked(create);


### PR DESCRIPTION
This change cleans up remaining tests  to not use index.mapping.single_type=false
but instead where applicable use a single type or markt the index as created
with a pre 6.x version.

Yet, there is still on leftover in the client tests that needs special attention.
See `org.elasticsearch.client.SearchIT`

Relates to #24961
