### PR TITLE
correct expected thrown exception in mappingMetaData to ElasticsearchParseException

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MappingMetaData.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
@@ -170,7 +171,7 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
     /**
      * Converts the serialized compressed form of the mappings into a parsed map.
      */
-    public Map<String, Object> sourceAsMap() throws IOException {
+    public Map<String, Object> sourceAsMap() throws ElasticsearchParseException {
         Map<String, Object> mapping = XContentHelper.convertToMap(source.compressedReference(), true).v2();
         if (mapping.size() == 1 && mapping.containsKey(type())) {
             // the type name is the root value, reduce it
@@ -182,7 +183,7 @@ public class MappingMetaData extends AbstractDiffable<MappingMetaData> {
     /**
      * Converts the serialized compressed form of the mappings into a parsed map.
      */
-    public Map<String, Object> getSourceAsMap() throws IOException {
+    public Map<String, Object> getSourceAsMap() throws ElasticsearchParseException {
         return sourceAsMap();
     }
 

--- a/core/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.indices.state;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
@@ -274,7 +275,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
             Object properties;
             try {
                 properties = typeMappings.getSourceAsMap().get("properties");
-            } catch (IOException e) {
+            } catch (ElasticsearchParseException e) {
                 throw new AssertionError(e);
             }
             assertNotNull(properties);


### PR DESCRIPTION
Not sure why these methods claim to throw IOException

This PR relaxes this claim to the appropriate ElasticsearchParseException that is thrown by the method calls within the scope of the function (`convertToMap` returns this).