### PR TITLE
Bump the min compat version to 5.6.0

### DIFF
--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -308,8 +308,8 @@ public class Version implements Comparable<Version> {
         final int bwcMajor;
         final int bwcMinor;
         if (major == 6) { // we only specialize for current major here
-            bwcMajor = Version.V_5_5_0.major;
-            bwcMinor = Version.V_5_5_0.minor;
+            bwcMajor = Version.V_5_6_0.major;
+            bwcMinor = Version.V_5_6_0.minor;
         } else if (major > 6) { // all the future versions are compatible with first minor...
             bwcMajor = major -1;
             bwcMinor = 0;

--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -170,7 +170,7 @@ public class VersionTests extends ESTestCase {
         assertThat(Version.fromString("2.3.0").minimumCompatibilityVersion(), equalTo(major));
         // from 6.0 on we are supporting the latest minor of the previous major... this might fail once we add a new version ie. 5.x is
         // released since we need to bump the supported minor in Version#minimumCompatibilityVersion()
-        Version lastVersion = VersionUtils.getPreviousVersion(Version.V_6_0_0_alpha1);
+        Version lastVersion = Version.V_5_6_0; // TODO: remove this once min compat version is a constant instead of method
         assertEquals(lastVersion.major, Version.V_6_0_0_beta1.minimumCompatibilityVersion().major);
         assertEquals("did you miss to bump the minor in Version#minimumCompatibilityVersion()",
                 lastVersion.minor, Version.V_6_0_0_beta1.minimumCompatibilityVersion().minor);
@@ -330,7 +330,7 @@ public class VersionTests extends ESTestCase {
 
     public void testIsCompatible() {
         assertTrue(isCompatible(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion()));
-        assertTrue(isCompatible(Version.V_5_5_0, Version.V_6_0_0_alpha2));
+        assertTrue(isCompatible(Version.V_5_6_0, Version.V_6_0_0_alpha2));
         assertFalse(isCompatible(Version.fromId(2000099), Version.V_6_0_0_alpha2));
         assertFalse(isCompatible(Version.fromId(2000099), Version.V_5_0_0));
         assertTrue(isCompatible(Version.fromString("6.0.0"), Version.fromString("7.0.0")));

--- a/core/src/test/java/org/elasticsearch/transport/TCPTransportTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/TCPTransportTests.java
@@ -158,16 +158,16 @@ public class TCPTransportTests extends ESTestCase {
         TcpTransport.ensureVersionCompatibility(Version.fromString("5.0.0"), Version.fromString("6.0.0"), true);
         IllegalStateException ise = expectThrows(IllegalStateException.class, () ->
             TcpTransport.ensureVersionCompatibility(Version.fromString("5.0.0"), Version.fromString("6.0.0"), false));
-        assertEquals("Received message from unsupported version: [5.0.0] minimal compatible version is: [5.5.0]", ise.getMessage());
+        assertEquals("Received message from unsupported version: [5.0.0] minimal compatible version is: [5.6.0]", ise.getMessage());
 
         ise = expectThrows(IllegalStateException.class, () ->
             TcpTransport.ensureVersionCompatibility(Version.fromString("2.3.0"), Version.fromString("6.0.0"), true));
-        assertEquals("Received handshake message from unsupported version: [2.3.0] minimal compatible version is: [5.5.0]",
+        assertEquals("Received handshake message from unsupported version: [2.3.0] minimal compatible version is: [5.6.0]",
             ise.getMessage());
 
         ise = expectThrows(IllegalStateException.class, () ->
             TcpTransport.ensureVersionCompatibility(Version.fromString("2.3.0"), Version.fromString("6.0.0"), false));
-        assertEquals("Received message from unsupported version: [2.3.0] minimal compatible version is: [5.5.0]",
+        assertEquals("Received message from unsupported version: [2.3.0] minimal compatible version is: [5.6.0]",
             ise.getMessage());
     }
 


### PR DESCRIPTION
This commit increases the min compat version for 6.0 to 5.6.0. This is
already what is being tested by gradle, but the code was out of sync.
