### PR TITLE
Close raw channel when bind / connect fails

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ChannelFactory.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ChannelFactory.java
@@ -114,8 +114,8 @@ public class ChannelFactory {
 
         SocketChannel openNioChannel(InetSocketAddress remoteAddress) throws IOException {
             SocketChannel socketChannel = SocketChannel.open();
-            configureSocketChannel(socketChannel);
             try {
+                configureSocketChannel(socketChannel);
                 PrivilegedSocketAccess.connect(socketChannel, remoteAddress);
             } catch (IOException e) {
                 closeRawChannel(socketChannel, e);
@@ -135,8 +135,8 @@ public class ChannelFactory {
             ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
             serverSocketChannel.configureBlocking(false);
             ServerSocket socket = serverSocketChannel.socket();
-            socket.setReuseAddress(tcpReusedAddress);
             try {
+                socket.setReuseAddress(tcpReusedAddress);
                 serverSocketChannel.bind(address);
             } catch (IOException e) {
                 closeRawChannel(serverSocketChannel, e);


### PR DESCRIPTION
Currently we are failing to close socket channels when the initial bind
or connect operation fails. This leaves the file descriptor hanging
around. This closes the channel when an exception occurs during bind or
connect.