### PR TITLE
Remove unused Netty-related settings

### DIFF
--- a/docs/reference/migration/migrate_6_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_6_0/settings.asciidoc
@@ -66,8 +66,9 @@ As a consequence, the `network.tcp.blocking_server`, `network.tcp.blocking_clien
 `network.tcp.blocking`,`transport.tcp.blocking_client`, `transport.tcp.blocking_server`,
 and `http.tcp.blocking_server` settings are not recognized anymore.
 
-The previously unused settings `transport.netty.max_cumulation_buffer_capacity` and
-`transport.netty.max_composite_buffer_components` have been removed.
+The previously unused settings `transport.netty.max_cumulation_buffer_capacity`,
+`transport.netty.max_composite_buffer_components` and
+`http.netty.max_cumulation_buffer_capacity` have been removed.
 
 ==== Similarity settings
 

--- a/docs/reference/migration/migrate_6_0/settings.asciidoc
+++ b/docs/reference/migration/migrate_6_0/settings.asciidoc
@@ -66,6 +66,9 @@ As a consequence, the `network.tcp.blocking_server`, `network.tcp.blocking_clien
 `network.tcp.blocking`,`transport.tcp.blocking_client`, `transport.tcp.blocking_server`,
 and `http.tcp.blocking_server` settings are not recognized anymore.
 
+The previously unused settings `transport.netty.max_cumulation_buffer_capacity` and
+`transport.netty.max_composite_buffer_components` have been removed.
+
 ==== Similarity settings
 
 The `base` similarity is now ignored as coords and query normalization have

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -118,8 +118,6 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
         Netty4Utils.setup();
     }
 
-    public static Setting<ByteSizeValue> SETTING_HTTP_NETTY_MAX_CUMULATION_BUFFER_CAPACITY =
-        Setting.byteSizeSetting("http.netty.max_cumulation_buffer_capacity", new ByteSizeValue(-1), Property.NodeScope);
     public static Setting<Integer> SETTING_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS =
         Setting.intSetting("http.netty.max_composite_buffer_components", -1, Property.NodeScope);
 
@@ -187,7 +185,6 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
     protected final ByteSizeValue tcpReceiveBufferSize;
     protected final RecvByteBufAllocator recvByteBufAllocator;
 
-    protected final ByteSizeValue maxCumulationBufferCapacity;
     protected final int maxCompositeBufferComponents;
     private final Dispatcher dispatcher;
 
@@ -218,7 +215,6 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
         this.maxHeaderSize = SETTING_HTTP_MAX_HEADER_SIZE.get(settings);
         this.maxInitialLineLength = SETTING_HTTP_MAX_INITIAL_LINE_LENGTH.get(settings);
         this.resetCookies = SETTING_HTTP_RESET_COOKIES.get(settings);
-        this.maxCumulationBufferCapacity = SETTING_HTTP_NETTY_MAX_CUMULATION_BUFFER_CAPACITY.get(settings);
         this.maxCompositeBufferComponents = SETTING_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS.get(settings);
         this.workerCount = SETTING_HTTP_WORKER_COUNT.get(settings);
         this.port = SETTING_HTTP_PORT.get(settings);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
@@ -65,8 +65,6 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
             Netty4HttpServerTransport.SETTING_HTTP_NETTY_RECEIVE_PREDICTOR_MIN,
             Netty4HttpServerTransport.SETTING_HTTP_NETTY_RECEIVE_PREDICTOR_MAX,
             Netty4Transport.WORKER_COUNT,
-            Netty4Transport.NETTY_MAX_CUMULATION_BUFFER_CAPACITY,
-            Netty4Transport.NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS,
             Netty4Transport.NETTY_RECEIVE_PREDICTOR_SIZE,
             Netty4Transport.NETTY_RECEIVE_PREDICTOR_MIN,
             Netty4Transport.NETTY_RECEIVE_PREDICTOR_MAX,

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/Netty4Plugin.java
@@ -53,7 +53,6 @@ public class Netty4Plugin extends Plugin implements NetworkPlugin {
     @Override
     public List<Setting<?>> getSettings() {
         return Arrays.asList(
-            Netty4HttpServerTransport.SETTING_HTTP_NETTY_MAX_CUMULATION_BUFFER_CAPACITY,
             Netty4HttpServerTransport.SETTING_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS,
             Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT,
             Netty4HttpServerTransport.SETTING_HTTP_TCP_NO_DELAY,

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -96,11 +96,6 @@ public class Netty4Transport extends TcpTransport<Channel> {
             (s) -> Integer.toString(EsExecutors.numberOfProcessors(s) * 2),
             (s) -> Setting.parseInt(s, 1, "transport.netty.worker_count"), Property.NodeScope);
 
-    public static final Setting<ByteSizeValue> NETTY_MAX_CUMULATION_BUFFER_CAPACITY =
-        Setting.byteSizeSetting("transport.netty.max_cumulation_buffer_capacity", new ByteSizeValue(-1), Property.NodeScope);
-    public static final Setting<Integer> NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS =
-        Setting.intSetting("transport.netty.max_composite_buffer_components", -1, -1, Property.NodeScope);
-
     public static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_SIZE = Setting.byteSizeSetting(
             "transport.netty.receive_predictor_size", new ByteSizeValue(64, ByteSizeUnit.KB), Property.NodeScope);
     public static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_MIN =
@@ -111,8 +106,6 @@ public class Netty4Transport extends TcpTransport<Channel> {
         intSetting("transport.netty.boss_count", 1, 1, Property.NodeScope);
 
 
-    protected final ByteSizeValue maxCumulationBufferCapacity;
-    protected final int maxCompositeBufferComponents;
     protected final RecvByteBufAllocator recvByteBufAllocator;
     protected final int workerCount;
     protected final ByteSizeValue receivePredictorMin;
@@ -127,8 +120,6 @@ public class Netty4Transport extends TcpTransport<Channel> {
         super("netty", settings, threadPool, bigArrays, circuitBreakerService, namedWriteableRegistry, networkService);
         Netty4Utils.setAvailableProcessors(EsExecutors.PROCESSORS_SETTING.get(settings));
         this.workerCount = WORKER_COUNT.get(settings);
-        this.maxCumulationBufferCapacity = NETTY_MAX_CUMULATION_BUFFER_CAPACITY.get(settings);
-        this.maxCompositeBufferComponents = NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS.get(settings);
 
         // See AdaptiveReceiveBufferSizePredictor#DEFAULT_XXX for default values in netty..., we can use higher ones for us, even fixed one
         this.receivePredictorMin = NETTY_RECEIVE_PREDICTOR_MIN.get(settings);


### PR DESCRIPTION
With this commit we remove the three previously unused Netty 4 related settings
`transport.netty.max_cumulation_buffer_capacity`,
`transport.netty.max_composite_buffer_components` and
`http.netty.max_cumulation_buffer_capacity`  from Elasticsearch.

As this is a breaking change (we remove settings), I'd like to get this in for 6.0, otherwise we need to keep them around until 7.0. However, as they were unused (and undocumented) previously I think the risk is low.