### PR TITLE
Add recommendation on unicast hosts to docs

### DIFF
--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -33,6 +33,9 @@ negative hostname resolutions for ten seconds. This can be modified by adding
 http://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html[`networkaddress.cache.negative.ttl=<timeout>`]
 to your http://docs.oracle.com/javase/8/docs/technotes/guides/security/PolicyFiles.html[Java security policy].
 
+It is recommended that the unicast hosts list be maintained as the list of
+master-eligible nodes in the cluster.
+
 Unicast discovery provides the following settings with the `discovery.zen.ping.unicast` prefix:
 
 [cols="<,<",options="header",]


### PR DESCRIPTION
This commit adds a small note to the discovery docs to include a note that we recommend that the unicast hosts list be maintained as the list of master-eligible nodes in the cluster.

Closes #25810
