### PR TITLE
Remove `mapping.single_type` from parent join test

### DIFF
--- a/modules/parent-join/src/test/resources/rest-api-spec/test/11_parent_child.yml
+++ b/modules/parent-join/src/test/resources/rest-api-spec/test/11_parent_child.yml
@@ -3,8 +3,6 @@ setup:
       indices.create:
         index: test
         body:
-            settings:
-              mapping.single_type: true
             mappings:
               doc:
                 properties:

--- a/modules/parent-join/src/test/resources/rest-api-spec/test/20_parent_join.yml
+++ b/modules/parent-join/src/test/resources/rest-api-spec/test/20_parent_join.yml
@@ -3,8 +3,6 @@ setup:
       indices.create:
         index: test
         body:
-          settings:
-            mapping.single_type: true
           mappings:
             doc:
               properties:

--- a/qa/mixed-cluster/src/test/resources/rest-api-spec/test/10_parent_child.yml
+++ b/qa/mixed-cluster/src/test/resources/rest-api-spec/test/10_parent_child.yml
@@ -3,8 +3,6 @@ setup:
       indices.create:
         index: test
         body:
-            settings:
-              mapping.single_type: false
             mappings:
               type_2: {}
               type_3:


### PR DESCRIPTION
This removes the remaining usage of `mapping.single_type` from the parent join
module and moves it's bwc test to the mixed cluster tests

Relates to #24961
Relates to #20257