### PR TITLE
 Also handle IndexOrDocValuesQuery when indexing percolator queries

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.PhraseQuery;
@@ -85,6 +86,7 @@ final class QueryAnalyzer {
         map.put(SynonymQuery.class, synonymQuery());
         map.put(FunctionScoreQuery.class, functionScoreQuery());
         map.put(PointRangeQuery.class, pointRangeQuery());
+        map.put(IndexOrDocValuesQuery.class, indexOrDocValuesQuery());
         queryProcessors = Collections.unmodifiableMap(map);
     }
 
@@ -367,6 +369,13 @@ final class QueryAnalyzer {
         byte[] result = new byte[BinaryRange.BYTES];
         System.arraycopy(original, 0, result, offset, original.length);
         return result;
+    }
+
+    private static Function<Query, Result> indexOrDocValuesQuery() {
+        return query -> {
+            IndexOrDocValuesQuery indexOrDocValuesQuery = (IndexOrDocValuesQuery) query;
+            return analyze(indexOrDocValuesQuery.getIndexQuery());
+        };
     }
 
     private static Result handleDisjunction(List<Query> disjunctions, int minimumShouldMatch, boolean otherClauses) {

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
@@ -24,6 +24,7 @@ import org.apache.lucene.document.HalfFloatPoint;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.BlendedTermQuery;
 import org.apache.lucene.queries.CommonTermsQuery;
@@ -32,6 +33,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
@@ -674,6 +676,19 @@ public class QueryAnalyzerTests extends ESTestCase {
         assertEquals("_field", ranges.get(0).range.fieldName);
         assertArrayEquals(ranges.get(0).range.lowerPoint, InetAddressPoint.encode(InetAddresses.forString("192.168.1.0")));
         assertArrayEquals(ranges.get(0).range.upperPoint, InetAddressPoint.encode(InetAddresses.forString("192.168.1.255")));
+    }
+
+    public void testIndexOrDocValuesQuery() {
+        Query query = new IndexOrDocValuesQuery(IntPoint.newRangeQuery("_field", 10, 20),
+            SortedNumericDocValuesField.newSlowRangeQuery("_field", 10, 20));
+        Result result = analyze(query);
+        assertFalse(result.verified);
+        List<QueryAnalyzer.QueryExtraction> ranges = new ArrayList<>(result.extractions);
+        assertThat(ranges.size(), equalTo(1));
+        assertNull(ranges.get(0).term);
+        assertEquals("_field", ranges.get(0).range.fieldName);
+        assertDimension(ranges.get(0).range.lowerPoint, bytes -> IntPoint.encodeDimension(10, bytes, 0));
+        assertDimension(ranges.get(0).range.upperPoint, bytes -> IntPoint.encodeDimension(20, bytes, 0));
     }
 
     public void testPointRangeQuerySelectShortestRange() {


### PR DESCRIPTION
Otherwise ranges are never extracted properly. This is a bug for an improvement added via #25647, but since that is unreleased this pr is marked as non-issue.

