### PR TITLE
[DOCS] add links to javadoc in clients docs pages

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -27,11 +27,19 @@ Javadoc roots used to generate links from Painless's API reference
 
 ifeval::["{release-state}"=="unreleased"]
 :elasticsearch-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}-SNAPSHOT
+:transport-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/transport/{version}-SNAPSHOT
+:rest-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/{version}-SNAPSHOT
+:rest-client-sniffer-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client-sniffer/{version}-SNAPSHOT
+:rest-high-level-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-high-level-client/{version}-SNAPSHOT
 :painless-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/painless/lang-painless/{version}-SNAPSHOT
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 :elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}
+:transport-client-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/transport/{version}-SNAPSHOT
+:rest-client-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/{version}-SNAPSHOT
+:rest-client-sniffer-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client-sniffer/{version}-SNAPSHOT
+:rest-high-level-client-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-high-level-client/{version}-SNAPSHOT
 :painless-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/painless/lang-painless/{version}
 endif::[]
 

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -17,6 +17,9 @@ Additionally, operations on a client may be accumulated and executed in
 Note, all the APIs are exposed through the
 Java API (actually, the Java API is used internally to execute them).
 
+== Javadoc
+
+The javadoc for the transport client can be found at {transport-client-javadoc}/index.html.
 
 == Maven Repository
 

--- a/docs/java-rest/high-level/usage.asciidoc
+++ b/docs/java-rest/high-level/usage.asciidoc
@@ -4,6 +4,11 @@
 This section describes how to get started with the high-level REST client from
 getting the artifact to using it in an application.
 
+[[java-rest-high-javadoc]]
+=== Javadoc
+
+The javadoc for the REST high level client can be found at {rest-high-level-client-javadoc}/index.html.
+
 [[java-rest-high-usage-maven]]
 === Maven Repository
 

--- a/docs/java-rest/low-level/sniffer.asciidoc
+++ b/docs/java-rest/low-level/sniffer.asciidoc
@@ -8,9 +8,14 @@ Nodes Info api and uses jackson to parse the obtained json response.
 
 Compatible with Elasticsearch 2.x and onwards.
 
+[[java-rest-sniffer-javadoc]]
+=== Javadoc
+
+The javadoc for the REST client sniffer can be found at {rest-client-sniffer-javadoc}/index.html.
+
 === Maven Repository
 
-The low-level REST client is subject to the same release cycle as
+The REST client sniffer is subject to the same release cycle as
 elasticsearch. Replace the version with the desired sniffer version, first
 released with `5.0.0-alpha4`. There is no relation between the sniffer version
 and the elasticsearch version that the client can communicate with. Sniffer

--- a/docs/java-rest/low-level/usage.asciidoc
+++ b/docs/java-rest/low-level/usage.asciidoc
@@ -4,6 +4,11 @@
 This section describes how to get started with the low-level REST client from
 getting the artifact to using it in an application.
 
+[[java-rest-low-javadoc]]
+=== Javadoc
+
+The javadoc for the low level REST client can be found at {rest-client-javadoc}/index.html.
+
 [[java-rest-low-usage-maven]]
 === Maven Repository
 


### PR DESCRIPTION
We have been publishing javadoc to artifacts.elastic.co (and snapshots.elastic.co) for a while. This commit adds the link to them to the transport client, low level REST client, sniffer and high level REST client pages.

Closes #23761