### PR TITLE
Ensure that gcs client creation is privileged

### DIFF
--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -112,7 +112,10 @@ class GoogleCloudStorageRepository extends BlobStoreRepository {
         logger.debug("using bucket [{}], base_path [{}], chunk_size [{}], compress [{}], application [{}]",
                 bucket, basePath, chunkSize, compress, application);
 
-        Storage client = storageService.createClient(clientName, application, connectTimeout, readTimeout);
+        TimeValue finalConnectTimeout = connectTimeout;
+        TimeValue finalReadTimeout = readTimeout;
+        Storage client = SocketAccess.doPrivilegedIOException(() ->
+            storageService.createClient(clientName, application, finalConnectTimeout, finalReadTimeout));
         this.blobStore = new GoogleCloudStorageBlobStore(settings, bucket, client);
     }
 

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -82,6 +82,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESBlobStoreRepos
         @Override
         public Storage createClient(String accountName, String application,
                                     TimeValue connectTimeout, TimeValue readTimeout) throws Exception {
+            // The actual impl might open a connection. So check we have permission when this call is made.
             AccessController.checkPermission(new SocketPermission("*", "connect"));
             return storage.get();
         }

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -30,6 +30,8 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
 import org.junit.BeforeClass;
 
+import java.net.SocketPermission;
+import java.security.AccessController;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
@@ -80,6 +82,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESBlobStoreRepos
         @Override
         public Storage createClient(String accountName, String application,
                                     TimeValue connectTimeout, TimeValue readTimeout) throws Exception {
+            AccessController.checkPermission(new SocketPermission("*", "connect"));
             return storage.get();
         }
     }


### PR DESCRIPTION
This is related to #25932. Currently when we create the
`GoogleCloudStorageService` client we do not wrap that call in a
doPrivileged block. The call might open a connection. This commit
ensures that the creation is wrapped in a doPrivileged block.