### PR TITLE
Add strict parsing of aggregation ranges

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories.Builder;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
@@ -44,6 +45,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import static org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range.FROM_FIELD;
+import static org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range.KEY_FIELD;
+import static org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range.TO_FIELD;
 
 public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilder<ValuesSource.GeoPoint, GeoDistanceAggregationBuilder> {
     public static final String NAME = "geo_distance";
@@ -167,25 +172,38 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
         double from = 0.0;
         double to = Double.POSITIVE_INFINITY;
         String key = null;
-        String toOrFromOrKey = null;
+        String currentFieldName = null;
         Token token;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
-                toOrFromOrKey = parser.currentName();
+                currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.VALUE_NUMBER) {
-                if (Range.FROM_FIELD.match(toOrFromOrKey)) {
+                if (FROM_FIELD.match(currentFieldName)) {
                     from = parser.doubleValue();
-                } else if (Range.TO_FIELD.match(toOrFromOrKey)) {
+                } else if (TO_FIELD.match(currentFieldName)) {
                     to = parser.doubleValue();
+                } else {
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (Range.KEY_FIELD.match(toOrFromOrKey)) {
+                if (KEY_FIELD.match(currentFieldName)) {
                     key = parser.text();
-                } else if (Range.FROM_FIELD.match(toOrFromOrKey)) {
+                } else if (FROM_FIELD.match(currentFieldName)) {
                     fromAsStr = parser.text();
-                } else if (Range.TO_FIELD.match(toOrFromOrKey)) {
+                } else if (TO_FIELD.match(currentFieldName)) {
                     toAsStr = parser.text();
+                } else {
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
                 }
+            } else if (token == XContentParser.Token.VALUE_NULL) {
+                if (FROM_FIELD.match(currentFieldName) || TO_FIELD.match(currentFieldName)
+                        || KEY_FIELD.match(currentFieldName)) {
+                    // ignore null value
+                } else if (KEY_FIELD.match(currentFieldName)) {
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
+                }
+            } else {
+                XContentParserUtils.throwUnknownToken(token, parser.getTokenLocation());
             }
         }
         if (fromAsStr != null || toAsStr != null) {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -199,7 +199,7 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
                 if (FROM_FIELD.match(currentFieldName) || TO_FIELD.match(currentFieldName)
                         || KEY_FIELD.match(currentFieldName)) {
                     // ignore null value
-                } else if (KEY_FIELD.match(currentFieldName)) {
+                } else {
                     XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
                 }
             } else {

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -161,7 +161,7 @@ public class RangeAggregator extends BucketsAggregator {
                     if (FROM_FIELD.match(currentFieldName) || TO_FIELD.match(currentFieldName)
                             || KEY_FIELD.match(currentFieldName)) {
                         // ignore null value
-                    } else if (KEY_FIELD.match(currentFieldName)) {
+                    } else {
                         XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
                     }
                 } else {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -19,9 +19,16 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
 import org.elasticsearch.search.aggregations.bucket.range.DateRangeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class DateRangeTests extends BaseAggregationTestCase<DateRangeAggregationBuilder> {
 
@@ -60,6 +67,19 @@ public class DateRangeTests extends BaseAggregationTestCase<DateRangeAggregation
             factory.timeZone(randomDateTimeZone());
         }
         return factory;
+    }
+
+    public void testParsingRangeStrict() throws IOException {
+        final String rangeAggregation = "{\n" +
+                "\"field\" : \"date\",\n" +
+                "\"format\" : \"yyyy-MM-dd\",\n" +
+                "\"ranges\" : [\n" +
+                "    { \"from\" : \"2017-01-01\", \"to\" : \"2017-01-02\", \"badField\" : \"abcd\" }\n" +
+                "]\n" +
+            "}";
+        XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
+        ParsingException ex = expectThrows(ParsingException.class, () -> DateRangeAggregationBuilder.parse("aggregationName", parser));
+        assertThat(ex.getDetailedMessage(), containsString("badField"));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
@@ -82,4 +82,23 @@ public class GeoDistanceRangeTests extends BaseAggregationTestCase<GeoDistanceAg
         assertThat(ex.getDetailedMessage(), containsString("badField"));
     }
 
+    /**
+     * We never render "null" values to xContent, but we should test that we can parse them (and they return correct defaults)
+     */
+    public void testParsingNull() throws IOException {
+        final String rangeAggregation = "{\n" +
+                "\"field\" : \"location\",\n" +
+                "\"origin\" : \"52.3760, 4.894\",\n" +
+                "\"unit\" : \"m\",\n" +
+                "\"ranges\" : [\n" +
+                "    { \"from\" : null, \"to\" : null }\n" +
+                "]\n" +
+            "}";
+        XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
+        GeoDistanceAggregationBuilder aggregationBuilder = (GeoDistanceAggregationBuilder) GeoDistanceAggregationBuilder
+                .parse("aggregationName", parser);
+        assertEquals(1, aggregationBuilder.range().size());
+        assertEquals(0.0, aggregationBuilder.range().get(0).getFrom(), 0.0);
+        assertEquals(Double.POSITIVE_INFINITY, aggregationBuilder.range().get(0).getTo(), 0.0);
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -78,4 +78,20 @@ public class RangeTests extends BaseAggregationTestCase<RangeAggregationBuilder>
         assertThat(ex.getDetailedMessage(), containsString("badField"));
     }
 
+    /**
+     * We never render "null" values to xContent, but we should test that we can parse them (and they return correct defaults)
+     */
+    public void testParsingNull() throws IOException {
+        final String rangeAggregation = "{\n" +
+                "\"field\" : \"price\",\n" +
+                "\"ranges\" : [\n" +
+                "    { \"from\" : null, \"to\" : null }\n" +
+                "]\n" +
+            "}";
+        XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
+        RangeAggregationBuilder aggregationBuilder = (RangeAggregationBuilder) RangeAggregationBuilder.parse("aggregationName", parser);
+        assertEquals(1, aggregationBuilder.ranges().size());
+        assertEquals(Double.NEGATIVE_INFINITY, aggregationBuilder.ranges().get(0).getFrom(), 0.0);
+        assertEquals(Double.POSITIVE_INFINITY, aggregationBuilder.ranges().get(0).getTo(), 0.0);
+    }
 }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -19,9 +19,16 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
-import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class RangeTests extends BaseAggregationTestCase<RangeAggregationBuilder> {
 
@@ -57,6 +64,18 @@ public class RangeTests extends BaseAggregationTestCase<RangeAggregationBuilder>
             factory.missing(randomIntBetween(0, 10));
         }
         return factory;
+    }
+
+    public void testParsingRangeStrict() throws IOException {
+        final String rangeAggregation = "{\n" +
+                "\"field\" : \"price\",\n" +
+                "\"ranges\" : [\n" +
+                "    { \"from\" : 50, \"to\" : 100, \"badField\" : \"abcd\" }\n" +
+                "]\n" +
+            "}";
+        XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
+        ParsingException ex = expectThrows(ParsingException.class, () -> RangeAggregationBuilder.parse("aggregationName", parser));
+        assertThat(ex.getDetailedMessage(), containsString("badField"));
     }
 
 }


### PR DESCRIPTION
Currently we ignore unknown field names when parsing RangeAggregator.Range and GeoDistanceAggregationBuilder.Range from `range`, `date_range` or `geo_distance` aggregations. 
This can hide subtle errors, e.g. I ran into this yesterday by mistakenly trying to specify a "format" parameter but put it inside the range object, so it was ignored. To avoid this kind of mistakes we should make parsing strict here like we do with other queries, aggregations etc...