### PR TITLE
Docs: Remove docs for aws region and signer type

### DIFF
--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -77,35 +77,6 @@ cloud:
                 password: theBestPasswordEver2!
 ----
 
-[[discovery-ec2-usage-region]]
-===== Region
-
-The `cloud.aws.region` can be set to a region and will automatically use the relevant settings for both `ec2` and `s3`.
-The available values are:
-
-* `us-east` (`us-east-1`) for US East (N. Virginia)
-* `us-east-2` for US East (Ohio)
-* `us-west` (`us-west-1`) for US West (N. California)
-* `us-west-2` for US West (Oregon)
-* `ap-south` (`ap-south-1`) for Asia Pacific (Mumbai)
-* `ap-southeast` (`ap-southeast-1`) for Asia Pacific (Singapore)
-* `ap-southeast-2` for Asia Pacific (Sydney)
-* `ap-northeast` (`ap-northeast-1`) for Asia Pacific (Tokyo)
-* `ap-northeast-2` (`ap-northeast-2`) for Asia Pacific (Seoul)
-* `eu-west` (`eu-west-1`) for EU (Ireland)
-* `eu-west-2` (`eu-west-2`) for EU (London)
-* `eu-central` (`eu-central-1`) for EU (Frankfurt)
-* `sa-east` (`sa-east-1`) for South America (São Paulo)
-* `cn-north` (`cn-north-1`) for China (Beijing)
-* `ca-central` (`ca-central-1`) for Canada (Central)
-
-[[discovery-ec2-usage-signer]]
-===== EC2 Signer API
-
-If you are using a compatible EC2 service, they might be using an older API to sign the requests.
-You can set your compatible signer API using `cloud.aws.signer` (or `cloud.aws.ec2.signer`)
-with the right signer to use.
-
 ===== Read timeout
 
 Read timeout determines the amount of time to wait for data to be transferred over an established,
@@ -128,8 +99,6 @@ environments). Here is a simple sample configuration:
 discovery:
     zen.hosts_provider: ec2
 ----
-
-You must also set `cloud.aws.region` if you are not using default AWS region. See <<discovery-ec2-usage-region>> for details.
 
 The ec2 discovery is using the same credentials as the rest of the AWS services provided by this plugin (`repositories`).
 See <<discovery-ec2-usage>> for details.

--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -81,39 +81,6 @@ cloud:
                 password: theBestPasswordEver2!
 ----
 
-[[repository-s3-usage-region]]
-===== Region
-
-The `cloud.aws.region` can be set to a region and will automatically use the relevant settings for both `ec2` and `s3`.
-You can specifically set it for s3 only using `cloud.aws.s3.region`.
-The available values are:
-
-* `us-east` (`us-east-1`) for US East (N. Virginia)
-* `us-east-2` for US East (Ohio)
-* `us-west` (`us-west-1`) for US West (N. California)
-* `us-west-2` for US West (Oregon)
-* `ap-south` (`ap-south-1`) for Asia Pacific (Mumbai)
-* `ap-southeast` (`ap-southeast-1`) for Asia Pacific (Singapore)
-* `ap-southeast-2` for Asia Pacific (Sydney)
-* `ap-northeast` (`ap-northeast-1`) for Asia Pacific (Tokyo)
-* `ap-northeast-2` (`ap-northeast-2`) for Asia Pacific (Seoul)
-* `eu-west` (`eu-west-1`) for EU (Ireland)
-* `eu-west-2` (`eu-west-2`) for EU (London)
-* `eu-central` (`eu-central-1`) for EU (Frankfurt)
-* `sa-east` (`sa-east-1`) for South America (São Paulo)
-* `cn-north` (`cn-north-1`) for China (Beijing)
-* `ca-central` (`ca-central-1`) for Canada (Central)
-
-[[repository-s3-usage-signer]]
-===== S3 Signer API
-
-If you are using a S3 compatible service, they might be using an older API to sign the requests.
-You can set your compatible signer API using `cloud.aws.signer` (or `cloud.aws.s3.signer`) with the right
-signer to use.
-
-If you are using a compatible S3 service which do not support Version 4 signing process, you may need to
-use `S3SignerType`, which is Signature Version 2.
-
 ===== Read timeout
 
 Read timeout determines the amount of time to wait for data to be transferred over an established,
@@ -136,8 +103,7 @@ PUT _snapshot/my_s3_repository
 {
   "type": "s3",
   "settings": {
-    "bucket": "my_bucket_name",
-    "region": "us-west"
+    "bucket": "my_bucket_name"
   }
 }
 ----
@@ -150,14 +116,10 @@ The following settings are supported:
 
     The name of the bucket to be used for snapshots. (Mandatory)
 
-`region`::
-
-    The region where bucket is located. Defaults to US Standard
-
 `endpoint`::
 
-    The endpoint to the S3 API. Defaults to AWS's default S3 endpoint. Note
-    that setting a region overrides the endpoint setting.
+    The endpoint for the S3 region in which the bucket exists. The default S3 endpoint
+    will automatically find the region of the configured bucket and forward to there.
 
 `protocol`::
 
@@ -365,7 +327,7 @@ specific bucket like this:
 If you are using any S3 api compatible service, you can set a global endpoint by setting `cloud.aws.s3.endpoint`
 to your URL provider. Note that this setting will be used for all S3 repositories.
 
-Different `endpoint`, `region` and `protocol` settings can be set on a per-repository basis
+Different `endpoint` and `protocol` settings can be set on a per-repository basis
 See <<repository-s3-repository>> for details.
 
 [[repository-s3-aws-vpc]]


### PR DESCRIPTION
These settings are removed in 6.0. This commit removes the corresponding
documentation.

relates #22872
relates #23984
