### PR TITLE
Exit Windows scripts promptly on failure

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -25,7 +25,7 @@ if defined JAVA_HOME (
 
 if not exist %JAVA% (
   echo could not find java; set JAVA_HOME or ensure java is in PATH 1>&2
-  exit /B 1
+  exit /b 1
 )
 
 rem check the Java version
@@ -34,7 +34,7 @@ rem check the Java version
 if errorlevel 1 (
   echo|set /p="the minimum required Java version is 8; "
   echo your Java version from %JAVA% does not meet this requirement
-  exit /B 1
+  exit /b 1
 )
 
 rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we

--- a/distribution/src/main/resources/bin/elasticsearch-keystore.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-keystore.bat
@@ -2,7 +2,7 @@
 
 setlocal enabledelayedexpansion
 
-call "%~dp0elasticsearch-env.bat"
+call "%~dp0elasticsearch-env.bat" || exit /b 1
 
 %JAVA% ^
   %ES_JAVA_OPTS% ^

--- a/distribution/src/main/resources/bin/elasticsearch-plugin.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin.bat
@@ -2,7 +2,7 @@
 
 setlocal enabledelayedexpansion
 
-call "%~dp0elasticsearch-env.bat"
+call "%~dp0elasticsearch-env.bat" || exit /b 1
 
 %JAVA% ^
   %ES_JAVA_OPTS% ^

--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -2,7 +2,7 @@
 
 setlocal enabledelayedexpansion
 
-call "%~dp0elasticsearch-env.bat"
+call "%~dp0elasticsearch-env.bat" || exit /b 1
 
 set EXECUTABLE=%ES_HOME%\bin\elasticsearch-service-x64.exe
 set SERVICE_ID=elasticsearch-service-x64

--- a/distribution/src/main/resources/bin/elasticsearch-translog.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-translog.bat
@@ -2,7 +2,7 @@
 
 setlocal enabledelayedexpansion
 
-call "%~dp0elasticsearch-env.bat"
+call "%~dp0elasticsearch-env.bat" || exit /b 1
 
 %JAVA% ^
   %ES_JAVA_OPTS% ^

--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -32,7 +32,7 @@ FOR /F "usebackq tokens=1* delims= " %%A IN (!params!) DO (
 	)
 )
 
-CALL "%~dp0elasticsearch-env.bat"
+CALL "%~dp0elasticsearch-env.bat" || exit /b 1
 IF ERRORLEVEL 1 (
 	IF NOT DEFINED nopauseonerror (
 		PAUSE


### PR DESCRIPTION
When invoking the elasticsearch-env.bat batch script on Windows, if the script exits due to an error (e.g., Java can not be found, or the wrong version of Java is found), then the script exits. Sadly, on Windows, this does not also terminate the caller, instead returning control. This means we have to explicitly exit so that is what we do in this commit.

