### PR TITLE
Treat aliases as unavailable indices in delete index and update aliases api

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -598,8 +598,6 @@ public class IndexNameExpressionResolver extends AbstractComponent {
                 }
                 final boolean add;
                 if (expression.charAt(0) == '-' && wildcardSeen) {
-                    // if there is a negation without a wildcard being previously seen, add it verbatim,
-                    // otherwise return the expression
                     add = false;
                     expression = expression.substring(1);
                 } else {
@@ -741,7 +739,6 @@ public class IndexNameExpressionResolver extends AbstractComponent {
             } else if (options.expandWildcardsClosed()) {
                 return Arrays.asList(metaData.getConcreteAllClosedIndices());
             } else {
-                assert true : "shouldn't end up here";
                 return Collections.emptyList();
             }
         }

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -66,11 +66,10 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             assertEquals(1, results.length);
             assertEquals("foo", results[0]);
 
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "bar");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("bar"));
+            {
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "bar"));
+                assertThat(infe.getIndex().getName(), equalTo("bar"));
             }
 
             results = indexNameExpressionResolver.concreteIndexNames(context, "foofoo", "foobar");
@@ -81,29 +80,26 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             assertEquals(new HashSet<>(Arrays.asList("foo", "foobar")),
                          new HashSet<>(Arrays.asList(results)));
 
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "bar");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("bar"));
+            {
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "bar"));
+                assertThat(infe.getIndex().getName(), equalTo("bar"));
             }
 
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "foo", "bar");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("bar"));
+            {
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "foo", "bar"));
+                assertThat(infe.getIndex().getName(), equalTo("bar"));
             }
 
             results = indexNameExpressionResolver.concreteIndexNames(context, "barbaz", "foobar");
             assertEquals(2, results.length);
             assertThat(results, arrayContainingInAnyOrder("foofoo", "foobar"));
 
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "barbaz", "bar");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("bar"));
+            {
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "barbaz", "bar"));
+                assertThat(infe.getIndex().getName(), equalTo("bar"));
             }
 
             results = indexNameExpressionResolver.concreteIndexNames(context, "baz*");
@@ -224,25 +220,20 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             assertEquals(1, results.length);
             assertEquals("foo", results[0]);
 
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "bar");
-                fail();
-            } catch(IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("bar"));
+            {
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "bar"));
+                assertThat(infe.getIndex().getName(), equalTo("bar"));
             }
-
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "baz*");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("baz*"));
+            {
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "baz*"));
+                assertThat(infe.getIndex().getName(), equalTo("baz*"));
             }
-
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "foo", "baz*");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("baz*"));
+            {
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "foo", "baz*"));
+                assertThat(infe.getIndex().getName(), equalTo("baz*"));
             }
         }
 
@@ -312,17 +303,18 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertEquals(1, results.length);
         assertEquals("bar", results[0]);
 
+        results = indexNameExpressionResolver.concreteIndexNames(context, "*", "-foo", "-foobar");
+        assertEquals(1, results.length);
+        assertEquals("bar", results[0]);
+
         results = indexNameExpressionResolver.concreteIndexNames(context, "-*");
         assertEquals(0, results.length);
 
         options = IndicesOptions.fromOptions(false, false, true, true);
-        context = new IndexNameExpressionResolver.Context(state, options);
-        try {
-            indexNameExpressionResolver.concreteIndexNames(context, "-*");
-            fail();
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getResourceId().toString(), equalTo("[-*]"));
-        }
+        IndexNameExpressionResolver.Context context2 = new IndexNameExpressionResolver.Context(state, options);
+        IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                () -> indexNameExpressionResolver.concreteIndexNames(context2, "-*"));
+        assertThat(infe.getResourceId().toString(), equalTo("[-*]"));
     }
 
     public void testIndexOptionsNoExpandWildcards() {
@@ -359,11 +351,11 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         {
             IndicesOptions noExpandDisallowEmpty = IndicesOptions.fromOptions(true, false, false, false);
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, noExpandDisallowEmpty);
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "baz*");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("baz*"));
+
+            {
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "baz*"));
+                assertThat(infe.getIndex().getName(), equalTo("baz*"));
             }
 
             String[] results = indexNameExpressionResolver.concreteIndexNames(context, "foo", "baz*");
@@ -373,44 +365,50 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             results = indexNameExpressionResolver.concreteIndexNames(context, "foofoobar");
             assertEquals(2, results.length);
             assertThat(results, arrayContainingInAnyOrder("foo", "foobar"));
