### PR TITLE
Unzip quietly while provisioning virtual machines

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -272,7 +272,7 @@ def provision(config,
     installed gradle || {
       echo "==> Installing Gradle"
       curl -sS -o /tmp/gradle.zip -L https://services.gradle.org/distributions/gradle-3.3-bin.zip
-      unzip /tmp/gradle.zip -d /opt
+      unzip -q /tmp/gradle.zip -d /opt
       rm -rf /tmp/gradle.zip
       ln -s /opt/gradle-3.3/bin/gradle /usr/bin/gradle
       # make nfs mounted gradle home dir writeable


### PR DESCRIPTION
When provisioning the virtual machines used for packaging, we download the Gradle zip archive and unzip. This unzip is noisy produing a lot of unnecessary output. This commit silences this output.
