### PR TITLE
Tests: Fix failure in InternalGeoBoundsTests

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBoundsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/geobounds/InternalGeoBoundsTests.java
@@ -121,7 +121,11 @@ public class InternalGeoBoundsTests extends InternalAggregationTestCase<Internal
             name += randomAlphaOfLength(5);
             break;
         case 1:
-            top += between(1, 20);
+            if (Double.isFinite(top)) {
+                top += between(1, 20);
+            } else {
+                top = randomDouble();
+            }
             break;
         case 2:
             bottom += between(1, 20);


### PR DESCRIPTION
This occasionally fails now because if `top` is `-Infinity` (which we sometimes
test for), the value might not get changed for the equals/hashCode tests.

Closes #26107