+
+            {
+                //unavailable indices are ignored but no indices are disallowed
+                expectThrows(IndexNotFoundException.class, () -> indexNameExpressionResolver.concreteIndexNames(context, "bar", "baz"));
+            }
         }
 
         //error on unavailable but allow no indices
         {
             IndicesOptions noExpandErrorUnavailable = IndicesOptions.fromOptions(false, true, false, false);
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, noExpandErrorUnavailable);
-            String[] results = indexNameExpressionResolver.concreteIndexNames(context, "baz*");
-            assertThat(results, emptyArray());
-
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "foo", "baz*");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("baz*"));
+            {
+                String[] results = indexNameExpressionResolver.concreteIndexNames(context, "baz*");
+                assertThat(results, emptyArray());
             }
-
-            results = indexNameExpressionResolver.concreteIndexNames(context, "foofoobar");
-            assertEquals(2, results.length);
-            assertThat(results, arrayContainingInAnyOrder("foo", "foobar"));
+            {
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "foo", "baz*"));
+                assertThat(infe.getIndex().getName(), equalTo("baz*"));
+            }
+            {
+                //unavailable indices are not ignored, hence the error on the first unavailable indices encountered
+                IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                        () -> indexNameExpressionResolver.concreteIndexNames(context, "bar", "baz"));
+                assertThat(infe.getIndex().getName(), equalTo("bar"));
+            }
+            {
+                String[] results = indexNameExpressionResolver.concreteIndexNames(context, "foofoobar");
+                assertEquals(2, results.length);
+                assertThat(results, arrayContainingInAnyOrder("foo", "foobar"));
+            }
         }
 
         //error on both unavailable and no indices
         {
             IndicesOptions noExpandStrict = IndicesOptions.fromOptions(false, false, false, false);
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, noExpandStrict);
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "baz*");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("baz*"));
-            }
+            IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(context, "baz*"));
+            assertThat(infe.getIndex().getName(), equalTo("baz*"));
 
-            try {
-                indexNameExpressionResolver.concreteIndexNames(context, "foo", "baz*");
-                fail();
-            } catch (IndexNotFoundException e) {
-                assertThat(e.getIndex().getName(), equalTo("baz*"));
-            }
+            IndexNotFoundException infe2 = expectThrows(IndexNotFoundException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(context, "foo", "baz*"));
+            assertThat(infe2.getIndex().getName(), equalTo("baz*"));
 
             String[] results = indexNameExpressionResolver.concreteIndexNames(context, "foofoobar");
             assertEquals(2, results.length);
@@ -428,45 +426,40 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
 
         //error on both unavailable and no indices + every alias needs to expand to a single index
 
-        try {
+        {
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
-            indexNameExpressionResolver.concreteIndexNames(context, "baz*");
-            fail();
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getIndex().getName(), equalTo("baz*"));
+            IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(context, "baz*"));
+            assertThat(infe.getIndex().getName(), equalTo("baz*"));
         }
 
-        try {
+        {
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
-            indexNameExpressionResolver.concreteIndexNames(context, "foo", "baz*");
-            fail();
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getIndex().getName(), equalTo("baz*"));
+            IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(context, "foo", "baz*"));
+            assertThat(infe.getIndex().getName(), equalTo("baz*"));
         }
 
-        try {
+        {
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
-            indexNameExpressionResolver.concreteIndexNames(context, "foofoobar");
-            fail();
-        } catch(IllegalArgumentException e) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(context, "foofoobar"));
             assertThat(e.getMessage(), containsString("Alias [foofoobar] has more than one indices associated with it"));
         }
 
-        try {
+        {
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
-            indexNameExpressionResolver.concreteIndexNames(context, "foo", "foofoobar");
-            fail();
-        } catch(IllegalArgumentException e) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(context, "foo", "foofoobar"));
             assertThat(e.getMessage(), containsString("Alias [foofoobar] has more than one indices associated with it"));
         }
 
-        try {
+        {
             IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
-            indexNameExpressionResolver.concreteIndexNames(context, "foofoo-closed", "foofoobar");
-            fail();
-        } catch(IndexClosedException e) {
-            assertThat(e.getMessage(), equalTo("closed"));
-            assertEquals(e.getIndex().getName(), "foofoo-closed");
+            IndexClosedException ince = expectThrows(IndexClosedException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(context, "foofoo-closed", "foofoobar"));
+            assertThat(ince.getMessage(), equalTo("closed"));
+            assertEquals(ince.getIndex().getName(), "foofoo-closed");
         }
 
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictSingleIndexNoExpandForbidClosed());
@@ -479,44 +472,43 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(MetaData.builder().build()).build();
 
         IndicesOptions options = IndicesOptions.strictExpandOpen();
