### PR TITLE
Fix typo

### DIFF
--- a/docs/reference/analysis/tokenizers/pattern-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/pattern-tokenizer.asciidoc
@@ -111,7 +111,7 @@ The `pattern` tokenizer accepts the following parameters:
 `flags`::
 
     Java regular expression http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#field.summary[flags].
-    lags should be pipe-separated, eg `"CASE_INSENSITIVE|COMMENTS"`.
+    Flags should be pipe-separated, eg `"CASE_INSENSITIVE|COMMENTS"`.
 
 `group`::
 


### PR DESCRIPTION
Replacement for https://github.com/elastic/elasticsearch/pull/25598 against master branch.