### PR TITLE
[DOCS] Remove ambiguity from compared aggregation SQL

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -1092,7 +1092,7 @@ In SQL, the above aggregation is similar in concept to:
 
 [source,sh]
 --------------------------------------------------
-SELECT state, COUNT(*) FROM bank GROUP BY state ORDER BY COUNT(*) DESC
+SELECT bank.`state.keyword`, COUNT(*) FROM bank GROUP BY bank.`state.keyword` ORDER BY COUNT(*) DESC LIMIT 10
 --------------------------------------------------
 
 And the response (partially shown):


### PR DESCRIPTION
I would like to remove ambiguity from document.

* Fix target column from `state` to `state.keyword`.
* Also, add implicit `LIMIT 10` to SQL.