-        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, options);
+        final IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, options);
         String[] results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
         assertThat(results, emptyArray());
-        try {
-            indexNameExpressionResolver.concreteIndexNames(context, "foo");
-            fail();
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getIndex().getName(), equalTo("foo"));
+
+        {
+            IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(context, "foo"));
+            assertThat(infe.getIndex().getName(), equalTo("foo"));
         }
+
         results = indexNameExpressionResolver.concreteIndexNames(context, "foo*");
         assertThat(results, emptyArray());
-        try {
-            indexNameExpressionResolver.concreteIndexNames(context, "foo*", "bar");
-            fail();
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getIndex().getName(), equalTo("bar"));
+
+        {
+            IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(context, "foo*", "bar"));
+            assertThat(infe.getIndex().getName(), equalTo("bar"));
         }
 
 
-        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.lenientExpandOpen());
-        results = indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
+        final IndexNameExpressionResolver.Context context2 = new IndexNameExpressionResolver.Context(state, IndicesOptions.lenientExpandOpen());
+        results = indexNameExpressionResolver.concreteIndexNames(context2, Strings.EMPTY_ARRAY);
         assertThat(results, emptyArray());
-        results = indexNameExpressionResolver.concreteIndexNames(context, "foo");
+        results = indexNameExpressionResolver.concreteIndexNames(context2, "foo");
         assertThat(results, emptyArray());
-        results = indexNameExpressionResolver.concreteIndexNames(context, "foo*");
+        results = indexNameExpressionResolver.concreteIndexNames(context2, "foo*");
         assertThat(results, emptyArray());
-        results = indexNameExpressionResolver.concreteIndexNames(context, "foo*", "bar");
+        results = indexNameExpressionResolver.concreteIndexNames(context2, "foo*", "bar");
         assertThat(results, emptyArray());
 
-        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, false, true, false));
-        try {
-            indexNameExpressionResolver.concreteIndexNames(context, Strings.EMPTY_ARRAY);
-        } catch (IndexNotFoundException e) {
-            assertThat(e.getResourceId().toString(), equalTo("[_all]"));
-        }
+        final IndexNameExpressionResolver.Context context3 = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, false, true, false));
+        IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                () -> indexNameExpressionResolver.concreteIndexNames(context3, Strings.EMPTY_ARRAY));
+        assertThat(infe.getResourceId().toString(), equalTo("[_all]"));
     }
 
-    private IndexMetaData.Builder indexBuilder(String index) {
+    private static IndexMetaData.Builder indexBuilder(String index) {
         return IndexMetaData.builder(index).settings(settings(Version.CURRENT).put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0));
     }
 
@@ -527,12 +519,9 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictExpandOpen());
 
-        try {
-            indexNameExpressionResolver.concreteIndexNames(context, "testZZZ");
-            fail("Expected IndexNotFoundException");
-        } catch(IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
-        }
+        IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                () -> indexNameExpressionResolver.concreteIndexNames(context, "testZZZ"));
+        assertThat(infe.getMessage(), is("no such index"));
     }
 
     public void testConcreteIndicesIgnoreIndicesOneMissingIndexOtherFound() {
@@ -552,12 +541,9 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
         IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictExpandOpen());
 
