### PR TITLE
[Doc] Remove mention of generated fields in get/mget docs

### DIFF
--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -222,13 +222,6 @@ Also only leaf fields can be returned via the `stored_field` option. So object f
 will fail.
 
 [float]
-[[generated-fields]]
-=== Generated fields
-If no refresh occurred between indexing and refresh, GET will access the transaction log to fetch the document. However, some fields are generated only when indexing. 
-If you try to access a field that is only generated when indexing, you will get an exception (default). You can choose to ignore field that are generated if the transaction log is accessed by setting `ignore_errors_on_generated_fields=true`.
-
-
-[float]
 [[_source]]
 === Getting the _source directly
 

--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -216,11 +216,6 @@ GET /test/type/_mget?stored_fields=field1,field2
 <2> Returns `field3` and `field4`
 
 [float]
-=== Generated fields
-
-See <<generated-fields>> for fields generated only when indexing.
-
-[float]
 [[mget-routing]]
 === Routing
 


### PR DESCRIPTION
This option has been removed in #20102.