### PR TITLE
match .seeds with seeds.0

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -509,7 +509,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
             Set<String> keysToRemove = new HashSet<>();
             Set<String> keySet = builder.internalMap().keySet();
             for (String key : keySet) {
-                if (Regex.simpleMatch(entry, key) && canRemove.test(key)) {
+                if ( (Regex.simpleMatch(entry, key) || Regex.simpleMatch(entry + ".*", key)) && canRemove.test(key)) {
                     // we have to re-check with canRemove here since we might have a wildcard expression foo.* that matches
                     // dynamic as well as static settings if that is the case we might remove static settings since we resolve the
                     // wildcards late


### PR DESCRIPTION
Hello guys, 
I' m having a look on this problem. 
Can I ask which one should be the allowed behaviour?
if the value sent is:
`"search.remote.my_cluster.seeds": null`
seems that there is a missed match in `AbstractScopedSettings:512`
`if (Regex.simpleMatch(entry, key) && canRemove.test(key)) {`
entry value: `search.remote.my_cluster.seeds`
key value: `search.remote.my_cluster.seeds.0`
so, the simpleMatch fails and the key is not added as value to be removed.

Which behaviour should be accepted? Error or accepting the straight null value?
I wrote a simple solution that makes the match successful.
 I don't know if it can be considered correct, please let me know your thought!
Closes #25953