-        try {
-            indexNameExpressionResolver.concreteIndexNames(context, "testMo", "testMahdy");
-            fail("Expected IndexNotFoundException");
-        } catch(IndexNotFoundException e) {
-            assertThat(e.getMessage(), is("no such index"));
-        }
+        IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                () -> indexNameExpressionResolver.concreteIndexNames(context, "testMo", "testMahdy"));
+        assertThat(infe.getMessage(), is("no such index"));
     }
 
     public void testConcreteIndicesIgnoreIndicesEmptyRequest() {
@@ -705,64 +691,60 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
      */
     public void testConcreteIndicesAllPatternRandom() {
         for (int i = 0; i < 10; i++) {
-            String[] allIndices = null;
+            final String[] allIndices;
             switch (randomIntBetween(0, 2)) {
-            case 0:
-                break;
-            case 1:
-                allIndices = new String[0];
-                break;
-            case 2:
-                allIndices = new String[] { MetaData.ALL };
-                break;
+                case 0:
+                    allIndices = null;
+                    break;
+                case 1:
+                    allIndices = new String[0];
+                    break;
+                case 2:
+                    allIndices = new String[] { MetaData.ALL };
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
             }
+            final IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(),
+                    randomBoolean(), randomBoolean());
 
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
-            ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(MetaData.builder().build()).build();
-            IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, indicesOptions);
+            {
+                ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(MetaData.builder().build()).build();
+                IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, indicesOptions);
 
-            // with no indices, asking for all indices should return empty list or exception, depending on indices options
-            if (indicesOptions.allowNoIndices()) {
-                String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(context, allIndices);
-                assertThat(concreteIndices, notNullValue());
-                assertThat(concreteIndices.length, equalTo(0));
-            } else {
-                checkCorrectException(indexNameExpressionResolver, context, allIndices);
-            }
-
-            // with existing indices, asking for all indices should return all open/closed indices depending on options
-            MetaData.Builder mdBuilder = MetaData.builder()
-                    .put(indexBuilder("aaa").state(State.OPEN).putAlias(AliasMetaData.builder("aaa_alias1")))
-                    .put(indexBuilder("bbb").state(State.OPEN).putAlias(AliasMetaData.builder("bbb_alias1")))
-                    .put(indexBuilder("ccc").state(State.CLOSE).putAlias(AliasMetaData.builder("ccc_alias1")));
-            state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
-            context = new IndexNameExpressionResolver.Context(state, indicesOptions);
-            if (indicesOptions.expandWildcardsOpen() || indicesOptions.expandWildcardsClosed() || indicesOptions.allowNoIndices()) {
-                String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(context, allIndices);
-                assertThat(concreteIndices, notNullValue());
-                int expectedNumberOfIndices = 0;
-                if (indicesOptions.expandWildcardsOpen()) {
-                    expectedNumberOfIndices += 2;
+                // with no indices, asking for all indices should return empty list or exception, depending on indices options
+                if (indicesOptions.allowNoIndices()) {
+                    String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(context, allIndices);
+                    assertThat(concreteIndices, notNullValue());
+                    assertThat(concreteIndices.length, equalTo(0));
+                } else {
+                    expectThrows(IndexNotFoundException.class, () -> indexNameExpressionResolver.concreteIndexNames(context, allIndices));
                 }
-                if (indicesOptions.expandWildcardsClosed()) {
-                    expectedNumberOfIndices += 1;
-                }
-                assertThat(concreteIndices.length, equalTo(expectedNumberOfIndices));
-            } else {
-                checkCorrectException(indexNameExpressionResolver, context, allIndices);
             }
-        }
-    }
 
-    /**
-     * check for correct exception type depending on indicesOptions and provided index name list
-     */
-    private void checkCorrectException(IndexNameExpressionResolver indexNameExpressionResolver, IndexNameExpressionResolver.Context context, String[] allIndices) {
-        try {
-            indexNameExpressionResolver.concreteIndexNames(context, allIndices);
-            fail("wildcard expansion on should trigger IndexMissingException");
-        } catch (IndexNotFoundException e) {
-            // expected
+            {
+                // with existing indices, asking for all indices should return all open/closed indices depending on options
+                MetaData.Builder mdBuilder = MetaData.builder()
+                        .put(indexBuilder("aaa").state(State.OPEN).putAlias(AliasMetaData.builder("aaa_alias1")))
+                        .put(indexBuilder("bbb").state(State.OPEN).putAlias(AliasMetaData.builder("bbb_alias1")))
+                        .put(indexBuilder("ccc").state(State.CLOSE).putAlias(AliasMetaData.builder("ccc_alias1")));
+                ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
+                IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, indicesOptions);
+                if (indicesOptions.expandWildcardsOpen() || indicesOptions.expandWildcardsClosed() || indicesOptions.allowNoIndices()) {
+                    String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(context, allIndices);
+                    assertThat(concreteIndices, notNullValue());
+                    int expectedNumberOfIndices = 0;
+                    if (indicesOptions.expandWildcardsOpen()) {
+                        expectedNumberOfIndices += 2;
+                    }
+                    if (indicesOptions.expandWildcardsClosed()) {
+                        expectedNumberOfIndices += 1;
+                    }
+                    assertThat(concreteIndices.length, equalTo(expectedNumberOfIndices));
+                } else {
+                    expectThrows(IndexNotFoundException.class, () -> indexNameExpressionResolver.concreteIndexNames(context, allIndices));
+                }
+            }
         }
     }
 
