### PR TITLE
Fix serialization of the `_all` field.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/AllFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/AllFieldMapper.java
@@ -273,6 +273,9 @@ public class AllFieldMapper extends MetadataFieldMapper {
         if (includeDefaults || enabledState != Defaults.ENABLED) {
             builder.field("enabled", enabledState.enabled);
         }
+        if (enabled() == false) {
+            return;
+        }
         if (includeDefaults || fieldType().stored() != Defaults.FIELD_TYPE.stored()) {
             builder.field("store", fieldType().stored());
         }

--- a/core/src/test/java/org/elasticsearch/index/mapper/AllFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/AllFieldMapperTests.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.mapper.MapperService.MergeReason;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+public class AllFieldMapperTests extends ESSingleNodeTestCase {
+
+    public void testUpdateDefaultSearchAnalyzer() throws Exception {
+        IndexService indexService = createIndex("test", Settings.builder()
+                .put("index.analysis.analyzer.default_search.type", "custom")
+                .put("index.analysis.analyzer.default_search.tokenizer", "standard").build());
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("doc").endObject().endObject().string();
+        indexService.mapperService().merge("doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+        assertEquals(mapping, indexService.mapperService().documentMapper("doc").mapping().toString());
+    }
+
+}


### PR DESCRIPTION
By default we only serialize analyzers if the index analyzer is not the
`default` analyzer or if the `search_analyzer` is different from the index
`analyzer`. This raises issues with the `_all` field when the
`index.analysis.analyzer.default_search` is set, since it automatically makes
the `search_analyzer` different from the index `analyzer`. Then there are
exceptions since we expect the `_all` configuration to be empty on 6.0 indices.

Closes #26136