### PR TITLE
Document how to import Lucene Snapshot libs when elasticsearch clients

### DIFF
--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -43,6 +43,37 @@ For example, you can define the latest version in your `pom.xml` file:
 </dependency>
 --------------------------------------------------
 
+[[java-transport-usage-maven-lucene]]
+==== Lucene Snapshot repository
+
+The very first releases of any major version (like a beta), might have been built on top of a Lucene Snapshot version.
+In such a case you will be unable to resolve the Lucene dependencies of the client.
+
+For example, if you want to use the `6.0.0-beta1` version which depends on Lucene `7.0.0-snapshot-00142c9`, you must
+define the following repository.
+
+For Maven:
+
+["source","xml",subs="attributes"]
+--------------------------------------------------
+<repository>
+    <id>elastic-lucene-snapshots</id>
+    <name>Elastic Lucene Snapshots</name>
+    <url>http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/00142c9</url>
+    <releases><enabled>true</enabled></releases>
+    <snapshots><enabled>false</enabled></snapshots>
+</repository>
+--------------------------------------------------
+
+For Gradle:
+
+["source","groovy",subs="attributes"]
+--------------------------------------------------
+maven {
+    url 'http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/00142c9'
+}
+--------------------------------------------------
+
 === Log4j 2 Logger
 
 You need to also include Log4j 2 dependencies:

--- a/docs/java-rest/high-level/usage.asciidoc
+++ b/docs/java-rest/high-level/usage.asciidoc
@@ -66,7 +66,7 @@ dependencies {
 ==== Lucene Snapshot repository
 
 The very first releases of any major version (like a beta), might have been built on top of a Lucene Snapshot version.
-In such a case, you will need to define the Lucene Snapshot repository within your project.
+In such a case you will be unable to resolve the Lucene dependencies of the client.
 
 For example, if you want to use the `6.0.0-beta1` version which depends on Lucene `7.0.0-snapshot-00142c9`, you must
 define the following repository.

--- a/docs/java-rest/high-level/usage.asciidoc
+++ b/docs/java-rest/high-level/usage.asciidoc
@@ -62,6 +62,37 @@ dependencies {
 }
 --------------------------------------------------
 
+[[java-rest-high-usage-maven-lucene]]
+==== Lucene Snapshot repository
+
+The very first releases of any major version (like a beta), might have been built on top of a Lucene Snapshot version.
+In such a case, you will need to define the Lucene Snapshot repository within your project.
+
+For example, if you want to use the `6.0.0-beta1` version which depends on Lucene `7.0.0-snapshot-00142c9`, you must
+define the following repository.
+
+For Maven:
+
+["source","xml",subs="attributes"]
+--------------------------------------------------
+<repository>
+    <id>elastic-lucene-snapshots</id>
+    <name>Elastic Lucene Snapshots</name>
+    <url>http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/00142c9</url>
+    <releases><enabled>true</enabled></releases>
+    <snapshots><enabled>false</enabled></snapshots>
+</repository>
+--------------------------------------------------
+
+For Gradle:
+
+["source","groovy",subs="attributes"]
+--------------------------------------------------
+maven {
+    url 'http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/00142c9'
+}
+--------------------------------------------------
+
 [[java-rest-high-usage-dependencies]]
 === Dependencies
 


### PR DESCRIPTION
When using the High Level Rest Client 6.0.0-beta1, we are missing some transitive dependencies for Lucene as Lucene 7 has not been released yet. See the following `pom.xml`:

```xml
        <dependency>
            <groupId>org.elasticsearch.client</groupId>
            <artifactId>elasticsearch-rest-client</artifactId>
            <version>6.0.0-beta1</version>
        </dependency>
        <dependency>
            <groupId>org.elasticsearch.client</groupId>
            <artifactId>elasticsearch-rest-high-level-client</artifactId>
            <version>6.0.0-beta1</version>
        </dependency>
```

It gives:

```
[ERROR] Failed to execute goal on project fscrawler: Could not resolve dependencies for project fr.pilato.elasticsearch.crawler:fscrawler:jar:2.4-SNAPSHOT: The following artifacts could not be resolved: org.apache.lucene:lucene-analyzers-common:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-backward-codecs:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-grouping:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-highlighter:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-join:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-memory:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-misc:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-queries:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-queryparser:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-sandbox:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-spatial:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-spatial-extras:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-spatial3d:jar:7.0.0-snapshot-00142c9, org.apache.lucene:lucene-suggest:jar:7.0.0-snapshot-00142c9: Failure to find org.apache.lucene:lucene-analyzers-common:jar:7.0.0-snapshot-00142c9 in https://artifacts.elastic.co/maven/ was cached in the local repository, resolution will not be reattempted until the update interval of elastic-download-service has elapsed or updates are forced -
```

We need to add some temporary documentation on how to add the missing repository to a gradle or maven project:

```xml
        <repository>
            <id>elastic-lucene-snapshots</id>
            <name>Elastic Lucene Snapshots</name>
            <url>http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/00142c9</url>
            <releases><enabled>true</enabled></releases>
            <snapshots><enabled>false</enabled></snapshots>
        </repository>
```

Closes #26106.