### PR TITLE
Fix random score generation when no seed is provided.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
+++ b/core/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
@@ -70,7 +70,7 @@ public class RandomScoreFunction extends ScoreFunction {
             public double score(int docId, float subQueryScore) throws IOException {
                 int hash;
                 if (values == null) {
-                    hash = BitMixer.mix(ctx.docBase + docId);
+                    hash = BitMixer.mix(docId, saltedSeed);
                 } else if (values.advanceExact(docId)) {
                     hash = StringHelper.murmurhash3_x86_32(values.nextValue(), saltedSeed);
                 } else {


### PR DESCRIPTION
It fixes random score generation to ensure that you will not always get the
same scores on a read-only index by integrating the seed into the score
computation when using doc ids. It also removes `ctx.docBase` from the formula
since it might change over time if deletes are compacted while scores are
supposed to be cacheable per segment.