### PR TITLE
Remove remaining `index.mapper.single_type` setting usage from tests

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -134,7 +134,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
 
     @Before
     public void setup() throws Exception {
-        indexService = createIndex("test", Settings.builder().put("mapping.single_type", false).build());
+        indexService = createIndex("test", Settings.builder().build());
         mapperService = indexService.mapperService();
         indicesFieldDataCache = getInstanceFromNode(IndicesService.class).getIndicesFieldDataCache();
         ifdService = indexService.fieldData();

--- a/core/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -19,16 +19,21 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.ObjectMapper.Dynamic;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.containsString;
@@ -36,6 +41,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class NestedObjectMapperTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(InternalSettingsPlugin.class);
+    }
+
     public void testEmptyNested() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")
                 .startObject("nested1").field("type", "nested").endObject()
@@ -382,16 +393,34 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
                 .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE, false));
         assertThat(e.getMessage(), containsString("Limit of nested fields [1] in index [test3] has been exceeded"));
 
+        // do not check nested fields limit if mapping is not updated
+        createIndex("test4", Settings.builder().put(MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.getKey(), 0).build())
+            .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_RECOVERY, false);
+    }
+
+    public void testLimitOfNestedFieldsWithMultiTypePerIndex() throws Exception {
+        Function<String, String> mapping = type -> {
+            try {
+                return XContentFactory.jsonBuilder().startObject().startObject(type).startObject("properties")
+                    .startObject("nested1").field("type", "nested").startObject("properties")
+                    .startObject("nested2").field("type", "nested")
+                    .endObject().endObject().endObject()
+                    .endObject().endObject().endObject().string();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+
         MapperService mapperService = createIndex("test4", Settings.builder()
-                .put("mapping.single_type", false)
-                .put(MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.getKey(), 2).build()).mapperService();
+            .put("index.version.created", Version.V_5_6_0)
+            .put(MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.getKey(), 2).build()).mapperService();
         mapperService.merge("type1", new CompressedXContent(mapping.apply("type1")), MergeReason.MAPPING_UPDATE, false);
         // merging same fields, but different type is ok
         mapperService.merge("type2", new CompressedXContent(mapping.apply("type2")), MergeReason.MAPPING_UPDATE, false);
         // adding new fields from different type is not ok
         String mapping2 = XContentFactory.jsonBuilder().startObject().startObject("type3").startObject("properties").startObject("nested3")
             .field("type", "nested").startObject("properties").endObject().endObject().endObject().endObject().endObject().string();
-        e = expectThrows(IllegalArgumentException.class, () ->
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
             mapperService.merge("type3", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, false));
         assertThat(e.getMessage(), containsString("Limit of nested fields [2] in index [test4] has been exceeded"));
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/ParentFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ParentFieldMapperTests.java
@@ -20,6 +20,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -35,9 +36,12 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.IndicesModule;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
+import org.elasticsearch.test.InternalSettingsPlugin;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -46,6 +50,11 @@ import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 public class ParentFieldMapperTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(InternalSettingsPlugin.class);
+    }
 
     public void testParentSetInDocNotAllowed() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
@@ -67,7 +76,7 @@ public class ParentFieldMapperTests extends ESSingleNodeTestCase {
         String childMapping = XContentFactory.jsonBuilder().startObject().startObject("child_type")
                 .startObject("_parent").field("type", "parent_type").endObject()
                 .endObject().endObject().string();
-        IndexService indexService = createIndex("test", Settings.builder().put("mapping.single_type", false).build());
+        IndexService indexService = createIndex("test", Settings.builder().put("index.version.created", Version.V_5_6_0).build());
         indexService.mapperService().merge("parent_type", new CompressedXContent(parentMapping), MergeReason.MAPPING_UPDATE, false);
         indexService.mapperService().merge("child_type", new CompressedXContent(childMapping), MergeReason.MAPPING_UPDATE, false);
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/UpdateMappingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/UpdateMappingTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -150,7 +151,8 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
                 .startObject("properties").startObject("foo").field("type", "long").endObject()
                 .endObject().endObject().endObject();
         XContentBuilder mapping2 = XContentFactory.jsonBuilder().startObject().startObject("type2").endObject().endObject();
-        MapperService mapperService = createIndex("test", Settings.builder().put("mapping.single_type", false).build()).mapperService();
+        MapperService mapperService = createIndex("test", Settings.builder().put("index.version.created",
+            Version.V_5_6_0).build()).mapperService();
 
         mapperService.merge("type1", new CompressedXContent(mapping1.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
         mapperService.merge("type2", new CompressedXContent(mapping2.string()), MapperService.MergeReason.MAPPING_UPDATE, false);

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.exists_type/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.exists_type/10_basic.yml
@@ -2,14 +2,12 @@
 "Exists type":
  - skip:
     version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
+    reason:  multiple types are not supported on 6.x indices onwards
 
  - do:
      indices.create:
        index: test_1
        body:
-         settings:
-           mapping.single_type: false
          mappings:
            type_1: {}
            type_2: {}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/10_basic.yml
@@ -4,21 +4,14 @@ setup:
         indices.create:
           index: test_1
           body:
-              settings:
-                mapping.single_type: false
               mappings:
-                type_1: {}
-                type_2: {}
+                doc: {}
   - do:
         indices.create:
           index: test_2
           body:
-              settings:
-                mapping.single_type: false
               mappings:
-                type_2: {}
-                type_3: {}
-
+                doc: {}
 ---
 "Get /{index}/_mapping with empty mappings":
 
@@ -35,191 +28,117 @@ setup:
 ---
 "Get /_mapping":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
  - do:
     indices.get_mapping: {}
 
- - is_true: test_1.mappings.type_1
- - is_true: test_1.mappings.type_2
- - is_true: test_2.mappings.type_2
- - is_true: test_2.mappings.type_3
+ - is_true: test_1.mappings.doc
+ - is_true: test_2.mappings.doc
 
 ---
 "Get /{index}/_mapping":
-
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
 
  - do:
     indices.get_mapping:
         index: test_1
 
- - is_true: test_1.mappings.type_1
- - is_true: test_1.mappings.type_2
+ - is_true: test_1.mappings.doc
  - is_false: test_2
 
 
 ---
 "Get /{index}/_mapping/_all":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: test_1
         type:  _all
 
- - is_true: test_1.mappings.type_1
- - is_true: test_1.mappings.type_2
+ - is_true: test_1.mappings.doc
  - is_false: test_2
 
 ---
 "Get /{index}/_mapping/*":
-
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
 
  - do:
     indices.get_mapping:
         index: test_1
         type:  '*'
 
- - is_true: test_1.mappings.type_1
- - is_true: test_1.mappings.type_2
+ - is_true: test_1.mappings.doc
  - is_false: test_2
 
 ---
 "Get /{index}/_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: test_1
-        type:  type_1
+        type:  doc
 
- - is_false: test_1.mappings.type_2
- - is_false: test_2
-
----
-"Get /{index}/_mapping/{type,type}":
-
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
- - do:
-    indices.get_mapping:
-        index: test_1
-        type:  type_1,type_2
-
- - is_true: test_1.mappings.type_1
- - is_true: test_1.mappings.type_2
+ - is_true: test_1.mappings.doc
  - is_false: test_2
 
 ---
 "Get /{index}/_mapping/{type*}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: test_1
-        type:  '*2'
+        type:  'd*'
 
- - is_true: test_1.mappings.type_2
- - is_false: test_1.mappings.type_1
+ - is_true: test_1.mappings.doc
  - is_false: test_2
 
 ---
 "Get /_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
  - do:
     indices.get_mapping:
-        type: type_2
+        type: doc
 
- - is_true: test_1.mappings.type_2
- - is_true: test_2.mappings.type_2
- - is_false: test_1.mappings.type_1
- - is_false: test_2.mappings.type_3
+ - is_true: test_1.mappings.doc
+ - is_true: test_2.mappings.doc
 
 ---
 "Get /_all/_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: _all
-        type: type_2
+        type: doc
 
- - is_true: test_1.mappings.type_2
- - is_true: test_2.mappings.type_2
- - is_false: test_1.mappings.type_1
- - is_false: test_2.mappings.type_3
+ - is_true: test_1.mappings.doc
+ - is_true: test_2.mappings.doc
 
 ---
 "Get /*/_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: '*'
-        type: type_2
+        type: doc
 
- - is_true: test_1.mappings.type_2
- - is_true: test_2.mappings.type_2
- - is_false: test_1.mappings.type_1
- - is_false: test_2.mappings.type_3
+ - is_true: test_1.mappings.doc
+ - is_true: test_2.mappings.doc
 
 ---
 "Get /index,index/_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: test_1,test_2
-        type: type_2
+        type: doc
 
- - is_true: test_1.mappings.type_2
- - is_true: test_2.mappings.type_2
- - is_false: test_2.mappings.type_3
+ - is_true: test_1.mappings.doc
+ - is_true: test_2.mappings.doc
 
 ---
 "Get /index*/_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  mapping.single_type can not be changed on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: '*2'
-        type: type_2
+        type: doc
 
- - is_true: test_2.mappings.type_2
+ - is_true: test_2.mappings.doc
  - is_false: test_1
- - is_false: test_2.mappings.type_3

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/70_legacy_multi_type.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/70_legacy_multi_type.yml
@@ -1,0 +1,208 @@
+---
+setup:
+  - do:
+        indices.create:
+          index: test_1
+          body:
+              mappings:
+                type_1: {}
+                type_2: {}
+  - do:
+        indices.create:
+          index: test_2
+          body:
+              mappings:
+                type_2: {}
+                type_3: {}
+
+---
+"Get /_mapping":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping: {}
+
+ - is_true: test_1.mappings.type_1
+ - is_true: test_1.mappings.type_2
+ - is_true: test_2.mappings.type_2
+ - is_true: test_2.mappings.type_3
+
+---
+"Get /{index}/_mapping":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: test_1
+
+ - is_true: test_1.mappings.type_1
+ - is_true: test_1.mappings.type_2
+ - is_false: test_2
+
+
+---
+"Get /{index}/_mapping/_all":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: test_1
+        type:  _all
+
+ - is_true: test_1.mappings.type_1
+ - is_true: test_1.mappings.type_2
+ - is_false: test_2
+
+---
+"Get /{index}/_mapping/*":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: test_1
+        type:  '*'
+
+ - is_true: test_1.mappings.type_1
+ - is_true: test_1.mappings.type_2
+ - is_false: test_2
+
+---
+"Get /{index}/_mapping/{type}":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: test_1
+        type:  type_1
+
+ - is_false: test_1.mappings.type_2
+ - is_false: test_2
+
+---
+"Get /{index}/_mapping/{type,type}":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: test_1
+        type:  type_1,type_2
+
+ - is_true: test_1.mappings.type_1
+ - is_true: test_1.mappings.type_2
+ - is_false: test_2
+
+---
+"Get /{index}/_mapping/{type*}":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: test_1
+        type:  '*2'
+
+ - is_true: test_1.mappings.type_2
+ - is_false: test_1.mappings.type_1
+ - is_false: test_2
+
+---
+"Get /_mapping/{type}":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        type: type_2
+
+ - is_true: test_1.mappings.type_2
+ - is_true: test_2.mappings.type_2
+ - is_false: test_1.mappings.type_1
+ - is_false: test_2.mappings.type_3
+
+---
+"Get /_all/_mapping/{type}":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: _all
+        type: type_2
+
+ - is_true: test_1.mappings.type_2
+ - is_true: test_2.mappings.type_2
+ - is_false: test_1.mappings.type_1
+ - is_false: test_2.mappings.type_3
+
+---
+"Get /*/_mapping/{type}":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: '*'
+        type: type_2
+
+ - is_true: test_1.mappings.type_2
+ - is_true: test_2.mappings.type_2
+ - is_false: test_1.mappings.type_1
+ - is_false: test_2.mappings.type_3
+
+---
+"Get /index,index/_mapping/{type}":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: test_1,test_2
+        type: type_2
+
+ - is_true: test_1.mappings.type_2
+ - is_true: test_2.mappings.type_2
+ - is_false: test_2.mappings.type_3
+
+---
+"Get /index*/_mapping/{type}":
+
+ - skip:
+    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
+    reason:  multiple types are not supported on 6.x indices onwards
+
+ - do:
+    indices.get_mapping:
+        index: '*2'
+        type: type_2
+
+ - is_true: test_2.mappings.type_2
+ - is_false: test_1
+ - is_false: test_2.mappings.type_3

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mget/15_ids.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mget/15_ids.yml
@@ -2,14 +2,11 @@
 "IDs":
   - skip:
         version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-        reason:  mapping.single_type can not be changed on 6.x indices onwards
+        reason:  multiple types are not supported on 6.x indices onwards
 
   - do:
         indices.create:
           index: test_1
-          body:
-              settings:
-                mapping.single_type: false
 
   - do:
       index:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.inner_hits/10_basic.yml
@@ -4,8 +4,6 @@ setup:
       indices.create:
         index: test
         body:
-            settings:
-              mapping.single_type: false
             mappings:
               type_1:
                 properties:
@@ -16,7 +14,7 @@ setup:
 "Nested inner hits":
     - skip:
         version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-        reason:  mapping.single_type can not be changed on 6.x indices onwards
+        reason:  multiple types are not supported on 6.x indices onwards
     - do:
         index:
           index: test


### PR DESCRIPTION
This change removes the remaining explicitly specified `index.mapper.single_type`
settings from tests in order to allow the removal of the setting.
This is the already approved part of #25375 broken out to simplify reviews on #25375