### PR TITLE
Exit immediately if shell scripts encounter error

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -524,8 +524,8 @@ Map<String, String> expansionsForDistribution(distributionType) {
       'def': 'if [ -z "$CONF_DIR" ]; then CONF_DIR="$ES_HOME"/config; done',
     ],
     'source.path.env': [
-       'deb': 'source /etc/default/elasticsearch',
-       'rpm': 'source /etc/sysconfig/elasticsearch',
+       'deb': 'if [ -f /etc/default/elasticsearch ]; then source /etc/default/elasticsearch; fi',
+       'rpm': 'if [ -f /etc/sysconfig/elasticsearch ]; then source /etc/sysconfig/elasticsearch; fi',
        'def': 'if [ -z "$CONF_DIR" ]; then CONF_DIR="$ES_HOME"/config; fi',
     ],
     'path.logs': [

--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -14,21 +14,20 @@
 #
 #   ES_JAVA_OPTS="-Xms8g -Xmx8g" ./bin/elasticsearch
 
+source "`dirname "$0"`"/elasticsearch-env
+
 parse_jvm_options() {
   if [ -f "$1" ]; then
-    echo "$(grep "^-" "$1" | tr '\n' ' ')"
+    echo "`grep "^-" "$1" | tr '\n' ' '`"
   fi
 }
 
-source "`dirname "$0"`"/elasticsearch-env
-
 ES_JVM_OPTIONS="$CONF_DIR"/jvm.options
 
-ES_JAVA_OPTS="$(parse_jvm_options "$ES_JVM_OPTIONS") $ES_JAVA_OPTS"
+ES_JAVA_OPTS="`parse_jvm_options "$ES_JVM_OPTIONS"` $ES_JAVA_OPTS"
 
 # manual parsing to find out, if process should be detached
-daemonized=`echo $* | egrep -- '(^-d |-d$| -d |--daemonize$|--daemonize )'`
-if [ -z "$daemonized" ] ; then
+if [ ! `echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )'` ]; then
   exec \
     "$JAVA" \
     $ES_JAVA_OPTS \

--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -o pipefail
+
 CDPATH=""
 
 SCRIPT="$0"
@@ -46,26 +48,20 @@ if [ ! -x "$JAVA" ]; then
 fi
 
 # do not let JAVA_TOOL_OPTIONS slip in (as the JVM does by default)
-if [ "x$JAVA_TOOL_OPTIONS" != "x" ]; then
+if [ ! -z "$JAVA_TOOL_OPTIONS" ]; then
   echo "warning: ignoring JAVA_TOOL_OPTIONS=$JAVA_TOOL_OPTIONS"
   unset JAVA_TOOL_OPTIONS
 fi
 
 # JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
 # warn them that we are not observing the value of $JAVA_OPTS
-if [ "x$JAVA_OPTS" != "x" ]; then
+if [ ! -z "$JAVA_OPTS" ]; then
   echo -n "warning: ignoring JAVA_OPTS=$JAVA_OPTS; "
   echo "pass JVM parameters via ES_JAVA_OPTS"
 fi
 
 # check the Java version
 "$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.JavaVersionChecker
-
-if [ $? -ne 0 ]; then
-  echo -n "the minimum required Java version is 8; "
-  echo "your Java version from $JAVA does not meet this requirement"
-  exit 1
-fi
 
 ${source.path.env}
 

--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -39,7 +39,9 @@ ES_CLASSPATH="$ES_HOME/lib/*"
 if [ -x "$JAVA_HOME/bin/java" ]; then
   JAVA="$JAVA_HOME/bin/java"
 else
+  set +e
   JAVA=`which java`
+  set -e
 fi
 
 if [ ! -x "$JAVA" ]; then

--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -42,13 +42,7 @@ if not "%JAVA_OPTS%" == "" (
 )
 
 rem check the Java version
-%JAVA% -cp "%ES_CLASSPATH%" "org.elasticsearch.tools.JavaVersionChecker"
-
-if errorlevel 1 (
-  echo|set /p="the minimum required Java version is 8; "
-  echo your Java version from %JAVA% does not meet this requirement
-  exit /b 1
-)
+%JAVA% -cp "%ES_CLASSPATH%" "org.elasticsearch.tools.JavaVersionChecker" || exit /b 1
 
 if "%CONF_DIR%" == "" (
   set CONF_DIR=!ES_HOME!\config

--- a/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/JavaVersionChecker.java
+++ b/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/JavaVersionChecker.java
@@ -51,7 +51,7 @@ final class JavaVersionChecker {
                     Locale.ROOT,
                     "the minimum required Java version is 8; your Java version from [%s] does not meet this requirement",
                     System.getProperty("java.home"));
-            System.err.println(message);
+            systemErrPrintln(message);
             exit(1);
         }
         exit(0);
@@ -86,7 +86,12 @@ final class JavaVersionChecker {
         return 0;
     }
 
-    @SuppressForbidden(reason = "exit")
+    @SuppressForbidden(reason = "System#err")
+    private static void systemErrPrintln(String message) {
+        System.err.println(message);
+    }
+
+    @SuppressForbidden(reason = "System#exit")
     private static void exit(final int status) {
         System.exit(status);
     }

--- a/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/JavaVersionChecker.java
+++ b/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/JavaVersionChecker.java
@@ -51,7 +51,7 @@ final class JavaVersionChecker {
                     Locale.ROOT,
                     "the minimum required Java version is 8; your Java version from [%s] does not meet this requirement",
                     System.getProperty("java.home"));
-            systemErrPrintln(message);
+            println(message);
             exit(1);
         }
         exit(0);
