### PR TITLE
[TEST] Remove duplicated main response unit test

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -41,7 +41,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     private ClusterName clusterName;
     private String clusterUuid;
     private Build build;
-    private boolean available;
+    boolean available;
 
     MainResponse() {
     }
@@ -122,7 +122,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     }
 
     private static final ObjectParser<MainResponse, Void> PARSER = new ObjectParser<>(MainResponse.class.getName(), true,
-            () -> new MainResponse());
+            MainResponse::new);
 
     static {
         PARSER.declareString((response, value) -> response.nodeName = value, new ParseField("name"));

--- a/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/main/MainActionTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.action.main;
 
-import org.elasticsearch.Build;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterName;
@@ -30,73 +28,20 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class MainActionTests extends ESTestCase {
-
-    public void testMainResponseSerialization() throws IOException {
-        final String nodeName = "node1";
-        final ClusterName clusterName = new ClusterName("cluster1");
-        final String clusterUUID = randomAlphaOfLengthBetween(10, 20);
-        final boolean available = randomBoolean();
-        final Version version = Version.CURRENT;
-        final Build build = Build.CURRENT;
-
-        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, clusterUUID, build, available);
-        BytesStreamOutput streamOutput = new BytesStreamOutput();
-        mainResponse.writeTo(streamOutput);
-        final MainResponse serialized = new MainResponse();
-        serialized.readFrom(streamOutput.bytes().streamInput());
-
-        assertThat(serialized.getNodeName(), equalTo(nodeName));
-        assertThat(serialized.getClusterName(), equalTo(clusterName));
-        assertThat(serialized.getBuild(), equalTo(build));
-        assertThat(serialized.isAvailable(), equalTo(available));
-        assertThat(serialized.getVersion(), equalTo(version));
-    }
-
-    public void testMainResponseXContent() throws IOException {
-        String clusterUUID = randomAlphaOfLengthBetween(10, 20);
-        final MainResponse mainResponse = new MainResponse("node1", Version.CURRENT, new ClusterName("cluster1"), clusterUUID,
-                Build.CURRENT, false);
-        final String expected = "{" +
-                "\"name\":\"node1\"," +
-                "\"cluster_name\":\"cluster1\"," +
-                "\"cluster_uuid\":\"" + clusterUUID + "\"," +
-                "\"version\":{" +
-                "\"number\":\"" + Version.CURRENT.toString() + "\"," +
-                "\"build_hash\":\"" + Build.CURRENT.shortHash() + "\"," +
-                "\"build_date\":\"" + Build.CURRENT.date() + "\"," +
-                "\"build_snapshot\":" + Build.CURRENT.isSnapshot() + "," +
-                "\"lucene_version\":\"" + Version.CURRENT.luceneVersion.toString() + "\"," +
-                "\"minimum_wire_compatibility_version\":\"" + Version.CURRENT.minimumCompatibilityVersion().toString() + "\"," +
-                "\"minimum_index_compatibility_version\":\"" + Version.CURRENT.minimumIndexCompatibilityVersion().toString() +
-                "\"}," +
-                "\"tagline\":\"You Know, for Search\"}";
-
-        XContentBuilder builder = XContentFactory.jsonBuilder();
-        mainResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        String xContent = builder.string();
-
-        assertEquals(expected, xContent);
-    }
 
     public void testMainActionClusterAvailable() {
         final ClusterService clusterService = mock(ClusterService.class);

--- a/core/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -26,14 +26,11 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -50,7 +47,6 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.mock;
@@ -203,21 +199,9 @@ public class CollapseBuilderTests extends AbstractSerializingTestCase<CollapseBu
         return CollapseBuilder.fromXContent(parser);
     }
 
-    /**
-     * Rewrite this test to disable xcontent shuffling on the highlight builder
-     */
     @Override
-    public void testFromXContent() throws IOException {
-        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
-            CollapseBuilder testInstance = createTestInstance();
-            XContentType xContentType = randomFrom(XContentType.values());
-            XContentBuilder builder = toXContent(testInstance, xContentType);
-            XContentBuilder shuffled = shuffleXContent(builder, "fields");
-            assertParsedInstance(xContentType, shuffled.bytes(), testInstance);
-            for (Map.Entry<String, CollapseBuilder> alternateVersion : getAlternateVersions().entrySet()) {
-                String instanceAsString = alternateVersion.getKey();
-                assertParsedInstance(XContentType.JSON, new BytesArray(instanceAsString), alternateVersion.getValue());
-            }
-        }
+    protected String[] getShuffleFieldsExceptions() {
+        //disable xcontent shuffling on the highlight builder
+        return new String[]{"fields"};
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSerializingTestCase.java
@@ -18,18 +18,14 @@
  */
 package org.elasticsearch.test;
 
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
 
 public abstract class AbstractSerializingTestCase<T extends ToXContent & Writeable> extends AbstractWireSerializingTestCase<T> {
 
@@ -41,13 +37,8 @@ public abstract class AbstractSerializingTestCase<T extends ToXContent & Writeab
         for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
             T testInstance = createTestInstance();
             XContentType xContentType = randomFrom(XContentType.values());
-            XContentBuilder builder = toXContent(testInstance, xContentType);
-            XContentBuilder shuffled = shuffleXContent(builder);
-            assertParsedInstance(xContentType, shuffled.bytes(), testInstance);
-            for (Map.Entry<String, T> alternateVersion : getAlternateVersions().entrySet()) {
-                String instanceAsString = alternateVersion.getKey();
-                assertParsedInstance(XContentType.JSON, new BytesArray(instanceAsString), alternateVersion.getValue());
-            }
+            BytesReference shuffled = toShuffledXContent(testInstance, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
+            assertParsedInstance(xContentType, shuffled, testInstance);
         }
     }
 
@@ -71,40 +62,4 @@ public abstract class AbstractSerializingTestCase<T extends ToXContent & Writeab
      * Parses to a new instance using the provided {@link XContentParser}
      */
     protected abstract T doParseInstance(XContentParser parser) throws IOException;
-
-    /**
-     * Renders the provided instance in XContent
-     *
-     * @param instance
-     *            the instance to render
-     * @param contentType
-     *            the content type to render to
-     */
-    protected XContentBuilder toXContent(T instance, XContentType contentType)
-            throws IOException {
-        XContentBuilder builder = XContentFactory.contentBuilder(contentType);
-        if (randomBoolean()) {
-            builder.prettyPrint();
-        }
-        if (instance.isFragment()) {
-            builder.startObject();
-        }
-        instance.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        if (instance.isFragment()) {
-            builder.endObject();
-        }
-        return builder;
-    }
-
-    /**
-     * Returns alternate string representation of the instance that need to be
-     * tested as they are never used as output of the test instance. By default
-     * there are no alternate versions.
-     *
-     * These alternatives must be JSON strings.
-     */
-    protected Map<String, T> getAlternateVersions() {
-        return Collections.emptyMap();
-    }
-
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSerializingTestCase.java
@@ -39,7 +39,7 @@ public abstract class AbstractSerializingTestCase<T extends ToXContent & Writeab
             T testInstance = createTestInstance();
             XContentType xContentType = randomFrom(XContentType.values());
             BytesReference shuffled = toShuffledXContent(testInstance, xContentType, ToXContent.EMPTY_PARAMS,
-                    randomBoolean(), getShuffleFieldsExceptions());
+                    false, getShuffleFieldsExceptions());
             assertParsedInstance(xContentType, shuffled, testInstance);
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSerializingTestCase.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -37,7 +38,8 @@ public abstract class AbstractSerializingTestCase<T extends ToXContent & Writeab
         for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
             T testInstance = createTestInstance();
             XContentType xContentType = randomFrom(XContentType.values());
-            BytesReference shuffled = toShuffledXContent(testInstance, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
+            BytesReference shuffled = toShuffledXContent(testInstance, xContentType, ToXContent.EMPTY_PARAMS,
+                    randomBoolean(), getShuffleFieldsExceptions());
             assertParsedInstance(xContentType, shuffled, testInstance);
         }
     }
@@ -62,4 +64,11 @@ public abstract class AbstractSerializingTestCase<T extends ToXContent & Writeab
      * Parses to a new instance using the provided {@link XContentParser}
      */
     protected abstract T doParseInstance(XContentParser parser) throws IOException;
+
+    /**
+     * Fields that have to be ignored when shuffling as part of testFromXContent
+     */
+    protected String[] getShuffleFieldsExceptions() {
+        return Strings.EMPTY_ARRAY;
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractStreamableTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractStreamableTestCase.java
@@ -105,7 +105,7 @@ public abstract class AbstractStreamableTestCase<T extends Streamable> extends E
     /**
      * Round trip {@code instance} through binary serialization, setting the wire compatibility version to {@code version}.
      */
-    protected T copyInstance(T instance, Version version) throws IOException {
+    private T copyInstance(T instance, Version version) throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.setVersion(version);
             instance.writeTo(output);


### PR DESCRIPTION
The `toXContent` output of `MainResponse` was tested in two different test classes, unified tests in the existing `MainResponseTests`