### PR TITLE
Set address space limit in systemd service file

### DIFF
--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -32,6 +32,9 @@ LimitNOFILE=65536
 # Specifies the maximum number of processes
 LimitNPROC=4096
 
+# Specifies the maximum size of virtual memory
+LimitAS=infinity
+
 # Specifies the maximum number of bytes of memory that may be locked into RAM
 # Set to "infinity" if you use the 'bootstrap.memory_lock: true' option
 # in elasticsearch.yml and 'MAX_LOCKED_MEMORY=unlimited' in ${path.env}


### PR DESCRIPTION
We have a bootstrap check for the maximum size of the virtual memory address space for the Elasticsearch process. We can set this in the service file for Elasticsearch when installed as a service on systemd-based systems for a better user experience than them fumbling through thinking they should set this via /etc/security/limits.d (as a lot of pages on the Internet would tell them) not realizing that systemd completely ignores these for services and then trying to figure out how to add a unit file for the Elasticsearch service.

