### PR TITLE
Declare XContent deprecation logger as static

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -54,7 +54,7 @@ public abstract class AbstractXContentParser implements XContentParser {
         }
     }
 
-    private final DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(getClass()));
+    private static final DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(AbstractXContentParser.class));
 
     private final NamedXContentRegistry xContentRegistry;
 


### PR DESCRIPTION
With this commit we declare the deprecation logger in
AbstractXContentParser as static. It was not static previously in order
to let users see which concrete subclass issued a deprecation log
statement. As there is a performance overhead when allocating a lot of
parser instances and there are only four subclasses (out of which JSON
is the most likely one) we opt to declare it static instead.

Closes #25879