### PR TITLE
Epoch millis and second formats accept float implicitly

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -332,7 +332,7 @@ public class Joda {
         @Override
         public int parseInto(DateTimeParserBucket bucket, String text, int position) {
             boolean isPositive = text.startsWith("-") == false;
-            int firstDotIndex = text.indexOf((int)'.');
+            int firstDotIndex = text.indexOf('.');
             boolean isTooLong = (firstDotIndex == -1 ? text.length() : firstDotIndex) > estimateParsedLength();
 
             if (bucket.getZone() != DateTimeZone.UTC) {

--- a/core/src/main/java/org/elasticsearch/common/joda/Joda.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/Joda.java
@@ -42,6 +42,7 @@ import org.joda.time.format.StrictISODateTimeFormat;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.math.BigDecimal;
 import java.util.Locale;
 
 public class Joda {
@@ -331,7 +332,8 @@ public class Joda {
         @Override
         public int parseInto(DateTimeParserBucket bucket, String text, int position) {
             boolean isPositive = text.startsWith("-") == false;
-            boolean isTooLong = text.length() > estimateParsedLength();
+            int firstDotIndex = text.indexOf((int)'.');
+            boolean isTooLong = (firstDotIndex == -1 ? text.length() : firstDotIndex) > estimateParsedLength();
 
             if (bucket.getZone() != DateTimeZone.UTC) {
                 String format = hasMilliSecondPrecision ? "epoch_millis" : "epoch_second";
@@ -342,7 +344,7 @@ public class Joda {
 
             int factor = hasMilliSecondPrecision ? 1 : 1000;
             try {
-                long millis = Long.valueOf(text) * factor;
+                long millis = new BigDecimal(text).longValue() * factor;
                 DateTime dt = new DateTime(millis, DateTimeZone.UTC);
                 bucket.saveField(DateTimeFieldType.year(), dt.getYear());
                 bucket.saveField(DateTimeFieldType.monthOfYear(), dt.getMonthOfYear());

--- a/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
+++ b/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
@@ -260,26 +260,10 @@ public class SimpleJodaTests extends ESTestCase {
         } else {
             assertThat(dateTime.getMillisOfSecond(), is(0));
         }
-    }
 
-    public void testThatFloatEpochsCanBeParsed() {
-
-        long millisFromEpoch = randomNonNegativeLong();
-
-        String epochFloatValue = String.format(Locale.US, "%d.%d", millisFromEpoch, randomNonNegativeLong());
-        FormatDateTimeFormatter formatter = Joda.forPattern("epoch_millis");
-
-        DateTime dateTime = formatter.parser().parseDateTime(epochFloatValue);
-
-        assertEquals(dateTime.getMillis(), millisFromEpoch);
-
-
-        epochFloatValue = String.format(Locale.US, "%d.%d", millisFromEpoch / 1000, randomNonNegativeLong());
-        formatter = Joda.forPattern("epoch_second");
-
-        dateTime = formatter.parser().parseDateTime(epochFloatValue);
-
-        assertEquals(dateTime.getMillis(), millisFromEpoch / 1000 * 1000);
+        // test floats get truncated
+        String epochFloatValue = String.format(Locale.US, "%d.%d", dateTime.getMillis() / (parseMilliSeconds ? 1L : 1000L), randomNonNegativeLong());
+        assertThat(formatter.parser().parseDateTime(epochFloatValue).getMillis(), is(dateTime.getMillis()));
     }
 
     public void testThatNegativeEpochsCanBeParsed() {
@@ -301,16 +285,26 @@ public class SimpleJodaTests extends ESTestCase {
             assertThat(dateTime.getSecondOfMinute(), is(20));
         }
 
+        // test floats get truncated
+        String epochFloatValue = String.format(Locale.US, "%d.%d", dateTime.getMillis() / (parseMilliSeconds ? 1L : 1000L), randomNonNegativeLong());
+        assertThat(formatter.parser().parseDateTime(epochFloatValue).getMillis(), is(dateTime.getMillis()));
+
         // every negative epoch must be parsed, no matter if exact the size or bigger
         if (parseMilliSeconds) {
             formatter.parser().parseDateTime("-100000000");
             formatter.parser().parseDateTime("-999999999999");
             formatter.parser().parseDateTime("-1234567890123");
             formatter.parser().parseDateTime("-1234567890123456789");
+
+            formatter.parser().parseDateTime("-1234567890123.9999");
+            formatter.parser().parseDateTime("-1234567890123456789.9999");
         } else {
             formatter.parser().parseDateTime("-100000000");
             formatter.parser().parseDateTime("-1234567890");
             formatter.parser().parseDateTime("-1234567890123456");
+
+            formatter.parser().parseDateTime("-1234567890.9999");
+            formatter.parser().parseDateTime("-1234567890123456.9999");
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
+++ b/core/src/test/java/org/elasticsearch/deps/joda/SimpleJodaTests.java
@@ -262,6 +262,26 @@ public class SimpleJodaTests extends ESTestCase {
         }
     }
 
+    public void testThatFloatEpochsCanBeParsed() {
+
+        long millisFromEpoch = randomNonNegativeLong();
+
+        String epochFloatValue = String.format(Locale.US, "%d.%d", millisFromEpoch, randomNonNegativeLong());
+        FormatDateTimeFormatter formatter = Joda.forPattern("epoch_millis");
+
+        DateTime dateTime = formatter.parser().parseDateTime(epochFloatValue);
+
+        assertEquals(dateTime.getMillis(), millisFromEpoch);
+
+
+        epochFloatValue = String.format(Locale.US, "%d.%d", millisFromEpoch / 1000, randomNonNegativeLong());
+        formatter = Joda.forPattern("epoch_second");
+
+        dateTime = formatter.parser().parseDateTime(epochFloatValue);
+
+        assertEquals(dateTime.getMillis(), millisFromEpoch / 1000 * 1000);
+    }
+
     public void testThatNegativeEpochsCanBeParsed() {
         // problem: negative epochs can be arbitrary in size...
         boolean parseMilliSeconds = randomBoolean();

--- a/core/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
@@ -212,6 +213,32 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
         assertEquals(2, fields.length);
         IndexableField pointField = fields[0];
         assertEquals(1457654400000L, pointField.numericValue().longValue());
+    }
+
+    public void testFloatEpochFormat() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "date")
+                .field("format", "epoch_millis").endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        long millisFromEpoch = randomNonNegativeLong();
+        String epochFloatValue = String.format(Locale.US, "%d.%d", millisFromEpoch, randomNonNegativeLong());
+
+        ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", epochFloatValue)
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(millisFromEpoch, pointField.numericValue().longValue());
     }
 
     public void testChangeLocale() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -225,8 +225,8 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
 
         assertEquals(mapping, mapper.mappingSource().toString());
 
-        long millisFromEpoch = randomNonNegativeLong();
-        String epochFloatValue = String.format(Locale.US, "%d.%d", millisFromEpoch, randomNonNegativeLong());
+        double epochFloatMillisFromEpoch = (randomDouble() * 2 - 1) * 1000000;
+        String epochFloatValue = String.format(Locale.US, "%f", epochFloatMillisFromEpoch);
 
         ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()
@@ -238,7 +238,7 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(2, fields.length);
         IndexableField pointField = fields[0];
-        assertEquals(millisFromEpoch, pointField.numericValue().longValue());
+        assertEquals((long)epochFloatMillisFromEpoch, pointField.numericValue().longValue());
     }
 
     public void testChangeLocale() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -245,6 +245,11 @@ public class RangeFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         IndexableField pointField = fields[1];
         assertEquals(2, pointField.fieldType().pointDimensionCount());
 
+        // date_range ignores the coerce parameter and epoch_millis date format truncates floats (see issue: #14641)
+        if (type.equals("date_range")) {
+            return;
+        }
+
         mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
             .startObject("properties").startObject("field").field("type", type).field("coerce", false).endObject().endObject()
             .endObject().endObject();

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -1699,11 +1699,15 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertAcked(client().admin().indices().preparePutMapping("test").setType("type").setSource("field", "type=date,format=epoch_millis").get());
         indexRandom(true, client().prepareIndex("test", "type", "1").setSource("field", -1000000000001L),
                 client().prepareIndex("test", "type", "2").setSource("field", -1000000000000L),
-                client().prepareIndex("test", "type", "3").setSource("field", -999999999999L));
+                client().prepareIndex("test", "type", "3").setSource("field", -999999999999L),
+                client().prepareIndex("test", "type", "4").setSource("field", -1000000000001.0123456789),
+                client().prepareIndex("test", "type", "5").setSource("field", -1000000000000.0123456789),
+                client().prepareIndex("test", "type", "6").setSource("field", -999999999999.0123456789));
 
 
-        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(rangeQuery("field").lte(-1000000000000L)).get(), 2);
-        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(rangeQuery("field").lte(-999999999999L)).get(), 3);
+        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(rangeQuery("field").lte(-1000000000000L)).get(), 4);
+        assertHitCount(client().prepareSearch("test").setSize(0).setQuery(rangeQuery("field").lte(-999999999999L)).get(), 6);
+
     }
 
     public void testRangeQueryWithTimeZone() throws Exception {


### PR DESCRIPTION
All floats parsed by epoch_millis/second date formatter get truncated, either as strings or as numbers - coerce behavior. This builds on the existing behavior of parsing all dates to strings.
In this way there is no 'coerce parameter' for the DateFieldMapper. 'Coerce parameter' remains valid only for numeric data types.
The coerce behavior is implicitly enabled for a specific Formatter only, i.e. epoch_*.
A coerce parameter at the DateFieldMapper level cannot be defined irrespective of the date format because of conflicts, e.g. basic_time and epoch_second as float.

Closes: #14641