### PR TITLE
Ignore JVM options before checking Java version

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -45,15 +45,6 @@ if [ ! -x "$JAVA" ]; then
   exit 1
 fi
 
-# check the Java version
-"$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.JavaVersionChecker
-
-if [ $? -ne 0 ]; then
-  echo -n "the minimum required Java version is 8; "
-  echo "your Java version from $JAVA does not meet this requirement"
-  exit 1
-fi
-
 # don't let JAVA_TOOL_OPTIONS slip in (e.g. agents in Ubuntu); works around
 # https://bugs.launchpad.net/ubuntu/+source/jayatana/+bug/1441487
 if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
@@ -66,6 +57,15 @@ fi
 if [ "x$JAVA_OPTS" != "x" ]; then
   echo -n "warning: ignoring JAVA_OPTS=$JAVA_OPTS; "
   echo "pass JVM parameters via ES_JAVA_OPTS"
+fi
+
+# check the Java version
+"$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.JavaVersionChecker
+
+if [ $? -ne 0 ]; then
+  echo -n "the minimum required Java version is 8; "
+  echo "your Java version from $JAVA does not meet this requirement"
+  exit 1
 fi
 
 ${source.path.env}

--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -28,6 +28,13 @@ if not exist %JAVA% (
   exit /B 1
 )
 
+rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
+rem warn them that we are not observing the value of %JAVA_OPTS%
+if not "%JAVA_OPTS%" == "" (
+  echo|set /p="warning: ignoring JAVA_OPTS=%JAVA_OPTS%; "
+  echo pass JVM parameters via ES_JAVA_OPTS
+)
+
 rem check the Java version
 %JAVA% -cp "%ES_CLASSPATH%" "org.elasticsearch.tools.JavaVersionChecker"
 
@@ -35,13 +42,6 @@ if errorlevel 1 (
   echo|set /p="the minimum required Java version is 8; "
   echo your Java version from %JAVA% does not meet this requirement
   exit /B 1
-)
-
-rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
-rem warn them that we are not observing the value of %JAVA_OPTS%
-if not "%JAVA_OPTS%" == "" (
-  echo|set /p="warning: ignoring JAVA_OPTS=%JAVA_OPTS%; "
-  echo pass JVM parameters via ES_JAVA_OPTS
 )
 
 if "%CONF_DIR%" == "" (


### PR DESCRIPTION
Today we strip some ignored JVM options before starting the main Java process (e.g., we unset `JAVA_TOOL_OPTIONS`, and we ignore `JAVA_OPTS`). However, there is another Java process that we start before starting the main process: the Java version checker. We are currently starting this before ignoring the undesired JVM options so the Java version checker will pick up `JAVA_TOOL_OPTIONS` and it will silently ignore `JAVA_OPTS`. Instead, we should ignore `JAVA_TOOL_OPTIONS` here too, and not silently ignore `JAVA_OPTS` but instead warn before doing so (as we already do for the main Java process). This commit rearranges the execution of these steps so that we do the right thing here.

