### PR TITLE
Deprecate omitting terms lookup index name in 5.6

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/TermsQueryBuilder.java
@@ -37,6 +37,8 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -64,6 +66,7 @@ import java.util.stream.IntStream;
 public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
     public static final String NAME = "terms";
     public static final ParseField QUERY_NAME_FIELD = new ParseField(NAME, "in");
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(TermsQueryBuilder.class));
 
     private final String fieldName;
     private final List<?> values;
@@ -474,6 +477,7 @@ public class TermsQueryBuilder extends AbstractQueryBuilder<TermsQueryBuilder> {
         if (this.termsLookup != null) {
             TermsLookup termsLookup = new TermsLookup(this.termsLookup);
             if (termsLookup.index() == null) { // TODO this should go away?
+                DEPRECATION_LOGGER.deprecated("Omitting the index in terms lookup is deprecated");
                 if (queryRewriteContext.getIndexSettings() != null) {
                     termsLookup.index(queryRewriteContext.getIndexSettings().getIndex().getName());
                 } else {

--- a/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -280,6 +280,12 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
             randomTerms.stream().filter(x -> x != null).collect(Collectors.toList()))); // terms lookup removes null values
     }
 
+    public void testNullIndexIsDeprecated() throws IOException {
+        TermsQueryBuilder termsQueryBuilder = new TermsQueryBuilder(STRING_FIELD_NAME, new TermsLookup(null, "foo", "bar", "baz"));
+        termsQueryBuilder.rewrite(createShardContext());
+        assertWarnings("Omitting the index in terms lookup is deprecated");
+    }
+
     public void testGeo() throws Exception {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         TermsQueryBuilder query = new TermsQueryBuilder(GEO_POINT_FIELD_NAME, "2,3");

--- a/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/TermsQueryBuilderTests.java
@@ -93,7 +93,7 @@ public class TermsQueryBuilderTests extends AbstractQueryTestCase<TermsQueryBuil
     }
 
     private TermsLookup randomTermsLookup() {
-        return new TermsLookup(randomBoolean() ? randomAlphaOfLength(10) : null, randomAlphaOfLength(10), randomAlphaOfLength(10),
+        return new TermsLookup(randomAlphaOfLength(10), randomAlphaOfLength(10), randomAlphaOfLength(10),
                 termsPath).routing(randomBoolean() ? randomAlphaOfLength(10) : null);
     }
 

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -38,7 +38,8 @@ The terms lookup mechanism supports the following options:
 [horizontal]
 `index`::
     The index to fetch the term values from. Defaults to the
-    current index. Note, omitting the index is deprecated future version will require the index to be set explicitly.
+    current index. deprecated[5.6.0, omitting the index is deprecated
+    future version will require the index to be set explicitly]
 
 `type`::
     The type to fetch the term values from.

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -38,7 +38,7 @@ The terms lookup mechanism supports the following options:
 [horizontal]
 `index`::
     The index to fetch the term values from. Defaults to the
-    current index.
+    current index. Note, omitting the index is deprecated future version will require the index to be set explicitly.
 
 `type`::
     The type to fetch the term values from.


### PR DESCRIPTION
We remove this feature since it super misleading and error prone
if you go through aliases etc. This commit deprecates the feature in 5.x and
adds deprecation logging.

Relates to #25750