### PR TITLE
Fix term(s) query for range field

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -283,7 +283,7 @@ public class RangeFieldMapper extends FieldMapper {
 
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
-            Query query = rangeQuery(value, value, true, true, context);
+            Query query = rangeQuery(value, value, true, true, ShapeRelation.INTERSECTS, context);
             if (boost() != 1f) {
                 query = new BoostQuery(query, boost());
             }

--- a/core/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -276,4 +276,23 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
         assertEquals(InetAddresses.forString("::1"), RangeFieldMapper.RangeType.IP.parse("::1", randomBoolean()));
         assertEquals(InetAddresses.forString("::1"), RangeFieldMapper.RangeType.IP.parse(new BytesRef("::1"), randomBoolean()));
     }
+
+    public void testTermQuery() throws Exception, IllegalArgumentException {
+        // See https://github.com/elastic/elasticsearch/issues/25950
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(randomAlphaOfLengthBetween(1, 10), indexSettings);
+        QueryShardContext context = new QueryShardContext(0, idxSettings, null, null, null, null, null, xContentRegistry(),
+            writableRegistry(), null, null, () -> nowInMillis, null);
+        RangeFieldMapper.RangeFieldType ft = new RangeFieldMapper.RangeFieldType(type, Version.CURRENT);
+        ft.setName(FIELDNAME);
+        ft.setIndexOptions(IndexOptions.DOCS);
+
+        Object value = nextFrom();
+        ShapeRelation relation = ShapeRelation.INTERSECTS;
+        boolean includeLower = true;
+        boolean includeUpper = true;
+        assertEquals(getExpectedRangeQuery(relation, value, value, includeLower, includeUpper),
+            ft.termQuery(value, context));
+    }
 }


### PR DESCRIPTION
No longer able to run a term(s) query on a `long_range` field from v5.5.0 and later.

Example query:
```
{
    "query": {
        "bool": {
            "filter": {
                "terms": {
                    "iprange": [1593315665,1595584936,1184220823,1187276336]
                }
            }
        }
    }
}
```

The following error message is produced: `java.lang.IllegalArgumentException: Field [iprange] of type [long_range] does not support range queries`

This occurs after the removal of the `rangeQuery` definition in `RangeFieldMapper.java` (see [commit](https://github.com/elastic/elasticsearch/commit/0e7c4cd58e437d1a82a37a04f5b7877131252c2a#diff-bc271544999af8a1941e5422b178e389)) between v5.4.0 and v5.5.0. This caused the call to `rangeQuery` inside `termQuery` to resort to the `rangeQuery` in `MappedFieldType.java`, where the exception is thrown.

I've modified the call to `rangeQuery` in `termQuery` to do what it had been doing before the 5-length argument definition was removed: pass in `ShapeRelation.INTERSECTS` before `context`.

Example error message:
```
        at org.elasticsearch.index.query.QueryShardContext.toQuery(QueryShardContext.java:329) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.QueryShardContext.toQuery(QueryShardContext.java:312) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.search.SearchService.parseSource(SearchService.java:613) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.search.SearchService.createContext(SearchService.java:481) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.search.SearchService.createAndPutContext(SearchService.java:457) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.search.SearchService.executeQueryPhase(SearchService.java:253) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.action.search.SearchTransportService$6.messageReceived(SearchTransportService.java:330) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.action.search.SearchTransportService$6.messageReceived(SearchTransportService.java:327) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:69) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.transport.TcpTransport$RequestHandler.doRun(TcpTransport.java:1544) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:638) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[elasticsearch-5.5.0.jar:5.5.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_121]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_121]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_121]
Caused by: java.lang.IllegalArgumentException: Field [iprange] of type [long_range] does not support range queries
        at org.elasticsearch.index.mapper.MappedFieldType.rangeQuery(MappedFieldType.java:354) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.mapper.RangeFieldMapper$RangeFieldType.termQuery(RangeFieldMapper.java:278) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.mapper.MappedFieldType.termsQuery(MappedFieldType.java:348) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.TermsQueryBuilder.handleTermsQuery(TermsQueryBuilder.java:438) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.TermsQueryBuilder.doToQuery(TermsQueryBuilder.java:411) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.AbstractQueryBuilder.toQuery(AbstractQueryBuilder.java:96) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.AbstractQueryBuilder.toFilter(AbstractQueryBuilder.java:118) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.BoolQueryBuilder.addBooleanClauses(BoolQueryBuilder.java:446) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.BoolQueryBuilder.doToQuery(BoolQueryBuilder.java:419) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.AbstractQueryBuilder.toQuery(AbstractQueryBuilder.java:96) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.QueryShardContext.lambda$toQuery$1(QueryShardContext.java:313) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.QueryShardContext.toQuery(QueryShardContext.java:325) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.index.query.QueryShardContext.toQuery(QueryShardContext.java:312) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.search.SearchService.parseSource(SearchService.java:613) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.search.SearchService.createContext(SearchService.java:481) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.search.SearchService.createAndPutContext(SearchService.java:457) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.search.SearchService.executeQueryPhase(SearchService.java:253) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.action.search.SearchTransportService$6.messageReceived(SearchTransportService.java:330) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.action.search.SearchTransportService$6.messageReceived(SearchTransportService.java:327) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:69) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.transport.TcpTransport$RequestHandler.doRun(TcpTransport.java:1544) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:638) ~[elasticsearch-5.5.0.jar:5.5.0]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[elasticsearch-5.5.0.jar:5.5.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_121]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_121]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_121]
```
