### PR TITLE
Parse "*" in query_string_query as MatchAllDocsQuery

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -23,6 +23,7 @@ import org.apache.lucene.queryparser.classic.MapperQueryParser;
 import org.apache.lucene.queryparser.classic.QueryParserSettings;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.Version;
@@ -969,6 +970,9 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
             resolvedFields = allQueryableDefaultFields(context);
             // Automatically set leniency to "true" so mismatched fields don't cause exceptions
             qpSettings.lenient(true);
+            if ("*".equals(queryString)) {
+                return new MatchAllDocsQuery();
+            }
         } else {
             qpSettings.defaultField(this.defaultField == null ? context.defaultField() : this.defaultField);
 

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -187,6 +187,9 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryMatchAllQuery() throws Exception {
         Query query = queryStringQuery("*:*").toQuery(createShardContext());
         assertThat(query, instanceOf(MatchAllDocsQuery.class));
+
+        query = queryStringQuery("*").toQuery(createShardContext());
+        assertThat(query, instanceOf(MatchAllDocsQuery.class));
     }
 
     public void testToQueryTermQuery() throws IOException {


### PR DESCRIPTION
Related to #25726, this resolves #25556 for the 5.x series by parsing "*" as a
`MatchAllDocsQuery` instead of expanding it to a (potentially expensive) query
on the `_field_names`.

This fixes the performance regression in 5.x.