### PR TITLE
Tests: Fix edge case in InternalSimpleValueTests

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
@@ -81,7 +81,11 @@ public class InternalSimpleValueTests extends InternalAggregationTestCase<Intern
             name += randomAlphaOfLength(5);
             break;
         case 1:
-            value += between(1, 100);
+            if (Double.isFinite(value)) {
+                value += between(1, 100);
+            } else {
+                value = randomDoubleBetween(0, 100000, true);
+            }
             break;
         case 2:
             if (metaData == null) {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivativeTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/derivative/InternalDerivativeTests.java
@@ -84,7 +84,11 @@ public class InternalDerivativeTests extends InternalAggregationTestCase<Interna
             name += randomAlphaOfLength(5);
             break;
         case 1:
-            value += between(1, 100);
+            if (Double.isFinite(value)) {
+                value += between(1, 100);
+            } else {
+                value = randomDoubleBetween(0, 100000, true);
+            }
             break;
         case 2:
             normalizationFactor += between(1, 100);


### PR DESCRIPTION
When value is NaN, the mutate function might return a new instance that is equal to the original one.

This is a small test glitch I just ran into while doing local tests, it can be reproduced on master with:
gradle :core:test -Dtests.seed=BA95C23D09BE2B4D -Dtests.class=org.elasticsearch.search.aggregations.pipeline.InternalSimpleValueTests -Dtests.method="testEqualsAndHashcode" -Dtests.security.manager=true -Dtests.locale=es-PE -Dtests.timezone=Turkey

