### PR TITLE
Update getting-started.asciidoc

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -654,7 +654,7 @@ You can download the sample dataset (accounts.json) from https://github.com/elas
 
 [source,sh]
 --------------------------------------------------
-curl -H "Content-Type: application/json" -XPOST 'localhost:9200/bank/account/_bulk?pretty&refresh' --data-binary "@accounts.json"
+curl -XPUT "http://localhost:9200/bank/account/_bulk?pretty&refresh" -H 'Content-Type: application/json'
 curl 'localhost:9200/_cat/indices?v'
 --------------------------------------------------
 // NOTCONSOLE


### PR DESCRIPTION
Pasting this command in Kibana - curl -H "Content-Type: application/json" -XPOST 'localhost:9200/bank/account/_bulk?pretty&refresh' --data-binary "@accounts.json"
Gives - POST /json -binary @accounts.json and Error - {  "error": "Content-Type header [text/plain] is not supported",   "status": 406 }

Mainly because it is not mentioned explicitly, which directory is  "our current directory" referring to.

I may be wrong, since I've just started using this, but why not simply ask the reader to use - curl -XPUT "http://localhost:9200/bank/account/_bulk?pretty&refresh" -H 'Content-Type: application/json' and paste the content from Account.json?

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
