### PR TITLE
remove ingest.new_date_format

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -162,18 +162,18 @@ public class SimulatePipelineRequest extends ActionRequest {
         if (pipeline == null) {
             throw new IllegalArgumentException("pipeline [" + pipelineId + "] does not exist");
         }
-        List<IngestDocument> ingestDocumentList = parseDocs(config, pipelineStore.isNewIngestDateFormat());
+        List<IngestDocument> ingestDocumentList = parseDocs(config);
         return new Parsed(pipeline, ingestDocumentList, verbose);
     }
 
     static Parsed parse(Map<String, Object> config, boolean verbose, PipelineStore pipelineStore) throws Exception {
         Map<String, Object> pipelineConfig = ConfigurationUtils.readMap(null, null, config, Fields.PIPELINE);
         Pipeline pipeline = PIPELINE_FACTORY.create(SIMULATED_PIPELINE_ID, pipelineConfig, pipelineStore.getProcessorFactories());
-        List<IngestDocument> ingestDocumentList = parseDocs(config, pipelineStore.isNewIngestDateFormat());
+        List<IngestDocument> ingestDocumentList = parseDocs(config);
         return new Parsed(pipeline, ingestDocumentList, verbose);
     }
 
-    private static List<IngestDocument> parseDocs(Map<String, Object> config, boolean newDateFormat) {
+    private static List<IngestDocument> parseDocs(Map<String, Object> config) {
         List<Map<String, Object>> docs = ConfigurationUtils.readList(null, null, config, Fields.DOCS);
         List<IngestDocument> ingestDocumentList = new ArrayList<>();
         for (Map<String, Object> dataMap : docs) {
@@ -183,7 +183,7 @@ public class SimulatePipelineRequest extends ActionRequest {
                     ConfigurationUtils.readStringProperty(null, null, dataMap, MetaData.ID.getFieldName(), "_id"),
                     ConfigurationUtils.readOptionalStringProperty(null, null, dataMap, MetaData.ROUTING.getFieldName()),
                     ConfigurationUtils.readOptionalStringProperty(null, null, dataMap, MetaData.PARENT.getFieldName()),
-                    document, newDateFormat);
+                    document);
             ingestDocumentList.add(ingestDocument);
         }
         return ingestDocumentList;

--- a/core/src/main/java/org/elasticsearch/action/ingest/WriteableIngestDocument.java
+++ b/core/src/main/java/org/elasticsearch/action/ingest/WriteableIngestDocument.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.ingest;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -27,6 +28,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.ingest.IngestDocument;
 
 import java.io.IOException;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 
@@ -42,6 +45,12 @@ final class WriteableIngestDocument implements Writeable, ToXContent {
     WriteableIngestDocument(StreamInput in) throws IOException {
         Map<String, Object> sourceAndMetadata = in.readMap();
         Map<String, Object> ingestMetadata = in.readMap();
+        if (in.getVersion().before(Version.V_6_0_0_beta1)) {
+            ingestMetadata.computeIfPresent("timestamp", (k, o) -> {
+                Date date = (Date) o;
+                return date.toInstant().atZone(ZoneId.systemDefault());
+            });
+        }
         this.ingestDocument = new IngestDocument(sourceAndMetadata, ingestMetadata);
     }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -53,6 +53,9 @@ import java.nio.file.FileSystemException;
 import java.nio.file.FileSystemLoopException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -542,6 +545,8 @@ public abstract class StreamInput extends InputStream {
                 return readBytesRef();
             case 22:
                 return readGeoPoint();
+            case 23:
+                return readZonedDateTime();
             default:
                 throw new IOException("Can't read unknown type [" + type + "]");
         }
@@ -560,6 +565,11 @@ public abstract class StreamInput extends InputStream {
     private DateTime readDateTime() throws IOException {
         final String timeZoneId = readString();
         return new DateTime(readLong(), DateTimeZone.forID(timeZoneId));
+    }
+
+    private ZonedDateTime readZonedDateTime() throws IOException {
+        final String timeZoneId = readString();
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(readLong()), ZoneId.of(timeZoneId));
     }
 
     private Object[] readArray() throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -50,6 +50,7 @@ import java.nio.file.FileSystemException;
 import java.nio.file.FileSystemLoopException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -619,6 +620,13 @@ public abstract class StreamOutput extends OutputStream {
         writers.put(GeoPoint.class, (o, v) -> {
             o.writeByte((byte) 22);
             o.writeGeoPoint((GeoPoint) v);
+        });
+        writers.put(ZonedDateTime.class, (o, v) -> {
+            o.writeByte((byte) 23);
+            final ZonedDateTime zonedDateTime = (ZonedDateTime) v;
+            zonedDateTime.getZone().getId();
+            o.writeString(zonedDateTime.getZone().getId());
+            o.writeLong(zonedDateTime.toInstant().toEpochMilli());
         });
         WRITERS = Collections.unmodifiableMap(writers);
     }

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -411,7 +411,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING,
                     ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING,
                     FastVectorHighlighter.SETTING_TV_HIGHLIGHT_MULTI_VALUE,
-                    Node.BREAKER_TYPE_KEY,
-                    IngestService.NEW_INGEST_DATE_FORMAT
+                    Node.BREAKER_TYPE_KEY
             )));
 }

