### PR TITLE
reworded to prevent code span rendering glitch

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -120,7 +120,7 @@ specific index module:
 
 `index.max_rescore_window`::
 
-    The maximum value of `window_size` for `rescore`s in searches of this index.
+    The maximum value of `window_size` for `rescore` requests in searches of this index.
     Defaults to `index.max_result_window` which defaults to `10000`. Search
     requests take heap memory and time proportional to
     `max(window_size, from + size)` and this limits that memory.


### PR DESCRIPTION
Changed ```rescore`s``` to `rescore` requests as an backtick followed by the s character appears to be interpreted as an apostrophe  which then leads to an unbalanced backtick for the next code span in the remainder of the paragraph

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.

Closes #25443