### PR TITLE
exists template needs a template name

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -8,7 +8,7 @@
       "parts": {
         "name": {
           "type": "list",
-          "required": false,
+          "required": true,
           "description": "The comma separated names of the index templates"
         }
       },


### PR DESCRIPTION
running `curl -X HEAD localhost:9200/_template` results in `405 Method Not Allowed`