### PR TITLE
Add support for selecting percolator query candidate matches containing range queries

### DIFF
--- a/core/src/main/java/org/apache/lucene/document/BinaryRange.java
+++ b/core/src/main/java/org/apache/lucene/document/BinaryRange.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.lucene.document;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * A range field for binary encoded ranges
+ */
+public final class BinaryRange extends Field {
+    /** The number of bytes per dimension, use {@link InetAddressPoint#BYTES} as max, because that is maximum we need to support */
+    public static final int BYTES = InetAddressPoint.BYTES;
+
+    private static final FieldType TYPE;
+    static {
+        TYPE = new FieldType();
+        TYPE.setDimensions(2, BYTES);
+        TYPE.freeze();
+    }
+
+    /**
+     * Create a new BinaryRange from a provided encoded binary range
+     * @param name              field name. must not be null.
+     * @param encodedRange      Encoded range
+     */
+    public BinaryRange(String name, byte[] encodedRange) {
+        super(name, TYPE);
+        if (encodedRange.length != BYTES * 2) {
+            throw new IllegalArgumentException("Unexpected encoded range length [" + encodedRange.length + "]");
+        }
+        fieldsData = new BytesRef(encodedRange);
+    }
+
+    /**
+     * Create a query for matching indexed ip ranges that {@code INTERSECT} the defined range.
+     * @param field         field name. must not be null.
+     * @param encodedRange  Encoded range
+     * @return query for matching intersecting encoded ranges (overlap, within, crosses, or contains)
+     * @throws IllegalArgumentException if {@code field} is null, {@code min} or {@code max} is invalid
+     */
+    public static Query newIntersectsQuery(String field, byte[] encodedRange) {
+        return newRelationQuery(field, encodedRange, RangeFieldQuery.QueryType.INTERSECTS);
+    }
+
+    static Query newRelationQuery(String field, byte[] encodedRange, RangeFieldQuery.QueryType relation) {
+        return new RangeFieldQuery(field, encodedRange, 1, relation) {
+            @Override
+            protected String toString(byte[] ranges, int dimension) {
+                return "[" + new BytesRef(ranges, 0, BYTES) + " TO " + new BytesRef(ranges, BYTES, BYTES) + "]";
+            }
+        };
+    }
+
+}

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQuery.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQuery.java
@@ -44,7 +44,7 @@ import java.util.Set;
 final class PercolateQuery extends Query implements Accountable {
 
     // cost of matching the query against the document, arbitrary as it would be really complex to estimate
-    public static final float MATCH_COST = 1000;
+    private static final float MATCH_COST = 1000;
 
     private final QueryStore queryStore;
     private final BytesReference documentSource;
@@ -164,15 +164,15 @@ final class PercolateQuery extends Query implements Accountable {
         };
     }
 
