### PR TITLE
Add a simple random sampling query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -686,6 +686,25 @@ public abstract class QueryBuilders {
     }
 
     /**
+     * Creates a random sampler query
+     *
+     * @param probability The probability that a document is randomly sampled
+     */
+    public static RandomSampleQueryBuilder randomSampleQuery(double probability) {
+        return new RandomSampleQueryBuilder(probability);
+    }
+
+    /**
+     * Creates a random sampler query
+     *
+     * @param probability The probability that a document is randomly sampled
+     * @param seed  A seed to use with the random generator
+     */
+    public static RandomSampleQueryBuilder randomSampleQuery(double probability, Long seed) {
+        return new RandomSampleQueryBuilder(probability, seed);
+    }
+
+    /**
      * A filter to filter only documents where a field exists in them.
      *
      * @param name The name of the field

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -700,8 +700,8 @@ public abstract class QueryBuilders {
      * @param probability The probability that a document is randomly sampled
      * @param seed  A seed to use with the random generator
      */
-    public static RandomSampleQueryBuilder randomSampleQuery(double probability, Long seed) {
-        return new RandomSampleQueryBuilder(probability, seed);
+    public static RandomSampleQueryBuilder randomSampleQuery(double probability, int seed, String field) {
+        return new RandomSampleQueryBuilder(probability, seed, field);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/query/RandomSampleQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RandomSampleQuery.java
@@ -1,0 +1,318 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Random;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
+import org.elasticsearch.common.Randomness;
+
+/**
+ * A query that randomly matches documents with a user-provided probability.  May
+ * optionally include a seed so that matches are reproducible.
+ *
+ * This query uses two strategies depending on the size of the segment.
+ * For small segments, this uses simple random sampling per-document.  For larger
+ * segments, sampling is sped up by approximating the _gap_ between samples, then
+ * skipping forward that amount.
+ *
+ * Gap-sampling is based on the work of Jeffrey Vitter in "An Efficient Algorithm
+ * for Sequential Random Sampling" (http://www.ittc.ku.edu/~jsv/Papers/Vit87.RandomSampling.pdf),
+ * and more recently documented by Erik Erlandson
+ * (http://erikerlandson.github.io/blog/2014/09/11/faster-random-samples-with-gap-sampling/)
+ */
+public final class RandomSampleQuery extends Query {
+
+    private final double p;
+    private final Long seed;
+
+    // Above this threshold, it is probably faster to just use simple random sampling
+    private static final double PROBABILITY_THRESHOLD = 0.7;
+    private static final double EPSILON = 1e-10;
+    private static double LOG_INVERSE_P;
+
+    RandomSampleQuery(double p, Long seed) {
+        assert(p > 0.0 && p <= 1.0);
+        this.p = p;
+        this.seed = seed;
+        LOG_INVERSE_P =  Math.log(1-p);
+    }
+
+    static int getGap(Random rng) {
+        double u = Math.max(rng.nextDouble(), EPSILON);
+        return (int)(Math.floor(Math.log(u) / LOG_INVERSE_P)) + 1;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, boolean needsScores, float boost) {
+        return new ConstantScoreWeight(this, boost) {
+            @Override
+            public String toString() {
+                return "weight(" + RandomSampleQuery.this + ")";
+            }
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                final Random rng = seed == null ? Randomness.get() : new Random(seed);
+                int maxDoc = context.reader().maxDoc();
+
+                // For small doc sets, it's easier/more accurate to just sample directly
+                // instead of sampling gaps. Or, if the probability is high, faster to use SRS
+                if (maxDoc < 100 || p > PROBABILITY_THRESHOLD) {
+                    return new ConstantScoreScorer(this, score(), new RandomSamplingDocIdSetIterator(maxDoc, rng, p));
+                } else {
+                    return new ConstantScoreScorer(this, score(), new RandomGapSamplingDocIdSetIterator(maxDoc, rng, p));
+                }
+
+            }
+            @Override
+            public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
+                final float score = score();
+                final int maxDoc = context.reader().maxDoc();
+                final Random rng = seed == null ? Randomness.get() : new Random(seed);
+
+                // For small doc sets, it's easier/more accurate to just sample directly
+                // instead of sampling gaps. Or, if the probability is high, faster to use SRS
+                if (maxDoc < 100 || p > PROBABILITY_THRESHOLD) {
+                    return new BulkScorer() {
+                        @Override
+                        public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                            max = Math.min(max, maxDoc);
+                            FakeScorer scorer = new FakeScorer();
+                            scorer.score = score;
+                            collector.setScorer(scorer);
+
+                            for (int current = min; current < max; current++) {
+                                if (rng.nextDouble() <= p) {
+                                    scorer.doc = current;
+                                    if (acceptDocs == null || acceptDocs.get(current)) {
+                                        collector.collect(current);
+                                    }
+                                }
+                            }
+                            return max == maxDoc ? DocIdSetIterator.NO_MORE_DOCS : max;
+                        }
+                        @Override
+                        public long cost() {
+                            return maxDoc;
+                        }
+                    };
+                } else {
+                    return new BulkScorer() {
+                        @Override
+                        public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+                            max = Math.min(max, maxDoc);
+                            FakeScorer scorer = new FakeScorer();
+                            scorer.score = score;
+                            collector.setScorer(scorer);
+
+                            int current = min;
+                            while (current < max) {
+                                int gap = getGap(rng);
+                                current = current + gap;
+                                if (current >= maxDoc) {
+                                    return DocIdSetIterator.NO_MORE_DOCS;
+                                }
+                                scorer.doc = current;
+                                if (acceptDocs == null || acceptDocs.get(current)) {
+                                    collector.collect(current);
+                                }
+                            }
+                            return max == maxDoc ? DocIdSetIterator.NO_MORE_DOCS : max;
+                        }
+                        @Override
+                        public long cost() {
+                            return maxDoc;
+                        }
+                    };
+                }
+
+            }
+        };
+    }
+
+    @Override
+    public String toString(String field) {
+        return "RandomSample[p=" + this.p + "](*:*)";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RandomSampleQuery other = (RandomSampleQuery)o;
+        return Objects.equals(this.p, other.p) &&
+            Objects.equals(this.seed, other.seed);
+    }
+
+    @Override
+    public int hashCode() {
+        return classHash();
+    }
+
+    /**
+     * A DocIDSetIter that samples on each document.  Empirically, this tends to
+     * be more accurate when the segment is small.  It may also be faster
+     * when the probability is high, since many docs are collected and gap approximation
+     * uses more expensive math
+     */
+    private static class RandomSamplingDocIdSetIterator extends DocIdSetIterator {
+        int doc = -1;
+        final int maxDoc;
+        final Random rng;
+        final double p;
+
+        RandomSamplingDocIdSetIterator(int maxDoc, Random rng, double p) {
+            this.maxDoc = maxDoc;
+            this.rng = rng;
+            this.p = p;
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return advance(doc + 1);
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            doc = target;
+            while (doc < maxDoc) {
+                if (rng.nextDouble() <= p) {
+                    return doc;
+                }
+                doc = doc + 1;
+            }
+            return NO_MORE_DOCS;
+        }
+
+        @Override
+        public long cost() {
+            return maxDoc;
+        }
+    }
+
+    /**
+     * A DocIDSetIter that approximates the gaps between sampled documents, and advances
+     * according to the gap.  This is more efficient, especially for low probabilities,
+     * because it can skip by many documents entirely.
+     */
+    private static class RandomGapSamplingDocIdSetIterator extends DocIdSetIterator {
+        final int maxDoc;
+        final Random rng;
+        final double p;
+        int doc = -1;
+
+        RandomGapSamplingDocIdSetIterator(int maxDoc, Random rng, double p) {
+            this.maxDoc = maxDoc;
+            this.rng = rng;
+            this.p = p;
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return advance(doc);
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            // Keep approximating gaps until we hit or surpass the target
+            while (doc <= target) {
+                doc += getGap(rng);
+            }
+            if (doc >= maxDoc) {
+                doc = NO_MORE_DOCS;
+            }
+            return doc;
+        }
+
+        @Override
+        public long cost() {
+            return (long)(maxDoc * p);
+        }
+    }
+
+    /**
+     *  This is a copy of Lucene's FakeScorer since it is package-private
+     */
+    final class FakeScorer extends Scorer {
+        float score;
+        int doc = -1;
+        int freq = 1;
+
+        FakeScorer() {
+            super(null);
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int freq() {
+            return freq;
+        }
+
+        @Override
+        public float score() {
+            return score;
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Weight getWeight() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Collection<ChildScorer> getChildren() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+}

--- a/core/src/main/java/org/elasticsearch/index/query/RandomSampleQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RandomSampleQueryBuilder.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A query that randomly matches documents with a user-provided probability.  May
+ * optionally include a seed so that matches are deterministic
+ */
+public class RandomSampleQueryBuilder extends AbstractQueryBuilder<RandomSampleQueryBuilder> {
+    public static final String NAME = "random_sample";
+    private static final ParseField PROBABILITY = new ParseField("probability");
+    private static final ParseField SEED = new ParseField("seed");
+
+    private double p = 0.5;
+    private Long seed = null;
+
+    RandomSampleQueryBuilder(double probability) {
+        this(probability, null);
+    }
+
+    RandomSampleQueryBuilder(double probability, Long seed) {
+        this.p = validateProbability(probability);
+        this.seed = seed;
+    }
+
+    private RandomSampleQueryBuilder() {
+    }
+
+    /**
+     * Read from a stream.
+     */
+    public RandomSampleQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        p = in.readDouble();
+        seed = in.readOptionalLong();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeDouble(p);
+        out.writeOptionalLong(seed);
+    }
+
+    public double getProbability() {
+        return p;
+    }
+
+    public void setProbability(double p) {
+        this.p = validateProbability(p);
+    }
+
+    public Long getSeed() {
+        return seed;
+    }
+
+    public void setSeed(Long seed) {
+        this.seed = seed;
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        printBoostAndQueryName(builder);
+        builder.field(PROBABILITY.getPreferredName(), p);
+        if (seed != null) {
+            builder.field(SEED.getPreferredName(), seed);
+        }
+        builder.endObject();
+    }
+
+    private static final ObjectParser<RandomSampleQueryBuilder, QueryParseContext> PARSER
+        = new ObjectParser<>(NAME, RandomSampleQueryBuilder::new);
+
+    static {
+        declareStandardFields(PARSER);
+        PARSER.declareDouble(RandomSampleQueryBuilder::setProbability, PROBABILITY);
+        PARSER.declareLong(RandomSampleQueryBuilder::setSeed, SEED);
+    }
+
+    public static RandomSampleQueryBuilder fromXContent(QueryParseContext context) {
+        try {
+            return PARSER.apply(context.parser(), context);
+        } catch (IllegalArgumentException e) {
+            throw new ParsingException(context.parser().getTokenLocation(), e.getMessage(), e);
+        }
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) {
+        return new RandomSampleQuery(p, seed);
+    }
+
+    @Override
+    protected boolean doEquals(RandomSampleQueryBuilder other) {
+        return Objects.equals(p, other.p) &&
+            Objects.equals(seed, other.seed);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(p, seed);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    private double validateProbability(double p) {
+        if (p <= 0.0) {
+            throw new IllegalArgumentException("[" + PROBABILITY.getPreferredName() + "] cannot be less than or equal to 0.0.");
+        }
+        if (p >= 1.0) {
+            throw new IllegalArgumentException("[" + PROBABILITY.getPreferredName() + "] cannot be greater than or equal to 1.0.");
+        }
+        return p;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -56,6 +56,7 @@ import org.elasticsearch.index.query.PrefixQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
+import org.elasticsearch.index.query.RandomSampleQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.RegexpQueryBuilder;
 import org.elasticsearch.index.query.ScriptQueryBuilder;
@@ -740,6 +741,8 @@ public class SearchModule {
         registerQuery(new QuerySpec<>(GeoPolygonQueryBuilder.NAME, GeoPolygonQueryBuilder::new, GeoPolygonQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(ExistsQueryBuilder.NAME, ExistsQueryBuilder::new, ExistsQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(MatchNoneQueryBuilder.NAME, MatchNoneQueryBuilder::new, MatchNoneQueryBuilder::fromXContent));
+        registerQuery(new QuerySpec<>(RandomSampleQueryBuilder.NAME, RandomSampleQueryBuilder::new,
+            RandomSampleQueryBuilder::fromXContent));
 
         if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {
             registerQuery(new QuerySpec<>(GeoShapeQueryBuilder.NAME, GeoShapeQueryBuilder::new, GeoShapeQueryBuilder::fromXContent));

--- a/core/src/test/java/org/elasticsearch/index/query/RandomSampleQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RandomSampleQueryBuilderTests.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.test.AbstractQueryTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class RandomSampleQueryBuilderTests extends AbstractQueryTestCase<RandomSampleQueryBuilder> {
+
+    @Override
+    protected RandomSampleQueryBuilder doCreateTestQueryBuilder() {
+        RandomSampleQueryBuilder query;
+        double p = randomDoubleBetween(0.00001, 0.999999, true);
+        if (randomBoolean()) {
+            query = new RandomSampleQueryBuilder(p, randomLong());
+        } else {
+            query = new RandomSampleQueryBuilder(p);
+        }
+        return query;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(RandomSampleQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {
+        assertThat(query, instanceOf(RandomSampleQuery.class));
+    }
+
+    public void testIllegalArguments() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new RandomSampleQueryBuilder(0.0));
+        assertEquals("[probability] cannot be less than or equal to 0.0.", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class, () -> new RandomSampleQueryBuilder(-5.0));
+        assertEquals("[probability] cannot be less than or equal to 0.0.", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class, () -> new RandomSampleQueryBuilder(1.0));
+        assertEquals("[probability] cannot be greater than or equal to 1.0.", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class, () -> new RandomSampleQueryBuilder(5.0));
+        assertEquals("[probability] cannot be greater than or equal to 1.0.", e.getMessage());
+
+    }
+
+
+    public void testFromJson() throws IOException {
+        String json =
+            "{\n" +
+                "  \"random_sample\" : {\n" +
+                "    \"boost\" : 1.0,\n" +
+                "    \"probability\" : 0.5\n" +
+                "  }\n" +
+                "}";
+        RandomSampleQueryBuilder parsed = (RandomSampleQueryBuilder) parseQuery(json);
+        checkGeneratedJson(json, parsed);
+        assertThat(parsed.getProbability(), equalTo(0.5));
+        assertThat(parsed.getSeed(), nullValue());
+
+        // try with seed
+        json =
+            "{\n" +
+                "  \"random_sample\" : {\n" +
+                "    \"boost\" : 1.0,\n" +
+                "    \"probability\" : 0.5,\n" +
+                "    \"seed\" : 123\n" +
+                "  }\n" +
+                "}";
+        parsed = (RandomSampleQueryBuilder) parseQuery(json);
+        assertThat(parsed.getProbability(), equalTo(0.5));
+        assertThat(parsed.getSeed(), equalTo(123L));
+
+    }
+}

--- a/core/src/test/java/org/elasticsearch/index/search/RandomSampleQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/index/search/RandomSampleQueryIT.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.search;
+
+import org.elasticsearch.action.bulk.BulkAction;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
+
+public class RandomSampleQueryIT extends ESIntegTestCase {
+
+    private static final int NUM_DOCS = 1000;
+    private static final int NUM_DOCS_SMALL = 100;
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        BulkRequestBuilder bulk = new BulkRequestBuilder(client(), BulkAction.INSTANCE);
+        for (int i = 0; i < NUM_DOCS; i++) {
+            bulk.add(client().prepareIndex("test", "test", Integer.toString(i)).setSource("field",  Integer.toString(i)));
+        }
+        for (int i = 0; i < NUM_DOCS_SMALL; i++) {
+            bulk.add(client().prepareIndex("test_small", "test", Integer.toString(i)).setSource("field",  Integer.toString(i)));
+        }
+        bulk.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        bulk.get();
+
+    }
+
+    public void testProbability() {
+        for (int i = 10; i < 100; i+=10) {
+            double p = ((double)i)/100;
+            SearchResponse searchResponse = client()
+                .prepareSearch("test")
+                .setQuery(QueryBuilders.randomSampleQuery(p))
+                .get();
+
+            long hits = searchResponse.getHits().getTotalHits();
+            long lower = Math.max((long)((NUM_DOCS * p)-50), 0L);
+            long upper = Math.min((long)((NUM_DOCS * p)+50), NUM_DOCS);
+            if (hits <= lower || hits >= upper) {
+                fail("Hit count was [" + hits + "], expected to be close to " + NUM_DOCS * p
+                    + " ([" + lower + " - " + upper +"]), p=" + p);
+            }
+        }
+    }
+
+    public void testProbabilitySmallIndex() {
+        for (int i = 10; i < 100; i+=10) {
+            double p = ((double)i)/100;
+            SearchResponse searchResponse = client()
+                .prepareSearch("test_small")
+                .setQuery(QueryBuilders.randomSampleQuery(p))
+                .get();
+
+            long hits = searchResponse.getHits().getTotalHits();
+            long lower = Math.max((long)((NUM_DOCS_SMALL * p)-10), 0L);
+            long upper = Math.min((long)((NUM_DOCS_SMALL * p)+10), NUM_DOCS_SMALL);
+            if (hits < lower || hits > upper) {
+                fail("Hit count was [" + hits + "], expected to be close to " + NUM_DOCS_SMALL * p
+                    + " ([" + lower + " - " + upper +"]), p=" + p);
+            }
+        }
+    }
+}

--- a/docs/reference/query-dsl/random-sample-query.asciidoc
+++ b/docs/reference/query-dsl/random-sample-query.asciidoc
@@ -1,0 +1,62 @@
+[[query-dsl-random-sample-query]]
+=== Random Sample Query
+
+This query matches documents randomly according to the user-provided probability.
+For example, if there are 100 documents in the index and `probability = 0.5`,
+roughly 50 of the documents will be matched.
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "query": {
+        "random_sample" : {
+            "probability" : 0.5
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+The `probability` parameter is required, and accepts values ` 0.0 > p > 1.0`.
+
+==== Seeding
+
+Optionally, the random number generator can be seeded with a Long.  This allows
+deterministic operation of the query so that the same documents are matched each
+time.
+
+This can be accomplished by adding the `seed` parameter:
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "query": {
+        "random_sample" : {
+            "probability" : 0.5,
+            "seed": 1234
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+==== Boosting
+
+Like all other queries, the `random_sample` query can accept an optional boost.
+This is a convenient way to boost a subset of random documents:
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "query": {
+        "random_sample" : {
+            "probability" : 0.5,
+            "boost": 5.0
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE

--- a/docs/reference/query-dsl/special-queries.asciidoc
+++ b/docs/reference/query-dsl/special-queries.asciidoc
@@ -19,9 +19,15 @@ This query allows a script to act as a filter.  Also see the
 This query finds queries that are stored as documents that match with
 the specified document.
 
+<<query-dsl-random-sample-query,`random_sample` query>>::
+
+A query that matches documents randomly according to a user-defined
+probability.
+
 include::mlt-query.asciidoc[]
 
 include::script-query.asciidoc[]
 
 include::percolate-query.asciidoc[]
 
+include::random-sample-query.asciidoc[]


### PR DESCRIPTION
This adds a query that randomly matches documents with a user-defined probability. The user can also specify a seed for reproducible randomness.

This query uses a trick to accelerate sampling.  Instead of checking the rng on each document, it approximates the gap between documents and skips forward. This should allow Lucene to shave off a fair amount of execution time, making the collection process sub-linear instead of linear.

Gap approximation is only used for segments with >100 documents, since empirically it seems approximation doesn't work well with small numbers.

It also skips approximating if the probability is very high; in this case, many documents are returned so there is less benefit to "skipping" forward, and the math invoked (two logs) is a bit more expensive than just the RNG.  Probably... this has not been benchmarked.  If we think it's worthwhile I can try to workup a benchmark for that.  Maybe the overhead of collecting the document is high enough to always do gap sampling?

This is the first time I've implemented a query, so hopefully I got all the bits right :)  If this is accepted, I'd like to implement a Reservoir Sampling version too.