### PR TITLE
[Tests] Add tests for SuggestionBuilder#build method

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
@@ -43,6 +44,7 @@ import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexSortConfig;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.similarity.SimilarityService;
@@ -185,6 +187,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     public IndexAnalyzers getIndexAnalyzers() {
         return this.indexAnalyzers;
+    }
+
+    public NamedAnalyzer getNamedAnalyzer(String analyzerName) {
+        return this.indexAnalyzers.get(analyzerName);
     }
 
     public DocumentMapperParser documentMapperParser() {

--- a/core/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
@@ -298,8 +298,7 @@ public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implemen
      * Transfers the text, prefix, regex, analyzer, field, size and shard size settings from the
      * original {@link SuggestionBuilder} to the target {@link SuggestionContext}
      */
-    protected void populateCommonFields(MapperService mapperService,
-            SuggestionSearchContext.SuggestionContext suggestionContext) throws IOException {
+    protected void populateCommonFields(MapperService mapperService, SuggestionSearchContext.SuggestionContext suggestionContext) {
 
         Objects.requireNonNull(field, "field must not be null");
 
@@ -314,7 +313,7 @@ public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implemen
                 suggestionContext.setAnalyzer(fieldType.searchAnalyzer());
             }
         } else {
-            Analyzer luceneAnalyzer = mapperService.getIndexAnalyzers().get(analyzer);
+            Analyzer luceneAnalyzer = mapperService.getNamedAnalyzer(analyzer);
             if (luceneAnalyzer == null) {
                 throw new IllegalArgumentException("analyzer [" + analyzer + "] doesn't exists");
             }

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
@@ -412,13 +412,13 @@ public final class DirectCandidateGeneratorBuilder implements CandidateGenerator
         generator.setField(this.field);
         transferIfNotNull(this.size, generator::size);
         if (this.preFilter != null) {
-            generator.preFilter(mapperService.getIndexAnalyzers().get(this.preFilter));
+            generator.preFilter(mapperService.getNamedAnalyzer(this.preFilter));
             if (generator.preFilter() == null) {
                 throw new IllegalArgumentException("Analyzer [" + this.preFilter + "] doesn't exists");
             }
         }
         if (this.postFilter != null) {
-            generator.postFilter(mapperService.getIndexAnalyzers().get(this.postFilter));
+            generator.postFilter(mapperService.getNamedAnalyzer(this.postFilter));
             if (generator.postFilter() == null) {
                 throw new IllegalArgumentException("Analyzer [" + this.postFilter + "] doesn't exists");
             }

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -37,9 +37,7 @@ import org.elasticsearch.index.analysis.ShingleTokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.search.suggest.SuggestionBuilder;
@@ -55,7 +53,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * Defines the actual suggest command for phrase suggestions ( <tt>phrase</tt>).

--- a/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.search.suggest;
 
+import org.apache.lucene.analysis.core.SimpleAnalyzer;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
@@ -28,15 +31,32 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.mock.orig.Mockito;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.IndexSettingsModule;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.common.lucene.BytesRefs.toBytesRef;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBuilder<SB>> extends ESTestCase {
 
@@ -48,7 +68,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
      * setup for the whole base test class
      */
     @BeforeClass
-    public static void init() throws IOException {
+    public static void init() {
         SearchModule searchModule = new SearchModule(Settings.EMPTY, false, emptyList());
         namedWriteableRegistry = new NamedWriteableRegistry(searchModule.getNamedWriteables());
         xContentRegistry = new NamedXContentRegistry(searchModule.getNamedXContents());
@@ -98,7 +118,7 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
     /**
      * Test equality and hashCode properties
      */
-    public void testEqualsAndHashcode() throws IOException {
+    public void testEqualsAndHashcode() {
         for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
             checkEqualsAndHashCode(randomTestBuilder(), this::copy, this::mutate);
         }
@@ -129,6 +149,62 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             assertEquals(suggestionBuilder, secondSuggestionBuilder);
             assertEquals(suggestionBuilder.hashCode(), secondSuggestionBuilder.hashCode());
         }
+    }
+
+    public void testBuild() throws IOException {
+        Settings indexSettings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(new Index(randomAlphaOfLengthBetween(1, 10), "_na_"),
+                indexSettings);
+        MapperService mapperService = mock(MapperService.class);
+        ScriptService scriptService = mock(ScriptService.class);
+        MappedFieldType fieldType = mockFieldType();
+        boolean fieldTypeSearchAnalyzerSet = randomBoolean();
+        if (fieldTypeSearchAnalyzerSet) {
+            NamedAnalyzer searchAnalyzer = new NamedAnalyzer("fieldSearchAnalyzer", AnalyzerScope.INDEX, new SimpleAnalyzer());
+            if (Mockito.mockingDetails(fieldType).isMock()) {
+                when(fieldType.searchAnalyzer()).thenReturn(searchAnalyzer);
+            } else {
+                fieldType.setSearchAnalyzer(searchAnalyzer);
+            }
+        } else {
+            when(mapperService.searchAnalyzer())
+                .thenReturn(new NamedAnalyzer("mapperServiceSearchAnalyzer", AnalyzerScope.INDEX, new SimpleAnalyzer()));
+        }
+        when(mapperService.fullName(any(String.class))).thenReturn(fieldType);
+        when(mapperService.getNamedAnalyzer(any(String.class))).then(
+                invocation -> new NamedAnalyzer((String) invocation.getArguments()[0], AnalyzerScope.INDEX, new SimpleAnalyzer()));
+        when(scriptService.compile(any(Script.class), any())).thenReturn(mock(TemplateScript.Factory.class));
+        QueryShardContext mockShardContext = new QueryShardContext(0, idxSettings, null, null, mapperService, null, scriptService,
+                xContentRegistry(), null, null, System::currentTimeMillis);
+
+        for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
+            SB suggestionBuilder = randomTestBuilder();
+            SuggestionContext suggestionContext = suggestionBuilder.build(mockShardContext);
+            assertEquals(toBytesRef(suggestionBuilder.text()), suggestionContext.getText());
+            if (suggestionBuilder.text() != null && suggestionBuilder.prefix() == null) {
+                assertEquals(toBytesRef(suggestionBuilder.text()), suggestionContext.getPrefix());
+            } else {
+                assertEquals(toBytesRef(suggestionBuilder.prefix()), suggestionContext.getPrefix());
+            }
+            assertEquals(toBytesRef(suggestionBuilder.regex()), suggestionContext.getRegex());
+            assertEquals(suggestionBuilder.field(), suggestionContext.getField());
+            int expectedSize = suggestionBuilder.size() != null ? suggestionBuilder.size : 5;
+            assertEquals(expectedSize, suggestionContext.getSize());
+            Integer expectedShardSize = suggestionBuilder.shardSize != null ? suggestionBuilder.shardSize : Math.max(expectedSize, 5);
+            assertEquals(expectedShardSize, suggestionContext.getShardSize());
+            assertSame(mockShardContext, suggestionContext.getShardContext());
+            if (suggestionBuilder.analyzer() != null) {
+                assertEquals(suggestionBuilder.analyzer(), ((NamedAnalyzer) suggestionContext.getAnalyzer()).name());
+            } else if (fieldTypeSearchAnalyzerSet){
+                assertEquals("fieldSearchAnalyzer", ((NamedAnalyzer) suggestionContext.getAnalyzer()).name());
+            } else {
+                assertEquals("mapperServiceSearchAnalyzer", ((NamedAnalyzer) suggestionContext.getAnalyzer()).name());
+            }
+        }
+    }
+
+    protected MappedFieldType mockFieldType() {
+        return mock(MappedFieldType.class);
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
@@ -22,12 +22,18 @@ package org.elasticsearch.search.suggest.completion;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.index.mapper.CompletionFieldMapper.CompletionFieldType;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.suggest.AbstractSuggestionBuilderTestCase;
 import org.elasticsearch.search.suggest.completion.context.CategoryQueryContext;
+import org.elasticsearch.search.suggest.completion.context.ContextBuilder;
+import org.elasticsearch.search.suggest.completion.context.ContextMapping;
+import org.elasticsearch.search.suggest.completion.context.ContextMappings;
 import org.elasticsearch.search.suggest.completion.context.GeoQueryContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +41,11 @@ import java.util.Map;
 
 public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTestCase<CompletionSuggestionBuilder> {
 
-    private static final String[] SHUFFLE_PROTECTED_FIELDS = new String[] {CompletionSuggestionBuilder.CONTEXTS_FIELD.getPreferredName()};
+    private static final String[] SHUFFLE_PROTECTED_FIELDS = new String[] { CompletionSuggestionBuilder.CONTEXTS_FIELD.getPreferredName() };
+    private static final Map<String, List<? extends ToXContent>> contextMap = new HashMap<>();
+    private static String categoryContextName;
+    private static String geoQueryContextName;
+    private static List<ContextMapping> contextMappings;
 
     @Override
     protected CompletionSuggestionBuilder randomSuggestionBuilder() {
@@ -43,17 +53,18 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
     }
 
     public static CompletionSuggestionBuilder randomCompletionSuggestionBuilder() {
-        return randomSuggestionBuilderWithContextInfo().builder;
-    }
-
-    private static class BuilderAndInfo {
-        CompletionSuggestionBuilder builder;
-        List<String> catContexts = new ArrayList<>();
-        List<String> geoContexts = new ArrayList<>();
-    }
-
-    private static BuilderAndInfo randomSuggestionBuilderWithContextInfo() {
-        final BuilderAndInfo builderAndInfo = new BuilderAndInfo();
+        // lazy initialization of context names and mappings, cannot be done in init method because other test
+        // also create random CompletionSuggestionBuilder instances
+        if (categoryContextName == null) {
+            categoryContextName = randomAlphaOfLength(10);
+        }
+        if (geoQueryContextName == null) {
+            geoQueryContextName = randomAlphaOfLength(10);
+        }
+        if (contextMappings == null) {
+            contextMappings = Arrays.asList(new ContextMapping[] { ContextBuilder.category(categoryContextName).build(),
+                    ContextBuilder.geo(geoQueryContextName).build() });
+        }
         CompletionSuggestionBuilder testBuilder = new CompletionSuggestionBuilder(randomAlphaOfLengthBetween(2, 20));
         setCommonPropertiesOnRandomBuilder(testBuilder);
         switch (randomIntBetween(0, 3)) {
@@ -77,9 +88,7 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
             for (int i = 0; i < numContext; i++) {
                 contexts.add(CategoryQueryContextTests.randomCategoryQueryContext());
             }
-            String name = randomAlphaOfLength(10);
-            contextMap.put(name, contexts);
-            builderAndInfo.catContexts.add(name);
+            contextMap.put(categoryContextName, contexts);
         }
         if (randomBoolean()) {
             int numContext = randomIntBetween(1, 5);
@@ -87,13 +96,10 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
             for (int i = 0; i < numContext; i++) {
                 contexts.add(GeoQueryContextTests.randomGeoQueryContext());
             }
-            String name = randomAlphaOfLength(10);
-            contextMap.put(name, contexts);
-            builderAndInfo.geoContexts.add(name);
+            contextMap.put(geoQueryContextName, contexts);
         }
         testBuilder.contexts(contextMap);
-        builderAndInfo.builder = testBuilder;
-        return builderAndInfo;
+        return testBuilder;
     }
 
     /**
@@ -136,5 +142,12 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
             default:
                 throw new IllegalStateException("should not through");
         }
+    }
+
+    @Override
+    protected MappedFieldType mockFieldType() {
+        CompletionFieldType completionFieldType = new CompletionFieldType();
+        completionFieldType.setContextMappings(new ContextMappings(contextMappings));
+        return completionFieldType;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -146,7 +146,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
         }
     }
 
-    public void testInvalidParameters() throws IOException {
+    public void testInvalidParameters() {
         // test missing field name
         Exception e = expectThrows(NullPointerException.class, () -> new PhraseSuggestionBuilder((String) null));
         assertEquals("suggestion requires a field name", e.getMessage());

--- a/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
@@ -142,7 +142,7 @@ public class TermSuggestionBuilderTests extends AbstractSuggestionBuilderTestCas
         }
     }
 
-    public void testInvalidParameters() throws IOException {
+    public void testInvalidParameters() {
         // test missing field name
         Exception e = expectThrows(NullPointerException.class, () -> new TermSuggestionBuilder((String) null));
         assertEquals("suggestion requires a field name", e.getMessage());


### PR DESCRIPTION
This change adds a basic unit test for the SuggestionSearchContext that is
created as output of SuggestionBuilder#build. The current test only adds checks
for the common fields (like text, prefix, fieldName etc...). Individual checks
for each SuggestionBuilder subtype will be added in follow-up PRs.

Relates to #17118