### PR TITLE
Sync the API definition for put_script with the docs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
@@ -3,8 +3,8 @@
     "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-scripting.html",
     "methods": ["PUT", "POST"],
     "url": {
-      "path": "/_scripts/{lang}",
-      "paths": [ "/_scripts/{lang}", "/_scripts/{lang}/{id}" ],
+      "path": "/_scripts/{id}",
+      "paths": [ "/_scripts/{lang}/{id}" ],
       "parts": {
         "id": {
           "type" : "string",
@@ -13,8 +13,7 @@
         },
         "lang" : {
           "type" : "string",
-          "description" : "Script language",
-          "required" : true
+          "description" : "Script language"
         }
       },
       "params" : {


### PR DESCRIPTION
According to the docs (0) the `lang` portion of the URL is not required, also it only 1 parameter is supplied, it should be the `id`, not `lang`.

0 - https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-using.html#_request_examples