### PR TITLE
Introduce elasticsearch-env

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -161,8 +161,6 @@ class NodeInfo {
         env.put('CONF_DIR', confDir)
         if (Version.fromString(nodeVersion).major == 5) {
             args.addAll("-E", "path.conf=${confDir}")
-        } else {
-            args.addAll("--path.conf", "${confDir}")
         }
         if (!System.properties.containsKey("tests.es.path.data")) {
             args.addAll("-E", "path.data=${-> dataDir.toString()}")

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -506,9 +506,9 @@ Map<String, String> expansionsForDistribution(distributionType) {
     'project.version': version,
 
     'path.conf': [
-      'tar': '$ES_HOME/config',
-      'zip': '$ES_HOME/config',
-      'integ-test-zip': '$ES_HOME/config',
+      'tar': '"$ES_HOME"/config',
+      'zip': '"$ES_HOME"/config',
+      'integ-test-zip': '"$ES_HOME"/config',
       'def': '/etc/elasticsearch',
     ],
     'path.data': [
@@ -521,7 +521,12 @@ Map<String, String> expansionsForDistribution(distributionType) {
       'rpm': '/etc/sysconfig/elasticsearch',
       /* There isn't one of these files for tar or zip but its important to
         make an empty string here so the script can properly skip it. */
-      'def': '',
+      'def': 'if [ -z "$CONF_DIR" ]; then CONF_DIR="$ES_HOME"/config; done',
+    ],
+    'source.path.env': [
+       'deb': 'source /etc/default/elasticsearch',
+       'rpm': 'source /etc/sysconfig/elasticsearch',
+       'def': 'if [ -z "$CONF_DIR" ]; then CONF_DIR="$ES_HOME"/config; fi',
     ],
     'path.logs': [
       'deb': packagingPathLogs,

--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -69,7 +69,7 @@ fi
 # Define other required variables
 PID_FILE="$PID_DIR/$NAME.pid"
 DAEMON=$ES_HOME/bin/elasticsearch
-DAEMON_OPTS="-d -p $PID_FILE --path.conf $CONF_DIR"
+DAEMON_OPTS="-d -p $PID_FILE
 
 export ES_JAVA_OPTS
 export JAVA_HOME

--- a/distribution/deb/src/main/packaging/init.d/elasticsearch
+++ b/distribution/deb/src/main/packaging/init.d/elasticsearch
@@ -69,7 +69,7 @@ fi
 # Define other required variables
 PID_FILE="$PID_DIR/$NAME.pid"
 DAEMON=$ES_HOME/bin/elasticsearch
-DAEMON_OPTS="-d -p $PID_FILE
+DAEMON_OPTS="-d -p $PID_FILE"
 
 export ES_JAVA_OPTS
 export JAVA_HOME

--- a/distribution/rpm/src/main/packaging/init.d/elasticsearch
+++ b/distribution/rpm/src/main/packaging/init.d/elasticsearch
@@ -105,7 +105,7 @@ start() {
     cd $ES_HOME
     echo -n $"Starting $prog: "
     # if not running, start it up here, usually something like "daemon $exec"
-    daemon --user elasticsearch --pidfile $pidfile $exec -p $pidfile -d --path.conf $CONF_DIR
+    daemon --user elasticsearch --pidfile $pidfile $exec -p $pidfile -d
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile

--- a/distribution/src/main/packaging/env/elasticsearch
+++ b/distribution/src/main/packaging/env/elasticsearch
@@ -9,7 +9,7 @@
 #JAVA_HOME=
 
 # Elasticsearch configuration directory
-#CONF_DIR=${path.conf}
+CONF_DIR=${path.conf}
 
 # Elasticsearch PID directory
 #PID_DIR=/var/run/elasticsearch

--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -102,8 +102,12 @@ chown -R elasticsearch:elasticsearch /var/log/elasticsearch
 chown -R root:elasticsearch /etc/elasticsearch
 chmod 0750 /etc/elasticsearch
 
+if [ -f /etc/default/elasticsearch ]; then
+   chown root:elasticsearch /etc/default/elasticsearch
+fi
+
 if [ -f /etc/sysconfig/elasticsearch ]; then
-   chmod 0660 /etc/sysconfig/elasticsearch
+   chown root:elasticsearch /etc/sysconfig/elasticsearch
 fi
 
 ${scripts.footer}

--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -15,10 +15,7 @@ WorkingDirectory=/usr/share/elasticsearch
 User=elasticsearch
 Group=elasticsearch
 
-ExecStart=/usr/share/elasticsearch/bin/elasticsearch \
-                                                -p ${PID_DIR}/elasticsearch.pid \
-                                                --quiet \
-                                                --path.conf ${CONF_DIR}
+ExecStart=/usr/share/elasticsearch/bin/elasticsearch -p ${PID_DIR}/elasticsearch.pid --quiet
 
 # StandardOutput is configured to redirect to journalctl since
 # some error messages may be logged in standard output before

--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -15,7 +15,7 @@ WorkingDirectory=/usr/share/elasticsearch
 User=elasticsearch
 Group=elasticsearch
 
-ExecStart=/usr/share/elasticsearch/bin/elasticsearch -p ${PID_DIR}/elasticsearch.pid --quiet
+ExecStart=/usr/share/elasticsearch/bin/elasticsearch -p "${PID_DIR}"/elasticsearch.pid --quiet
 
 # StandardOutput is configured to redirect to journalctl since
 # some error messages may be logged in standard output before

--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -8,22 +8,22 @@
 #   CONF_DIR -- Path to config directory
 #   ES_JAVA_OPTS -- External Java Opts on top of the defaults set
 #
-# Optionally, exact memory values can be set using the `ES_JAVA_OPTS`.
-# Note that the Xms and Xmx lines in the JVM options file must be
-# commented out. Sample format include "512m", and "10g".
+# Optionally, exact memory values can be set using the `ES_JAVA_OPTS`. Note that
+# the Xms and Xmx lines in the JVM options file must be commented out. Example
+# values are "512m", and "10g".
 #
 #   ES_JAVA_OPTS="-Xms8g -Xmx8g" ./bin/elasticsearch
 
 # Check to see if you are trying to run this without building it first. Gradle
 # will replace the project.name with _something_.
 
-if echo '${project.name}' | grep project.name > /dev/null ; then
-    cat >&2 << EOF
+if echo '${project.name}' | grep project.name > /dev/null; then
+  cat >&2 << EOF
 Error: You must build the project with Gradle or download a pre-built package
 before you can run Elasticsearch. See 'Building from Source' in README.textile
 or visit https://www.elastic.co/download to get a pre-built package.
 EOF
-    exit 1
+  exit 1
 fi
 
 parse_jvm_options() {
@@ -44,21 +44,21 @@ args=("${args[@]}" --path.conf "$CONF_DIR")
 # manual parsing to find out, if process should be detached
 daemonized=`echo $* | egrep -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`
 if [ -z "$daemonized" ] ; then
-    exec "$JAVA" $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" \
-          org.elasticsearch.bootstrap.Elasticsearch "${args[@]}"
+  exec "$JAVA" $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" \
+    org.elasticsearch.bootstrap.Elasticsearch "${args[@]}"
 else
-    exec "$JAVA" $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" \
-          org.elasticsearch.bootstrap.Elasticsearch "${args[@]}" <&- &
-    retval=$?
-    pid=$!
-    [ $retval -eq 0 ] || exit $retval
-    if [ ! -z "$ES_STARTUP_SLEEP_TIME" ]; then
-      sleep $ES_STARTUP_SLEEP_TIME
-    fi
-    if ! ps -p $pid > /dev/null ; then
-      exit 1
-    fi
-    exit 0
+  exec "$JAVA" $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" \
+    org.elasticsearch.bootstrap.Elasticsearch "${args[@]}" <&- &
+  retval=$?
+  pid=$!
+  [ $retval -eq 0 ] || exit $retval
+  if [ ! -z "$ES_STARTUP_SLEEP_TIME" ]; then
+    sleep $ES_STARTUP_SLEEP_TIME
+  fi
+  if ! ps -p $pid > /dev/null ; then
+    exit 1
+  fi
+  exit 0
 fi
 
 exit $?

--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -2,10 +2,9 @@
 
 # CONTROLLING STARTUP:
 #
-# This script relies on few environment variables to determine startup
+# This script relies on a few environment variables to determine startup
 # behavior, those variables are:
 #
-#   ES_CLASSPATH -- A Java classpath containing everything necessary to run.
 #   CONF_DIR -- Path to config directory
 #   ES_JAVA_OPTS -- External Java Opts on top of the defaults set
 #
@@ -33,83 +32,24 @@ parse_jvm_options() {
   fi
 }
 
-CDPATH=""
-SCRIPT="$0"
+source "`dirname "$0"`"/elasticsearch-env
 
-# SCRIPT may be an arbitrarily deep series of symlinks. Loop until we have the concrete path.
-while [ -h "$SCRIPT" ] ; do
-  ls=`ls -ld "$SCRIPT"`
-  # Drop everything prior to ->
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    SCRIPT="$link"
-  else
-    SCRIPT=`dirname "$SCRIPT"`/"$link"
-  fi
-done
-
-# determine elasticsearch home
-ES_HOME=`dirname "$SCRIPT"`/..
-
-# make ELASTICSEARCH_HOME absolute
-ES_HOME=`cd "$ES_HOME"; pwd`
-
-if [ -z "$CONF_DIR" ]; then
-    ES_JVM_OPTIONS="$ES_HOME"/config/jvm.options
-else
-    ES_JVM_OPTIONS="$CONF_DIR"/jvm.options
-fi
+ES_JVM_OPTIONS="$CONF_DIR"/jvm.options
 
 ES_JAVA_OPTS="$(parse_jvm_options "$ES_JVM_OPTIONS") $ES_JAVA_OPTS"
 
-source "$ES_HOME/bin/elasticsearch.in.sh"
-
-if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA="$JAVA_HOME/bin/java"
-else
-    JAVA=`which java`
-fi
-
-if [ ! -x "$JAVA" ]; then
-    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
-    exit 1
-fi
-
-if [ -z "$ES_CLASSPATH" ]; then
-    echo "You must set the ES_CLASSPATH var" >&2
-    exit 1
-fi
-
-# don't let JAVA_TOOL_OPTIONS slip in (e.g. crazy agents in ubuntu)
-# works around https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487
-if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
-    echo "Warning: Ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-    echo "Please pass JVM parameters via ES_JAVA_OPTS instead"
-    unset JAVA_TOOL_OPTIONS
-fi
-
-# JAVA_OPTS is not a built-in JVM mechanism but some people think it is
-# so let us warn them that we are not observing the value of $JAVA_OPTS
-if [ "x$JAVA_OPTS" != "x" ]; then
-    echo "Warning: Ignoring JAVA_OPTS=$JAVA_OPTS"
-    echo "Please pass JVM parameters via ES_JAVA_OPTS instead"
-fi
-
-"$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.JavaVersionChecker
-
-if [ $? -ne 0 ]; then
-    echo "Elasticsearch requires at least Java 8 but your Java version from $JAVA does not meet this requirement"
-    exit 1
+if [ -e "$CONF_DIR" ]; then
+  args=("${args[@]}" --path.conf "$CONF_DIR")
 fi
 
 # manual parsing to find out, if process should be detached
 daemonized=`echo $* | egrep -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`
 if [ -z "$daemonized" ] ; then
     exec "$JAVA" $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" \
-          org.elasticsearch.bootstrap.Elasticsearch "$@"
+          org.elasticsearch.bootstrap.Elasticsearch "${args[@]}"
 else
     exec "$JAVA" $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" \
-          org.elasticsearch.bootstrap.Elasticsearch "$@" <&- &
+          org.elasticsearch.bootstrap.Elasticsearch "${args[@]}" <&- &
     retval=$?
     pid=$!
     [ $retval -eq 0 ] || exit $retval

--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -33,6 +33,7 @@ parse_jvm_options() {
 }
 
 source "`dirname "$0"`"/elasticsearch-env
+declare -a args=("$@")
 
 ES_JVM_OPTIONS="$CONF_DIR"/jvm.options
 

--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -33,15 +33,13 @@ parse_jvm_options() {
 }
 
 source "`dirname "$0"`"/elasticsearch-env
-declare -a args=("$@")
 
 ES_JVM_OPTIONS="$CONF_DIR"/jvm.options
 
 ES_JAVA_OPTS="$(parse_jvm_options "$ES_JVM_OPTIONS") $ES_JAVA_OPTS"
 
-if [ -e "$CONF_DIR" ]; then
-  args=("${args[@]}" --path.conf "$CONF_DIR")
-fi
+declare -a args=("$@")
+args=("${args[@]}" --path.conf "$CONF_DIR")
 
 # manual parsing to find out, if process should be detached
 daemonized=`echo $* | egrep -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`

--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -34,37 +34,37 @@ ES_CLASSPATH="$ES_HOME/lib/*"
 
 # now set the path to java
 if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA="$JAVA_HOME/bin/java"
+  JAVA="$JAVA_HOME/bin/java"
 else
-    JAVA=`which java`
+  JAVA=`which java`
 fi
 
 if [ ! -x "$JAVA" ]; then
-    echo "could not find java; set JAVA_HOME or ensure java is in PATH"
-    exit 1
+  echo "could not find java; set JAVA_HOME or ensure java is in PATH"
+  exit 1
 fi
 
 # check the JAVA version
 "$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.JavaVersionChecker
 
 if [ $? -ne 0 ]; then
-    echo -n "the minimum required Java version is 8; "
-    echo "your Java version from $JAVA does not meet this requirement"
-    exit 1
+  echo -n "the minimum required Java version is 8; "
+  echo "your Java version from $JAVA does not meet this requirement"
+  exit 1
 fi
 
 # don't let JAVA_TOOL_OPTIONS slip in (e.g. agents in Ubuntu); works around
 # https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487
 if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
-    echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-    unset JAVA_TOOL_OPTIONS
+  echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+  unset JAVA_TOOL_OPTIONS
 fi
 
 # JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
 # warn them that we are not observing the value of $JAVA_OPTS
 if [ "x$JAVA_OPTS" != "x" ]; then
-    echo -n "warning: ignoring JAVA_OPTS=$JAVA_OPTS; "
-    echo "pass JVM parameters via ES_JAVA_OPTS"
+  echo -n "warning: ignoring JAVA_OPTS=$JAVA_OPTS; "
+  echo "pass JVM parameters via ES_JAVA_OPTS"
 fi
 
 ${source.path.env}

--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+CDPATH=""
+
+SCRIPT="$0"
+
+# SCRIPT might be an arbitrarily deep series of symbolic links; loop until we
+# have the concrete path
+while [ -h "$SCRIPT" ] ; do
+  ls=`ls -ld "$SCRIPT"`
+  # Drop everything prior to ->
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    SCRIPT="$link"
+  else
+    SCRIPT=`dirname "$SCRIPT"`/"$link"
+  fi
+done
+
+# determine Elasticsearch home; to do this, we strip from the path until we find
+# bin, and then strip bin (there is an assumption here that there is no nested
+# directory under bin also named bin)
+ES_HOME=`dirname "$SCRIPT"`
+while [ "`basename "$ES_HOME"`" != "bin" ]; do
+  ES_HOME=`dirname "$ES_HOME"`
+done
+ES_HOME=`dirname "$ES_HOME"`
+
+# now make ES_HOME absolute
+ES_HOME=`cd "$ES_HOME"; pwd`
+
+# now set the classpath
+ES_CLASSPATH="$ES_HOME/lib/*"
+
+# now set the path to java
+if [ -x "$JAVA_HOME/bin/java" ]; then
+    JAVA="$JAVA_HOME/bin/java"
+else
+    JAVA=`which java`
+fi
+
+if [ ! -x "$JAVA" ]; then
+    echo "could not find java; set JAVA_HOME or ensure java is in PATH"
+    exit 1
+fi
+
+# check the JAVA version
+"$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.JavaVersionChecker
+
+if [ $? -ne 0 ]; then
+    echo -n "the minimum required Java version is 8; "
+    echo "your Java version from $JAVA does not meet this requirement"
+    exit 1
+fi
+
+# don't let JAVA_TOOL_OPTIONS slip in (e.g. agents in Ubuntu); works around
+# https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487
+if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
+    echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+    unset JAVA_TOOL_OPTIONS
+fi
+
+# JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
+# warn them that we are not observing the value of $JAVA_OPTS
+if [ "x$JAVA_OPTS" != "x" ]; then
+    echo -n "warning: ignoring JAVA_OPTS=$JAVA_OPTS; "
+    echo "pass JVM parameters via ES_JAVA_OPTS"
+fi
+
+${source.path.env}
+
+if [ -z "$CONF_DIR" ]; then
+  echo "CONF_DIR must be set to the configuration path"
+  exit 1
+fi

--- a/distribution/src/main/resources/bin/elasticsearch-keystore
+++ b/distribution/src/main/resources/bin/elasticsearch-keystore
@@ -1,74 +1,8 @@
 #!/bin/bash
 
-CDPATH=""
-SCRIPT="$0"
-
-# SCRIPT may be an arbitrarily deep series of symlinks. Loop until we have the concrete path.
-while [ -h "$SCRIPT" ] ; do
-  ls=`ls -ld "$SCRIPT"`
-  # Drop everything prior to ->
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    SCRIPT="$link"
-  else
-    SCRIPT=`dirname "$SCRIPT"`/"$link"
-  fi
-done
-
-# determine elasticsearch home
-ES_HOME=`dirname "$SCRIPT"`/..
-
-# make ELASTICSEARCH_HOME absolute
-ES_HOME=`cd "$ES_HOME"; pwd`
-
-
-# Sets the default values for elasticsearch variables used in this script
-if [ -z "$CONF_DIR" ]; then
-  CONF_DIR="${path.conf}"
-fi
-
-# The default env file is defined at building/packaging time.
-# For a ${project.name} package, the value is "${path.env}".
-ES_ENV_FILE="${path.env}"
-
-# Source the environment file
-if [ -n "$ES_ENV_FILE" ]; then
-
-  # If the ES_ENV_FILE is not found, try to resolve the path
-  # against the ES_HOME directory
-  if [ ! -f "$ES_ENV_FILE" ]; then
-      ES_ENV_FILE="$ELASTIC_HOME/$ES_ENV_FILE"
-  fi
-
-  . "$ES_ENV_FILE"
-  if [ $? -ne 0 ]; then
-      echo "Unable to source environment file: $ES_ENV_FILE" >&2
-      exit 1
-  fi
-fi
-
-# don't let JAVA_TOOL_OPTIONS slip in (e.g. crazy agents in ubuntu)
-# works around https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487
-if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
-    echo "Warning: Ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-    unset JAVA_TOOL_OPTIONS
-fi
-
-if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA=$JAVA_HOME/bin/java
-else
-    JAVA=`which java`
-fi
-
-if [ ! -x "$JAVA" ]; then
-    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
-    exit 1
-fi
+source "`dirname "$0"`"/elasticsearch-env
 
 declare -a args=("$@")
+args=("${args[@]}" --path.conf "$CONF_DIR")
 
-if [ -e "$CONF_DIR" ]; then
-  args=("${args[@]}" --path.conf "$CONF_DIR")
-fi
-
-exec "$JAVA" $ES_JAVA_OPTS -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.common.settings.KeyStoreCli "${args[@]}"
+exec "$JAVA" $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" org.elasticsearch.common.settings.KeyStoreCli "${args[@]}"

--- a/distribution/src/main/resources/bin/elasticsearch-plugin
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin
@@ -1,75 +1,8 @@
 #!/bin/bash
 
-CDPATH=""
-SCRIPT="$0"
-
-# SCRIPT may be an arbitrarily deep series of symlinks. Loop until we have the concrete path.
-while [ -h "$SCRIPT" ] ; do
-  ls=`ls -ld "$SCRIPT"`
-  # Drop everything prior to ->
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    SCRIPT="$link"
-  else
-    SCRIPT=`dirname "$SCRIPT"`/"$link"
-  fi
-done
-
-# determine elasticsearch home
-ES_HOME=`dirname "$SCRIPT"`/..
-
-# make ELASTICSEARCH_HOME absolute
-ES_HOME=`cd "$ES_HOME"; pwd`
-
-
-# Sets the default values for elasticsearch variables used in this script
-if [ -z "$CONF_DIR" ]; then
-  CONF_DIR="${path.conf}"
-fi
-
-# The default env file is defined at building/packaging time.
-# For a ${project.name} package, the value is "${path.env}".
-ES_ENV_FILE="${path.env}"
-
-# Source the environment file
-if [ -n "$ES_ENV_FILE" ]; then
-
-  # If the ES_ENV_FILE is not found, try to resolve the path
-  # against the ES_HOME directory
-  if [ ! -f "$ES_ENV_FILE" ]; then
-      ES_ENV_FILE="$ELASTIC_HOME/$ES_ENV_FILE"
-  fi
-
-  . "$ES_ENV_FILE"
-  if [ $? -ne 0 ]; then
-      echo "Unable to source environment file: $ES_ENV_FILE" >&2
-      exit 1
-  fi
-fi
-
-# don't let JAVA_TOOL_OPTIONS slip in (e.g. crazy agents in ubuntu)
-# works around https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487
-if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
-    echo "Warning: Ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-    unset JAVA_TOOL_OPTIONS
-fi
-
-if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA=$JAVA_HOME/bin/java
-else
-    JAVA=`which java`
-fi
-
-if [ ! -x "$JAVA" ]; then
-    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
-    exit 1
-fi
+source "`dirname "$0"`"/elasticsearch-env
 
 declare -a args=("$@")
-path_props=(-Des.path.home="$ES_HOME")
+args=("${args[@]}" --path.conf "$CONF_DIR")
 
-if [ -e "$CONF_DIR" ]; then
-  args=("${args[@]}" --path.conf "$CONF_DIR")
-fi
-
-exec "$JAVA" $ES_JAVA_OPTS -Delasticsearch "${path_props[@]}" -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginCli "${args[@]}"
+exec "$JAVA" $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" org.elasticsearch.plugins.PluginCli "${args[@]}"

--- a/distribution/src/main/resources/bin/elasticsearch-translog
+++ b/distribution/src/main/resources/bin/elasticsearch-translog
@@ -1,75 +1,8 @@
 #!/bin/bash
 
-CDPATH=""
-SCRIPT="$0"
-
-# SCRIPT may be an arbitrarily deep series of symlinks. Loop until we have the concrete path.
-while [ -h "$SCRIPT" ] ; do
-  ls=`ls -ld "$SCRIPT"`
-  # Drop everything prior to ->
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    SCRIPT="$link"
-  else
-    SCRIPT=`dirname "$SCRIPT"`/"$link"
-  fi
-done
-
-# determine elasticsearch home
-ES_HOME=`dirname "$SCRIPT"`/..
-
-# make ELASTICSEARCH_HOME absolute
-ES_HOME=`cd "$ES_HOME"; pwd`
-
-
-# Sets the default values for elasticsearch variables used in this script
-if [ -z "$CONF_DIR" ]; then
-  CONF_DIR="${path.conf}"
-fi
-
-# The default env file is defined at building/packaging time.
-# For a ${project.name} package, the value is "${path.env}".
-ES_ENV_FILE="${path.env}"
-
-# Source the environment file
-if [ -n "$ES_ENV_FILE" ]; then
-
-  # If the ES_ENV_FILE is not found, try to resolve the path
-  # against the ES_HOME directory
-  if [ ! -f "$ES_ENV_FILE" ]; then
-      ES_ENV_FILE="$ELASTIC_HOME/$ES_ENV_FILE"
-  fi
-
-  . "$ES_ENV_FILE"
-  if [ $? -ne 0 ]; then
-      echo "Unable to source environment file: $ES_ENV_FILE" >&2
-      exit 1
-  fi
-fi
-
-# don't let JAVA_TOOL_OPTIONS slip in (e.g. crazy agents in ubuntu)
-# works around https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487
-if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
-    echo "Warning: Ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
-    unset JAVA_TOOL_OPTIONS
-fi
-
-
-if [ -x "$JAVA_HOME/bin/java" ]; then
-    JAVA=$JAVA_HOME/bin/java
-else
-    JAVA=`which java`
-fi
-
-if [ ! -x "$JAVA" ]; then
-    echo "Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
-    exit 1
-fi
+source "`dirname "$0"`"/elasticsearch-env
 
 declare -a args=("$@")
+args=("${args[@]}" --path.conf "$CONF_DIR")
 
-if [ -e "$CONF_DIR" ]; then
-  args=("${args[@]}" --path.conf "$CONF_DIR")
-fi
-
-exec "$JAVA" $ES_JAVA_OPTS -Delasticsearch -Des.path.home="$ES_HOME" -cp "$ES_HOME/lib/*" org.elasticsearch.index.translog.TranslogToolCli "${args[@]}"
+exec "$JAVA" $ES_JAVA_OPTS -Des.path.home="$ES_HOME" -cp "$ES_CLASSPATH" org.elasticsearch.index.translog.TranslogToolCli "${args[@]}"

--- a/qa/vagrant/src/test/resources/packaging/tests/20_tar_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/20_tar_package.bats
@@ -93,7 +93,7 @@ setup() {
   sudo chmod +x $JAVA
 
   [ "$status" -eq 1 ]
-  local expected="Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+  local expected="could not find java; set JAVA_HOME or ensure java is in PATH"
   [[ "$output" == *"$expected"* ]] || {
     echo "Expected error message [$expected] but found: $output"
     false

--- a/qa/vagrant/src/test/resources/packaging/tests/module_and_plugin_test_cases.bash
+++ b/qa/vagrant/src/test/resources/packaging/tests/module_and_plugin_test_cases.bash
@@ -152,7 +152,7 @@ fi
   sudo chmod +x $JAVA
 
   [ "$status" -eq 1 ]
-  local expected="Could not find any executable java binary. Please install java in your PATH or set JAVA_HOME"
+  local expected="could not find java; set JAVA_HOME or ensure java is in PATH"
   [[ "$output" == *"$expected"* ]] || {
     echo "Expected error message [$expected] but found: $output"
     false

--- a/qa/vagrant/src/test/resources/packaging/utils/packages.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/packages.bash
@@ -108,7 +108,7 @@ verify_package_installation() {
 
     if is_dpkg; then
         # Env file
-        assert_file "/etc/default/elasticsearch" f root root 660
+        assert_file "/etc/default/elasticsearch" f root elasticsearch 660
 
         # Doc files
         assert_file "/usr/share/doc/elasticsearch" d root root 755
@@ -117,7 +117,7 @@ verify_package_installation() {
 
     if is_rpm; then
         # Env file
-        assert_file "/etc/sysconfig/elasticsearch" f root root 660
+        assert_file "/etc/sysconfig/elasticsearch" f root elasticsearch 660
         # License file
         assert_file "/usr/share/elasticsearch/LICENSE.txt" f root root 644
     fi

--- a/qa/vagrant/src/test/resources/packaging/utils/plugins.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/plugins.bash
@@ -38,6 +38,14 @@ install_plugin() {
 
     assert_file_exist "$path"
 
+    if [ ! -z "$CONF_DIR" ] ; then
+        if is_dpkg; then
+            echo "CONF_DIR=$CONF_DIR" >> /etc/default/elasticsearch;
+        elif is_rpm; then
+            echo "CONF_DIR=$CONF_DIR" >> /etc/sysconfig/elasticsearch;
+        fi
+    fi
+
     if [ -z "$umask" ]; then
       sudo -E -u $ESPLUGIN_COMMAND_USER "$ESHOME/bin/elasticsearch-plugin" install -batch "file://$path"
     else

--- a/qa/vagrant/src/test/resources/packaging/utils/utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/utils.bash
@@ -364,7 +364,7 @@ run_elasticsearch_service() {
 # And now we can start Elasticsearch normally, in the background (-d) and with a pidfile (-p).
 export CONF_DIR=$CONF_DIR
 export ES_JAVA_OPTS=$ES_JAVA_OPTS
-$timeoutCommand/tmp/elasticsearch/bin/elasticsearch $background -p /tmp/elasticsearch/elasticsearch.pid commandLineArgs
+$timeoutCommand/tmp/elasticsearch/bin/elasticsearch $background -p /tmp/elasticsearch/elasticsearch.pid $commandLineArgs
 BASH
         [ "$status" -eq "$expectedStatus" ]
     elif is_systemd; then

--- a/qa/vagrant/src/test/resources/packaging/utils/utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/utils.bash
@@ -345,12 +345,6 @@ run_elasticsearch_service() {
     fi
 
     if [ -f "/tmp/elasticsearch/bin/elasticsearch" ]; then
-        if [ -z "$CONF_DIR" ]; then
-            local CONF_DIR=""
-            local ES_PATH_CONF=""
-        else
-            local ES_PATH_CONF="--path.conf $CONF_DIR"
-        fi
         # we must capture the exit code to compare so we don't want to start as background process in case we expect something other than 0
         local background=""
         local timeoutCommand=""
@@ -370,7 +364,7 @@ run_elasticsearch_service() {
 # And now we can start Elasticsearch normally, in the background (-d) and with a pidfile (-p).
 export CONF_DIR=$CONF_DIR
 export ES_JAVA_OPTS=$ES_JAVA_OPTS
-$timeoutCommand/tmp/elasticsearch/bin/elasticsearch $background -p /tmp/elasticsearch/elasticsearch.pid $ES_PATH_CONF $commandLineArgs
+$timeoutCommand/tmp/elasticsearch/bin/elasticsearch $background -p /tmp/elasticsearch/elasticsearch.pid commandLineArgs
 BASH
         [ "$status" -eq "$expectedStatus" ]
     elif is_systemd; then

--- a/qa/vagrant/src/test/resources/packaging/utils/utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/utils.bash
@@ -337,7 +337,7 @@ run_elasticsearch_service() {
     local commandLineArgs=$2
     # Set the CONF_DIR setting in case we start as a service
     if [ ! -z "$CONF_DIR" ] ; then
-        if is_dpkg ; then
+        if is_dpkg; then
             echo "CONF_DIR=$CONF_DIR" >> /etc/default/elasticsearch;
         elif is_rpm; then
             echo "CONF_DIR=$CONF_DIR" >> /etc/sysconfig/elasticsearch;


### PR DESCRIPTION
This commit introduces the elasticsearch-env script. The purpose of this script is threefold:
 - vastly simplify the various scripts used in Elasticsearch
 - provide a script that can be included in other scripts in the Elasticsearch ecosystem (e.g., plugins)
 - correctly establish the environment for all scripts (e.g., so that users can run `elasticsearch-keystore` from a package distribution without having to worry about setting `CONF_DIR` first, otherwise the keystone would be created in the wrong location)

Relates #20286