### PR TITLE
do not generate random unicode strings for field names

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
@@ -56,11 +56,8 @@ public final class RandomDocumentPicks {
      * Returns a random leaf field name.
      */
     public static String randomLeafFieldName(Random random) {
-        String fieldName;
-        do {
-            fieldName = randomString(random);
-        } while (fieldName.contains("."));
-        return fieldName;
+        // Never generates a dot:
+        return RandomStrings.randomAsciiAlphanumOfLengthBetween(random, 1, 10);
     }
 
     /**


### PR DESCRIPTION
but instead just random alpha ascii strings

Should fix build failures like this one: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.0+multijob-unix-compatibility/os=debian/43/console