@@ -785,12 +767,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 assertThat(concreteIndices, notNullValue());
                 assertThat(concreteIndices.length, equalTo(0));
             } else {
-                try {
-                    indexNameExpressionResolver.concreteIndexNames(context, "Foo*");
-                    fail("expecting exception when result empty and allowNoIndicec=false");
-                } catch (IndexNotFoundException e) {
-                    // expected exception
-                }
+                expectThrows(IndexNotFoundException.class, () -> indexNameExpressionResolver.concreteIndexNames(context, "Foo*"));
             }
         }
     }
@@ -909,22 +886,12 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 .put(indexBuilder("foo3").putAlias(AliasMetaData.builder("foobar2-closed")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
 
-        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictExpandOpenAndForbidClosed());
-        try {
-            indexNameExpressionResolver.concreteIndexNames(context, "foo1-closed");
-            fail("foo1-closed should be closed, but it is open");
-        } catch (IndexClosedException e) {
-            // expected
-        }
+        IndexNameExpressionResolver.Context contextICE = new IndexNameExpressionResolver.Context(state, IndicesOptions.strictExpandOpenAndForbidClosed());
+        expectThrows(IndexClosedException.class, () -> indexNameExpressionResolver.concreteIndexNames(contextICE, "foo1-closed"));
+        expectThrows(IndexClosedException.class, () -> indexNameExpressionResolver.concreteIndexNames(contextICE, "foobar1-closed"));
 
-        try {
-            indexNameExpressionResolver.concreteIndexNames(context, "foobar1-closed");
-            fail("foo1-closed should be closed, but it is open");
-        } catch (IndexClosedException e) {
-            // expected
-        }
-
-        context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true, context.getOptions().allowNoIndices(), context.getOptions().expandWildcardsOpen(), context.getOptions().expandWildcardsClosed(), context.getOptions()));
+        IndexNameExpressionResolver.Context context = new IndexNameExpressionResolver.Context(state, IndicesOptions.fromOptions(true,
+                contextICE.getOptions().allowNoIndices(), contextICE.getOptions().expandWildcardsOpen(), contextICE.getOptions().expandWildcardsClosed(), contextICE.getOptions()));
         String[] results = indexNameExpressionResolver.concreteIndexNames(context, "foo1-closed");
         assertThat(results, emptyArray());
 
@@ -973,7 +940,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         }
     }
 
-    private MetaData metaDataBuilder(String... indices) {
+    private static MetaData metaDataBuilder(String... indices) {
         MetaData.Builder mdBuilder = MetaData.builder();
         for (String concreteIndex : indices) {
             mdBuilder.put(indexBuilder(concreteIndex));
@@ -1035,8 +1002,27 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                         .putAlias(AliasMetaData.builder("test-alias2")));
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metaData(mdBuilder).build();
         {
-            String[] indices = indexNameExpressionResolver.concreteIndexNames(state, new DeleteIndexRequest("test-alias"));
+            IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(state, new DeleteIndexRequest("does_not_exist")));
+            assertEquals("does_not_exist", infe.getIndex().getName());
+        }
+        {
+            IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(state, new DeleteIndexRequest("test-alias")));
+            assertEquals("test-alias", infe.getIndex().getName());
+        }
+        {
+            DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("test-alias");
+            deleteIndexRequest.indicesOptions(IndicesOptions.fromOptions(true, true, true, true, false, false, true));
+            String[] indices = indexNameExpressionResolver.concreteIndexNames(state, deleteIndexRequest);
             assertEquals(0, indices.length);
+        }
+        {
+            DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("test-a*");
+            deleteIndexRequest.indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, true, false, false, true));
+            IndexNotFoundException infe = expectThrows(IndexNotFoundException.class,
+                    () -> indexNameExpressionResolver.concreteIndexNames(state, deleteIndexRequest));
+            assertEquals(infe.getIndex().getName(), "test-a*");
         }
         {
             String[] indices = indexNameExpressionResolver.concreteIndexNames(state, new DeleteIndexRequest("test-a*"));


### PR DESCRIPTION
This is a follow-up of #23997 and #25268.

When resolving wildcards, aliases should be treated as unavailable indices when the `ignoreAliases` option is set to `true` (currently enabled with delete index api and update aliases api). This way the `allow_no_indices` and `ignore_unavailable` options can be honoured, otherwise `WildcardExpressionResolver` ends up treating aliases differently and there is no way to control when an error is thrown.

The default behaviour for the delete index api, which has `ignore_unavailable` set to `false` and `allow_no_indices` set to `true` by default, is to throw an error when executed against an alias, same as when it's executed against an index that does not exist.