### PR TITLE
[Docs] Add link to grok debugger docs

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1186,8 +1186,7 @@ that is generally written for humans and not computer consumption.
 This processor comes packaged with over
 https://github.com/elastic/elasticsearch/tree/master/modules/ingest-common/src/main/resources/patterns[120 reusable patterns].
 
-If you need help building patterns to match your logs, you will find the <http://grokdebug.herokuapp.com> and
-<http://grokconstructor.appspot.com/> applications quite useful!
+If you need help building patterns to match your logs, you will find the {kibana-ref}/xpack-grokdebugger.html[Grok Debugger] tool quite useful! The Grok Debugger is an {xpack} feature under the Basic License and is therefore *free to use*. The Grok Constructor at <http://grokconstructor.appspot.com/> is also a useful tool. 
 
 [[grok-basics]]
 ==== Grok Basics


### PR DESCRIPTION
Now that we have a grok debugger tool, we want to point to that instead of external resources.