### PR TITLE
Replace outdated WordPress plugins

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -17,10 +17,7 @@ Integrations are not plugins, but are external tools or modules that make it eas
 * https://drupal.org/project/elasticsearch_connector[Drupal]:
   Drupal Elasticsearch integration.
 
-* http://searchbox-io.github.com/wp-elasticsearch/[Wp-Elasticsearch]:
-  Elasticsearch WordPress Plugin
-
-* https://github.com/wallmanderco/elasticsearch-indexer[Elasticsearch Indexer]:
+* https://github.com/10up/elasticpress[ElasticPress]:
   Elasticsearch WordPress Plugin
 
 * https://doc.tiki.org/Elasticsearch[Tiki Wiki CMS Groupware]:


### PR DESCRIPTION
Both WordPress plugins mentioned here were not updated for over 2 years. ElasticPress is a very good alternative and covers the features of both plugins and provides a solid plugin system for extending it further. It has a strong development community behind it and is actively maintained.
