### PR TITLE
Remove support for ES_INCLUDE

### DIFF
--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -79,7 +79,6 @@ DAEMON_OPTS="-d -p $PID_FILE --path.conf $CONF_DIR"
 
 export ES_JAVA_OPTS
 export JAVA_HOME
-export ES_INCLUDE
 export CONF_DIR
 
 if [ ! -x "$DAEMON" ]; then

--- a/distribution/rpm/src/main/packaging/init.d/elasticsearch
+++ b/distribution/rpm/src/main/packaging/init.d/elasticsearch
@@ -63,7 +63,6 @@ pidfile="$PID_DIR/${prog}.pid"
 
 export ES_JAVA_OPTS
 export JAVA_HOME
-export ES_INCLUDE
 export CONF_DIR
 export ES_STARTUP_SLEEP_TIME
 

--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -14,33 +14,6 @@
 # commented out. Sample format include "512m", and "10g".
 #
 #   ES_JAVA_OPTS="-Xms8g -Xmx8g" ./bin/elasticsearch
-#
-# As a convenience, a fragment of shell is sourced in order to set one or
-# more of these variables. This so-called `include' can be placed in a
-# number of locations and will be searched for in order. The lowest
-# priority search path is the same directory as the startup script, and
-# since this is the location of the sample in the project tree, it should
-# almost work Out Of The Box.
-#
-# Any serious use-case though will likely require customization of the
-# include. For production installations, it is recommended that you copy
-# the sample to one of /usr/share/elasticsearch/elasticsearch.in.sh,
-# /usr/local/share/elasticsearch/elasticsearch.in.sh, or
-# /opt/elasticsearch/elasticsearch.in.sh and make your modifications there.
-#
-# Another option is to specify the full path to the include file in the
-# environment. For example:
-#
-#   $ ES_INCLUDE=/path/to/in.sh elasticsearch -p /var/run/es.pid
-#
-# Note: This is particularly handy for running multiple instances on a
-# single installation, or for quick tests.
-#
-# If you would rather configure startup entirely from the environment, you
-# can disable the include by exporting an empty ES_INCLUDE, or by
-# ensuring that no include files exist in the aforementioned search list.
-# Be aware that you will be entirely responsible for populating the needed
-# environment variables.
 
 # Check to see if you are trying to run this without building it first. Gradle
 # will replace the project.name with _something_.
@@ -89,24 +62,7 @@ fi
 
 ES_JAVA_OPTS="$(parse_jvm_options "$ES_JVM_OPTIONS") $ES_JAVA_OPTS"
 
-# If an include wasn't specified in the environment, then search for one...
-if [ "x$ES_INCLUDE" = "x" ]; then
-    # Locations (in order) to use when searching for an include file.
-    for include in /usr/share/elasticsearch/elasticsearch.in.sh \
-                   /usr/local/share/elasticsearch/elasticsearch.in.sh \
-                   /opt/elasticsearch/elasticsearch.in.sh \
-                   ~/.elasticsearch.in.sh \
-                   "$ES_HOME/bin/elasticsearch.in.sh" \
-                   "`dirname "$0"`"/elasticsearch.in.sh; do
-        if [ -r "$include" ]; then
-            . "$include"
-            break
-        fi
-    done
-# ...otherwise, source the specified include.
-elif [ -r "$ES_INCLUDE" ]; then
-    . "$ES_INCLUDE"
-fi
+source "$ES_HOME/bin/elasticsearch.in.sh"
 
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA="$JAVA_HOME/bin/java"

--- a/distribution/src/main/resources/bin/elasticsearch-keystore
+++ b/distribution/src/main/resources/bin/elasticsearch-keystore
@@ -31,11 +31,6 @@ fi
 # For a ${project.name} package, the value is "${path.env}".
 ES_ENV_FILE="${path.env}"
 
-# If an include is specified with the ES_INCLUDE environment variable, use it
-if [ -n "$ES_INCLUDE" ]; then
-    ES_ENV_FILE="$ES_INCLUDE"
-fi
-
 # Source the environment file
 if [ -n "$ES_ENV_FILE" ]; then
 

--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -31,11 +31,6 @@ fi
 # For a ${project.name} package, the value is "${path.env}".
 ES_ENV_FILE="${path.env}"
 
-# If an include is specified with the ES_INCLUDE environment variable, use it
-if [ -n "$ES_INCLUDE" ]; then
-    ES_ENV_FILE="$ES_INCLUDE"
-fi
-
 # Source the environment file
 if [ -n "$ES_ENV_FILE" ]; then
 

--- a/distribution/src/main/resources/bin/elasticsearch-translog
+++ b/distribution/src/main/resources/bin/elasticsearch-translog
@@ -31,11 +31,6 @@ fi
 # For a ${project.name} package, the value is "${path.env}".
 ES_ENV_FILE="${path.env}"
 
-# If an include is specified with the ES_INCLUDE environment variable, use it
-if [ -n "$ES_INCLUDE" ]; then
-    ES_ENV_FILE="$ES_INCLUDE"
-fi
-
 # Source the environment file
 if [ -n "$ES_ENV_FILE" ]; then
 

--- a/docs/reference/migration/migrate_6_0/packaging.asciidoc
+++ b/docs/reference/migration/migrate_6_0/packaging.asciidoc
@@ -60,3 +60,11 @@ The environment variable `ES_JVM_OPTIONS` that enabled a custom location for the
 `CONF_DIR`. This environment variable is already used in the packaging to
 support relocating the configuration files so this change merely aligns the
 other configuration files with the location of the `jvm.options` file.
+
+==== `ES_INCLUDE` is no longer supported
+
+The environment variable `ES_INCLUDE` could previously be used to establish the
+environment used to start Elasticsearch (and various supporting scripts). This
+legacy feature could be useful when there were several environment variables
+useful for configuring JVM options; this functionality had previously been
+replaced by <<jvm-options>>. Therefore, `ES_INCLUDE` has been removed.


### PR DESCRIPTION
Today we enable users to customize the environment through the use of ES_INCLUDE. This made sense for legacy reasons when we did not have nicities like jvm.options (so dumped JVM options in the default include script) and somewhat duplicates some of the functionality that we will need from a dedicated environment script. This commit removes support for ES_INCLUDE as a first step towards a dedicated include script.
