### PR TITLE
Small error in geo queries docs

### DIFF
--- a/docs/reference/query-dsl/geo-queries.asciidoc
+++ b/docs/reference/query-dsl/geo-queries.asciidoc
@@ -24,7 +24,7 @@ The queries in this group are:
 
 <<query-dsl-geo-distance-range-query,`geo_distance_range`>> query::
 
-    Like the `geo_point` query, but the range starts at a specified distance
+    Like the `geo_distance` query, but the range starts at a specified distance
     from the central point.
 
 <<query-dsl-geo-polygon-query,`geo_polygon`>> query::


### PR DESCRIPTION
I think that
```
like the `geo_point` query, but the range starts at a specified distance from the central point.
```
should be :
```
like the `geo_distance` query, but the range starts at a specified distance from the central point.
```

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
