### PR TITLE
QueryBuilders does not need to be abstract

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  * Utility class to create search queries.
  */
-public class QueryBuilders {
+public final class QueryBuilders {
 
     private QueryBuilders() {
     }

--- a/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -35,9 +35,12 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * A static factory for simple "import static" usage.
+ * Utility class to create search queries.
  */
-public abstract class QueryBuilders {
+public class QueryBuilders {
+
+    private QueryBuilders() {
+    }
 
     /**
      * A query that matches on all documents.
@@ -692,9 +695,5 @@ public abstract class QueryBuilders {
      */
     public static ExistsQueryBuilder existsQuery(String name) {
         return new ExistsQueryBuilder(name);
-    }
-
-    private QueryBuilders() {
-
     }
 }


### PR DESCRIPTION
It looks like a leftover from "The Great Query Refactoring" era.