### PR TITLE
Allow `restTestRunner` to use --debug-jvm

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -51,13 +51,14 @@ public class RestIntegTestTask extends DefaultTask {
     boolean includePackaged = false
 
     public RestIntegTestTask() {
-        runner = project.tasks.create("${name}Runner", RandomizedTestingTask.class)
+        runner = project.tasks.create("${name}Runner", RestRandomizedTestingTask.class)
         super.dependsOn(runner)
         clusterInit = project.tasks.create(name: "${name}Cluster#init", dependsOn: project.testClasses)
         runner.dependsOn(clusterInit)
         runner.classpath = project.sourceSets.test.runtimeClasspath
         runner.testClassesDir = project.sourceSets.test.output.classesDir
         clusterConfig = project.extensions.create("${name}Cluster", ClusterConfiguration.class, project)
+        runner.clusterConfig = clusterConfig
 
         // start with the common test configuration
         runner.configure(BuildPlugin.commonTestConfig(project))
@@ -183,6 +184,17 @@ public class RestIntegTestTask extends DefaultTask {
             stream.close()
         }
         println('=========================================')
+    }
 
+    static class RestRandomizedTestingTask extends RandomizedTestingTask {
+        protected ClusterConfiguration clusterConfig
+
+        @Option(
+            option = "debug-jvm",
+            description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch."
+        )
+        public void setDebug(boolean enabled) {
+            clusterConfig.debug = enabled;
+        }
     }
 }


### PR DESCRIPTION
When an integration test fails we output a repdoction line which
run can run to rerun the test. This works fine. But we have this
extra command line argument that you can usually add to gradle,
`--debug-jvm`, that configures the jvm under test to wait on
startup for a debugger to connect to it. The reproduction line
for integration tests does not work with `--debug-jvm`. This
PR enhances the task printed in the reproduction info printer
to support `--debug-jvm`.

Another option to fix the same problem is to change the reproduction
info printer to print to `integTest` instead of `integTestRunner`.
This seemed like a less clean fix though.
