### PR TITLE
Fix indices options parsing from REST in delete index API

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/core/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -141,17 +141,11 @@ public class IndicesOptions {
     }
 
     public static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices, boolean expandToClosedIndices) {
-        return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, true, false);
+        return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, true, false, false);
     }
 
     public static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices, boolean expandToClosedIndices, IndicesOptions defaultOptions) {
-        return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, defaultOptions.allowAliasesToMultipleIndices(), defaultOptions.forbidClosedIndices());
-    }
-
-    public static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices,
-            boolean expandToClosedIndices, boolean allowAliasesToMultipleIndices, boolean forbidClosedIndices) {
-        return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, allowAliasesToMultipleIndices,
-                forbidClosedIndices, false);
+        return fromOptions(ignoreUnavailable, allowNoIndices, expandToOpenIndices, expandToClosedIndices, defaultOptions.allowAliasesToMultipleIndices(), defaultOptions.forbidClosedIndices(), defaultOptions.ignoreAliases());
     }
 
     public static IndicesOptions fromOptions(boolean ignoreUnavailable, boolean allowNoIndices, boolean expandToOpenIndices,
@@ -223,7 +217,8 @@ public class IndicesOptions {
                 expandWildcardsOpen,
                 expandWildcardsClosed,
                 defaultSettings.allowAliasesToMultipleIndices(),
-                defaultSettings.forbidClosedIndices()
+                defaultSettings.forbidClosedIndices(),
+                defaultSettings.ignoreAliases()
         );
     }
 

