### PR TITLE
Removes deprecated fielddata_fields

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/AbstractTDigestPercentilesAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/percentiles/tdigest/AbstractTDigestPercentilesAggregator.java
@@ -90,7 +90,8 @@ public abstract class AbstractTDigestPercentilesAggregator extends NumericMetric
                 if (values.advanceExact(doc)) {
                     final int valueCount = values.docValueCount();
                     for (int i = 0; i < valueCount; i++) {
-                        state.add(values.nextValue());
+                        double nextValue = values.nextValue();
+                        state.add(nextValue);
                     }
                 }
             }

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -87,7 +87,7 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
     public static final ParseField _SOURCE_FIELD = new ParseField("_source");
     public static final ParseField FIELDS_FIELD = new ParseField("fields");
     public static final ParseField STORED_FIELDS_FIELD = new ParseField("stored_fields");
-    public static final ParseField DOCVALUE_FIELDS_FIELD = new ParseField("docvalue_fields", "fielddata_fields");
+    public static final ParseField DOCVALUE_FIELDS_FIELD = new ParseField("docvalue_fields");
     public static final ParseField SCRIPT_FIELDS_FIELD = new ParseField("script_fields");
     public static final ParseField SCRIPT_FIELD = new ParseField("script");
     public static final ParseField IGNORE_FAILURE_FIELD = new ParseField("ignore_failure");
@@ -753,32 +753,6 @@ public final class SearchSourceBuilder extends ToXContentToBytes implements Writ
      */
     public StoredFieldsContext storedFields() {
         return storedFieldsContext;
-    }
-
-
-    /**
-     * Adds a field to load from the docvalue and return as part of the
-     * search request.
-     *
-     * @deprecated Use {@link SearchSourceBuilder#docValueField(String)} instead.
-     */
-    @Deprecated
-    public SearchSourceBuilder fieldDataField(String name) {
-        if (docValueFields == null) {
-            docValueFields = new ArrayList<>();
-        }
-        docValueFields.add(name);
-        return this;
-    }
-
-    /**
-     * Gets the docvalue fields.
-     *
-     * @deprecated Use {@link SearchSourceBuilder#docValueFields()} instead.
-     */
-    @Deprecated
-    public List<String> fieldDataFields() {
-        return docValueFields;
     }
 
 

--- a/core/src/test/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.fields;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -706,13 +705,13 @@ public class SearchFieldsIT extends ESIntegTestCase {
     }
 
     // see #8203
-    public void testSingleValueFieldDatatField() throws ExecutionException, InterruptedException {
+    public void testSingleValueDocValueField() throws ExecutionException, InterruptedException {
         assertAcked(client().admin().indices().prepareCreate("test")
                 .addMapping("type", "test_field", "type=keyword").get());
         indexRandom(true, client().prepareIndex("test", "type", "1").setSource("test_field", "foobar"));
         refresh();
         SearchResponse searchResponse = client().prepareSearch("test").setTypes("type").setSource(
-                new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).fieldDataField("test_field")).get();
+                new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).docValueField("test_field")).get();
         assertHitCount(searchResponse, 1);
         Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
         assertThat(fields.get("test_field").getValue(), equalTo("foobar"));

--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -112,3 +112,7 @@ It is still possible to force the highlighter to `fvh` or `plain` types.
 The `postings` highlighter has been removed from Lucene and Elasticsearch.
 The `unified` highlighter outputs the same highlighting when `index_options` is set
  to `offsets`.
+ 
+ ==== `fielddata_fields`
+ 
+ The deprecated `fielddata_fields` have now been removed. `docvalue_fields` should be used instead.


### PR DESCRIPTION
This change removes the already deprecated fielddata_field methods from SearchSourceBuilder.

Closes #19027