### PR TITLE
Stop exporting HOSTNAME from scripts

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -102,11 +102,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# full hostname passed through cut for portability on systems that do not support hostname -s
-# export on separate line for shells that do not support combining definition and export
-HOSTNAME=`hostname | cut -d. -f1`
-export HOSTNAME
-
 # manual parsing to find out, if process should be detached
 daemonized=`echo $* | egrep -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`
 if [ -z "$daemonized" ] ; then

--- a/distribution/src/main/resources/bin/elasticsearch-keystore
+++ b/distribution/src/main/resources/bin/elasticsearch-keystore
@@ -71,11 +71,6 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-# full hostname passed through cut for portability on systems that do not support hostname -s
-# export on separate line for shells that do not support combining definition and export
-HOSTNAME=`hostname | cut -d. -f1`
-export HOSTNAME
-
 declare -a args=("$@")
 path_props=(-Des.path.home="$ES_HOME")
 

--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -71,11 +71,6 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-# full hostname passed through cut for portability on systems that do not support hostname -s
-# export on separate line for shells that do not support combining definition and export
-HOSTNAME=`hostname | cut -d. -f1`
-export HOSTNAME
-
 declare -a args=("$@")
 path_props=(-Des.path.home="$ES_HOME")
 

--- a/distribution/src/main/resources/bin/elasticsearch-translog
+++ b/distribution/src/main/resources/bin/elasticsearch-translog
@@ -71,11 +71,6 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-# full hostname passed through cut for portability on systems that do not support hostname -s
-# export on separate line for shells that do not support combining definition and export
-HOSTNAME=`hostname | cut -d. -f1`
-export HOSTNAME
-
 declare -a args=("$@")
 
 if [ -e "$CONF_DIR" ]; then


### PR DESCRIPTION
Today we explicitly export the HOSTNAME variable from scripts. This is probably a relic from the days when the scripts were not run on bash but instead assume a POSIX-compliant shell only where HOSTNAME is not guaranteed to exist. Yet, bash guarantees that HOSTNAME is set so we do not need to set it in scripts. This commit removes this legacy.
