### PR TITLE
Setup: Change default heap to 1G

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -495,7 +495,7 @@ task run(type: RunTask) {
  * </dl>
  */
 Map<String, String> expansionsForDistribution(distributionType) {
-  final String defaultHeapSize = "2g"
+  final String defaultHeapSize = "1g"
   final String packagingPathData = "path.data: /var/lib/elasticsearch"
   final String packagingPathLogs = "path.logs: /var/log/elasticsearch"
 

--- a/docs/reference/setup/sysconfig/heap_size.asciidoc
+++ b/docs/reference/setup/sysconfig/heap_size.asciidoc
@@ -2,7 +2,7 @@
 === Set JVM heap size via jvm.options
 
 By default, Elasticsearch tells the JVM to use a heap with a minimum
-and maximum size of 2 GB. When moving to production, it is
+and maximum size of 1 GB. When moving to production, it is
 important to configure heap size to ensure that Elasticsearch has enough
 heap available.
 


### PR DESCRIPTION
This commit changes the default heap size to 1 GB. Experimenting with
elasticsearch is often done on laptops, and 1 GB is much friendlier to
laptop memory. It does put more pressure on gc, but the tradeoff is
a smaller default footprint. Users running in production can (and
should) adjust the heap size as necessary for their usecase.