--- a/core/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/core/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -57,11 +57,6 @@ public final class IngestDocument {
     private final Map<String, Object> ingestMetadata;
 
     public IngestDocument(String index, String type, String id, String routing, String parent, Map<String, Object> source) {
-        this(index, type, id, routing, parent, source, false);
-    }
-
-    public IngestDocument(String index, String type, String id, String routing, String parent, Map<String, Object> source,
-                          boolean newDateFormat) {
         this.sourceAndMetadata = new HashMap<>();
         this.sourceAndMetadata.putAll(source);
         this.sourceAndMetadata.put(MetaData.INDEX.getFieldName(), index);
@@ -75,11 +70,7 @@ public final class IngestDocument {
         }
 
         this.ingestMetadata = new HashMap<>();
-        if (newDateFormat) {
-            this.ingestMetadata.put(TIMESTAMP, ZonedDateTime.now(ZoneOffset.UTC));
-        } else {
-            this.ingestMetadata.put(TIMESTAMP, new Date());
-        }
+        this.ingestMetadata.put(TIMESTAMP, ZonedDateTime.now(ZoneOffset.UTC));
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/core/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -40,13 +40,10 @@ import static org.elasticsearch.common.settings.Setting.Property;
  * Holder class for several ingest related services.
  */
 public class IngestService {
-    public static final Setting<Boolean> NEW_INGEST_DATE_FORMAT =
-        Setting.boolSetting("ingest.new_date_format", false, Property.NodeScope, Property.Dynamic, Property.Deprecated);
-
     private final PipelineStore pipelineStore;
     private final PipelineExecutionService pipelineExecutionService;
 
-    public IngestService(ClusterSettings clusterSettings, Settings settings, ThreadPool threadPool,
+    public IngestService(Settings settings, ThreadPool threadPool,
                          Environment env, ScriptService scriptService, AnalysisRegistry analysisRegistry,
                          List<IngestPlugin> ingestPlugins) {
         Processor.Parameters parameters = new Processor.Parameters(env, scriptService,
@@ -60,7 +57,7 @@ public class IngestService {
                 }
             }
         }
-        this.pipelineStore = new PipelineStore(clusterSettings, settings, Collections.unmodifiableMap(processorFactories));
+        this.pipelineStore = new PipelineStore(settings, Collections.unmodifiableMap(processorFactories));
         this.pipelineExecutionService = new PipelineExecutionService(pipelineStore, threadPool);
     }
 

--- a/core/src/main/java/org/elasticsearch/ingest/PipelineExecutionService.java
+++ b/core/src/main/java/org/elasticsearch/ingest/PipelineExecutionService.java
@@ -160,8 +160,7 @@ public class PipelineExecutionService implements ClusterStateApplier {
             String routing = indexRequest.routing();
             String parent = indexRequest.parent();
             Map<String, Object> sourceAsMap = indexRequest.sourceAsMap();
-            IngestDocument ingestDocument = new IngestDocument(index, type, id, routing, parent,
-                sourceAsMap, store.isNewIngestDateFormat());
+            IngestDocument ingestDocument = new IngestDocument(index, type, id, routing, parent, sourceAsMap);
             pipeline.execute(ingestDocument);
 
             Map<IngestDocument.MetaData, String> metadataMap = ingestDocument.extractMetadata();

--- a/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
+++ b/core/src/main/java/org/elasticsearch/ingest/PipelineStore.java
@@ -52,7 +52,6 @@ public class PipelineStore extends AbstractComponent implements ClusterStateAppl
 
     private final Pipeline.Factory factory = new Pipeline.Factory();
     private final Map<String, Processor.Factory> processorFactories;
-    private volatile boolean newIngestDateFormat;
 
     // Ideally this should be in IngestMetadata class, but we don't have the processor factories around there.
     // We know of all the processor factories when a node with all its plugin have been initialized. Also some
@@ -60,15 +59,9 @@ public class PipelineStore extends AbstractComponent implements ClusterStateAppl
     // are loaded, so in the cluster state we just save the pipeline config and here we keep the actual pipelines around.
     volatile Map<String, Pipeline> pipelines = new HashMap<>();
 
-    public PipelineStore(ClusterSettings clusterSettings, Settings settings, Map<String, Processor.Factory> processorFactories) {
+    public PipelineStore(Settings settings, Map<String, Processor.Factory> processorFactories) {
         super(settings);
         this.processorFactories = processorFactories;
-        this.newIngestDateFormat = IngestService.NEW_INGEST_DATE_FORMAT.get(settings);
-        clusterSettings.addSettingsUpdateConsumer(IngestService.NEW_INGEST_DATE_FORMAT, this::setNewIngestDateFormat);
-    }
-
-    private void setNewIngestDateFormat(Boolean newIngestDateFormat) {
-        this.newIngestDateFormat = newIngestDateFormat;
     }
 
     @Override
@@ -210,10 +203,6 @@ public class PipelineStore extends AbstractComponent implements ClusterStateAppl
 
     public Map<String, Processor.Factory> getProcessorFactories() {
         return processorFactories;
-    }
-
-    public boolean isNewIngestDateFormat() {
-        return newIngestDateFormat;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/node/Node.java
+++ b/core/src/main/java/org/elasticsearch/node/Node.java
@@ -334,7 +334,7 @@ public class Node implements Closeable {
             final ClusterService clusterService = new ClusterService(settings, settingsModule.getClusterSettings(), threadPool);
             clusterService.addListener(scriptModule.getScriptService());
             resourcesToClose.add(clusterService);
-            final IngestService ingestService = new IngestService(clusterService.getClusterSettings(), settings, threadPool, this.environment,
+            final IngestService ingestService = new IngestService(settings, threadPool, this.environment,
                 scriptModule.getScriptService(), analysisModule.getAnalysisRegistry(), pluginsService.filterPlugins(IngestPlugin.class));
             final DiskThresholdMonitor listener = new DiskThresholdMonitor(settings, clusterService::state,
                 clusterService.getClusterSettings(), client);

--- a/core/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -40,8 +40,8 @@ public class IngestServiceTests extends ESTestCase {
 
     public void testIngestPlugin() {
         ThreadPool tp = Mockito.mock(ThreadPool.class);
-        IngestService ingestService = new IngestService(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-            Settings.EMPTY, tp, null, null, null, Collections.singletonList(DUMMY_PLUGIN));
+        IngestService ingestService = new IngestService(Settings.EMPTY, tp, null, null,
+            null, Collections.singletonList(DUMMY_PLUGIN));
         Map<String, Processor.Factory> factories = ingestService.getPipelineStore().getProcessorFactories();
         assertTrue(factories.containsKey("foo"));
         assertEquals(1, factories.size());
@@ -50,9 +50,8 @@ public class IngestServiceTests extends ESTestCase {
     public void testIngestPluginDuplicate() {
         ThreadPool tp = Mockito.mock(ThreadPool.class);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
-            new IngestService(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-                Settings.EMPTY, tp, null, null, null, Arrays.asList(DUMMY_PLUGIN, DUMMY_PLUGIN))
-        );
+            new IngestService(Settings.EMPTY, tp, null, null,
+            null, Arrays.asList(DUMMY_PLUGIN, DUMMY_PLUGIN)));
         assertTrue(e.getMessage(), e.getMessage().contains("already registered"));
     }
 }

--- a/core/src/test/java/org/elasticsearch/ingest/PipelineStoreTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/PipelineStoreTests.java
@@ -50,7 +50,6 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class PipelineStoreTests extends ESTestCase {
 
-    private ClusterSettings clusterSettings;
     private PipelineStore store;
 
     @Before
@@ -95,8 +94,7 @@ public class PipelineStoreTests extends ESTestCase {
                 }
             };
         });
-        clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        store = new PipelineStore(clusterSettings, Settings.EMPTY, processorFactories);
+        store = new PipelineStore(Settings.EMPTY, processorFactories);
     }
 
     public void testUpdatePipelines() {
@@ -370,13 +368,5 @@ public class PipelineStoreTests extends ESTestCase {
                 emptyMap(), emptySet(), Version.CURRENT);
         IngestInfo ingestInfo = new IngestInfo(Collections.singletonList(new ProcessorInfo("set")));
         store.validatePipeline(Collections.singletonMap(discoveryNode, ingestInfo), putRequest);
-    }
-
-    public void testUpdateIngestNewDateFormatSetting() throws Exception {
-        assertFalse(store.isNewIngestDateFormat());
-        clusterSettings.applySettings(Settings.builder().put(IngestService.NEW_INGEST_DATE_FORMAT.getKey(), true).build());
-        assertTrue(store.isNewIngestDateFormat());
-        assertWarnings("[ingest.new_date_format] setting was deprecated in Elasticsearch and will be " +
-            "removed in a future release! See the breaking changes documentation for the next major version.");
     }
 }

--- a/docs/reference/migration/migrate_6_0/ingest.asciidoc
+++ b/docs/reference/migration/migrate_6_0/ingest.asciidoc
@@ -4,3 +4,11 @@
 ==== Timestamp meta-data field type has changed
 
 The type of the "timestamp" meta-data field has changed from `java.lang.String` to `java.util.Date`.
+
+==== The format of the string-formatted ingest.timestamp field has changed
+
+Previously, since Elasticsearch 5.4.0, you needed to use `ingest.new_date_format` to have the
+`ingest.timestamp` metadata field be formatted in such a way that ES can coerce it to a field
+of type `date` without further transformation. This is not necessary anymore and this setting was
+removed. You can now simply set a field to `{{ingest.timestamp}}` in a pipeline, and have that
+field be of type `date` without any mapping errors.

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/60_pipeline_timestamp_date_mapping.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/60_pipeline_timestamp_date_mapping.yml
@@ -1,5 +1,5 @@
 ---
-"Test timestamp templating does not match date-mapping defaults":
+"Test timestamp templating matches date-mapping defaults":
   - do:
       cluster.health:
           wait_for_status: green
@@ -23,25 +23,6 @@
                   "field": "my_time",
                   "value": "{{ _ingest.timestamp }}"
                 }
-              },
-              {
-                "grok" : {
-                  "field" : "my_time",
-                  "patterns": ["%{DAY:day} %{MONTH:month} %{MONTHDAY:monthday} %{TIME:time} %{WORD} %{YEAR:year}"]
-                }
-              },
-              {
-                "set": {
-                  "field": "my_time",
-                  "value": "{{day}} {{month}} {{monthday}} {{time}} {{year}}"
-                }
-              },
-              {
-                "date" : {
-                  "field" : "my_time",
-                  "target_field": "my_time",
-                  "formats": ["EEE MMM dd HH:mm:ss yyyy"]
-                }
               }
             ]
           }
