### PR TITLE
Search API - stricter fieldname validation.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.action.admin.indices.validate.query;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.broadcast.BroadcastShardRequest;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -39,6 +41,7 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
     private String[] types = Strings.EMPTY_ARRAY;
     private boolean explain;
     private boolean rewrite;
+    private boolean checkFieldNames = SearchRequest.DEFAULT_CHECK_FIELDNAMES;
     private long nowInMillis;
     private AliasFilter filteringAliases;
 
@@ -51,6 +54,7 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
         this.types = request.types();
         this.explain = request.explain();
         this.rewrite = request.rewrite();
+        this.checkFieldNames = request.checkFieldNames();
         this.filteringAliases = Objects.requireNonNull(filteringAliases, "filteringAliases must not be null");
         this.nowInMillis = request.nowInMillis;
     }
@@ -69,6 +73,10 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
 
     public boolean rewrite() {
         return this.rewrite;
+    }
+
+    public boolean checkFieldNames() {
+        return this.checkFieldNames;
     }
 
     public AliasFilter filteringAliases() {
@@ -95,6 +103,10 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
         explain = in.readBoolean();
         rewrite = in.readBoolean();
         nowInMillis = in.readVLong();
+        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+            checkFieldNames = in.readBoolean();
+        }
+        
     }
 
     @Override
@@ -109,5 +121,8 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
         out.writeBoolean(explain);
         out.writeBoolean(rewrite);
         out.writeVLong(nowInMillis);
+        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+            out.writeBoolean(checkFieldNames);
+        }
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -103,7 +103,10 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
         explain = in.readBoolean();
         rewrite = in.readBoolean();
         nowInMillis = in.readVLong();
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (in.getVersion().after(Version.V_6_1_0)) {
             checkFieldNames = in.readBoolean();
         }
         
