### PR TITLE
[Test] Use a common testing class for all XContent filtering tests

### DIFF
--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
@@ -22,6 +22,7 @@ package org.elasticsearch.common.xcontent.support;
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ESTestCase;
 
@@ -32,7 +33,7 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 
 /**
- * Tests for {@link org.elasticsearch.common.xcontent.XContent} filtering.
+ * Tests for {@link XContent} filtering.
  */
 public abstract class AbstractFilteringTestCase extends ESTestCase {
 

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
@@ -21,14 +21,12 @@ package org.elasticsearch.common.xcontent.support;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.test.ESTestCase;
-import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -36,9 +34,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
+import static org.elasticsearch.common.xcontent.XContentHelper.convertToMap;
+import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -46,60 +45,29 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class XContentMapValuesTests extends ESTestCase {
-    public void testFilter() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .field("test1", "value1")
-                .field("test2", "value2")
-                .field("something_else", "value3")
-                .endObject();
+public class XContentMapValuesTests extends AbstractFilteringTestCase {
 
-        Map<String, Object> source;
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, builder.string())) {
-            source = parser.map();
+    @Override
+    protected void testFilter(Builder expected, Builder actual, Set<String> includes, Set<String> excludes) throws IOException {
+        final XContentType xContentType = randomFrom(XContentType.values());
+        final boolean humanReadable = randomBoolean();
+
+        String[] sourceIncludes;
+        if (includes == null) {
+            sourceIncludes = randomBoolean() ? Strings.EMPTY_ARRAY : null;
+        } else {
+            sourceIncludes = includes.toArray(new String[includes.size()]);
         }
-        Map<String, Object> filter = XContentMapValues.filter(source, new String[]{"test1"}, Strings.EMPTY_ARRAY);
-        assertThat(filter.size(), equalTo(1));
-        assertThat(filter.get("test1").toString(), equalTo("value1"));
-
-        filter = XContentMapValues.filter(source, new String[]{"test*"}, Strings.EMPTY_ARRAY);
-        assertThat(filter.size(), equalTo(2));
-        assertThat(filter.get("test1").toString(), equalTo("value1"));
-        assertThat(filter.get("test2").toString(), equalTo("value2"));
-
-        filter = XContentMapValues.filter(source, Strings.EMPTY_ARRAY, new String[]{"test1"});
-        assertThat(filter.size(), equalTo(2));
-        assertThat(filter.get("test2").toString(), equalTo("value2"));
-        assertThat(filter.get("something_else").toString(), equalTo("value3"));
-
-        // more complex object...
-        builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("path1")
-                .startArray("path2")
-                .startObject().field("test", "value1").endObject()
-                .startObject().field("test", "value2").endObject()
-                .endArray()
-                .endObject()
-                .field("test1", "value1")
-                .endObject();
-
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, builder.string())) {
-            source = parser.map();
+        String[] sourceExcludes;
+        if (excludes == null) {
+            sourceExcludes = randomBoolean() ? Strings.EMPTY_ARRAY : null;
+        } else {
+            sourceExcludes = excludes.toArray(new String[excludes.size()]);
         }
-        filter = XContentMapValues.filter(source, new String[]{"path1"}, Strings.EMPTY_ARRAY);
-        assertThat(filter.size(), equalTo(1));
 
-        filter = XContentMapValues.filter(source, new String[]{"path1*"}, Strings.EMPTY_ARRAY);
-        assertThat(filter.get("path1"), equalTo(source.get("path1")));
-        assertThat(filter.containsKey("test1"), equalTo(false));
-
-        filter = XContentMapValues.filter(source, new String[]{"test1*"}, Strings.EMPTY_ARRAY);
-        assertThat(filter.get("test1"), equalTo(source.get("test1")));
-        assertThat(filter.containsKey("path1"), equalTo(false));
-
-        filter = XContentMapValues.filter(source, new String[]{"path1.path2.*"}, Strings.EMPTY_ARRAY);
-        assertThat(filter.get("path1"), equalTo(source.get("path1")));
-        assertThat(filter.containsKey("test1"), equalTo(false));
+        assertEquals("Filtered map must be equal to the expected map",
+                toMap(expected, xContentType, humanReadable),
+                XContentMapValues.filter(toMap(actual, xContentType, humanReadable), sourceIncludes, sourceExcludes));
     }
 
     @SuppressWarnings({"unchecked"})
@@ -376,7 +344,6 @@ public class XContentMapValuesTests extends ESTestCase {
         Map<String, Object> filteredMap = XContentMapValues.filter(map, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
         assertThat(filteredMap.size(), equalTo(1));
         assertThat(filteredMap.get("field").toString(), equalTo("value"));
-
     }
 
     public void testThatFilterIncludesEmptyObjectWhenUsingIncludes() throws Exception {
@@ -385,7 +352,7 @@ public class XContentMapValuesTests extends ESTestCase {
                 .endObject()
                 .endObject();
 
-        Tuple<XContentType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(builder.bytes(), true, builder.contentType());
+        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(builder.bytes(), true, builder.contentType());
         Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"obj"}, Strings.EMPTY_ARRAY);
 
         assertThat(mapTuple.v2(), equalTo(filteredSource));
@@ -397,7 +364,7 @@ public class XContentMapValuesTests extends ESTestCase {
                 .endObject()
                 .endObject();
 
-        Tuple<XContentType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(builder.bytes(), true, builder.contentType());
+        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(builder.bytes(), true, builder.contentType());
         Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[]{"nonExistingField"});
 
         assertThat(mapTuple.v2(), equalTo(filteredSource));
@@ -410,7 +377,7 @@ public class XContentMapValuesTests extends ESTestCase {
                 .endObject()
                 .endObject();
 
-        Tuple<XContentType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(builder.bytes(), true, builder.contentType());
+        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(builder.bytes(), true, builder.contentType());
         Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[]{"obj.f1"});
 
         assertThat(filteredSource.size(), equalTo(1));
@@ -430,7 +397,7 @@ public class XContentMapValuesTests extends ESTestCase {
                 .endObject();
 
         // implicit include
-        Tuple<XContentType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(builder.bytes(), true, builder.contentType());
+        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(builder.bytes(), true, builder.contentType());
         Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[]{"*.obj2"});
 
         assertThat(filteredSource.size(), equalTo(1));
@@ -460,7 +427,7 @@ public class XContentMapValuesTests extends ESTestCase {
                 .endObject()
                 .endObject();
 
-        Tuple<XContentType, Map<String, Object>> mapTuple = XContentHelper.convertToMap(builder.bytes(), true, builder.contentType());
+        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(builder.bytes(), true, builder.contentType());
         Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"*.obj2"}, Strings.EMPTY_ARRAY);
 
         assertThat(filteredSource.size(), equalTo(1));
@@ -470,85 +437,6 @@ public class XContentMapValuesTests extends ESTestCase {
         assertThat(((Map) ((Map) filteredSource.get("obj1")).get("obj2")).size(), equalTo(0));
     }
 
-    public void testEmptyList() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startArray("some_array")
-                .endArray().endObject();
-
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, builder.string())) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("some_array", parser.currentName());
-            if (random().nextBoolean()) {
-                // sometimes read the start array token, sometimes not
-                assertEquals(XContentParser.Token.START_ARRAY, parser.nextToken());
-            }
-            assertEquals(Collections.emptyList(), parser.list());
-        }
-    }
-
-    public void testSimpleList() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startArray("some_array")
-                    .value(1)
-                    .value(3)
-                    .value(0)
-                .endArray().endObject();
-
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, builder.string())) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("some_array", parser.currentName());
-            if (random().nextBoolean()) {
-                // sometimes read the start array token, sometimes not
-                assertEquals(XContentParser.Token.START_ARRAY, parser.nextToken());
-            }
-            assertEquals(Arrays.asList(1, 3, 0), parser.list());
-        }
-    }
-
-    public void testNestedList() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startArray("some_array")
-                    .startArray().endArray()
-                    .startArray().value(1).value(3).endArray()
-                    .startArray().value(2).endArray()
-                .endArray().endObject();
-
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, builder.string())) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("some_array", parser.currentName());
-            if (random().nextBoolean()) {
-                // sometimes read the start array token, sometimes not
-                assertEquals(XContentParser.Token.START_ARRAY, parser.nextToken());
-            }
-            assertEquals(
-                    Arrays.asList(Collections.<Integer>emptyList(), Arrays.asList(1, 3), Arrays.asList(2)),
-                    parser.list());
-        }
-    }
-
-    public void testNestedMapInList() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startArray("some_array")
-                    .startObject().field("foo", "bar").endObject()
-                    .startObject().endObject()
-                .endArray().endObject();
-
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, builder.string())) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals("some_array", parser.currentName());
-            if (random().nextBoolean()) {
-                // sometimes read the start array token, sometimes not
-                assertEquals(XContentParser.Token.START_ARRAY, parser.nextToken());
-            }
-            assertEquals(
-                    Arrays.asList(singletonMap("foo", "bar"), emptyMap()),
-                    parser.list());
-        }
-    }
 
     public void testDotsInFieldNames() {
         Map<String, Object> map = new HashMap<>();
@@ -598,5 +486,10 @@ public class XContentMapValuesTests extends ESTestCase {
         Map<String, Object> expected = new HashMap<>();
         expected.put("photosCount", 2);
         assertEquals(expected, filtered);
+    }
+
+    private static Map<String, Object> toMap(Builder test, XContentType xContentType, boolean humanReadable) throws IOException {
+        ToXContentObject toXContent = (builder, params) -> test.apply(builder);
+        return convertToMap(toXContent(toXContent, xContentType, humanReadable), true, xContentType).v2();
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent.support.filtering;
+
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.support.AbstractFilteringTestCase;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public abstract class AbstractXContentFilteringTestCase extends AbstractFilteringTestCase {
+
+    protected final void testFilter(Builder expected, Builder actual, Set<String> includes, Set<String> excludes) throws IOException {
+        assertFilterResult(expected.apply(createBuilder()), actual.apply(createBuilder(includes, excludes)));
+    }
+
+    protected abstract void assertFilterResult(XContentBuilder expected, XContentBuilder actual);
+
+    protected abstract XContentType getXContentType();
+
+    private XContentBuilder createBuilder() throws IOException {
+        return XContentBuilder.builder(getXContentType().xContent());
+    }
+
+    private XContentBuilder createBuilder(Set<String> includes, Set<String> excludes) throws IOException {
+        return XContentBuilder.builder(getXContentType().xContent(), includes, excludes);
+    }
+
+    public void testSingleFieldObject() throws IOException {
+        final Builder sample = builder -> builder.startObject().startObject("foo").field("bar", "test").endObject().endObject();
+
+        Builder expected = builder -> builder.startObject().startObject("foo").field("bar", "test").endObject().endObject();
+        testFilter(expected, sample, singleton("foo.bar"), emptySet());
+        testFilter(expected, sample, emptySet(), singleton("foo.baz"));
+        testFilter(expected, sample, singleton("foo"), singleton("foo.baz"));
+
+        expected = builder -> builder.startObject().endObject();
+        testFilter(expected, sample, emptySet(), singleton("foo.bar"));
+        testFilter(expected, sample, singleton("foo"), singleton("foo.b*"));
+    }
+
+    static void assertXContentBuilderAsString(final XContentBuilder expected, final XContentBuilder actual) {
+        assertThat(actual.bytes().utf8ToString(), is(expected.bytes().utf8ToString()));
+    }
+
+    static void assertXContentBuilderAsBytes(final XContentBuilder expected, final XContentBuilder actual) {
+        try {
+            XContent xContent = XContentFactory.xContent(actual.contentType());
+            XContentParser jsonParser = xContent.createParser(NamedXContentRegistry.EMPTY, expected.bytes());
+            XContentParser testParser = xContent.createParser(NamedXContentRegistry.EMPTY, actual.bytes());
+
+            while (true) {
+                XContentParser.Token token1 = jsonParser.nextToken();
+                XContentParser.Token token2 = testParser.nextToken();
+                if (token1 == null) {
+                    assertThat(token2, nullValue());
+                    return;
+                }
+                assertThat(token1, equalTo(token2));
+                switch (token1) {
+                    case FIELD_NAME:
+                        assertThat(jsonParser.currentName(), equalTo(testParser.currentName()));
+                        break;
+                    case VALUE_STRING:
+                        assertThat(jsonParser.text(), equalTo(testParser.text()));
+                        break;
+                    case VALUE_NUMBER:
+                        assertThat(jsonParser.numberType(), equalTo(testParser.numberType()));
+                        assertThat(jsonParser.numberValue(), equalTo(testParser.numberValue()));
+                        break;
+                }
+            }
+        } catch (Exception e) {
+            fail("Fail to verify the result of the XContentBuilder: " + e.getMessage());
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/CborXContentFilteringTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/CborXContentFilteringTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.common.xcontent.support.filtering;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
-public class CborFilteringGeneratorTests extends JsonFilteringGeneratorTests {
+public class CborXContentFilteringTests extends AbstractXContentFilteringTestCase {
 
     @Override
     protected XContentType getXContentType() {
@@ -30,7 +30,7 @@ public class CborFilteringGeneratorTests extends JsonFilteringGeneratorTests {
     }
 
     @Override
-    protected void assertXContentBuilder(XContentBuilder expected, XContentBuilder builder) {
-        assertBinary(expected, builder);
+    protected void assertFilterResult(XContentBuilder expected, XContentBuilder actual) {
+        assertXContentBuilderAsBytes(expected, actual);
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/JsonXContentFilteringTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/JsonXContentFilteringTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.common.xcontent.support.filtering;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
-public class JsonFilteringGeneratorTests extends AbstractFilteringJsonGeneratorTestCase {
+public class JsonXContentFilteringTests extends AbstractXContentFilteringTestCase {
 
     @Override
     protected XContentType getXContentType() {
@@ -30,7 +30,11 @@ public class JsonFilteringGeneratorTests extends AbstractFilteringJsonGeneratorT
     }
 
     @Override
-    protected void assertXContentBuilder(XContentBuilder expected, XContentBuilder builder) {
-        assertString(expected, builder);
+    protected void assertFilterResult(XContentBuilder expected, XContentBuilder actual) {
+        if (randomBoolean()) {
+            assertXContentBuilderAsString(expected, actual);
+        } else {
+            assertXContentBuilderAsBytes(expected, actual);
+        }
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/SmileFilteringGeneratorTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/SmileFilteringGeneratorTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.common.xcontent.support.filtering;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
-public class SmileFilteringGeneratorTests extends JsonFilteringGeneratorTests {
+public class SmileFilteringGeneratorTests extends AbstractXContentFilteringTestCase {
 
     @Override
     protected XContentType getXContentType() {
@@ -30,7 +30,7 @@ public class SmileFilteringGeneratorTests extends JsonFilteringGeneratorTests {
     }
 
     @Override
-    protected void assertXContentBuilder(XContentBuilder expected, XContentBuilder builder) {
-        assertBinary(expected, builder);
+    protected void assertFilterResult(XContentBuilder expected, XContentBuilder actual) {
+        assertXContentBuilderAsBytes(expected, actual);
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/YamlFilteringGeneratorTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/YamlFilteringGeneratorTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.common.xcontent.support.filtering;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
-public class YamlFilteringGeneratorTests extends AbstractFilteringJsonGeneratorTestCase {
+public class YamlFilteringGeneratorTests extends AbstractXContentFilteringTestCase {
 
     @Override
     protected XContentType getXContentType() {
@@ -30,7 +30,11 @@ public class YamlFilteringGeneratorTests extends AbstractFilteringJsonGeneratorT
     }
 
     @Override
-    protected void assertXContentBuilder(XContentBuilder expected, XContentBuilder builder) {
-        assertString(expected, builder);
+    protected void assertFilterResult(XContentBuilder expected, XContentBuilder actual) {
+        if (randomBoolean()) {
+            assertXContentBuilderAsString(expected, actual);
+        } else {
+            assertXContentBuilderAsBytes(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
We have two ways to filter XContent:

- The first method is to parse the XContent as a map and use
`XContentMapValues.filter()`. This method filters the content of the map
using an automaton. It is used for source filtering, both at search and
indexing time. It performs well but can generate a lot of objects and
garbage collections when large XContent are filtered. It also returns
empty objects (see f2710c16ebd918f646be9d0ab64b4871c25be4c2) when all
the sub fields have been filtered out and handle dots in field names as
if they were sub fields.

- The second method is to parse the XContent and copy the XContentParser
 structure to a XContentBuilder initialized with includes/excludes
 filters. This method uses the Jackson streaming filter feature. It is
 used by the Response Filtering ('filter_path') feature. It does not
 generate a lot of objects, and does not return empty objects and also
 does not handle dots in field names explicitly.

 Both methods have similar goals but different tests. This commit changes
 the current `AbstractFilteringJsonGeneratorTestCase` class so that it tests
the expected behavior when filtering XContent to ensure that filtering methods 
generate the same results. Custom behaviors are still tested in specific classes.

 It also removes some tests from the `XContentMapValuesTests` class that
 should be in `XContentParserTests`.