### PR TITLE
[TEST] Move version skip to setup in Indices.GetMapping#70_legacy_multi_type

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/70_legacy_multi_type.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/70_legacy_multi_type.yml
@@ -1,5 +1,10 @@
 ---
 setup:
+
+  - skip:
+        version: "5.99.99 - " # this will only run in a mixed cluster environment with at least 1 5.x node
+        reason:  multiple types are not supported on 6.x indices onwards
+
   - do:
         indices.create:
           index: test_1
@@ -18,10 +23,6 @@ setup:
 ---
 "Get /_mapping":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
-
  - do:
     indices.get_mapping: {}
 
@@ -32,10 +33,6 @@ setup:
 
 ---
 "Get /{index}/_mapping":
-
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
 
  - do:
     indices.get_mapping:
@@ -49,10 +46,6 @@ setup:
 ---
 "Get /{index}/_mapping/_all":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: test_1
@@ -64,10 +57,6 @@ setup:
 
 ---
 "Get /{index}/_mapping/*":
-
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
 
  - do:
     indices.get_mapping:
@@ -81,10 +70,6 @@ setup:
 ---
 "Get /{index}/_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: test_1
@@ -95,10 +80,6 @@ setup:
 
 ---
 "Get /{index}/_mapping/{type,type}":
-
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
 
  - do:
     indices.get_mapping:
@@ -112,10 +93,6 @@ setup:
 ---
 "Get /{index}/_mapping/{type*}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: test_1
@@ -128,10 +105,6 @@ setup:
 ---
 "Get /_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         type: type_2
@@ -143,10 +116,6 @@ setup:
 
 ---
 "Get /_all/_mapping/{type}":
-
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
 
  - do:
     indices.get_mapping:
@@ -161,10 +130,6 @@ setup:
 ---
 "Get /*/_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: '*'
@@ -178,10 +143,6 @@ setup:
 ---
 "Get /index,index/_mapping/{type}":
 
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
-
  - do:
     indices.get_mapping:
         index: test_1,test_2
@@ -193,10 +154,6 @@ setup:
 
 ---
 "Get /index*/_mapping/{type}":
-
- - skip:
-    version: "5.99.99 - "# this will only run in a mixed cluster environment with at least 1 5.x node
-    reason:  multiple types are not supported on 6.x indices onwards
 
  - do:
     indices.get_mapping:


### PR DESCRIPTION
Since the setup attempts to create an index with two types, and the setup runs before any test, this will fail on versions 6.0+ before it has a chance to check the skip in each individual test.  Moving to the setup resolves this issue.

@elastic/es-clients anyone have a problem with this?