### PR TITLE
Fix incorrect class name in deleteByQuery docs

### DIFF
--- a/docs/java-api/docs/delete.asciidoc
+++ b/docs/java-api/docs/delete.asciidoc
@@ -65,9 +65,9 @@ and provide a listener like:
 DeleteByQueryAction.INSTANCE.newRequestBuilder(client)
     .filter(QueryBuilders.matchQuery("gender", "male"))                  <1>
     .source("persons")                                                   <2>
-    .execute(new ActionListener<BulkIndexByScrollResponse>() {           <3>
+    .execute(new ActionListener<BulkByScrollResponse>() {           <3>
         @Override
-        public void onResponse(BulkIndexByScrollResponse response) {
+        public void onResponse(BulkByScrollResponse response) {
             long deleted = response.getDeleted();                        <4>
         }
         @Override


### PR DESCRIPTION
I did not find BulkIndexByScrollResponse in the source code and returned BulkByScrollResponse in the action:newResponse method