### PR TITLE
[Tests] Add test for CompletionSuggestionBuilder#build output

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -201,14 +201,14 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             } else {
                 assertEquals("mapperServiceSearchAnalyzer", ((NamedAnalyzer) suggestionContext.getAnalyzer()).name());
             }
-            assertSuggester(suggestionBuilder, suggestionContext);
+            assertSuggestionContext(suggestionBuilder, suggestionContext);
         }
     }
 
     /**
-     * put suggester dependent assertions in the sub type test
+     * put implementation dependent assertions in the sub-type test
      */
-    protected abstract void assertSuggester(SB builder, SuggestionContext context);
+    protected abstract void assertSuggestionContext(SB builder, SuggestionContext context) throws IOException;
 
     protected MappedFieldType mockFieldType() {
         return mock(MappedFieldType.class);

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -188,7 +188,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
     }
 
     @Override
-    protected void assertSuggester(PhraseSuggestionBuilder builder, SuggestionContext context) {
+    protected void assertSuggestionContext(PhraseSuggestionBuilder builder, SuggestionContext context) {
         assertThat(context, instanceOf(PhraseSuggestionContext.class));
         assertThat(context.getSuggester(), instanceOf(PhraseSuggester.class));
         PhraseSuggestionContext phraseSuggesterCtx = (PhraseSuggestionContext) context;

--- a/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilderTests.java
@@ -227,7 +227,7 @@ public class TermSuggestionBuilderTests extends AbstractSuggestionBuilderTestCas
     }
 
     @Override
-    protected void assertSuggester(TermSuggestionBuilder builder, SuggestionContext context) {
+    protected void assertSuggestionContext(TermSuggestionBuilder builder, SuggestionContext context) {
         assertThat(context, instanceOf(TermSuggestionContext.class));
         assertThat(context.getSuggester(), instanceOf(TermSuggester.class));
         TermSuggestionContext termSuggesterCtx = (TermSuggestionContext) context;


### PR DESCRIPTION
Based on #25549, this adds a unit test that checks the CompletionSuggestionBuilder contents that are the output of CompletionSuggestionBuilder#build vs. the values the original builder contains.