### PR TITLE
[Docs] Add sorting and source filtering section to client docs

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
@@ -52,6 +52,7 @@ import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
+import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.ScoreSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.search.suggest.Suggest;
@@ -136,9 +137,23 @@ public class SearchDocumentationIT extends ESRestHighLevelClientTestCase {
             sourceBuilder.query(QueryBuilders.termQuery("user", "kimchy")); // <2>
             sourceBuilder.from(0); // <3>
             sourceBuilder.size(5); // <4>
-            sourceBuilder.sort(new ScoreSortBuilder().order(SortOrder.ASC));
             sourceBuilder.timeout(new TimeValue(60, TimeUnit.SECONDS)); // <5>
             // end::search-source-basics
+
+            // tag::search-source-sorting
+            sourceBuilder.sort(new ScoreSortBuilder().order(SortOrder.DESC)); // <1>
+            sourceBuilder.sort(new FieldSortBuilder("_id").order(SortOrder.ASC));  // <2>
+            // end::search-source-sorting
+
+            // tag::search-source-filtering-off
+            sourceBuilder.fetchSource(false);
+            // end::search-source-filtering-off
+            // tag::search-source-filtering-includes
+            String[] includeFields = new String[] {"title", "user", "innerObject.*"};
+            String[] excludeFields = new String[] {"_type"};
+            sourceBuilder.fetchSource(includeFields, excludeFields);
+            // end::search-source-filtering-includes
+            sourceBuilder.fetchSource(true);
 
             // tag::search-source-setter
             SearchRequest searchRequest = new SearchRequest();

--- a/docs/java-rest/high-level/apis/search.asciidoc
+++ b/docs/java-rest/high-level/apis/search.asciidoc
@@ -82,6 +82,34 @@ After this, the `SearchSourceBuilder` only needs to be added to the
 include-tagged::{doc-tests}/SearchDocumentationIT.java[search-source-setter]
 --------------------------------------------------
 
+===== Specifying Sorting
+
+
+The `SearchSourceBuilder` allows to add one or more `SortBuilder` instances. There are four special implementations (Field-, Score-, GeoDistance- and ScriptSortBuilder).
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/SearchDocumentationIT.java[search-source-sorting]
+--------------------------------------------------
+<1> Sort descending by `_score` (the default)
+<2> Also sort ascending by `_id` field 
+
+===== Source filtering
+
+By default, search requests return the contents of the document `_source` but like in the Rest API you can overwrite this behaviour. For example, you can turn off `_source` retrieval completely:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/SearchDocumentationIT.java[search-source-filtering-off]
+--------------------------------------------------
+
+The method also accepts and array of one or more wildcard patterns to control which fields get included or excluded in a more fine grained way:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/SearchDocumentationIT.java[search-source-filtering-includes]
+--------------------------------------------------
+
 [[java-rest-high-request-highlighting]]
 ===== Requesting Highlighting
 

--- a/docs/java-rest/high-level/apis/search.asciidoc
+++ b/docs/java-rest/high-level/apis/search.asciidoc
@@ -96,14 +96,14 @@ include-tagged::{doc-tests}/SearchDocumentationIT.java[search-source-sorting]
 
 ===== Source filtering
 
-By default, search requests return the contents of the document `_source` but like in the Rest API you can overwrite this behaviour. For example, you can turn off `_source` retrieval completely:
+By default, search requests return the contents of the document `_source` but like in the Rest API you can overwrite this behavior. For example, you can turn off `_source` retrieval completely:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests}/SearchDocumentationIT.java[search-source-filtering-off]
 --------------------------------------------------
 
-The method also accepts and array of one or more wildcard patterns to control which fields get included or excluded in a more fine grained way:
+The method also accepts an array of one or more wildcard patterns to control which fields get included or excluded in a more fine grained way:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------


### PR DESCRIPTION
Add a short section on sorting and fetching `_source`.