### PR TITLE
Add compatibility versions to main action response

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -113,6 +113,8 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("build_date", build.date())
             .field("build_snapshot", build.isSnapshot())
             .field("lucene_version", version.luceneVersion.toString())
+            .field("minimum_wire_compatibility_version", version.minimumCompatibilityVersion().toString())
+            .field("minimum_index_compatibility_version", version.minimumIndexCompatibilityVersion().toString())
             .endObject();
         builder.field("tagline", "You Know, for Search");
         builder.endObject();

--- a/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
@@ -84,8 +84,10 @@ public class MainActionTests extends ESTestCase {
                 "\"number\":\"" + Version.CURRENT.toString() + "\"," +
                 "\"build_hash\":\"" + Build.CURRENT.shortHash() + "\"," +
                 "\"build_date\":\"" + Build.CURRENT.date() + "\"," +
-                "\"build_snapshot\":" + Build.CURRENT.isSnapshot() +
-                ",\"lucene_version\":\"" + Version.CURRENT.luceneVersion.toString() +
+                "\"build_snapshot\":" + Build.CURRENT.isSnapshot() + "," +
+                "\"lucene_version\":\"" + Version.CURRENT.luceneVersion.toString() + "\"," +
+                "\"minimum_wire_compatibility_version\":\"" + Version.CURRENT.minimumCompatibilityVersion().toString() + "\"," +
+                "\"minimum_index_compatibility_version\":\"" + Version.CURRENT.minimumIndexCompatibilityVersion().toString() +
                 "\"}," +
                 "\"tagline\":\"You Know, for Search\"}";
 

--- a/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -88,7 +88,9 @@ public class MainResponseTests extends ESTestCase {
                     + "\"build_hash\":\"buildHash\","
                     + "\"build_date\":\"2016-11-15\","
                     + "\"build_snapshot\":true,"
-                    + "\"lucene_version\":\"" + version.luceneVersion.toString() + "\"},"
+                    + "\"lucene_version\":\"" + version.luceneVersion.toString() + "\","
+                    + "\"minimum_wire_compatibility_version\":\"" + version.minimumCompatibilityVersion().toString() + "\","
+                    + "\"minimum_index_compatibility_version\":\"" + version.minimumIndexCompatibilityVersion().toString() + "\"},"
                 + "\"tagline\":\"You Know, for Search\""
           + "}", builder.string());
     }

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -375,7 +375,9 @@ This command should give you a JSON result:
     "build_hash" : "f27399d",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,
-    "lucene_version" : "{lucene_version}"
+    "lucene_version" : "{lucene_version}",
+    "minimum_wire_compatibility_version" : "1.2.3",
+    "minimum_index_compatibility_version" : "1.2.3"
   },
   "tagline" : "You Know, for Search"
 }
@@ -386,6 +388,8 @@ This command should give you a JSON result:
 // TESTRESPONSE[s/"build_hash" : "f27399d",/"build_hash" : "$body.version.build_hash",/]
 // TESTRESPONSE[s/"build_date" : "2016-03-30T09:51:41.449Z",/"build_date" : $body.version.build_date,/]
 // TESTRESPONSE[s/"build_snapshot" : false,/"build_snapshot" : $body.version.build_snapshot,/]
+// TESTRESPONSE[s/"minimum_wire_compatibility_version" : "1.2.3"/"minimum_wire_compatibility_version" : $body.version.minimum_wire_compatibility_version/]
+// TESTRESPONSE[s/"minimum_index_compatibility_version" : "1.2.3"/"minimum_index_compatibility_version" : $body.version.minimum_index_compatibility_version/]
 // So much s/// but at least we test that the layout is close to matching....
 
 [[discovery-azure-classic-long-plugin]]

--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -22,7 +22,9 @@ which should give you a response something like this:
     "build_hash" : "f27399d",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,
-    "lucene_version" : "{lucene_version}"
+    "lucene_version" : "{lucene_version}",
+    "minimum_wire_compatibility_version" : "1.2.3",
+    "minimum_index_compatibility_version" : "1.2.3"
   },
   "tagline" : "You Know, for Search"
 }
@@ -33,4 +35,6 @@ which should give you a response something like this:
 // TESTRESPONSE[s/"build_hash" : "f27399d",/"build_hash" : "$body.version.build_hash",/]
 // TESTRESPONSE[s/"build_date" : "2016-03-30T09:51:41.449Z",/"build_date" : $body.version.build_date,/]
 // TESTRESPONSE[s/"build_snapshot" : false,/"build_snapshot" : $body.version.build_snapshot,/]
+// TESTRESPONSE[s/"minimum_wire_compatibility_version" : "1.2.3"/"minimum_wire_compatibility_version" : $body.version.minimum_wire_compatibility_version/]
+// TESTRESPONSE[s/"minimum_index_compatibility_version" : "1.2.3"/"minimum_index_compatibility_version" : $body.version.minimum_index_compatibility_version/]
 // So much s/// but at least we test that the layout is close to matching....


### PR DESCRIPTION
This commit adds the min wire/index compat versions to the main action
output. Not only will this make the compatility expected more
transparent, but it also allows to test which version others think the
compat versions are, similar to how we test the lucene version.
