### PR TITLE
Use concrete version for BWC checks in SearchTransportService

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -105,7 +105,7 @@ public class SearchTransportService extends AbstractComponent {
 
     public void sendCanMatch(Transport.Connection connection, final ShardSearchTransportRequest request, SearchTask task, final
                             ActionListener<CanMatchResponse> listener) {
-        if (connection.getNode().getVersion().onOrAfter(Version.CURRENT.minimumCompatibilityVersion())) {
+        if (connection.getNode().getVersion().onOrAfter(Version.V_5_6_0)) {
             transportService.sendChildRequest(connection, QUERY_CAN_MATCH_NAME, request, task,
                 TransportRequestOptions.EMPTY, new ActionListenerResponseHandler<>(listener, CanMatchResponse::new));
         } else {
@@ -114,8 +114,7 @@ public class SearchTransportService extends AbstractComponent {
             // instead of sending the request we shortcut it here and let the caller deal with this -- see #25704
             // also failing the request instead of returning a fake answer might trigger a retry on a replica which might be on a
             // compatible node
-            throw new IllegalArgumentException("can_match is not supported on pre "+ Version.CURRENT.minimumCompatibilityVersion() +
-                " nodes");
+            throw new IllegalArgumentException("can_match is not supported on pre 5.6 nodes");
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -106,13 +106,12 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
     public void testOldNodesTriggerException() {
         SearchTransportService searchTransportService = new SearchTransportService(
             Settings.builder().put("search.remote.connect", false).build(), null);
-        DiscoveryNode node = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), VersionUtils.getPreviousVersion(Version
-            .CURRENT.minimumCompatibilityVersion()));
+        DiscoveryNode node = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), VersionUtils.randomVersionBetween(random(),
+            VersionUtils.getFirstVersion(), VersionUtils.getPreviousVersion(Version.V_5_6_0)));
         SearchAsyncActionTests.MockConnection mockConnection = new SearchAsyncActionTests.MockConnection(node);
         IllegalArgumentException illegalArgumentException = expectThrows(IllegalArgumentException.class,
             () -> searchTransportService.sendCanMatch(mockConnection, null, null, null));
-        assertEquals("can_match is not supported on pre " + Version
-            .CURRENT.minimumCompatibilityVersion() + " nodes", illegalArgumentException.getMessage());
+        assertEquals("can_match is not supported on pre 5.6 nodes", illegalArgumentException.getMessage());
     }
 
     public void testFilterWithFailure() throws InterruptedException {


### PR DESCRIPTION
We used to compare against the min compatible version which is misleading since
it might move over time and since we back-ported the `can_match` API entirely
it's better to compare against a version constant.

