### PR TITLE
Improves AbstractWireSerializingTestCase equals test

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractStreamableTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractStreamableTestCase.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Streamable;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 import org.elasticsearch.test.EqualsHashCodeTestUtils.MutateFunction;
 
@@ -52,7 +51,7 @@ public abstract class AbstractStreamableTestCase<T extends Streamable> extends E
     /**
      * Returns a {@link CopyFunction} that can be used to make an exact copy of
      * the given instance. This defaults to a function that uses
-     * {@link #copyInstance(Writeable)} to create the copy.
+     * {@link #copyInstance(Streamable, Version)} to create the copy.
      */
     protected CopyFunction<T> getCopyFunction() {
         return (original) -> copyInstance(original, Version.CURRENT);

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractStreamableTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractStreamableTestCase.java
@@ -25,11 +25,12 @@ import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.MutateFunction;
 
 import java.io.IOException;
 import java.util.Collections;
-
-import static org.hamcrest.Matchers.equalTo;
 
 public abstract class AbstractStreamableTestCase<T extends Streamable> extends ESTestCase {
     protected static final int NUMBER_OF_TEST_RUNS = 20;
@@ -49,35 +50,31 @@ public abstract class AbstractStreamableTestCase<T extends Streamable> extends E
     protected abstract T createBlankInstance();
 
     /**
+     * Returns a {@link CopyFunction} that can be used to make an exact copy of
+     * the given instance. This defaults to a function that uses
+     * {@link #copyInstance(Writeable)} to create the copy.
+     */
+    protected CopyFunction<T> getCopyFunction() {
+        return (original) -> copyInstance(original, Version.CURRENT);
+    }
+
+    /**
+     * Returns a {@link MutateFunction} that can be used to make create a copy
+     * of the given instance that is different to this instance. This defaults
+     * to null.
+     */
+    // TODO: Make this abstract when all sub-classes implement this (https://github.com/elastic/elasticsearch/issues/25929)
+    protected MutateFunction<T> getMutateFunction() {
+        return null;
+    }
+
+    /**
      * Tests that the equals and hashcode methods are consistent and copied
      * versions of the instance have are equal.
      */
     public void testEqualsAndHashcode() throws IOException {
         for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
-            T firstInstance = createTestInstance();
-            assertFalse("instance is equal to null", firstInstance.equals(null));
-            assertFalse("instance is equal to incompatible type", firstInstance.equals(""));
-            assertEquals("instance is not equal to self", firstInstance, firstInstance);
-            assertThat("same instance's hashcode returns different values if called multiple times", firstInstance.hashCode(),
-                    equalTo(firstInstance.hashCode()));
-
-            T secondInstance = copyInstance(firstInstance, Version.CURRENT);
-            assertEquals("instance is not equal to self", secondInstance, secondInstance);
-            assertEquals("instance is not equal to its copy", firstInstance, secondInstance);
-            assertEquals("equals is not symmetric", secondInstance, firstInstance);
-            assertThat("instance copy's hashcode is different from original hashcode", secondInstance.hashCode(),
-                    equalTo(firstInstance.hashCode()));
-
-            T thirdInstance = copyInstance(secondInstance, Version.CURRENT);
-            assertEquals("instance is not equal to self", thirdInstance, thirdInstance);
-            assertEquals("instance is not equal to its copy", secondInstance, thirdInstance);
-            assertThat("instance copy's hashcode is different from original hashcode", secondInstance.hashCode(),
-                    equalTo(thirdInstance.hashCode()));
-            assertEquals("equals is not transitive", firstInstance, thirdInstance);
-            assertThat("instance copy's hashcode is different from original hashcode", firstInstance.hashCode(),
-                    equalTo(thirdInstance.hashCode()));
-            assertEquals("equals is not symmetric", thirdInstance, secondInstance);
-            assertEquals("equals is not symmetric", thirdInstance, firstInstance);
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), getCopyFunction(), getMutateFunction());
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractWireSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractWireSerializingTestCase.java
@@ -26,11 +26,11 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
+import org.elasticsearch.test.EqualsHashCodeTestUtils.MutateFunction;
 
 import java.io.IOException;
 import java.util.Collections;
-
-import static org.hamcrest.Matchers.equalTo;
 
 public abstract class AbstractWireSerializingTestCase<T extends Writeable> extends ESTestCase {
     protected static final int NUMBER_OF_TEST_RUNS = 20;
@@ -48,35 +48,30 @@ public abstract class AbstractWireSerializingTestCase<T extends Writeable> exten
     protected abstract Reader<T> instanceReader();
 
     /**
+     * Returns a {@link CopyFunction} that can be used to make an exact copy of
+     * the given instance. This defaults to a function that uses
+     * {@link #copyInstance(Writeable)} to create the copy.
+     */
+    protected CopyFunction<T> getCopyFunction() {
+        return (original) -> copyInstance(original);
+    }
+
+    /**
+     * Returns a {@link MutateFunction} that can be used to make create a copy
+     * of the given instance that is different to this instance. This defaults
+     * to null.
+     */
+    protected MutateFunction<T> getMutateFunction() {
+        return null;
+    }
+
+    /**
      * Tests that the equals and hashcode methods are consistent and copied
      * versions of the instance have are equal.
      */
     public void testEqualsAndHashcode() throws IOException {
         for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
-            T firstInstance = createTestInstance();
-            assertFalse("instance is equal to null", firstInstance.equals(null));
-            assertFalse("instance is equal to incompatible type", firstInstance.equals(""));
-            assertEquals("instance is not equal to self", firstInstance, firstInstance);
-            assertThat("same instance's hashcode returns different values if called multiple times", firstInstance.hashCode(),
-                    equalTo(firstInstance.hashCode()));
-
-            T secondInstance = copyInstance(firstInstance);
-            assertEquals("instance is not equal to self", secondInstance, secondInstance);
-            assertEquals("instance is not equal to its copy", firstInstance, secondInstance);
-            assertEquals("equals is not symmetric", secondInstance, firstInstance);
-            assertThat("instance copy's hashcode is different from original hashcode", secondInstance.hashCode(),
-                    equalTo(firstInstance.hashCode()));
-
-            T thirdInstance = copyInstance(secondInstance);
-            assertEquals("instance is not equal to self", thirdInstance, thirdInstance);
-            assertEquals("instance is not equal to its copy", secondInstance, thirdInstance);
-            assertThat("instance copy's hashcode is different from original hashcode", secondInstance.hashCode(),
-                    equalTo(thirdInstance.hashCode()));
-            assertEquals("equals is not transitive", firstInstance, thirdInstance);
-            assertThat("instance copy's hashcode is different from original hashcode", firstInstance.hashCode(),
-                    equalTo(thirdInstance.hashCode()));
-            assertEquals("equals is not symmetric", thirdInstance, secondInstance);
-            assertEquals("equals is not symmetric", thirdInstance, firstInstance);
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), getCopyFunction(), getMutateFunction());
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractWireSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractWireSerializingTestCase.java
@@ -61,6 +61,7 @@ public abstract class AbstractWireSerializingTestCase<T extends Writeable> exten
      * of the given instance that is different to this instance. This defaults
      * to null.
      */
+    // TODO: Make this abstract when all sub-classes implement this (https://github.com/elastic/elasticsearch/issues/25929)
     protected MutateFunction<T> getMutateFunction() {
         return null;
     }


### PR DESCRIPTION
`AbstractWireSerializingTestCase.testEqualsAndHashcode()` now uses `EqualsHashcodeTestUtils` to perform the hashCode and equals checks. To support this `AbstractWireSerializingTestCase` has two new methods: `getCopyFunction()` and `getMutateFunction` which are used when calling `EqualsHashcodeTestUtils`.

This makes this test more like the equivalent tests in `AbstractQueryTestCase` and `BaseAggregationTestCase` and paves the way to get those class to extend `AbstractSerializingTestCase`