@@ -121,7 +124,10 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
         out.writeBoolean(explain);
         out.writeBoolean(rewrite);
         out.writeVLong(nowInMillis);
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (out.getVersion().after(Version.V_6_1_0)) {
             out.writeBoolean(checkFieldNames);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -41,7 +41,7 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
     private String[] types = Strings.EMPTY_ARRAY;
     private boolean explain;
     private boolean rewrite;
-    private boolean checkFieldNames = SearchRequest.DEFAULT_CHECK_FIELDNAMES;
+    private boolean checkFieldNames = SearchRequest.DEFAULT_CHECK_FIELD_NAMES;
     private long nowInMillis;
     private AliasFilter filteringAliases;
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -106,7 +106,7 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (in.getVersion().after(Version.V_6_1_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             checkFieldNames = in.readBoolean();
         }
         
@@ -127,7 +127,7 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (out.getVersion().after(Version.V_6_1_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             out.writeBoolean(checkFieldNames);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -175,7 +175,10 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
         if (in.getVersion().onOrAfter(Version.V_5_4_0)) {
             allShards = in.readBoolean();
         }
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (in.getVersion().after(Version.V_6_1_0)) {
             checkFieldNames = in.readBoolean();
         }
     }
@@ -193,7 +196,10 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
         if (out.getVersion().onOrAfter(Version.V_5_4_0)) {
             out.writeBoolean(allShards);
         }
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (out.getVersion().after(Version.V_6_1_0)) {
             out.writeBoolean(checkFieldNames);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -45,7 +45,7 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
 
     private boolean explain;
     private boolean rewrite;
-    private boolean checkFieldNames = SearchRequest.DEFAULT_CHECK_FIELDNAMES;
+    private boolean checkFieldNames = SearchRequest.DEFAULT_CHECK_FIELD_NAMES;
     private boolean allShards;
 
     private String[] types = Strings.EMPTY_ARRAY;

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -178,7 +178,7 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (in.getVersion().after(Version.V_6_1_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             checkFieldNames = in.readBoolean();
         }
     }
@@ -199,7 +199,7 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (out.getVersion().after(Version.V_6_1_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             out.writeBoolean(checkFieldNames);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
@@ -66,6 +66,13 @@ public class ValidateQueryRequestBuilder extends BroadcastOperationRequestBuilde
     }
 
     /**
+     * Indicates whether the query should fail if all shards see field as unmapped
+     */
+    public ValidateQueryRequestBuilder setCheckFieldNames(boolean checkFieldNames) {
+        request.checkFieldNames(checkFieldNames);
+        return this;
+    }
+    /**
      * Indicates whether the query should be validated on all shards
      */
     public ValidateQueryRequestBuilder setAllShards(boolean rewrite) {

--- a/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/core/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -89,7 +89,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
     @Override
     protected ExplainResponse shardOperation(ExplainRequest request, ShardId shardId) throws IOException {
         ShardSearchLocalRequest shardSearchLocalRequest = new ShardSearchLocalRequest(shardId,
-            new String[]{request.type()}, request.nowInMillis, request.filteringAlias());
+            new String[]{request.type()}, request.nowInMillis, request.filteringAlias(), false);
         SearchContext context = searchService.createSearchContext(shardSearchLocalRequest, SearchService.NO_TIMEOUT);
         Engine.GetResult result = null;
         try {

--- a/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -320,4 +320,10 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         skippedOps.incrementAndGet();
         super.skipShard(iterator);
     }
+    
+    
+    @Override
+    public int getNumSkippedShards() {
+        return skippedOps.get();        
+    }
 }

--- a/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -321,7 +321,6 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         super.skipShard(iterator);
     }
     
-    
     @Override
     public int getNumSkippedShards() {
         return skippedOps.get();        

--- a/core/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
+++ b/core/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
@@ -104,6 +104,11 @@ final class FetchSearchPhase extends SearchPhase {
         final Runnable finishPhase = ()
             -> moveToNextPhase(searchPhaseController, scrollId, reducedQueryPhase, queryAndFetchOptimization ?
             queryResults : fetchResults);
+
+        if (context.getRequest().checkFieldNames() && context.getNumSkippedShards() == 0) {
+            reducedQueryPhase.fieldNamesCheck();
+        }
+
         if (queryAndFetchOptimization) {
             assert phaseResults.isEmpty() || phaseResults.get(0).fetchResult() != null : "phaseResults empty [" + phaseResults.isEmpty()
                 + "], single result: " +  phaseResults.get(0).fetchResult();

--- a/core/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
+++ b/core/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
@@ -106,7 +106,7 @@ final class FetchSearchPhase extends SearchPhase {
             queryResults : fetchResults);
 
         if (context.getRequest().checkFieldNames() && context.getNumSkippedShards() == 0) {
-            reducedQueryPhase.fieldNamesCheck();
+            reducedQueryPhase.checkFieldNames();
         }
 
         if (queryAndFetchOptimization) {

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseContext.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseContext.java
@@ -39,6 +39,11 @@ interface SearchPhaseContext extends ActionListener<SearchResponse>, Executor {
      * Returns the total number of shards to the current search across all indices
      */
     int getNumShards();
+    
+    /**
+     * Returns the number of shards that have been skipped so far
+     */
+    int getNumSkippedShards();
 
     /**
      * Returns a logger for this context to prevent each individual phase to create their own logger.

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -475,11 +475,8 @@ public final class SearchPhaseController extends AbstractComponent {
             QuerySearchResult result = entry.queryResult();
             
             // OR the list of unmapped fieldnames from the same index.
-            Set<String> unmappedFieldNamesForIndex = perIndexUnmappedFieldsNames.get(result.getSearchShardTarget().getIndex());
-            if (unmappedFieldNamesForIndex == null){
-                unmappedFieldNamesForIndex = new HashSet<String>();
-                perIndexUnmappedFieldsNames.put(result.getSearchShardTarget().getIndex(), unmappedFieldNamesForIndex);
-            }
+            Set<String> unmappedFieldNamesForIndex = perIndexUnmappedFieldsNames.computeIfAbsent(result.getSearchShardTarget().getIndex(), 
+                    key -> new HashSet<>());
             unmappedFieldNamesForIndex.addAll(result.unmappedFieldnames());
             
                 
@@ -641,7 +638,7 @@ public final class SearchPhaseController extends AbstractComponent {
          * Throws an error if all indices have reported the same query field names as unmapped.
          */
         public void checkFieldNames() {
-            if (unanimouslyUnmappedFieldNames.size() > 0) {
+            if (unanimouslyUnmappedFieldNames.isEmpty() == false) {
                 throw new ParsingException(null, "The following fields were unmapped in all indices searched: " + unanimouslyUnmappedFieldNames);
             }
         }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -516,7 +516,7 @@ public final class SearchPhaseController extends AbstractComponent {
         for (Set<String> unmappedFields : perIndexUnmappedFieldsNames.values()) {
             if (unanimouslyUnmappedFieldNames == null){
                 unanimouslyUnmappedFieldNames  = new HashSet<>(unmappedFields);
-            }else{
+            } else {
                 unanimouslyUnmappedFieldNames.retainAll(unmappedFields);                
             }
         }
@@ -640,7 +640,7 @@ public final class SearchPhaseController extends AbstractComponent {
         /**
          * Throws an error if all indices have reported the same query field names as unmapped.
          */
-        public void fieldNamesCheck() {
+        public void checkFieldNames() {
             if (unanimouslyUnmappedFieldNames.size() > 0) {
                 throw new ParsingException(null, "The following fields were unmapped in all indices searched: " + unanimouslyUnmappedFieldNames);
             }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -87,7 +87,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
         if (shardFailures.length == 0) {
             // If we have a cause that can report a REST status code then return that.
             // One such failure occurs when a globally unmapped field is searched with 
-            // check_fieldnames search mode on.
+            // check_field_names search mode on.
             Throwable cause = unwrapCause();
             if (cause instanceof ElasticsearchException) {
                 return ((ElasticsearchException) getCause()).status();

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -73,9 +73,9 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
 
     private Boolean requestCache;
     
-    public static final boolean DEFAULT_CHECK_FIELDNAMES = false;
+    public static final boolean DEFAULT_CHECK_FIELD_NAMES = false;
 
-    private boolean checkFieldNames = DEFAULT_CHECK_FIELDNAMES;
+    private boolean checkFieldNames = DEFAULT_CHECK_FIELD_NAMES;
     
     private Scroll scroll;
 

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -138,7 +138,10 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
             maxConcurrentShardRequests = in.readVInt();
             preFilterShardSize = in.readVInt();
         }
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (in.getVersion().after(Version.V_6_1_0)) {
             checkFieldNames = in.readBoolean();
         }
     }
@@ -163,7 +166,10 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
             out.writeVInt(maxConcurrentShardRequests);
             out.writeVInt(preFilterShardSize);
         }
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (out.getVersion().after(Version.V_6_1_0)) {
             out.writeBoolean(checkFieldNames);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -141,7 +141,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (in.getVersion().after(Version.V_6_1_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             checkFieldNames = in.readBoolean();
         }
     }
@@ -169,7 +169,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (out.getVersion().after(Version.V_6_1_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             out.writeBoolean(checkFieldNames);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -488,6 +488,15 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
         request.requestCache(requestCache);
         return this;
     }
+    
+
+    /**
+     * Sets if this request should try validate field names
+     */
+    public SearchRequestBuilder setCheckFieldNames(boolean checkFieldNames) {
+        request.checkFieldNames(checkFieldNames);
+        return this;
+    }    
 
     /**
      * Should the query be profiled. Defaults to <code>false</code>

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -491,7 +491,9 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     
 
     /**
-     * Sets if this request should try validate field names
+     * Sets if this request should try check field names are mapped. When set
+     * to true, an error will be thrown if it can be confirmed that all searched 
+     * indices failed to identify a mapping for a field name provided in the search. 
      */
     public SearchRequestBuilder setCheckFieldNames(boolean checkFieldNames) {
         request.checkFieldNames(checkFieldNames);

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
@@ -69,7 +69,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
         validateQueryRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         validateQueryRequest.rewrite(request.paramAsBoolean("rewrite", false));
         validateQueryRequest.allShards(request.paramAsBoolean("all_shards", false));
-        validateQueryRequest.checkFieldNames(request.paramAsBoolean("check_fieldnames", SearchRequest.DEFAULT_CHECK_FIELDNAMES));
+        validateQueryRequest.checkFieldNames(request.paramAsBoolean("check_field_names", SearchRequest.DEFAULT_CHECK_FIELD_NAMES));
 
         Exception bodyParsingException = null;
         try {

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestValidateQueryAction.java
@@ -22,6 +22,7 @@ package org.elasticsearch.rest.action.admin.indices;
 import org.elasticsearch.action.admin.indices.validate.query.QueryExplanation;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryRequest;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParsingException;
@@ -68,6 +69,7 @@ public class RestValidateQueryAction extends BaseRestHandler {
         validateQueryRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
         validateQueryRequest.rewrite(request.paramAsBoolean("rewrite", false));
         validateQueryRequest.allShards(request.paramAsBoolean("all_shards", false));
+        validateQueryRequest.checkFieldNames(request.paramAsBoolean("check_fieldnames", SearchRequest.DEFAULT_CHECK_FIELDNAMES));
 
         Exception bodyParsingException = null;
         try {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -175,6 +175,8 @@ public class RestMultiSearchAction extends BaseRestHandler {
                             searchRequest.searchType(nodeStringValue(value, null));
                         } else if ("request_cache".equals(entry.getKey()) || "requestCache".equals(entry.getKey())) {
                             searchRequest.requestCache(nodeBooleanValue(value, entry.getKey()));
+                        } else if ("check_fieldnames".equals(entry.getKey())) {
+                            searchRequest.checkFieldNames(nodeBooleanValue(value, entry.getKey()));
                         } else if ("preference".equals(entry.getKey())) {
                             searchRequest.preference(nodeStringValue(value, null));
                         } else if ("routing".equals(entry.getKey())) {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -175,7 +175,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
                             searchRequest.searchType(nodeStringValue(value, null));
                         } else if ("request_cache".equals(entry.getKey()) || "requestCache".equals(entry.getKey())) {
                             searchRequest.requestCache(nodeBooleanValue(value, entry.getKey()));
-                        } else if ("check_fieldnames".equals(entry.getKey())) {
+                        } else if ("check_field_names".equals(entry.getKey())) {
                             searchRequest.checkFieldNames(nodeBooleanValue(value, entry.getKey()));
                         } else if ("preference".equals(entry.getKey())) {
                             searchRequest.preference(nodeStringValue(value, null));

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -136,7 +136,7 @@ public class RestSearchAction extends BaseRestHandler {
         }
         parseSearchSource(searchRequest.source(), request, setSize);
         searchRequest.requestCache(request.paramAsBoolean("request_cache", null));
-        searchRequest.checkFieldNames(request.paramAsBoolean("check_fieldnames", SearchRequest.DEFAULT_CHECK_FIELDNAMES));
+        searchRequest.checkFieldNames(request.paramAsBoolean("check_field_names", SearchRequest.DEFAULT_CHECK_FIELD_NAMES));
 
         String scroll = request.param("scroll");
         if (scroll != null) {

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -136,6 +136,7 @@ public class RestSearchAction extends BaseRestHandler {
         }
         parseSearchSource(searchRequest.source(), request, setSize);
         searchRequest.requestCache(request.paramAsBoolean("request_cache", null));
+        searchRequest.checkFieldNames(request.paramAsBoolean("check_fieldnames", SearchRequest.DEFAULT_CHECK_FIELDNAMES));
 
         String scroll = request.param("scroll");
         if (scroll != null) {

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -222,7 +222,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (in.getVersion().after(Version.V_6_1_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             checkFieldNames = in.readBoolean();
         }
     }
@@ -250,7 +250,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (out.getVersion().after(Version.V_6_1_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             out.writeBoolean(checkFieldNames);
         }
 

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -72,6 +72,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     private float indexBoost;
     private SearchSourceBuilder source;
     private Boolean requestCache;
+    private boolean checkFieldNames;
     private long nowInMillis;
 
     private boolean profile;
@@ -82,22 +83,24 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     ShardSearchLocalRequest(SearchRequest searchRequest, ShardId shardId, int numberOfShards,
                             AliasFilter aliasFilter, float indexBoost, long nowInMillis, String clusterAlias) {
         this(shardId, numberOfShards, searchRequest.searchType(),
-                searchRequest.source(), searchRequest.types(), searchRequest.requestCache(), aliasFilter, indexBoost);
+                searchRequest.source(), searchRequest.types(), searchRequest.requestCache(), aliasFilter, indexBoost,
+                searchRequest.checkFieldNames());
         this.scroll = searchRequest.scroll();
         this.nowInMillis = nowInMillis;
         this.clusterAlias = clusterAlias;
     }
 
-    public ShardSearchLocalRequest(ShardId shardId, String[] types, long nowInMillis, AliasFilter aliasFilter) {
+    public ShardSearchLocalRequest(ShardId shardId, String[] types, long nowInMillis, AliasFilter aliasFilter, boolean checkFieldnames) {
         this.types = types;
         this.nowInMillis = nowInMillis;
         this.aliasFilter = aliasFilter;
         this.shardId = shardId;
+        this.checkFieldNames = checkFieldnames;
         indexBoost = 1.0f;
     }
 
     public ShardSearchLocalRequest(ShardId shardId, int numberOfShards, SearchType searchType, SearchSourceBuilder source, String[] types,
-            Boolean requestCache, AliasFilter aliasFilter, float indexBoost) {
+            Boolean requestCache, AliasFilter aliasFilter, float indexBoost, boolean checkFieldNames) {
         this.shardId = shardId;
         this.numberOfShards = numberOfShards;
         this.searchType = searchType;
@@ -106,6 +109,7 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         this.requestCache = requestCache;
         this.aliasFilter = aliasFilter;
         this.indexBoost = indexBoost;
+        this.checkFieldNames = checkFieldNames;
     }
 
 
@@ -165,6 +169,11 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
     }
 
     @Override
+    public boolean checkFieldNames() {
+        return checkFieldNames;
+    }
+
+    @Override
     public Scroll scroll() {
         return scroll;
     }
@@ -210,6 +219,9 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         if (in.getVersion().onOrAfter(Version.V_5_6_0)) {
             clusterAlias = in.readOptionalString();
         }
+        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+            checkFieldNames = in.readBoolean();
+        }
     }
 
     protected void innerWriteTo(StreamOutput out, boolean asKey) throws IOException {
@@ -232,6 +244,10 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         if (out.getVersion().onOrAfter(Version.V_5_6_0)) {
             out.writeOptionalString(clusterAlias);
         }
+        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+            out.writeBoolean(checkFieldNames);
+        }
+
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchLocalRequest.java
@@ -219,7 +219,10 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         if (in.getVersion().onOrAfter(Version.V_5_6_0)) {
             clusterAlias = in.readOptionalString();
         }
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (in.getVersion().after(Version.V_6_1_0)) {
             checkFieldNames = in.readBoolean();
         }
     }
@@ -244,7 +247,10 @@ public class ShardSearchLocalRequest implements ShardSearchRequest {
         if (out.getVersion().onOrAfter(Version.V_5_6_0)) {
             out.writeOptionalString(clusterAlias);
         }
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (out.getVersion().after(Version.V_6_1_0)) {
             out.writeBoolean(checkFieldNames);
         }
 

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -68,6 +68,8 @@ public interface ShardSearchRequest {
     long nowInMillis();
 
     Boolean requestCache();
+    
+    boolean checkFieldNames();
 
     Scroll scroll();
 

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -156,7 +156,6 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
         return shardSearchLocalRequest.checkFieldNames();
     }
     
-    
     @Override
     public Scroll scroll() {
         return shardSearchLocalRequest.scroll();

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -152,6 +152,12 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
     }
 
     @Override
+    public boolean checkFieldNames() {
+        return shardSearchLocalRequest.checkFieldNames();
+    }
+    
+    
+    @Override
     public Scroll scroll() {
         return shardSearchLocalRequest.scroll();
     }

--- a/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -279,6 +279,7 @@ public class QueryPhase implements SearchPhase {
             }
 
             final QuerySearchResult result = searchContext.queryResult();
+            result.unmappedFieldnames(searchContext.getQueryShardContext().getUnmappedFields());
             for (QueryCollectorContext ctx : collectors) {
                 ctx.postProcess(result, shouldCollect);
             }

--- a/core/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
@@ -314,7 +314,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (in.getVersion().after(Version.V_6_1_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             String[] unmappedFieldsArray = in.readStringArray();            
             unmappedFields = unmappedFieldsArray.length == 0 ? Collections.emptySet() : new HashSet<>(Arrays.asList(unmappedFieldsArray));
         }
@@ -363,7 +363,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
         // TODO - reinstate this line once checkFieldNames is backported to 6.1 
         // otherwise 7.0 commit will cause many BWC failures
 //        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
-        if (out.getVersion().after(Version.V_6_1_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             out.writeStringArray(unmappedFields.toArray(new String[unmappedFields.size()]));
         }
         

--- a/core/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
@@ -311,7 +311,10 @@ public final class QuerySearchResult extends SearchPhaseResult {
             serviceTimeEWMA = -1;
             nodeQueueSize = -1;
         }
-        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (in.getVersion().after(Version.V_6_1_0)) {
             String[] unmappedFieldsArray = in.readOptionalStringArray();            
             unmappedFields = unmappedFieldsArray == null ? Collections.emptySet() : new HashSet<>(Arrays.asList(unmappedFieldsArray));
         }
@@ -357,7 +360,10 @@ public final class QuerySearchResult extends SearchPhaseResult {
             out.writeZLong(serviceTimeEWMA);
             out.writeInt(nodeQueueSize);
         }
-        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        // TODO - reinstate this line once checkFieldNames is backported to 6.1 
+        // otherwise 7.0 commit will cause many BWC failures
+//        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
+        if (out.getVersion().after(Version.V_6_1_0)) {
             String[] unmappedFieldsArray = unmappedFields.size() == 0 ? null : unmappedFields.toArray(new String[unmappedFields.size()]);
             out.writeOptionalStringArray(unmappedFieldsArray);
         }

--- a/core/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
@@ -315,8 +315,8 @@ public final class QuerySearchResult extends SearchPhaseResult {
         // otherwise 7.0 commit will cause many BWC failures
 //        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
         if (in.getVersion().after(Version.V_6_1_0)) {
-            String[] unmappedFieldsArray = in.readOptionalStringArray();            
-            unmappedFields = unmappedFieldsArray == null ? Collections.emptySet() : new HashSet<>(Arrays.asList(unmappedFieldsArray));
+            String[] unmappedFieldsArray = in.readStringArray();            
+            unmappedFields = unmappedFieldsArray.length == 0 ? Collections.emptySet() : new HashSet<>(Arrays.asList(unmappedFieldsArray));
         }
         
     }
@@ -364,8 +364,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
         // otherwise 7.0 commit will cause many BWC failures
 //        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
         if (out.getVersion().after(Version.V_6_1_0)) {
-            String[] unmappedFieldsArray = unmappedFields.size() == 0 ? null : unmappedFields.toArray(new String[unmappedFields.size()]);
-            out.writeOptionalStringArray(unmappedFieldsArray);
+            out.writeStringArray(unmappedFields.toArray(new String[unmappedFields.size()]));
         }
         
     }

--- a/core/src/test/java/org/elasticsearch/action/ShardValidateQueryRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/ShardValidateQueryRequestTests.java
@@ -55,6 +55,7 @@ public class ShardValidateQueryRequestTests extends ESTestCase {
             ValidateQueryRequest validateQueryRequest = new ValidateQueryRequest("indices");
             validateQueryRequest.query(QueryBuilders.termQuery("field", "value"));
             validateQueryRequest.rewrite(true);
+            validateQueryRequest.checkFieldNames(randomBoolean());
             validateQueryRequest.explain(false);
             validateQueryRequest.types("type1", "type2");
             ShardValidateQueryRequest request = new ShardValidateQueryRequest(new ShardId("index", "foobar", 1),
@@ -68,6 +69,7 @@ public class ShardValidateQueryRequestTests extends ESTestCase {
                 assertEquals(request.explain(), readRequest.explain());
                 assertEquals(request.query(), readRequest.query());
                 assertEquals(request.rewrite(), readRequest.rewrite());
+                assertEquals(request.checkFieldNames(), readRequest.checkFieldNames());
                 assertEquals(request.shardId(), readRequest.shardId());
             }
         }

--- a/core/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
@@ -52,7 +52,8 @@ public class FetchSearchPhaseTests extends ESTestCase {
         boolean hasHits = randomBoolean();
         final int numHits;
         if (hasHits) {
-            QuerySearchResult queryResult = new QuerySearchResult();
+            QuerySearchResult queryResult = new QuerySearchResult(1, new SearchShardTarget("nodeId", 
+                    new Index("index", "uid"), 1, "clusterAlias"));
             queryResult.topDocs(new TopDocs(1, new ScoreDoc[] {new ScoreDoc(42, 1.0F)}, 1.0F), new DocValueFormat[0]);
             queryResult.size(1);
             FetchSearchResult fetchResult = new FetchSearchResult();

--- a/core/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/core/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -144,4 +144,9 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     public void sendReleaseSearchContext(long contextId, Transport.Connection connection, OriginalIndices originalIndices) {
         releasedSearchContexts.add(contextId);
     }
+
+    @Override
+    public int getNumSkippedShards() {
+        return 0;
+    }
 }

--- a/core/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/SearchSlowLogTests.java
@@ -113,6 +113,11 @@ public class SearchSlowLogTests extends ESSingleNodeTestCase {
                 }
 
                 @Override
+                public boolean checkFieldNames() {
+                    return false;
+                }
+                
+                @Override
                 public Scroll scroll() {
                     return null;
                 }

--- a/core/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -212,7 +212,8 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 try {
                     SearchPhaseResult searchPhaseResult = service.executeQueryPhase(
                             new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.DEFAULT,
-                                    new SearchSourceBuilder(), new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f),
+                                    new SearchSourceBuilder(), new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY),
+                                    1.0f, false),
                         new SearchTask(123L, "", "", "", null));
                     IntArrayList intCursors = new IntArrayList(1);
                     intCursors.add(0);
@@ -248,7 +249,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                         new String[0],
                         false,
                         new AliasFilter(null, Strings.EMPTY_ARRAY),
-                        1.0f)
+                        1.0f, false)
         );
         try {
             // the search context should inherit the default timeout
@@ -268,7 +269,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                         new String[0],
                         false,
                         new AliasFilter(null, Strings.EMPTY_ARRAY),
-                        1.0f)
+                        1.0f, false)
         );
         try {
             // the search context should inherit the query timeout
@@ -296,12 +297,12 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             searchSourceBuilder.docValueField("field" + i);
         }
         try (SearchContext context = service.createContext(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.DEFAULT,
-                searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f))) {
+                searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f, false))) {
             assertNotNull(context);
             searchSourceBuilder.docValueField("one_field_too_much");
             IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
                     () -> service.createContext(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.DEFAULT,
-                            searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f)));
+                            searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f, false)));
             assertEquals(
                     "Trying to retrieve too many docvalue_fields. Must be less than or equal to: [100] but was [101]. "
                             + "This limit can be set by changing the [index.max_docvalue_fields_search] index level setting.",
@@ -327,13 +328,13 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                     new Script(ScriptType.INLINE, MockScriptEngine.NAME, CustomScriptPlugin.DUMMY_SCRIPT, Collections.emptyMap()));
         }
         try (SearchContext context = service.createContext(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.DEFAULT,
-                searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f))) {
+                searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f, false))) {
             assertNotNull(context);
             searchSourceBuilder.scriptField("anotherScriptField",
                     new Script(ScriptType.INLINE, MockScriptEngine.NAME, CustomScriptPlugin.DUMMY_SCRIPT, Collections.emptyMap()));
             IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
                     () -> service.createContext(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.DEFAULT,
-                            searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f)));
+                            searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f, false)));
             assertEquals(
                     "Trying to retrieve too many script_fields. Must be less than or equal to: [" + maxScriptFields + "] but was ["
                             + (maxScriptFields + 1)
@@ -404,27 +405,27 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         final IndexService indexService = indicesService.indexServiceSafe(resolveIndex("index"));
         final IndexShard indexShard = indexService.getShard(0);
         assertTrue(service.canMatch(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.QUERY_THEN_FETCH, null,
-            Strings.EMPTY_ARRAY, false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1f)));
+            Strings.EMPTY_ARRAY, false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1f, false)));
 
         assertTrue(service.canMatch(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.QUERY_THEN_FETCH,
-            new SearchSourceBuilder(), Strings.EMPTY_ARRAY, false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1f)));
+            new SearchSourceBuilder(), Strings.EMPTY_ARRAY, false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1f, false)));
 
         assertTrue(service.canMatch(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.QUERY_THEN_FETCH,
             new SearchSourceBuilder().query(new MatchAllQueryBuilder()), Strings.EMPTY_ARRAY, false,
-            new AliasFilter(null, Strings.EMPTY_ARRAY), 1f)));
+            new AliasFilter(null, Strings.EMPTY_ARRAY), 1f, false)));
 
         assertTrue(service.canMatch(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.QUERY_THEN_FETCH,
             new SearchSourceBuilder().query(new MatchNoneQueryBuilder())
             .aggregation(new TermsAggregationBuilder("test", ValueType.STRING).minDocCount(0)), Strings.EMPTY_ARRAY, false,
-            new AliasFilter(null, Strings.EMPTY_ARRAY), 1f)));
+            new AliasFilter(null, Strings.EMPTY_ARRAY), 1f, false)));
         assertTrue(service.canMatch(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.QUERY_THEN_FETCH,
             new SearchSourceBuilder().query(new MatchNoneQueryBuilder())
                 .aggregation(new GlobalAggregationBuilder("test")), Strings.EMPTY_ARRAY, false,
-            new AliasFilter(null, Strings.EMPTY_ARRAY), 1f)));
+            new AliasFilter(null, Strings.EMPTY_ARRAY), 1f, false)));
 
         assertFalse(service.canMatch(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.QUERY_THEN_FETCH,
             new SearchSourceBuilder().query(new MatchNoneQueryBuilder()), Strings.EMPTY_ARRAY, false,
-            new AliasFilter(null, Strings.EMPTY_ARRAY), 1f)));
+            new AliasFilter(null, Strings.EMPTY_ARRAY), 1f, false)));
 
     }
 

