### PR TITLE
Fix the repository hdfs plugin to check the right variable for vagrant support

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -167,7 +167,7 @@ if (fixtureSupported) {
 
 boolean secureFixtureSupported = false
 if (fixtureSupported) {
-  secureFixtureSupported = project.rootProject.vagrantSupported
+  secureFixtureSupported = project.rootProject.ext.vagrantSupported
 }
 
 // Create a Integration Test suite just for security based tests


### PR DESCRIPTION
This commit fixes the check in the repository hdfs build to use the right variable for vagrant
support.