### PR TITLE
Corrected HTTP method from GET to POST

### DIFF
--- a/docs/reference/query-dsl/match-query.asciidoc
+++ b/docs/reference/query-dsl/match-query.asciidoc
@@ -7,7 +7,7 @@ them, and constructs a query. For example:
 
 [source,js]
 --------------------------------------------------
-GET /_search
+POST /_search
 {
     "query": {
         "match" : {
@@ -61,7 +61,7 @@ change in structure, `message` is the field name):
 
 [source,js]
 --------------------------------------------------
-GET /_search
+POST /_search
 {
     "query": {
         "match" : {
@@ -84,7 +84,7 @@ change that the `zero_terms_query` option can be used, which accepts
 
 [source,js]
 --------------------------------------------------
-GET /_search
+POST /_search
 {
     "query": {
         "match" : {
@@ -125,7 +125,7 @@ Here is an example showing a query composed of stopwords exclusively:
 
 [source,js]
 --------------------------------------------------
-GET /_search
+POST /_search
 {
     "query": {
         "match" : {


### PR DESCRIPTION
HTTP get method is not supposed to contain JSON body. The method required by Elasticsearch should have been POST. I have tested  POST method using Postman and the query executed but Postman doesnot shows an option to use JSON data with Get request. That GET caused me a lot of trouble and I mean it.
