### PR TITLE
Test fix for SignificantTermsAggregatorTests

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTermsAggregatorTests.java
@@ -95,7 +95,6 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
     /**
      * Uses the significant terms aggregation to find the keywords in text fields
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/25429")
     public void testSignificance() throws IOException {
         TextFieldType textFieldType = new TextFieldType();
         textFieldType.setName("text");
@@ -103,6 +102,9 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
         textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
         IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        indexWriterConfig.setMaxBufferedDocs(100);
+        indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
+        
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
             addMixedTextDocs(textFieldType, w);
 
@@ -117,6 +119,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
             sigNumAgg.executionHint(randomExecutionHint());
 
             try (IndexReader reader = DirectoryReader.open(w)) {
+                assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);
 
                 // Search "odd"
@@ -183,6 +186,8 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
         textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
         IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        indexWriterConfig.setMaxBufferedDocs(100);
+        indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         final long ODD_VALUE = 3;
         final long EVEN_VALUE = 6;
         final long COMMON_VALUE = 2;
@@ -206,6 +211,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
             sigNumAgg.executionHint(randomExecutionHint());
 
             try (IndexReader reader = DirectoryReader.open(w)) {
+                assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);
 
                 // Search "odd"
@@ -237,6 +243,8 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
         textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
         IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        indexWriterConfig.setMaxBufferedDocs(100);
+        indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
             addMixedTextDocs(textFieldType, w);
 
@@ -245,6 +253,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
             sigAgg.executionHint(randomExecutionHint());
 
             try (IndexReader reader = DirectoryReader.open(w)) {
+                assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);
 
                 // Search "odd"

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificantTextAggregatorTests.java
@@ -65,6 +65,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
         textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
         IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        indexWriterConfig.setMaxBufferedDocs(100);
+        indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
             for (int i = 0; i < 10; i++) {
                 Document doc = new Document();
@@ -91,6 +93,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                     .subAggregation(sigAgg);
             
             try (IndexReader reader = DirectoryReader.open(w)) {
+                assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);
                                 
                 // Search "odd" which should have no duplication
@@ -128,6 +131,8 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
         textFieldType.setIndexAnalyzer(new NamedAnalyzer("my_analyzer", AnalyzerScope.GLOBAL, new StandardAnalyzer()));
 
         IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+        indexWriterConfig.setMaxBufferedDocs(100);
+        indexWriterConfig.setRAMBufferSizeMB(100); // flush on open to have a single segment
         try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, indexWriterConfig)) {
             for (int i = 0; i < 10; i++) {
                 Document doc = new Document();
@@ -140,6 +145,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
             SignificantTextAggregationBuilder sigAgg = new SignificantTextAggregationBuilder("sig_text", "text");
             sigAgg.sourceFieldNames(Arrays.asList(new String [] {"title", "text"}));
             try (IndexReader reader = DirectoryReader.open(w)) {
+                assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);                                
                 searchAndReduce(searcher, new TermQuery(new Term("text", "foo")), sigAgg, textFieldType);
                 // No significant results to be found in this test - only checking we don't end up


### PR DESCRIPTION
Significant terms/text aggs return Lucene index-level statistics that when merged are assumed to be from different shards. However the Aggregator unit tests assume segments can be treated as shards and thus break the significance stats by introducing double-counting of background doc frequencies. This change addresses this problem by ensuring test indexes have only one shard.

Closes #25429