### PR TITLE
Remove SearchHit#internalHits

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.search;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.ObjectObjectHashMap;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.CollectionStatistics;
 import org.apache.lucene.search.FieldDoc;
@@ -329,9 +330,9 @@ public final class SearchPhaseController extends AbstractComponent {
                         }
                         FetchSearchResult fetchResult = searchResultProvider.fetchResult();
                         final int index = fetchResult.counterGetAndIncrement();
-                        assert index < fetchResult.hits().internalHits().length : "not enough hits fetched. index [" + index + "] length: "
-                            + fetchResult.hits().internalHits().length;
-                        SearchHit hit = fetchResult.hits().internalHits()[index];
+                        assert index < fetchResult.hits().getHits().length : "not enough hits fetched. index [" + index + "] length: "
+                            + fetchResult.hits().getHits().length;
+                        SearchHit hit = fetchResult.hits().getHits()[index];
                         CompletionSuggestion.Entry.Option suggestOption =
                             suggestionOptions.get(scoreDocIndex - currentOffset);
                         hit.score(shardDoc.score);
@@ -381,9 +382,9 @@ public final class SearchPhaseController extends AbstractComponent {
                 }
                 FetchSearchResult fetchResult = fetchResultProvider.fetchResult();
                 final int index = fetchResult.counterGetAndIncrement();
-                assert index < fetchResult.hits().internalHits().length : "not enough hits fetched. index [" + index + "] length: "
-                    + fetchResult.hits().internalHits().length;
-                SearchHit searchHit = fetchResult.hits().internalHits()[index];
+                assert index < fetchResult.hits().getHits().length : "not enough hits fetched. index [" + index + "] length: "
+                    + fetchResult.hits().getHits().length;
+                SearchHit searchHit = fetchResult.hits().getHits()[index];
                 searchHit.score(shardDoc.score);
                 searchHit.shard(fetchResult.getSearchShardTarget());
                 if (sorted) {

--- a/core/src/main/java/org/elasticsearch/search/SearchHits.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchHits.java
@@ -95,10 +95,6 @@ public final class SearchHits implements Streamable, ToXContent, Iterable<Search
         return Arrays.stream(getHits()).iterator();
     }
 
-    public SearchHit[] internalHits() {
-        return this.hits;
-    }
-
     public static final class Fields {
         public static final String HITS = "hits";
         public static final String TOTAL = "total";

--- a/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsAggregator.java
@@ -33,6 +33,8 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
@@ -41,8 +43,6 @@ import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.search.fetch.FetchSearchResult;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.SubSearchContext;
 import org.elasticsearch.search.rescore.RescoreSearchContext;
@@ -165,7 +165,7 @@ public class TopHitsAggregator extends MetricsAggregator {
             subSearchContext.docIdsToLoad(docIdsToLoad, 0, docIdsToLoad.length);
             fetchPhase.execute(subSearchContext);
             FetchSearchResult fetchResult = subSearchContext.fetchResult();
-            SearchHit[] internalHits = fetchResult.fetchResult().hits().internalHits();
+            SearchHit[] internalHits = fetchResult.fetchResult().hits().getHits();
             for (int i = 0; i < internalHits.length; i++) {
                 ScoreDoc scoreDoc = topDocs.scoreDocs[i];
                 SearchHit searchHitFields = internalHits[i];

--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsFetchSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/InnerHitsFetchSubPhase.java
@@ -66,7 +66,7 @@ public final class InnerHitsFetchSubPhase implements FetchSubPhase {
                 innerHits.docIdsToLoad(docIdsToLoad, 0, docIdsToLoad.length);
                 fetchPhase.execute(innerHits);
                 FetchSearchResult fetchResult = innerHits.fetchResult();
-                SearchHit[] internalHits = fetchResult.fetchResult().hits().internalHits();
+                SearchHit[] internalHits = fetchResult.fetchResult().hits().getHits();
                 for (int j = 0; j < internalHits.length; j++) {
                     ScoreDoc scoreDoc = topDoc.scoreDocs[j];
                     SearchHit searchHitFields = internalHits[j];

--- a/core/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
@@ -350,7 +350,7 @@ public class FetchSearchPhaseTests extends ESTestCase {
         mockSearchPhaseContext.assertNoFailure();
         assertNotNull(responseRef.get());
         assertEquals(2, responseRef.get().getHits().totalHits);
-        assertEquals(1, responseRef.get().getHits().internalHits().length);
+        assertEquals(1, responseRef.get().getHits().getHits().length);
         assertEquals(84, responseRef.get().getHits().getAt(0).docId());
         assertEquals(0, responseRef.get().getFailedShards());
         assertEquals(2, responseRef.get().getSuccessfulShards());

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHitsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/tophits/InternalTopHitsTests.java
@@ -178,14 +178,14 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
             SearchHits internalHits = inputs.get(input).getHits();
             totalHits += internalHits.getTotalHits();
             maxScore = max(maxScore, internalHits.getMaxScore());
-            for (int i = 0; i < internalHits.internalHits().length; i++) {
+            for (int i = 0; i < internalHits.getHits().length; i++) {
                 ScoreDoc doc = inputs.get(input).getTopDocs().scoreDocs[i];
                 if (testInstancesLookSortedByField) {
                     doc = new FieldDoc(doc.doc, doc.score, ((FieldDoc) doc).fields, input);
                 } else {
                     doc = new ScoreDoc(doc.doc, doc.score, input);
                 }
-                allHits.add(new Tuple<>(doc, internalHits.internalHits()[i]));
+                allHits.add(new Tuple<>(doc, internalHits.getHits()[i]));
             }
         }
         allHits.sort(comparing(Tuple::v1, scoreDocComparator()));


### PR DESCRIPTION
This method does exactly what getHits() does and is used in only a few places,
so it can safely be removed. It seems to be a left-over from when
InternalSearchHits was folded into the SearchHits interface, which didn't
contain this method.