### PR TITLE
Allow Eclipse to run REST tests directly

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
@@ -31,9 +31,10 @@ import java.security.PermissionCollection;
 import java.security.Permissions;
 import java.security.Policy;
 import java.security.ProtectionDomain;
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Predicate;
+
+import static java.util.Collections.emptyMap;
 
 /** custom policy for union of static and dynamic permissions */
 final class ESPolicy extends Policy {
@@ -49,9 +50,9 @@ final class ESPolicy extends Policy {
     final PermissionCollection dynamic;
     final Map<String,Policy> plugins;
 
-    ESPolicy(PermissionCollection dynamic, Map<String,Policy> plugins, boolean filterBadDefaults) {
-        this.template = Security.readPolicy(getClass().getResource(POLICY_RESOURCE), JarHell.parseClassPath());
-        this.untrusted = Security.readPolicy(getClass().getResource(UNTRUSTED_RESOURCE), Collections.emptySet());
+    ESPolicy(PermissionCollection dynamic, Map<String,Policy> plugins, boolean filterBadDefaults, Map<String, URL> shortNameToCodebases) {
+        this.template = Security.readPolicy(getClass().getResource(POLICY_RESOURCE), shortNameToCodebases);
+        this.untrusted = Security.readPolicy(getClass().getResource(UNTRUSTED_RESOURCE), emptyMap());
         if (filterBadDefaults) {
             this.system = new SystemPolicy(Policy.getPolicy());
         } else {

--- a/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -63,6 +63,7 @@ grant codeBase "${codebase.mocksocket-1.2.jar}" {
   permission java.net.SocketPermission "*", "accept,connect";
 };
 
+// Tests run with gradle need this permission because they use the shaded jar
 grant codeBase "${codebase.elasticsearch-rest-client-6.0.0-beta1-SNAPSHOT.jar}" {
   // rest makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";
@@ -70,21 +71,19 @@ grant codeBase "${codebase.elasticsearch-rest-client-6.0.0-beta1-SNAPSHOT.jar}" 
   permission java.net.NetPermission "getProxySelector";
 };
 
-// IDEs need this because they do not play nicely with removing artifacts on projects,
-// so we keep it in here for IDE test support
+// Tests run inside IDEs need this permission because they use the shaded deps but not the fully shaded jar.
 grant codeBase "${codebase.elasticsearch-rest-client-6.0.0-beta1-SNAPSHOT-deps.jar}" {
-  // rest makes socket connections for rest tests
-  permission java.net.SocketPermission "*", "connect";
-};
-
-grant codeBase "${codebase.httpcore-nio-4.4.5.jar}" {
-  // httpcore makes socket connections for rest tests
-  permission java.net.SocketPermission "*", "connect";
-};
-
-grant codeBase "${codebase.httpasyncclient-4.1.2.jar}" {
-  // httpasyncclient makes socket connections for rest tests
+  // rest client makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";
   // rest client uses system properties which gets the default proxy
+  permission java.net.NetPermission "getProxySelector";
+};
+
+// Tests run inside IDEs need this permission because they use the shaded deps but not the fully shaded jar.
+grant codeBase "${codebase.elasticsearch-rest-client-6.0.0-beta1-SNAPSHOT-nodeps.jar}" {
+  // even though the rest client's deps make the connection the rest client is still on the stack
+  // when the conenction is made so the client itself needs permission to connect and read the
+  // proxy system setting.
+  permission java.net.SocketPermission "*", "connect";
   permission java.net.NetPermission "getProxySelector";
 };


### PR DESCRIPTION
We've been able to run REST tests in Eclipse until #25757 which
changed the rest client to read from system properties. This saves
quite a bit of time and we'd like it back.

This change fixes permissions by moving leniency in `Security` for
tests into `BootstrapForTesting` and adding a hack to identify
rest client's codebase as
`codebase.elasticsearch-rest-client-6.0.0-beta1-SNAPSHOT-nodeps.jar`
which is the name of the jar file that gradle builds for it.

As much as I don't like adding extra hacks to security code I feel
like the faster development cycle is worth it and I feel like I removed
some unwanted leniency from the production code path.

While this technique only works for Eclipse it should be simple enough
to extend it for IntelliJ.
