### PR TITLE
Remove legacy checks for config file settings

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -290,8 +290,6 @@ final class Bootstrap {
         } catch (IOException e) {
             throw new BootstrapException(e);
         }
-        checkForCustomConfFile();
-
         if (environment.pidFile() != null) {
             try {
                 PidFile.create(environment.pidFile(), true);
@@ -387,28 +385,6 @@ final class Bootstrap {
     @SuppressForbidden(reason = "System#err")
     private static void closeSysError() {
         System.err.close();
-    }
-
-    private static void checkForCustomConfFile() {
-        String confFileSetting = System.getProperty("es.default.config");
-        checkUnsetAndMaybeExit(confFileSetting, "es.default.config");
-        confFileSetting = System.getProperty("es.config");
-        checkUnsetAndMaybeExit(confFileSetting, "es.config");
-        confFileSetting = System.getProperty("elasticsearch.config");
-        checkUnsetAndMaybeExit(confFileSetting, "elasticsearch.config");
-    }
-
-    private static void checkUnsetAndMaybeExit(String confFileSetting, String settingName) {
-        if (confFileSetting != null && confFileSetting.isEmpty() == false) {
-            Logger logger = Loggers.getLogger(Bootstrap.class);
-            logger.info("{} is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed.", settingName);
-            exit(1);
-        }
-    }
-
-    @SuppressForbidden(reason = "Allowed to exit explicitly in bootstrap phase")
-    private static void exit(int status) {
-        System.exit(status);
     }
 
     private static void checkLucene() {

--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -60,12 +60,6 @@ if [ -f "$DEFAULT" ]; then
 	. "$DEFAULT"
 fi
 
-# CONF_FILE setting was removed
-if [ ! -z "$CONF_FILE" ]; then
-    echo "CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed."
-    exit 1
-fi
-
 # ES_USER and ES_GROUP settings were removed
 if [ ! -z "$ES_USER" ] || [ ! -z "$ES_GROUP" ]; then
     echo "ES_USER and ES_GROUP settings are no longer supported. To run as a custom user/group use the archive distribution of Elasticsearch."

--- a/distribution/rpm/src/main/packaging/init.d/elasticsearch
+++ b/distribution/rpm/src/main/packaging/init.d/elasticsearch
@@ -45,12 +45,6 @@ if [ -f "$ES_ENV_FILE" ]; then
     . "$ES_ENV_FILE"
 fi
 
-# CONF_FILE setting was removed
-if [ ! -z "$CONF_FILE" ]; then
-    echo "CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed."
-    exit 1
-fi
-
 # ES_USER and ES_GROUP settings were removed
 if [ ! -z "$ES_USER" ] || [ ! -z "$ES_GROUP" ]; then
     echo "ES_USER and ES_GROUP settings are no longer supported. To run as a custom user/group use the archive distribution of Elasticsearch."

--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -15,8 +15,6 @@ WorkingDirectory=/usr/share/elasticsearch
 User=elasticsearch
 Group=elasticsearch
 
-ExecStartPre=/usr/share/elasticsearch/bin/elasticsearch-systemd-pre-exec
-
 ExecStart=/usr/share/elasticsearch/bin/elasticsearch \
                                                 -p ${PID_DIR}/elasticsearch.pid \
                                                 --quiet \

--- a/distribution/src/main/resources/bin/elasticsearch-keystore
+++ b/distribution/src/main/resources/bin/elasticsearch-keystore
@@ -54,12 +54,6 @@ if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
     unset JAVA_TOOL_OPTIONS
 fi
 
-# CONF_FILE setting was removed
-if [ ! -z "$CONF_FILE" ]; then
-    echo "CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed."
-    exit 1
-fi
-
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA=$JAVA_HOME/bin/java
 else

--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -54,12 +54,6 @@ if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
     unset JAVA_TOOL_OPTIONS
 fi
 
-# CONF_FILE setting was removed
-if [ ! -z "$CONF_FILE" ]; then
-    echo "CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed."
-    exit 1
-fi
-
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA=$JAVA_HOME/bin/java
 else

--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -22,8 +22,6 @@ IF %JAVA:~-13% == "\bin\java.exe" (
 )
 
 :cont
-if not "%CONF_FILE%" == "" goto conffileset
-
 set SCRIPT_DIR=%~dp0
 for %%I in ("%SCRIPT_DIR%..") do set ES_HOME=%%~dpfI
 
@@ -296,10 +294,6 @@ rem convert to KB
 set /a conv=%conv% * 1024 * 1024
 :kilo
 set "%~2=%conv%"
-goto:eof
-
-:conffileset
-echo CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed.
 goto:eof
 
 ENDLOCAL

--- a/distribution/src/main/resources/bin/elasticsearch-systemd-pre-exec
+++ b/distribution/src/main/resources/bin/elasticsearch-systemd-pre-exec
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# CONF_FILE setting was removed
-if [ ! -z "$CONF_FILE" ]; then
-    echo "CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed."
-    exit 1
-fi

--- a/distribution/src/main/resources/bin/elasticsearch-translog
+++ b/distribution/src/main/resources/bin/elasticsearch-translog
@@ -54,11 +54,6 @@ if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
     unset JAVA_TOOL_OPTIONS
 fi
 
-# CONF_FILE setting was removed
-if [ ! -z "$CONF_FILE" ]; then
-    echo "CONF_FILE setting is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed."
-    exit 1
-fi
 
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA=$JAVA_HOME/bin/java

--- a/qa/vagrant/src/test/resources/packaging/tests/module_and_plugin_test_cases.bash
+++ b/qa/vagrant/src/test/resources/packaging/tests/module_and_plugin_test_cases.bash
@@ -89,35 +89,6 @@ else
     }
 fi
 
-@test "[$GROUP] install jvm-example plugin with a custom CONFIG_FILE and check failure" {
-    local relativePath=${1:-$(readlink -m jvm-example-*.zip)}
-    CONF_FILE="$ESCONFIG/elasticsearch.yml" run sudo -E -u $ESPLUGIN_COMMAND_USER "$ESHOME/bin/elasticsearch-plugin" install "file://$relativePath"
-    # this should fail because CONF_FILE is no longer supported
-    [ $status = 1 ]
-    CONF_FILE="$ESCONFIG/elasticsearch.yml" run sudo -E -u $ESPLUGIN_COMMAND_USER "$ESHOME/bin/elasticsearch-plugin" remove jvm-example
-    echo "status is $status"
-    [ $status = 1 ]
-}
-
-@test "[$GROUP] start elasticsearch with a custom CONFIG_FILE and check failure" {
-    local CONF_FILE="$ESCONFIG/elasticsearch.yml"
-
-    if is_dpkg; then
-        echo "CONF_FILE=$CONF_FILE" >> /etc/default/elasticsearch;
-    elif is_rpm; then
-        echo "CONF_FILE=$CONF_FILE" >> /etc/sysconfig/elasticsearch;
-    fi
-
-    run_elasticsearch_service 1 -Ees.default.config="$CONF_FILE"
-
-    # remove settings again otherwise cleaning up before next testrun will fail
-    if is_dpkg ; then
-        sudo sed -i '/CONF_FILE/d' /etc/default/elasticsearch
-    elif is_rpm; then
-        sudo sed -i '/CONF_FILE/d' /etc/sysconfig/elasticsearch
-    fi
-}
-
 @test "[$GROUP] install jvm-example plugin with a symlinked plugins path" {
     # Clean up after the last time this test was run
     rm -rf /tmp/plugins.*


### PR DESCRIPTION
This commit removes legacy checks for unsupported an environment variable and unsupported system properties. This environment variable and these system properties have not been supported since 1.x so it is safe to stop checking for the existence of these settings.