--- a/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -60,29 +60,82 @@ public class IndicesOptionsTests extends ESTestCase {
     }
 
     public void testFromOptions() {
-        int iterations = randomIntBetween(5, 20);
-        for (int i = 0; i < iterations; i++) {
-            boolean ignoreUnavailable = randomBoolean();
-            boolean allowNoIndices = randomBoolean();
-            boolean expandToOpenIndices = randomBoolean();
-            boolean expandToClosedIndices = randomBoolean();
-            boolean allowAliasesToMultipleIndices = randomBoolean();
-            boolean forbidClosedIndices = randomBoolean();
-            boolean ignoreAliases = randomBoolean();
+        boolean ignoreUnavailable = randomBoolean();
+        boolean allowNoIndices = randomBoolean();
+        boolean expandToOpenIndices = randomBoolean();
+        boolean expandToClosedIndices = randomBoolean();
+        boolean allowAliasesToMultipleIndices = randomBoolean();
+        boolean forbidClosedIndices = randomBoolean();
+        boolean ignoreAliases = randomBoolean();
 
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(
-                    ignoreUnavailable, allowNoIndices,expandToOpenIndices, expandToClosedIndices,
-                    allowAliasesToMultipleIndices, forbidClosedIndices, ignoreAliases
-            );
+        IndicesOptions indicesOptions = IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices,expandToOpenIndices,
+                expandToClosedIndices, allowAliasesToMultipleIndices, forbidClosedIndices, ignoreAliases);
 
-            assertThat(indicesOptions.ignoreUnavailable(), equalTo(ignoreUnavailable));
-            assertThat(indicesOptions.allowNoIndices(), equalTo(allowNoIndices));
-            assertThat(indicesOptions.expandWildcardsOpen(), equalTo(expandToOpenIndices));
-            assertThat(indicesOptions.expandWildcardsClosed(), equalTo(expandToClosedIndices));
-            assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
-            assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
-            assertThat(indicesOptions.forbidClosedIndices(), equalTo(forbidClosedIndices));
-            assertEquals(ignoreAliases, indicesOptions.ignoreAliases());
+        assertThat(indicesOptions.ignoreUnavailable(), equalTo(ignoreUnavailable));
+        assertThat(indicesOptions.allowNoIndices(), equalTo(allowNoIndices));
+        assertThat(indicesOptions.expandWildcardsOpen(), equalTo(expandToOpenIndices));
+        assertThat(indicesOptions.expandWildcardsClosed(), equalTo(expandToClosedIndices));
+        assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
+        assertThat(indicesOptions.allowAliasesToMultipleIndices(), equalTo(allowAliasesToMultipleIndices));
+        assertThat(indicesOptions.forbidClosedIndices(), equalTo(forbidClosedIndices));
+        assertEquals(ignoreAliases, indicesOptions.ignoreAliases());
+    }
+
+    public void testFromOptionsWithDefaultOptions() {
+        boolean ignoreUnavailable = randomBoolean();
+        boolean allowNoIndices = randomBoolean();
+        boolean expandToOpenIndices = randomBoolean();
+        boolean expandToClosedIndices = randomBoolean();
+
+        IndicesOptions defaultOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(),
+                randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+
+        IndicesOptions indicesOptions = IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices,expandToOpenIndices,
+                expandToClosedIndices, defaultOptions);
+
+        assertEquals(ignoreUnavailable, indicesOptions.ignoreUnavailable());
+        assertEquals(allowNoIndices, indicesOptions.allowNoIndices());
+        assertEquals(expandToOpenIndices, indicesOptions.expandWildcardsOpen());
+        assertEquals(expandToClosedIndices, indicesOptions.expandWildcardsClosed());
+        assertEquals(defaultOptions.allowAliasesToMultipleIndices(), indicesOptions.allowAliasesToMultipleIndices());
+        assertEquals(defaultOptions.forbidClosedIndices(), indicesOptions.forbidClosedIndices());
+        assertEquals(defaultOptions.ignoreAliases(), indicesOptions.ignoreAliases());
+    }
+
+    public void testFromParameters() {
+        boolean expandWildcardsOpen = randomBoolean();
+        boolean expandWildcardsClosed = randomBoolean();
+        String expandWildcardsString;
+        if (expandWildcardsOpen && expandWildcardsClosed) {
+            if (randomBoolean()) {
+                expandWildcardsString = "open,closed";
+            } else {
+                expandWildcardsString = "all";
+            }
+        } else if (expandWildcardsOpen) {
+            expandWildcardsString = "open";
+        } else if (expandWildcardsClosed) {
+            expandWildcardsString = "closed";
+        } else {
+            expandWildcardsString = "none";
         }
+        boolean ignoreUnavailable = randomBoolean();
+        String ignoreUnavailableString = Boolean.toString(ignoreUnavailable);
+        boolean allowNoIndices = randomBoolean();
+        String allowNoIndicesString = Boolean.toString(allowNoIndices);
+
+        IndicesOptions defaultOptions = IndicesOptions.fromOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(),
+                randomBoolean(), randomBoolean(), randomBoolean());
+
+        IndicesOptions updatedOptions = IndicesOptions.fromParameters(expandWildcardsString, ignoreUnavailableString,
+                allowNoIndicesString, defaultOptions);
+
+        assertEquals(expandWildcardsOpen, updatedOptions.expandWildcardsOpen());
+        assertEquals(expandWildcardsClosed, updatedOptions.expandWildcardsClosed());
+        assertEquals(ignoreUnavailable, updatedOptions.ignoreUnavailable());
+        assertEquals(allowNoIndices, updatedOptions.allowNoIndices());
+        assertEquals(defaultOptions.allowAliasesToMultipleIndices(), updatedOptions.allowAliasesToMultipleIndices());
+        assertEquals(defaultOptions.forbidClosedIndices(), updatedOptions.forbidClosedIndices());
+        assertEquals(defaultOptions.ignoreAliases(), updatedOptions.ignoreAliases());
     }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -20,6 +20,20 @@
         "master_timeout": {
           "type" : "time",
           "description" : "Specify timeout for connection to master"
+        },
+        "ignore_unavailable": {
+          "type": "boolean",
+          "description": "Ignore unavailable indexes (default: false)"
+        },
+        "allow_no_indices": {
+          "type": "boolean",
+          "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
+        },
+        "expand_wildcards": {
+          "type": "enum",
+          "options": [ "open", "closed", "none", "all" ],
+          "default": "open",
+          "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/10_basic.yml
@@ -33,9 +33,6 @@ setup:
         ignore_unavailable: true
   - do:
       indices.get:
-        index: index
-  - do:
-      indices.get:
         index: index,index2
   - is_true: index
   - is_true: index2
@@ -76,10 +73,6 @@ setup:
   - do:
       indices.delete:
         index: alia*
-
-  - do:
-      indices.get:
-        index: index
   - do:
       indices.get:
         index: index,index2
@@ -110,9 +103,6 @@ setup:
         index: alia*,index2
   - do:
       indices.get:
-        index: index
-  - do:
-      indices.get:
         index: index,index2
         ignore_unavailable: true
   - is_true: index
@@ -127,7 +117,6 @@ setup:
       indices.delete:
         index: index2,alia*
         allow_no_indices: false
-
   - do:
       indices.get:
         index: index,index2

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/10_basic.yml
@@ -1,0 +1,133 @@
+setup:
+  - do:
+      indices.create:
+        index: index
+        body:
+          aliases:
+            alias: {}
+  - do:
+      indices.create:
+        index: index2
+---
+"Delete index against alias":
+
+  - do:
+      catch: missing
+      indices.delete:
+        index: alias
+
+  - do:
+      indices.get:
+        index: index,index2
+  - is_true: index
+  - is_true: index2
+
+---
+"Delete index against alias - ignore unavailable":
+
+  - do:
+      indices.delete:
+        index: alias
+        ignore_unavailable: true
+
+  - do:
+      indices.get:
+        index: index
+  - do:
+      indices.get:
+        index: index,index2
+  - is_true: index
+  - is_true: index2
+
+---
+"Delete index against alias -  multiple indices":
+
+  - do:
+      catch: missing
+      indices.delete:
+        index: alias,index2
+
+  - do:
+      indices.get:
+        index: index,index2
+  - is_true: index
+  - is_true: index2
+
+---
+"Delete index against alias -  ignore unavailable - multiple indices":
+
+  - do:
+      indices.delete:
+        index: alias,index2
+        ignore_unavailable: true
+
+  - do:
+      indices.get:
+        index: index,index2
+        ignore_unavailable: true
+  - is_true: index
+  - is_false: index2
+
+---
+"Delete index against wildcard matching alias":
+
+  - do:
+      indices.delete:
+        index: alia*
+
+  - do:
+      indices.get:
+        index: index
+  - do:
+      indices.get:
+        index: index,index2
+  - is_true: index
+  - is_true: index2
+
+---
+"Delete index against wildcard matching alias - disallow no indices":
+
+  - do:
+      catch: missing
+      indices.delete:
+        index: alia*
+        allow_no_indices: false
+
+  - do:
+      indices.get:
+        index: index,index2
+  - is_true: index
+  - is_true: index2
+
+---
+"Delete index against wildcard matching alias - multiple indices":
+
+  - do:
+      indices.delete:
+        index: alia*,index2
+
+  - do:
+      indices.get:
+        index: index
+  - do:
+      indices.get:
+        index: index,index2
+        ignore_unavailable: true
+  - is_true: index
+  - is_false: index2
+
+---
+"Delete index against wildcard matching alias - disallow no indices - multiple indices":
+
+  - do:
+      catch: missing
+      indices.delete:
+        index: index2,alia*
+        allow_no_indices: false
+
+  - do:
+      indices.get:
+        index: index,index2
+  - is_true: index
+  - is_true: index2
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.delete/10_basic.yml
@@ -10,26 +10,27 @@ setup:
         index: index2
 ---
 "Delete index against alias":
-
+  - skip:
+      version: " - 5.99.0"
+      reason: delete index doesn't support aliases only from 6.0.0 on
   - do:
       catch: missing
       indices.delete:
         index: alias
-
   - do:
       indices.get:
         index: index,index2
   - is_true: index
   - is_true: index2
-
 ---
 "Delete index against alias - ignore unavailable":
-
+  - skip:
+      version: " - 5.99.0"
+      reason: delete index doesn't support aliases only from 6.0.0 on
   - do:
       indices.delete:
         index: alias
         ignore_unavailable: true
-
   - do:
       indices.get:
         index: index
@@ -38,39 +39,40 @@ setup:
         index: index,index2
   - is_true: index
   - is_true: index2
-
 ---
 "Delete index against alias -  multiple indices":
-
+  - skip:
+      version: " - 5.99.0"
+      reason: delete index doesn't support aliases only from 6.0.0 on
   - do:
       catch: missing
       indices.delete:
         index: alias,index2
-
   - do:
       indices.get:
         index: index,index2
   - is_true: index
   - is_true: index2
-
 ---
 "Delete index against alias -  ignore unavailable - multiple indices":
-
+  - skip:
+      version: " - 5.99.0"
+      reason: delete index doesn't support aliases only from 6.0.0 on
   - do:
       indices.delete:
         index: alias,index2
         ignore_unavailable: true
-
   - do:
       indices.get:
         index: index,index2
         ignore_unavailable: true
   - is_true: index
   - is_false: index2
-
 ---
 "Delete index against wildcard matching alias":
-
+  - skip:
+      version: " - 5.99.0"
+      reason: delete index doesn't support aliases only from 6.0.0 on
   - do:
       indices.delete:
         index: alia*
@@ -83,29 +85,29 @@ setup:
         index: index,index2
   - is_true: index
   - is_true: index2
-
 ---
 "Delete index against wildcard matching alias - disallow no indices":
-
+  - skip:
+      version: " - 5.99.0"
+      reason: delete index doesn't support aliases only from 6.0.0 on
   - do:
       catch: missing
       indices.delete:
         index: alia*
         allow_no_indices: false
-
   - do:
       indices.get:
         index: index,index2
   - is_true: index
   - is_true: index2
-
 ---
 "Delete index against wildcard matching alias - multiple indices":
-
+  - skip:
+      version: " - 5.99.0"
+      reason: delete index doesn't support aliases only from 6.0.0 on
   - do:
       indices.delete:
         index: alia*,index2
-
   - do:
       indices.get:
         index: index
@@ -115,10 +117,11 @@ setup:
         ignore_unavailable: true
   - is_true: index
   - is_false: index2
-
 ---
 "Delete index against wildcard matching alias - disallow no indices - multiple indices":
-
+  - skip:
+      version: " - 5.99.0"
+      reason: delete index doesn't support aliases only from 6.0.0 on
   - do:
       catch: missing
       indices.delete:
@@ -130,4 +133,3 @@ setup:
         index: index,index2
   - is_true: index
   - is_true: index2
-


### PR DESCRIPTION
When parsing indices options from REST, we parse the optional parameters that are supported at REST (ignore_unavailable, allow_no_indices and expand_wildcards) and we provide the API default values for all the other (internal) options so that they are set to the new indices options while parsing. The `ignoreAliases` option was forgotten though, which means that whenever you pass in any index option at REST to the delete index API, you get to delete aliases like it was supported before (as ignoreAliases gets set to false like in all the other APIs).

Added unit tests for IndicesOptions parsing from REST parameters, and yaml tests for the delete index API.

I labelled this PR non-issue as this bug has fortunately not yet been released.