### PR TITLE
Remove memlock suggestion from systemd service

### DIFF
--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -32,11 +32,6 @@ LimitNOFILE=65536
 # Specifies the maximum number of processes
 LimitNPROC=4096
 
-# Specifies the maximum number of bytes of memory that may be locked into RAM
-# Set to "infinity" if you use the 'bootstrap.memory_lock: true' option
-# in elasticsearch.yml and 'MAX_LOCKED_MEMORY=unlimited' in ${path.env}
-#LimitMEMLOCK=infinity
-
 # Disable timeout logic and wait until process is stopped
 TimeoutStopSec=0
 


### PR DESCRIPTION
The systemd service file that ships with Elasticsearch installs on systemd-based systems contains a suggestion for setting `LimitMEMLOCK` if the user wants to enable `bootstrap.memory_lock`. However, this setting this in the installed service file goes against best practices for working with systemd, and goes against our existing documentation for how to set this. Therefore, we should not have this suggestion in the service file otherwise users might be led to think they should edit it there.

