### PR TITLE
Remove running outside of distribution check

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -14,18 +14,6 @@
 #
 #   ES_JAVA_OPTS="-Xms8g -Xmx8g" ./bin/elasticsearch
 
-# Check to see if you are trying to run this without building it first. Gradle
-# will replace the project.name with _something_.
-
-if echo '${project.name}' | grep project.name > /dev/null; then
-  cat >&2 << EOF
-Error: You must build the project with Gradle or download a pre-built package
-before you can run Elasticsearch. See 'Building from Source' in README.textile
-or visit https://www.elastic.co/download to get a pre-built package.
-EOF
-  exit 1
-fi
-
 parse_jvm_options() {
   if [ -f "$1" ]; then
     echo "$(grep "^-" "$1" | tr '\n' ' ')"


### PR DESCRIPTION
This commit removes a legacy check against running bin/elasticsearch that is not produced from a distribution. This check exists for legacy reasons, namely when bin/elasticsearch previously sat in the root of the Elasticsearch repository. In this old scenario, someone might clone the repository, see the bin folder and try to run bin/elasticsearch without first production a distribution. Today, this is unlikely since bin/elasticsearch now sits in distribution/src/main/resources/bin/elasticsearch so first, bin is no longer in the root of the repository, and second, the src indicates this is source and not already for production. Moreover, our README in the root of the repository provides clear instructions for getting started: either download a distribution or build one from source. In the name of simplicity, we therefore remove this legacy check.

Relates #2954
