### PR TITLE
Simplify selector close method

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/ESSelector.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/ESSelector.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -49,6 +50,7 @@ public abstract class ESSelector implements Closeable {
 
     private final EventHandler eventHandler;
     private final ReentrantLock runLock = new ReentrantLock();
+    private final CountDownLatch exitedLoop = new CountDownLatch(1);
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
     private final PlainActionFuture<Boolean> isRunningFuture = PlainActionFuture.newFuture();
     private final Set<NioChannel> registeredChannels = Collections.newSetFromMap(new ConcurrentHashMap<NioChannel, Boolean>());
@@ -84,6 +86,7 @@ public abstract class ESSelector implements Closeable {
                         eventHandler.closeSelectorException(e);
                     } finally {
                         runLock.unlock();
+                        exitedLoop.countDown();
                     }
                 }
             }
@@ -157,7 +160,13 @@ public abstract class ESSelector implements Closeable {
     public void close() throws IOException {
         if (isClosed.compareAndSet(false, true)) {
             wakeup();
-            runLock.lock(); // wait for the shutdown to complete
+            if (isRunning()) {
+                try {
+                    exitedLoop.await();
+                } catch (InterruptedException e) {
+                    eventHandler.uncaughtException(e);
+                }
+            }
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/ESSelector.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/ESSelector.java
@@ -64,8 +64,7 @@ public abstract class ESSelector implements Closeable {
     }
 
     /**
-     * Starts this selector. The selector will run until {@link #close()} or {@link #close(boolean)} is
-     * called.
+     * Starts this selector. The selector will run until {@link #close()} is called.
      */
     public void runLoop() {
         if (runLock.tryLock()) {
@@ -156,16 +155,8 @@ public abstract class ESSelector implements Closeable {
 
     @Override
     public void close() throws IOException {
-        close(false);
-    }
-
-    public void close(boolean shouldInterrupt) throws IOException {
         if (isClosed.compareAndSet(false, true)) {
-            if (shouldInterrupt && thread != null) {
-                thread.interrupt();
-            } else {
-                wakeup();
-            }
+            wakeup();
             runLock.lock(); // wait for the shutdown to complete
         }
     }


### PR DESCRIPTION
Currently we have an option to interrupt the selector thread on close.
This option is not needed as we do not call this method and we should
not be blocking on the network thread. Instead we only need to ever call
wakeup() on the raw selector.