-    public IndexSearcher getPercolatorIndexSearcher() {
+    IndexSearcher getPercolatorIndexSearcher() {
         return percolatorIndexSearcher;
     }
 
-    public BytesReference getDocumentSource() {
+    BytesReference getDocumentSource() {
         return documentSource;
     }
 
-    public QueryStore getQueryStore() {
+    QueryStore getQueryStore() {
         return queryStore;
     }
 

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.percolator;
 
+import org.apache.lucene.document.BinaryRange;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
@@ -25,6 +26,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
@@ -40,6 +42,7 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -54,6 +57,8 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParseContext;
+import org.elasticsearch.index.mapper.RangeFieldMapper;
+import org.elasticsearch.index.mapper.RangeFieldMapper.RangeType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoostingQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
@@ -65,9 +70,11 @@ import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -77,10 +84,10 @@ import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQuery
 
 public class PercolatorFieldMapper extends FieldMapper {
 
-    public static final XContentType QUERY_BUILDER_CONTENT_TYPE = XContentType.SMILE;
-    public static final Setting<Boolean> INDEX_MAP_UNMAPPED_FIELDS_AS_STRING_SETTING =
+    static final XContentType QUERY_BUILDER_CONTENT_TYPE = XContentType.SMILE;
+    static final Setting<Boolean> INDEX_MAP_UNMAPPED_FIELDS_AS_STRING_SETTING =
             Setting.boolSetting("index.percolator.map_unmapped_fields_as_string", false, Setting.Property.IndexScope);
-    public static final String CONTENT_TYPE = "percolator";
+    static final String CONTENT_TYPE = "percolator";
     private static final FieldType FIELD_TYPE = new FieldType();
 
     static final byte FIELD_VALUE_SEPARATOR = 0;  // nul code point
@@ -88,15 +95,16 @@ public class PercolatorFieldMapper extends FieldMapper {
     static final String EXTRACTION_PARTIAL = "partial";
     static final String EXTRACTION_FAILED = "failed";
 
-    public static final String EXTRACTED_TERMS_FIELD_NAME = "extracted_terms";
-    public static final String EXTRACTION_RESULT_FIELD_NAME = "extraction_result";
-    public static final String QUERY_BUILDER_FIELD_NAME = "query_builder_field";
+    static final String EXTRACTED_TERMS_FIELD_NAME = "extracted_terms";
+    static final String EXTRACTION_RESULT_FIELD_NAME = "extraction_result";
+    static final String QUERY_BUILDER_FIELD_NAME = "query_builder_field";
+    static final String RANGE_FIELD_NAME = "range_field";
 
-    public static class Builder extends FieldMapper.Builder<Builder, PercolatorFieldMapper> {
+    static class Builder extends FieldMapper.Builder<Builder, PercolatorFieldMapper> {
 
         private final Supplier<QueryShardContext> queryShardContext;
 
-        public Builder(String fieldName, Supplier<QueryShardContext> queryShardContext) {
+        Builder(String fieldName, Supplier<QueryShardContext> queryShardContext) {
             super(fieldName, FIELD_TYPE, FIELD_TYPE);
             this.queryShardContext = queryShardContext;
         }
@@ -111,11 +119,15 @@ public class PercolatorFieldMapper extends FieldMapper {
             fieldType.extractionResultField = extractionResultField.fieldType();
             BinaryFieldMapper queryBuilderField = createQueryBuilderFieldBuilder(context);
             fieldType.queryBuilderField = queryBuilderField.fieldType();
+            // Range field is of type ip, because that matches closest with BinaryRange field. Otherwise we would
+            // have to introduce a new field type...
+            RangeFieldMapper rangeFieldMapper = createExtractedRangeFieldBuilder(RANGE_FIELD_NAME, RangeType.IP, context);
+            fieldType.rangeField = rangeFieldMapper.fieldType();
             context.path().remove();
             setupFieldType(context);
             return new PercolatorFieldMapper(name(), fieldType, defaultFieldType, context.indexSettings(),
                     multiFieldsBuilder.build(this, context), copyTo, queryShardContext, extractedTermsField,
-                    extractionResultField, queryBuilderField);
+                    extractionResultField, queryBuilderField, rangeFieldMapper);
         }
 
         static KeywordFieldMapper createExtractQueryFieldBuilder(String name, BuilderContext context) {
@@ -135,9 +147,16 @@ public class PercolatorFieldMapper extends FieldMapper {
             return builder.build(context);
         }
 
+        static RangeFieldMapper createExtractedRangeFieldBuilder(String name, RangeType rangeType, BuilderContext context) {
+            RangeFieldMapper.Builder builder = new RangeFieldMapper.Builder(name, rangeType, context.indexCreatedVersion());
+            // For now no doc values, because in processQuery(...) only the Lucene range fields get added:
+            builder.docValues(false);
+            return builder.build(context);
+        }
+
     }
 
-    public static class TypeParser implements FieldMapper.TypeParser {
+    static class TypeParser implements FieldMapper.TypeParser {
 
         @Override
         public Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
@@ -145,23 +164,26 @@ public class PercolatorFieldMapper extends FieldMapper {
         }
     }
 
-    public static class FieldType extends MappedFieldType {
+    static class FieldType extends MappedFieldType {
 
         MappedFieldType queryTermsField;
         MappedFieldType extractionResultField;
         MappedFieldType queryBuilderField;
 
-        public FieldType() {
+        RangeFieldMapper.RangeFieldType rangeField;
+
+        FieldType() {
             setIndexOptions(IndexOptions.NONE);
             setDocValuesType(DocValuesType.NONE);
             setStored(false);
         }
 
-        public FieldType(FieldType ref) {
+        FieldType(FieldType ref) {
             super(ref);
             queryTermsField = ref.queryTermsField;
             extractionResultField = ref.extractionResultField;
             queryBuilderField = ref.queryBuilderField;
+            rangeField = ref.rangeField;
         }
 
         @Override
@@ -198,33 +220,49 @@ public class PercolatorFieldMapper extends FieldMapper {
 
         Query createCandidateQuery(IndexReader indexReader) throws IOException {
             List<BytesRef> extractedTerms = new ArrayList<>();
+            Map<String, List<byte[]>> encodedPointValuesByField = new HashMap<>();
+
             LeafReader reader = indexReader.leaves().get(0).reader();
             for (FieldInfo info : reader.getFieldInfos()) {
                 Terms terms = reader.terms(info.name);
-                if (terms == null) {
-                    continue;
+                if (terms != null) {
+                    BytesRef fieldBr = new BytesRef(info.name);
+                    TermsEnum tenum = terms.iterator();
+                    for (BytesRef term = tenum.next(); term != null; term = tenum.next()) {
+                        BytesRefBuilder builder = new BytesRefBuilder();
+                        builder.append(fieldBr);
+                        builder.append(FIELD_VALUE_SEPARATOR);
+                        builder.append(term);
+                        extractedTerms.add(builder.toBytesRef());
+                    }
                 }
-
-                BytesRef fieldBr = new BytesRef(info.name);
-                TermsEnum tenum = terms.iterator();
-                for (BytesRef term = tenum.next(); term != null; term = tenum.next()) {
-                    BytesRefBuilder builder = new BytesRefBuilder();
-                    builder.append(fieldBr);
-                    builder.append(FIELD_VALUE_SEPARATOR);
-                    builder.append(term);
-                    extractedTerms.add(builder.toBytesRef());
+                if (info.getPointDimensionCount() == 1) { // not != 0 because range fields are not supported
+                    PointValues values = reader.getPointValues(info.name);
+                    List<byte[]> encodedPointValues = new ArrayList<>();
+                    encodedPointValues.add(values.getMinPackedValue().clone());
+                    encodedPointValues.add(values.getMaxPackedValue().clone());
+                    encodedPointValuesByField.put(info.name, encodedPointValues);
                 }
             }
-            Query extractionSuccess = new TermInSetQuery(queryTermsField.name(), extractedTerms);
+
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            if (extractedTerms.size() != 0) {
+                builder.add(new TermInSetQuery(queryTermsField.name(), extractedTerms), Occur.SHOULD);
+            }
             // include extractionResultField:failed, because docs with this term have no extractedTermsField
             // and otherwise we would fail to return these docs. Docs that failed query term extraction
             // always need to be verified by MemoryIndex:
-            Query extractionFailure = new TermQuery(new Term(extractionResultField.name(), EXTRACTION_FAILED));
+            builder.add(new TermQuery(new Term(extractionResultField.name(), EXTRACTION_FAILED)), Occur.SHOULD);
 
-            return new BooleanQuery.Builder()
-                    .add(extractionSuccess, Occur.SHOULD)
-                    .add(extractionFailure, Occur.SHOULD)
-                    .build();
+            for (Map.Entry<String, List<byte[]>> entry : encodedPointValuesByField.entrySet()) {
+                String rangeFieldName = entry.getKey();
+                List<byte[]> encodedPointValues = entry.getValue();
+                byte[] min = encodedPointValues.get(0);
+                byte[] max = encodedPointValues.get(1);
+                Query query = BinaryRange.newIntersectsQuery(rangeField.name(), encodeRange(rangeFieldName, min, max));
+                builder.add(query, Occur.SHOULD);
+            }
+            return builder.build();
         }
 
     }
@@ -235,17 +273,20 @@ public class PercolatorFieldMapper extends FieldMapper {
     private KeywordFieldMapper extractionResultField;
     private BinaryFieldMapper queryBuilderField;
 
-    public PercolatorFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
+    private RangeFieldMapper rangeFieldMapper;
+
+    PercolatorFieldMapper(String simpleName, MappedFieldType fieldType, MappedFieldType defaultFieldType,
                                  Settings indexSettings, MultiFields multiFields, CopyTo copyTo,
                                  Supplier<QueryShardContext> queryShardContext,
                                  KeywordFieldMapper queryTermsField, KeywordFieldMapper extractionResultField,
-                                 BinaryFieldMapper queryBuilderField) {
+                                 BinaryFieldMapper queryBuilderField, RangeFieldMapper rangeFieldMapper) {
         super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
         this.queryShardContext = queryShardContext;
         this.queryTermsField = queryTermsField;
         this.extractionResultField = extractionResultField;
         this.queryBuilderField = queryBuilderField;
         this.mapUnmappedFieldAsString = INDEX_MAP_UNMAPPED_FIELDS_AS_STRING_SETTING.get(indexSettings);
+        this.rangeFieldMapper = rangeFieldMapper;
     }
 
     @Override
@@ -254,9 +295,10 @@ public class PercolatorFieldMapper extends FieldMapper {
         KeywordFieldMapper queryTermsUpdated = (KeywordFieldMapper) queryTermsField.updateFieldType(fullNameToFieldType);
         KeywordFieldMapper extractionResultUpdated = (KeywordFieldMapper) extractionResultField.updateFieldType(fullNameToFieldType);
         BinaryFieldMapper queryBuilderUpdated = (BinaryFieldMapper) queryBuilderField.updateFieldType(fullNameToFieldType);
+        RangeFieldMapper rangeFieldMapperUpdated = (RangeFieldMapper) rangeFieldMapper.updateFieldType(fullNameToFieldType);
 
         if (updated == this && queryTermsUpdated == queryTermsField && extractionResultUpdated == extractionResultField
-                && queryBuilderUpdated == queryBuilderField) {
+                && queryBuilderUpdated == queryBuilderField && rangeFieldMapperUpdated == rangeFieldMapper) {
             return this;
         }
         if (updated == this) {
@@ -265,6 +307,7 @@ public class PercolatorFieldMapper extends FieldMapper {
         updated.queryTermsField = queryTermsUpdated;
         updated.extractionResultField = extractionResultUpdated;
         updated.queryBuilderField = queryBuilderUpdated;
+        updated.rangeFieldMapper = rangeFieldMapperUpdated;
         return updated;
     }
 
@@ -310,12 +353,18 @@ public class PercolatorFieldMapper extends FieldMapper {
             doc.add(new Field(pft.extractionResultField.name(), EXTRACTION_FAILED, extractionResultField.fieldType()));
             return;
         }
-        for (Term term : result.terms) {
-            BytesRefBuilder builder = new BytesRefBuilder();
-            builder.append(new BytesRef(term.field()));
-            builder.append(FIELD_VALUE_SEPARATOR);
-            builder.append(term.bytes());
-            doc.add(new Field(queryTermsField.name(), builder.toBytesRef(), queryTermsField.fieldType()));
+        for (QueryAnalyzer.QueryExtraction term : result.extractions) {
+            if (term.term != null) {
+                BytesRefBuilder builder = new BytesRefBuilder();
+                builder.append(new BytesRef(term.field()));
+                builder.append(FIELD_VALUE_SEPARATOR);
+                builder.append(term.bytes());
+                doc.add(new Field(queryTermsField.name(), builder.toBytesRef(), queryTermsField.fieldType()));
+            } else if (term.range != null) {
+                byte[] min = term.range.lowerPoint;
+                byte[] max = term.range.upperPoint;
+                doc.add(new BinaryRange(rangeFieldMapper.name(), encodeRange(term.range.fieldName, min, max)));
+            }
         }
         if (result.verified) {
             doc.add(new Field(extractionResultField.name(), EXTRACTION_COMPLETE, extractionResultField.fieldType()));
@@ -324,7 +373,7 @@ public class PercolatorFieldMapper extends FieldMapper {
         }
     }
 
-    public static Query parseQuery(QueryShardContext context, boolean mapUnmappedFieldsAsString, XContentParser parser) throws IOException {
+    static Query parseQuery(QueryShardContext context, boolean mapUnmappedFieldsAsString, XContentParser parser) throws IOException {
         return toQuery(context, mapUnmappedFieldsAsString, parseQueryBuilder(parser, parser.getTokenLocation()));
     }
 
@@ -356,7 +405,7 @@ public class PercolatorFieldMapper extends FieldMapper {
 
     @Override
     public Iterator<Mapper> iterator() {
-        return Arrays.<Mapper>asList(queryTermsField, extractionResultField, queryBuilderField).iterator();
+        return Arrays.<Mapper>asList(queryTermsField, extractionResultField, queryBuilderField, rangeFieldMapper).iterator();
     }
 
     @Override
@@ -368,7 +417,6 @@ public class PercolatorFieldMapper extends FieldMapper {
     protected String contentType() {
         return CONTENT_TYPE;
     }
-
 
     /**
      * Fails if a percolator contains an unsupported query. The following queries are not supported:
@@ -403,6 +451,26 @@ public class PercolatorFieldMapper extends FieldMapper {
                 verifyQuery(innerQueryBuilder);
             }
         }
+    }
+
+    static byte[] encodeRange(String rangeFieldName, byte[] minEncoded, byte[] maxEncoded) {
+        assert minEncoded.length == maxEncoded.length;
+        byte[] bytes = new byte[BinaryRange.BYTES * 2];
+
+        // First compute hash for field name and write the full hash into the byte array
+        BytesRef fieldAsBytesRef = new BytesRef(rangeFieldName);
+        MurmurHash3.Hash128 hash = new MurmurHash3.Hash128();
+        MurmurHash3.hash128(fieldAsBytesRef.bytes, fieldAsBytesRef.offset, fieldAsBytesRef.length, 0, hash);
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        bb.putLong(hash.h1).putLong(hash.h2).putLong(hash.h1).putLong(hash.h2);
+        assert bb.position() == bb.limit();
+
+        // Secondly, overwrite the min and max encoded values in the byte array
+        // This way we are able to reuse as much as possible from the hash for any range type.
+        int offset = BinaryRange.BYTES - minEncoded.length;
+        System.arraycopy(minEncoded, 0, bytes, offset, minEncoded.length);
+        System.arraycopy(maxEncoded, 0, bytes, BinaryRange.BYTES + offset, maxEncoded.length);
+        return bytes;
     }
 
 }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
@@ -50,7 +50,7 @@ import java.util.Map;
  * Highlighting in the case of the percolate query is a bit different, because the PercolateQuery itself doesn't get highlighted,
  * but the source of the PercolateQuery gets highlighted by each hit containing a query.
  */
-public final class PercolatorHighlightSubFetchPhase extends HighlightPhase {
+final class PercolatorHighlightSubFetchPhase extends HighlightPhase {
 
     PercolatorHighlightSubFetchPhase(Settings settings, Map<String, Highlighter> highlighters) {
         super(settings, highlighters);

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.percolator;
 
+import org.apache.lucene.document.BinaryRange;
 import org.apache.lucene.index.PrefixCodedTerms;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.BlendedTermQuery;
@@ -30,6 +31,7 @@ import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermInSetQuery;
@@ -41,6 +43,7 @@ import org.apache.lucene.search.spans.SpanOrQuery;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 
@@ -51,10 +54,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
-public final class QueryAnalyzer {
+import static java.util.stream.Collectors.toSet;
+
+final class QueryAnalyzer {
 
     private static final Map<Class<? extends Query>, Function<Query, Result>> queryProcessors;
 
@@ -78,6 +84,7 @@ public final class QueryAnalyzer {
         map.put(DisjunctionMaxQuery.class, disjunctionMaxQuery());
         map.put(SynonymQuery.class, synonymQuery());
         map.put(FunctionScoreQuery.class, functionScoreQuery());
+        map.put(PointRangeQuery.class, pointRangeQuery());
         queryProcessors = Collections.unmodifiableMap(map);
     }
 
@@ -85,7 +92,7 @@ public final class QueryAnalyzer {
     }
 
     /**
-     * Extracts terms from the provided query. These terms are stored with the percolator query and
+     * Extracts terms and ranges from the provided query. These terms and ranges are stored with the percolator query and
      * used by the percolate query's candidate query as fields to be query by. The candidate query
      * holds the terms from the document to be percolated and allows to the percolate query to ignore
      * percolator queries that we know would otherwise never match.
@@ -104,11 +111,11 @@ public final class QueryAnalyzer {
      * since that those terms are likely to be the rarest. Boolean query's must_not clauses are always ignored.
      *
      * <p>
-     * Sometimes the query analyzer can't always extract terms from a sub query, if that happens then
+     * Sometimes the query analyzer can't always extract terms or ranges from a sub query, if that happens then
      * query analysis is stopped and an UnsupportedQueryException is thrown. So that the caller can mark
      * this query in such a way that the PercolatorQuery always verifies if this query with the MemoryIndex.
      */
-    public static Result analyze(Query query) {
+    static Result analyze(Query query) {
         Class queryClass = query.getClass();
         if (queryClass.isAnonymousClass()) {
             // Sometimes queries have anonymous classes in that case we need the direct super class.
@@ -123,65 +130,65 @@ public final class QueryAnalyzer {
         }
     }
 
-    static Function<Query, Result> matchNoDocsQuery() {
+    private static Function<Query, Result> matchNoDocsQuery() {
         return (query -> new Result(true, Collections.emptySet()));
     }
 
-    static Function<Query, Result> constantScoreQuery() {
+    private static Function<Query, Result> constantScoreQuery() {
         return query -> {
             Query wrappedQuery = ((ConstantScoreQuery) query).getQuery();
             return analyze(wrappedQuery);
         };
     }
 
-    static Function<Query, Result> boostQuery() {
+    private static Function<Query, Result> boostQuery() {
         return query -> {
             Query wrappedQuery = ((BoostQuery) query).getQuery();
             return analyze(wrappedQuery);
         };
     }
 
-    static Function<Query, Result> termQuery() {
+    private static Function<Query, Result> termQuery() {
         return (query -> {
             TermQuery termQuery = (TermQuery) query;
-            return new Result(true, Collections.singleton(termQuery.getTerm()));
+            return new Result(true, Collections.singleton(new QueryExtraction(termQuery.getTerm())));
         });
     }
 
-    static Function<Query, Result> termInSetQuery() {
+    private static Function<Query, Result> termInSetQuery() {
         return query -> {
             TermInSetQuery termInSetQuery = (TermInSetQuery) query;
-            Set<Term> terms = new HashSet<>();
+            Set<QueryExtraction> terms = new HashSet<>();
             PrefixCodedTerms.TermIterator iterator = termInSetQuery.getTermData().iterator();
             for (BytesRef term = iterator.next(); term != null; term = iterator.next()) {
-                terms.add(new Term(iterator.field(), term));
+                terms.add(new QueryExtraction(new Term(iterator.field(), term)));
             }
             return new Result(true, terms);
         };
     }
 
-    static Function<Query, Result> synonymQuery() {
+    private static Function<Query, Result> synonymQuery() {
         return query -> {
-            Set<Term> terms = new HashSet<>(((SynonymQuery) query).getTerms());
+            Set<QueryExtraction> terms = ((SynonymQuery) query).getTerms().stream().map(QueryExtraction::new).collect(toSet());
             return new Result(true, terms);
         };
     }
 
-    static Function<Query, Result> commonTermsQuery() {
+    private static Function<Query, Result> commonTermsQuery() {
         return query -> {
-            List<Term> terms = ((CommonTermsQuery) query).getTerms();
-            return new Result(false, new HashSet<>(terms));
+            Set<QueryExtraction> terms = ((CommonTermsQuery) query).getTerms().stream().map(QueryExtraction::new).collect(toSet());
+            return new Result(false, terms);
         };
     }
 
-    static Function<Query, Result> blendedTermQuery() {
+    private static Function<Query, Result> blendedTermQuery() {
         return query -> {
-            List<Term> terms = ((BlendedTermQuery) query).getTerms();
-            return new Result(true, new HashSet<>(terms));
+            Set<QueryExtraction> terms = ((BlendedTermQuery) query).getTerms().stream().map(QueryExtraction::new).collect(toSet());
+            return new Result(true, terms);
         };
     }
 
-    static Function<Query, Result> phraseQuery() {
+    private static Function<Query, Result> phraseQuery() {
         return query -> {
             Term[] terms = ((PhraseQuery) query).getTerms();
             if (terms.length == 0) {
@@ -196,70 +203,71 @@ public final class QueryAnalyzer {
                     longestTerm = term;
                 }
             }
-            return new Result(false, Collections.singleton(longestTerm));
+            return new Result(false, Collections.singleton(new QueryExtraction(longestTerm)));
         };
     }
 
-    static Function<Query, Result> multiPhraseQuery() {
+    private static Function<Query, Result> multiPhraseQuery() {
         return query -> {
             Term[][] terms = ((MultiPhraseQuery) query).getTermArrays();
             if (terms.length == 0) {
                 return new Result(true, Collections.emptySet());
             }
 
-            Set<Term> bestTermArr = null;
+            Set<QueryExtraction> bestTermArr = null;
             for (Term[] termArr : terms) {
-                bestTermArr = selectTermListWithTheLongestShortestTerm(bestTermArr, new HashSet<>(Arrays.asList(termArr)));
+                Set<QueryExtraction> queryExtractions = Arrays.stream(termArr).map(QueryExtraction::new).collect(toSet());
+                bestTermArr = selectBestExtraction(bestTermArr, queryExtractions);
             }
             return new Result(false, bestTermArr);
         };
     }
 
-    static Function<Query, Result> spanTermQuery() {
+    private static Function<Query, Result> spanTermQuery() {
         return query -> {
             Term term = ((SpanTermQuery) query).getTerm();
-            return new Result(true, Collections.singleton(term));
+            return new Result(true, Collections.singleton(new QueryExtraction(term)));
         };
     }
 
-    static Function<Query, Result> spanNearQuery() {
+    private static Function<Query, Result> spanNearQuery() {
         return query -> {
-            Set<Term> bestClauses = null;
+            Set<QueryExtraction> bestClauses = null;
             SpanNearQuery spanNearQuery = (SpanNearQuery) query;
             for (SpanQuery clause : spanNearQuery.getClauses()) {
                 Result temp = analyze(clause);
-                bestClauses = selectTermListWithTheLongestShortestTerm(temp.terms, bestClauses);
+                bestClauses = selectBestExtraction(temp.extractions, bestClauses);
             }
             return new Result(false, bestClauses);
         };
     }
 
-    static Function<Query, Result> spanOrQuery() {
+    private static Function<Query, Result> spanOrQuery() {
         return query -> {
-            Set<Term> terms = new HashSet<>();
+            Set<QueryExtraction> terms = new HashSet<>();
             SpanOrQuery spanOrQuery = (SpanOrQuery) query;
             for (SpanQuery clause : spanOrQuery.getClauses()) {
-                terms.addAll(analyze(clause).terms);
+                terms.addAll(analyze(clause).extractions);
             }
             return new Result(false, terms);
         };
     }
 
-    static Function<Query, Result> spanNotQuery() {
+    private static Function<Query, Result> spanNotQuery() {
         return query -> {
             Result result = analyze(((SpanNotQuery) query).getInclude());
-            return new Result(false, result.terms);
+            return new Result(false, result.extractions);
         };
     }
 
-    static Function<Query, Result> spanFirstQuery() {
+    private static Function<Query, Result> spanFirstQuery() {
         return query -> {
             Result result = analyze(((SpanFirstQuery) query).getMatch());
-            return new Result(false, result.terms);
+            return new Result(false, result.extractions);
         };
     }
 
-    static Function<Query, Result> booleanQuery() {
+    private static Function<Query, Result> booleanQuery() {
         return query -> {
             BooleanQuery bq = (BooleanQuery) query;
             List<BooleanClause> clauses = bq.clauses();
@@ -279,7 +287,7 @@ public final class QueryAnalyzer {
                 }
             }
             if (numRequiredClauses > 0) {
-                Set<Term> bestClause = null;
+                Set<QueryExtraction> bestClause = null;
                 UnsupportedQueryException uqe = null;
                 for (BooleanClause clause : clauses) {
                     if (clause.isRequired() == false) {
@@ -296,7 +304,7 @@ public final class QueryAnalyzer {
                         uqe = e;
                         continue;
                     }
-                    bestClause = selectTermListWithTheLongestShortestTerm(temp.terms, bestClause);
+                    bestClause = selectBestExtraction(temp.extractions, bestClause);
                 }
                 if (bestClause != null) {
                     return new Result(false, bestClause);
@@ -321,14 +329,14 @@ public final class QueryAnalyzer {
         };
     }
 
-    static Function<Query, Result> disjunctionMaxQuery() {
+    private static Function<Query, Result> disjunctionMaxQuery() {
         return query -> {
             List<Query> disjuncts = ((DisjunctionMaxQuery) query).getDisjuncts();
             return handleDisjunction(disjuncts, 1, false);
         };
     }
 
-    static Function<Query, Result> functionScoreQuery() {
+    private static Function<Query, Result> functionScoreQuery() {
         return query -> {
             FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) query;
             Result result = analyze(functionScoreQuery.getSubQuery());
@@ -337,58 +345,176 @@ public final class QueryAnalyzer {
             // (if it matches with the percolator document matches with the extracted terms.
             // Min score filters out docs, which is different than the functions, which just influences the score.)
             boolean verified = functionScoreQuery.getMinScore() == null;
-            return new Result(verified, result.terms);
+            return new Result(verified, result.extractions);
         };
     }
 
-    static Result handleDisjunction(List<Query> disjunctions, int minimumShouldMatch, boolean otherClauses) {
+    private static Function<Query, Result> pointRangeQuery() {
+        return query -> {
+            PointRangeQuery pointRangeQuery = (PointRangeQuery) query;
+            byte[] lowerPoint = pointRangeQuery.getLowerPoint();
+            byte[] upperPoint = pointRangeQuery.getUpperPoint();
+            byte[] interval = new byte[16];
+            NumericUtils.subtract(16, 0, prepad(upperPoint), prepad(lowerPoint), interval);
+            return new Result(false, Collections.singleton(new QueryExtraction(
+                new Range(pointRangeQuery.getField(), lowerPoint, upperPoint, interval))
+            ));
+        };
+    }
+
+    private static byte[] prepad(byte[] original) {
+        int offset = BinaryRange.BYTES - original.length;
+        byte[] result = new byte[BinaryRange.BYTES];
+        System.arraycopy(original, 0, result, offset, original.length);
+        return result;
+    }
+
+    private static Result handleDisjunction(List<Query> disjunctions, int minimumShouldMatch, boolean otherClauses) {
         boolean verified = minimumShouldMatch <= 1 && otherClauses == false;
-        Set<Term> terms = new HashSet<>();
+        Set<QueryExtraction> terms = new HashSet<>();
         for (Query disjunct : disjunctions) {
             Result subResult = analyze(disjunct);
             if (subResult.verified == false) {
                 verified = false;
             }
-            terms.addAll(subResult.terms);
+            terms.addAll(subResult.extractions);
         }
         return new Result(verified, terms);
     }
 
-    static Set<Term> selectTermListWithTheLongestShortestTerm(Set<Term> terms1, Set<Term> terms2) {
-        if (terms1 == null) {
-            return terms2;
-        } else if (terms2 == null) {
-            return terms1;
+    static Set<QueryExtraction> selectBestExtraction(Set<QueryExtraction> extractions1, Set<QueryExtraction> extractions2) {
+        assert extractions1 != null || extractions2 != null;
+        if (extractions1 == null) {
+            return extractions2;
+        } else if (extractions2 == null) {
+            return extractions1;
         } else {
-            int terms1ShortestTerm = minTermLength(terms1);
-            int terms2ShortestTerm = minTermLength(terms2);
-            // keep the clause with longest terms, this likely to be rarest.
-            if (terms1ShortestTerm >= terms2ShortestTerm) {
-                return terms1;
+            // Prefer term based extractions over range based extractions:
+            boolean onlyRangeBasedExtractions = true;
+            for (QueryExtraction clause : extractions1) {
+                if (clause.term != null) {
+                    onlyRangeBasedExtractions = false;
+                    break;
+                }
+            }
+            for (QueryExtraction clause : extractions2) {
+                if (clause.term != null) {
+                    onlyRangeBasedExtractions = false;
+                    break;
+                }
+            }
+
+            if (onlyRangeBasedExtractions) {
+                BytesRef terms1SmallestRange = smallestRange(extractions1);
+                BytesRef terms2SmallestRange = smallestRange(extractions2);
+                // Keep the clause with smallest range, this is likely to be the rarest.
+                if (terms1SmallestRange.compareTo(terms2SmallestRange) <= 0) {
+                    return extractions1;
+                } else {
+                    return extractions2;
+                }
             } else {
-                return terms2;
+                int terms1ShortestTerm = minTermLength(extractions1);
+                int terms2ShortestTerm = minTermLength(extractions2);
+                // keep the clause with longest terms, this likely to be rarest.
+                if (terms1ShortestTerm >= terms2ShortestTerm) {
+                    return extractions1;
+                } else {
+                    return extractions2;
+                }
             }
         }
     }
 
-    static int minTermLength(Set<Term> terms) {
+    private static int minTermLength(Set<QueryExtraction> extractions) {
+        // In case there are only range extractions, then we return Integer.MIN_VALUE,
+        // so that selectBestExtraction(...) we are likely to prefer the extractions that contains at least a single extraction
+        if (extractions.stream().filter(queryExtraction -> queryExtraction.term != null).count() == 0 &&
+            extractions.stream().filter(queryExtraction -> queryExtraction.range != null).count() > 0) {
+            return Integer.MIN_VALUE;
+        }
+
         int min = Integer.MAX_VALUE;
-        for (Term term : terms) {
-            min = Math.min(min, term.bytes().length);
+        for (QueryExtraction qt : extractions) {
+            if (qt.term != null) {
+                min = Math.min(min, qt.bytes().length);
+            }
+        }
+        return min;
+    }
+
+    private static BytesRef smallestRange(Set<QueryExtraction> terms) {
+        BytesRef min = terms.iterator().next().range.interval;
+        for (QueryExtraction qt : terms) {
+            if (qt.range != null) {
+                if (qt.range.interval.compareTo(min) < 0) {
+                    min = qt.range.interval;
+                }
+            }
         }
         return min;
     }
 
     static class Result {
 
-        final Set<Term> terms;
+        final Set<QueryExtraction> extractions;
         final boolean verified;
 
-        Result(boolean verified, Set<Term> terms) {
-            this.terms = terms;
+        Result(boolean verified, Set<QueryExtraction> extractions) {
+            this.extractions = extractions;
             this.verified = verified;
         }
 
+    }
+
+    static class QueryExtraction {
+
+        final Term term;
+        final Range range;
+
+        QueryExtraction(Term term) {
+            this.term = term;
+            this.range = null;
+        }
+
+        QueryExtraction(Range range) {
+            this.term = null;
+            this.range = range;
+        }
+
+        String field() {
+            return term != null ? term.field() : null;
+        }
+
+        BytesRef bytes() {
+            return term != null ? term.bytes() : null;
+        }
+
+        String text() {
+            return term != null ? term.text() : null;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            QueryExtraction queryExtraction = (QueryExtraction) o;
+            return Objects.equals(term, queryExtraction.term) &&
+                Objects.equals(range, queryExtraction.range);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(term, range);
+        }
+
+        @Override
+        public String toString() {
+            return "QueryExtraction{" +
+                "term=" + term +
+                ",range=" + range +
+                '}';
+        }
     }
 
     /**
@@ -406,8 +532,51 @@ public final class QueryAnalyzer {
         /**
          * The actual Lucene query that was unsupported and caused this exception to be thrown.
          */
-        public Query getUnsupportedQuery() {
+        Query getUnsupportedQuery() {
             return unsupportedQuery;
+        }
+    }
+
+    static class Range {
+
+        final String fieldName;
+        final byte[] lowerPoint;
+        final byte[] upperPoint;
+        final BytesRef interval;
+
+        Range(String fieldName, byte[] lowerPoint, byte[] upperPoint, byte[] interval) {
+            this.fieldName = fieldName;
+            this.lowerPoint = lowerPoint;
+            this.upperPoint = upperPoint;
+            // using BytesRef here just to make use of its compareTo method.
+            this.interval = new BytesRef(interval);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Range range = (Range) o;
+            return Objects.equals(fieldName, range.fieldName) &&
+                Arrays.equals(lowerPoint, range.lowerPoint) &&
+                Arrays.equals(upperPoint, range.upperPoint);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = 1;
+            result += 31 * fieldName.hashCode();
+            result += Arrays.hashCode(lowerPoint);
+            result += Arrays.hashCode(upperPoint);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Range{" +
+                ", fieldName='" + fieldName + '\'' +
+                ", interval=" + interval +
+                '}';
         }
     }
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -21,7 +21,12 @@ package org.elasticsearch.percolator;
 
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.HalfFloatPoint;
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
@@ -81,6 +86,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
+import static org.elasticsearch.common.network.InetAddresses.forString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class CandidateQueryTests extends ESSingleNodeTestCase {
@@ -287,6 +293,174 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         duelRun(queryStore, memoryIndex, shardSearcher);
     }
 
+    public void testRangeQueries() throws Exception {
+        List<ParseContext.Document> docs = new ArrayList<>();
+        addQuery(IntPoint.newRangeQuery("int_field", 0, 5), docs);
+        addQuery(LongPoint.newRangeQuery("long_field", 5L, 10L), docs);
+        addQuery(HalfFloatPoint.newRangeQuery("half_float_field", 10, 15), docs);
+        addQuery(FloatPoint.newRangeQuery("float_field", 15, 20), docs);
+        addQuery(DoublePoint.newRangeQuery("double_field", 20, 25), docs);
+        addQuery(InetAddressPoint.newRangeQuery("ip_field", forString("192.168.0.1"), forString("192.168.0.10")), docs);
+        indexWriter.addDocuments(docs);
+        indexWriter.close();
+        directoryReader = DirectoryReader.open(directory);
+        IndexSearcher shardSearcher = newSearcher(directoryReader);
+        shardSearcher.setQueryCache(null);
+
+        MemoryIndex memoryIndex = MemoryIndex.fromDocument(Collections.singleton(new IntPoint("int_field", 3)), new WhitespaceAnalyzer());
+        IndexSearcher percolateSearcher = memoryIndex.createSearcher();
+        Query query = fieldType.percolateQuery(queryStore, new BytesArray("{}"), percolateSearcher);
+        TopDocs topDocs = shardSearcher.search(query, 1);
+        assertEquals(1L, topDocs.totalHits);
+        assertEquals(1, topDocs.scoreDocs.length);
+        assertEquals(0, topDocs.scoreDocs[0].doc);
+
+        memoryIndex = MemoryIndex.fromDocument(Collections.singleton(new LongPoint("long_field", 7L)), new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery(queryStore, new BytesArray("{}"), percolateSearcher);
+        topDocs = shardSearcher.search(query, 1);
+        assertEquals(1L, topDocs.totalHits);
+        assertEquals(1, topDocs.scoreDocs.length);
+        assertEquals(1, topDocs.scoreDocs[0].doc);
+
+        memoryIndex = MemoryIndex.fromDocument(Collections.singleton(new HalfFloatPoint("half_float_field", 12)),
+            new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery(queryStore, new BytesArray("{}"), percolateSearcher);
+        topDocs = shardSearcher.search(query, 1);
+        assertEquals(1L, topDocs.totalHits);
+        assertEquals(1, topDocs.scoreDocs.length);
+        assertEquals(2, topDocs.scoreDocs[0].doc);
+
+        memoryIndex = MemoryIndex.fromDocument(Collections.singleton(new FloatPoint("float_field", 17)), new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery(queryStore, new BytesArray("{}"), percolateSearcher);
+        topDocs = shardSearcher.search(query, 1);
+        assertEquals(1, topDocs.totalHits);
+        assertEquals(1, topDocs.scoreDocs.length);
+        assertEquals(3, topDocs.scoreDocs[0].doc);
+
+        memoryIndex = MemoryIndex.fromDocument(Collections.singleton(new DoublePoint("double_field", 21)), new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery(queryStore, new BytesArray("{}"), percolateSearcher);
+        topDocs = shardSearcher.search(query, 1);
+        assertEquals(1, topDocs.totalHits);
+        assertEquals(1, topDocs.scoreDocs.length);
+        assertEquals(4, topDocs.scoreDocs[0].doc);
+
+        memoryIndex = MemoryIndex.fromDocument(Collections.singleton(new InetAddressPoint("ip_field",
+            forString("192.168.0.4"))), new WhitespaceAnalyzer());
+        percolateSearcher = memoryIndex.createSearcher();
+        query = fieldType.percolateQuery(queryStore, new BytesArray("{}"), percolateSearcher);
+        topDocs = shardSearcher.search(query, 1);
+        assertEquals(1, topDocs.totalHits);
+        assertEquals(1, topDocs.scoreDocs.length);
+        assertEquals(5, topDocs.scoreDocs[0].doc);
+    }
+
+    public void testDuelRangeQueries() throws Exception {
+        List<ParseContext.Document> documents = new ArrayList<>();
+
+        int lowerInt = randomIntBetween(0, 256);
+        int upperInt = lowerInt + randomIntBetween(0, 32);
+        addQuery(IntPoint.newRangeQuery("int_field", lowerInt, upperInt), documents);
+
+        long lowerLong = randomIntBetween(0, 256);
+        long upperLong = lowerLong + randomIntBetween(0, 32);
+        addQuery(LongPoint.newRangeQuery("long_field", lowerLong, upperLong), documents);
+
+        float lowerHalfFloat = randomIntBetween(0, 256);
+        float upperHalfFloat = lowerHalfFloat + randomIntBetween(0, 32);
+        addQuery(HalfFloatPoint.newRangeQuery("half_float_field", lowerHalfFloat, upperHalfFloat), documents);
+
+        float lowerFloat = randomIntBetween(0, 256);
+        float upperFloat = lowerFloat + randomIntBetween(0, 32);
+        addQuery(FloatPoint.newRangeQuery("float_field", lowerFloat, upperFloat), documents);
+
+        double lowerDouble = randomDoubleBetween(0, 256, true);
+        double upperDouble = lowerDouble + randomDoubleBetween(0, 32, true);
+        addQuery(DoublePoint.newRangeQuery("double_field", lowerDouble, upperDouble), documents);
+
+        int lowerIpPart = randomIntBetween(0, 255);
+        int upperIpPart = randomIntBetween(lowerIpPart, 255);
+        addQuery(InetAddressPoint.newRangeQuery("ip_field", forString("192.168.1." + lowerIpPart),
+            forString("192.168.1." + upperIpPart)), documents);
+
+        indexWriter.addDocuments(documents);
+        indexWriter.close();
+        directoryReader = DirectoryReader.open(directory);
+        IndexSearcher shardSearcher = newSearcher(directoryReader);
+        // Disable query cache, because ControlQuery cannot be cached...
+        shardSearcher.setQueryCache(null);
+
+        int randomInt = randomIntBetween(lowerInt, upperInt);
+        Iterable<? extends IndexableField> doc = Collections.singleton(new IntPoint("int_field", randomInt));
+        MemoryIndex memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        TopDocs result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(0));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new IntPoint("int_field", randomInt()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        long randomLong = randomIntBetween((int) lowerLong, (int) upperLong);
+        doc = Collections.singleton(new LongPoint("long_field", randomLong));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(1));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new LongPoint("long_field", randomLong()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        float randomHalfFloat = randomIntBetween((int) lowerHalfFloat, (int) upperHalfFloat);
+        doc = Collections.singleton(new HalfFloatPoint("half_float_field", randomHalfFloat));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(2));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new HalfFloatPoint("half_float_field", randomFloat()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        float randomFloat = randomIntBetween((int) lowerFloat, (int) upperFloat);
+        doc = Collections.singleton(new FloatPoint("float_field", randomFloat));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(3));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new FloatPoint("float_field", randomFloat()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        double randomDouble = randomDoubleBetween(lowerDouble, upperDouble, true);
+        doc = Collections.singleton(new DoublePoint("double_field", randomDouble));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(4));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new DoublePoint("double_field", randomFloat()));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+
+        doc = Collections.singleton(new InetAddressPoint("ip_field",
+            forString("192.168.1." + randomIntBetween(lowerIpPart, upperIpPart))));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        result = executeQuery(queryStore, memoryIndex, shardSearcher);
+        assertThat(result.scoreDocs.length, equalTo(1));
+        assertThat(result.scoreDocs[0].doc, equalTo(5));
+        duelRun(queryStore, memoryIndex, shardSearcher);
+        doc = Collections.singleton(new InetAddressPoint("ip_field",
+            forString("192.168.1." + randomIntBetween(0, 255))));
+        memoryIndex = MemoryIndex.fromDocument(doc, new WhitespaceAnalyzer());
+        duelRun(queryStore, memoryIndex, shardSearcher);
+    }
+
     private void duelRun(PercolateQuery.QueryStore queryStore, MemoryIndex memoryIndex, IndexSearcher shardSearcher) throws IOException {
         boolean requireScore = randomBoolean();
         IndexSearcher percolateSearcher = memoryIndex.createSearcher();
@@ -317,6 +491,14 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         fieldMapper.processQuery(query, parseContext);
         docs.add(parseContext.doc());
         queries.add(query);
+    }
+
+    private TopDocs executeQuery(PercolateQuery.QueryStore queryStore,
+                                 MemoryIndex memoryIndex,
+                                 IndexSearcher shardSearcher) throws IOException {
+        IndexSearcher percolateSearcher = memoryIndex.createSearcher();
+        Query percolateQuery = fieldType.percolateQuery(queryStore, new BytesArray("{}"), percolateSearcher);
+        return shardSearcher.search(percolateQuery, 10);
     }
 
     private static final class CustomQuery extends Query {


### PR DESCRIPTION
Extracts ranges from range queries on byte, short, integer, long, half_float, scaled_float, float, double, date and ip fields. byte, short, integer and date ranges are normalized to Lucene's LongRange.
half_float and float are normalized to Lucene's DoubleRange.

When extracting range queries, the QueryAnalyzer computes the width of the range.  This width is used to determine what range should be preferred in a conjunction query. The QueryAnalyzer prefers the smaller ranges, because these ranges tend to match with less documents. 

PR for #21040