### PR TITLE
Adds check for negative search request size

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/core/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -171,6 +171,9 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
      * documents.
      */
     public Self setSize(int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("[size] parameter cannot be negative, found [" + size + "]");
+        }
         this.size = size;
         return self();
     }

--- a/core/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/core/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -370,10 +370,13 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
                 .setShouldStoreResult(false)
                 // Split requests per second between all slices
                 .setRequestsPerSecond(requestsPerSecond / slices)
-                // Size is split between workers. This means the size might round down!
-                .setSize(size == SIZE_ALL_MATCHES ? SIZE_ALL_MATCHES : size / slices)
                 // Sub requests don't have workers
                 .setSlices(1);
+        if (size != -1) {
+            // Size is split between workers. This means the size might round
+            // down!
+            request.setSize(size == SIZE_ALL_MATCHES ? SIZE_ALL_MATCHES : size / slices);
+        }
         // Set the parent task so this task is cancelled if we cancel the parent
         request.setParentTask(slicingTask);
         // TODO It'd be nice not to refresh on every slice. Instead we should refresh after the sub requests finish.

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -346,6 +346,9 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
      * The number of search hits to return. Defaults to <tt>10</tt>.
      */
     public SearchSourceBuilder size(int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("[size] parameter cannot be negative");
+        }
         this.size = size;
         return this;
     }

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -347,7 +347,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
      */
     public SearchSourceBuilder size(int size) {
         if (size < 0) {
-            throw new IllegalArgumentException("[size] parameter cannot be negative");
+            throw new IllegalArgumentException("[size] parameter cannot be negative, found " + size);
         }
         this.size = size;
         return this;

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -347,7 +347,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
      */
     public SearchSourceBuilder size(int size) {
         if (size < 0) {
-            throw new IllegalArgumentException("[size] parameter cannot be negative, found " + size);
+            throw new IllegalArgumentException("[size] parameter cannot be negative, found [" + size + "]");
         }
         this.size = size;
         return this;

--- a/core/src/test/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequestTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequestTestCase.java
@@ -42,7 +42,9 @@ public abstract class AbstractBulkByScrollRequestTestCase<R extends AbstractBulk
         original.setSlices(between(2, 1000));
         original.setRequestsPerSecond(
                 randomBoolean() ? Float.POSITIVE_INFINITY : randomValueOtherThanMany(r -> r < 0, ESTestCase::randomFloat));
-        original.setSize(randomBoolean() ? AbstractBulkByScrollRequest.SIZE_ALL_MATCHES : between(0, Integer.MAX_VALUE));
+        if (randomBoolean()) {
+            original.setSize(between(0, Integer.MAX_VALUE));
+        }
 
         TaskId slicingTask = new TaskId(randomAlphaOfLength(5), randomLong());
         SearchRequest sliceRequest = new SearchRequest();

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -365,6 +365,13 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         assertEquals("[from] parameter cannot be negative", expected.getMessage());
     }
 
+    public void testNegativeSizeErrors() {
+        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-2));
+        assertEquals("[size] parameter cannot be negative", expected.getMessage());
+        expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-1));
+        assertEquals("[size] parameter cannot be negative", expected.getMessage());
+    }
+
     private void assertIndicesBoostParseErrorMessage(String restContent, String expectedErrorMessage) throws IOException {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
             ParsingException e = expectThrows(ParsingException.class, () -> SearchSourceBuilder.fromXContent(createParseContext(parser)));

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -369,7 +369,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-2));
         assertEquals("[size] parameter cannot be negative", expected.getMessage());
         expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-1));
-        assertEquals("[size] parameter cannot be negative", expected.getMessage());
+        assertEquals("[size] parameter cannot be negative, found -1", expected.getMessage());
     }
 
     private void assertIndicesBoostParseErrorMessage(String restContent, String expectedErrorMessage) throws IOException {

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -367,9 +367,9 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
 
     public void testNegativeSizeErrors() {
         IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-2));
-        assertEquals("[size] parameter cannot be negative", expected.getMessage());
+        assertEquals("[size] parameter cannot be negative, found [-2]", expected.getMessage());
         expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-1));
-        assertEquals("[size] parameter cannot be negative, found -1", expected.getMessage());
+        assertEquals("[size] parameter cannot be negative, found [-1]", expected.getMessage());
     }
 
     private void assertIndicesBoostParseErrorMessage(String restContent, String expectedErrorMessage) throws IOException {

--- a/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -366,8 +366,10 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
     }
 
     public void testNegativeSizeErrors() {
-        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-2));
-        assertEquals("[size] parameter cannot be negative, found [-2]", expected.getMessage());
+        int randomSize = randomIntBetween(-100000, -2);
+        IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
+                () -> new SearchSourceBuilder().size(randomSize));
+        assertEquals("[size] parameter cannot be negative, found [" + randomSize + "]", expected.getMessage());
         expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-1));
         assertEquals("[size] parameter cannot be negative, found [-1]", expected.getMessage());
     }

