### PR TITLE
Important note for MSI upgrade from command line

### DIFF
--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -246,11 +246,11 @@ Defaults to `%ALLUSERSPROFILE%\Elastic\Elasticsearch\data`
   A comma separated list of the plugins to download and install as part of the installation. Defaults `""`
 
 To pass a value, simply append the property name and value using the format `<PROPERTYNAME>="<VALUE>"` to
-the installation command. For example, to use a different installation directory to the default one:
+the installation command. For example, to use a different installation directory to the default one and to install https://www.elastic.co/products/x-pack[X-Pack]:
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------
-start /wait msiexec.exe /i elasticsearch-{version}.msi /qn INSTALLDIR="C:\Custom Install Directory"
+start /wait msiexec.exe /i elasticsearch-{version}.msi /qn INSTALLDIR="C:\Custom Install Directory" PLUGINS="x-pack"
 --------------------------------------------
 
 Consult the https://msdn.microsoft.com/en-us/library/windows/desktop/aa367988(v=vs.85).aspx[Windows Installer SDK Command-Line Options]
@@ -339,8 +339,8 @@ service in order to take affect.
 ==== Upgrade using the graphical user interface (GUI)
 
 The `.msi` package supports upgrading an installed version of Elasticsearch to a newer 
-version of Elasticsearch. The upgrade process handles upgrading all installed plugins as
-well as retaining both your data and configuration.
+version of Elasticsearch. The upgrade process through the GUI handles upgrading all 
+installed plugins as well as retaining both your data and configuration.
 
 Downloading and clicking on a newer version of the `.msi` package will launch the GUI wizard. 
 The first step will list the read only properties from the previous installation:
@@ -362,9 +362,20 @@ image::images/msi_installer/msi_installer_upgrade_plugins.png[]
 [[upgrade-msi-command-line]]
 ==== Upgrade using the command line
 
-The `.msi` can also upgrade Elasticsearch using the command line. The simplest upgrade
-using the same defaults as the currently installed version is achieved by first 
-navigating to the download directory, then running:
+The `.msi` can also upgrade Elasticsearch using the command line. 
+
+[IMPORTANT]
+===========================================
+A command line upgrade requires passing the **same** command line properties as
+used at first install time; the Windows Installer does not remember these properties.
+
+For example, if you originally installed with the command line options `PLUGINS="x-pack"` and
+`LOCKMEMORY="true"`, then you must pass these same values when performing an
+upgrade from the command line.
+===========================================
+
+The simplest upgrade, assuming Elasticsearch was installed using all defaults, 
+is achieved by first navigating to the download directory, then running:
 
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------


### PR DESCRIPTION
Add an Important admonition for upgrading via the command line
using the Windows MSI Installer. This calls out the need to pass
the same command line options for an upgrade as were used for
the initial installation.