### PR TITLE
incorrect painless script sample

### DIFF
--- a/docs/painless/painless-getting-started.asciidoc
+++ b/docs/painless/painless-getting-started.asciidoc
@@ -55,7 +55,7 @@ GET hockey/_search
       "script_score": {
         "script": {
           "lang": "painless",
-          "source": "int total = 0; for (int i = 0; i < doc['goals'].length; ++i) { total += doc['goals'][i]; } return total;"
+          "inline": "int total = 0; for (int i = 0; i < doc['goals'].length; ++i) { total += doc['goals'][i]; } return total;"
         }
       }
     }
@@ -77,7 +77,7 @@ GET hockey/_search
     "total_goals": {
       "script": {
         "lang": "painless",
-        "source": "int total = 0; for (int i = 0; i < doc['goals'].length; ++i) { total += doc['goals'][i]; } return total;"
+        "inline": "int total = 0; for (int i = 0; i < doc['goals'].length; ++i) { total += doc['goals'][i]; } return total;"
       }
     }
   }
@@ -101,7 +101,7 @@ GET hockey/_search
       "order": "asc",
       "script": {
         "lang": "painless",
-        "source": "doc['first.keyword'].value + ' ' + doc['last.keyword'].value"
+        "inline": "doc['first.keyword'].value + ' ' + doc['last.keyword'].value"
       }
     }
   }
@@ -189,7 +189,7 @@ GET hockey/_search
   "script_fields": {
     "birth_year": {
       "script": {
-        "source": "doc.born.value.year"
+        "inline": "doc.born.value.year"
       }
     }
   }
@@ -230,7 +230,7 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "if (ctx._source.last =~ /b/) {ctx._source.last += \"matched\"} else {ctx.op = 'noop'}"
+    "inline": "if (ctx._source.last =~ /b/) {ctx._source.last += \"matched\"} else {ctx.op = 'noop'}"
   }
 }
 ----------------------------------------------------------------
@@ -245,7 +245,7 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "if (ctx._source.last ==~ /[^aeiou].*[aeiou]/) {ctx._source.last += \"matched\"} else {ctx.op = 'noop'}"
+    "inline": "if (ctx._source.last ==~ /[^aeiou].*[aeiou]/) {ctx._source.last += \"matched\"} else {ctx.op = 'noop'}"
   }
 }
 ----------------------------------------------------------------
@@ -260,7 +260,7 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "ctx._source.last = /[aeiou]/.matcher(ctx._source.last).replaceAll('')"
+    "inline": "ctx._source.last = /[aeiou]/.matcher(ctx._source.last).replaceAll('')"
   }
 }
 ----------------------------------------------------------------
@@ -276,7 +276,7 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "ctx._source.last = /n([aeiou])/.matcher(ctx._source.last).replaceAll('$1')"
+    "inline": "ctx._source.last = /n([aeiou])/.matcher(ctx._source.last).replaceAll('$1')"
   }
 }
 ----------------------------------------------------------------
@@ -298,7 +298,7 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "ctx._source.last = ctx._source.last.replaceAll(/[aeiou]/, m -> m.group().toUpperCase(Locale.ROOT))"
+    "inline": "ctx._source.last = ctx._source.last.replaceAll(/[aeiou]/, m -> m.group().toUpperCase(Locale.ROOT))"
   }
 }
 ----------------------------------------------------------------
@@ -313,7 +313,7 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "ctx._source.last = ctx._source.last.replaceFirst(/[aeiou]/, m -> m.group().toUpperCase(Locale.ROOT))"
+    "inline": "ctx._source.last = ctx._source.last.replaceFirst(/[aeiou]/, m -> m.group().toUpperCase(Locale.ROOT))"
   }
 }
 ----------------------------------------------------------------


### PR DESCRIPTION
The samples in which script block referring to "source" should be changed to "inline".

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
