### PR TITLE
Fix eclipse issues related to rest client shading

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -94,6 +94,7 @@ dependencies {
   compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
   compile 'de.thetaphi:forbiddenapis:2.3'
   compile 'org.apache.rat:apache-rat:0.11'
+  compile 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
 }
 
 // Gradle 2.14+ removed ProgressLogger(-Factory) classes from the public APIs

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -94,7 +94,6 @@ dependencies {
   compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
   compile 'de.thetaphi:forbiddenapis:2.3'
   compile 'org.apache.rat:apache-rat:0.11'
-  compile 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
 }
 
 // Gradle 2.14+ removed ProgressLogger(-Factory) classes from the public APIs

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -39,8 +39,11 @@ import org.elasticsearch.gradle.precommit.PrecommitTasks
  * 3) The *actual* jar that will be used by clients. This has no classifier, contains the rest client src and
  *    `org.elasticsearch.client`. This jar is the only actual output artifact of this job.
  */
+plugins {
+  id "com.github.johnrengelman.shadow" version "2.0.1"
+}
+
 apply plugin: 'elasticsearch.build'
-apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'ru.vyarus.animalsniffer'
 apply plugin: 'nebula.maven-base-publish'
 apply plugin: 'nebula.maven-scm'

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -39,11 +39,8 @@ import org.elasticsearch.gradle.precommit.PrecommitTasks
  * 3) The *actual* jar that will be used by clients. This has no classifier, contains the rest client src and
  *    `org.elasticsearch.client`. This jar is the only actual output artifact of this job.
  */
-plugins {
-  id "com.github.johnrengelman.shadow" version "2.0.1"
-}
-
 apply plugin: 'elasticsearch.build'
+apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'ru.vyarus.animalsniffer'
 apply plugin: 'nebula.maven-base-publish'
 apply plugin: 'nebula.maven-scm'
@@ -109,6 +106,18 @@ if (isIdea == false && isEclipse == false) {
   }
 }
 
+if (isEclipse) {
+  // in eclipse the project is under a fake root, we need to change around the source sets
+  sourceSets {
+    if (project.path == ":client:rest") {
+      main.java.srcDirs = ['java']
+      //main.resources.srcDirs = ['resources']
+    } else {
+      test.java.srcDirs = ['java']
+      test.resources.srcDirs = ['resources']
+    }
+  }
+}
 // adds a dependency to compile, so the -deps jar is built first
 sourceSets.main.output.dir(shadedSrcDir, builtBy: 'shadeDeps')
 
@@ -122,7 +131,12 @@ dependencies {
 
   compile shadeDeps.outputs.files
 
-  testCompile "org.elasticsearch.client:test:${version}"
+  if (isEclipse == false || project.path == ":client:rest-tests") {
+    testCompile("org.elasticsearch.client:test:${version}") {
+      // tests use the locally compiled version of core
+      exclude group: 'org.elasticsearch', module: 'elasticsearch'
+    }
+  }
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
   testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
@@ -130,6 +144,14 @@ dependencies {
   testCompile "org.elasticsearch:mocksocket:${versions.mocksocket}"
   testCompile "org.codehaus.mojo:animal-sniffer-annotations:1.15"
   signature "org.codehaus.mojo.signature:java17:1.0@signature"
+}
+
+// Set the exported=true for the generated rest client deps since it is used by other projects in eclipse.
+// https://docs.gradle.org/3.3/userguide/eclipse_plugin.html#sec:eclipse_modify_domain_objects
+eclipse.classpath.file {
+    whenMerged { classpath ->
+        classpath.entries.findAll { entry -> entry.path.contains("elasticsearch-rest-client") }*.exported = true
+    }
 }
 
 dependencyLicenses.dependencies = project.configurations.shade

--- a/client/rest/src/main/eclipse-build.gradle
+++ b/client/rest/src/main/eclipse-build.gradle
@@ -1,0 +1,2 @@
+// this is just shell gradle file for eclipse to have separate projects for src and tests
+apply from: '../../build.gradle'

--- a/client/rest/src/test/eclipse-build.gradle
+++ b/client/rest/src/test/eclipse-build.gradle
@@ -1,0 +1,6 @@
+// this is just shell gradle file for eclipse to have separate projects for src and tests
+apply from: '../../build.gradle'
+
+dependencies {
+  testCompile project(':client:rest')
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -96,6 +96,7 @@ if (isEclipse) {
   // eclipse cannot handle an intermediate dependency between main and test, so we must create separate projects
   // for core-src and core-tests
   projects << 'core-tests'
+  projects << 'client:rest-tests'
 }
 
 include projects.toArray(new String[0])
@@ -119,6 +120,11 @@ if (isEclipse) {
   project(":core").buildFileName = 'eclipse-build.gradle'
   project(":core-tests").projectDir = new File(rootProject.projectDir, 'core/src/test')
   project(":core-tests").buildFileName = 'eclipse-build.gradle'
+
+  project(":client:rest").projectDir = new File(rootProject.projectDir, 'client/rest/src/main')
+  project(":client:rest").buildFileName = 'eclipse-build.gradle'
+  project(":client:rest-tests").projectDir = new File(rootProject.projectDir, 'client/rest/src/test')
+  project(":client:rest-tests").buildFileName = 'eclipse-build.gradle'
 }
 
 /**


### PR DESCRIPTION
* A cycle was detected in eclipse, and was fixed in the same fashion as
  core and core-tests.
* The rest client deps jar was not properly exported in the generated
  eclipse classpath file for rest client.
* Moved the plugin dependency due to eclipse-build 'apply from' not
  liking the plugin declaration in the rest client build.

Relates #25208