### PR TITLE
Reduce profiling overhead.

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/profile/AbstractProfileBreakdown.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/AbstractProfileBreakdown.java
@@ -53,7 +53,7 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
     public Map<String, Long> toTimingMap() {
         Map<String, Long> map = new HashMap<>();
         for (T timingType : timingTypes) {
-            map.put(timingType.toString(), timings[timingType.ordinal()].getTiming());
+            map.put(timingType.toString(), timings[timingType.ordinal()].getApproximateTiming());
             map.put(timingType.toString() + "_count", timings[timingType.ordinal()].getCount());
         }
         return Collections.unmodifiableMap(map);

--- a/core/src/main/java/org/elasticsearch/search/profile/Timer.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/Timer.java
@@ -33,38 +33,59 @@ package org.elasticsearch.search.profile;
  *  }
  *  </pre>
  */
-// TODO: do not time every single call as discussed in https://github.com/elastic/elasticsearch/issues/24799
-public final class Timer {
+public class Timer {
 
-    private long timing, count, start;
+    private boolean doTiming;
+    private long timing, count, lastCount, start;
+
+    /** pkg-private for testing */
+    long nanoTime() {
+        return System.nanoTime();
+    }
 
     /** Start the timer. */
-    public void start() {
+    public final void start() {
         assert start == 0 : "#start call misses a matching #stop call";
+        // We measure the timing of each method call for the first 256
+        // calls, then 1/2 call up to 512 then 1/3 up to 768, etc. with
+        // a maximum interval of 1024, which is reached for 1024*2^8 ~= 262000
+        // This allows to not slow down things too much because of calls
+        // to System.nanoTime() when methods are called millions of time
+        // in tight loops, while still providing useful timings for methods
+        // that are only called a couple times per search execution.
+        doTiming = (count - lastCount) >= Math.min(lastCount >>> 8, 1024);
+        if (doTiming) {
+            start = nanoTime();
+        }
         count++;
-        start = System.nanoTime();
     }
 
     /** Stop the timer. */
-    public void stop() {
-        timing += Math.max(System.nanoTime() - start, 1L);
-        start = 0;
+    public final void stop() {
+        if (doTiming) {
+            timing += (count - lastCount) * Math.max(nanoTime() - start, 1L);
+            lastCount = count;
+            start = 0;
+        }
     }
 
     /** Return the number of times that {@link #start()} has been called. */
-    public long getCount() {
+    public final long getCount() {
         if (start != 0) {
             throw new IllegalStateException("#start call misses a matching #stop call");
         }
         return count;
     }
 
-    /** Return an approximation of the total time spend between consecutive calls of #start and #stop. */
-    public long getTiming() {
+    /** Return an approximation of the total time spent between consecutive calls of #start and #stop. */
+    public final long getTiming() {
         if (start != 0) {
             throw new IllegalStateException("#start call misses a matching #stop call");
         }
-        return timing;
+        // We don't have timings for the last `count-lastCount` method calls
+        // se we assume that they had the same timing as the lastCount first
+        // calls. This approximation is ok since at most 1/256th of method
+        // calls have not been timed.
+        return timing + (count - lastCount) * timing / lastCount;
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/search/profile/Timer.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/Timer.java
@@ -78,12 +78,12 @@ public class Timer {
     }
 
     /** Return an approximation of the total time spent between consecutive calls of #start and #stop. */
-    public final long getTiming() {
+    public final long getApproximateTiming() {
         if (start != 0) {
             throw new IllegalStateException("#start call misses a matching #stop call");
         }
         // We don't have timings for the last `count-lastCount` method calls
-        // se we assume that they had the same timing as the lastCount first
+        // so we assume that they had the same timing as the lastCount first
         // calls. This approximation is ok since at most 1/256th of method
         // calls have not been timed.
         return timing + (count - lastCount) * timing / lastCount;

--- a/core/src/main/java/org/elasticsearch/search/profile/Timer.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/Timer.java
@@ -86,6 +86,11 @@ public class Timer {
         // so we assume that they had the same timing as the lastCount first
         // calls. This approximation is ok since at most 1/256th of method
         // calls have not been timed.
-        return timing + (count - lastCount) * timing / lastCount;
+        long timing = this.timing;
+        if (count > lastCount) {
+            assert lastCount > 0;
+            timing += (count - lastCount) * timing / lastCount;
+        }
+        return timing;
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/profile/TimerTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/TimerTests.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.profile;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TimerTests extends ESTestCase {
+
+    public void testTimingInterval() {
+        final AtomicLong counter = new AtomicLong();
+        Timer t = new Timer() {
+            long time = 50;
+            @Override
+            long nanoTime() {
+                counter.incrementAndGet();
+                return time += 1;
+            }
+        };
+        for (int i = 0; i < 100000; ++i) {
+            t.start();
+            t.stop();
+            if (i < 256) {
+                // for the first 256 calls, nanoTime() is called
+                // once for `start` and once for `stop`
+                assertEquals((i + 1) * 2, counter.get());
+            }
+        }
+        // only called 3356 times, which is significantly less than 100000
+        assertEquals(3356L, counter.get());
+    }
+
+    public void testExtrapolate() {
+        Timer t = new Timer() {
+            long time = 50;
+            @Override
+            long nanoTime() {
+                return time += 42;
+            }
+        };
+        for (int i = 1; i < 100000; ++i) {
+            t.start();
+            t.stop();
+            assertEquals(i, t.getCount());
+            // Make sure the cumulated timing is 42 times the number of calls as expected
+            assertEquals(i * 42L, t.getTiming());
+        }
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/profile/TimerTests.java
+++ b/core/src/test/java/org/elasticsearch/search/profile/TimerTests.java
@@ -26,12 +26,12 @@ import java.util.concurrent.atomic.AtomicLong;
 public class TimerTests extends ESTestCase {
 
     public void testTimingInterval() {
-        final AtomicLong counter = new AtomicLong();
+        final AtomicLong nanoTimeCallCounter = new AtomicLong();
         Timer t = new Timer() {
             long time = 50;
             @Override
             long nanoTime() {
-                counter.incrementAndGet();
+                nanoTimeCallCounter.incrementAndGet();
                 return time += 1;
             }
         };
@@ -41,11 +41,11 @@ public class TimerTests extends ESTestCase {
             if (i < 256) {
                 // for the first 256 calls, nanoTime() is called
                 // once for `start` and once for `stop`
-                assertEquals((i + 1) * 2, counter.get());
+                assertEquals((i + 1) * 2, nanoTimeCallCounter.get());
             }
         }
-        // only called 3356 times, which is significantly less than 100000
-        assertEquals(3356L, counter.get());
+        // only called nanoTime() 3356 times, which is significantly less than 100000
+        assertEquals(3356L, nanoTimeCallCounter.get());
     }
 
     public void testExtrapolate() {
@@ -61,7 +61,7 @@ public class TimerTests extends ESTestCase {
             t.stop();
             assertEquals(i, t.getCount());
             // Make sure the cumulated timing is 42 times the number of calls as expected
-            assertEquals(i * 42L, t.getTiming());
+            assertEquals(i * 42L, t.getApproximateTiming());
         }
     }
 


### PR DESCRIPTION
Calling `System.nanoTime()` for each method call may have a significant
performance impact.

Closes #24799