### PR TITLE
Remove deprecated IdsQueryBuilder ctor

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -66,15 +66,6 @@ public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
     }
 
     /**
-     * Creates a new IdsQueryBuilder by providing the types of the documents to look for
-     * @deprecated Replaced by {@link #types(String...)}
-     */
-    @Deprecated
-    public IdsQueryBuilder(String... types) {
-        types(types);
-    }
-
-    /**
      * Read from a stream.
      */
     public IdsQueryBuilder(StreamInput in) throws IOException {


### PR DESCRIPTION
The constructor using `types` has been deprecated for a while now (starting with
ES 5.1.). It can be removed in the next mayor version. Since types are optional
they should be added with the #types() setter.