### PR TITLE
Context suggester should filter doc values field

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
@@ -19,7 +19,10 @@
 
 package org.elasticsearch.search.suggest.completion.context;
 
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.SortedSetSortField;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -28,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParseContext.Document;
+import org.elasticsearch.index.mapper.StringFieldType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -138,8 +142,11 @@ public class CategoryContextMapping extends ContextMapping<CategoryQueryContext>
             for (IndexableField field : fields) {
                 if (field.fieldType() instanceof KeywordFieldMapper.KeywordFieldType) {
                     values.add(field.binaryValue().utf8ToString());
-                } else {
+                } else if (field.fieldType() instanceof StringFieldType) {
                     values.add(field.stringValue());
+                } else {
+                    // ignore doc_values field
+                    assert field.fieldType() instanceof SortedDocValuesField || field.fieldType() instanceof SortedSetDocValuesField;
                 }
             }
         }


### PR DESCRIPTION
The context suggester extracts the context field values from the document but it does not filter doc values field coming from Keyword field.
This change filters doc values field when building the context values.

Fixes #25404