--- a/core/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -302,7 +302,11 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             searchSourceBuilder.docValueField("one_field_too_much");
             IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
                     () -> service.createContext(new ShardSearchLocalRequest(indexShard.shardId(), 1, SearchType.DEFAULT,
+//<<<<<<< HEAD
                             searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f, false)));
+//=======
+//                            searchSourceBuilder, new String[0], false, new AliasFilter(null, Strings.EMPTY_ARRAY), 1.0f, false), null));
+//>>>>>>> Fix new test in master that was missing checkFieldnames arg
             assertEquals(
                     "Trying to retrieve too many docvalue_fields. Must be less than or equal to: [100] but was [101]. "
                             + "This limit can be set by changing the [index.max_docvalue_fields_search] index level setting.",

--- a/core/src/test/java/org/elasticsearch/search/aggregations/CombiIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/CombiIT.java
@@ -122,7 +122,7 @@ public class CombiIT extends ESIntegTestCase {
         ensureSearchable("idx");
 
         SubAggCollectionMode aggCollectionMode = randomFrom(SubAggCollectionMode.values());
-        SearchResponse searchResponse = client().prepareSearch("idx")
+        SearchResponse searchResponse = client().prepareSearch("idx").setCheckFieldNames(false)
                 .addAggregation(histogram("values").field("value1").interval(1)
                         .subAggregation(terms("names").field("name")
                                 .collectMode(aggCollectionMode )))

--- a/core/src/test/java/org/elasticsearch/search/aggregations/MetaDataIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/MetaDataIT.java
@@ -66,7 +66,7 @@ public class MetaDataIT extends ESIntegTestCase {
             put("complex", nestedMetaData);
         }};
 
-        SearchResponse response = client().prepareSearch("idx")
+        SearchResponse response = client().prepareSearch("idx").setCheckFieldNames(false)
                 .addAggregation(
                     terms("the_terms")
                         .setMetaData(metaData)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/MissingValueIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/MissingValueIT.java
@@ -61,7 +61,8 @@ public class MissingValueIT extends ESIntegTestCase {
     }
 
     public void testUnmappedTerms() {
-        SearchResponse response = client().prepareSearch("idx").addAggregation(terms("my_terms").field("non_existing_field").missing("bar")).get();
+        SearchResponse response = client().prepareSearch("idx").setCheckFieldNames(false)
+                .addAggregation(terms("my_terms").field("non_existing_field").missing("bar")).get();
         assertSearchResponse(response);
         Terms terms = response.getAggregations().get("my_terms");
         assertEquals(1, terms.getBuckets().size());
@@ -120,7 +121,8 @@ public class MissingValueIT extends ESIntegTestCase {
     }
 
     public void testUnmappedHistogram() {
-        SearchResponse response = client().prepareSearch("idx").addAggregation(histogram("my_histogram").field("non-existing_field").interval(5).missing(12)).get();
+        SearchResponse response = client().prepareSearch("idx").setCheckFieldNames(false)
+                .addAggregation(histogram("my_histogram").field("non-existing_field").interval(5).missing(12)).get();
         assertSearchResponse(response);
         Histogram histogram = response.getAggregations().get("my_histogram");
         assertEquals(1, histogram.getBuckets().size());
@@ -193,7 +195,8 @@ public class MissingValueIT extends ESIntegTestCase {
     }
 
     public void testUnmappedGeoBounds() {
-        SearchResponse response = client().prepareSearch("idx").addAggregation(geoBounds("bounds").field("non_existing_field").missing("2,1")).get();
+        SearchResponse response = client().prepareSearch("idx").setCheckFieldNames(false)
+                .addAggregation(geoBounds("bounds").field("non_existing_field").missing("2,1")).get();
         assertSearchResponse(response);
         GeoBounds bounds = response.getAggregations().get("bounds");
         assertThat(bounds.bottomRight().lat(), closeTo(2.0, 1E-5));

--- a/core/src/test/java/org/elasticsearch/search/aggregations/UnmappedFieldValidationIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/UnmappedFieldValidationIT.java
@@ -92,15 +92,11 @@ public class UnmappedFieldValidationIT extends ESIntegTestCase {
     }  
     
     public void testStrictUnmappedStringTermsMultiIndexMultiReduce() {
-        try {
-            client().prepareSearch("idx","idx_unmapped").setBatchedReduceSize(2).setCheckFieldNames(true)
-                .addAggregation(terms("my_terms").field("all_unmapped_str")).get();
-            fail("All unmapped fields failure expected");
-        } catch (SearchPhaseExecutionException e) {
-            assertTrue(e.getCause().getMessage().contains(
-                    "The following fields were unmapped in all indices searched: [all_unmapped_str]"));
-        }
-    }      
+        expectThrows(SearchPhaseExecutionException.class,
+                () -> client().prepareSearch("idx", "idx_unmapped").setBatchedReduceSize(2).setCheckFieldNames(true)
+                        .addAggregation(terms("my_terms").field("all_unmapped_str")).get()
+               );
+    }
     
     public void testStrictPartiallyUnmappedStringTerms() {
         SearchResponse response = client().prepareSearch("idx","idx_unmapped").setBatchedReduceSize(2)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/UnmappedFieldValidationIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/UnmappedFieldValidationIT.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
+
+@ESIntegTestCase.SuiteScopeTestCase
+public class UnmappedFieldValidationIT extends ESIntegTestCase {
+
+    @Override
+    protected int maximumNumberOfShards() {
+        return 5;
+    }
+    
+
+    @Override
+    protected int minimumNumberOfShards() {
+        return 5;
+    }
+
+
+    @Override
+    protected void setupSuiteScopeCluster() throws Exception {
+        assertAcked(prepareCreate("idx").addMapping("type", "foo", "type=keyword").get());
+        assertAcked(prepareCreate("idx_unmapped").addMapping("type", "bar", "type=keyword").get());
+        indexRandom(true,
+                client().prepareIndex("idx", "type").setSource("foo", "1"),
+                client().prepareIndex("idx", "type").setSource("foo", "2"),
+                client().prepareIndex("idx", "type").setSource("foo", "3"),
+                client().prepareIndex("idx", "type").setSource("foo", "4"),
+                client().prepareIndex("idx", "type").setSource("foo", "5"),
+                client().prepareIndex("idx_unmapped", "type").setSource("bar", "1"),
+                client().prepareIndex("idx_unmapped", "type").setSource("bar", "2"),
+                client().prepareIndex("idx_unmapped", "type").setSource("bar", "3"),
+                client().prepareIndex("idx_unmapped", "type").setSource("bar", "4"),
+                client().prepareIndex("idx_unmapped", "type").setSource("bar", "5")
+                );
+    }
+
+    public void testUnmappedTerms() {
+        
+        SearchResponse response = client().prepareSearch("idx", "idx_unmapped")
+                .addAggregation(terms("my_terms").field(randomFrom("foo", "bar"))).get();
+        assertSearchResponse(response);
+        Terms terms = response.getAggregations().get("my_terms");
+        assertEquals(5, terms.getBuckets().size());
+    }
+    
+    public void testStrictUnmappedStringTermsSingleIndex() {
+        try {
+            client().prepareSearch("idx_unmapped").setBatchedReduceSize(2).setCheckFieldNames(true)
+                .addAggregation(terms("my_terms1").field("foo")).get();
+            fail("All unmapped fields failure expected");
+        } catch (SearchPhaseExecutionException e) {
+            assertTrue(e.getCause().getMessage().contains("The following fields were unmapped in all indices searched: [foo]"));
+        }
+    }
+    
+    public void testStrictUnmappedStringTermsMultiIndex() {
+        try {
+            client().prepareSearch("idx","idx_unmapped").setCheckFieldNames(true)
+                .addAggregation(terms("my_terms").field("all_unmapped_str")).get();
+            fail("All unmapped fields failure expected");
+        } catch (SearchPhaseExecutionException e) {
+            assertTrue(e.getCause().getMessage().contains(
+                    "The following fields were unmapped in all indices searched: [all_unmapped_str]"));
+        }
+    }  
+    
+    public void testStrictUnmappedStringTermsMultiIndexMultiReduce() {
+        try {
+            client().prepareSearch("idx","idx_unmapped").setBatchedReduceSize(2).setCheckFieldNames(true)
+                .addAggregation(terms("my_terms").field("all_unmapped_str")).get();
+            fail("All unmapped fields failure expected");
+        } catch (SearchPhaseExecutionException e) {
+            assertTrue(e.getCause().getMessage().contains(
+                    "The following fields were unmapped in all indices searched: [all_unmapped_str]"));
+        }
+    }      
+    
+    public void testStrictPartiallyUnmappedStringTerms() {
+        SearchResponse response = client().prepareSearch("idx","idx_unmapped").setBatchedReduceSize(2)
+                .setCheckFieldNames(true)
+                .addAggregation(terms("my_terms").field("foo")).get();
+        assertSearchResponse(response);
+        Terms terms = response.getAggregations().get("my_terms");
+        assertEquals(5, terms.getBuckets().size());
+    }  
+    
+    public void testLaxUnmappedStringTerms() {
+        SearchResponse response = client().prepareSearch("idx","idx_unmapped").setCheckFieldNames(false)
+                .addAggregation(terms("my_terms").field("all_unmapped_str")).get();
+        assertSearchResponse(response);
+        Terms terms = response.getAggregations().get("my_terms");
+        assertEquals(0, terms.getBuckets().size());
+    }       
+}

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
@@ -82,7 +82,7 @@ public class BooleanTermsIT extends ESIntegTestCase {
     }
 
     public void testSingleValueField() throws Exception {
-        SearchResponse response = client().prepareSearch("idx").setTypes("type")
+        SearchResponse response = client().prepareSearch("idx").setCheckFieldNames(false).setTypes("type")
                 .addAggregation(terms("terms")
                         .field(SINGLE_VALUED_FIELD_NAME)
                         .collectMode(randomFrom(SubAggCollectionMode.values())))
@@ -116,7 +116,7 @@ public class BooleanTermsIT extends ESIntegTestCase {
     }
 
     public void testMultiValueField() throws Exception {
-        SearchResponse response = client().prepareSearch("idx").setTypes("type")
+        SearchResponse response = client().prepareSearch("idx").setTypes("type").setCheckFieldNames(false)
                 .addAggregation(terms("terms")
                         .field(MULTI_VALUED_FIELD_NAME)
                         .collectMode(randomFrom(SubAggCollectionMode.values())))
@@ -150,7 +150,7 @@ public class BooleanTermsIT extends ESIntegTestCase {
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch("idx_unmapped").setTypes("type")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false).setTypes("type")
                 .addAggregation(terms("terms")
                         .field(SINGLE_VALUED_FIELD_NAME)
                         .size(between(1, 5))

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -891,7 +891,7 @@ public class DateHistogramIT extends ESIntegTestCase {
      */
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch("idx_unmapped")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(dateHistogram("histo").field("date").dateHistogramInterval(DateHistogramInterval.MONTH))
                 .execute().actionGet();
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
@@ -704,7 +704,7 @@ public class DateRangeIT extends ESIntegTestCase {
     public void testUnmapped() throws Exception {
         client().admin().cluster().prepareHealth("idx_unmapped").setWaitForYellowStatus().execute().actionGet();
 
-        SearchResponse response = client().prepareSearch("idx_unmapped")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(dateRange("range")
                         .field("date")
                         .addUnboundedTo(date(2, 15))
@@ -750,7 +750,7 @@ public class DateRangeIT extends ESIntegTestCase {
     }
 
     public void testUnmappedWithStringDates() throws Exception {
-        SearchResponse response = client().prepareSearch("idx_unmapped")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(dateRange("range")
                         .field("date")
                         .addUnboundedTo("2012-02-15")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
@@ -234,7 +234,8 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
         DiversifiedAggregationBuilder sampleAgg = new DiversifiedAggregationBuilder("sample").shardSize(100);
         sampleAgg.field("author").maxDocsPerValue(MAX_DOCS_PER_AUTHOR).executionHint(randomExecutionHint());
         sampleAgg.subAggregation(terms("authors").field("author"));
-        SearchResponse response = client().prepareSearch("idx_unmapped", "idx_unmapped_author").setSearchType(SearchType.QUERY_THEN_FETCH)
+        SearchResponse response = client().prepareSearch("idx_unmapped", "idx_unmapped_author").setCheckFieldNames(false)
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
                 .setQuery(new TermQueryBuilder("genre", "fantasy")).setFrom(0).setSize(60).addAggregation(sampleAgg).execute().actionGet();
         assertSearchResponse(response);
         Sampler sample = response.getAggregations().get("sample");

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -237,7 +237,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
     public void testUnmapped() throws Exception {
         client().admin().cluster().prepareHealth("idx_unmapped").setWaitForYellowStatus().execute().actionGet();
 
-        SearchResponse response = client().prepareSearch("idx_unmapped")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(geoDistance("amsterdam_rings", new GeoPoint(52.3760, 4.894))
                         .field("location")
                         .unit(DistanceUnit.KILOMETERS)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
@@ -237,7 +237,7 @@ public class GeoHashGridIT extends ESIntegTestCase {
 
     public void testUnmapped() throws Exception {
         for (int precision = 1; precision <= PRECISION; precision++) {
-            SearchResponse response = client().prepareSearch("idx_unmapped")
+            SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                     .addAggregation(geohashGrid("geohashgrid")
                             .field("location")
                             .precision(precision)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
@@ -823,7 +823,7 @@ public class HistogramIT extends ESIntegTestCase {
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch("idx_unmapped")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval))
                 .execute().actionGet();
 
@@ -1027,7 +1027,7 @@ public class HistogramIT extends ESIntegTestCase {
 
         SearchResponse response = null;
         try {
-            response = client().prepareSearch("idx")
+            response = client().prepareSearch("idx").setCheckFieldNames(false)
                     .setQuery(QueryBuilders.termQuery("foo", "bar"))
                     .addAggregation(histogram("histo")
                             .field(SINGLE_VALUED_FIELD_NAME)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpRangeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpRangeIT.java
@@ -183,7 +183,7 @@ public class IpRangeIT extends ESIntegTestCase {
     }
 
     public void testUnmapped() {
-        SearchResponse rsp = client().prepareSearch("idx_unmapped").addAggregation(
+        SearchResponse rsp = client().prepareSearch("idx_unmapped").setCheckFieldNames(false).addAggregation(
                 AggregationBuilders.ipRange("my_range")
                     .field("ip")
                     .addUnboundedTo("192.168.1.0")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/MissingIT.java
@@ -88,7 +88,7 @@ public class MissingIT extends ESIntegTestCase {
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch("unmapped_idx")
+        SearchResponse response = client().prepareSearch("unmapped_idx").setCheckFieldNames(false)
                 .addAggregation(missing("missing_tag").field("tag"))
                 .execute().actionGet();
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/NaNSortingIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/NaNSortingIT.java
@@ -150,7 +150,7 @@ public class NaNSortingIT extends ESIntegTestCase {
     public void testTerms(String fieldName) {
         final boolean asc = randomBoolean();
         SubAggregation agg = randomFrom(SubAggregation.values());
-        SearchResponse response = client().prepareSearch("idx")
+        SearchResponse response = client().prepareSearch("idx").setCheckFieldNames(false)
                 .addAggregation(terms("terms").field(fieldName).collectMode(randomFrom(SubAggCollectionMode.values())).subAggregation(agg.builder()).order(BucketOrder.aggregation(agg.sortKey(), asc)))
                 .execute().actionGet();
 
@@ -174,7 +174,7 @@ public class NaNSortingIT extends ESIntegTestCase {
     public void testLongHistogram() {
         final boolean asc = randomBoolean();
         SubAggregation agg = randomFrom(SubAggregation.values());
-        SearchResponse response = client().prepareSearch("idx")
+        SearchResponse response = client().prepareSearch("idx").setCheckFieldNames(false)
                 .addAggregation(histogram("histo")
                         .field("long_value").interval(randomIntBetween(1, 2)).subAggregation(agg.builder()).order(BucketOrder.aggregation(agg.sortKey(), asc)))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeIT.java
@@ -746,7 +746,7 @@ public class RangeIT extends ESIntegTestCase {
      */
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch("idx_unmapped")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(range("range")
                         .field(SINGLE_VALUED_FIELD_NAME)
                         .addUnboundedTo(3)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
@@ -148,7 +148,7 @@ public class SamplerIT extends ESIntegTestCase {
     public void testUnmappedChildAggNoDiversity() throws Exception {
         SamplerAggregationBuilder sampleAgg = sampler("sample").shardSize(100);
         sampleAgg.subAggregation(terms("authors").field("author"));
-        SearchResponse response = client().prepareSearch("idx_unmapped")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setSearchType(SearchType.QUERY_THEN_FETCH)
                 .setQuery(new TermQueryBuilder("genre", "fantasy"))
                 .setFrom(0).setSize(60)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardReduceIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardReduceIT.java
@@ -117,7 +117,7 @@ public class ShardReduceIT extends ESIntegTestCase {
     }
 
     public void testMissing() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
+        SearchResponse response = client().prepareSearch("idx").setCheckFieldNames(false)
                 .setQuery(QueryBuilders.matchAllQuery())
                 .addAggregation(missing("missing").field("foobar")
                         .subAggregation(dateHistogram("histo").field("date").dateHistogramInterval(DateHistogramInterval.DAY).minDocCount(0)))
@@ -131,7 +131,7 @@ public class ShardReduceIT extends ESIntegTestCase {
     }
 
     public void testGlobalWithFilterWithMissing() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
+        SearchResponse response = client().prepareSearch("idx").setCheckFieldNames(false)
                 .setQuery(QueryBuilders.matchAllQuery())
                 .addAggregation(global("global")
                         .subAggregation(filter("filter", QueryBuilders.matchAllQuery())

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -323,7 +323,8 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
 
-        SearchResponse testResponse = client().prepareSearch("idx_with_routing").setTypes("type").setRouting(String.valueOf(between(1, numRoutingValues)))
+        SearchResponse testResponse = client().prepareSearch("idx_with_routing").setCheckFieldNames(false)
+                .setTypes("type").setRouting(String.valueOf(between(1, numRoutingValues)))
                 .addAggregation(terms("terms")
                         .executionHint(randomExecutionHint())
                         .field(STRING_FIELD_NAME)
@@ -559,7 +560,8 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
 
-        SearchResponse testResponse = client().prepareSearch("idx_with_routing").setTypes("type").setRouting(String.valueOf(between(1, numRoutingValues)))
+        SearchResponse testResponse = client().prepareSearch("idx_with_routing").setCheckFieldNames(false)
+                .setTypes("type").setRouting(String.valueOf(between(1, numRoutingValues)))
                 .addAggregation(terms("terms")
                         .executionHint(randomExecutionHint())
                         .field(LONG_FIELD_NAME)
@@ -795,7 +797,8 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
 
-        SearchResponse testResponse = client().prepareSearch("idx_with_routing").setTypes("type").setRouting(String.valueOf(between(1, numRoutingValues)))
+        SearchResponse testResponse = client().prepareSearch("idx_with_routing").setCheckFieldNames(false)
+                .setTypes("type").setRouting(String.valueOf(between(1, numRoutingValues)))
                 .addAggregation(terms("terms")
                         .executionHint(randomExecutionHint())
                         .field(DOUBLE_FIELD_NAME)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgIT.java
@@ -85,7 +85,7 @@ public class AvgIT extends AbstractNumericTestCase {
 
     @Override
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(avg("avg").field("value"))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityIT.java
@@ -173,7 +173,7 @@ public class CardinalityIT extends ESIntegTestCase {
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch("idx_unmapped").setTypes("type")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false).setTypes("type")
                 .addAggregation(cardinality("cardinality").precisionThreshold(precisionThreshold).field("str_value"))
                 .execute().actionGet();
 

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
@@ -107,7 +107,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
 
     @Override
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(extendedStats("stats").field("value"))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
@@ -125,6 +125,7 @@ public class GeoBoundsIT extends AbstractGeoTestCase {
 
     public void testUnmapped() throws Exception {
         SearchResponse response = client().prepareSearch(UNMAPPED_IDX_NAME)
+                .setCheckFieldNames(false)
                 .addAggregation(geoBounds(aggName).field(SINGLE_VALUED_FIELD_NAME)
                         .wrapLongitude(false))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
@@ -63,7 +63,7 @@ public class GeoCentroidIT extends AbstractGeoTestCase {
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = client().prepareSearch(UNMAPPED_IDX_NAME)
+        SearchResponse response = client().prepareSearch(UNMAPPED_IDX_NAME).setCheckFieldNames(false)
                 .addAggregation(geoCentroid(aggName).field(SINGLE_VALUED_FIELD_NAME))
                 .execute().actionGet();
         assertSearchResponse(response);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -150,7 +150,7 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
     public void testUnmapped() throws Exception {
         int sigDigits = randomSignificantDigits();
         SearchResponse searchResponse = client()
-                .prepareSearch("idx_unmapped")
+                .prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(
                         percentileRanks("percentile_ranks", new double[]{0, 10, 15, 100})

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
@@ -152,7 +152,7 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
     public void testUnmapped() throws Exception {
         int sigDigits = randomSignificantDigits();
         SearchResponse searchResponse = client()
-                .prepareSearch("idx_unmapped")
+                .prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(
                         percentiles("percentiles").numberOfSignificantValueDigits(sigDigits).method(PercentilesMethod.HDR).field("value")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxIT.java
@@ -79,7 +79,7 @@ public class MaxIT extends AbstractNumericTestCase {
 
     @Override
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(max("max").field("value"))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/MinIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/MinIT.java
@@ -79,7 +79,7 @@ public class MinIT extends AbstractNumericTestCase {
 
     @Override
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(min("min").field("value"))
                 .execute().actionGet();
@@ -147,7 +147,7 @@ public class MinIT extends AbstractNumericTestCase {
 
     @Override
     public void testSingleValuedFieldPartiallyUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx", "idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx", "idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(min("min").field("value"))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
@@ -90,7 +90,7 @@ public class StatsIT extends AbstractNumericTestCase {
 
     @Override
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(stats("stats").field("value"))
                 .execute().actionGet();
@@ -113,7 +113,7 @@ public class StatsIT extends AbstractNumericTestCase {
         Stats s1 = client().prepareSearch("idx")
                 .addAggregation(stats("stats").field("value")).get()
                 .getAggregations().get("stats");
-        Stats s2 = client().prepareSearch("idx", "idx_unmapped")
+        Stats s2 = client().prepareSearch("idx", "idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(stats("stats").field("value")).get()
                 .getAggregations().get("stats");
         assertEquals(s1.getAvg(), s2.getAvg(), 1e-10);

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -83,7 +83,7 @@ public class SumIT extends AbstractNumericTestCase {
 
     @Override
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(sum("sum").field("value"))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
@@ -164,7 +164,7 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
 
     @Override
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentileRanks("percentile_ranks", new double[]{0, 10, 15, 100}))
                         .field("value"))

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
@@ -143,7 +143,7 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
 
     @Override
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(randomCompression(percentiles("percentiles"))
                         .field("value")

--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
@@ -78,7 +78,7 @@ public class ValueCountIT extends ESIntegTestCase {
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = client().prepareSearch("idx_unmapped")
+        SearchResponse searchResponse = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addAggregation(count("count").field("value"))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -531,7 +531,7 @@ public class BucketScriptIT extends ESIntegTestCase {
 
     public void testUnmapped() throws Exception {
         SearchResponse response = client()
-                .prepareSearch("idx_unmapped")
+                .prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(
                         histogram("histo")
                                 .field(FIELD_1_NAME)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketSelectorIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketSelectorIT.java
@@ -474,7 +474,7 @@ public class BucketSelectorIT extends ESIntegTestCase {
         Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME,
             "Double.isNaN(_value0) ? false : (_value0 + _value1 > 100)", Collections.emptyMap());
 
-        SearchResponse response = client().prepareSearch("idx_unmapped")
+        SearchResponse response = client().prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(
                         histogram("histo")
                                 .field(FIELD_1_NAME)

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DateDerivativeIT.java
@@ -464,7 +464,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
 
     public void testUnmapped() throws Exception {
         SearchResponse response = client()
-                .prepareSearch("idx_unmapped")
+                .prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(
                         dateHistogram("histo").field("date").dateHistogramInterval(DateHistogramInterval.MONTH).minDocCount(0)
                                 .subAggregation(derivative("deriv", "_count"))).execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeIT.java
@@ -341,7 +341,7 @@ public class DerivativeIT extends ESIntegTestCase {
 
     public void testUnmapped() throws Exception {
         SearchResponse response = client()
-                .prepareSearch("idx_unmapped")
+                .prepareSearch("idx_unmapped").setCheckFieldNames(false)
                 .addAggregation(
                         histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(interval)
                                 .subAggregation(derivative("deriv", "_count"))).execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/moving/avg/MovAvgIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/pipeline/moving/avg/MovAvgIT.java
@@ -763,7 +763,7 @@ public class MovAvgIT extends ESIntegTestCase {
     public void testNoBucketsInHistogram() {
 
         SearchResponse response = client()
-                .prepareSearch("idx").setTypes("type")
+                .prepareSearch("idx").setTypes("type").setCheckFieldNames(false)
                 .addAggregation(
                         histogram("histo").field("test").interval(interval)
                                 .subAggregation(randomMetric("the_metric", VALUE_FIELD))
@@ -785,7 +785,7 @@ public class MovAvgIT extends ESIntegTestCase {
     public void testNoBucketsInHistogramWithPredict() {
         int numPredictions = randomIntBetween(1,10);
         SearchResponse response = client()
-                .prepareSearch("idx").setTypes("type")
+                .prepareSearch("idx").setTypes("type").setCheckFieldNames(false)
                 .addAggregation(
                         histogram("histo").field("test").interval(interval)
                                 .subAggregation(randomMetric("the_metric", VALUE_FIELD))

--- a/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
+++ b/core/src/test/java/org/elasticsearch/search/nested/SimpleNestedIT.java
@@ -65,7 +65,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
         // check on no data, see it works
         SearchResponse searchResponse = client().prepareSearch("test").execute().actionGet();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
-        searchResponse = client().prepareSearch("test").setQuery(termQuery("n_field1", "n_value1_1")).execute().actionGet();
+        searchResponse = client().prepareSearch("test").setCheckFieldNames(false).setQuery(termQuery("n_field1", "n_value1_1")).execute().actionGet();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
@@ -90,13 +90,13 @@ public class SimpleNestedIT extends ESIntegTestCase {
         // check the numDocs
         assertDocumentCount("test", 3);
 
-        searchResponse = client().prepareSearch("test").setQuery(termQuery("n_field1", "n_value1_1")).execute().actionGet();
+        searchResponse = client().prepareSearch("test").setCheckFieldNames(false).setQuery(termQuery("n_field1", "n_value1_1")).execute().actionGet();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         // search for something that matches the nested doc, and see that we don't find the nested doc
         searchResponse = client().prepareSearch("test").setQuery(matchAllQuery()).get();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(1L));
-        searchResponse = client().prepareSearch("test").setQuery(termQuery("n_field1", "n_value1_1")).get();
+        searchResponse = client().prepareSearch("test").setCheckFieldNames(false).setQuery(termQuery("n_field1", "n_value1_1")).get();
         assertThat(searchResponse.getHits().getTotalHits(), equalTo(0L));
 
         // now, do a nested query

--- a/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
@@ -218,18 +218,18 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
     }
 
     public void testPhraseType() {
-        SearchResponse searchResponse = client().prepareSearch("test")
+        SearchResponse searchResponse = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(randomizeType(multiMatchQuery("Man the Ultimate", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase")
                         .operator(Operator.OR).type(MatchQuery.Type.PHRASE))).get();
         assertFirstHit(searchResponse, hasId("ultimate2"));
         assertHitCount(searchResponse, 1L);
 
-        searchResponse = client().prepareSearch("test")
+        searchResponse = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(randomizeType(multiMatchQuery("Captain", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase")
                         .operator(Operator.OR).type(MatchQuery.Type.PHRASE))).get();
         assertThat(searchResponse.getHits().getTotalHits(), greaterThan(1L));
 
-        searchResponse = client().prepareSearch("test")
+        searchResponse = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(randomizeType(multiMatchQuery("the Ul", "full_name_phrase", "first_name_phrase", "last_name_phrase", "category_phrase")
                         .operator(Operator.OR).type(MatchQuery.Type.PHRASE_PREFIX))).get();
         assertSearchHits(searchResponse, "ultimate2", "ultimate1");
@@ -237,12 +237,12 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
     }
 
     public void testSingleField() throws NoSuchFieldException, IllegalAccessException {
-        SearchResponse searchResponse = client().prepareSearch("test")
+        SearchResponse searchResponse = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(randomizeType(multiMatchQuery("15", "skill"))).get();
         assertNoFailures(searchResponse);
         assertFirstHit(searchResponse, hasId("theone"));
 
-        searchResponse = client().prepareSearch("test")
+        searchResponse = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(randomizeType(multiMatchQuery("15", "skill", "int-field")).analyzer("category")).get();
         assertNoFailures(searchResponse);
         assertFirstHit(searchResponse, hasId("theone"));
@@ -263,7 +263,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                 builder.append(RandomPicks.randomFrom(random(), query)).append(" ");
             }
             MultiMatchQueryBuilder multiMatchQueryBuilder = randomizeType(multiMatchQuery(builder.toString(), field));
-            SearchResponse multiMatchResp = client().prepareSearch("test")
+            SearchResponse multiMatchResp = client().prepareSearch("test").setCheckFieldNames(false)
                     // _id sort field is a tie, in case hits have the same score,
                     // the hits will be sorted the same consistently
                     .addSort("_score", SortOrder.DESC)
@@ -271,7 +271,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                     .setQuery(multiMatchQueryBuilder).get();
             MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery(field, builder.toString());
 
-            SearchResponse matchResp = client().prepareSearch("test")
+            SearchResponse matchResp = client().prepareSearch("test").setCheckFieldNames(false)
                     // _id tie sort
                     .addSort("_score", SortOrder.DESC)
                     .addSort("_id", SortOrder.ASC)

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -1176,7 +1176,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "2", "4");
 
-        searchResponse = client().prepareSearch("test")
+        searchResponse = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(termsLookupQuery("not_exists", new TermsLookup("lookup2", "type", "3", "arr.term"))).get();
         assertHitCount(searchResponse, 0L);
 

--- a/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -140,20 +140,20 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
         assertSearchHits(searchResponse, "3", "4");
 
         logger.info("--> query 2");
-        searchResponse = client().prepareSearch()
+        searchResponse = client().prepareSearch().setCheckFieldNames(false)
                 .setQuery(simpleQueryStringQuery("foo bar").field("body").field("body2").minimumShouldMatch("2")).get();
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "3", "4");
 
         // test case from #13884
         logger.info("--> query 3");
-                searchResponse = client().prepareSearch().setQuery(simpleQueryStringQuery("foo")
+                searchResponse = client().prepareSearch().setCheckFieldNames(false).setQuery(simpleQueryStringQuery("foo")
                         .field("body").field("body2").field("body3").minimumShouldMatch("-50%")).get();
                 assertHitCount(searchResponse, 3L);
                 assertSearchHits(searchResponse, "1", "3", "4");
 
         logger.info("--> query 4");
-        searchResponse = client().prepareSearch()
+        searchResponse = client().prepareSearch().setCheckFieldNames(false)
                 .setQuery(simpleQueryStringQuery("foo bar baz").field("body").field("body2").minimumShouldMatch("70%")).get();
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "3", "4");

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -899,7 +899,7 @@ public class FieldSortIT extends ESIntegTestCase {
 
         logger.info("--> sort with an unmapped field, verify it fails");
         try {
-            SearchResponse result = client().prepareSearch()
+            SearchResponse result = client().prepareSearch().setCheckFieldNames(false)
                     .setQuery(matchAllQuery())
                     .addSort(SortBuilders.fieldSort("kkk"))
                     .execute().actionGet();
@@ -911,7 +911,7 @@ public class FieldSortIT extends ESIntegTestCase {
             }
         }
 
-        SearchResponse searchResponse = client().prepareSearch()
+        SearchResponse searchResponse = client().prepareSearch().setCheckFieldNames(false)
                 .setQuery(matchAllQuery())
                 .addSort(SortBuilders.fieldSort("kkk").unmappedType("keyword"))
                 .execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderIT.java
@@ -339,7 +339,7 @@ public class GeoDistanceSortBuilderIT extends ESIntegTestCase {
                 client().prepareIndex("test1", "type").setSource("str_field", "bcd", "long_field", 3, "double_field", 0.65),
                 client().prepareIndex("test2", "type").setSource());
 
-        SearchResponse resp = client().prepareSearch("test1", "test2")
+        SearchResponse resp = client().prepareSearch("test1", "test2").setCheckFieldNames(false)
                 .addSort(fieldSort("str_field").order(SortOrder.ASC).unmappedType("keyword"))
                 .addSort(fieldSort("str_field2").order(SortOrder.DESC).unmappedType("keyword")).get();
 
@@ -347,14 +347,14 @@ public class GeoDistanceSortBuilderIT extends ESIntegTestCase {
                 new Object[] {"bcd", null},
                 new Object[] {null, null});
 
-        resp = client().prepareSearch("test1", "test2")
+        resp = client().prepareSearch("test1", "test2").setCheckFieldNames(false)
                 .addSort(fieldSort("long_field").order(SortOrder.ASC).unmappedType("long"))
                 .addSort(fieldSort("long_field2").order(SortOrder.DESC).unmappedType("long")).get();
         assertSortValues(resp,
                 new Object[] {3L, Long.MIN_VALUE},
                 new Object[] {Long.MAX_VALUE, Long.MIN_VALUE});
 
-        resp = client().prepareSearch("test1", "test2")
+        resp = client().prepareSearch("test1", "test2").setCheckFieldNames(false)
                 .addSort(fieldSort("double_field").order(SortOrder.ASC).unmappedType("double"))
                 .addSort(fieldSort("double_field2").order(SortOrder.DESC).unmappedType("double")).get();
         assertSortValues(resp,

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -101,9 +101,14 @@ And here is a sample response:
     reduce the memory overhead per search request if the potential  number of
     shards in the request can be large.
 
+`check_field_names`::
 
+    Set to true if field names passed in searches are to be checked against
+    index mappings. When true an error will be returned if it can be confirmed
+    that a provided field name is unmapped in all indices. Default to false.
+ 
 
-Out of the above, the `search_type` and the `request_cache` must be passed as
+Out of the above, the `search_type`, `check_field_names` and the `request_cache` must be passed as
 query-string parameters. The rest of the search request should be passed
 within the body itself. The body content can also be passed as a REST
 parameter named `source`.

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -103,9 +103,8 @@ And here is a sample response:
 
 `check_field_names`::
 
-    Set to true if field names passed in searches are to be checked against
-    index mappings. When true an error will be returned if it can be confirmed
-    that a provided field name is unmapped in all indices. Default to false.
+    If set to true can cause search to fail with an error if all searched indexes 
+    fail to find a field mapping. This is a best-efforts check. Defaults to false.
  
 
 Out of the above, the `search_type`, `check_field_names` and the `request_cache` must be passed as

--- a/docs/reference/search/uri-request.asciidoc
+++ b/docs/reference/search/uri-request.asciidoc
@@ -79,7 +79,7 @@ number of shards in the request can be large.
 |`lenient` |If set to true will cause format based failures (like
 providing text to a numeric field) to be ignored. Defaults to false.
 
-|`check_fieldnames` |If set to true can cause search to fail with an
+|`check_field_names` |If set to true can cause search to fail with an
 error if all searched indexes fail to find a field mapping. This is 
 a best-efforts check. Defaults to false.
 

--- a/docs/reference/search/uri-request.asciidoc
+++ b/docs/reference/search/uri-request.asciidoc
@@ -79,6 +79,11 @@ number of shards in the request can be large.
 |`lenient` |If set to true will cause format based failures (like
 providing text to a numeric field) to be ignored. Defaults to false.
 
+|`check_fieldnames` |If set to true can cause search to fail with an
+error if all searched indexes fail to find a field mapping. This is 
+a best-efforts check. Defaults to false.
+
+
 |`explain` |For each hit, contain an explanation of how scoring of the
 hits was computed.
 

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
@@ -826,7 +826,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         }
         ensureGreen();
 
-        SearchResponse response = client().prepareSearch("test")
+        SearchResponse response = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(hasChildQuery("child", matchQuery("text", "value"), ScoreMode.None)).get();
         assertNoFailures(response);
         assertThat(response.getHits().getTotalHits(), equalTo(0L));
@@ -839,7 +839,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
                 .setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         }
 
-        response = client().prepareSearch("test")
+        response = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(hasChildQuery("child", matchQuery("text", "value"), ScoreMode.None)).get();
         assertNoFailures(response);
         assertThat(response.getHits().getTotalHits(), equalTo(0L));
@@ -849,12 +849,13 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         assertNoFailures(response);
         assertThat(response.getHits().getTotalHits(), equalTo(0L));
 
-        response = client().prepareSearch("test")
+        response = client().prepareSearch("test").setCheckFieldNames(false)
             .setQuery(hasParentQuery("parent", matchQuery("text", "value"), false)).get();
         assertNoFailures(response);
         assertThat(response.getHits().getTotalHits(), equalTo(0L));
 
-        response = client().prepareSearch("test").setQuery(hasParentQuery("parent", matchQuery("text", "value"), true))
+        response = client().prepareSearch("test").setCheckFieldNames(false)
+                .setQuery(hasParentQuery("parent", matchQuery("text", "value"), true))
                 .get();
         assertNoFailures(response);
         assertThat(response.getHits().getTotalHits(), equalTo(0L));
@@ -1134,10 +1135,10 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
         SearchResponse response;
         if (legacy()){
-            response = client().prepareSearch("test").setQuery(termQuery("_parent#parent:p1", "p1"))
+            response = client().prepareSearch("test").setCheckFieldNames(false).setQuery(termQuery("_parent#parent:p1", "p1"))
                 .get();
         } else {
-            response = client().prepareSearch("test")
+            response = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(boolQuery().filter(termQuery("join_field#parent", "p1")).filter(termQuery("join_field", "child")))
                 .get();
         }
@@ -1147,35 +1148,36 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         refresh();
 
         if (legacy()){
-            response = client().prepareSearch("test").setQuery(termQuery("_parent#parent", "p1"))
+            response = client().prepareSearch("test").setCheckFieldNames(false).setQuery(termQuery("_parent#parent", "p1"))
                 .get();
         } else {
-            response = client().prepareSearch("test")
+            response = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(boolQuery().filter(termQuery("join_field#parent", "p1")).filter(termQuery("join_field", "child")))
                 .get();
         }
         assertHitCount(response, 1L);
 
         if (legacy()) {
-            response = client().prepareSearch("test").setQuery(queryStringQuery("_parent#parent:p1")).get();
+            response = client().prepareSearch("test").setCheckFieldNames(false)
+                    .setQuery(queryStringQuery("_parent#parent:p1")).get();
             assertHitCount(response, 1L);
         }
 
         createIndexRequest("test", "child", "c2", "p2").get();
         refresh();
         if (legacy()) {
-            response = client().prepareSearch("test").setQuery(termsQuery("_parent#parent", "p1", "p2")).get();
+            response = client().prepareSearch("test").setCheckFieldNames(false).setQuery(termsQuery("_parent#parent", "p1", "p2")).get();
             assertHitCount(response, 2L);
         }
 
         if (legacy()) {
-            response = client().prepareSearch("test")
+            response = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(boolQuery()
                     .should(termQuery("_parent#parent", "p1"))
                     .should(termQuery("_parent#parent", "p2"))
                 ).get();
         } else {
-            response = client().prepareSearch("test")
+            response = client().prepareSearch("test").setCheckFieldNames(false)
                 .setQuery(boolQuery()
                     .should(boolQuery().filter(termQuery("join_field#parent", "p1")).filter(termQuery("join_field", "child")))
                     .should(boolQuery().filter(termQuery("join_field#parent", "p2")).filter(termQuery("join_field", "child")))

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -93,6 +93,11 @@
           "type" : "number",
           "description" : "Number of hits to return (default: 10)"
         },
+        "check_fieldnames": {
+          "type" : "boolean",
+          "default": false,
+          "description" : "Specify whether globally unmapped fields should cause errors. Introduced in 6.1.0 default=false and 7.0.0 defaulted to true"
+        },
         "sort": {
           "type" : "list",
           "description" : "A comma-separated list of <field>:<direction> pairs"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -93,7 +93,7 @@
           "type" : "number",
           "description" : "Number of hits to return (default: 10)"
         },
-        "check_fieldnames": {
+        "check_field_names": {
           "type" : "boolean",
           "default": false,
           "description" : "Specify whether globally unmapped fields should cause errors. Introduced in 6.1.0 default=false and 7.0.0 defaulted to true"

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yml
@@ -99,11 +99,17 @@ setup:
       msearch:
         typed_keys: true                        
         body:
-          - { index: test-*, check_fieldnames: false}
+      # TODO reinstate this in master once backport to 6.x is backported
+#          - { index: test-*, check_fieldnames: false}
+          - { index: test-*}
           - {query: {match_all: {} }, size: 0, aggs: {test_sampler: {sampler: {shard_size: 200}, aggs: {test_significant_terms: {significant_terms: {field:  name} } } } } }
-          - { index: test-*, check_fieldnames: false}
+      # TODO reinstate this in master once backport to 6.x is backported
+#          - { index: test-*, check_fieldnames: false}
+          - { index: test-*}
           - {query: {match_all: {} }, size: 0, aggs: {test_umterms: {terms: {field: surname} } } }
-          - { index: test-*, check_fieldnames: false}
+      # TODO reinstate this in master once backport to 6.x is backported
+#          - { index: test-*, check_fieldnames: false}
+          - { index: test-*}
           - {query: {match_all: {} }, size: 0, aggs: {test_sterms: {terms: {field: name}, aggs: {test_umsignificant_terms: {significant_terms: {field:  surname} } } } } }
 
   - match:    { responses.0.hits.total: 5 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yml
@@ -100,15 +100,15 @@ setup:
         typed_keys: true                        
         body:
       # TODO reinstate this in master once backport to 6.x is backported
-#          - { index: test-*, check_fieldnames: false}
+#          - { index: test-*, check_field_names: false}
           - { index: test-*}
           - {query: {match_all: {} }, size: 0, aggs: {test_sampler: {sampler: {shard_size: 200}, aggs: {test_significant_terms: {significant_terms: {field:  name} } } } } }
       # TODO reinstate this in master once backport to 6.x is backported
-#          - { index: test-*, check_fieldnames: false}
+#          - { index: test-*, check_field_names: false}
           - { index: test-*}
           - {query: {match_all: {} }, size: 0, aggs: {test_umterms: {terms: {field: surname} } } }
       # TODO reinstate this in master once backport to 6.x is backported
-#          - { index: test-*, check_fieldnames: false}
+#          - { index: test-*, check_field_names: false}
           - { index: test-*}
           - {query: {match_all: {} }, size: 0, aggs: {test_sterms: {terms: {field: name}, aggs: {test_umsignificant_terms: {significant_terms: {field:  surname} } } } } }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/20_typed_keys.yml
@@ -97,13 +97,13 @@ setup:
 "Multisearch test with typed_keys parameter for sampler and significant terms":
   - do:
       msearch:
-        typed_keys: true
+        typed_keys: true                        
         body:
-          - index: test-*
+          - { index: test-*, check_fieldnames: false}
           - {query: {match_all: {} }, size: 0, aggs: {test_sampler: {sampler: {shard_size: 200}, aggs: {test_significant_terms: {significant_terms: {field:  name} } } } } }
-          - index: test-*
+          - { index: test-*, check_fieldnames: false}
           - {query: {match_all: {} }, size: 0, aggs: {test_umterms: {terms: {field: surname} } } }
-          - index: test-*
+          - { index: test-*, check_fieldnames: false}
           - {query: {match_all: {} }, size: 0, aggs: {test_sterms: {terms: {field: name}, aggs: {test_umsignificant_terms: {significant_terms: {field:  surname} } } } } }
 
   - match:    { responses.0.hits.total: 5 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -501,7 +501,7 @@ setup:
   - do:
       search:
       # TODO reinstate this in master once backport to 6.x is backported
-#        check_fieldnames: false
+#        check_field_names: false
         body: { "size" : 0, "aggs" : { "string_terms" : { "terms" : { "field" : "unmapped_string", "value_type" : "string", "missing": "abc" } } } }
 
   - match: { hits.total: 1 }
@@ -532,7 +532,7 @@ setup:
   - do:
       search:
       # TODO reinstate this in master once backport to 6.x is backported
-#        check_fieldnames: false
+#        check_field_names: false
         body: { "size" : 0, "aggs" : { "boolean_terms" : { "terms" : { "field" : "unmapped_boolean", "value_type" : "boolean", "missing": true } } } }
 
   - match: { hits.total: 1 }
@@ -565,7 +565,7 @@ setup:
   - do:
       search:
       # TODO reinstate this in master once backport to 6.x is backported
-#        check_fieldnames: false      
+#        check_field_names: false      
         body: { "size" : 0, "aggs" : { "date_terms" : { "terms" : { "field" : "unmapped_date", "value_type" : "date", "missing": "2016-05-11" } } } }
 
   - match: { hits.total: 1 }
@@ -598,7 +598,7 @@ setup:
   - do:
       search:
       # TODO reinstate this in master once backport to 6.x is backported
-#        check_fieldnames: false
+#        check_field_names: false
         body: { "size" : 0, "aggs" : { "long_terms" : { "terms" : { "field" : "unmapped_long", "value_type" : "long", "missing": 3 } } } }
 
   - match: { hits.total: 1 }
@@ -629,7 +629,7 @@ setup:
   - do:
       search:
       # TODO reinstate this in master once backport to 6.x is backported
-#        check_fieldnames: false
+#        check_field_names: false
         body: { "size" : 0, "aggs" : { "double_terms" : { "terms" : { "field" : "unmapped_double", "value_type" : "double", "missing": 3.5 } } } }
 
   - match: { hits.total: 1 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -500,7 +500,8 @@ setup:
 
   - do:
       search:
-        check_fieldnames: false
+      # TODO reinstate this in master once backport to 6.x is backported
+#        check_fieldnames: false
         body: { "size" : 0, "aggs" : { "string_terms" : { "terms" : { "field" : "unmapped_string", "value_type" : "string", "missing": "abc" } } } }
 
   - match: { hits.total: 1 }
@@ -530,7 +531,8 @@ setup:
 
   - do:
       search:
-        check_fieldnames: false
+      # TODO reinstate this in master once backport to 6.x is backported
+#        check_fieldnames: false
         body: { "size" : 0, "aggs" : { "boolean_terms" : { "terms" : { "field" : "unmapped_boolean", "value_type" : "boolean", "missing": true } } } }
 
   - match: { hits.total: 1 }
@@ -562,7 +564,8 @@ setup:
 
   - do:
       search:
-        check_fieldnames: false      
+      # TODO reinstate this in master once backport to 6.x is backported
+#        check_fieldnames: false      
         body: { "size" : 0, "aggs" : { "date_terms" : { "terms" : { "field" : "unmapped_date", "value_type" : "date", "missing": "2016-05-11" } } } }
 
   - match: { hits.total: 1 }
@@ -594,7 +597,8 @@ setup:
 
   - do:
       search:
-        check_fieldnames: false
+      # TODO reinstate this in master once backport to 6.x is backported
+#        check_fieldnames: false
         body: { "size" : 0, "aggs" : { "long_terms" : { "terms" : { "field" : "unmapped_long", "value_type" : "long", "missing": 3 } } } }
 
   - match: { hits.total: 1 }
@@ -624,7 +628,8 @@ setup:
 
   - do:
       search:
-        check_fieldnames: false
+      # TODO reinstate this in master once backport to 6.x is backported
+#        check_fieldnames: false
         body: { "size" : 0, "aggs" : { "double_terms" : { "terms" : { "field" : "unmapped_double", "value_type" : "double", "missing": 3.5 } } } }
 
   - match: { hits.total: 1 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/20_terms.yml
@@ -500,6 +500,7 @@ setup:
 
   - do:
       search:
+        check_fieldnames: false
         body: { "size" : 0, "aggs" : { "string_terms" : { "terms" : { "field" : "unmapped_string", "value_type" : "string", "missing": "abc" } } } }
 
   - match: { hits.total: 1 }
@@ -529,6 +530,7 @@ setup:
 
   - do:
       search:
+        check_fieldnames: false
         body: { "size" : 0, "aggs" : { "boolean_terms" : { "terms" : { "field" : "unmapped_boolean", "value_type" : "boolean", "missing": true } } } }
 
   - match: { hits.total: 1 }
@@ -560,6 +562,7 @@ setup:
 
   - do:
       search:
+        check_fieldnames: false      
         body: { "size" : 0, "aggs" : { "date_terms" : { "terms" : { "field" : "unmapped_date", "value_type" : "date", "missing": "2016-05-11" } } } }
 
   - match: { hits.total: 1 }
@@ -591,6 +594,7 @@ setup:
 
   - do:
       search:
+        check_fieldnames: false
         body: { "size" : 0, "aggs" : { "long_terms" : { "terms" : { "field" : "unmapped_long", "value_type" : "long", "missing": 3 } } } }
 
   - match: { hits.total: 1 }
@@ -620,6 +624,7 @@ setup:
 
   - do:
       search:
+        check_fieldnames: false
         body: { "size" : 0, "aggs" : { "double_terms" : { "terms" : { "field" : "unmapped_double", "value_type" : "double", "missing": 3.5 } } } }
 
   - match: { hits.total: 1 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
@@ -165,7 +165,9 @@ setup:
 ---
 "check_fieldnames is on but canMatch optimizes out crucial index":
   - skip:
-      version: " - 6.0.99"
+# TODO set this back to 6.0.99 once this master change is backported to 6.x
+      version: " - 6.1.99"
+#      version: " - 6.0.99"
       reason:  check_fieldnames was added in 6.1.0
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
@@ -163,12 +163,12 @@ setup:
 
 
 ---
-"check_fieldnames is on but canMatch optimizes out crucial index":
+"check_field_names is on but canMatch optimizes out crucial index":
   - skip:
 # TODO set this back to 6.0.99 once this master change is backported to 6.x
       version: " - 6.1.99"
 #      version: " - 6.0.99"
-      reason:  check_fieldnames was added in 6.1.0
+      reason:  check_field_names was added in 6.1.0
 
   - do:
       index:
@@ -194,7 +194,7 @@ setup:
 
   - do:
       search:
-        check_fieldnames: true
+        check_field_names: true
         pre_filter_shard_size: 1
         body: { "size" : 0, "query" : { "range" : { "created_at" : { "lte" : "2017-01-01"}}}, "aggs" : { "idx_terms" :  { "terms" : { "field" : "mostly_unmapped" } } } }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/140_pre_filter_search_shards.yml
@@ -32,6 +32,8 @@ setup:
             mappings:
               doc:
                 properties:
+                  mostly_unmapped:
+                     type: keyword
                   created_at:
                      type: date
                      format: "yyyy-MM-dd"
@@ -159,6 +161,47 @@ setup:
   - match: { hits.total: 2 }
   - length: { aggregations.idx_terms.buckets: 2 }
 
+
+---
+"check_fieldnames is on but canMatch optimizes out crucial index":
+  - skip:
+      version: " - 6.0.99"
+      reason:  check_fieldnames was added in 6.1.0
+
+  - do:
+      index:
+        index: index_1
+        type: doc
+        id: 1
+        body: { "created_at": "2016-01-01"}
+  - do:
+      index:
+        index: index_2
+        type: doc
+        id: 2
+        body: { "created_at": "2017-01-01" }
+
+  - do:
+      index:
+        index: index_3
+        type: doc
+        id: 3
+        body: { "created_at": "2018-01-01", "mostly_unmapped" : "foo"  }
+  - do:
+      indices.refresh: {}      
+
+  - do:
+      search:
+        check_fieldnames: true
+        pre_filter_shard_size: 1
+        body: { "size" : 0, "query" : { "range" : { "created_at" : { "lte" : "2017-01-01"}}}, "aggs" : { "idx_terms" :  { "terms" : { "field" : "mostly_unmapped" } } } }
+
+  - match: { _shards.total: 3 }
+  - match: { _shards.successful: 3 }
+  - match: { _shards.skipped : 1 }
+  - match: { _shards.failed: 0 }
+  - match: { hits.total: 2 }
+  - length: { aggregations.idx_terms.buckets: 0 }
 
 
 


### PR DESCRIPTION
New "strict" flag on search results defaults to true and forces throwing of errors when all indices fail to find a field mapping referenced in search requests.
This will mean existing user searches that work today may not work in future versions.
Implementation details:
* Each shard now records all failed fieldmapper lookups in a set of fieldnames in the QueryShardContext. QueryShardContext is cloned per request so this looks like a convenient place to stash this information
* Each shard now returns set of unmapped fieldnames in the QuerySearchResult
* Reducer node logic in SearchPhaseController now records if all shard results agree a fieldname is unmapped
* FetchSearchPhase will now fail if strict search mode is on and there are fieldnames unanimously agreed as unmapped
* New integration test for unmapped field validation: UnmappedFieldValidationIT
* Many integrations tests altered to setStrict(false) in order to preserve tests of unmapped aggs etc when no fieldname validation

Closes #26013