### PR TITLE
Hint what clauses are important in a conjunction query based on fields

### DIFF
--- a/docs/reference/mapping/types/percolator.asciidoc
+++ b/docs/reference/mapping/types/percolator.asciidoc
@@ -60,6 +60,69 @@ Fields referred in a percolator query may exist in any type of the index contain
 =====================================
 
 [float]
+==== Influencing query extraction
+
+As part of indexing the percolator query, the percolator field mapper extracts the query terms and numeric ranges from the provided
+query and indexes that alongside the query in separate internal fields. The `percolate` query uses these internal fields
+to build a candidate query from the document being percolated in order to reduce the number of document that need to be verified.
+
+In case a percolator query contains a `bool` query with must or filter clauses, then the percolator field mapper only has to
+extract ranges or terms from a single clause. The percolator field mapper will prefer longer terms over shorter terms, because
+longer terms in general match with less documents. For the same reason it prefers smaller ranges over bigger ranges.
+
+In general this behaviour works well. However sometimes there are fields in a bool query that shouldn't be taken into account
+when selecting the best must or filter clause, or fields are known to be more selective than other fields.
+
+For example a status like field may in fact not work well, because each status matches with many percolator queries and
+then the candidate query the `percolate` query generates may not be able to filter out that many percolator queries.
+
+The percolator field mapping allows to configure `boost_fields` in order to indicate to the percolator what fields are
+important or not important when selecting the best must or filter clause in a `bool` query:
+
+[source,js]
+--------------------------------------------------
+PUT another_index
+{
+    "mappings": {
+        "doc": {
+            "properties": {
+                "query": {
+                    "type": "percolator",
+                    "boost_fields": {
+                        "status_field": 0, <1>
+                        "price_field": 2 <2>
+                    }
+                },
+                "status_field": {
+                    "type": "keyword"
+                },
+                "price_field": {
+                    "type": "long"
+                },
+                "field": {
+                    "type": "text"
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+<1> A boost of zero hints to the percolator that if there are other clauses in a conjunction query then these should be
+    preferred over this one.
+
+<2> Any boost higher than 1 overrides the default behaviour when it comes to selecting the best clause. The clause
+    that has the field with the highest boost will be selected from a conjunction query for extraction.
+
+The steps the percolator field mapper takes when selecting a clause from a conjunction query:
+
+* If there are clauses that have boosted fields then the clause with highest boost field is selected.
+* If there are range based clauses and term based clauses then term based clauses are picked over range based clauses
+* From all term based clauses the clause with longest term is picked.
+* In the case when there are only range based clauses then the range clause with smallest range is picked over clauses with wider ranges.
+
+[float]
 ==== Reindexing your percolator queries
 
 Reindexing percolator queries is sometimes required to benefit from improvements made to the `percolator` field type in

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -44,11 +44,11 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -739,6 +739,90 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
     private static byte[] subByteArray(byte[] source, int offset, int length) {
         return Arrays.copyOfRange(source, offset, offset + length);
+    }
+
+    public void testBoostFields() throws Exception {
+        IndexService indexService = createIndex("another_index");
+        MapperService mapperService = indexService.mapperService();
+
+        String mapper = XContentFactory.jsonBuilder().startObject().startObject("doc")
+            .startObject("_field_names").field("enabled", false).endObject() // makes testing easier
+            .startObject("properties")
+            .startObject("status").field("type", "keyword").endObject()
+            .startObject("update_field").field("type", "keyword").endObject()
+            .startObject("price").field("type", "long").endObject()
+            .startObject("query1").field("type", "percolator")
+                .startObject("boost_fields").field("status", 0).field("updated_field", 2).endObject()
+            .endObject()
+            .startObject("query2").field("type", "percolator").endObject()
+            .endObject().endObject().endObject().string();
+        mapperService.merge("doc", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper documentMapper = mapperService.documentMapper("doc");
+
+        BooleanQuery.Builder bq = new BooleanQuery.Builder();
+        bq.add(new TermQuery(new Term("status", "updated")), Occur.FILTER);
+        bq.add(LongPoint.newRangeQuery("price", 5, 10), Occur.FILTER);
+
+        // Boost fields will ignore status_field:
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper("query1");
+        ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
+            mapperService.documentMapperParser(), documentMapper, null, null);
+        fieldMapper.processQuery(bq.build(), parseContext);
+        ParseContext.Document document = parseContext.doc();
+        PercolatorFieldMapper.FieldType fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
+        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
+        assertThat(document.getFields(fieldType.queryTermsField.name()).length, equalTo(0));
+        List<IndexableField> fields = new ArrayList<>(Arrays.asList(document.getFields(fieldType.rangeField.name())));
+        assertThat(fields.size(), equalTo(1));
+        assertThat(LongPoint.decodeDimension(subByteArray(fields.get(0).binaryValue().bytes, 8, 8), 0), equalTo(5L));
+        assertThat(LongPoint.decodeDimension(subByteArray(fields.get(0).binaryValue().bytes, 24, 8), 0), equalTo(10L));
+
+        // No boost fields, so default extraction logic:
+        fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper("query2");
+        parseContext = new ParseContext.InternalParseContext(Settings.EMPTY, mapperService.documentMapperParser(),
+            documentMapper, null, null);
+        fieldMapper.processQuery(bq.build(), parseContext);
+        document = parseContext.doc();
+        fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
+        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
+        assertThat(document.getFields(fieldType.rangeField.name()).length, equalTo(0));
+        fields = new ArrayList<>(Arrays.asList(document.getFields(fieldType.queryTermsField.name())));
+        assertThat(fields.size(), equalTo(1));
+        assertThat(fields.get(0).binaryValue().utf8ToString(), equalTo("status\0updated"));
+
+        // Second clause is extracted, because it is boosted by 2:
+        bq = new BooleanQuery.Builder();
+        bq.add(new TermQuery(new Term("status", "updated")), Occur.FILTER);
+        bq.add(new TermQuery(new Term("updated_field", "done")), Occur.FILTER);
+
+        fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper("query1");
+        parseContext = new ParseContext.InternalParseContext(Settings.EMPTY, mapperService.documentMapperParser(),
+            documentMapper, null, null);
+        fieldMapper.processQuery(bq.build(), parseContext);
+        document = parseContext.doc();
+        fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
+        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
+        assertThat(document.getFields(fieldType.rangeField.name()).length, equalTo(0));
+        fields = new ArrayList<>(Arrays.asList(document.getFields(fieldType.queryTermsField.name())));
+        assertThat(fields.size(), equalTo(1));
+        assertThat(fields.get(0).binaryValue().utf8ToString(), equalTo("updated_field\0done"));
+
+        // First clause is extracted, because default logic:
+        bq = new BooleanQuery.Builder();
+        bq.add(new TermQuery(new Term("status", "updated")), Occur.FILTER);
+        bq.add(new TermQuery(new Term("updated_field", "done")), Occur.FILTER);
+
+        fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper("query2");
+        parseContext = new ParseContext.InternalParseContext(Settings.EMPTY, mapperService.documentMapperParser(),
+            documentMapper, null, null);
+        fieldMapper.processQuery(bq.build(), parseContext);
+        document = parseContext.doc();
+        fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
+        assertThat(document.getField(fieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
+        assertThat(document.getFields(fieldType.rangeField.name()).length, equalTo(0));
+        fields = new ArrayList<>(Arrays.asList(document.getFields(fieldType.queryTermsField.name())));
+        assertThat(fields.size(), equalTo(1));
+        assertThat(fields.get(0).binaryValue().utf8ToString(), equalTo("status\0updated"));
     }
 
     // Just so that we store scripts in percolator queries, but not really execute these scripts.

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
@@ -650,4 +650,34 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
         assertThat(item.getFailureMessage(), containsString("[test/type/6] couldn't be found"));
     }
 
+    public void testBoostFields() throws Exception {
+        XContentBuilder mappingSource = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties")
+            .startObject("status").field("type", "keyword").endObject()
+            .startObject("price").field("type", "long").endObject()
+            .startObject("query").field("type", "percolator")
+                .startObject("boost_fields").field("status", 0.0F).endObject()
+            .endObject()
+            .endObject().endObject().endObject();
+        assertAcked(client().admin().indices().prepareCreate("test").addMapping("type", mappingSource));
+
+        client().prepareIndex("test", "type", "q1")
+            .setSource(jsonBuilder().startObject().field("query", boolQuery()
+                .must(matchQuery("status", "sold"))
+                .must(matchQuery("price", 100))
+            ).endObject())
+            .get();
+        refresh();
+
+        SearchResponse response = client().prepareSearch()
+            .setQuery(new PercolateQueryBuilder("query",
+                XContentFactory.jsonBuilder().startObject()
+                    .field("status", "sold")
+                    .field("price", 100)
+                    .endObject().bytes(), XContentType.JSON))
+            .get();
+        assertHitCount(response, 1);
+        assertThat(response.getHits().getAt(0).getId(), equalTo("q1"));
+    }
+
 }


### PR DESCRIPTION
The percolator field mapper doesn't need to extract all terms and ranges from a bool query with must or filter clauses. In order to help to default extraction behavior, boost fields can be configured, so that fields that are known for not being selective enough can be ignored in favor for other fields or clauses with specific fields can  forcefully take precedence over other clauses. This can help selecting clauses for fields that don't match with a lot of percolator queries over other clauses and thus improving performance of the `percolate` query.

For example a status like field is something that should configured as an ignore field. Queries on this field tend to match with more documents and so if clauses for this fields get selected as best clause then that isn't very helpful for the candidate query that the `percolate` query generates to filter out percolator queries that are likely not going to match.
