### PR TITLE
Settings: Add keystore creation to add commands

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/AddFileKeyStoreCommand.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AddFileKeyStoreCommand.java
@@ -61,10 +61,17 @@ class AddFileKeyStoreCommand extends EnvironmentAwareCommand {
     protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
         KeyStoreWrapper keystore = KeyStoreWrapper.load(env.configFile());
         if (keystore == null) {
-            throw new UserException(ExitCodes.DATA_ERROR, "Elasticsearch keystore not found. Use 'create' command to create one.");
+            if (options.has(forceOption) == false &&
+                terminal.promptYesNo("The elasticsearch keystore does not exist. Do you want to create it?", false) == false) {
+                terminal.println("Exiting without creating keystore.");
+                return;
+            }
+            keystore = KeyStoreWrapper.create(new char[0] /* always use empty passphrase for auto created keystore */);
+            keystore.save(env.configFile());
+            terminal.println("Created elasticsearch keystore in " + env.configFile());
+        } else {
+            keystore.decrypt(new char[0] /* TODO: prompt for password when they are supported */);
         }
-
-        keystore.decrypt(new char[0] /* TODO: prompt for password when they are supported */);
 
         List<String> argumentValues = arguments.values(options);
         if (argumentValues.size() == 0) {

--- a/core/src/test/java/org/elasticsearch/common/settings/AddFileKeyStoreCommandTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/AddFileKeyStoreCommandTests.java
@@ -59,10 +59,24 @@ public class AddFileKeyStoreCommandTests extends KeyStoreCommandTestCase {
         keystore.save(env.configFile());
     }
 
-    public void testMissing() throws Exception {
-        UserException e = expectThrows(UserException.class, this::execute);
-        assertEquals(ExitCodes.DATA_ERROR, e.exitCode);
-        assertThat(e.getMessage(), containsString("keystore not found"));
+    public void testMissingPromptCreate() throws Exception {
+        Path file1 = createRandomFile();
+        terminal.addTextInput("y");
+        execute("foo", file1.toString());
+        assertSecureFile("foo", file1);
+    }
+
+    public void testMissingForceCreate() throws Exception {
+        Path file1 = createRandomFile();
+        terminal.addSecretInput("bar");
+        execute("-f", "foo", file1.toString());
+        assertSecureFile("foo", file1);
+    }
+
+    public void testMissingNoCreate() throws Exception {
+        terminal.addTextInput("n"); // explicit no
+        execute("foo");
+        assertNull(KeyStoreWrapper.load(env.configFile()));
     }
 
     public void testOverwritePromptDefault() throws Exception {

--- a/core/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/AddStringKeyStoreCommandTests.java
@@ -49,10 +49,23 @@ public class AddStringKeyStoreCommandTests extends KeyStoreCommandTestCase {
         };
     }
 
-    public void testMissing() throws Exception {
-        UserException e = expectThrows(UserException.class, this::execute);
-        assertEquals(ExitCodes.DATA_ERROR, e.exitCode);
-        assertThat(e.getMessage(), containsString("keystore not found"));
+    public void testMissingPromptCreate() throws Exception {
+        terminal.addTextInput("y");
+        terminal.addSecretInput("bar");
+        execute("foo");
+        assertSecureString("foo", "bar");
+    }
+
+    public void testMissingForceCreate() throws Exception {
+        terminal.addSecretInput("bar");
+        execute("-f", "foo");
+        assertSecureString("foo", "bar");
+    }
+
+    public void testMissingNoCreate() throws Exception {
+        terminal.addTextInput("n"); // explicit no
+        execute("foo");
+        assertNull(KeyStoreWrapper.load(env.configFile()));
     }
 
     public void testOverwritePromptDefault() throws Exception {


### PR DESCRIPTION
This commits changes the keystore cli add commands to prompt for
creating the keystore if it does not exist. This will make it easier on
users starting out, not having to run a separate command for creation.