### PR TITLE
Stop disabling explicit GC

### DIFF
--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -39,9 +39,6 @@
 
 ## optimizations
 
-# disable calls to System#gc
--XX:+DisableExplicitGC
-
 # pre-touch memory pages used by the JVM during initialization
 -XX:+AlwaysPreTouch
 


### PR DESCRIPTION
The problem here is simple: when using direct buffers as in NIO, the JDK relies on [explict GC invocataions](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/nio/Bits.java#l649) to trigger cleaning up direct buffers; if such GCs do not occur and the direct buffer limit is reached, the JVM will throw an out of memory exception. With explicit GCs disabled, the JVM is neutered from explicitly cleaning up direct buffers in the act of reserving a new direct buffer and instead relies on a GC occurring for another reason. If such a GC never occurs, the JVM will OOM. This commit removes disabling of explicit GCs. Note that these explicit GCs only occur as a last ditch effort before going OOM when the JVM is trying to reserve more direct memory. This is a known issue, see for example: [JDK-8142537](https://bugs.openjdk.java.net/browse/JDK-8142537).