### PR TITLE
Avoid failing install if system-sysctl is masked

### DIFF
--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -49,7 +49,7 @@ esac
 
 # to pick up /usr/lib/sysctl.d/elasticsearch.conf
 if command -v systemctl > /dev/null; then
-    systemctl restart systemd-sysctl.service
+    systemctl restart systemd-sysctl.service || true
 fi
 
 if [ "x$IS_UPGRADE" != "xtrue" ]; then

--- a/qa/vagrant/src/test/resources/packaging/tests/10_systemd.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/10_systemd.bats
@@ -186,3 +186,12 @@ setup() {
 
     systemctl stop elasticsearch.service
 }
+
+@test "[SYSTEMD] masking systemd-sysctl" {
+    clean_before_test
+
+    systemctl mask systemd-sysctl.service
+    install_package
+
+    systemctl unmask systemd-sysctl.service
+}

--- a/qa/vagrant/src/test/resources/packaging/utils/utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/utils.bash
@@ -268,13 +268,16 @@ clean_before_test() {
     userdel elasticsearch > /dev/null 2>&1 || true
     groupdel elasticsearch > /dev/null 2>&1 || true
 
-
     # Removes all files
     for d in "${ELASTICSEARCH_TEST_FILES[@]}"; do
         if [ -e "$d" ]; then
             rm -rf "$d"
         fi
     done
+
+    if is_systemd; then
+        systemctl unmask systemd-sysctl.service
+    fi
 }
 
 purge_elasticsearch() {


### PR DESCRIPTION
On Debian-based systems the install scripts are run with set -e meaning that if there is an error in executing one of these scripts then the script fails. If systemd-sysctl is masked then trying to restart the systemd-sysctl service to pick up the changes to vm.max_map_count will fail leading to the post-install script failing. Instead, we should account for the possbility of failure here by not letting the command to restart this service exit with non-zero status code. This commit does this, and adds a test for this situation.

Relates #24234

