### PR TITLE
Test: Allow merging mock secure settings

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -718,6 +718,14 @@ public final class Settings implements ToXContent {
             if (secureSettings.isLoaded() == false) {
                 throw new IllegalStateException("Secure settings must already be loaded");
             }
+            if (secureSettings.getSettingNames().isEmpty()) {
+                // TODO: fix this leniency!!!
+                return this; // no secure settings to add...
+            }
+            if (this.secureSettings.get() != null) {
+                throw new IllegalArgumentException("Secure settings already set. Existing settings: " +
+                    this.secureSettings.get().getSettingNames() + ", new settings: " + secureSettings.getSettingNames());
+            }
             this.secureSettings.set(secureSettings);
             return this;
         }

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -718,10 +718,10 @@ public final class Settings implements ToXContent {
             if (secureSettings.isLoaded() == false) {
                 throw new IllegalStateException("Secure settings must already be loaded");
             }
-            if (secureSettings.getSettingNames().isEmpty()) {
+            /*if (secureSettings.getSettingNames().isEmpty()) {
                 // TODO: fix this leniency!!!
                 return this; // no secure settings to add...
-            }
+            }*/
             if (this.secureSettings.get() != null) {
                 throw new IllegalArgumentException("Secure settings already set. Existing settings: " +
                     this.secureSettings.get().getSettingNames() + ", new settings: " + secureSettings.getSettingNames());

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -718,10 +718,6 @@ public final class Settings implements ToXContent {
             if (secureSettings.isLoaded() == false) {
                 throw new IllegalStateException("Secure settings must already be loaded");
             }
-            /*if (secureSettings.getSettingNames().isEmpty()) {
-                // TODO: fix this leniency!!!
-                return this; // no secure settings to add...
-            }*/
             if (this.secureSettings.get() != null) {
                 throw new IllegalArgumentException("Secure settings already set. Existing settings: " +
                     this.secureSettings.get().getSettingNames() + ", new settings: " + secureSettings.getSettingNames());

--- a/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -677,8 +677,8 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
                 continue;
             }
             Settings mergedSettings = Settings.builder()
-                .put(defaultSettings)
-                .put(profileSettings)
+                .put(defaultSettings.getAsMap())
+                .put(profileSettings.getAsMap())
                 .build();
             result.put(name, mergedSettings);
         }

--- a/test/framework/src/main/java/org/elasticsearch/common/settings/MockSecureSettings.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/settings/MockSecureSettings.java
@@ -72,6 +72,18 @@ public class MockSecureSettings implements SecureSettings {
         settingNames.add(setting);
     }
 
+    /** Merge the given secure settings into this one. */
+    public void merge(MockSecureSettings secureSettings) {
+        for (String setting : secureSettings.getSettingNames()) {
+            if (settingNames.contains(setting)) {
+                throw new IllegalArgumentException("Cannot overwrite existing secure setting " + setting);
+            }
+        }
+        settingNames.addAll(secureSettings.settingNames);
+        secureStrings.putAll(secureSettings.secureStrings);
+        files.putAll(secureSettings.files);
+    }
+
     @Override
     public void close() throws IOException {
         closed.set(true);


### PR DESCRIPTION
While real secure settings (ie an ES keystore) cannot be merged
together, mocked secure settings can and need to be sometimes merged.
This commit adds a merge method to allow tests to merge together
multiple instances of secure settings. Also, a bit of unfortunate leniency is added, which makes passing an empty secure settings a no-op (eg when a test has an empty MockSecureSettings). Finally it adds an explicit error message when secure settings are already set on the settings builder.