### PR TITLE
"result" : created -> "result" : "created"

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -33,7 +33,7 @@ The result of the above index operation is:
     "created" : true,
     "_seq_no" : 0,
     "_primary_term" : 1,
-    "result" : created
+    "result" : "created"
 }
 --------------------------------------------------
 // TESTRESPONSE[s/"successful" : 2/"successful" : 1/]


### PR DESCRIPTION
The value of key "result" seems to be a string type, which should be in quotation marks.