### PR TITLE
Add another parent value option to join documentation

### DIFF
--- a/docs/reference/mapping/types/parent-join.asciidoc
+++ b/docs/reference/mapping/types/parent-join.asciidoc
@@ -39,6 +39,32 @@ For instance the following creates two parent documents in the `my_parent` conte
 PUT my_index/doc/1?refresh
 {
   "text": "This is a parent document",
+  "my_join_field": {
+    "name": "my_parent" <1>
+  }
+}
+
+PUT my_index/doc/2?refresh
+{
+  "text": "This is a another parent document",
+  "my_join_field": {
+    "name": "my_parent"
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+<1> This document is a `my_parent` document.
+
+When indexing parent documents, you can choose to specify just the name of the relation
+as a shortcut instead of encapsulating it in the normal object notation:
+
+[source,js]
+--------------------------------------------------
+PUT my_index/doc/1?refresh
+{
+  "text": "This is a parent document",
   "my_join_field": "my_parent" <1>
 }
 
@@ -51,7 +77,7 @@ PUT my_index/doc/2?refresh
 // CONSOLE
 // TEST[continued]
 
-<1> This document is a `my_parent` document.
+<1> Simpler notation for a parent document just uses the relation name.
 
 When indexing a child, the name of the relation as well as the parent id of the document
 must be added in the `_source`.


### PR DESCRIPTION
When indexing a document using a `join` field, the user must always specify the name of the relation, and in the case of a child document, must specify the parent document id. When indexing a parent document you can simply send the name of the relation as the value of the join field instead of an object with the relation name as a subfield. This PR adds documentation for both indexing cases, and implies that sending just the relation name is a short-form for the object use case.