### PR TITLE
Do not search locally if remote index pattern resolves to no indices

### DIFF
--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/50_missing.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/50_missing.yml
@@ -1,0 +1,44 @@
+---
+"Search with missing remote index pattern":
+  - do:
+      catch: "request"
+      search:
+        index: "my_remote_cluster:foo"
+
+  - do:
+      search:
+        index: "my_remote_cluster:fooo*"
+  - match: { _shards.total: 0 }
+  - match: { hits.total: 0 }
+
+  - do:
+      search:
+        index: "*:foo*"
+
+  - match: { _shards.total: 0 }
+  - match: { hits.total: 0 }
+
+  - do:
+      search:
+        index: "my_remote_cluster:test_index,my_remote_cluster:foo*"
+        body:
+          aggs:
+            cluster:
+              terms:
+                field: f1.keyword
+
+  - match: { _shards.total: 3 }
+  - match: { hits.total: 6 }
+  - length: { aggregations.cluster.buckets: 1 }
+  - match: { aggregations.cluster.buckets.0.key: "remote_cluster" }
+  - match: { aggregations.cluster.buckets.0.doc_count: 6 }
+
+  - do:
+      catch: "request"
+      search:
+        index: "my_remote_cluster:test_index,my_remote_cluster:foo"
+        body:
+          aggs:
+            cluster:
+              terms:
+                field: f1.keyword


### PR DESCRIPTION
This commit changes how we determine if there were any remote indices that a search should have
been executed against. Previously, we used the list of remote shard iterators but if the remote
index pattern resolved to no indices there would be no remote shard iterators even though the
request specified remote indices. The map of remote cluster names to the original indices is used
instead so that we can determine if there were remote indices even when there are no remote shard
iterators.

Closes #25426