### PR TITLE
Fix elasticsearch-keystore handling of path.conf

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-keystore
+++ b/distribution/src/main/resources/bin/elasticsearch-keystore
@@ -77,10 +77,9 @@ HOSTNAME=`hostname | cut -d. -f1`
 export HOSTNAME
 
 declare -a args=("$@")
-path_props=(-Des.path.home="$ES_HOME")
 
 if [ -e "$CONF_DIR" ]; then
-  path_props=("${path_props[@]}" -Des.path.conf="$CONF_DIR")
+  args=("${args[@]}" --path.conf "$CONF_DIR")
 fi
 
-exec "$JAVA" $ES_JAVA_OPTS -Delasticsearch "${path_props[@]}" -cp "$ES_HOME/lib/*" org.elasticsearch.common.settings.KeyStoreCli "${args[@]}"
+exec "$JAVA" $ES_JAVA_OPTS -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.common.settings.KeyStoreCli "${args[@]}"


### PR DESCRIPTION
This commit fixes the elasticsearch-keystore script handling of path.conf; the problem here is that the script is setting a system property that is completely unobserved. Instead, we use the path.conf command line flag.
