### PR TITLE
Upgrade randomizedrunner to 2.5.2

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -13,7 +13,7 @@ slf4j             = 1.6.2
 jna               = 4.4.0-1
 
 # test dependencies
-randomizedrunner  = 2.5.0
+randomizedrunner  = 2.5.2
 junit             = 4.12
 httpclient        = 4.5.2
 # When updating httpcore, please also update core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy

--- a/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -42,7 +42,7 @@ grant codeBase "${codebase.lucene-test-framework-7.0.0-snapshot-ad2cb77.jar}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
-grant codeBase "${codebase.randomizedtesting-runner-2.5.0.jar}" {
+grant codeBase "${codebase.randomizedtesting-runner-2.5.2.jar}" {
   // optionally needed for access to private test methods (e.g. beforeClass)
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed to fail tests on uncaught exceptions from other threads


### PR DESCRIPTION
An issue causing confusing error messages during test exectuion
has been fixed randomizedtesting/randomizedtesting#250
