### PR TITLE
Remove the shadow plugin apply in the rest client

### DIFF
--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -35,8 +35,13 @@ import org.elasticsearch.gradle.precommit.PrecommitTasks
  * 2) The *actual* jar that will be used by clients. This has no classifier, contains the rest client src and
  *    `org.elasticsearch.client`. This jar is the only actual output artifact of this job.
  */
-plugins {
-  id "com.github.johnrengelman.shadow" version "2.0.1"
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
+    }
 }
 
 apply plugin: 'elasticsearch.build'


### PR DESCRIPTION
The low level rest client does not need the shadow plugin applied. It
only needs the plugin jar in the classpath in order to create a
ShadowJar task.

Relates #25208