### PR TITLE
[DOCS] Add docs-dir to Painless

### DIFF
--- a/docs/painless/index.asciidoc
+++ b/docs/painless/index.asciidoc
@@ -1,7 +1,7 @@
 [[painless]]
 = Painless Scripting Language
 
-:ref: https://www.elastic.co/guide/en/elasticsearch/reference
+:docs-dir:  {docdir}/../../../docs
 
 include::../Versions.asciidoc[]
 
@@ -20,7 +20,7 @@ include::painless-api-reference.asciidoc[]
 ////
 Proposed Outline (WIP)
 Getting Started with Painless
-  Accessing Doc Values 
+  Accessing Doc Values
   Updating Fields
   Working with Dates
   Using Regular Expressions


### PR DESCRIPTION
This pull request updates the Painless Reference to use the shared attributes that are listed in the elastic/docs/shared/attributes.asciidoc file. 

It is related to https://github.com/elastic/elasticsearch/pull/25479