### PR TITLE
IndexClosedException to return 400 rather than 403

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/IndexClosedException.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndexClosedException.java
@@ -42,6 +42,6 @@ public class IndexClosedException extends ElasticsearchException {
 
     @Override
     public RestStatus status() {
-        return RestStatus.FORBIDDEN;
+        return RestStatus.BAD_REQUEST;
     }
 }

--- a/docs/reference/migration/migrate_6_0/rest.asciidoc
+++ b/docs/reference/migration/migrate_6_0/rest.asciidoc
@@ -107,8 +107,15 @@ $ curl -v -XPOST 'localhost:9200/my_index/_settings'
 * Connection #0 to host localhost left intact
 --------------------------------------------
 
-==== Dissallow using `_cache` and `_cache_key`
+==== Disallow using `_cache` and `_cache_key`
 
 The `_cache` and `_cache_key` options in queries have been deprecated since version 2.0.0 and
 have been ignored since then, issuing a deprecation warning. These options have now been completely
 removed, so using them now will throw an error.
+
+==== IndexClosedException to return 400 status code
+
+An `IndexClosedException` is returned whenever an api that doesn't support
+closed indices (e.g. search) is called passing closed indices as parameters
+and `ignore_unavailable` is set to `false`. The response status code returned
+in such case changed from `403` to `400`

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
@@ -99,7 +99,7 @@
         index: index1
 
   - do:
-      catch: forbidden
+      catch: request
       cat.segments:
         index: index1
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.segments/10_basic.yml
@@ -86,6 +86,10 @@
 ---
 "Test cat segments on closed index behaviour":
 
+  - skip:
+      version: " - 5.99.99"
+      reason:  status code  on closed indices changed in 6.0.0 from 403 to 400
+
   - do:
       indices.create:
         index: index1

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -1,5 +1,9 @@
 ---
 "Basic test for index open/close":
+  - skip:
+      version: " - 5.99.99"
+      reason:  status code  on closed indices changed in 6.0.0 from 403 to 400
+
   - do:
       indices.create:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -16,7 +16,7 @@
         index: test_index
 
   - do:
-      catch: forbidden
+      catch: request
       search:
         index: test_index
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
@@ -28,7 +28,7 @@ setup:
         index: _all
 
   - do:
-      catch: forbidden
+      catch: request
       search:
         index: test_index2
 
@@ -51,7 +51,7 @@ setup:
         index: test_*
 
   - do:
-      catch: forbidden
+      catch: request
       search:
         index: test_index2
 
@@ -74,7 +74,7 @@ setup:
         index: '*'
 
   - do:
-      catch: forbidden
+      catch: request
       search:
         index: test_index3
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
@@ -23,6 +23,10 @@ setup:
 
 ---
 "All indices":
+  - skip:
+      version: " - 5.99.99"
+      reason:  status code  on closed indices changed in 6.0.0 from 403 to 400
+
   - do:
       indices.close:
         index: _all
@@ -46,6 +50,10 @@ setup:
 
 ---
 "Trailing wildcard":
+  - skip:
+      version: " - 5.99.99"
+      reason:  status code  on closed indices changed in 6.0.0 from 403 to 400
+
   - do:
       indices.close:
         index: test_*
@@ -69,6 +77,10 @@ setup:
 
 ---
 "Only wildcard":
+  - skip:
+      version: " - 5.99.99"
+      reason:  status code  on closed indices changed in 6.0.0 from 403 to 400
+
   - do:
       indices.close:
         index: '*'

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
@@ -43,6 +43,9 @@
 
 ---
 "closed segments test":
+  - skip:
+      version: " - 5.99.99"
+      reason:  status code  on closed indices changed in 6.0.0 from 403 to 400
 
   - do:
       indices.create:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.segments/10_basic.yml
@@ -63,7 +63,7 @@
         index: index1
 
   - do:
-      catch: forbidden
+      catch: request
       indices.segments:
           index: index1
 


### PR DESCRIPTION
`IndexClosedException` is thrown whenever an API that doesn't support closed indices (e.g. search) is called passing closed indices as parameters and `ignore_unavailable` is set to `false`. As a result, an error is returned to users. The response status code currently is 403 as closed indices are forbidden in that specific context, but 400 seems more appropriate as effectively the request is malformed and the error doesn't have anything to do with security / required accounts.