### PR TITLE
Calculate once the number of machine cores

### DIFF
--- a/core/src/main/java/org/elasticsearch/threadpool/AutoQueueAdjustingExecutorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/AutoQueueAdjustingExecutorBuilder.java
@@ -65,7 +65,7 @@ public final class AutoQueueAdjustingExecutorBuilder extends ExecutorBuilder<Aut
                 new Setting<>(
                         sizeKey,
                         s -> Integer.toString(size),
-                        s -> Setting.parseInt(s, 1, applyHardSizeLimit(settings, name), sizeKey),
+                        s -> Setting.parseInt(s, 1, applyHardSizeLimit(size, name), sizeKey),
                         Setting.Property.NodeScope);
         final String queueSizeKey = settingsKey(prefix, "queue_size");
         final String minSizeKey = settingsKey(prefix, "min_queue_size");

--- a/core/src/main/java/org/elasticsearch/threadpool/ExecutorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ExecutorBuilder.java
@@ -21,7 +21,6 @@ package org.elasticsearch.threadpool;
 
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 
 import java.util.List;
@@ -47,9 +46,9 @@ public abstract class ExecutorBuilder<U extends ExecutorBuilder.ExecutorSettings
         return String.join(".", prefix, key);
     }
 
-    protected int applyHardSizeLimit(final Settings settings, final String name) {
+    protected int applyHardSizeLimit(final int size, final String name) {
         if (name.equals(ThreadPool.Names.BULK) || name.equals(ThreadPool.Names.INDEX)) {
-            return 1 + EsExecutors.numberOfProcessors(settings);
+            return size + 1;
         } else {
             return Integer.MAX_VALUE;
         }

--- a/core/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
@@ -69,7 +69,7 @@ public final class FixedExecutorBuilder extends ExecutorBuilder<FixedExecutorBui
             new Setting<>(
                 sizeKey,
                 s -> Integer.toString(size),
-                s -> Setting.parseInt(s, 1, applyHardSizeLimit(settings, name), sizeKey),
+                s -> Setting.parseInt(s, 1, applyHardSizeLimit(size, name), sizeKey),
                 Setting.Property.NodeScope);
         final String queueSizeKey = settingsKey(prefix, "queue_size");
         this.queueSizeSetting =


### PR DESCRIPTION
1、When building the FixedExecutorBuilder and AutoQueueAdjustingExecutorBuilder instance, the parameter availableProcessors is passed in the construction method. 
2、numberOfProcessors: There is no need to calculate the number of machine cores again.