### PR TITLE
First increment shard stats before notifying and potentially sending response

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -316,8 +316,8 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
 
     @Override
     protected void skipShard(SearchShardIterator iterator) {
-        super.skipShard(iterator);
         successfulOps.incrementAndGet();
         skippedOps.incrementAndGet();
+        super.skipShard(iterator);
     }
 }


### PR DESCRIPTION
When we skip a shard we should first increment the skip and successful shard
counters before we notify the super class about a skipped shard which could
send back the result before we increment the stats.

here is a test failure related to this: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+intake/75/
