### PR TITLE
Use nio transport in test clusters

### DIFF
--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
@@ -42,7 +42,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.MockTransportClient;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportException;
@@ -53,7 +52,6 @@ import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.nio.NioTransportPlugin;
 
 import java.util.Collections;
 import java.util.List;
@@ -82,7 +80,7 @@ public class TransportClientHeadersTests extends AbstractClientHeadersTestCase {
         transportService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool, null);
         transportService.start();
         transportService.acceptIncomingRequests();
-        String transport = randomTestTransport();
+        String transport = randomTestTransportKey();
         TransportClient client = new MockTransportClient(Settings.builder()
                 .put("client.transport.sniff", false)
                 .put("cluster.name", "cluster1")
@@ -99,7 +97,7 @@ public class TransportClientHeadersTests extends AbstractClientHeadersTestCase {
     }
 
     public void testWithSniffing() throws Exception {
-        String transport = randomTestTransport();
+        String transport = randomTestTransportKey();
         try (TransportClient client = new MockTransportClient(
                 Settings.builder()
                         .put("client.transport.sniff", true)

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientHeadersTests.java
@@ -80,7 +80,7 @@ public class TransportClientHeadersTests extends AbstractClientHeadersTestCase {
         transportService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool, null);
         transportService.start();
         transportService.acceptIncomingRequests();
-        String transport = randomTestTransportKey();
+        String transport = getTestTransportType();
         TransportClient client = new MockTransportClient(Settings.builder()
                 .put("client.transport.sniff", false)
                 .put("cluster.name", "cluster1")
@@ -97,7 +97,7 @@ public class TransportClientHeadersTests extends AbstractClientHeadersTestCase {
     }
 
     public void testWithSniffing() throws Exception {
-        String transport = randomTestTransportKey();
+        String transport = getTestTransportType();
         try (TransportClient client = new MockTransportClient(
                 Settings.builder()
                         .put("client.transport.sniff", true)

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientIT.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientIT.java
@@ -61,11 +61,11 @@ public class TransportClientIT extends ESIntegTestCase {
                 .put(internalCluster().getDefaultSettings())
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .put("node.name", "testNodeVersionIsUpdated")
-                .put("transport.type", randomTestTransportKey())
+                .put("transport.type", getTestTransportType())
                 .put(NetworkModule.HTTP_ENABLED.getKey(), false)
                 .put(Node.NODE_DATA_SETTING.getKey(), false)
                 .put("cluster.name", "foobar")
-                .build(), Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class)).start()) {
+                .build(), Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class)).start()) {
             TransportAddress transportAddress = node.injector().getInstance(TransportService.class).boundAddress().publishAddress();
             client.addTransportAddress(transportAddress);
             // since we force transport clients there has to be one node started that we connect to.
@@ -94,7 +94,7 @@ public class TransportClientIT extends ESIntegTestCase {
     }
 
     public void testThatTransportClientSettingCannotBeChanged() {
-        String transport = randomTestTransportKey();
+        String transport = getTestTransportType();
         Settings baseSettings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), transport)

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientIT.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientIT.java
@@ -33,10 +33,8 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.discovery.TestZenDiscovery;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.MockTransportClient;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.nio.NioTransportPlugin;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -63,11 +61,11 @@ public class TransportClientIT extends ESIntegTestCase {
                 .put(internalCluster().getDefaultSettings())
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .put("node.name", "testNodeVersionIsUpdated")
-                .put("transport.type", MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
+                .put("transport.type", randomTestTransportKey())
                 .put(NetworkModule.HTTP_ENABLED.getKey(), false)
                 .put(Node.NODE_DATA_SETTING.getKey(), false)
                 .put("cluster.name", "foobar")
-                .build(), Arrays.asList(MockTcpTransportPlugin.class, TestZenDiscovery.TestPlugin.class)).start()) {
+                .build(), Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class)).start()) {
             TransportAddress transportAddress = node.injector().getInstance(TransportService.class).boundAddress().publishAddress();
             client.addTransportAddress(transportAddress);
             // since we force transport clients there has to be one node started that we connect to.
@@ -96,7 +94,7 @@ public class TransportClientIT extends ESIntegTestCase {
     }
 
     public void testThatTransportClientSettingCannotBeChanged() {
-        String transport = randomTestTransport();
+        String transport = randomTestTransportKey();
         Settings baseSettings = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), transport)

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientRetryIT.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientRetryIT.java
@@ -32,10 +32,8 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.MockTransportClient;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.nio.NioTransportPlugin;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -52,7 +50,7 @@ public class TransportClientRetryIT extends ESIntegTestCase {
             addresses[i++] = instance.boundAddress().publishAddress();
         }
 
-        String transport = randomTestTransport();
+        String transport = randomTestTransportKey();
 
         Settings.Builder builder = Settings.builder().put("client.transport.nodes_sampler_interval", "1s")
                 .put("node.name", "transport_client_retry_test")

--- a/core/src/test/java/org/elasticsearch/client/transport/TransportClientRetryIT.java
+++ b/core/src/test/java/org/elasticsearch/client/transport/TransportClientRetryIT.java
@@ -50,7 +50,7 @@ public class TransportClientRetryIT extends ESIntegTestCase {
             addresses[i++] = instance.boundAddress().publishAddress();
         }
 
-        String transport = randomTestTransportKey();
+        String transport = getTestTransportType();
 
         Settings.Builder builder = Settings.builder().put("client.transport.nodes_sampler_interval", "1s")
                 .put("node.name", "transport_client_retry_test")

--- a/core/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -35,7 +35,6 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.NodeConfigurationSource;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.Closeable;
@@ -125,7 +124,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                         .builder()
                         .put("discovery.type", "single-node")
                         .put("http.enabled", false)
-                        .put("transport.type", "mock-socket-network")
+                        .put("transport.type", randomTestTransportKey())
                         /*
                          * We align the port ranges of the two as then with zen discovery these two
                          * nodes would find each other.
@@ -152,7 +151,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                         0,
                         false,
                         "other",
-                        Collections.singletonList(MockTcpTransportPlugin.class),
+                        Collections.singletonList(randomTestTransportPlugin()),
                         Function.identity())) {
             other.beforeTest(random(), 0);
             final ClusterState first = internalCluster().getInstance(ClusterService.class).state();

--- a/core/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -124,7 +124,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                         .builder()
                         .put("discovery.type", "single-node")
                         .put("http.enabled", false)
-                        .put("transport.type", randomTestTransportKey())
+                        .put("transport.type", getTestTransportType())
                         /*
                          * We align the port ranges of the two as then with zen discovery these two
                          * nodes would find each other.
@@ -151,7 +151,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                         0,
                         false,
                         "other",
-                        Collections.singletonList(randomTestTransportPlugin()),
+                        Collections.singletonList(getTestTransportPlugin()),
                         Function.identity())) {
             other.beforeTest(random(), 0);
             final ClusterState first = internalCluster().getInstance(ClusterService.class).state();

--- a/core/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/core/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -23,31 +23,22 @@ import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasToString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -62,7 +53,7 @@ public class NodeTests extends ESTestCase {
         if (name != null) {
             settings.put(Node.NODE_NAME_SETTING.getKey(), name);
         }
-        try (Node node = new MockNode(settings.build(), Collections.singleton(MockTcpTransportPlugin.class))) {
+        try (Node node = new MockNode(settings.build(), Collections.singleton(randomTestTransportPlugin()))) {
             final Settings nodeSettings = randomBoolean() ? node.settings() : node.getEnvironment().settings();
             if (name == null) {
                 assertThat(Node.NODE_NAME_SETTING.get(nodeSettings), equalTo(node.getNodeEnvironment().nodeId().substring(0, 7)));
@@ -97,7 +88,7 @@ public class NodeTests extends ESTestCase {
             settings.put(Node.NODE_NAME_SETTING.getKey(), name);
         }
         AtomicBoolean executed = new AtomicBoolean(false);
-        try (Node node = new MockNode(settings.build(), Arrays.asList(MockTcpTransportPlugin.class, CheckPlugin.class)) {
+        try (Node node = new MockNode(settings.build(), Arrays.asList(randomTestTransportPlugin(), CheckPlugin.class)) {
             @Override
             protected void validateNodeBeforeAcceptingRequests(Settings settings, BoundTransportAddress boundTransportAddress,
                                                                List<BootstrapCheck> bootstrapChecks) throws NodeValidationException {
@@ -139,7 +130,7 @@ public class NodeTests extends ESTestCase {
     public void testNodeAttributes() throws IOException {
         String attr = randomAlphaOfLength(5);
         Settings.Builder settings = baseSettings().put(Node.NODE_ATTRIBUTES.getKey() + "test_attr", attr);
-        try (Node node = new MockNode(settings.build(), Collections.singleton(MockTcpTransportPlugin.class))) {
+        try (Node node = new MockNode(settings.build(), Collections.singleton(randomTestTransportPlugin()))) {
             final Settings nodeSettings = randomBoolean() ? node.settings() : node.getEnvironment().settings();
             assertEquals(attr, Node.NODE_ATTRIBUTES.get(nodeSettings).getAsMap().get("test_attr"));
         }
@@ -147,7 +138,7 @@ public class NodeTests extends ESTestCase {
         // leading whitespace not allowed
         attr = " leading";
         settings = baseSettings().put(Node.NODE_ATTRIBUTES.getKey() + "test_attr", attr);
-        try (Node node = new MockNode(settings.build(), Collections.singleton(MockTcpTransportPlugin.class))) {
+        try (Node node = new MockNode(settings.build(), Collections.singleton(randomTestTransportPlugin()))) {
             fail("should not allow a node attribute with leading whitespace");
         } catch (IllegalArgumentException e) {
             assertEquals("node.attr.test_attr cannot have leading or trailing whitespace [ leading]", e.getMessage());
@@ -156,7 +147,7 @@ public class NodeTests extends ESTestCase {
         // trailing whitespace not allowed
         attr = "trailing ";
         settings = baseSettings().put(Node.NODE_ATTRIBUTES.getKey() + "test_attr", attr);
-        try (Node node = new MockNode(settings.build(), Collections.singleton(MockTcpTransportPlugin.class))) {
+        try (Node node = new MockNode(settings.build(), Collections.singleton(randomTestTransportPlugin()))) {
             fail("should not allow a node attribute with trailing whitespace");
         } catch (IllegalArgumentException e) {
             assertEquals("node.attr.test_attr cannot have leading or trailing whitespace [trailing ]", e.getMessage());

--- a/core/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/core/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -160,7 +160,7 @@ public class NodeTests extends ESTestCase {
                 .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), InternalTestCluster.clusterName("single-node-cluster", randomLong()))
                 .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
                 .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-                .put(NetworkModule.TRANSPORT_TYPE_KEY, "mock-socket-network")
+                .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                 .put(Node.NODE_DATA_SETTING.getKey(), true);
     }
 

--- a/core/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/core/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -53,7 +53,7 @@ public class NodeTests extends ESTestCase {
         if (name != null) {
             settings.put(Node.NODE_NAME_SETTING.getKey(), name);
         }
-        try (Node node = new MockNode(settings.build(), Collections.singleton(randomTestTransportPlugin()))) {
+        try (Node node = new MockNode(settings.build(), Collections.singleton(getTestTransportPlugin()))) {
             final Settings nodeSettings = randomBoolean() ? node.settings() : node.getEnvironment().settings();
             if (name == null) {
                 assertThat(Node.NODE_NAME_SETTING.get(nodeSettings), equalTo(node.getNodeEnvironment().nodeId().substring(0, 7)));
@@ -88,7 +88,7 @@ public class NodeTests extends ESTestCase {
             settings.put(Node.NODE_NAME_SETTING.getKey(), name);
         }
         AtomicBoolean executed = new AtomicBoolean(false);
-        try (Node node = new MockNode(settings.build(), Arrays.asList(randomTestTransportPlugin(), CheckPlugin.class)) {
+        try (Node node = new MockNode(settings.build(), Arrays.asList(getTestTransportPlugin(), CheckPlugin.class)) {
             @Override
             protected void validateNodeBeforeAcceptingRequests(Settings settings, BoundTransportAddress boundTransportAddress,
                                                                List<BootstrapCheck> bootstrapChecks) throws NodeValidationException {
@@ -130,7 +130,7 @@ public class NodeTests extends ESTestCase {
     public void testNodeAttributes() throws IOException {
         String attr = randomAlphaOfLength(5);
         Settings.Builder settings = baseSettings().put(Node.NODE_ATTRIBUTES.getKey() + "test_attr", attr);
-        try (Node node = new MockNode(settings.build(), Collections.singleton(randomTestTransportPlugin()))) {
+        try (Node node = new MockNode(settings.build(), Collections.singleton(getTestTransportPlugin()))) {
             final Settings nodeSettings = randomBoolean() ? node.settings() : node.getEnvironment().settings();
             assertEquals(attr, Node.NODE_ATTRIBUTES.get(nodeSettings).getAsMap().get("test_attr"));
         }
@@ -138,7 +138,7 @@ public class NodeTests extends ESTestCase {
         // leading whitespace not allowed
         attr = " leading";
         settings = baseSettings().put(Node.NODE_ATTRIBUTES.getKey() + "test_attr", attr);
-        try (Node node = new MockNode(settings.build(), Collections.singleton(randomTestTransportPlugin()))) {
+        try (Node node = new MockNode(settings.build(), Collections.singleton(getTestTransportPlugin()))) {
             fail("should not allow a node attribute with leading whitespace");
         } catch (IllegalArgumentException e) {
             assertEquals("node.attr.test_attr cannot have leading or trailing whitespace [ leading]", e.getMessage());
@@ -147,7 +147,7 @@ public class NodeTests extends ESTestCase {
         // trailing whitespace not allowed
         attr = "trailing ";
         settings = baseSettings().put(Node.NODE_ATTRIBUTES.getKey() + "test_attr", attr);
-        try (Node node = new MockNode(settings.build(), Collections.singleton(randomTestTransportPlugin()))) {
+        try (Node node = new MockNode(settings.build(), Collections.singleton(getTestTransportPlugin()))) {
             fail("should not allow a node attribute with trailing whitespace");
         } catch (IllegalArgumentException e) {
             assertEquals("node.attr.test_attr cannot have leading or trailing whitespace [trailing ]", e.getMessage());

--- a/modules/tribe/src/test/java/org/elasticsearch/tribe/TribeIntegrationTests.java
+++ b/modules/tribe/src/test/java/org/elasticsearch/tribe/TribeIntegrationTests.java
@@ -290,7 +290,7 @@ public class TribeIntegrationTests extends ESIntegTestCase {
         settings.put(Node.NODE_MASTER_SETTING.getKey(), false);
         settings.put(Node.NODE_INGEST_SETTING.getKey(), false);
         settings.put(NetworkModule.HTTP_ENABLED.getKey(), false);
-        settings.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
+        settings.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), getTestTransportType());
         // add dummy tribe setting so that node is always identifiable as tribe in this test even if the set of connecting cluster is empty
         settings.put(TribeService.BLOCKS_WRITE_SETTING.getKey(), TribeService.BLOCKS_WRITE_SETTING.getDefault(Settings.EMPTY));
 
@@ -298,7 +298,7 @@ public class TribeIntegrationTests extends ESIntegTestCase {
             String tribeSetting = "tribe." + c.getClusterName() + ".";
             settings.put(tribeSetting + ClusterName.CLUSTER_NAME_SETTING.getKey(), c.getClusterName());
             settings.put(tribeSetting + DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "100ms");
-            settings.put(tribeSetting + NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
+            settings.put(tribeSetting + NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), getTestTransportType());
         });
 
         return settings;

--- a/modules/tribe/src/test/java/org/elasticsearch/tribe/TribeIntegrationTests.java
+++ b/modules/tribe/src/test/java/org/elasticsearch/tribe/TribeIntegrationTests.java
@@ -50,7 +50,6 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.NodeConfigurationSource;
 import org.elasticsearch.test.TestCustomMetaData;
 import org.elasticsearch.test.discovery.TestZenDiscovery;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.tribe.TribeServiceTests.MergableCustomMetaData1;
 import org.elasticsearch.tribe.TribeServiceTests.MergableCustomMetaData2;
 import org.junit.After;
@@ -291,7 +290,7 @@ public class TribeIntegrationTests extends ESIntegTestCase {
         settings.put(Node.NODE_MASTER_SETTING.getKey(), false);
         settings.put(Node.NODE_INGEST_SETTING.getKey(), false);
         settings.put(NetworkModule.HTTP_ENABLED.getKey(), false);
-        settings.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME);
+        settings.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
         // add dummy tribe setting so that node is always identifiable as tribe in this test even if the set of connecting cluster is empty
         settings.put(TribeService.BLOCKS_WRITE_SETTING.getKey(), TribeService.BLOCKS_WRITE_SETTING.getDefault(Settings.EMPTY));
 
@@ -299,7 +298,7 @@ public class TribeIntegrationTests extends ESIntegTestCase {
             String tribeSetting = "tribe." + c.getClusterName() + ".";
             settings.put(tribeSetting + ClusterName.CLUSTER_NAME_SETTING.getKey(), c.getClusterName());
             settings.put(tribeSetting + DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "100ms");
-            settings.put(tribeSetting + NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME);
+            settings.put(tribeSetting + NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
         });
 
         return settings;

--- a/modules/tribe/src/test/java/org/elasticsearch/tribe/TribeServiceTests.java
+++ b/modules/tribe/src/test/java/org/elasticsearch/tribe/TribeServiceTests.java
@@ -185,7 +185,7 @@ public class TribeServiceTests extends ESTestCase {
 
     public static class MockTribePlugin extends TribePlugin {
 
-        static List<Class<? extends Plugin>> classpathPlugins = Arrays.asList(MockTribePlugin.class, randomTestTransportPlugin());
+        static List<Class<? extends Plugin>> classpathPlugins = Arrays.asList(MockTribePlugin.class, getTestTransportPlugin());
 
         public MockTribePlugin(Settings settings) {
             super(settings);
@@ -203,14 +203,14 @@ public class TribeServiceTests extends ESTestCase {
             .put("node.name", "test-node")
             .put("path.home", tempDir)
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-            .put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
+            .put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), getTestTransportType());
 
         final boolean tribeServiceEnable = randomBoolean();
         if (tribeServiceEnable) {
             String clusterName = "single-node-cluster";
             String tribeSetting = "tribe." + clusterName + ".";
             settings.put(tribeSetting + ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterName)
-                .put(tribeSetting + NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
+                .put(tribeSetting + NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), getTestTransportType());
         }
         try (Node node = new MockNode(settings.build(), MockTribePlugin.classpathPlugins)) {
             if (tribeServiceEnable) {

--- a/modules/tribe/src/test/java/org/elasticsearch/tribe/TribeServiceTests.java
+++ b/modules/tribe/src/test/java/org/elasticsearch/tribe/TribeServiceTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestCustomMetaData;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -186,7 +185,7 @@ public class TribeServiceTests extends ESTestCase {
 
     public static class MockTribePlugin extends TribePlugin {
 
-        static List<Class<? extends Plugin>> classpathPlugins = Arrays.asList(MockTribePlugin.class, MockTcpTransportPlugin.class);
+        static List<Class<? extends Plugin>> classpathPlugins = Arrays.asList(MockTribePlugin.class, randomTestTransportPlugin());
 
         public MockTribePlugin(Settings settings) {
             super(settings);
@@ -204,14 +203,14 @@ public class TribeServiceTests extends ESTestCase {
             .put("node.name", "test-node")
             .put("path.home", tempDir)
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-            .put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), "mock-socket-network");
+            .put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
 
         final boolean tribeServiceEnable = randomBoolean();
         if (tribeServiceEnable) {
             String clusterName = "single-node-cluster";
             String tribeSetting = "tribe." + clusterName + ".";
             settings.put(tribeSetting + ClusterName.CLUSTER_NAME_SETTING.getKey(), clusterName)
-                .put(tribeSetting + NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), "mock-socket-network");
+                .put(tribeSetting + NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
         }
         try (Node node = new MockNode(settings.build(), MockTribePlugin.classpathPlugins)) {
             if (tribeServiceEnable) {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
@@ -63,12 +63,12 @@ public class TribeUnitTests extends ESTestCase {
     public static void createTribes() throws NodeValidationException {
         Settings baseSettings = Settings.builder()
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-            .put("transport.type", randomTestTransportKey())
+            .put("transport.type", getTestTransportType())
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), 2)
             .build();
 
-        classpathPlugins = Arrays.asList(TribeAwareTestZenDiscoveryPlugin.class, MockTribePlugin.class, randomTestTransportPlugin());
+        classpathPlugins = Arrays.asList(TribeAwareTestZenDiscoveryPlugin.class, MockTribePlugin.class, getTestTransportPlugin());
 
         tribe1 = new MockNode(
             Settings.builder()
@@ -130,9 +130,9 @@ public class TribeUnitTests extends ESTestCase {
     private static void assertTribeNodeSuccessfullyCreated(Path configPath) throws Exception {
         // the tribe clients do need it to make sure they can find their corresponding tribes using the proper transport
         Settings settings = Settings.builder().put(NetworkModule.HTTP_ENABLED.getKey(), false).put("node.name", "tribe_node")
-                .put("transport.type", randomTestTransportKey())
-                .put("tribe.t1.transport.type", randomTestTransportKey())
-                .put("tribe.t2.transport.type", randomTestTransportKey())
+                .put("transport.type", getTestTransportType())
+                .put("tribe.t1.transport.type", getTestTransportType())
+                .put("tribe.t2.transport.type", getTestTransportType())
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .build();
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/tribe/TribeUnitTests.java
@@ -19,12 +19,6 @@
 
 package org.elasticsearch.tribe;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.Function;
-
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -41,9 +35,14 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.discovery.TestZenDiscovery;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -64,12 +63,12 @@ public class TribeUnitTests extends ESTestCase {
     public static void createTribes() throws NodeValidationException {
         Settings baseSettings = Settings.builder()
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-            .put("transport.type", MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
+            .put("transport.type", randomTestTransportKey())
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), 2)
             .build();
 
-        classpathPlugins = Arrays.asList(TribeAwareTestZenDiscoveryPlugin.class, MockTribePlugin.class, MockTcpTransportPlugin.class);
+        classpathPlugins = Arrays.asList(TribeAwareTestZenDiscoveryPlugin.class, MockTribePlugin.class, randomTestTransportPlugin());
 
         tribe1 = new MockNode(
             Settings.builder()
@@ -131,9 +130,9 @@ public class TribeUnitTests extends ESTestCase {
     private static void assertTribeNodeSuccessfullyCreated(Path configPath) throws Exception {
         // the tribe clients do need it to make sure they can find their corresponding tribes using the proper transport
         Settings settings = Settings.builder().put(NetworkModule.HTTP_ENABLED.getKey(), false).put("node.name", "tribe_node")
-                .put("transport.type", MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
-                .put("tribe.t1.transport.type", MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
-                .put("tribe.t2.transport.type",MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
+                .put("transport.type", randomTestTransportKey())
+                .put("tribe.t1.transport.type", randomTestTransportKey())
+                .put("tribe.t2.transport.type", randomTestTransportKey())
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
                 .build();
 

--- a/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
+++ b/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
@@ -30,7 +30,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import org.elasticsearch.transport.nio.NioTransportPlugin;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -47,8 +49,6 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
-import static org.elasticsearch.test.ESTestCase.randomTestTransportKey;
-import static org.elasticsearch.test.ESTestCase.randomTestTransportPlugin;
 import static org.hamcrest.Matchers.notNullValue;
 
 /**
@@ -82,9 +82,19 @@ public abstract class ESSmokeClientTestCase extends LuceneTestCase {
             .put("client.transport.ignore_cluster_name", true)
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir);
         final Collection<Class<? extends Plugin>> plugins;
+        boolean usNio = random().nextBoolean();
+        String transportKey;
+        Class<? extends Plugin> transportPlugin;
+        if (usNio) {
+            transportKey = NioTransportPlugin.NIO_TRANSPORT_NAME;
+            transportPlugin = NioTransportPlugin.class;
+        } else {
+            transportKey = MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME;
+            transportPlugin = MockTcpTransportPlugin.class;
+        }
         if (random().nextBoolean()) {
-            builder.put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey());
-            plugins = Collections.singleton(randomTestTransportPlugin());
+            builder.put(NetworkModule.TRANSPORT_TYPE_KEY, transportKey);
+            plugins = Collections.singleton(transportPlugin);
         } else {
             plugins = Collections.emptyList();
         }

--- a/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
+++ b/qa/smoke-test-client/src/test/java/org/elasticsearch/smoketest/ESSmokeClientTestCase.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -48,6 +47,8 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
+import static org.elasticsearch.test.ESTestCase.randomTestTransportKey;
+import static org.elasticsearch.test.ESTestCase.randomTestTransportPlugin;
 import static org.hamcrest.Matchers.notNullValue;
 
 /**
@@ -82,8 +83,8 @@ public abstract class ESSmokeClientTestCase extends LuceneTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir);
         final Collection<Class<? extends Plugin>> plugins;
         if (random().nextBoolean()) {
-            builder.put(NetworkModule.TRANSPORT_TYPE_KEY, MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME);
-            plugins = Collections.singleton(MockTcpTransportPlugin.class);
+            builder.put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey());
+            plugins = Collections.singleton(randomTestTransportPlugin());
         } else {
             plugins = Collections.emptyList();
         }

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/HttpSmokeTestCase.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/HttpSmokeTestCase.java
@@ -39,9 +39,9 @@ public abstract class HttpSmokeTestCase extends ESIntegTestCase {
     @SuppressWarnings("unchecked")
     @BeforeClass
     public static void setUpTransport() {
-        nodeTransportTypeKey = getTypeKey(randomFrom(randomTestTransportPlugin(), Netty4Plugin.class));
+        nodeTransportTypeKey = getTypeKey(randomFrom(getTestTransportPlugin(), Netty4Plugin.class));
         nodeHttpTypeKey = getTypeKey(Netty4Plugin.class);
-        clientTypeKey = getTypeKey(randomFrom(randomTestTransportPlugin(), Netty4Plugin.class));
+        clientTypeKey = getTypeKey(randomFrom(getTestTransportPlugin(), Netty4Plugin.class));
     }
 
     private static String getTypeKey(Class<? extends Plugin> clazz) {
@@ -66,12 +66,12 @@ public abstract class HttpSmokeTestCase extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(randomTestTransportPlugin(), Netty4Plugin.class);
+        return Arrays.asList(getTestTransportPlugin(), Netty4Plugin.class);
     }
 
     @Override
     protected Collection<Class<? extends Plugin>> transportClientPlugins() {
-        return Arrays.asList(randomTestTransportPlugin(), Netty4Plugin.class);
+        return Arrays.asList(getTestTransportPlugin(), Netty4Plugin.class);
     }
 
     @Override

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/HttpSmokeTestCase.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/HttpSmokeTestCase.java
@@ -24,6 +24,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.Netty4Plugin;
+import org.elasticsearch.transport.nio.NioTransportPlugin;
 import org.junit.BeforeClass;
 
 import java.util.Arrays;
@@ -38,14 +39,16 @@ public abstract class HttpSmokeTestCase extends ESIntegTestCase {
     @SuppressWarnings("unchecked")
     @BeforeClass
     public static void setUpTransport() {
-        nodeTransportTypeKey = getTypeKey(randomFrom(MockTcpTransportPlugin.class, Netty4Plugin.class));
+        nodeTransportTypeKey = getTypeKey(randomFrom(randomTestTransportPlugin(), Netty4Plugin.class));
         nodeHttpTypeKey = getTypeKey(Netty4Plugin.class);
-        clientTypeKey = getTypeKey(randomFrom(MockTcpTransportPlugin.class,Netty4Plugin.class));
+        clientTypeKey = getTypeKey(randomFrom(randomTestTransportPlugin(), Netty4Plugin.class));
     }
 
     private static String getTypeKey(Class<? extends Plugin> clazz) {
         if (clazz.equals(MockTcpTransportPlugin.class)) {
             return MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME;
+        } else if (clazz.equals(NioTransportPlugin.class)) {
+            return NioTransportPlugin.NIO_TRANSPORT_NAME;
         } else {
             assert clazz.equals(Netty4Plugin.class);
             return Netty4Plugin.NETTY_TRANSPORT_NAME;
@@ -63,12 +66,12 @@ public abstract class HttpSmokeTestCase extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(MockTcpTransportPlugin.class, Netty4Plugin.class);
+        return Arrays.asList(randomTestTransportPlugin(), Netty4Plugin.class);
     }
 
     @Override
     protected Collection<Class<? extends Plugin>> transportClientPlugins() {
-        return Arrays.asList(MockTcpTransportPlugin.class, Netty4Plugin.class);
+        return Arrays.asList(randomTestTransportPlugin(), Netty4Plugin.class);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1805,8 +1805,8 @@ public abstract class ESIntegTestCase extends ESTestCase {
             ArrayList<Class<? extends Plugin>> mocks = new ArrayList<>(mockPlugins);
             // add both mock plugins - local and tcp if they are not there
             // we do this in case somebody overrides getMockPlugins and misses to call super
-            if (mockPlugins.contains(randomTestTransportPlugin()) == false) {
-                mocks.add(randomTestTransportPlugin());
+            if (mockPlugins.contains(getTestTransportPlugin()) == false) {
+                mocks.add(getTestTransportPlugin());
             }
             mockPlugins = mocks;
         }
@@ -1819,7 +1819,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
     protected NodeConfigurationSource getNodeConfigSource() {
         Settings.Builder networkSettings = Settings.builder();
         if (addMockTransportService()) {
-            networkSettings.put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey());
+            networkSettings.put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType());
         }
 
         NodeConfigurationSource nodeConfigurationSource = new NodeConfigurationSource() {
@@ -1850,9 +1850,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
             @Override
             public Collection<Class<? extends Plugin>> transportClientPlugins() {
                 Collection<Class<? extends Plugin>> plugins = ESIntegTestCase.this.transportClientPlugins();
-                if (plugins.contains(randomTestTransportPlugin()) == false) {
+                if (plugins.contains(getTestTransportPlugin()) == false) {
                     plugins = new ArrayList<>(plugins);
-                    plugins.add(randomTestTransportPlugin());
+                    plugins.add(getTestTransportPlugin());
                 }
                 return Collections.unmodifiableCollection(plugins);
             }
@@ -1910,7 +1910,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         }
 
         if (addMockTransportService()) {
-            mocks.add(randomTestTransportPlugin());
+            mocks.add(getTestTransportPlugin());
         }
 
         if (addTestZenDiscovery()) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
@@ -51,7 +50,6 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.discovery.TestZenDiscovery;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -175,15 +173,15 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
             .put(ScriptService.SCRIPT_MAX_COMPILATIONS_PER_MINUTE.getKey(), 1000)
             .put(EsExecutors.PROCESSORS_SETTING.getKey(), 1) // limit the number of threads created
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-            .put("transport.type", MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
+            .put("transport.type", randomTestTransportKey())
             .put(Node.NODE_DATA_SETTING.getKey(), true)
             .put(NodeEnvironment.NODE_ID_SEED_SETTING.getKey(), random().nextLong())
             .put(nodeSettings()) // allow test cases to provide their own settings or override these
             .build();
         Collection<Class<? extends Plugin>> plugins = getPlugins();
-        if (plugins.contains(MockTcpTransportPlugin.class) == false) {
+        if (plugins.contains(randomTestTransportPlugin()) == false) {
             plugins = new ArrayList<>(plugins);
-            plugins.add(MockTcpTransportPlugin.class);
+            plugins.add(randomTestTransportPlugin());
         }
         if (plugins.contains(TestZenDiscovery.TestPlugin.class) == false) {
             plugins = new ArrayList<>(plugins);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -173,15 +173,15 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
             .put(ScriptService.SCRIPT_MAX_COMPILATIONS_PER_MINUTE.getKey(), 1000)
             .put(EsExecutors.PROCESSORS_SETTING.getKey(), 1) // limit the number of threads created
             .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-            .put("transport.type", randomTestTransportKey())
+            .put("transport.type", getTestTransportType())
             .put(Node.NODE_DATA_SETTING.getKey(), true)
             .put(NodeEnvironment.NODE_ID_SEED_SETTING.getKey(), random().nextLong())
             .put(nodeSettings()) // allow test cases to provide their own settings or override these
             .build();
         Collection<Class<? extends Plugin>> plugins = getPlugins();
-        if (plugins.contains(randomTestTransportPlugin()) == false) {
+        if (plugins.contains(getTestTransportPlugin()) == false) {
             plugins = new ArrayList<>(plugins);
-            plugins.add(randomTestTransportPlugin());
+            plugins.add(getTestTransportPlugin());
         }
         if (plugins.contains(TestZenDiscovery.TestPlugin.class) == false) {
             plugins = new ArrayList<>(plugins);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -901,11 +901,11 @@ public abstract class ESTestCase extends LuceneTestCase {
         return useNio.get();
     }
 
-    public static String randomTestTransportKey() {
+    public static String getTestTransportType() {
         return getUseNio() ? NioTransportPlugin.NIO_TRANSPORT_NAME : MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME;
     }
 
-    public static Class<? extends Plugin> randomTestTransportPlugin() {
+    public static Class<? extends Plugin> getTestTransportPlugin() {
         return getUseNio() ? NioTransportPlugin.class : MockTcpTransportPlugin.class;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -888,25 +888,19 @@ public abstract class ESTestCase extends LuceneTestCase {
         return geohashGenerator.ofStringLength(random(), minPrecision, maxPrecision);
     }
 
-    private static final SetOnce<Boolean> useNio = new SetOnce<>();
+    private static boolean useNio;
 
-    private static boolean getUseNio() {
-        if (useNio.get() == null) {
-            synchronized (useNio) {
-                if (useNio.get() == null) {
-                    useNio.set(randomBoolean());
-                }
-            }
-        }
-        return useNio.get();
+    @BeforeClass
+    public static void setUseNio() throws Exception {
+        useNio = randomBoolean();
     }
 
     public static String getTestTransportType() {
-        return getUseNio() ? NioTransportPlugin.NIO_TRANSPORT_NAME : MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME;
+        return useNio ? NioTransportPlugin.NIO_TRANSPORT_NAME : MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME;
     }
 
     public static Class<? extends Plugin> getTestTransportPlugin() {
-        return getUseNio() ? NioTransportPlugin.class : MockTcpTransportPlugin.class;
+        return useNio ? NioTransportPlugin.class : MockTcpTransportPlugin.class;
     }
 
     private static final GeohashGenerator geohashGenerator = new GeohashGenerator();

--- a/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -46,7 +46,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.elasticsearch.test.ESTestCase.randomTestTransportKey;
+import static org.elasticsearch.test.ESTestCase.getTestTransportType;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -82,7 +82,7 @@ public final class ExternalTestCluster extends TestCluster {
         boolean addMockTcpTransport = additionalSettings.get(NetworkModule.TRANSPORT_TYPE_KEY) == null;
 
         if (addMockTcpTransport) {
-            String transport = randomTestTransportKey();
+            String transport = getTestTransportType();
             clientSettingsBuilder.put(NetworkModule.TRANSPORT_TYPE_KEY, transport);
             if (pluginClasses.contains(MockTcpTransportPlugin.class) == false &&
                 pluginClasses.contains(NioTransportPlugin.class) == false) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -36,6 +36,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.MockTransportClient;
+import org.elasticsearch.transport.nio.NioTransportPlugin;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -45,6 +46,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.elasticsearch.test.ESTestCase.randomTestTransportKey;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -80,10 +82,16 @@ public final class ExternalTestCluster extends TestCluster {
         boolean addMockTcpTransport = additionalSettings.get(NetworkModule.TRANSPORT_TYPE_KEY) == null;
 
         if (addMockTcpTransport) {
-            clientSettingsBuilder.put(NetworkModule.TRANSPORT_TYPE_KEY, MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME);
-            if (pluginClasses.contains(MockTcpTransportPlugin.class) == false) {
+            String transport = randomTestTransportKey();
+            clientSettingsBuilder.put(NetworkModule.TRANSPORT_TYPE_KEY, transport);
+            if (pluginClasses.contains(MockTcpTransportPlugin.class) == false &&
+                pluginClasses.contains(NioTransportPlugin.class) == false) {
                 pluginClasses = new ArrayList<>(pluginClasses);
-                pluginClasses.add(MockTcpTransportPlugin.class);
+                if (transport.equals(NioTransportPlugin.NIO_TRANSPORT_NAME)) {
+                    pluginClasses.add(NioTransportPlugin.class);
+                } else {
+                    pluginClasses.add(MockTcpTransportPlugin.class);
+                }
             }
         }
         Settings clientSettings = clientSettingsBuilder.build();

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -137,7 +137,7 @@ import static org.elasticsearch.discovery.zen.ElectMasterService.DISCOVERY_ZEN_M
 import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.ESTestCase.awaitBusy;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
-import static org.elasticsearch.test.ESTestCase.randomTestTransportKey;
+import static org.elasticsearch.test.ESTestCase.getTestTransportType;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -976,7 +976,7 @@ public final class InternalTestCluster extends TestCluster {
             if (NetworkModule.TRANSPORT_TYPE_SETTING.exists(settings)) {
                 builder.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), NetworkModule.TRANSPORT_TYPE_SETTING.get(settings));
             } else {
-                builder.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
+                builder.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), getTestTransportType());
             }
             TransportClient client = new MockTransportClient(builder.build(), plugins);
             client.addTransportAddress(addr);

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -95,12 +95,10 @@ import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.MockTransportClient;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.nio.NioTransportPlugin;
 import org.junit.Assert;
 
 import java.io.Closeable;
@@ -138,8 +136,8 @@ import static org.elasticsearch.discovery.DiscoverySettings.INITIAL_STATE_TIMEOU
 import static org.elasticsearch.discovery.zen.ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING;
 import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.ESTestCase.awaitBusy;
-import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomTestTransportKey;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -978,9 +976,7 @@ public final class InternalTestCluster extends TestCluster {
             if (NetworkModule.TRANSPORT_TYPE_SETTING.exists(settings)) {
                 builder.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), NetworkModule.TRANSPORT_TYPE_SETTING.get(settings));
             } else {
-                String transport = randomBoolean() ? NioTransportPlugin.NIO_TRANSPORT_NAME :
-                    MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME;
-                builder.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), transport);
+                builder.put(NetworkModule.TRANSPORT_TYPE_SETTING.getKey(), randomTestTransportKey());
             }
             TransportClient client = new MockTransportClient(builder.build(), plugins);
             client.addTransportAddress(addr);

--- a/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransportPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransportPlugin.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class MockTcpTransportPlugin extends Plugin implements NetworkPlugin {
+
     public static final String MOCK_TCP_TRANSPORT_NAME = "mock-socket-network";
 
     @Override

--- a/test/framework/src/test/java/org/elasticsearch/node/MockNodeTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/node/MockNodeTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.MockSearchService;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,11 +40,11 @@ public class MockNodeTests extends ESTestCase {
     public void testComponentsMockedByMarkerPlugins() throws IOException {
         Settings settings = Settings.builder() // All these are required or MockNode will fail to build.
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
-                .put("transport.type", MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
+                .put("transport.type", randomTestTransportKey())
                 .put("http.enabled", false)
                 .build();
         List<Class<? extends Plugin>> plugins = new ArrayList<>();
-        plugins.add(MockTcpTransportPlugin.class);
+        plugins.add(randomTestTransportPlugin());
         boolean useMockBigArrays = randomBoolean();
         boolean useMockSearchService = randomBoolean();
         if (useMockBigArrays) {

--- a/test/framework/src/test/java/org/elasticsearch/node/MockNodeTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/node/MockNodeTests.java
@@ -40,11 +40,11 @@ public class MockNodeTests extends ESTestCase {
     public void testComponentsMockedByMarkerPlugins() throws IOException {
         Settings settings = Settings.builder() // All these are required or MockNode will fail to build.
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
-                .put("transport.type", randomTestTransportKey())
+                .put("transport.type", getTestTransportType())
                 .put("http.enabled", false)
                 .build();
         List<Class<? extends Plugin>> plugins = new ArrayList<>();
-        plugins.add(randomTestTransportPlugin());
+        plugins.add(getTestTransportPlugin());
         boolean useMockBigArrays = randomBoolean();
         boolean useMockSearchService = randomBoolean();
         if (useMockBigArrays) {

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -175,7 +175,7 @@ public class InternalTestClusterTests extends ESTestCase {
         final int numClientNodes = randomIntBetween(0, 2);
         final String clusterName1 = "shared1";
         final String clusterName2 = "shared2";
-        String transportClient = randomTestTransportKey();
+        String transportClient = getTestTransportType();
         NodeConfigurationSource nodeConfigurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
@@ -184,7 +184,7 @@ public class InternalTestClusterTests extends ESTestCase {
                         NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(),
                         2 * ((masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes))
                     .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-                    .put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey());
+                    .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType());
                 if (autoManageMinMasterNodes == false) {
                     assert minNumDataNodes == maxNumDataNodes;
                     assert masterNodes == false;
@@ -209,7 +209,7 @@ public class InternalTestClusterTests extends ESTestCase {
         String nodePrefix = "foobar";
 
         Path baseDir = createTempDir();
-        final List<Class<? extends Plugin>> mockPlugins = Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class);
+        final List<Class<? extends Plugin>> mockPlugins = Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class);
         InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, baseDir, masterNodes,
             autoManageMinMasterNodes, minNumDataNodes, maxNumDataNodes, clusterName1, nodeConfigurationSource, numClientNodes,
             enableHttpPipelining, nodePrefix, mockPlugins, Function.identity());
@@ -253,7 +253,7 @@ public class InternalTestClusterTests extends ESTestCase {
         final int maxNumDataNodes = 2;
         final int numClientNodes = randomIntBetween(0, 2);
         final String clusterName1 = "shared1";
-        String transportClient = randomTestTransportKey();
+        String transportClient = getTestTransportType();
         NodeConfigurationSource nodeConfigurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
@@ -261,7 +261,7 @@ public class InternalTestClusterTests extends ESTestCase {
                     .put(
                         NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(),
                         2 + (masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes)
-                    .put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey())
+                    .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                     .build();
             }
 
@@ -281,7 +281,7 @@ public class InternalTestClusterTests extends ESTestCase {
         Path baseDir = createTempDir();
         InternalTestCluster cluster = new InternalTestCluster(clusterSeed, baseDir, masterNodes,
             true, minNumDataNodes, maxNumDataNodes, clusterName1, nodeConfigurationSource, numClientNodes,
-            enableHttpPipelining, nodePrefix, Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class),
+            enableHttpPipelining, nodePrefix, Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class),
             Function.identity());
         try {
             cluster.beforeTest(random(), 0.0);
@@ -362,7 +362,7 @@ public class InternalTestClusterTests extends ESTestCase {
         final Path baseDir = createTempDir();
         final int numNodes = 5;
 
-        String transportClient = randomTestTransportKey();
+        String transportClient = getTestTransportType();
         InternalTestCluster cluster = new InternalTestCluster(randomLong(), baseDir, false,
                 false, 0, 0, "test", new NodeConfigurationSource() {
             @Override
@@ -370,7 +370,7 @@ public class InternalTestClusterTests extends ESTestCase {
                 return Settings.builder()
                         .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), numNodes)
                         .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-                        .put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey())
+                        .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                         .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), 0)
                         // speedup join timeout as setting initial state timeout to 0 makes split
                         // elections more likely
@@ -388,7 +388,7 @@ public class InternalTestClusterTests extends ESTestCase {
                 return Settings.builder()
                         .put(NetworkModule.TRANSPORT_TYPE_KEY, transportClient).build();
             }
-        }, 0, randomBoolean(), "", Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class), Function.identity());
+        }, 0, randomBoolean(), "", Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class), Function.identity());
         cluster.beforeTest(random(), 0.0);
         List<DiscoveryNode.Role> roles = new ArrayList<>();
         for (int i = 0; i < numNodes; i++) {
@@ -450,13 +450,13 @@ public class InternalTestClusterTests extends ESTestCase {
     }
 
     public void testTwoNodeCluster() throws Exception {
-        String transportClient = randomTestTransportKey();
+        String transportClient = getTestTransportType();
         NodeConfigurationSource nodeConfigurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
                 return Settings.builder().put(NetworkModule.HTTP_ENABLED.getKey(), false)
                     .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), 2)
-                    .put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey())
+                    .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
                     .build();
             }
 
@@ -476,7 +476,7 @@ public class InternalTestClusterTests extends ESTestCase {
         Path baseDir = createTempDir();
         InternalTestCluster cluster = new InternalTestCluster(randomLong(), baseDir, false, true, 2, 2,
             "test", nodeConfigurationSource, 0, enableHttpPipelining, nodePrefix,
-            Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class), Function.identity());
+            Arrays.asList(getTestTransportPlugin(), TestZenDiscovery.TestPlugin.class), Function.identity());
         try {
             cluster.beforeTest(random(), 0.0);
             assertMMNinNodeSetting(cluster, 2);

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -35,9 +35,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.NodeConfigurationSource;
 import org.elasticsearch.test.discovery.TestZenDiscovery;
-import org.elasticsearch.transport.MockTcpTransportPlugin;
 import org.elasticsearch.transport.TcpTransport;
-import org.elasticsearch.transport.nio.NioTransportPlugin;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -177,7 +175,7 @@ public class InternalTestClusterTests extends ESTestCase {
         final int numClientNodes = randomIntBetween(0, 2);
         final String clusterName1 = "shared1";
         final String clusterName2 = "shared2";
-        String transportClient = randomTestTransport();
+        String transportClient = randomTestTransportKey();
         NodeConfigurationSource nodeConfigurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
@@ -186,7 +184,7 @@ public class InternalTestClusterTests extends ESTestCase {
                         NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(),
                         2 * ((masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes))
                     .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-                    .put(NetworkModule.TRANSPORT_TYPE_KEY, MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME);
+                    .put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey());
                 if (autoManageMinMasterNodes == false) {
                     assert minNumDataNodes == maxNumDataNodes;
                     assert masterNodes == false;
@@ -211,7 +209,7 @@ public class InternalTestClusterTests extends ESTestCase {
         String nodePrefix = "foobar";
 
         Path baseDir = createTempDir();
-        final List<Class<? extends Plugin>> mockPlugins = Arrays.asList(MockTcpTransportPlugin.class, TestZenDiscovery.TestPlugin.class);
+        final List<Class<? extends Plugin>> mockPlugins = Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class);
         InternalTestCluster cluster0 = new InternalTestCluster(clusterSeed, baseDir, masterNodes,
             autoManageMinMasterNodes, minNumDataNodes, maxNumDataNodes, clusterName1, nodeConfigurationSource, numClientNodes,
             enableHttpPipelining, nodePrefix, mockPlugins, Function.identity());
@@ -255,7 +253,7 @@ public class InternalTestClusterTests extends ESTestCase {
         final int maxNumDataNodes = 2;
         final int numClientNodes = randomIntBetween(0, 2);
         final String clusterName1 = "shared1";
-        String transportClient = randomTestTransport();
+        String transportClient = randomTestTransportKey();
         NodeConfigurationSource nodeConfigurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
@@ -263,7 +261,7 @@ public class InternalTestClusterTests extends ESTestCase {
                     .put(
                         NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(),
                         2 + (masterNodes ? InternalTestCluster.DEFAULT_HIGH_NUM_MASTER_NODES : 0) + maxNumDataNodes + numClientNodes)
-                    .put(NetworkModule.TRANSPORT_TYPE_KEY, MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
+                    .put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey())
                     .build();
             }
 
@@ -283,7 +281,7 @@ public class InternalTestClusterTests extends ESTestCase {
         Path baseDir = createTempDir();
         InternalTestCluster cluster = new InternalTestCluster(clusterSeed, baseDir, masterNodes,
             true, minNumDataNodes, maxNumDataNodes, clusterName1, nodeConfigurationSource, numClientNodes,
-            enableHttpPipelining, nodePrefix, Arrays.asList(MockTcpTransportPlugin.class, TestZenDiscovery.TestPlugin.class),
+            enableHttpPipelining, nodePrefix, Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class),
             Function.identity());
         try {
             cluster.beforeTest(random(), 0.0);
@@ -364,7 +362,7 @@ public class InternalTestClusterTests extends ESTestCase {
         final Path baseDir = createTempDir();
         final int numNodes = 5;
 
-        String transportClient = randomTestTransport();
+        String transportClient = randomTestTransportKey();
         InternalTestCluster cluster = new InternalTestCluster(randomLong(), baseDir, false,
                 false, 0, 0, "test", new NodeConfigurationSource() {
             @Override
@@ -372,7 +370,7 @@ public class InternalTestClusterTests extends ESTestCase {
                 return Settings.builder()
                         .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), numNodes)
                         .put(NetworkModule.HTTP_ENABLED.getKey(), false)
-                        .put(NetworkModule.TRANSPORT_TYPE_KEY, MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
+                        .put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey())
                         .put(DiscoverySettings.INITIAL_STATE_TIMEOUT_SETTING.getKey(), 0)
                         // speedup join timeout as setting initial state timeout to 0 makes split
                         // elections more likely
@@ -390,7 +388,7 @@ public class InternalTestClusterTests extends ESTestCase {
                 return Settings.builder()
                         .put(NetworkModule.TRANSPORT_TYPE_KEY, transportClient).build();
             }
-        }, 0, randomBoolean(), "", Arrays.asList(MockTcpTransportPlugin.class, TestZenDiscovery.TestPlugin.class), Function.identity());
+        }, 0, randomBoolean(), "", Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class), Function.identity());
         cluster.beforeTest(random(), 0.0);
         List<DiscoveryNode.Role> roles = new ArrayList<>();
         for (int i = 0; i < numNodes; i++) {
@@ -452,13 +450,13 @@ public class InternalTestClusterTests extends ESTestCase {
     }
 
     public void testTwoNodeCluster() throws Exception {
-        String transportClient = randomTestTransport();
+        String transportClient = randomTestTransportKey();
         NodeConfigurationSource nodeConfigurationSource = new NodeConfigurationSource() {
             @Override
             public Settings nodeSettings(int nodeOrdinal) {
                 return Settings.builder().put(NetworkModule.HTTP_ENABLED.getKey(), false)
                     .put(NodeEnvironment.MAX_LOCAL_STORAGE_NODES_SETTING.getKey(), 2)
-                    .put(NetworkModule.TRANSPORT_TYPE_KEY, MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME)
+                    .put(NetworkModule.TRANSPORT_TYPE_KEY, randomTestTransportKey())
                     .build();
             }
 
@@ -478,7 +476,7 @@ public class InternalTestClusterTests extends ESTestCase {
         Path baseDir = createTempDir();
         InternalTestCluster cluster = new InternalTestCluster(randomLong(), baseDir, false, true, 2, 2,
             "test", nodeConfigurationSource, 0, enableHttpPipelining, nodePrefix,
-            Arrays.asList(MockTcpTransportPlugin.class, TestZenDiscovery.TestPlugin.class), Function.identity());
+            Arrays.asList(randomTestTransportPlugin(), TestZenDiscovery.TestPlugin.class), Function.identity());
         try {
             cluster.beforeTest(random(), 0.0);
             assertMMNinNodeSetting(cluster, 2);


### PR DESCRIPTION
This commit adds the nio transport as an option in place of the mock tcp
transport for tests. Each test will only use one transport type. The
transport type is decided by a random boolean generated inside of the
`ESTestCase` class.