### PR TITLE
Also skip JAVA_TOOL_OPTIONS on Windows

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -54,8 +54,8 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-# don't let JAVA_TOOL_OPTIONS slip in (e.g. agents in Ubuntu); works around
-# https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487
+# don't let JAVA_TOOL_OPTIONS slip in (e.g., agents in Ubuntu so this works
+# around https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487)
 if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
   echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
   unset JAVA_TOOL_OPTIONS

--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -45,8 +45,7 @@ if [ ! -x "$JAVA" ]; then
   exit 1
 fi
 
-# don't let JAVA_TOOL_OPTIONS slip in (e.g., agents in Ubuntu so this works
-# around https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487)
+# do not let JAVA_TOOL_OPTIONS slip in (as the JVM does by default)
 if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
   echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
   unset JAVA_TOOL_OPTIONS

--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -28,8 +28,7 @@ if not exist %JAVA% (
   exit /B 1
 )
 
-rem don't let JAVA_TOOL_OPTIONS slip in (e.g., agents in Ubuntu so this works
-rem around https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487)
+rem do not let JAVA_TOOL_OPTIONS slip in (as the JVM does by default)
 if not "%JAVA_TOOL_OPTIONS%" == "" (
   echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
   set JAVA_TOOL_OPTIONS=

--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -37,6 +37,13 @@ if errorlevel 1 (
   exit /B 1
 )
 
+rem don't let JAVA_TOOL_OPTIONS slip in (e.g., agents in Ubuntu so this works
+rem around https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487)
+if not "%JAVA_TOOL_OPTIONS%" == "" (
+  echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
+  set JAVA_TOOL_OPTIONS=
+)
+
 rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
 rem warn them that we are not observing the value of %JAVA_OPTS%
 if not "%JAVA_OPTS%" == "" (

--- a/docs/reference/setup/sysconfig/configuring.asciidoc
+++ b/docs/reference/setup/sysconfig/configuring.asciidoc
@@ -125,3 +125,16 @@ export ES_JAVA_OPTS="$ES_JAVA_OPTS -Djava.io.tmpdir=/path/to/temp/dir"
 
 When using the RPM or Debian packages, `ES_JAVA_OPTS` can be specified in the
 <<sysconfig,system configuration file>>.
+
+The JVM has a built-in mechanism for observing the `JAVA_TOOL_OPTIONS`
+environment variable. We intentionally ignore this environment variable in our
+packaging scripts. The primary reason for this is that on some OS (e.g., Ubuntu)
+there are agents installed by default via this environment variable that we do
+not want interfering with Elasticsearch.
+
+Additionally, some other Java programs support the `JAVA_OPTS` environment
+variable. This is *not* a mechanism built into the JVM but instead a convention
+in the ecosystem. However, we do not support this environment variable, instead
+supporting setting JVM options via the `jvm.options` file or the environment
+variable `ES_JAVA_OPTS` as above.
+


### PR DESCRIPTION
On non-Windows platforms, we ignore the environment variable JAVA_TOOL_OPTIONS (this is an environment variable that the JVM respects by default for picking up extra JVM options). The primary reason that we ignore this because of the Jayatana agent on Ubuntu; a secondary reason is that it produces an annoying "Picked up JAVA_TOOL_OPTIONS: ..." output message. When the elasticsearch-env batch script was introduced for Windows, ignoring this environment variable was deliberately not carried over as the primary reason does not apply on Windows. However, after additional thinking, it seems that we should simply be consistent to the extent possible here (and also avoid that annoying "Picked up JAVA_TOOL_OPTIONS: ..." on Windows too). This commit causes the Windows version of elasticsearch-env to also ignore JAVA_TOOL_OPTIONS.