--- a/docs/reference/migration/migrate_6_0.asciidoc
+++ b/docs/reference/migration/migrate_6_0.asciidoc
@@ -31,6 +31,7 @@ way to reindex old indices is to use the `reindex` API.
 * <<breaking_60_aggregations_changes>>
 * <<breaking_60_mappings_changes>>
 * <<breaking_60_docs_changes>>
+* <<breaking_60_reindex_changes>>
 * <<breaking_60_cluster_changes>>
 * <<breaking_60_settings_changes>>
 * <<breaking_60_plugins_changes>>
@@ -54,6 +55,8 @@ include::migrate_6_0/aggregations.asciidoc[]
 include::migrate_6_0/mappings.asciidoc[]
 
 include::migrate_6_0/docs.asciidoc[]
+
+include::migrate_6_0/reindex.asciidoc[]
 
 include::migrate_6_0/cluster.asciidoc[]
 

--- a/docs/reference/migration/migrate_6_0/reindex.asciidoc
+++ b/docs/reference/migration/migrate_6_0/reindex.asciidoc
@@ -1,0 +1,6 @@
+[[breaking_60_reindex_changes]]
+=== Reindex changes
+
+==== `size` parameter
+
+The `size` parameter can no longer be explicitly set to `-1`. If all documents are required then the `size` parameter should not be set.

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
@@ -50,7 +50,6 @@ public abstract class AbstractBulkByQueryRestHandler<
 
         SearchRequest searchRequest = internal.getSearchRequest();
         int scrollSize = searchRequest.source().size();
-        // searchRequest.source().size(SIZE_ALL_MATCHES);
 
         try (XContentParser parser = extractRequestSpecificFields(restRequest, bodyConsumers)) {
             RestSearchAction.parseSearchRequest(searchRequest, restRequest, parser);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
@@ -32,8 +32,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static org.elasticsearch.index.reindex.AbstractBulkByScrollRequest.SIZE_ALL_MATCHES;
-
 /**
  * Rest handler for reindex actions that accepts a search request like Update-By-Query or Delete-By-Query
  */
@@ -52,7 +50,7 @@ public abstract class AbstractBulkByQueryRestHandler<
 
         SearchRequest searchRequest = internal.getSearchRequest();
         int scrollSize = searchRequest.source().size();
-        searchRequest.source().size(SIZE_ALL_MATCHES);
+        // searchRequest.source().size(SIZE_ALL_MATCHES);
 
         try (XContentParser parser = extractRequestSpecificFields(restRequest, bodyConsumers)) {
             RestSearchAction.parseSearchRequest(searchRequest, restRequest, parser);

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
@@ -131,7 +131,9 @@ public class RoundTripTests extends ESTestCase {
     private void randomRequest(AbstractBulkByScrollRequest<?> request) {
         request.getSearchRequest().indices("test");
         request.getSearchRequest().source().size(between(1, 1000));
-        request.setSize(random().nextBoolean() ? between(1, Integer.MAX_VALUE) : -1);
+        if (randomBoolean()) {
+            request.setSize(between(1, Integer.MAX_VALUE));
+        }
         request.setAbortOnVersionConflict(random().nextBoolean());
         request.setRefresh(rarely());
         request.setTimeout(TimeValue.parseTimeValue(randomTimeValue(), null, "test"));

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/20_validation.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/20_validation.yml
@@ -44,7 +44,7 @@
         id:      1
         body:    { "text": "test" }
   - do:
-      catch: /size should be greater than 0 if the request is limited to some number of documents or -1 if it isn't but it was \[-4\]/
+      catch: /\[size\] parameter cannot be negative, found \[-4\]/
       delete_by_query:
         index: test
         size: -4

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/20_validation.yml
@@ -104,7 +104,7 @@
         id:      1
         body:    { "text": "test" }
   - do:
-      catch: /size should be greater than 0 if the request is limited to some number of documents or -1 if it isn't but it was \[-4\]/
+      catch: /\[size\] parameter cannot be negative, found \[-4\]/
       reindex:
         body:
           source:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/20_validation.yml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/20_validation.yml
@@ -21,7 +21,7 @@
         id:      1
         body:    { "text": "test" }
   - do:
-      catch: /size should be greater than 0 if the request is limited to some number of documents or -1 if it isn't but it was \[-4\]/
+      catch: /\[size\] parameter cannot be negative, found \[-4\]/
       update_by_query:
         index: test
         size: -4


### PR DESCRIPTION
This change adds a check to `SearchSourceBuilder` to throw and exception if the size set on it is set to a negative value.

Closes #22530
