### PR TITLE
repository is not required when doing ?help

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -10,7 +10,7 @@
       "parts": {
         "repository": {
           "type" : "list",
-          "required": true,
+          "required": false,
           "description": "Name of repository from which to fetch the snapshot information"
         }
       },


### PR DESCRIPTION
this behavior is required in the tests - https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/test/cat.snapshots/10_basic.yml#L4