### PR TITLE
[Tests] Add test for PhraseSuggestionBuilder#build output

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -312,6 +312,13 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
     }
 
     /**
+     * get the candidate generators.
+     */
+    Map<String, List<CandidateGenerator>> getCandidateGenerators() {
+        return this.generators;
+    }
+
+    /**
      * If set to <code>true</code> the phrase suggester will fail if the analyzer only
      * produces ngrams. the default it <code>true</code>.
      */
@@ -607,7 +614,6 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
         suggestionContext.setRealWordErrorLikelihood(this.realWordErrorLikelihood);
         suggestionContext.setConfidence(this.confidence);
         suggestionContext.setMaxErrors(this.maxErrors);
-        suggestionContext.setSeparator(BytesRefs.toBytesRef(this.separator));
         suggestionContext.setRequireUnigram(this.forceUnigrams);
         suggestionContext.setTokenLimit(this.tokenLimit);
         suggestionContext.setPreTag(BytesRefs.toBytesRef(this.preTag));

--- a/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -38,10 +38,10 @@ import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.ingest.TestTemplateService;
 import org.elasticsearch.mock.orig.Mockito;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.suggest.SuggestionSearchContext.SuggestionContext;
 import org.elasticsearch.test.ESTestCase;
@@ -175,7 +175,8 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             when(mapperService.fullName(any(String.class))).thenReturn(fieldType);
             when(mapperService.getNamedAnalyzer(any(String.class))).then(
                     invocation -> new NamedAnalyzer((String) invocation.getArguments()[0], AnalyzerScope.INDEX, new SimpleAnalyzer()));
-            when(scriptService.compile(any(Script.class), any())).thenReturn(mock(TemplateScript.Factory.class));
+            when(scriptService.compile(any(Script.class), any())).then(invocation -> new TestTemplateService.MockTemplateScript.Factory(
+                    ((Script) invocation.getArguments()[0]).getIdOrCode()));
             QueryShardContext mockShardContext = new QueryShardContext(0, idxSettings, null, null, mapperService, null, scriptService,
                     xContentRegistry(), null, null, System::currentTimeMillis);
 

--- a/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/completion/CompletionSuggesterBuilderTests.java
@@ -46,7 +46,7 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
     private static final Map<String, List<? extends ToXContent>> contextMap = new HashMap<>();
     private static String categoryContextName;
     private static String geoQueryContextName;
-    private static List<ContextMapping> contextMappings;
+    private static List<ContextMapping> contextMappings = new ArrayList<>();
 
     @Override
     protected CompletionSuggestionBuilder randomSuggestionBuilder() {
@@ -65,6 +65,18 @@ public class CompletionSuggesterBuilderTests extends AbstractSuggestionBuilderTe
         if (contextMappings == null) {
             contextMappings = Arrays.asList(new ContextMapping[] { ContextBuilder.category(categoryContextName).build(),
                     ContextBuilder.geo(geoQueryContextName).build() });
+        }
+        // lazy initialization of context names and mappings, cannot be done in some init method because other test
+        // also create random CompletionSuggestionBuilder instances
+        if (categoryContextName == null) {
+            categoryContextName = randomAlphaOfLength(10);
+        }
+        if (geoQueryContextName == null) {
+            geoQueryContextName = randomAlphaOfLength(10);
+        }
+        if (contextMappings.isEmpty()) {
+            contextMappings.add(ContextBuilder.category(categoryContextName).build());
+            contextMappings.add(ContextBuilder.geo(geoQueryContextName).build());
         }
         CompletionSuggestionBuilder testBuilder = new CompletionSuggestionBuilder(randomAlphaOfLengthBetween(2, 20));
         setCommonPropertiesOnRandomBuilder(testBuilder);

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.instanceOf;
+
 public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestCase<PhraseSuggestionBuilder> {
     @Override
     protected PhraseSuggestionBuilder randomSuggestionBuilder() {
@@ -187,5 +189,41 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
 
     @Override
     protected void assertSuggester(PhraseSuggestionBuilder builder, SuggestionContext context) {
+        assertThat(context, instanceOf(PhraseSuggestionContext.class));
+        assertThat(context.getSuggester(), instanceOf(PhraseSuggester.class));
+        PhraseSuggestionContext phraseSuggesterCtx = (PhraseSuggestionContext) context;
+        assertOptionalEquals(builder.confidence(), phraseSuggesterCtx.confidence(), PhraseSuggestionContext.DEFAULT_CONFIDENCE);
+        assertOptionalEquals(builder.collatePrune(), phraseSuggesterCtx.collatePrune(), PhraseSuggestionContext.DEFAULT_COLLATE_PRUNE);
+        assertEquals(builder.separator(), phraseSuggesterCtx.separator().utf8ToString());
+        assertOptionalEquals(builder.realWordErrorLikelihood(), phraseSuggesterCtx.realworldErrorLikelyhood(),
+                PhraseSuggestionContext.DEFAULT_RWE_ERRORLIKELIHOOD);
+        assertOptionalEquals(builder.maxErrors(), phraseSuggesterCtx.maxErrors(), PhraseSuggestionContext.DEFAULT_MAX_ERRORS);
+        assertOptionalEquals(builder.forceUnigrams(), phraseSuggesterCtx.getRequireUnigram(),
+                PhraseSuggestionContext.DEFAULT_REQUIRE_UNIGRAM);
+        assertOptionalEquals(builder.tokenLimit(), phraseSuggesterCtx.getTokenLimit(), NoisyChannelSpellChecker.DEFAULT_TOKEN_LIMIT);
+        assertEquals(builder.preTag(), phraseSuggesterCtx.getPreTag() != null ? phraseSuggesterCtx.getPreTag().utf8ToString() : null);
+        assertEquals(builder.postTag(), phraseSuggesterCtx.getPostTag() != null ? phraseSuggesterCtx.getPostTag().utf8ToString() : null);
+        assertOptionalEquals(builder.gramSize(), phraseSuggesterCtx.gramSize(), PhraseSuggestionContext.DEFAULT_GRAM_SIZE);
+        if (builder.collateQuery() != null) {
+            assertEquals(builder.collateQuery().getIdOrCode(), phraseSuggesterCtx.getCollateQueryScript().newInstance(null).execute());
+        }
+        if (builder.collateParams() != null) {
+            assertEquals(builder.collateParams(), phraseSuggesterCtx.getCollateScriptParams());
+        }
+        if (builder.smoothingModel() != null) {
+            assertEquals(builder.smoothingModel().buildWordScorerFactory().getClass(), phraseSuggesterCtx.model().getClass());
+        }
+        if (builder.getCandidateGenerators().isEmpty() == false) {
+            // currently, "direct_generator" is the only one available. Only compare size of the lists
+            assertEquals(builder.getCandidateGenerators().get("direct_generator").size(), phraseSuggesterCtx.generators().size());
+        }
+    }
+
+    private static <T> void assertOptionalEquals(T optional, T actual, T defaultValue) {
+        if (optional != null) {
+            assertEquals(optional, actual);
+        } else {
+            assertEquals(defaultValue, actual);
+        }
     }
 }


### PR DESCRIPTION
Based on #25549, this adds a unit test that checks the PhraseSuggestionContext contents that are the output of PhraseSuggestionBuilder#build vs. the values the original builder contains.