@@ -55,65 +36,3 @@
         pipeline: "my_timely_pipeline"
         body: {}
 
----
-"Test timestamp templating matches date-mapping defaults with ingest.new_date_format":
-  - skip:
-      version: " - 5.3.99"
-      reason: deprecated in 5.4.0
-      features: "warnings"
-
-  - do:
-      cluster.health:
-          wait_for_status: green
-
-  - do:
-      indices.create:
-        index: timetest_newdateformat
-        body:
-          mappings:
-            test: { "properties": { "my_time": {"type": "date"}}}
-
-  - do:
-      cluster.put_settings:
-        body:
-          transient:
-            ingest.new_date_format: true
-      warnings:
-        - "[ingest.new_date_format] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
-
-  - match: {transient: {ingest: {new_date_format: "true"}}}
-
-  - do:
-      ingest.put_pipeline:
-        id: "my_timely_pipeline_with_new_date_format"
-        body:  >
-          {
-            "description": "_description",
-            "processors": [
-              {
-                "set" : {
-                  "field": "my_time",
-                  "value": "{{ _ingest.timestamp }}"
-                }
-              }
-            ]
-          }
-  - match: { acknowledged: true }
-
-  - do:
-      index:
-        index: timetest
-        type: test
-        id: 1
-        pipeline: "my_timely_pipeline_with_new_date_format"
-        body: {}
-
-  - do:
-      cluster.put_settings:
-        body:
-          transient:
-            ingest.new_date_format: false
-      warnings:
-        - "[ingest.new_date_format] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
-
-  - match: {transient: {ingest: {new_date_format: "false"}}}


### PR DESCRIPTION
`ingest.new_date_format` was added here: https://github.com/elastic/elasticsearch/pull/24030 for the ability to more seamlessly set `ingest.timestamp` into a date field within an elasticsearch document. This is to become the default in 6.0 so the option is not necessary anymore