### PR TITLE
Reorder Filtered Query Examples

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -353,33 +353,8 @@ The filter cache has been renamed <<query-cache>>.
 [role="exclude",id="query-dsl-filtered-query"]
 === Filtered query
 
-The `filtered` query is replaced by the <<query-dsl-bool-query,bool>> query. Instead of
-the following:
-
-[source,js]
--------------------------
-GET _search
-{
-  "query": {
-    "filtered": {
-      "query": {
-        "match": {
-          "text": "quick brown fox"
-        }
-      },
-      "filter": {
-        "term": {
-          "status": "published"
-        }
-      }
-    }
-  }
-}
--------------------------
-// NOTCONSOLE
-
-move the query and filter to the `must` and `filter` parameters in the `bool`
-query:
+The `filtered` query is replaced by the <<query-dsl-bool-query,bool>> query.
+Move the query and filter to the `must` and `filter` parameters inside the `bool` query like so:
 
 [source,js]
 -------------------------
@@ -402,6 +377,30 @@ GET _search
 }
 -------------------------
 // CONSOLE
+
+The old, deprecated syntax for this query would have been the following:
+
+[source,js]
+-------------------------
+GET _search
+{
+  "query": {
+    "filtered": {
+      "query": {
+        "match": {
+          "text": "quick brown fox"
+        }
+      },
+      "filter": {
+        "term": {
+          "status": "published"
+        }
+      }
+    }
+  }
+}
+-------------------------
+// NOTCONSOLE
 
 [role="exclude",id="query-dsl-or-query"]
 === Or query

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -353,8 +353,34 @@ The filter cache has been renamed <<query-cache>>.
 [role="exclude",id="query-dsl-filtered-query"]
 === Filtered query
 
-The `filtered` query is replaced by the <<query-dsl-bool-query,bool>> query.
-Move the query and filter to the `must` and `filter` parameters inside the `bool` query like so:
+The `filtered` query is replaced by the <<query-dsl-bool-query,bool>> query. Instead of
+the following:
+
+[source,js]
+-------------------------
+## INCORRECT - DEPRECATED SYNTAX, DO NOT USE
+GET _search
+{
+  "query": {
+    "filtered": {
+      "query": {
+        "match": {
+          "text": "quick brown fox"
+        }
+      },
+      "filter": {
+        "term": {
+          "status": "published"
+        }
+      }
+    }
+  }
+}
+-------------------------
+// NOTCONSOLE
+
+move the query and filter to the `must` and `filter` parameters in the `bool`
+query:
 
 [source,js]
 -------------------------
@@ -377,30 +403,6 @@ GET _search
 }
 -------------------------
 // CONSOLE
-
-The old, deprecated syntax for this query would have been the following:
-
-[source,js]
--------------------------
-GET _search
-{
-  "query": {
-    "filtered": {
-      "query": {
-        "match": {
-          "text": "quick brown fox"
-        }
-      },
-      "filter": {
-        "term": {
-          "status": "published"
-        }
-      }
-    }
-  }
-}
--------------------------
-// NOTCONSOLE
 
 [role="exclude",id="query-dsl-or-query"]
 === Or query


### PR DESCRIPTION
The Filtered Query has been deprecated in favor of the Bool Query with a filter context. However, this deleted page for the Filtered Query is often ranked highly in search results when searching for documentation on "filtered queries". Often people just copy the first code snippet they see, which in this case is the INCORRECT syntax (the correct syntax follows). I think reordering the examples would help avoid a lot of confusion (I have seen people make this same mistake 3 times now)
