### PR TITLE
Support parent id being specified as number in the _source

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -387,6 +386,12 @@ public final class ParentJoinFieldMapper extends FieldMapper {
                         name = context.parser().text();
                     } else if ("parent".equals(currentFieldName)) {
                         parent = context.parser().text();
+                    } else {
+                        throw new IllegalArgumentException("unknown field name [" + currentFieldName + "] in join field [" + name() + "]");
+                    }
+                } else if (token == XContentParser.Token.VALUE_NUMBER) {
+                    if ("parent".equals(currentFieldName)) {
+                        parent = context.parser().numberValue().toString();
                     } else {
                         throw new IllegalArgumentException("unknown field name [" + currentFieldName + "] in join field [" + name() + "]");
                     }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DocumentFieldMappers;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperException;
 import org.elasticsearch.index.mapper.MapperParsingException;
@@ -92,6 +91,40 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                     .field("join_field", "unknown")
                     .endObject().bytes(), XContentType.JSON)));
         assertThat(exc.getRootCause().getMessage(), containsString("unknown join name [unknown] for field [join_field]"));
+    }
+
+    public void testParentIdSpecifiedAsNumber() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject()
+            .startObject("properties")
+                .startObject("join_field")
+                    .field("type", "join")
+                        .startObject("relations")
+                            .field("parent", "child")
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .endObject().string();
+        IndexService service = createIndex("test");
+        DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
+            MapperService.MergeReason.MAPPING_UPDATE, false);
+        ParsedDocument doc = docMapper.parse(SourceToParse.source("test", "type", "2",
+            XContentFactory.jsonBuilder().startObject()
+                .startObject("join_field")
+                .field("name", "child")
+                .field("parent", 1)
+                .endObject()
+                .endObject().bytes(), XContentType.JSON).routing("1"));
+        assertEquals("1", doc.rootDoc().getBinaryValue("join_field#parent").utf8ToString());
+        assertEquals("child", doc.rootDoc().getBinaryValue("join_field").utf8ToString());
+        doc = docMapper.parse(SourceToParse.source("test", "type", "2",
+            XContentFactory.jsonBuilder().startObject()
+                .startObject("join_field")
+                .field("name", "child")
+                .field("parent", 1.0)
+                .endObject()
+                .endObject().bytes(), XContentType.JSON).routing("1"));
+        assertEquals("1.0", doc.rootDoc().getBinaryValue("join_field#parent").utf8ToString());
+        assertEquals("child", doc.rootDoc().getBinaryValue("join_field").utf8ToString());
     }
 
     public void testMultipleLevels() throws Exception {


### PR DESCRIPTION
If the parent id is now specified as a number then this leads to an error during indexing. This maybe unexpected as incremental ids are very common.