### PR TITLE
Use LRU set to reduce repeat deprecation messages

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -292,11 +292,11 @@ public class DeprecationLogger {
      * @param message The deprecation message.
      * @param params The parameters used to fill in the message, if any exist.
      */
-    @SuppressLoggerChecks(reason = "safely delegates to logger")
     void deprecated(final Set<ThreadContext> threadContexts, final String message, final Object... params) {
         deprecated(threadContexts, message, true, params);
     }
 
+    @SuppressLoggerChecks(reason = "safely delegates to logger")
     void deprecated(final Set<ThreadContext> threadContexts, final String message, final boolean log, final Object... params) {
         final Iterator<ThreadContext> iterator = threadContexts.iterator();
 

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.common.settings;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.ToXContentToBytes;
@@ -342,14 +343,27 @@ public class Setting<T> extends ToXContentToBytes {
         return settings.get(getKey(), defaultValue.apply(settings));
     }
 
+    private static SetOnce<DeprecationLogger> deprecationLogger = new SetOnce<>();
+
+    // we have to initialize lazily otherwise a logger would be constructed before logging is initialized
+    private static synchronized DeprecationLogger getDeprecationLogger() {
+        if (deprecationLogger.get() == null) {
+            deprecationLogger.set(new DeprecationLogger(Loggers.getLogger(Settings.class)));
+        }
+        return deprecationLogger.get();
+    }
+
     /** Logs a deprecation warning if the setting is deprecated and used. */
-    protected void checkDeprecation(Settings settings) {
+    void checkDeprecation(Settings settings) {
         // They're using the setting, so we need to tell them to stop
-        if (this.isDeprecated() && this.exists(settings) && settings.addDeprecatedSetting(this)) {
+        if (this.isDeprecated() && this.exists(settings)) {
             // It would be convenient to show its replacement key, but replacement is often not so simple
-            final DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(getClass()));
-            deprecationLogger.deprecated("[{}] setting was deprecated in Elasticsearch and will be removed in a future release! " +
-                "See the breaking changes documentation for the next major version.", getKey());
+            final String key = getKey();
+            getDeprecationLogger().deprecatedAndMaybeLog(
+                    key,
+                    "[{}] setting was deprecated in Elasticsearch and will be removed in a future release! "
+                            + "See the breaking changes documentation for the next major version.",
+                    key);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -94,22 +94,6 @@ public final class Settings implements ToXContent {
     private final SetOnce<Set<String>> firstLevelNames = new SetOnce<>();
 
     /**
-     * The set of deprecated settings tracked by this settings object.
-     */
-    private final Set<String> deprecatedSettings = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
-    /**
-     * Add the setting as a tracked deprecated setting.
-     *
-     * @param setting the deprecated setting to track
-     * @return true if the setting was not already tracked as a deprecated setting, otherwise false
-     */
-    boolean addDeprecatedSetting(final Setting setting) {
-        assert setting.isDeprecated() && setting.exists(this) : setting.getKey();
-        return deprecatedSettings.add(setting.getKey());
-    }
-
-    /**
      * Setting names found in this Settings for both string and secure settings.
      * This is constructed lazily in {@link #keySet()}.
      */

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -154,22 +154,6 @@ public class SettingTests extends ESTestCase {
         assertNull(ab2.get());
     }
 
-    public void testDeprecatedSetting() {
-        final Setting<Boolean> deprecatedSetting = Setting.boolSetting("deprecated.foo.bar", false, Property.Deprecated);
-        final Settings settings = Settings.builder().put("deprecated.foo.bar", true).build();
-        final int iterations = randomIntBetween(0, 128);
-        for (int i = 0; i < iterations; i++) {
-            deprecatedSetting.get(settings);
-        }
-        if (iterations > 0) {
-            /*
-             * This tests that we log the deprecation warning exactly one time, otherwise we would have to assert the deprecation warning
-             * for each usage of the setting.
-             */
-            assertSettingDeprecationsAndWarnings(new Setting[]{deprecatedSetting});
-        }
-    }
-
     public void testDefault() {
         TimeValue defaultValue = TimeValue.timeValueMillis(randomIntBetween(0, 1000000));
         Setting<TimeValue> setting =

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -174,7 +174,7 @@ public class EvilLoggerTests extends ESTestCase {
         final int iterations = randomIntBetween(0, 128);
         for (int i = 0; i < iterations; i++) {
             setting.get(settings);
-            assertSettingDeprecationsAndWarnings(new Setting[]{setting});
+            assertSettingDeprecationsAndWarnings(new Setting<?>[]{setting});
         }
 
         final String deprecationPath =

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -183,13 +183,15 @@ public class EvilLoggerTests extends ESTestCase {
                         System.getProperty("es.logs.cluster_name") +
                         "_deprecation.log";
         final List<String> deprecationEvents = Files.readAllLines(PathUtils.get(deprecationPath));
-        assertThat(deprecationEvents.size(), equalTo(1));
-        assertLogLine(
-                deprecationEvents.get(0),
-                Level.WARN,
-                "org.elasticsearch.common.logging.DeprecationLogger.deprecated",
-                "\\[deprecated.foo\\] setting was deprecated in Elasticsearch and will be removed in a future release! " +
-                        "See the breaking changes documentation for the next major version.");
+        if (iterations > 0) {
+            assertThat(deprecationEvents.size(), equalTo(1));
+            assertLogLine(
+                    deprecationEvents.get(0),
+                    Level.WARN,
+                    "org.elasticsearch.common.logging.DeprecationLogger.deprecated",
+                    "\\[deprecated.foo\\] setting was deprecated in Elasticsearch and will be removed in a future release! " +
+                            "See the breaking changes documentation for the next major version.");
+        }
     }
 
     public void testFindAppender() throws IOException, UserException {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -168,7 +168,7 @@ public class EvilLoggerTests extends ESTestCase {
     public void testDeprecatedSettings() throws IOException, UserException {
         setupLogging("settings");
 
-        final Setting setting = Setting.boolSetting("deprecated.foo", false, Setting.Property.Deprecated);
+        final Setting<Boolean> setting = Setting.boolSetting("deprecated.foo", false, Setting.Property.Deprecated);
         final Settings settings = Settings.builder().put("deprecated.foo", true).build();
 
         final int iterations = randomIntBetween(0, 128);

--- a/qa/evil-tests/src/test/resources/org/elasticsearch/common/logging/settings/log4j2.properties
+++ b/qa/evil-tests/src/test/resources/org/elasticsearch/common/logging/settings/log4j2.properties
@@ -1,0 +1,25 @@
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%m%n
+
+appender.file.type = File
+appender.file.name = file
+appender.file.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = [%p][%l] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console
+rootLogger.appenderRef.file.ref = file
+
+appender.deprecation_file.type = File
+appender.deprecation_file.name = deprecation_file
+appender.deprecation_file.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
+appender.deprecation_file.layout.type = PatternLayout
+appender.deprecation_file.layout.pattern = [%p][%l] %marker%m%n
+
+logger.deprecation.name = org.elasticsearch.deprecation.common.settings
+logger.deprecation.level = warn
+logger.deprecation.appenderRef.deprecation_file.ref = deprecation_file
+logger.deprecation.additivity = false

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/DeprecationHttpIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/DeprecationHttpIT.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matcher;
 
 import java.io.IOException;
@@ -55,7 +54,6 @@ import static org.hamcrest.Matchers.hasSize;
 /**
  * Tests {@code DeprecationLogger} uses the {@code ThreadContext} to add response headers.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 public class DeprecationHttpIT extends HttpSmokeTestCase {
 
     @Override
@@ -125,6 +123,14 @@ public class DeprecationHttpIT extends HttpSmokeTestCase {
 
     public void testDeprecationWarningsAppearInHeaders() throws Exception {
         doTestDeprecationWarningsAppearInHeaders();
+    }
+
+    public void testDeprecationHeadersDoNotGetStuck() throws Exception {
+        doTestDeprecationWarningsAppearInHeaders();
+        doTestDeprecationWarningsAppearInHeaders();
+        if (rarely()) {
+            doTestDeprecationWarningsAppearInHeaders();
+        }
     }
 
     /**


### PR DESCRIPTION
This commit adds an LRU set to used to determine if a keyed deprecation message should be written to the deprecation logs, or only added to the response headers on the thread context.

Relates #25457
