### PR TITLE
Add doc note regarding explicit publish host

### DIFF
--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -116,12 +116,14 @@ two network cards, or a site-local address and a local address. Defaults to
 
 `network.publish_host`::
 
-The publish host is the single interface that the node advertises to other
-nodes in the cluster, so that those nodes can connect to it.   Currently an
-elasticsearch node may be bound to multiple addresses, but only publishes one.
-If not specified, this defaults to the ``best'' address from
-`network.host`, sorted by IPv4/IPv6 stack preference, then by
-reachability.
+The publish host is the single interface that the node advertises to other nodes
+in the cluster, so that those nodes can connect to it. Currently an
+Elasticsearch node may be bound to multiple addresses, but only publishes one.
+If not specified, this defaults to the ``best'' address from `network.host`,
+sorted by IPv4/IPv6 stack preference, then by reachability. If you set a
+`network.host` that results in multiple bind addresses yet rely on a specific
+address for node-to-node communication, you should explicitly set
+`network.publish_host`.
 
 Both of the above settings can be configured just like `network.host` -- they
 accept IP addresses, host names, and


### PR DESCRIPTION
This commit adds a note to the docs regarding explicilty setting a publish host if the network.host setting results in multiple bind addresses.

