### PR TITLE
[Tests] Add test for TermSuggestionBuilder#build output

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -200,8 +200,14 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             } else {
                 assertEquals("mapperServiceSearchAnalyzer", ((NamedAnalyzer) suggestionContext.getAnalyzer()).name());
             }
+            assertSuggester(suggestionBuilder, suggestionContext);
         }
     }
+
+    /**
+     * put suggester dependent assertions in the sub type test
+     */
+    protected abstract void assertSuggester(SB builder, SuggestionContext context);
 
     protected MappedFieldType mockFieldType() {
         return mock(MappedFieldType.class);

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.mapper.CompletionFieldMapper.CompletionFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.suggest.AbstractSuggestionBuilderTestCase;
+import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 import org.elasticsearch.search.suggest.completion.context.CategoryQueryContext;
 import org.elasticsearch.search.suggest.completion.context.ContextBuilder;
 import org.elasticsearch.search.suggest.completion.context.ContextMapping;
@@ -149,5 +150,9 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
         CompletionFieldType completionFieldType = new CompletionFieldType();
         completionFieldType.setContextMappings(new ContextMappings(contextMappings));
         return completionFieldType;
+    }
+
+    @Override
+    protected void assertSuggester(CompletionSuggestionBuilder builder, SuggestionContext context) {
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.suggest.phrase;
 
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.suggest.AbstractSuggestionBuilderTestCase;
+import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -184,4 +185,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
         assertEquals("Pre and post tag must both be null or both not be null.", e.getMessage());
     }
 
+    @Override
+    protected void assertSuggester(PhraseSuggestionBuilder builder, SuggestionContext context) {
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.suggest.AbstractSuggestionBuilderTestCase;
 import org.elasticsearch.search.suggest.SortBy;
 import org.elasticsearch.search.suggest.SuggestBuilder;
+import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 import org.elasticsearch.search.suggest.term.TermSuggestionBuilder.StringDistanceImpl;
 import org.elasticsearch.search.suggest.term.TermSuggestionBuilder.SuggestMode;
 
@@ -40,6 +41,7 @@ import static org.elasticsearch.search.suggest.DirectSpellcheckerSettings.DEFAUL
 import static org.elasticsearch.search.suggest.DirectSpellcheckerSettings.DEFAULT_MIN_WORD_LENGTH;
 import static org.elasticsearch.search.suggest.DirectSpellcheckerSettings.DEFAULT_PREFIX_LENGTH;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 
 /**
  * Test the {@link TermSuggestionBuilder} class.
@@ -222,5 +224,25 @@ public class TermSuggestionBuilderTests extends AbstractSuggestionBuilderTestCas
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString("parsing failed"));
         }
+    }
+
+    @Override
+    protected void assertSuggester(TermSuggestionBuilder builder, SuggestionContext context) {
+        assertThat(context, instanceOf(TermSuggestionContext.class));
+        assertThat(context.getSuggester(), instanceOf(TermSuggester.class));
+        TermSuggestionContext termSuggesterCtx = (TermSuggestionContext) context;
+        assertEquals(builder.accuracy(), termSuggesterCtx.getDirectSpellCheckerSettings().accuracy(), 0.0);
+        assertEquals(builder.maxTermFreq(), termSuggesterCtx.getDirectSpellCheckerSettings().maxTermFreq(), 0.0);
+        assertEquals(builder.minDocFreq(), termSuggesterCtx.getDirectSpellCheckerSettings().minDocFreq(), 0.0);
+        assertEquals(builder.maxEdits(), termSuggesterCtx.getDirectSpellCheckerSettings().maxEdits());
+        assertEquals(builder.maxInspections(), termSuggesterCtx.getDirectSpellCheckerSettings().maxInspections());
+        assertEquals(builder.minWordLength(), termSuggesterCtx.getDirectSpellCheckerSettings().minWordLength());
+        assertEquals(builder.prefixLength(), termSuggesterCtx.getDirectSpellCheckerSettings().prefixLength());
+        assertEquals(builder.prefixLength(), termSuggesterCtx.getDirectSpellCheckerSettings().prefixLength());
+        assertEquals(builder.suggestMode().toLucene(), termSuggesterCtx.getDirectSpellCheckerSettings().suggestMode());
+        assertEquals(builder.sort(), termSuggesterCtx.getDirectSpellCheckerSettings().sort());
+        // distance implementations don't implement equals() and have little to compare, so we only check class
+        assertEquals(builder.stringDistance().toLucene().getClass(),
+                termSuggesterCtx.getDirectSpellCheckerSettings().stringDistance().getClass());
     }
 }


### PR DESCRIPTION
As a follow-up to #25549, this adds a unit test that checks the TermSuggestionContext contents that are the output of TermSuggestionBuilder#build vs. the values the original builder contains. Relies on changes in #25549 which needs to go in first.