### PR TITLE
[DOCS] Update shared attributes for Elasticsearch

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -37,30 +37,3 @@ ifeval::["{release-state}"!="unreleased"]
 :elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}
 :painless-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/painless/lang-painless/{version}
 endif::[]
-
-//////////
-The following attributes are synchronized across multiple books 
-//////////
-:ref:             https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
-:xpack-ref:       https://www.elastic.co/guide/en/x-pack/{branch}
-:logstash-ref:    http://www.elastic.co/guide/en/logstash/{branch}
-:kibana-ref:      https://www.elastic.co/guide/en/kibana/{branch}
-:stack-ref:       http://www.elastic.co/guide/en/elastic-stack/{branch}
-:javaclient:      https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
-
-:xpack:           X-Pack
-:es:              Elasticsearch
-:kib:             Kibana
-
-:security:        X-Pack security
-:monitoring:      X-Pack monitoring
-:watcher:         Watcher
-:reporting:       X-Pack reporting
-:graph:           X-Pack graph
-:searchprofiler:  X-Pack search profiler
-:xpackml:         X-Pack machine learning
-:ml:              machine learning
-:dfeed:           datafeed
-:dfeeds:          datafeeds
-:dfeed-cap:       Datafeed
-:dfeeds-cap:      Datafeeds

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -37,3 +37,8 @@ ifeval::["{release-state}"!="unreleased"]
 :elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}
 :painless-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/painless/lang-painless/{version}
 endif::[]
+
+///////
+Shared attribute values are pulled from elastic/docs
+///////
+include::{docs-dir}/shared/attributes.asciidoc[]

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -11,9 +11,6 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:   prerelease
 
-:defguide:        https://www.elastic.co/guide/en/elasticsearch/guide/master
-:painless:        https://www.elastic.co/guide/en/elasticsearch/painless/master
-:plugins:         https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
 :issue:           https://github.com/elastic/elasticsearch/issues/
 :pull:            https://github.com/elastic/elasticsearch/pull/
 

--- a/docs/reference/index-shared1.asciidoc
+++ b/docs/reference/index-shared1.asciidoc
@@ -1,3 +1,4 @@
+include::{docs-dir}/shared/attributes.asciidoc[]
 
 include::getting-started.asciidoc[]
 

--- a/docs/reference/index-shared1.asciidoc
+++ b/docs/reference/index-shared1.asciidoc
@@ -1,4 +1,3 @@
-include::{docs-dir}/shared/attributes.asciidoc[]
 
 include::getting-started.asciidoc[]
 


### PR DESCRIPTION
This pull request removes shared attributes from the Versions.asciidoc file and instead adds a reference to the list of shared attributes in the elastic/docs/shared repository.
