### PR TITLE
Release operation permit on thread-pool rejection

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
@@ -270,7 +270,7 @@ final class IndexShardOperationPermits implements Closeable {
     }
 
     /**
-     * A permit-aware action listener wrapper that spawns listener invocations off on a configurable thread-pool.
+     * A permit-aware action listener wrapper that spawns onResponse listener invocations off on a configurable thread-pool.
      * Being permit-aware, it also releases the permit when hitting thread-pool rejections and falls back to the
      * invoker's thread to communicate failures.
      */
@@ -310,29 +310,14 @@ final class IndexShardOperationPermits implements Closeable {
 
                 @Override
                 public void onFailure(Exception e) {
-                    listener.onFailure(e); // will possibly execute on the generic thread spawned off in releaseDelayedOperations
+                    listener.onFailure(e); // will possibly execute on the caller thread
                 }
             });
         }
 
         @Override
         public void onFailure(final Exception e) {
-            threadPool.executor(executor).execute(new AbstractRunnable() {
-                @Override
-                public boolean isForceExecution() {
-                    return forceExecution;
-                }
-
-                @Override
-                protected void doRun() throws Exception {
-                    listener.onFailure(e);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(e); // will possibly execute on the generic thread spawned off in releaseDelayedOperations
-                }
-            });
+            listener.onFailure(e);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
@@ -198,11 +198,14 @@ final class IndexShardOperationPermits implements Closeable {
     /**
      * Acquires a permit whenever permit acquisition is not blocked. If the permit is directly available, the provided
      * {@link ActionListener} will be called on the calling thread. During calls of
-     * {@link #blockOperations(long, TimeUnit, CheckedRunnable)}, permit acquisition can be delayed. The provided {@link ActionListener}
-     * will then be called using the provided executor once operations are no longer blocked.
+     * {@link #blockOperations(long, TimeUnit, CheckedRunnable)}, permit acquisition can be delayed.
+     * The {@link ActionListener#onResponse(Object)} method will then be called using the provided executor once operations are no
+     * longer blocked. Note that the executor will not be used for {@link ActionListener#onFailure(Exception)} calls. Those will run
+     * directly on the calling thread, which in case of delays, will be a generic thread. Callers should thus make sure
+     * that the {@link ActionListener#onFailure(Exception)} method provided here only contains lightweight operations.
      *
      * @param onAcquired      {@link ActionListener} that is invoked once acquisition is successful or failed
-     * @param executorOnDelay executor to use for delayed call
+     * @param executorOnDelay executor to use for the possibly delayed {@link ActionListener#onResponse(Object)} call
      * @param forceExecution  whether the runnable should force its execution in case it gets rejected
      */
     public void acquire(final ActionListener<Releasable> onAcquired, final String executorOnDelay, final boolean forceExecution) {


### PR DESCRIPTION
At the shard level we use an operation permit to coordinate between regular shard operations and special operations that need exclusive access. In ES versions < 6, the operation requiring exclusive access was invoked during primary relocation, but ES versions >= 6 this exclusive access is also used when a replica learns about a new primary or when a replica is promoted to primary.

These special operations requiring exclusive access delay regular operations from running, by adding them to a queue, and after finishing the exclusive access, release these operations which then need to be put back on the original thread-pool they were running on. In the presence of thread pool rejections, the current implementation had two issues:
- it would not properly release the operation permit when hitting a rejection (i.e. when calling `ThreadedActionListener.onResponse` from `IndexShardOperationPermits.acquire`).
- it would not invoke the onFailure method of the action listener when the shard was closed, and just log a warning instead (see `ThreadedActionListener.onFailure`), which would ultimately lead to the replication task never being cleaned up (see #25863).

This PR fixes both issues by introducing a custom threaded action listener that is permit-aware and properly deals with rejections.

Closes #25863