### PR TITLE
Tests: Add Debian 9 (Stretch) to the packaging tests

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -347,7 +347,8 @@ These are the linux flavors the Vagrantfile currently supports:
 
 * ubuntu-1404 aka trusty
 * ubuntu-1604 aka xenial
-* debian-8 aka jessie, the current debian stable distribution
+* debian-8 aka jessie
+* debian-9 aka stretch, the current debian stable distribution
 * centos-6
 * centos-7
 * fedora-25

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,11 +33,15 @@ Vagrant.configure(2) do |config|
       [ -f /usr/share/java/jayatanaag.jar ] || install jayatana
     SHELL
   end
-  # Wheezy's backports don't contain Openjdk 8 and the backflips required to
-  # get the sun jdk on there just aren't worth it. We have jessie for testing
-  # debian and it works fine.
+  # Wheezy's backports don't contain Openjdk 8 and the backflips
+  # required to get the sun jdk on there just aren't worth it. We have
+  # jessie and stretch for testing debian and it works fine.
   config.vm.define "debian-8" do |config|
     config.vm.box = "elastic/debian-8-x86_64"
+    deb_common config
+  end
+  config.vm.define "debian-9" do |config|
+    config.vm.box = "elastic/debian-9-x86_64"
     deb_common config
   end
   config.vm.define "centos-6" do |config|

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -18,6 +18,7 @@ class VagrantTestPlugin implements Plugin<Project> {
             'centos-6',
             'centos-7',
             'debian-8',
+            'debian-9',
             'fedora-25',
             'oel-6',
             'oel-7',


### PR DESCRIPTION
Debian 9 aka Stretch is the current stable[1].

Add Debian-9 to the packaging tests.

[1] https://wiki.debian.org/DebianStretch
