### PR TITLE
Add NioTransport threads to thread name checks

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/core/src/main/java/org/elasticsearch/transport/Transports.java
@@ -29,8 +29,8 @@ public enum Transports {
     /** threads whose name is prefixed by this string will be considered network threads, even though they aren't */
     public static final String TEST_MOCK_TRANSPORT_THREAD_PREFIX = "__mock_network_thread";
 
-    public static final String ES_NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX = "es_nio_transport_worker";
-    public static final String ES_NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = "es_nio_transport_acceptor";
+    public static final String NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX = "es_nio_transport_worker";
+    public static final String NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = "es_nio_transport_acceptor";
 
     /**
      * Utility method to detect whether a thread is a network thread. Typically
@@ -44,8 +44,8 @@ public enum Transports {
                 TcpTransport.TRANSPORT_SERVER_WORKER_THREAD_NAME_PREFIX,
                 TcpTransport.TRANSPORT_CLIENT_BOSS_THREAD_NAME_PREFIX,
                 TEST_MOCK_TRANSPORT_THREAD_PREFIX,
-                ES_NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX,
-                ES_NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX)) {
+                NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX,
+                NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX)) {
             if (threadName.contains(s)) {
                 return true;
             }

--- a/core/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/core/src/main/java/org/elasticsearch/transport/Transports.java
@@ -29,8 +29,8 @@ public enum Transports {
     /** threads whose name is prefixed by this string will be considered network threads, even though they aren't */
     public static final String TEST_MOCK_TRANSPORT_THREAD_PREFIX = "__mock_network_thread";
 
-    public static final String NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX = "nio_transport_worker";
-    public static final String NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = "nio_transport_acceptor";
+    public static final String ES_NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX = "es_nio_transport_worker";
+    public static final String ES_NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = "es_nio_transport_acceptor";
 
     /**
      * Utility method to detect whether a thread is a network thread. Typically
@@ -44,8 +44,8 @@ public enum Transports {
                 TcpTransport.TRANSPORT_SERVER_WORKER_THREAD_NAME_PREFIX,
                 TcpTransport.TRANSPORT_CLIENT_BOSS_THREAD_NAME_PREFIX,
                 TEST_MOCK_TRANSPORT_THREAD_PREFIX,
-                NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX,
-                NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX)) {
+                ES_NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX,
+                ES_NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX)) {
             if (threadName.contains(s)) {
                 return true;
             }

--- a/core/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/core/src/main/java/org/elasticsearch/transport/Transports.java
@@ -29,6 +29,9 @@ public enum Transports {
     /** threads whose name is prefixed by this string will be considered network threads, even though they aren't */
     public static final String TEST_MOCK_TRANSPORT_THREAD_PREFIX = "__mock_network_thread";
 
+    public static final String NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX = "nio_transport_worker";
+    public static final String NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = "nio_transport_acceptor";
+
     /**
      * Utility method to detect whether a thread is a network thread. Typically
      * used in assertions to make sure that we do not call blocking code from
@@ -40,7 +43,9 @@ public enum Transports {
                 HttpServerTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX,
                 TcpTransport.TRANSPORT_SERVER_WORKER_THREAD_NAME_PREFIX,
                 TcpTransport.TRANSPORT_CLIENT_BOSS_THREAD_NAME_PREFIX,
-                TEST_MOCK_TRANSPORT_THREAD_PREFIX)) {
+                TEST_MOCK_TRANSPORT_THREAD_PREFIX,
+                NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX,
+                NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX)) {
             if (threadName.contains(s)) {
                 return true;
             }

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/NioTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/NioTransport.java
@@ -58,8 +58,8 @@ import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadF
 
 public class NioTransport extends TcpTransport<NioChannel> {
 
-    public static final String TRANSPORT_WORKER_THREAD_NAME_PREFIX = Transports.NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX;
-    public static final String TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = Transports.NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX;
+    public static final String TRANSPORT_WORKER_THREAD_NAME_PREFIX = Transports.ES_NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX;
+    public static final String TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = Transports.ES_NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX;
 
     public static final Setting<Integer> NIO_WORKER_COUNT =
         new Setting<>("transport.nio.worker_count",

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/NioTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/NioTransport.java
@@ -58,8 +58,8 @@ import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadF
 
 public class NioTransport extends TcpTransport<NioChannel> {
 
-    public static final String TRANSPORT_WORKER_THREAD_NAME_PREFIX = Transports.ES_NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX;
-    public static final String TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = Transports.ES_NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX;
+    public static final String TRANSPORT_WORKER_THREAD_NAME_PREFIX = Transports.NIO_TRANSPORT_WORKER_THREAD_NAME_PREFIX;
+    public static final String TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = Transports.NIO_TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX;
 
     public static final Setting<Integer> NIO_WORKER_COUNT =
         new Setting<>("transport.nio.worker_count",

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/AbstractNioChannel.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/AbstractNioChannel.java
@@ -102,11 +102,6 @@ public abstract class AbstractNioChannel<S extends SelectableChannel & NetworkCh
      */
     @Override
     public CloseFuture closeAsync() {
-        if (selector != null && selector.isOnCurrentThread()) {
-            closeFromSelector();
-            return closeFuture;
-        }
-
         for (; ; ) {
             int state = this.state.get();
             if (state == UNREGISTERED && this.state.compareAndSet(UNREGISTERED, CLOSING)) {

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ConnectFuture.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ConnectFuture.java
@@ -80,12 +80,14 @@ public class ConnectFuture extends BaseFuture<NioSocketChannel> {
         if (isDone()) {
             try {
                 // Get should always return without blocking as we already checked 'isDone'
-                return super.get();
+                return super.get(0, TimeUnit.NANOSECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return null;
             } catch (ExecutionException e) {
                 return null;
+            } catch (TimeoutException e) {
+                throw new AssertionError("This should never happen as we only call get() after isDone() is true.");
             }
         } else {
             return null;


### PR DESCRIPTION
We have various assertions that check we never block on transport
threads. This commit adds the thread names for the NioTransport to
these assertions.

With this change I had to fix two places where we were calling blocking
methods from the transport threads.
