### PR TITLE
Fix handling of invalid error trace parameter

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestController.java
@@ -48,7 +48,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -304,7 +303,7 @@ public class RestController extends AbstractComponent implements HttpServerTrans
      * Checks the request parameters against enabled settings for error trace support
      * @return true if the request does not have any parameters that conflict with system settings
      */
-    boolean checkRequestParameters(final RestRequest request, final RestChannel channel) {
+    boolean checkErrorTraceParameter(final RestRequest request, final RestChannel channel) {
         // error_trace cannot be used when we disable detailed errors
         // we consume the error_trace parameter first to ensure that it is always consumed
         if (request.paramAsBoolean("error_trace", false) && channel.detailedErrorsEnabled() == false) {
@@ -324,10 +323,10 @@ public class RestController extends AbstractComponent implements HttpServerTrans
         // Request execution flag
         boolean requestHandled = false;
 
-        if (checkRequestParameters(request, channel) == false) {
-            channel.sendResponse(BytesRestResponse.createSimpleErrorResponse(channel,
-                BAD_REQUEST, "error traces in responses are disabled."));
-            requestHandled = true;
+        if (checkErrorTraceParameter(request, channel) == false) {
+            channel.sendResponse(
+                    BytesRestResponse.createSimpleErrorResponse(channel, BAD_REQUEST, "error traces in responses are disabled."));
+            return;
         }
 
         // Loop through all possible handlers, attempting to dispatch the request


### PR DESCRIPTION
If a request contains an invalid error trace parameter, we send a error on the channel. This should immediately abort any additional processing of the request but instead we march on, dispatch the request and subsequently send another message on the channel. The problem here is this means two writes on the channel which leads to the request being released twice ultimately raising in illegal reference count exception. This commit addresses this by performing an early return in the case that the request contained an invalid error trace parameter.

Closes #25774