@@ -87,7 +87,7 @@ final class JavaVersionChecker {
     }
 
     @SuppressForbidden(reason = "System#err")
-    private static void systemErrPrintln(String message) {
+    private static void println(String message) {
         System.err.println(message);
     }
 

--- a/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/JavaVersionChecker.java
+++ b/distribution/tools/java-version-checker/src/main/java/org/elasticsearch/tools/JavaVersionChecker.java
@@ -22,6 +22,7 @@ package org.elasticsearch.tools;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Simple program that checks if the runtime Java version is at least 1.8.
@@ -46,6 +47,11 @@ final class JavaVersionChecker {
         final String javaSpecificationVersion = System.getProperty("java.specification.version");
         final List<Integer> current = parse(javaSpecificationVersion);
         if (compare(current, JAVA_8) < 0) {
+            final String message = String.format(
+                    Locale.ROOT,
+                    "the minimum required Java version is 8; your Java version from [%s] does not meet this requirement",
+                    System.getProperty("java.home"));
+            System.err.println(message);
             exit(1);
         }
         exit(0);


### PR DESCRIPTION
Today our shell scripts march on if they encounter an error during execution. One place that this actually causes a problem is with the Java version checker. What can happen is this: if the user botches their installation so that the JavaVersionChecker can not be found on the classpath, when we attempt to run the Java version checker, first an error message that the class can not be found is displayed, and then we print a message that their version of Java is not compatible; this happens even if they are using a Java 8 installation. The problem is that we should have immediately aborted when the class could not be loaded. Since we do not exit when the shell script encounters an error, we end up conflating failue to run the version check with a failed version check. Instead, we really should abort the moment that one of our scripts encounters an error. To do this, we make the following changes:
 - enable `set -e` and `set -o pipefail`
 - make the Java version checker responsible for printing the error message to the console
 - remove the exit status check from the scripts
 - actually on Windows, we still have to check the exit status because there is no equivalent of `set -e`
 - when we check for daemonization, we can no longer check the exit status from grep because a failed grep will abort the script; instead, we move the grep execution to be the condition for the if as this does not trip the `set -e` failure conditions
 - we should source `elasticsearch-env` before doing anything, so we move the definition of `parse_jvm_options` below sourcing `elasticsearch-env`
 - we make consistent all places where we use a subshell to use backticks

