### PR TITLE
Deprecate `include_in_root` and `include_in_parent`.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -228,7 +228,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             }
             fieldNode = node.remove("include_in_parent");
             if (fieldNode != null) {
-                if (false/*parserContext.indexVersionCreated().onOrAfter(Version.V_7_0_0)*/) {
+                if (parserContext.indexVersionCreated().onOrAfter(Version.V_7_0_0_alpha1)) {
                     throw new MapperParsingException("[include_in_parent] is now forbidden, you should use [copy_to] to copy to a field " +
                             "that belongs to the parent document");
                 } else if (parserContext.indexVersionCreated().onOrAfter(Version.V_6_0_0_beta1)) {
@@ -239,7 +239,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             }
             fieldNode = node.remove("include_in_root");
             if (fieldNode != null) {
-                if (false/*parserContext.indexVersionCreated().onOrAfter(Version.V_7_0_0)*/) {
+                if (parserContext.indexVersionCreated().onOrAfter(Version.V_7_0_0_alpha1)) {
                     throw new MapperParsingException("[include_in_root] is now forbidden, you should use [copy_to] to copy to a field " +
                             "that belongs to the root document");
                 } else if (parserContext.indexVersionCreated().onOrAfter(Version.V_6_0_0_beta1)) {

--- a/core/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -226,6 +226,9 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
         assertThat(doc.docs().get(6).get("field"), equalTo("value"));
         assertThat(doc.docs().get(6).get("nested1.field1"), nullValue());
         assertThat(doc.docs().get(6).get("nested1.nested2.field2"), nullValue());
+
+        assertWarnings("[include_in_parent] is deprecated, you should use [copy_to] to copy to a field that belongs to the parent " +
+                "document");
     }
 
     public void testMultiObjectAndNested2() throws Exception {
@@ -278,6 +281,9 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
         assertThat(doc.docs().get(6).get("field"), equalTo("value"));
         assertThat(doc.docs().get(6).getFields("nested1.field1").length, equalTo(2));
         assertThat(doc.docs().get(6).getFields("nested1.nested2.field2").length, equalTo(4));
+
+        assertWarnings("[include_in_parent] is deprecated, you should use [copy_to] to copy to a field that belongs to the parent " +
+                "document");
     }
 
     public void testMultiRootAndNested1() throws Exception {
@@ -330,6 +336,9 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
         assertThat(doc.docs().get(6).get("field"), equalTo("value"));
         assertThat(doc.docs().get(6).get("nested1.field1"), nullValue());
         assertThat(doc.docs().get(6).getFields("nested1.nested2.field2").length, equalTo(4));
+
+        assertWarnings("[include_in_root] is deprecated, you should use [copy_to] to copy to a field that belongs to the root " +
+                "document");
     }
 
     public void testNestedArrayStrict() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/NestedHelperTests.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -37,11 +38,20 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 
 public class NestedHelperTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(InternalSettingsPlugin.class);
+    }
 
     IndexService indexService;
     MapperService mapperService;
@@ -95,7 +105,10 @@ public class NestedHelperTests extends ESSingleNodeTestCase {
                         .endObject()
                     .endObject()
                 .endObject().endObject();
-        indexService = createIndex("index", Settings.EMPTY, "type", mapping);
+        Settings indexSettings = Settings.builder()
+                .put("index.version.created", Version.V_6_0_0_beta1) // so that include_in_root/include_in_parent are legal
+                .build();
+        indexService = createIndex("index", indexSettings, "type", mapping);
         mapperService = indexService.mapperService();
     }
 

--- a/docs/reference/migration/migrate_7_0.asciidoc
+++ b/docs/reference/migration/migrate_7_0.asciidoc
@@ -1,0 +1,30 @@
+[[breaking-changes-7.0]]
+== Breaking changes in 7.0
+
+This section discusses the changes that you need to be aware of when migrating
+your application to Elasticsearch 7.0.
+
+[float]
+=== Indices created before 7.0
+
+Elasticsearch 7.0 can read indices created in version 6.0 or above.  An
+Elasticsearch 7.0 node will not start in the presence of indices created in a
+version of Elasticsearch before 6.0.
+
+[IMPORTANT]
+.Reindex indices from Elasticseach 5.x or before
+=========================================
+
+Indices created in Elasticsearch 5.x or before will need to be reindexed with
+Elasticsearch 6.x in order to be readable by Elasticsearch 7.x. The easiest
+way to reindex old indices is to use the `reindex` API.
+
+=========================================
+
+[float]
+=== Also see:
+
+* <<breaking_70_mappings_changes>>
+
+
+include::migrate_7_0/mappings.asciidoc[]

--- a/docs/reference/migration/migrate_7_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/mappings.asciidoc
@@ -1,0 +1,8 @@
+[[breaking_70_mappings_changes]]
+=== Mapping changes
+
+==== Removal of `include_in_root` and `include_in_parent`
+
+These options allowed field valus to be copied from nested objects to their
+parent or root object at index time. They have been removed in favour of
+<<copy-to,`copy_to`>>.


### PR DESCRIPTION
`copy_to` must be used instead. I used to like the fact that these options
helped reduce sparsity compared to `copy_to` by reusing the same field name.
However as of Lucene 7, sparse doc values and sparse norms should make it less
of an issue.

Closes #12461