### PR TITLE
Fix tribe node cluster state version increments

### DIFF
--- a/core/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/core/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -367,7 +367,7 @@ public class TribeService extends AbstractLifecycleComponent {
         @Override
         public ClusterTasksResult<ClusterChangedEvent> execute(ClusterState currentState, List<ClusterChangedEvent> tasks) throws Exception {
             ClusterTasksResult.Builder<ClusterChangedEvent> builder = ClusterTasksResult.builder();
-            ClusterState.Builder newState = ClusterState.builder(currentState).incrementVersion();
+            ClusterState.Builder newState = ClusterState.builder(currentState);
             boolean clusterStateChanged = updateNodes(currentState, tasks, newState);
             clusterStateChanged |= updateIndicesAndMetaData(currentState, tasks, newState);
             builder.successes(tasks);

--- a/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
+++ b/core/src/test/java/org/elasticsearch/tribe/TribeIT.java
@@ -496,8 +496,11 @@ public class TribeIT extends ESIntegTestCase {
         Collections.sort(customMetaDatas, (cm1, cm2) -> cm2.getData().compareTo(cm1.getData()));
         final MergableCustomMetaData1 tribeNodeCustomMetaData = customMetaDatas.get(0);
         try (Releasable tribeNode = startTribeNode()) {
+            ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
             putCustomMetaData(cluster1, customMetaData1);
             assertCustomMetaDataUpdated(internalCluster(), customMetaData1);
+            // check that cluster state version is properly incremented
+            assertThat(client().admin().cluster().prepareState().get().getState().getVersion(), equalTo(clusterState.getVersion() + 1));
             putCustomMetaData(cluster2, customMetaData2);
             assertCustomMetaDataUpdated(internalCluster(), tribeNodeCustomMetaData);
         }


### PR DESCRIPTION
With #24236, tribe nodes submit cluster state changes to their MasterService, making it unnecessary to explicitly update the cluster state version. This PR fixes the double-incrementing of cluster state versions on tribe nodes, which are not harmful, but unnecessary.