### PR TITLE
[DOCS] Update docs to use shared attribute file

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -11,23 +11,14 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:   prerelease
 
-:ref:             https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :defguide:        https://www.elastic.co/guide/en/elasticsearch/guide/master
 :painless:        https://www.elastic.co/guide/en/elasticsearch/painless/master
 :plugins:         https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
-:javaclient:      https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
-:xpack-ref:       https://www.elastic.co/guide/en/x-pack/{branch}
-:logstash:        https://www.elastic.co/guide/en/logstash/{branch}
-:kibana:          https://www.elastic.co/guide/en/kibana/{branch}
 :issue:           https://github.com/elastic/elasticsearch/issues/
 :pull:            https://github.com/elastic/elasticsearch/pull/
 
 :docker-image:    docker.elastic.co/elasticsearch/elasticsearch:{version}
 :plugin_url:      https://artifacts.elastic.co/downloads/elasticsearch-plugins
-
-:xpack:           X-Pack
-:es:              Elasticsearch
-:kib:             Kibana
 
 ///////
 Javadoc roots used to generate links from Painless's API reference
@@ -46,3 +37,5 @@ ifeval::["{release-state}"!="unreleased"]
 :elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}
 :painless-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/painless/lang-painless/{version}
 endif::[]
+
+include::{docs-dir}/sharedattributes.asciidoc[]

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -38,4 +38,29 @@ ifeval::["{release-state}"!="unreleased"]
 :painless-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/painless/lang-painless/{version}
 endif::[]
 
-include::{docs-dir}/sharedattributes.asciidoc[]
+//////////
+The following attributes are synchronized across multiple books 
+//////////
+:ref:             https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
+:xpack-ref:       https://www.elastic.co/guide/en/x-pack/{branch}
+:logstash-ref:    http://www.elastic.co/guide/en/logstash/{branch}
+:kibana-ref:      https://www.elastic.co/guide/en/kibana/{branch}
+:stack-ref:       http://www.elastic.co/guide/en/elastic-stack/{branch}
+:javaclient:      https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
+
+:xpack:           X-Pack
+:es:              Elasticsearch
+:kib:             Kibana
+
+:security:        X-Pack security
+:monitoring:      X-Pack monitoring
+:watcher:         Watcher
+:reporting:       X-Pack reporting
+:graph:           X-Pack graph
+:searchprofiler:  X-Pack search profiler
+:xpackml:         X-Pack machine learning
+:ml:              machine learning
+:dfeed:           datafeed
+:dfeeds:          datafeeds
+:dfeed-cap:       Datafeed
+:dfeeds-cap:      Datafeeds

--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -41,13 +41,13 @@ releases 2.0 and later do not support rivers.
 [float]
 ==== Supported by Elasticsearch:
 
-* {logstash}/plugins-outputs-elasticsearch.html[Logstash output to Elasticsearch]:
+* {logstash-ref}/plugins-outputs-elasticsearch.html[Logstash output to Elasticsearch]:
   The Logstash `elasticsearch` output plugin.
-* {logstash}/plugins-inputs-elasticsearch.html[Elasticsearch input to Logstash]
+* {logstash-ref}/plugins-inputs-elasticsearch.html[Elasticsearch input to Logstash]
   The Logstash `elasticsearch` input plugin.
-* {logstash}/plugins-filters-elasticsearch.html[Elasticsearch event filtering in Logstash]
+* {logstash-ref}/plugins-filters-elasticsearch.html[Elasticsearch event filtering in Logstash]
   The Logstash `elasticsearch` filter plugin.
-* {logstash}/plugins-codecs-es_bulk.html[Elasticsearch bulk codec]
+* {logstash-ref}/plugins-codecs-es_bulk.html[Elasticsearch bulk codec]
   The Logstash `es_bulk` plugin decodes the Elasticsearch bulk format into individual events.
 
 [float]

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -111,10 +111,10 @@ java -version
 echo $JAVA_HOME
 --------------------------------------------------
 
-Once we have Java set up, we can then download and run Elasticsearch. The binaries are available from http://www.elastic.co/downloads[`www.elastic.co/downloads`] along with all the releases that have been made in the past. For each release, you have a choice among a `zip` or `tar` archive, a `DEB` or `RPM` package, or a Windows `MSI` installation package. 
+Once we have Java set up, we can then download and run Elasticsearch. The binaries are available from http://www.elastic.co/downloads[`www.elastic.co/downloads`] along with all the releases that have been made in the past. For each release, you have a choice among a `zip` or `tar` archive, a `DEB` or `RPM` package, or a Windows `MSI` installation package.
 
 [float]
-=== Installation example with tar 
+=== Installation example with tar
 
 For simplicity, let's use the <<zip-targz, tar>> file.
 
@@ -152,7 +152,7 @@ And now we are ready to start our node and single cluster:
 
 For Windows users, we recommend using the <<windows, MSI Installer package>>. The package contains a graphical user interface (GUI) that guides you through the installation process.
 
-First, download the Elasticsearch {version} MSI from 
+First, download the Elasticsearch {version} MSI from
 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.msi.
 
 Then double-click the downloaded file to launch the GUI. Within the first screen, select the deployment directories:
@@ -160,7 +160,7 @@ Then double-click the downloaded file to launch the GUI. Within the first screen
 [[getting-started-msi-installer-locations]]
 image::images/msi_installer/msi_installer_locations.png[]
 
-Then select whether to install as a service or start Elasticsearch manually as needed. 
+Then select whether to install as a service or start Elasticsearch manually as needed.
 To align with the tar example, choose not to install as a service:
 
 [[getting-started-msi-installer-service]]
@@ -176,7 +176,7 @@ Again, to align with the tar example, uncheck all plugins to not install any plu
 [[getting-started-msi-installer-plugins]]
 image::images/msi_installer/msi_installer_plugins.png[]
 
-After clicking the install button, Elasticsearch will be installed: 
+After clicking the install button, Elasticsearch will be installed:
 
 [[getting-started-msi-installer-success]]
 image::images/msi_installer/msi_installer_success.png[]
@@ -264,7 +264,7 @@ Now that we have our node (and cluster) up and running, the next step is to unde
 Let's start with a basic health check, which we can use to see how our cluster is doing. We'll be using curl to do this but you can use any tool that allows you to make HTTP/REST calls. Let's assume that we are still on the same node where we started Elasticsearch on and open another command shell window.
 
 To check the cluster health, we will be using the <<cat,`_cat` API>>. You can
-run the command below in {kibana}/console-kibana.html[Kibana's Console]
+run the command below in {kibana-ref}/console-kibana.html[Kibana's Console]
 by clicking "VIEW IN CONSOLE" or with `curl` by clicking the "COPY AS CURL"
 link below and pasting it into a terminal.
 

--- a/docs/reference/index.asciidoc
+++ b/docs/reference/index.asciidoc
@@ -1,8 +1,9 @@
 [[elasticsearch-reference]]
 = Elasticsearch Reference
 
-:es-test-dir: {docdir}/../src/test
-:plugins-examples-dir: {docdir}/../../plugins/examples
+:es-test-dir:           {docdir}/../src/test
+:plugins-examples-dir:  {docdir}/../../plugins/examples
+:docs-dir:              {docdir}/../../../docs
 
 include::../Versions.asciidoc[]
 include::index-shared1.asciidoc[]


### PR DESCRIPTION
This pull request is related to https://github.com/elastic/docs/pull/202

It updates the Elasticsearch Reference documentation build to use the list of shared attributes that is found in the elastic/docs repo.