### PR TITLE
[DOCS] Use shared versions file for doc builds

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -1,15 +1,7 @@
-:version:               5.5.1
-:major-version:         5.x
+
 :lucene_version:        6.5.1
 :lucene_version_path:   6_5_1
-:branch:                5.5
 :jdk:                   1.8.0_131
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:   released
 
 :issue:           https://github.com/elastic/elasticsearch/issues/
 :pull:            https://github.com/elastic/elasticsearch/pull/
@@ -39,4 +31,5 @@ endif::[]
 Shared attribute values are pulled from elastic/docs
 ///////
 
+include::{asciidoc-dir}/../../shared/versions55.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]


### PR DESCRIPTION
This pull request changes the Elasticsearch Reference documentation build so that it pulls version information from a shared file in elastic/docs/shared repository. This allows versioning information to be updated more uniformly and quickly across many books.

The X-Pack Reference already uses those shared files successfully and other books will be migrated to use them as well. 