### PR TITLE
ES_HOME needs to be made absolute before attempt at traversal

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -20,14 +20,11 @@ done
 # determine Elasticsearch home; to do this, we strip from the path until we find
 # bin, and then strip bin (there is an assumption here that there is no nested
 # directory under bin also named bin)
-ES_HOME=`dirname "$SCRIPT"`
+ES_HOME="$(cd "$(dirname "$SCRIPT")"; pwd)"
 while [ "`basename "$ES_HOME"`" != "bin" ]; do
   ES_HOME=`dirname "$ES_HOME"`
 done
 ES_HOME=`dirname "$ES_HOME"`
-
-# now make ES_HOME absolute
-ES_HOME=`cd "$ES_HOME"; pwd`
 
 # now set the classpath
 ES_CLASSPATH="$ES_HOME/lib/*"


### PR DESCRIPTION
otherwise infinite loop will occur if started from within bin as `./elasticsearch`