### PR TITLE
Remove Sort enum from Painless Definition

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/AnalyzerCaster.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/AnalyzerCaster.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless;
 
 import org.elasticsearch.painless.Definition.Cast;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 
 import java.util.Objects;
@@ -60,731 +59,430 @@ public final class AnalyzerCaster {
             return null;
         }
 
-        switch (actual.sort) {
-            case BOOL:
-                switch (expected.sort) {
-                    case DEF:
-                        return new Cast(BOOLEAN_OBJ_TYPE, DEF_TYPE, explicit, null, null, BOOLEAN_TYPE, null);
-                    case OBJECT:
-                        if (OBJECT_TYPE.equals(expected) && internal)
-                            return new Cast(BOOLEAN_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, BOOLEAN_TYPE, null);
-
-                        break;
-                    case BOOL_OBJ:
-                        if (internal)
-                            return new Cast(BOOLEAN_TYPE, BOOLEAN_TYPE, explicit, null, null, null, BOOLEAN_TYPE);
-                }
-
-                break;
-            case BYTE:
-                switch (expected.sort) {
-                    case SHORT:
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                        return new Cast(BYTE_TYPE, expected, explicit);
-                    case CHAR:
-                        if (explicit)
-                            return new Cast(BYTE_TYPE, CHAR_TYPE, true);
-
-                        break;
-                    case DEF:
-                        return new Cast(BYTE_OBJ_TYPE, DEF_TYPE, explicit, null, null, BYTE_TYPE, null);
-                    case OBJECT:
-                        if (OBJECT_TYPE.equals(expected) && internal)
-                            return new Cast(BYTE_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, BYTE_TYPE, null);
-
-                        break;
-                    case NUMBER:
-                        if (internal)
-                            return new Cast(BYTE_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, BYTE_TYPE, null);
-
-                        break;
-                    case BYTE_OBJ:
-                        if (internal)
-                            return new Cast(BYTE_TYPE, BYTE_TYPE, explicit, null, null, null, BYTE_TYPE);
-
-                        break;
-                    case SHORT_OBJ:
-                        if (internal)
-                            return new Cast(BYTE_TYPE, SHORT_TYPE, explicit, null, null, null, SHORT_TYPE);
-
-                        break;
-                    case INT_OBJ:
-                        if (internal)
-                            return new Cast(BYTE_TYPE, INT_TYPE, explicit, null, null, null, INT_TYPE);
-
-                        break;
-                    case LONG_OBJ:
-                        if (internal)
-                            return new Cast(BYTE_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
-
-                        break;
-                    case FLOAT_OBJ:
-                        if (internal)
-                            return new Cast(BYTE_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
-
-                        break;
-                    case DOUBLE_OBJ:
-                        if (internal)
-                            return new Cast(BYTE_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
-
-                        break;
-                    case CHAR_OBJ:
-                        if (explicit && internal)
-                            return new Cast(BYTE_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
-
-                        break;
-                }
-
-                break;
-            case SHORT:
-                switch (expected.sort) {
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                        return new Cast(SHORT_TYPE, expected, explicit);
-                    case BYTE:
-                    case CHAR:
-                        if (explicit)
-                            return new Cast(SHORT_TYPE, expected, true);
-
-                        break;
-                    case DEF:
-                        return new Cast(SHORT_OBJ_TYPE, DEF_TYPE, explicit, null, null, SHORT_TYPE, null);
-                    case OBJECT:
-                        if (OBJECT_TYPE.equals(expected) && internal)
-                            return new Cast(SHORT_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, SHORT_TYPE, null);
-
-                        break;
-                    case NUMBER:
-                        if (internal)
-                            return new Cast(SHORT_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, SHORT_TYPE, null);
-
-                        break;
-                    case SHORT_OBJ:
-                        if (internal)
-                            return new Cast(SHORT_TYPE, SHORT_TYPE, explicit, null, null, null, SHORT_TYPE);
-
-                        break;
-                    case INT_OBJ:
-                        if (internal)
-                            return new Cast(SHORT_TYPE, INT_TYPE, explicit, null, null, null, INT_TYPE);
-
-                        break;
-                    case LONG_OBJ:
-                        if (internal)
-                            return new Cast(SHORT_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
-
-                        break;
-                    case FLOAT_OBJ:
-                        if (internal)
-                            return new Cast(SHORT_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
-
-                        break;
-                    case DOUBLE_OBJ:
-                        if (internal)
-                            return new Cast(SHORT_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
-
-                        break;
-                    case BYTE_OBJ:
-                        if (explicit && internal)
-                            return new Cast(SHORT_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
-
-                        break;
-                    case CHAR_OBJ:
-                        if (explicit && internal)
-                            return new Cast(SHORT_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
-
-                        break;
-                }
-
-                break;
-            case CHAR:
-                switch (expected.sort) {
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                        return new Cast(CHAR_TYPE, expected, explicit);
-                    case BYTE:
-                    case SHORT:
-                        if (explicit)
-                            return new Cast(actual, expected, true);
-
-                        break;
-                    case DEF:
-                        return new Cast(CHAR_OBJ_TYPE, DEF_TYPE, explicit, null, null, CHAR_TYPE, null);
-                    case OBJECT:
-                        if (OBJECT_TYPE.equals(expected) && internal)
-                            return new Cast(CHAR_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, CHAR_TYPE, null);
-
-                        break;
-                    case NUMBER:
-                        if (internal)
-                            return new Cast(CHAR_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, CHAR_TYPE, null);
-
-                        break;
-                    case CHAR_OBJ:
-                        if (internal)
-                            return new Cast(CHAR_TYPE, CHAR_TYPE, explicit, null, null, null, CHAR_TYPE);
-
-                        break;
-                    case STRING:
-                        return new Cast(CHAR_TYPE, STRING_TYPE, explicit);
-                    case INT_OBJ:
-                        if (internal)
-                            return new Cast(CHAR_TYPE, INT_TYPE, explicit, null, null, null, INT_TYPE);
-
-                        break;
-                    case LONG_OBJ:
-                        if (internal)
-                            return new Cast(CHAR_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
-
-                        break;
-                    case FLOAT_OBJ:
-                        if (internal)
-                            return new Cast(CHAR_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
-
-                        break;
-                    case DOUBLE_OBJ:
-                        if (internal)
-                            return new Cast(CHAR_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
-
-                        break;
-                    case BYTE_OBJ:
-                        if (explicit && internal)
-                            return new Cast(CHAR_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
-
-                        break;
-                    case SHORT_OBJ:
-                        if (explicit && internal)
-                            return new Cast(CHAR_TYPE, SHORT_TYPE, true, null, null, null, SHORT_TYPE);
-
-                        break;
-                }
-
-                break;
-            case INT:
-                switch (expected.sort) {
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                        return new Cast(INT_TYPE, expected, explicit);
-                    case BYTE:
-                    case SHORT:
-                    case CHAR:
-                        if (explicit)
-                            return new Cast(INT_TYPE, expected, true);
-
-                        break;
-                    case DEF:
-                        return new Cast(INT_OBJ_TYPE, DEF_TYPE, explicit, null, null, INT_TYPE, null);
-                    case OBJECT:
-                        if (OBJECT_TYPE.equals(expected) && internal)
-                            return new Cast(INT_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, INT_TYPE, null);
-
-                        break;
-                    case NUMBER:
-                        if (internal)
-                            return new Cast(INT_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, INT_TYPE, null);
-
-                        break;
-                    case INT_OBJ:
-                        if (internal)
-                            return new Cast(INT_TYPE, INT_TYPE, explicit, null, null, null, INT_TYPE);
-
-                        break;
-                    case LONG_OBJ:
-                        if (internal)
-                            return new Cast(INT_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
-
-                        break;
-                    case FLOAT_OBJ:
-                        if (internal)
-                            return new Cast(INT_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
-
-                        break;
-                    case DOUBLE_OBJ:
-                        if (internal)
-                            return new Cast(INT_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
-
-                        break;
-                    case BYTE_OBJ:
-                        if (explicit && internal)
-                            return new Cast(INT_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
-
-                        break;
-                    case SHORT_OBJ:
-                        if (explicit && internal)
-                            return new Cast(INT_TYPE, SHORT_TYPE, true, null, null, null, SHORT_TYPE);
-
-                        break;
-                    case CHAR_OBJ:
-                        if (explicit && internal)
-                            return new Cast(INT_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
-
-                        break;
-                }
-
-                break;
-            case LONG:
-                switch (expected.sort) {
-                    case FLOAT:
-                    case DOUBLE:
-                        return new Cast(LONG_TYPE, expected, explicit);
-                    case BYTE:
-                    case SHORT:
-                    case CHAR:
-                    case INT:
-                        if (explicit)
-                            return new Cast(actual, expected, true);
-
-                        break;
-                    case DEF:
-                        return new Cast(LONG_TYPE, DEF_TYPE, explicit, null, null, LONG_TYPE, null);
-                    case OBJECT:
-                        if (OBJECT_TYPE.equals(expected) && internal)
-                            return new Cast(LONG_TYPE, actual, explicit, null, null, LONG_TYPE, null);
-
-                        break;
-                    case NUMBER:
-                        if (internal)
-                            return new Cast(LONG_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, LONG_TYPE, null);
-
-                        break;
-                    case LONG_OBJ:
-                        if (internal)
-                            return new Cast(LONG_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
-
-                        break;
-                    case FLOAT_OBJ:
-                        if (internal)
-                            return new Cast(LONG_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
-
-                        break;
-                    case DOUBLE_OBJ:
-                        if (internal)
-                            return new Cast(LONG_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
-
-                        break;
-                    case BYTE_OBJ:
-                        if (explicit && internal)
-                            return new Cast(LONG_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
-
-                        break;
-                    case SHORT_OBJ:
-                        if (explicit && internal)
-                            return new Cast(LONG_TYPE, SHORT_TYPE, true, null, null, null, SHORT_TYPE);
-
-                        break;
-                    case CHAR_OBJ:
-                        if (explicit && internal)
-                            return new Cast(LONG_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
-
-                        break;
-                    case INT_OBJ:
-                        if (explicit && internal)
-                            return new Cast(LONG_TYPE, INT_TYPE, true, null, null, null, INT_TYPE);
-
-                        break;
-                }
-
-                break;
-            case FLOAT:
-                switch (expected.sort) {
-                    case DOUBLE:
-                        return new Cast(actual, expected, explicit);
-                    case BYTE:
-                    case SHORT:
-                    case CHAR:
-                    case INT:
-                    case LONG:
-                        if (explicit)
-                            return new Cast(actual, expected, true);
-
-                        break;
-                    case DEF:
-                        return new Cast(FLOAT_OBJ_TYPE, DEF_TYPE, explicit, null, null, FLOAT_TYPE, null);
-                    case OBJECT:
-                        if (OBJECT_TYPE.equals(expected) && internal)
-                            return new Cast(FLOAT_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, FLOAT_TYPE, null);
-
-                        break;
-                    case NUMBER:
-                        if (internal)
-                            return new Cast(FLOAT_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, FLOAT_TYPE, null);
-
-                        break;
-                    case FLOAT_OBJ:
-                        if (internal)
-                            return new Cast(FLOAT_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
-
-                        break;
-                    case DOUBLE_OBJ:
-                        if (internal)
-                            return new Cast(FLOAT_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
-
-                        break;
-                    case BYTE_OBJ:
-                        if (explicit && internal)
-                            return new Cast(FLOAT_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
-
-                        break;
-                    case SHORT_OBJ:
-                        if (explicit && internal)
-                            return new Cast(FLOAT_TYPE, SHORT_TYPE, true, null, null, null, SHORT_TYPE);
-
-                        break;
-                    case CHAR_OBJ:
-                        if (explicit && internal)
-                            return new Cast(FLOAT_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
-
-                        break;
-                    case INT_OBJ:
-                        if (explicit && internal)
-                            return new Cast(FLOAT_TYPE, INT_TYPE, true, null, null, null, INT_TYPE);
-
-                        break;
-                    case LONG_OBJ:
-                        if (explicit && internal)
-                            return new Cast(FLOAT_TYPE, LONG_TYPE, true, null, null, null, LONG_TYPE);
-
-                        break;
-                }
-
-                break;
-            case DOUBLE:
-                switch (expected.sort) {
-                    case BYTE:
-                    case SHORT:
-                    case CHAR:
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                        if (explicit)
-                            return new Cast(DOUBLE_TYPE, expected, true);
-
-                        break;
-                    case DEF:
-                        return new Cast(DOUBLE_OBJ_TYPE, DEF_TYPE, explicit, null, null, DOUBLE_TYPE, null);
-                    case OBJECT:
-                        if (OBJECT_TYPE.equals(expected) && internal)
-                            return new Cast(DOUBLE_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, DOUBLE_TYPE, null);
-
-                        break;
-                    case NUMBER:
-                        if (internal)
-                            return new Cast(DOUBLE_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, DOUBLE_TYPE, null);
-
-                        break;
-                    case DOUBLE_OBJ:
-                        if (internal)
-                            return new Cast(DOUBLE_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
-
-                        break;
-                    case BYTE_OBJ:
-                        if (explicit && internal)
-                            return new Cast(DOUBLE_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
-
-                        break;
-                    case SHORT_OBJ:
-                        if (explicit && internal)
-                            return new Cast(DOUBLE_TYPE, SHORT_TYPE, true, null, null, null, SHORT_TYPE);
-
-                        break;
-                    case CHAR_OBJ:
-                        if (explicit && internal)
-                            return new Cast(DOUBLE_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
-
-                        break;
-                    case INT_OBJ:
-                        if (explicit && internal)
-                            return new Cast(DOUBLE_TYPE, INT_TYPE, true, null, null, null, INT_TYPE);
-
-                        break;
-                    case LONG_OBJ:
-                        if (explicit && internal)
-                            return new Cast(DOUBLE_TYPE, LONG_TYPE, true, null, null, null, LONG_TYPE);
-
-                        break;
-                    case FLOAT_OBJ:
-                        if (explicit && internal)
-                            return new Cast(DOUBLE_TYPE, FLOAT_TYPE, true, null, null, null, FLOAT_TYPE);
-
-                        break;
-                }
-
-                break;
-            case OBJECT:
-                if (OBJECT_TYPE.equals(actual))
-                    switch (expected.sort) {
-                        case BYTE:
-                            if (internal && explicit)
-                                return new Cast(OBJECT_TYPE, BYTE_OBJ_TYPE, true, null, BYTE_TYPE, null, null);
-
-                            break;
-                        case SHORT:
-                            if (internal && explicit)
-                                return new Cast(OBJECT_TYPE, SHORT_OBJ_TYPE, true, null, SHORT_TYPE, null, null);
-
-                            break;
-                        case CHAR:
-                            if (internal && explicit)
-                                return new Cast(OBJECT_TYPE, CHAR_OBJ_TYPE, true, null, CHAR_TYPE, null, null);
-
-                            break;
-                        case INT:
-                            if (internal && explicit)
-                                return new Cast(OBJECT_TYPE, INT_OBJ_TYPE, true, null, INT_TYPE, null, null);
-
-                            break;
-                        case LONG:
-                            if (internal && explicit)
-                                return new Cast(OBJECT_TYPE, LONG_OBJ_TYPE, true, null, LONG_TYPE, null, null);
-
-                            break;
-                        case FLOAT:
-                            if (internal && explicit)
-                                return new Cast(OBJECT_TYPE, FLOAT_OBJ_TYPE, true, null, FLOAT_TYPE, null, null);
-
-                            break;
-                        case DOUBLE:
-                            if (internal && explicit)
-                                return new Cast(OBJECT_TYPE, DOUBLE_OBJ_TYPE, true, null, DOUBLE_TYPE, null, null);
-
-                            break;
-                    }
-                break;
-            case NUMBER:
-                switch (expected.sort) {
-                    case BYTE:
-                        if (internal && explicit)
-                            return new Cast(NUMBER_TYPE, BYTE_OBJ_TYPE, true, null, BYTE_TYPE, null, null);
-
-                        break;
-                    case SHORT:
-                        if (internal && explicit)
-                            return new Cast(NUMBER_TYPE, SHORT_OBJ_TYPE, true, null, SHORT_TYPE, null, null);
-
-                        break;
-                    case CHAR:
-                        if (internal && explicit)
-                            return new Cast(NUMBER_TYPE, CHAR_OBJ_TYPE, true, null, CHAR_TYPE, null, null);
-
-                        break;
-                    case INT:
-                        if (internal && explicit)
-                            return new Cast(NUMBER_TYPE, INT_OBJ_TYPE, true, null, INT_TYPE, null, null);
-
-                        break;
-                    case LONG:
-                        if (internal && explicit)
-                            return new Cast(NUMBER_TYPE, LONG_OBJ_TYPE, true, null, LONG_TYPE, null, null);
-
-                        break;
-                    case FLOAT:
-                        if (internal && explicit)
-                            return new Cast(NUMBER_TYPE, FLOAT_OBJ_TYPE, true, null, FLOAT_TYPE, null, null);
-
-                        break;
-                    case DOUBLE:
-                        if (internal && explicit)
-                            return new Cast(NUMBER_TYPE, DOUBLE_OBJ_TYPE, true, null, DOUBLE_TYPE, null, null);
-
-                        break;
-                }
-
-                break;
-            case BOOL_OBJ:
-                switch (expected.sort) {
-                    case BOOL:
-                        if (internal)
-                            return new Cast(BOOLEAN_TYPE, BOOLEAN_TYPE, explicit, BOOLEAN_TYPE, null, null, null);
-
-                        break;
-                }
-
-                break;
-            case BYTE_OBJ:
-                switch (expected.sort) {
-                    case BYTE:
-                    case SHORT:
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                        if (internal)
-                            return new Cast(BYTE_TYPE, expected, explicit, BYTE_TYPE, null, null, null);
-
-                        break;
-                    case CHAR:
-                        if (internal && explicit)
-                            return new Cast(BYTE_TYPE, expected, true, BYTE_TYPE, null, null, null);
-
-                        break;
-                }
-
-                break;
-            case SHORT_OBJ:
-                switch (expected.sort) {
-                    case SHORT:
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                        if (internal)
-                            return new Cast(SHORT_TYPE, expected, explicit, SHORT_TYPE, null, null, null);
-
-                        break;
-                    case BYTE:
-                    case CHAR:
-                        if (internal && explicit)
-                            return new Cast(SHORT_TYPE, expected, true, SHORT_TYPE, null, null, null);
-
-                        break;
-                }
-
-                break;
-            case CHAR_OBJ:
-                switch (expected.sort) {
-                    case CHAR:
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                        if (internal)
-                            return new Cast(CHAR_TYPE, expected, explicit, CHAR_TYPE, null, null, null);
-
-                        break;
-                    case BYTE:
-                    case SHORT:
-                        if (internal && explicit)
-                            return new Cast(CHAR_TYPE, expected, true, CHAR_TYPE, null, null, null);
-
-                        break;
-                }
-
-                break;
-            case INT_OBJ:
-                switch (expected.sort) {
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                        if (internal)
-                            return new Cast(INT_TYPE, expected, explicit, INT_TYPE, null, null, null);
-
-                        break;
-                    case BYTE:
-                    case SHORT:
-                    case CHAR:
-                        if (internal && explicit)
-                            return new Cast(INT_TYPE, expected, true, INT_TYPE, null, null, null);
-
-                        break;
-                }
-
-                break;
-            case LONG_OBJ:
-                switch (expected.sort) {
-                    case LONG:
-                    case FLOAT:
-                    case DOUBLE:
-                        if (internal)
-                            return new Cast(LONG_TYPE, expected, explicit, LONG_TYPE, null, null, null);
-
-                        break;
-                    case BYTE:
-                    case SHORT:
-                    case CHAR:
-                    case INT:
-                        if (internal && explicit)
-                            return new Cast(LONG_TYPE, expected, true, LONG_TYPE, null, null, null);
-
-                        break;
-                }
-
-                break;
-            case FLOAT_OBJ:
-                switch (expected.sort) {
-                    case FLOAT:
-                    case DOUBLE:
-                        if (internal)
-                            return new Cast(FLOAT_TYPE, expected, explicit, FLOAT_TYPE, null, null, null);
-
-                        break;
-                    case BYTE:
-                    case SHORT:
-                    case CHAR:
-                    case INT:
-                    case LONG:
-                        if (internal && explicit)
-                            return new Cast(FLOAT_TYPE, expected, true, FLOAT_TYPE, null, null, null);
-
-                        break;
-                }
-
-                break;
-            case DOUBLE_OBJ:
-                switch (expected.sort) {
-                    case DOUBLE:
-                        if (internal)
-                            return new Cast(DOUBLE_TYPE, expected, explicit, DOUBLE_TYPE, null, null, null);
-
-                        break;
-                    case BYTE:
-                    case SHORT:
-                    case CHAR:
-                    case INT:
-                    case LONG:
-                    case FLOAT:
-                        if (internal && explicit)
-                            return new Cast(DOUBLE_TYPE, expected, true, DOUBLE_TYPE, null, null, null);
-
-                        break;
-                }
-
-                break;
-            case DEF:
-                switch (expected.sort) {
-                    case BOOL:
-                        return new Cast(DEF_TYPE, BOOLEAN_OBJ_TYPE, explicit, null, BOOLEAN_TYPE, null, null);
-                    case BYTE:
-                        return new Cast(DEF_TYPE, BYTE_OBJ_TYPE, explicit, null, BYTE_TYPE, null, null);
-                    case SHORT:
-                        return new Cast(DEF_TYPE, SHORT_OBJ_TYPE, explicit, null, SHORT_TYPE, null, null);
-                    case CHAR:
-                        return new Cast(DEF_TYPE, CHAR_OBJ_TYPE, explicit, null, CHAR_TYPE, null, null);
-                    case INT:
-                        return new Cast(DEF_TYPE, INT_OBJ_TYPE, explicit, null, INT_TYPE, null, null);
-                    case LONG:
-                        return new Cast(DEF_TYPE, LONG_OBJ_TYPE, explicit, null, LONG_TYPE, null, null);
-                    case FLOAT:
-                        return new Cast(DEF_TYPE, FLOAT_OBJ_TYPE, explicit, null, FLOAT_TYPE, null, null);
-                    case DOUBLE:
-                            return new Cast(DEF_TYPE, DOUBLE_OBJ_TYPE, explicit, null, DOUBLE_TYPE, null, null);
-                }
-
-                break;
-            case STRING:
-                switch (expected.sort) {
-                    case CHAR:
-                        if (explicit)
-                            return new Cast(STRING_TYPE, CHAR_TYPE, true);
-
-                        break;
-                }
-
-                break;
+        if (actual.dynamic) {
+            if (expected.clazz == boolean.class) {
+                return new Cast(DEF_TYPE, BOOLEAN_OBJ_TYPE, explicit, null, BOOLEAN_TYPE, null, null);
+            } else if (expected.clazz == byte.class) {
+                return new Cast(DEF_TYPE, BYTE_OBJ_TYPE, explicit, null, BYTE_TYPE, null, null);
+            } else if (expected.clazz == short.class) {
+                return new Cast(DEF_TYPE, SHORT_OBJ_TYPE, explicit, null, SHORT_TYPE, null, null);
+            } else if (expected.clazz == char.class) {
+                return new Cast(DEF_TYPE, CHAR_OBJ_TYPE, explicit, null, CHAR_TYPE, null, null);
+            } else if (expected.clazz == int.class) {
+                return new Cast(DEF_TYPE, INT_OBJ_TYPE, explicit, null, INT_TYPE, null, null);
+            } else if (expected.clazz == long.class) {
+                return new Cast(DEF_TYPE, LONG_OBJ_TYPE, explicit, null, LONG_TYPE, null, null);
+            } else if (expected.clazz == float.class) {
+                return new Cast(DEF_TYPE, FLOAT_OBJ_TYPE, explicit, null, FLOAT_TYPE, null, null);
+            } else if (expected.clazz == double.class) {
+                return new Cast(DEF_TYPE, DOUBLE_OBJ_TYPE, explicit, null, DOUBLE_TYPE, null, null);
+            }
+        } else if (actual.clazz == Object.class) {
+            if (expected.clazz == byte.class && explicit && internal) {
+                return new Cast(OBJECT_TYPE, BYTE_OBJ_TYPE, true, null, BYTE_TYPE, null, null);
+            } else if (expected.clazz == short.class && explicit && internal) {
+                return new Cast(OBJECT_TYPE, SHORT_OBJ_TYPE, true, null, SHORT_TYPE, null, null);
+            } else if (expected.clazz == char.class && explicit && internal) {
+                return new Cast(OBJECT_TYPE, CHAR_OBJ_TYPE, true, null, CHAR_TYPE, null, null);
+            } else if (expected.clazz == int.class && explicit && internal) {
+                return new Cast(OBJECT_TYPE, INT_OBJ_TYPE, true, null, INT_TYPE, null, null);
+            } else if (expected.clazz == long.class && explicit && internal) {
+                return new Cast(OBJECT_TYPE, LONG_OBJ_TYPE, true, null, LONG_TYPE, null, null);
+            } else if (expected.clazz == float.class && explicit && internal) {
+                return new Cast(OBJECT_TYPE, FLOAT_OBJ_TYPE, true, null, FLOAT_TYPE, null, null);
+            } else if (expected.clazz == double.class && explicit && internal) {
+                return new Cast(OBJECT_TYPE, DOUBLE_OBJ_TYPE, true, null, DOUBLE_TYPE, null, null);
+            }
+        } else if (actual.clazz == Number.class) {
+            if (expected.clazz == byte.class && explicit && internal) {
+                return new Cast(NUMBER_TYPE, BYTE_OBJ_TYPE, true, null, BYTE_TYPE, null, null);
+            } else if (expected.clazz == short.class && explicit && internal) {
+                return new Cast(NUMBER_TYPE, SHORT_OBJ_TYPE, true, null, SHORT_TYPE, null, null);
+            } else if (expected.clazz == char.class && explicit && internal) {
+                return new Cast(NUMBER_TYPE, CHAR_OBJ_TYPE, true, null, CHAR_TYPE, null, null);
+            } else if (expected.clazz == int.class && explicit && internal) {
+                return new Cast(NUMBER_TYPE, INT_OBJ_TYPE, true, null, INT_TYPE, null, null);
+            } else if (expected.clazz == long.class && explicit && internal) {
+                return new Cast(NUMBER_TYPE, LONG_OBJ_TYPE, true, null, LONG_TYPE, null, null);
+            } else if (expected.clazz == float.class && explicit && internal) {
+                return new Cast(NUMBER_TYPE, FLOAT_OBJ_TYPE, true, null, FLOAT_TYPE, null, null);
+            } else if (expected.clazz == double.class && explicit && internal) {
+                return new Cast(NUMBER_TYPE, DOUBLE_OBJ_TYPE, true, null, DOUBLE_TYPE, null, null);
+            }
+        } else if (actual.clazz == String.class) {
+            if (expected.clazz == char.class && explicit) {
+                return new Cast(STRING_TYPE, CHAR_TYPE, true);
+            }
+        } else if (actual.clazz == boolean.class) {
+            if (expected.dynamic) {
+                return new Cast(BOOLEAN_OBJ_TYPE, DEF_TYPE, explicit, null, null, BOOLEAN_TYPE, null);
+            } else if (expected.clazz == Object.class && internal) {
+                return new Cast(BOOLEAN_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, BOOLEAN_TYPE, null);
+            } else if (expected.clazz == Boolean.class && internal) {
+                return new Cast(BOOLEAN_TYPE, BOOLEAN_TYPE, explicit, null, null, null, BOOLEAN_TYPE);
+            }
+        } else if (actual.clazz == byte.class) {
+            if (expected.dynamic) {
+                return new Cast(BYTE_OBJ_TYPE, DEF_TYPE, explicit, null, null, BYTE_TYPE, null);
+            } else if (expected.clazz == Object.class && internal) {
+                return new Cast(BYTE_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, BYTE_TYPE, null);
+            } else if (expected.clazz == Number.class && internal) {
+                return new Cast(BYTE_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, BYTE_TYPE, null);
+            } else if (expected.clazz == short.class) {
+                return new Cast(BYTE_TYPE, SHORT_TYPE, explicit);
+            } else if (expected.clazz == char.class && explicit) {
+                return new Cast(BYTE_TYPE, CHAR_TYPE, true);
+            } else if (expected.clazz == int.class) {
+                return new Cast(BYTE_TYPE, INT_TYPE, explicit);
+            } else if (expected.clazz == long.class) {
+                return new Cast(BYTE_TYPE, LONG_TYPE, explicit);
+            } else if (expected.clazz == float.class) {
+                return new Cast(BYTE_TYPE, FLOAT_TYPE, explicit);
+            } else if (expected.clazz == double.class) {
+                return new Cast(BYTE_TYPE, DOUBLE_TYPE, explicit);
+            } else if (expected.clazz == Byte.class && internal) {
+                return new Cast(BYTE_TYPE, BYTE_TYPE, explicit, null, null, null, BYTE_TYPE);
+            } else if (expected.clazz == Short.class && internal) {
+                return new Cast(BYTE_TYPE, SHORT_TYPE, explicit, null, null, null, SHORT_TYPE);
+            } else if (expected.clazz == Character.class && explicit && internal) {
+                return new Cast(BYTE_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
+            } else if (expected.clazz == Integer.class && internal) {
+                return new Cast(BYTE_TYPE, INT_TYPE, explicit, null, null, null, INT_TYPE);
+            } else if (expected.clazz == Long.class && internal) {
+                return new Cast(BYTE_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
+            } else if (expected.clazz == Float.class && internal) {
+                return new Cast(BYTE_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
+            } else if (expected.clazz == Double.class && internal) {
+                return new Cast(BYTE_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
+            }
+        } else if (actual.clazz == short.class) {
+            if (expected.dynamic) {
+                return new Cast(SHORT_OBJ_TYPE, DEF_TYPE, explicit, null, null, SHORT_TYPE, null);
+            } else if (expected.clazz == Object.class && internal) {
+                return new Cast(SHORT_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, SHORT_TYPE, null);
+            } else if (expected.clazz == Number.class && internal) {
+                return new Cast(SHORT_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, SHORT_TYPE, null);
+            } else if (expected.clazz == byte.class && explicit) {
+                return new Cast(SHORT_TYPE, BYTE_TYPE, true);
+            } else if (expected.clazz == char.class && explicit) {
+                return new Cast(SHORT_TYPE, CHAR_TYPE, true);
+            } else if (expected.clazz == int.class) {
+                return new Cast(SHORT_TYPE, INT_TYPE, explicit);
+            } else if (expected.clazz == long.class) {
+                return new Cast(SHORT_TYPE, LONG_TYPE, explicit);
+            } else if (expected.clazz == float.class) {
+                return new Cast(SHORT_TYPE, FLOAT_TYPE, explicit);
+            } else if (expected.clazz == double.class) {
+                return new Cast(SHORT_TYPE, DOUBLE_TYPE, explicit);
+            } else if (expected.clazz == Byte.class && explicit && internal) {
+                return new Cast(SHORT_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
+            } else if (expected.clazz == Short.class && internal) {
+                return new Cast(SHORT_TYPE, SHORT_TYPE, explicit, null, null, null, SHORT_TYPE);
+            } else if (expected.clazz == Character.class && explicit && internal) {
+                return new Cast(SHORT_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
+            } else if (expected.clazz == Integer.class && internal) {
+                return new Cast(SHORT_TYPE, INT_TYPE, explicit, null, null, null, INT_TYPE);
+            } else if (expected.clazz == Long.class && internal) {
+                return new Cast(SHORT_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
+            } else if (expected.clazz == Float.class && internal) {
+                return new Cast(SHORT_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
+            } else if (expected.clazz == Double.class && internal) {
+                return new Cast(SHORT_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
+            }
+        } else if (actual.clazz == char.class) {
+            if (expected.dynamic) {
+                return new Cast(CHAR_OBJ_TYPE, DEF_TYPE, explicit, null, null, CHAR_TYPE, null);
+            } else if (expected.clazz == Object.class && internal) {
+                return new Cast(CHAR_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, CHAR_TYPE, null);
+            } else if (expected.clazz == Number.class && internal) {
+                return new Cast(CHAR_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, CHAR_TYPE, null);
+            } else if (expected.clazz == String.class) {
+                return new Cast(CHAR_TYPE, STRING_TYPE, explicit);
+            } else if (expected.clazz == byte.class && explicit) {
+                return new Cast(CHAR_TYPE, BYTE_TYPE, true);
+            } else if (expected.clazz == short.class && explicit) {
+                return new Cast(CHAR_TYPE, SHORT_TYPE, true);
+            } else if (expected.clazz == int.class) {
+                return new Cast(CHAR_TYPE, INT_TYPE, explicit);
+            } else if (expected.clazz == long.class) {
+                return new Cast(CHAR_TYPE, LONG_TYPE, explicit);
+            } else if (expected.clazz == float.class) {
+                return new Cast(CHAR_TYPE, FLOAT_TYPE, explicit);
+            } else if (expected.clazz == double.class) {
+                return new Cast(CHAR_TYPE, DOUBLE_TYPE, explicit);
+            } else if (expected.clazz == Byte.class && explicit && internal) {
+                return new Cast(CHAR_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
+            } else if (expected.clazz == Short.class && internal) {
+                return new Cast(CHAR_TYPE, SHORT_TYPE, explicit, null, null, null, SHORT_TYPE);
+            } else if (expected.clazz == Character.class && internal) {
+                return new Cast(CHAR_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
+            } else if (expected.clazz == Integer.class && internal) {
+                return new Cast(CHAR_TYPE, INT_TYPE, explicit, null, null, null, INT_TYPE);
+            } else if (expected.clazz == Long.class && internal) {
+                return new Cast(CHAR_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
+            } else if (expected.clazz == Float.class && internal) {
+                return new Cast(CHAR_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
+            } else if (expected.clazz == Double.class && internal) {
+                return new Cast(CHAR_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
+            }
+        } else if (actual.clazz == int.class) {
+            if (expected.dynamic) {
+                return new Cast(INT_OBJ_TYPE, DEF_TYPE, explicit, null, null, INT_TYPE, null);
+            } else if (expected.clazz == Object.class && internal) {
+                return new Cast(INT_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, INT_TYPE, null);
+            } else if (expected.clazz == Number.class && internal) {
+                return new Cast(INT_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, INT_TYPE, null);
+            } else if (expected.clazz == byte.class && explicit) {
+                return new Cast(INT_TYPE, BYTE_TYPE, true);
+            } else if (expected.clazz == char.class && explicit) {
+                return new Cast(INT_TYPE, CHAR_TYPE, true);
+            } else if (expected.clazz == short.class && explicit) {
+                return new Cast(INT_TYPE, SHORT_TYPE, true);
+            } else if (expected.clazz == long.class) {
+                return new Cast(INT_TYPE, LONG_TYPE, explicit);
+            } else if (expected.clazz == float.class) {
+                return new Cast(INT_TYPE, FLOAT_TYPE, explicit);
+            } else if (expected.clazz == double.class) {
+                return new Cast(INT_TYPE, DOUBLE_TYPE, explicit);
+            } else if (expected.clazz == Byte.class && explicit && internal) {
+                return new Cast(INT_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
+            } else if (expected.clazz == Short.class && explicit && internal) {
+                return new Cast(INT_TYPE, SHORT_TYPE, true, null, null, null, SHORT_TYPE);
+            } else if (expected.clazz == Character.class && explicit && internal) {
+                return new Cast(INT_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
+            } else if (expected.clazz == Integer.class && internal) {
+                return new Cast(INT_TYPE, INT_TYPE, explicit, null, null, null, INT_TYPE);
+            } else if (expected.clazz == Long.class && internal) {
+                return new Cast(INT_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
+            } else if (expected.clazz == Float.class && internal) {
+                return new Cast(INT_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
+            } else if (expected.clazz == Double.class && internal) {
+                return new Cast(INT_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
+            }
+        } else if (actual.clazz == long.class) {
+            if (expected.dynamic) {
+                return new Cast(LONG_OBJ_TYPE, DEF_TYPE, explicit, null, null, LONG_TYPE, null);
+            } else if (expected.clazz == Object.class && internal) {
+                return new Cast(LONG_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, LONG_TYPE, null);
+            } else if (expected.clazz == Number.class && internal) {
+                return new Cast(LONG_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, LONG_TYPE, null);
+            } else if (expected.clazz == byte.class && explicit) {
+                return new Cast(LONG_TYPE, BYTE_TYPE, true);
+            } else if (expected.clazz == char.class && explicit) {
+                return new Cast(LONG_TYPE, CHAR_TYPE, true);
+            } else if (expected.clazz == short.class && explicit) {
+                return new Cast(LONG_TYPE, SHORT_TYPE, true);
+            } else if (expected.clazz == int.class && explicit) {
+                return new Cast(LONG_TYPE, INT_TYPE, true);
+            } else if (expected.clazz == float.class) {
+                return new Cast(LONG_TYPE, FLOAT_TYPE, explicit);
+            } else if (expected.clazz == double.class) {
+                return new Cast(LONG_TYPE, DOUBLE_TYPE, explicit);
+            } else if (expected.clazz == Byte.class && explicit && internal) {
+                return new Cast(LONG_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
+            } else if (expected.clazz == Short.class && explicit && internal) {
+                return new Cast(LONG_TYPE, SHORT_TYPE, true, null, null, null, SHORT_TYPE);
+            } else if (expected.clazz == Character.class && explicit && internal) {
+                return new Cast(LONG_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
+            } else if (expected.clazz == Integer.class && explicit && internal) {
+                return new Cast(LONG_TYPE, INT_TYPE, true, null, null, null, INT_TYPE);
+            } else if (expected.clazz == Long.class && internal) {
+                return new Cast(LONG_TYPE, LONG_TYPE, explicit, null, null, null, LONG_TYPE);
+            } else if (expected.clazz == Float.class && internal) {
+                return new Cast(LONG_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
+            } else if (expected.clazz == Double.class && internal) {
+                return new Cast(LONG_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
+            }
+        } else if (actual.clazz == float.class) {
+            if (expected.dynamic) {
+                return new Cast(FLOAT_OBJ_TYPE, DEF_TYPE, explicit, null, null, FLOAT_TYPE, null);
+            } else if (expected.clazz == Object.class && internal) {
+                return new Cast(FLOAT_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, FLOAT_TYPE, null);
+            } else if (expected.clazz == Number.class && internal) {
+                return new Cast(FLOAT_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, FLOAT_TYPE, null);
+            } else if (expected.clazz == byte.class && explicit) {
+                return new Cast(FLOAT_TYPE, BYTE_TYPE, true);
+            } else if (expected.clazz == char.class && explicit) {
+                return new Cast(FLOAT_TYPE, CHAR_TYPE, true);
+            } else if (expected.clazz == short.class && explicit) {
+                return new Cast(FLOAT_TYPE, SHORT_TYPE, true);
+            } else if (expected.clazz == int.class && explicit) {
+                return new Cast(FLOAT_TYPE, INT_TYPE, true);
+            } else if (expected.clazz == long.class && explicit) {
+                return new Cast(FLOAT_TYPE, LONG_TYPE, true);
+            } else if (expected.clazz == double.class) {
+                return new Cast(FLOAT_TYPE, DOUBLE_TYPE, explicit);
+            } else if (expected.clazz == Byte.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
+            } else if (expected.clazz == Short.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, SHORT_TYPE, true, null, null, null, SHORT_TYPE);
+            } else if (expected.clazz == Character.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
+            } else if (expected.clazz == Integer.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, INT_TYPE, true, null, null, null, INT_TYPE);
+            } else if (expected.clazz == Long.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, LONG_TYPE, true, null, null, null, LONG_TYPE);
+            } else if (expected.clazz == Float.class && internal) {
+                return new Cast(FLOAT_TYPE, FLOAT_TYPE, explicit, null, null, null, FLOAT_TYPE);
+            } else if (expected.clazz == Double.class && internal) {
+                return new Cast(FLOAT_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
+            }
+        } else if (actual.clazz == double.class) {
+            if (expected.dynamic) {
+                return new Cast(DOUBLE_OBJ_TYPE, DEF_TYPE, explicit, null, null, DOUBLE_TYPE, null);
+            } else if (expected.clazz == Object.class && internal) {
+                return new Cast(DOUBLE_OBJ_TYPE, OBJECT_TYPE, explicit, null, null, DOUBLE_TYPE, null);
+            } else if (expected.clazz == Number.class && internal) {
+                return new Cast(DOUBLE_OBJ_TYPE, NUMBER_TYPE, explicit, null, null, DOUBLE_TYPE, null);
+            } else if (expected.clazz == byte.class && explicit) {
+                return new Cast(DOUBLE_TYPE, BYTE_TYPE, true);
+            } else if (expected.clazz == char.class && explicit) {
+                return new Cast(DOUBLE_TYPE, CHAR_TYPE, true);
+            } else if (expected.clazz == short.class && explicit) {
+                return new Cast(DOUBLE_TYPE, SHORT_TYPE, true);
+            } else if (expected.clazz == int.class && explicit) {
+                return new Cast(DOUBLE_TYPE, INT_TYPE, true);
+            } else if (expected.clazz == long.class && explicit) {
+                return new Cast(DOUBLE_TYPE, LONG_TYPE, true);
+            } else if (expected.clazz == float.class && explicit) {
+                return new Cast(DOUBLE_TYPE, FLOAT_TYPE, true);
+            } else if (expected.clazz == Byte.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, BYTE_TYPE, true, null, null, null, BYTE_TYPE);
+            } else if (expected.clazz == Short.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, SHORT_TYPE, true, null, null, null, SHORT_TYPE);
+            } else if (expected.clazz == Character.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, CHAR_TYPE, true, null, null, null, CHAR_TYPE);
+            } else if (expected.clazz == Integer.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, INT_TYPE, true, null, null, null, INT_TYPE);
+            } else if (expected.clazz == Long.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, LONG_TYPE, true, null, null, null, LONG_TYPE);
+            } else if (expected.clazz == Float.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, FLOAT_TYPE, true, null, null, null, FLOAT_TYPE);
+            } else if (expected.clazz == Double.class && internal) {
+                return new Cast(DOUBLE_TYPE, DOUBLE_TYPE, explicit, null, null, null, DOUBLE_TYPE);
+            }
+        } else if (actual.clazz == Boolean.class) {
+            if (expected.clazz == boolean.class && internal) {
+                return new Cast(BOOLEAN_TYPE, BOOLEAN_TYPE, explicit, BOOLEAN_TYPE, null, null, null);
+            }
+        } else if (actual.clazz == Byte.class) {
+            if (expected.clazz == byte.class && internal) {
+                return new Cast(BYTE_TYPE, BYTE_TYPE, explicit, BYTE_TYPE, null, null, null);
+            } else if (expected.clazz == short.class && internal) {
+                return new Cast(BYTE_TYPE, SHORT_TYPE, explicit, BYTE_TYPE, null, null, null);
+            } else if (expected.clazz == char.class && explicit && internal) {
+                return new Cast(BYTE_TYPE, CHAR_TYPE, true, BYTE_TYPE, null, null, null);
+            } else if (expected.clazz == int.class && internal) {
+                return new Cast(BYTE_TYPE, INT_TYPE, explicit, BYTE_TYPE, null, null, null);
+            } else if (expected.clazz == long.class && internal) {
+                return new Cast(BYTE_TYPE, LONG_TYPE, explicit, BYTE_TYPE, null, null, null);
+            } else if (expected.clazz == float.class && internal) {
+                return new Cast(BYTE_TYPE, FLOAT_TYPE, explicit, BYTE_TYPE, null, null, null);
+            } else if (expected.clazz == double.class && internal) {
+                return new Cast(BYTE_TYPE, DOUBLE_TYPE, explicit, BYTE_TYPE, null, null, null);
+            }
+        } else if (actual.clazz == Short.class) {
+            if (expected.clazz == byte.class && explicit && internal) {
+                return new Cast(SHORT_TYPE, BYTE_TYPE, true, SHORT_TYPE, null, null, null);
+            } else if (expected.clazz == short.class && internal) {
+                return new Cast(SHORT_TYPE, SHORT_TYPE, explicit, SHORT_TYPE, null, null, null);
+            } else if (expected.clazz == char.class && explicit && internal) {
+                return new Cast(SHORT_TYPE, CHAR_TYPE, true, SHORT_TYPE, null, null, null);
+            } else if (expected.clazz == int.class && internal) {
+                return new Cast(SHORT_TYPE, INT_TYPE, explicit, SHORT_TYPE, null, null, null);
+            } else if (expected.clazz == long.class && internal) {
+                return new Cast(SHORT_TYPE, LONG_TYPE, explicit, SHORT_TYPE, null, null, null);
+            } else if (expected.clazz == float.class && internal) {
+                return new Cast(SHORT_TYPE, FLOAT_TYPE, explicit, SHORT_TYPE, null, null, null);
+            } else if (expected.clazz == double.class && internal) {
+                return new Cast(SHORT_TYPE, DOUBLE_TYPE, explicit, SHORT_TYPE, null, null, null);
+            }
+        } else if (actual.clazz == Character.class) {
+            if (expected.clazz == byte.class && explicit && internal) {
+                return new Cast(CHAR_TYPE, BYTE_TYPE, true, CHAR_TYPE, null, null, null);
+            } else if (expected.clazz == short.class && explicit && internal) {
+                return new Cast(CHAR_TYPE, SHORT_TYPE, true, CHAR_TYPE, null, null, null);
+            } else if (expected.clazz == char.class && internal) {
+                return new Cast(CHAR_TYPE, CHAR_TYPE, explicit, CHAR_TYPE, null, null, null);
+            } else if (expected.clazz == int.class && internal) {
+                return new Cast(CHAR_TYPE, INT_TYPE, explicit, CHAR_TYPE, null, null, null);
+            } else if (expected.clazz == long.class && internal) {
+                return new Cast(CHAR_TYPE, LONG_TYPE, explicit, CHAR_TYPE, null, null, null);
+            } else if (expected.clazz == float.class && internal) {
+                return new Cast(CHAR_TYPE, FLOAT_TYPE, explicit, CHAR_TYPE, null, null, null);
+            } else if (expected.clazz == double.class && internal) {
+                return new Cast(CHAR_TYPE, DOUBLE_TYPE, explicit, CHAR_TYPE, null, null, null);
+            }
+        } else if (actual.clazz == Integer.class) {
+            if (expected.clazz == byte.class && explicit && internal) {
+                return new Cast(INT_TYPE, BYTE_TYPE, true, INT_TYPE, null, null, null);
+            } else if (expected.clazz == short.class && explicit && internal) {
+                return new Cast(INT_TYPE, SHORT_TYPE, true, INT_TYPE, null, null, null);
+            } else if (expected.clazz == char.class && explicit && internal) {
+                return new Cast(INT_TYPE, CHAR_TYPE, true, INT_TYPE, null, null, null);
+            } else if (expected.clazz == int.class && internal) {
+                return new Cast(INT_TYPE, INT_TYPE, explicit, INT_TYPE, null, null, null);
+            } else if (expected.clazz == long.class && internal) {
+                return new Cast(INT_TYPE, LONG_TYPE, explicit, INT_TYPE, null, null, null);
+            } else if (expected.clazz == float.class && internal) {
+                return new Cast(INT_TYPE, FLOAT_TYPE, explicit, INT_TYPE, null, null, null);
+            } else if (expected.clazz == double.class && internal) {
+                return new Cast(INT_TYPE, DOUBLE_TYPE, explicit, INT_TYPE, null, null, null);
+            }
+        } else if (actual.clazz == Long.class) {
+            if (expected.clazz == byte.class && explicit && internal) {
+                return new Cast(LONG_TYPE, BYTE_TYPE, true, LONG_TYPE, null, null, null);
+            } else if (expected.clazz == short.class && explicit && internal) {
+                return new Cast(LONG_TYPE, SHORT_TYPE, true, LONG_TYPE, null, null, null);
+            } else if (expected.clazz == char.class && explicit && internal) {
+                return new Cast(LONG_TYPE, CHAR_TYPE, true, LONG_TYPE, null, null, null);
+            } else if (expected.clazz == int.class && explicit && internal) {
+                return new Cast(LONG_TYPE, INT_TYPE, true, LONG_TYPE, null, null, null);
+            } else if (expected.clazz == long.class && internal) {
+                return new Cast(LONG_TYPE, LONG_TYPE, explicit, LONG_TYPE, null, null, null);
+            } else if (expected.clazz == float.class && internal) {
+                return new Cast(LONG_TYPE, FLOAT_TYPE, explicit, LONG_TYPE, null, null, null);
+            } else if (expected.clazz == double.class && internal) {
+                return new Cast(LONG_TYPE, DOUBLE_TYPE, explicit, LONG_TYPE, null, null, null);
+            }
+        } else if (actual.clazz == Float.class) {
+            if (expected.clazz == byte.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, BYTE_TYPE, true, FLOAT_TYPE, null, null, null);
+            } else if (expected.clazz == short.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, SHORT_TYPE, true, FLOAT_TYPE, null, null, null);
+            } else if (expected.clazz == char.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, CHAR_TYPE, true, FLOAT_TYPE, null, null, null);
+            } else if (expected.clazz == int.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, INT_TYPE, true, FLOAT_TYPE, null, null, null);
+            } else if (expected.clazz == long.class && explicit && internal) {
+                return new Cast(FLOAT_TYPE, LONG_TYPE, true, FLOAT_TYPE, null, null, null);
+            } else if (expected.clazz == float.class && internal) {
+                return new Cast(FLOAT_TYPE, FLOAT_TYPE, explicit, FLOAT_TYPE, null, null, null);
+            } else if (expected.clazz == double.class && internal) {
+                return new Cast(FLOAT_TYPE, DOUBLE_TYPE, explicit, FLOAT_TYPE, null, null, null);
+            }
+        } else if (actual.clazz == Double.class) {
+            if (expected.clazz == byte.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, BYTE_TYPE, true, DOUBLE_TYPE, null, null, null);
+            } else if (expected.clazz == short.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, SHORT_TYPE, true, DOUBLE_TYPE, null, null, null);
+            } else if (expected.clazz == char.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, CHAR_TYPE, true, DOUBLE_TYPE, null, null, null);
+            } else if (expected.clazz == int.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, INT_TYPE, true, DOUBLE_TYPE, null, null, null);
+            } else if (expected.clazz == long.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, LONG_TYPE, true, DOUBLE_TYPE, null, null, null);
+            } else if (expected.clazz == float.class && explicit && internal) {
+                return new Cast(DOUBLE_TYPE, FLOAT_TYPE, true, DOUBLE_TYPE, null, null, null);
+            } else if (expected.clazz == double.class && internal) {
+                return new Cast(DOUBLE_TYPE, DOUBLE_TYPE, explicit, DOUBLE_TYPE, null, null, null);
+            }
         }
 
-        if (       actual.sort == Sort.DEF
-                || (actual.sort != Sort.VOID && expected.sort == Sort.DEF)
-                || expected.clazz.isAssignableFrom(actual.clazz)
-                || (explicit && actual.clazz.isAssignableFrom(expected.clazz))) {
+        if (    actual.dynamic                                   ||
+                (actual.clazz != void.class && expected.dynamic) ||
+                expected.clazz.isAssignableFrom(actual.clazz)    ||
+                (actual.clazz.isAssignableFrom(expected.clazz) && explicit)) {
             return new Cast(actual, expected, explicit);
         } else {
             throw location.createError(new ClassCastException("Cannot cast from [" + actual.name + "] to [" + expected.name + "]."));
@@ -792,35 +490,34 @@ public final class AnalyzerCaster {
     }
 
     public static Object constCast(Location location, final Object constant, final Cast cast) {
-        final Sort fsort = cast.from.sort;
-        final Sort tsort = cast.to.sort;
+        Class<?> fsort = cast.from.clazz;
+        Class<?> tsort = cast.to.clazz;
 
         if (fsort == tsort) {
             return constant;
-        } else if (fsort == Sort.STRING && tsort == Sort.CHAR) {
+        } else if (fsort == String.class && tsort == char.class) {
             return Utility.StringTochar((String)constant);
-        } else if (fsort == Sort.CHAR && tsort == Sort.STRING) {
+        } else if (fsort == char.class && tsort == String.class) {
             return Utility.charToString((char)constant);
-        } else if (fsort.numeric && tsort.numeric) {
+        } else if (fsort.isPrimitive() && fsort != boolean.class && tsort.isPrimitive() && tsort != boolean.class) {
             final Number number;
 
-            if (fsort == Sort.CHAR) {
+            if (fsort == char.class) {
                 number = (int)(char)constant;
             } else {
                 number = (Number)constant;
             }
 
-            switch (tsort) {
-                case BYTE:   return number.byteValue();
-                case SHORT:  return number.shortValue();
-                case CHAR:   return (char)number.intValue();
-                case INT:    return number.intValue();
-                case LONG:   return number.longValue();
-                case FLOAT:  return number.floatValue();
-                case DOUBLE: return number.doubleValue();
-                default:
-                    throw location.createError(new IllegalStateException("Cannot cast from " +
-                        "[" + cast.from.clazz.getCanonicalName() + "] to [" + cast.to.clazz.getCanonicalName() + "]."));
+            if      (tsort == byte.class) return number.byteValue();
+            else if (tsort == short.class) return number.shortValue();
+            else if (tsort == char.class) return (char)number.intValue();
+            else if (tsort == int.class) return number.intValue();
+            else if (tsort == long.class) return number.longValue();
+            else if (tsort == float.class) return number.floatValue();
+            else if (tsort == double.class) return number.doubleValue();
+            else {
+                throw location.createError(new IllegalStateException("Cannot cast from " +
+                    "[" + cast.from.clazz.getCanonicalName() + "] to [" + cast.to.clazz.getCanonicalName() + "]."));
             }
         } else {
             throw location.createError(new IllegalStateException("Cannot cast from " +
@@ -829,17 +526,17 @@ public final class AnalyzerCaster {
     }
 
     public static Type promoteNumeric(Type from, boolean decimal) {
-        final Sort sort = from.sort;
+        Class<?> sort = from.clazz;
 
-        if (sort == Sort.DEF) {
+        if (from.dynamic) {
             return DEF_TYPE;
-        } else if ((sort == Sort.DOUBLE) && decimal) {
+        } else if ((sort == double.class) && decimal) {
             return DOUBLE_TYPE;
-        } else if ((sort == Sort.FLOAT) && decimal) {
+        } else if ((sort == float.class) && decimal) {
             return  FLOAT_TYPE;
-        } else if (sort == Sort.LONG) {
+        } else if (sort == long.class) {
             return LONG_TYPE;
-        } else if (sort == Sort.INT || sort == Sort.CHAR || sort == Sort.SHORT || sort == Sort.BYTE) {
+        } else if (sort == int.class || sort == char.class || sort == short.class || sort == byte.class) {
             return INT_TYPE;
         }
 
@@ -847,108 +544,106 @@ public final class AnalyzerCaster {
     }
 
     public static Type promoteNumeric(Type from0, Type from1, boolean decimal) {
-        final Sort sort0 = from0.sort;
-        final Sort sort1 = from1.sort;
+        Class<?> sort0 = from0.clazz;
+        Class<?> sort1 = from1.clazz;
 
-        if (sort0 == Sort.DEF || sort1 == Sort.DEF) {
+        if (from0.dynamic || from1.dynamic) {
             return DEF_TYPE;
         }
 
         if (decimal) {
-            if (sort0 == Sort.DOUBLE || sort1 == Sort.DOUBLE) {
+            if (sort0 == double.class || sort1 == double.class) {
                 return DOUBLE_TYPE;
-            } else if (sort0 == Sort.FLOAT || sort1 == Sort.FLOAT) {
+            } else if (sort0 == float.class || sort1 == float.class) {
                 return FLOAT_TYPE;
             }
         }
 
-        if (sort0 == Sort.LONG || sort1 == Sort.LONG) {
+        if (sort0 == long.class || sort1 == long.class) {
             return LONG_TYPE;
-        } else if (sort0 == Sort.INT   || sort1 == Sort.INT   ||
-                   sort0 == Sort.CHAR  || sort1 == Sort.CHAR  ||
-                   sort0 == Sort.SHORT || sort1 == Sort.SHORT ||
-                   sort0 == Sort.BYTE  || sort1 == Sort.BYTE) {
+        } else if (sort0 == int.class   || sort1 == int.class   ||
+                   sort0 == char.class  || sort1 == char.class  ||
+                   sort0 == short.class || sort1 == short.class ||
+                   sort0 == byte.class  || sort1 == byte.class) {
             return INT_TYPE;
         }
 
         return null;
     }
 
-    public static Type promoteAdd(final Type from0, final Type from1) {
-        final Sort sort0 = from0.sort;
-        final Sort sort1 = from1.sort;
+    public static Type promoteAdd(Type from0, Type from1) {
+        Class<?> sort0 = from0.clazz;
+        Class<?> sort1 = from1.clazz;
 
-        if (sort0 == Sort.STRING || sort1 == Sort.STRING) {
+        if (sort0 == String.class || sort1 == String.class) {
             return STRING_TYPE;
         }
 
         return promoteNumeric(from0, from1, true);
     }
 
-    public static Type promoteXor(final Type from0, final Type from1) {
-        final Sort sort0 = from0.sort;
-        final Sort sort1 = from1.sort;
+    public static Type promoteXor(Type from0, Type from1) {
+        Class<?> sort0 = from0.clazz;
+        Class<?> sort1 = from1.clazz;
 
-        if (sort0 == Sort.DEF || sort1 == Sort.DEF) {
+        if (from0.dynamic || from1.dynamic) {
             return DEF_TYPE;
         }
 
-        if (sort0.bool || sort1.bool) {
+        if (sort0 == boolean.class || sort1 == boolean.class) {
             return BOOLEAN_TYPE;
         }
 
         return promoteNumeric(from0, from1, false);
     }
 
-    public static Type promoteEquality(final Type from0, final Type from1) {
-        final Sort sort0 = from0.sort;
-        final Sort sort1 = from1.sort;
+    public static Type promoteEquality(Type from0, Type from1) {
+        Class<?> sort0 = from0.clazz;
+        Class<?> sort1 = from1.clazz;
 
-        if (sort0 == Sort.DEF || sort1 == Sort.DEF) {
+        if (from0.dynamic || from1.dynamic) {
             return DEF_TYPE;
         }
 
-        if (sort0.primitive && sort1.primitive) {
-            if (sort0.bool && sort1.bool) {
+        if (sort0.isPrimitive() && sort1.isPrimitive()) {
+            if (sort0 == boolean.class && sort1 == boolean.class) {
                 return BOOLEAN_TYPE;
             }
 
-            if (sort0.numeric && sort1.numeric) {
-                return promoteNumeric(from0, from1, true);
-            }
+            return promoteNumeric(from0, from1, true);
         }
 
         return OBJECT_TYPE;
     }
 
-    public static Type promoteConditional(final Type from0, final Type from1, final Object const0, final Object const1) {
+    public static Type promoteConditional(Type from0, Type from1, Object const0, Object const1) {
         if (from0.equals(from1)) {
             return from0;
         }
 
-        final Sort sort0 = from0.sort;
-        final Sort sort1 = from1.sort;
+        Class<?> sort0 = from0.clazz;
+        Class<?> sort1 = from1.clazz;
 
-        if (sort0 == Sort.DEF || sort1 == Sort.DEF) {
+        if (from0.dynamic || from1.dynamic) {
             return DEF_TYPE;
         }
 
-        if (sort0.primitive && sort1.primitive) {
-            if (sort0.bool && sort1.bool) {
+        if (sort0.isPrimitive() && sort1.isPrimitive()) {
+            if (sort0 == boolean.class && sort1 == boolean.class) {
                 return BOOLEAN_TYPE;
             }
 
-            if (sort0 == Sort.DOUBLE || sort1 == Sort.DOUBLE) {
+            if (sort0 == double.class || sort1 == double.class) {
                 return DOUBLE_TYPE;
-            } else if (sort0 == Sort.FLOAT || sort1 == Sort.FLOAT) {
+            } else if (sort0 == float.class || sort1 == float.class) {
                 return FLOAT_TYPE;
-            } else if (sort0 == Sort.LONG || sort1 == Sort.LONG) {
+            } else if (sort0 == long.class || sort1 == long.class) {
                 return LONG_TYPE;
             } else {
-                if (sort0 == Sort.BYTE) {
-                    if (sort1 == Sort.BYTE) {
+                if (sort0 == byte.class) {
+                    if (sort1 == byte.class) {
                         return BYTE_TYPE;
-                    } else if (sort1 == Sort.SHORT) {
+                    } else if (sort1 == short.class) {
                         if (const1 != null) {
                             final short constant = (short)const1;
 
@@ -958,9 +653,9 @@ public final class AnalyzerCaster {
                         }
 
                         return SHORT_TYPE;
-                    } else if (sort1 == Sort.CHAR) {
+                    } else if (sort1 == char.class) {
                         return INT_TYPE;
-                    } else if (sort1 == Sort.INT) {
+                    } else if (sort1 == int.class) {
                         if (const1 != null) {
                             final int constant = (int)const1;
 
@@ -971,8 +666,8 @@ public final class AnalyzerCaster {
 
                         return INT_TYPE;
                     }
-                } else if (sort0 == Sort.SHORT) {
-                    if (sort1 == Sort.BYTE) {
+                } else if (sort0 == short.class) {
+                    if (sort1 == byte.class) {
                         if (const0 != null) {
                             final short constant = (short)const0;
 
@@ -982,11 +677,11 @@ public final class AnalyzerCaster {
                         }
 
                         return SHORT_TYPE;
-                    } else if (sort1 == Sort.SHORT) {
+                    } else if (sort1 == short.class) {
                         return SHORT_TYPE;
-                    } else if (sort1 == Sort.CHAR) {
+                    } else if (sort1 == char.class) {
                         return INT_TYPE;
-                    } else if (sort1 == Sort.INT) {
+                    } else if (sort1 == int.class) {
                         if (const1 != null) {
                             final int constant = (int)const1;
 
@@ -997,14 +692,14 @@ public final class AnalyzerCaster {
 
                         return INT_TYPE;
                     }
-                } else if (sort0 == Sort.CHAR) {
-                    if (sort1 == Sort.BYTE) {
+                } else if (sort0 == char.class) {
+                    if (sort1 == byte.class) {
                         return INT_TYPE;
-                    } else if (sort1 == Sort.SHORT) {
+                    } else if (sort1 == short.class) {
                         return INT_TYPE;
-                    } else if (sort1 == Sort.CHAR) {
+                    } else if (sort1 == char.class) {
                         return CHAR_TYPE;
-                    } else if (sort1 == Sort.INT) {
+                    } else if (sort1 == int.class) {
                         if (const1 != null) {
                             final int constant = (int)const1;
 
@@ -1015,8 +710,8 @@ public final class AnalyzerCaster {
 
                         return INT_TYPE;
                     }
-                } else if (sort0 == Sort.INT) {
-                    if (sort1 == Sort.BYTE) {
+                } else if (sort0 == int.class) {
+                    if (sort1 == byte.class) {
                         if (const0 != null) {
                             final int constant = (int)const0;
 
@@ -1026,7 +721,7 @@ public final class AnalyzerCaster {
                         }
 
                         return INT_TYPE;
-                    } else if (sort1 == Sort.SHORT) {
+                    } else if (sort1 == short.class) {
                         if (const0 != null) {
                             final int constant = (int)const0;
 
@@ -1036,7 +731,7 @@ public final class AnalyzerCaster {
                         }
 
                         return INT_TYPE;
-                    } else if (sort1 == Sort.CHAR) {
+                    } else if (sort1 == char.class) {
                         if (const0 != null) {
                             final int constant = (int)const0;
 
@@ -1046,7 +741,7 @@ public final class AnalyzerCaster {
                         }
 
                         return INT_TYPE;
-                    } else if (sort1 == Sort.INT) {
+                    } else if (sort1 == int.class) {
                         return INT_TYPE;
                     }
                 }
@@ -1054,8 +749,8 @@ public final class AnalyzerCaster {
         }
 
         // TODO: In the rare case we still haven't reached a correct promotion we need
-        //       to calculate the highest upper bound for the two types and return that.
-        //       However, for now we just return objectType that may require an extra cast.
+        // TODO: to calculate the highest upper bound for the two types and return that.
+        // TODO: However, for now we just return objectType that may require an extra cast.
 
         return OBJECT_TYPE;
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless;
 
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.painless.api.Augmentation;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -99,72 +99,22 @@ public final class Definition {
     public static final Type ARRAY_LIST_TYPE = BUILTINS.getType("ArrayList");
     public static final Type HASH_MAP_TYPE = BUILTINS.getType("HashMap");
 
-    public enum Sort {
-        VOID(       void.class      , Void.class      , null          , 0 , true  , false , false , false ),
-        BOOL(       boolean.class   , Boolean.class   , null          , 1 , true  , true  , false , true  ),
-        BYTE(       byte.class      , Byte.class      , null          , 1 , true  , false , true  , true  ),
-        SHORT(      short.class     , Short.class     , null          , 1 , true  , false , true  , true  ),
-        CHAR(       char.class      , Character.class , null          , 1 , true  , false , true  , true  ),
-        INT(        int.class       , Integer.class   , null          , 1 , true  , false , true  , true  ),
-        LONG(       long.class      , Long.class      , null          , 2 , true  , false , true  , true  ),
-        FLOAT(      float.class     , Float.class     , null          , 1 , true  , false , true  , true  ),
-        DOUBLE(     double.class    , Double.class    , null          , 2 , true  , false , true  , true  ),
-
-        VOID_OBJ(   Void.class      , null            , void.class    , 1 , true  , false , false , false ),
-        BOOL_OBJ(   Boolean.class   , null            , boolean.class , 1 , false , true  , false , false ),
-        BYTE_OBJ(   Byte.class      , null            , byte.class    , 1 , false , false , true  , false ),
-        SHORT_OBJ(  Short.class     , null            , short.class   , 1 , false , false , true  , false ),
-        CHAR_OBJ(   Character.class , null            , char.class    , 1 , false , false , true  , false ),
-        INT_OBJ(    Integer.class   , null            , int.class     , 1 , false , false , true  , false ),
-        LONG_OBJ(   Long.class      , null            , long.class    , 1 , false , false , true  , false ),
-        FLOAT_OBJ(  Float.class     , null            , float.class   , 1 , false , false , true  , false ),
-        DOUBLE_OBJ( Double.class    , null            , double.class  , 1 , false , false , true  , false ),
-
-        NUMBER(     Number.class    , null            , null          , 1 , false , false , false , false ),
-        STRING(     String.class    , null            , null          , 1 , false , false , false , true  ),
-
-        OBJECT(     null            , null            , null          , 1 , false , false , false , false ),
-        DEF(        null            , null            , null          , 1 , false , false , false , false ),
-        ARRAY(      null            , null            , null          , 1 , false , false , false , false );
-
-        public final Class<?> clazz;
-        public final Class<?> boxed;
-        public final Class<?> unboxed;
-        public final int size;
-        public final boolean primitive;
-        public final boolean bool;
-        public final boolean numeric;
-        public final boolean constant;
-
-        Sort(final Class<?> clazz, final Class<?> boxed, final Class<?> unboxed, final int size,
-             final boolean primitive, final boolean bool, final boolean numeric, final boolean constant) {
-            this.clazz = clazz;
-            this.boxed = boxed;
-            this.unboxed = unboxed;
-            this.size = size;
-            this.bool = bool;
-            this.primitive = primitive;
-            this.numeric = numeric;
-            this.constant = constant;
-        }
-    }
-
     public static final class Type {
         public final String name;
         public final int dimensions;
+        public final boolean dynamic;
         public final Struct struct;
         public final Class<?> clazz;
         public final org.objectweb.asm.Type type;
-        public final Sort sort;
 
-        private Type(final String name, final int dimensions, final Struct struct,
-                     final Class<?> clazz, final org.objectweb.asm.Type type, final Sort sort) {
+        private Type(final String name, final int dimensions, final boolean dynamic,
+                     final Struct struct, final Class<?> clazz, final org.objectweb.asm.Type type) {
             this.name = name;
             this.dimensions = dimensions;
             this.struct = struct;
             this.clazz = clazz;
             this.type = type;
-            this.sort = sort;
+            this.dynamic = dynamic;
         }
 
         @Override
@@ -501,6 +451,62 @@ public final class Definition {
     /** Creates an array type from the given Struct. */
     public Type getType(final Struct struct, final int dimensions) {
         return BUILTINS.getTypeInternal(struct, dimensions);
+    }
+
+    public static Type getBoxedType(Type unboxed) {
+        if (unboxed.clazz == boolean.class) {
+            return BOOLEAN_OBJ_TYPE;
+        } else if (unboxed.clazz == byte.class) {
+            return BYTE_OBJ_TYPE;
+        } else if (unboxed.clazz == short.class) {
+            return SHORT_OBJ_TYPE;
+        } else if (unboxed.clazz == char.class) {
+            return CHAR_OBJ_TYPE;
+        } else if (unboxed.clazz == int.class) {
+            return INT_OBJ_TYPE;
+        } else if (unboxed.clazz == long.class) {
+            return LONG_OBJ_TYPE;
+        } else if (unboxed.clazz == float.class) {
+            return FLOAT_OBJ_TYPE;
+        } else if (unboxed.clazz == double.class) {
+            return DOUBLE_OBJ_TYPE;
+        }
+
+        return unboxed;
+    }
+
+    public static Type getUnboxedType(Type boxed) {
+        if (boxed.clazz == Boolean.class) {
+            return BOOLEAN_TYPE;
+        } else if (boxed.clazz == Byte.class) {
+            return BYTE_TYPE;
+        } else if (boxed.clazz == Short.class) {
+            return SHORT_TYPE;
+        } else if (boxed.clazz == Character.class) {
+            return CHAR_TYPE;
+        } else if (boxed.clazz == Integer.class) {
+            return INT_TYPE;
+        } else if (boxed.clazz == Long.class) {
+            return LONG_TYPE;
+        } else if (boxed.clazz == Float.class) {
+            return FLOAT_TYPE;
+        } else if (boxed.clazz == Double.class) {
+            return DOUBLE_TYPE;
+        }
+
+        return boxed;
+    }
+
+    public static boolean isConstantType(Type constant) {
+        return constant.clazz == boolean.class ||
+               constant.clazz == byte.class    ||
+               constant.clazz == short.class   ||
+               constant.clazz == char.class    ||
+               constant.clazz == int.class     ||
+               constant.clazz == long.class    ||
+               constant.clazz == float.class   ||
+               constant.clazz == double.class  ||
+               constant.clazz == String.class;
     }
 
     public RuntimeClass getRuntimeClass(Class<?> clazz) {
@@ -1136,7 +1142,6 @@ public final class Definition {
         String name = struct.name;
         org.objectweb.asm.Type type = struct.type;
         Class<?> clazz = struct.clazz;
-        Sort sort;
 
         if (dimensions > 0) {
             StringBuilder builder = new StringBuilder(name);
@@ -1158,27 +1163,9 @@ public final class Definition {
                 throw new IllegalArgumentException("The class [" + type.getInternalName() + "]" +
                     " could not be found to create type [" + name + "].");
             }
-
-            sort = Sort.ARRAY;
-        } else if ("def".equals(struct.name)) {
-            sort = Sort.DEF;
-        } else {
-            sort = Sort.OBJECT;
-
-            for (Sort value : Sort.values()) {
-                if (value.clazz == null) {
-                    continue;
-                }
-
-                if (value.clazz.equals(struct.clazz)) {
-                    sort = value;
-
-                    break;
-                }
-            }
         }
 
-        return new Type(name, dimensions, struct, clazz, type, sort);
+        return new Type(name, dimensions, "def".equals(name), struct, clazz, type);
     }
 
     private int getDimensions(String name) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless;
 
 import org.elasticsearch.painless.Definition.Cast;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
@@ -131,35 +130,39 @@ public final class MethodWriter extends GeneratorAdapter {
 
     public void writeCast(final Cast cast) {
         if (cast != null) {
-            if (cast.from.sort == Sort.CHAR && cast.to.sort == Sort.STRING) {
+            if (cast.from.clazz == char.class && cast.to.clazz == String.class) {
                 invokeStatic(UTILITY_TYPE, CHAR_TO_STRING);
-            } else if (cast.from.sort == Sort.STRING && cast.to.sort == Sort.CHAR) {
+            } else if (cast.from.clazz == String.class && cast.to.clazz == char.class) {
                 invokeStatic(UTILITY_TYPE, STRING_TO_CHAR);
             } else if (cast.unboxFrom != null) {
                 unbox(cast.unboxFrom.type);
                 writeCast(cast.from, cast.to);
             } else if (cast.unboxTo != null) {
-                if (cast.from.sort == Sort.DEF) {
+                if (cast.from.dynamic) {
                     if (cast.explicit) {
-                        if (cast.to.sort == Sort.BOOL_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_BOOLEAN);
-                        else if (cast.to.sort == Sort.BYTE_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_BYTE_EXPLICIT);
-                        else if (cast.to.sort == Sort.SHORT_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_SHORT_EXPLICIT);
-                        else if (cast.to.sort == Sort.CHAR_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_CHAR_EXPLICIT);
-                        else if (cast.to.sort == Sort.INT_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_INT_EXPLICIT);
-                        else if (cast.to.sort == Sort.LONG_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_LONG_EXPLICIT);
-                        else if (cast.to.sort == Sort.FLOAT_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_FLOAT_EXPLICIT);
-                        else if (cast.to.sort == Sort.DOUBLE_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_DOUBLE_EXPLICIT);
-                        else throw new IllegalStateException("Illegal tree structure.");
+                        if      (cast.to.clazz == Boolean.class) invokeStatic(DEF_UTIL_TYPE, DEF_TO_BOOLEAN);
+                        else if (cast.to.clazz == Byte.class)    invokeStatic(DEF_UTIL_TYPE, DEF_TO_BYTE_EXPLICIT);
+                        else if (cast.to.clazz == Short.class)   invokeStatic(DEF_UTIL_TYPE, DEF_TO_SHORT_EXPLICIT);
+                        else if (cast.to.clazz == Character.class)    invokeStatic(DEF_UTIL_TYPE, DEF_TO_CHAR_EXPLICIT);
+                        else if (cast.to.clazz == Integer.class)     invokeStatic(DEF_UTIL_TYPE, DEF_TO_INT_EXPLICIT);
+                        else if (cast.to.clazz == Long.class)    invokeStatic(DEF_UTIL_TYPE, DEF_TO_LONG_EXPLICIT);
+                        else if (cast.to.clazz == Float.class)   invokeStatic(DEF_UTIL_TYPE, DEF_TO_FLOAT_EXPLICIT);
+                        else if (cast.to.clazz == Double.class)  invokeStatic(DEF_UTIL_TYPE, DEF_TO_DOUBLE_EXPLICIT);
+                        else {
+                            throw new IllegalStateException("Illegal tree structure.");
+                        }
                     } else {
-                        if (cast.to.sort == Sort.BOOL_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_BOOLEAN);
-                        else if (cast.to.sort == Sort.BYTE_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_BYTE_IMPLICIT);
-                        else if (cast.to.sort == Sort.SHORT_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_SHORT_IMPLICIT);
-                        else if (cast.to.sort == Sort.CHAR_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_CHAR_IMPLICIT);
-                        else if (cast.to.sort == Sort.INT_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_INT_IMPLICIT);
-                        else if (cast.to.sort == Sort.LONG_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_LONG_IMPLICIT);
-                        else if (cast.to.sort == Sort.FLOAT_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_FLOAT_IMPLICIT);
-                        else if (cast.to.sort == Sort.DOUBLE_OBJ) invokeStatic(DEF_UTIL_TYPE, DEF_TO_DOUBLE_IMPLICIT);
-                        else throw new IllegalStateException("Illegal tree structure.");
+                        if      (cast.to.clazz == Boolean.class) invokeStatic(DEF_UTIL_TYPE, DEF_TO_BOOLEAN);
+                        else if (cast.to.clazz == Byte.class)    invokeStatic(DEF_UTIL_TYPE, DEF_TO_BYTE_IMPLICIT);
+                        else if (cast.to.clazz == Short.class)   invokeStatic(DEF_UTIL_TYPE, DEF_TO_SHORT_IMPLICIT);
+                        else if (cast.to.clazz == Character.class)    invokeStatic(DEF_UTIL_TYPE, DEF_TO_CHAR_IMPLICIT);
+                        else if (cast.to.clazz == Integer.class)     invokeStatic(DEF_UTIL_TYPE, DEF_TO_INT_IMPLICIT);
+                        else if (cast.to.clazz == Long.class)    invokeStatic(DEF_UTIL_TYPE, DEF_TO_LONG_IMPLICIT);
+                        else if (cast.to.clazz == Float.class)   invokeStatic(DEF_UTIL_TYPE, DEF_TO_FLOAT_IMPLICIT);
+                        else if (cast.to.clazz == Double.class)  invokeStatic(DEF_UTIL_TYPE, DEF_TO_DOUBLE_IMPLICIT);
+                        else {
+                            throw new IllegalStateException("Illegal tree structure.");
+                        }
                     }
                 } else {
                     writeCast(cast.from, cast.to);
@@ -182,7 +185,7 @@ public final class MethodWriter extends GeneratorAdapter {
             return;
         }
 
-        if (from.sort.numeric && from.sort.primitive && to.sort.numeric && to.sort.primitive) {
+        if (from.clazz != boolean.class && from.clazz.isPrimitive() && to.clazz != boolean.class && to.clazz.isPrimitive()) {
             cast(from.type, to.type);
         } else {
             if (!to.clazz.isAssignableFrom(from.clazz)) {
@@ -238,18 +241,16 @@ public final class MethodWriter extends GeneratorAdapter {
             }
         } else {
             // Java 8: push a StringBuilder append
-            switch (type.sort) {
-                case BOOL:   invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_BOOLEAN); break;
-                case CHAR:   invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_CHAR);    break;
-                case BYTE:
-                case SHORT:
-                case INT:    invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_INT);     break;
-                case LONG:   invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_LONG);    break;
-                case FLOAT:  invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_FLOAT);   break;
-                case DOUBLE: invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_DOUBLE);  break;
-                case STRING: invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_STRING);  break;
-                default:     invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_OBJECT);
-            }
+            if (type.clazz == boolean.class)      invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_BOOLEAN);
+            else if (type.clazz == char.class)    invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_CHAR);
+            else if (type.clazz == byte.class  ||
+                     type.clazz == short.class ||
+                     type.clazz == int.class)     invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_INT);
+            else if (type.clazz == long.class)    invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_LONG);
+            else if (type.clazz == float.class)   invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_FLOAT);
+            else if (type.clazz == double.class)  invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_DOUBLE);
+            else if (type.clazz == String.class)  invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_STRING);
+            else                                  invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_OBJECT);
         }
     }
 
@@ -318,9 +319,7 @@ public final class MethodWriter extends GeneratorAdapter {
 
     /** Writes a static binary instruction */
     public void writeBinaryInstruction(Location location, Type type, Operation operation) {
-        final Sort sort = type.sort;
-
-        if ((sort == Sort.FLOAT || sort == Sort.DOUBLE) &&
+        if ((type.clazz == float.class || type.clazz == double.class) &&
                 (operation == Operation.LSH || operation == Operation.USH ||
                 operation == Operation.RSH || operation == Operation.BWAND ||
                 operation == Operation.XOR || operation == Operation.BWOR)) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/AExpression.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/AExpression.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
+import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Locals;
@@ -157,7 +158,7 @@ public abstract class AExpression extends ANode {
 
                 return ecast;
             } else {
-                if (expected.sort.constant) {
+                if (Definition.isConstantType(expected)) {
                     // For the case where a cast is required, a constant is set,
                     // and the constant can be immediately cast to the expected type.
                     // An EConstant replaces this node with the constant cast appropriately

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EBinary.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EBinary.java
@@ -22,7 +22,6 @@ package org.elasticsearch.painless.node;
 import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -110,7 +109,7 @@ public final class EBinary extends AExpression {
 
         actual = promote;
 
-        if (promote.sort == Sort.DEF) {
+        if (promote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
             if (expected != null) {
@@ -125,15 +124,15 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant * (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant * (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant * (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant * (double)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -154,7 +153,7 @@ public final class EBinary extends AExpression {
 
         actual = promote;
 
-        if (promote.sort == Sort.DEF) {
+        if (promote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
 
@@ -170,16 +169,16 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
             try {
-                if (sort == Sort.INT) {
+                if (sort == int.class) {
                     constant = (int)left.constant / (int)right.constant;
-                } else if (sort == Sort.LONG) {
+                } else if (sort == long.class) {
                     constant = (long)left.constant / (long)right.constant;
-                } else if (sort == Sort.FLOAT) {
+                } else if (sort == float.class) {
                     constant = (float)left.constant / (float)right.constant;
-                } else if (sort == Sort.DOUBLE) {
+                } else if (sort == double.class) {
                     constant = (double)left.constant / (double)right.constant;
                 } else {
                     throw createError(new IllegalStateException("Illegal tree structure."));
@@ -203,7 +202,7 @@ public final class EBinary extends AExpression {
 
         actual = promote;
 
-        if (promote.sort == Sort.DEF) {
+        if (promote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
 
@@ -219,16 +218,16 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
             try {
-                if (sort == Sort.INT) {
+                if (sort == int.class) {
                     constant = (int)left.constant % (int)right.constant;
-                } else if (sort == Sort.LONG) {
+                } else if (sort == long.class) {
                     constant = (long)left.constant % (long)right.constant;
-                } else if (sort == Sort.FLOAT) {
+                } else if (sort == float.class) {
                     constant = (float)left.constant % (float)right.constant;
-                } else if (sort == Sort.DOUBLE) {
+                } else if (sort == double.class) {
                     constant = (double)left.constant % (double)right.constant;
                 } else {
                     throw createError(new IllegalStateException("Illegal tree structure."));
@@ -250,23 +249,23 @@ public final class EBinary extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        Sort sort = promote.sort;
+        Class<?> sort = promote.clazz;
 
         actual = promote;
 
-        if (sort == Sort.STRING) {
+        if (sort == String.class) {
             left.expected = left.actual;
 
-            if (left instanceof EBinary && ((EBinary)left).operation == Operation.ADD && left.actual.sort == Sort.STRING) {
+            if (left instanceof EBinary && ((EBinary)left).operation == Operation.ADD && left.actual.clazz == String.class) {
                 ((EBinary)left).cat = true;
             }
 
             right.expected = right.actual;
 
-            if (right instanceof EBinary && ((EBinary)right).operation == Operation.ADD && right.actual.sort == Sort.STRING) {
+            if (right instanceof EBinary && ((EBinary)right).operation == Operation.ADD && right.actual.clazz == String.class) {
                 ((EBinary)right).cat = true;
             }
-        } else if (sort == Sort.DEF) {
+        } else if (promote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
 
@@ -282,15 +281,15 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant + (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant + (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant + (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant + (double)right.constant;
-            } else if (sort == Sort.STRING) {
+            } else if (sort == String.class) {
                 constant = left.constant.toString() + right.constant.toString();
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -312,7 +311,7 @@ public final class EBinary extends AExpression {
 
         actual = promote;
 
-        if (promote.sort == Sort.DEF) {
+        if (promote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
 
@@ -328,15 +327,15 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant - (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant - (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant - (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant - (double)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -373,7 +372,7 @@ public final class EBinary extends AExpression {
         actual = promote = lhspromote;
         shiftDistance = rhspromote;
 
-        if (lhspromote.sort == Sort.DEF || rhspromote.sort == Sort.DEF) {
+        if (lhspromote.dynamic || rhspromote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
 
@@ -383,7 +382,7 @@ public final class EBinary extends AExpression {
         } else {
             left.expected = lhspromote;
 
-            if (rhspromote.sort == Sort.LONG) {
+            if (rhspromote.clazz == long.class) {
                 right.expected = Definition.INT_TYPE;
                 right.explicit = true;
             } else {
@@ -395,11 +394,11 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = lhspromote.sort;
+            Class<?> sort = lhspromote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant << (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant << (int)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -422,7 +421,7 @@ public final class EBinary extends AExpression {
         actual = promote = lhspromote;
         shiftDistance = rhspromote;
 
-        if (lhspromote.sort == Sort.DEF || rhspromote.sort == Sort.DEF) {
+        if (lhspromote.dynamic || rhspromote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
 
@@ -432,7 +431,7 @@ public final class EBinary extends AExpression {
         } else {
             left.expected = lhspromote;
 
-            if (rhspromote.sort == Sort.LONG) {
+            if (rhspromote.clazz == long.class) {
                 right.expected = Definition.INT_TYPE;
                 right.explicit = true;
             } else {
@@ -444,11 +443,11 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = lhspromote.sort;
+            Class<?> sort = lhspromote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant >> (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant >> (int)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -471,7 +470,7 @@ public final class EBinary extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        if (lhspromote.sort == Sort.DEF || rhspromote.sort == Sort.DEF) {
+        if (lhspromote.dynamic || rhspromote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
 
@@ -481,7 +480,7 @@ public final class EBinary extends AExpression {
         } else {
             left.expected = lhspromote;
 
-            if (rhspromote.sort == Sort.LONG) {
+            if (rhspromote.clazz == long.class) {
                 right.expected = Definition.INT_TYPE;
                 right.explicit = true;
             } else {
@@ -493,11 +492,11 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = lhspromote.sort;
+            Class<?> sort = lhspromote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant >>> (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant >>> (int)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -518,7 +517,7 @@ public final class EBinary extends AExpression {
 
         actual = promote;
 
-        if (promote.sort == Sort.DEF) {
+        if (promote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
 
@@ -534,11 +533,11 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant & (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant & (long)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -559,7 +558,7 @@ public final class EBinary extends AExpression {
 
         actual = promote;
 
-        if (promote.sort == Sort.DEF) {
+        if (promote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
             if (expected != null) {
@@ -574,13 +573,13 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
-            if (sort == Sort.BOOL) {
+            if (sort == boolean.class) {
                 constant = (boolean)left.constant ^ (boolean)right.constant;
-            } else if (sort == Sort.INT) {
+            } else if (sort == int.class) {
                 constant = (int)left.constant ^ (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant ^ (long)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -601,7 +600,7 @@ public final class EBinary extends AExpression {
 
         actual = promote;
 
-        if (promote.sort == Sort.DEF) {
+        if (promote.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
             if (expected != null) {
@@ -616,11 +615,11 @@ public final class EBinary extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant | (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant | (long)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -632,7 +631,7 @@ public final class EBinary extends AExpression {
     void write(MethodWriter writer, Globals globals) {
         writer.writeDebugInfo(location);
 
-        if (promote.sort == Sort.STRING && operation == Operation.ADD) {
+        if (promote.clazz == String.class && operation == Operation.ADD) {
             if (!cat) {
                 writer.writeNewStrings();
             }
@@ -668,7 +667,7 @@ public final class EBinary extends AExpression {
             left.write(writer, globals);
             right.write(writer, globals);
 
-            if (promote.sort == Sort.DEF || (shiftDistance != null && shiftDistance.sort == Sort.DEF)) {
+            if (promote.dynamic || (shiftDistance != null && shiftDistance.dynamic)) {
                 // def calls adopt the wanted return value. if there was a narrowing cast,
                 // we need to flag that so that its done at runtime.
                 int flags = 0;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECapturingFunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECapturingFunctionRef.java
@@ -64,7 +64,7 @@ public final class ECapturingFunctionRef extends AExpression implements ILambda 
     void analyze(Locals locals) {
         captured = locals.getVariable(location, variable);
         if (expected == null) {
-            if (captured.type.sort == Definition.Sort.DEF) {
+            if (captured.type.dynamic) {
                 // dynamic implementation
                 defPointer = "D" + variable + "." + call + ",1";
             } else {
@@ -75,7 +75,7 @@ public final class ECapturingFunctionRef extends AExpression implements ILambda 
         } else {
             defPointer = null;
             // static case
-            if (captured.type.sort != Definition.Sort.DEF) {
+            if (captured.type.dynamic == false) {
                 try {
                     ref = new FunctionRef(locals.getDefinition(), expected, captured.type.name, call, 1);
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EComp.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EComp.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Globals;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Location;
 import org.elasticsearch.painless.AnalyzerCaster;
@@ -97,7 +96,7 @@ public final class EComp extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        if (promotedType.sort == Sort.DEF) {
+        if (promotedType.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
         } else {
@@ -113,17 +112,17 @@ public final class EComp extends AExpression {
         }
 
         if ((left.constant != null || left.isNull) && (right.constant != null || right.isNull)) {
-            Sort sort = promotedType.sort;
+            Class<?> sort = promotedType.clazz;
 
-            if (sort == Sort.BOOL) {
+            if (sort == boolean.class) {
                 constant = (boolean)left.constant == (boolean)right.constant;
-            } else if (sort == Sort.INT) {
+            } else if (sort == int.class) {
                 constant = (int)left.constant == (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant == (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant == (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant == (double)right.constant;
             } else if (!left.isNull) {
                 constant = left.constant.equals(right.constant);
@@ -159,17 +158,17 @@ public final class EComp extends AExpression {
         }
 
         if ((left.constant != null || left.isNull) && (right.constant != null || right.isNull)) {
-            Sort sort = promotedType.sort;
+            Class<?> sort = promotedType.clazz;
 
-            if (sort == Sort.BOOL) {
+            if (sort == boolean.class) {
                 constant = (boolean)left.constant == (boolean)right.constant;
-            } else if (sort == Sort.INT) {
+            } else if (sort == int.class) {
                 constant = (int)left.constant == (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant == (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant == (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant == (double)right.constant;
             } else {
                 constant = left.constant == right.constant;
@@ -190,7 +189,7 @@ public final class EComp extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        if (promotedType.sort == Sort.DEF) {
+        if (promotedType.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
         } else {
@@ -206,17 +205,17 @@ public final class EComp extends AExpression {
         }
 
         if ((left.constant != null || left.isNull) && (right.constant != null || right.isNull)) {
-            Sort sort = promotedType.sort;
+            Class<?> sort = promotedType.clazz;
 
-            if (sort == Sort.BOOL) {
+            if (sort == boolean.class) {
                 constant = (boolean)left.constant != (boolean)right.constant;
-            } else if (sort == Sort.INT) {
+            } else if (sort == int.class) {
                 constant = (int)left.constant != (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant != (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant != (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant != (double)right.constant;
             } else if (!left.isNull) {
                 constant = !left.constant.equals(right.constant);
@@ -252,17 +251,17 @@ public final class EComp extends AExpression {
         }
 
         if ((left.constant != null || left.isNull) && (right.constant != null || right.isNull)) {
-            Sort sort = promotedType.sort;
+            Class<?> sort = promotedType.clazz;
 
-            if (sort == Sort.BOOL) {
+            if (sort == boolean.class) {
                 constant = (boolean)left.constant != (boolean)right.constant;
-            } else if (sort == Sort.INT) {
+            } else if (sort == int.class) {
                 constant = (int)left.constant != (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant != (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant != (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant != (double)right.constant;
             } else {
                 constant = left.constant != right.constant;
@@ -283,7 +282,7 @@ public final class EComp extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        if (promotedType.sort == Sort.DEF) {
+        if (promotedType.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
         } else {
@@ -295,15 +294,15 @@ public final class EComp extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promotedType.sort;
+            Class<?> sort = promotedType.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant >= (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant >= (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant >= (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant >= (double)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -324,7 +323,7 @@ public final class EComp extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        if (promotedType.sort == Sort.DEF) {
+        if (promotedType.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
         } else {
@@ -336,15 +335,15 @@ public final class EComp extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promotedType.sort;
+            Class<?> sort = promotedType.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant > (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant > (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant > (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant > (double)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -365,7 +364,7 @@ public final class EComp extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        if (promotedType.sort == Sort.DEF) {
+        if (promotedType.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
         } else {
@@ -377,15 +376,15 @@ public final class EComp extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promotedType.sort;
+            Class<?> sort = promotedType.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant <= (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant <= (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant <= (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant <= (double)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -406,7 +405,7 @@ public final class EComp extends AExpression {
                 "[" + left.actual.name + "] and [" + right.actual.name + "]."));
         }
 
-        if (promotedType.sort == Sort.DEF) {
+        if (promotedType.dynamic) {
             left.expected = left.actual;
             right.expected = right.actual;
         } else {
@@ -418,15 +417,15 @@ public final class EComp extends AExpression {
         right = right.cast(variables);
 
         if (left.constant != null && right.constant != null) {
-            Sort sort = promotedType.sort;
+            Class<?> sort = promotedType.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = (int)left.constant < (int)right.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = (long)left.constant < (long)right.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = (float)left.constant < (float)right.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = (double)left.constant < (double)right.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
@@ -458,96 +457,86 @@ public final class EComp extends AExpression {
 
         boolean writejump = true;
 
-        switch (promotedType.sort) {
-            case VOID:
-            case BYTE:
-            case SHORT:
-            case CHAR:
+        Class<?> sort = promotedType.clazz;
+
+        if (sort == void.class || sort == byte.class || sort == short.class || sort == char.class) {
+            throw createError(new IllegalStateException("Illegal tree structure."));
+        } else if (sort == boolean.class) {
+            if (eq) writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
+            else if (ne) writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
+            else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
-            case BOOL:
-                if      (eq) writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
-                else if (ne) writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
-                else {
-                    throw createError(new IllegalStateException("Illegal tree structure."));
-                }
+            }
+        } else if (sort == int.class || sort == long.class || sort == float.class || sort == double.class) {
+            if (eq) writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
+            else if (ne) writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
+            else if (lt) writer.ifCmp(promotedType.type, MethodWriter.LT, jump);
+            else if (lte) writer.ifCmp(promotedType.type, MethodWriter.LE, jump);
+            else if (gt) writer.ifCmp(promotedType.type, MethodWriter.GT, jump);
+            else if (gte) writer.ifCmp(promotedType.type, MethodWriter.GE, jump);
+            else {
+                throw createError(new IllegalStateException("Illegal tree structure."));
+            }
 
-                break;
-            case INT:
-            case LONG:
-            case FLOAT:
-            case DOUBLE:
-                if      (eq)  writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
-                else if (ne)  writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
-                else if (lt)  writer.ifCmp(promotedType.type, MethodWriter.LT, jump);
-                else if (lte) writer.ifCmp(promotedType.type, MethodWriter.LE, jump);
-                else if (gt)  writer.ifCmp(promotedType.type, MethodWriter.GT, jump);
-                else if (gte) writer.ifCmp(promotedType.type, MethodWriter.GE, jump);
-                else {
-                    throw createError(new IllegalStateException("Illegal tree structure."));
-                }
+        } else if (promotedType.dynamic) {
+            org.objectweb.asm.Type booleanType = org.objectweb.asm.Type.getType(boolean.class);
+            org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(booleanType, left.actual.type, right.actual.type);
 
-                break;
-            case DEF:
-                org.objectweb.asm.Type booleanType = org.objectweb.asm.Type.getType(boolean.class);
-                org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(booleanType, left.actual.type, right.actual.type);
-
-                if (eq) {
-                    if (right.isNull) {
-                        writer.ifNull(jump);
-                    } else if (!left.isNull && operation == Operation.EQ) {
-                        writer.invokeDefCall("eq", descriptor, DefBootstrap.BINARY_OPERATOR, DefBootstrap.OPERATOR_ALLOWS_NULL);
-                        writejump = false;
-                    } else {
-                        writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
-                    }
-                } else if (ne) {
-                    if (right.isNull) {
-                        writer.ifNonNull(jump);
-                    } else if (!left.isNull && operation == Operation.NE) {
-                        writer.invokeDefCall("eq", descriptor, DefBootstrap.BINARY_OPERATOR, DefBootstrap.OPERATOR_ALLOWS_NULL);
-                        writer.ifZCmp(MethodWriter.EQ, jump);
-                    } else {
-                        writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
-                    }
-                } else if (lt) {
-                    writer.invokeDefCall("lt", descriptor, DefBootstrap.BINARY_OPERATOR, 0);
-                    writejump = false;
-                } else if (lte) {
-                    writer.invokeDefCall("lte", descriptor, DefBootstrap.BINARY_OPERATOR, 0);
-                    writejump = false;
-                } else if (gt) {
-                    writer.invokeDefCall("gt", descriptor, DefBootstrap.BINARY_OPERATOR, 0);
-                    writejump = false;
-                } else if (gte) {
-                    writer.invokeDefCall("gte", descriptor, DefBootstrap.BINARY_OPERATOR, 0);
+            if (eq) {
+                if (right.isNull) {
+                    writer.ifNull(jump);
+                } else if (!left.isNull && operation == Operation.EQ) {
+                    writer.invokeDefCall("eq", descriptor, DefBootstrap.BINARY_OPERATOR, DefBootstrap.OPERATOR_ALLOWS_NULL);
                     writejump = false;
                 } else {
-                    throw createError(new IllegalStateException("Illegal tree structure."));
+                    writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
                 }
-
-                break;
-            default:
-                if (eq) {
-                    if (right.isNull) {
-                        writer.ifNull(jump);
-                    } else if (operation == Operation.EQ) {
-                        writer.invokeStatic(OBJECTS_TYPE, EQUALS);
-                        writejump = false;
-                    } else {
-                        writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
-                    }
-                } else if (ne) {
-                    if (right.isNull) {
-                        writer.ifNonNull(jump);
-                    } else if (operation == Operation.NE) {
-                        writer.invokeStatic(OBJECTS_TYPE, EQUALS);
-                        writer.ifZCmp(MethodWriter.EQ, jump);
-                    } else {
-                        writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
-                    }
+            } else if (ne) {
+                if (right.isNull) {
+                    writer.ifNonNull(jump);
+                } else if (!left.isNull && operation == Operation.NE) {
+                    writer.invokeDefCall("eq", descriptor, DefBootstrap.BINARY_OPERATOR, DefBootstrap.OPERATOR_ALLOWS_NULL);
+                    writer.ifZCmp(MethodWriter.EQ, jump);
                 } else {
-                    throw createError(new IllegalStateException("Illegal tree structure."));
+                    writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
                 }
+            } else if (lt) {
+                writer.invokeDefCall("lt", descriptor, DefBootstrap.BINARY_OPERATOR, 0);
+                writejump = false;
+            } else if (lte) {
+                writer.invokeDefCall("lte", descriptor, DefBootstrap.BINARY_OPERATOR, 0);
+                writejump = false;
+            } else if (gt) {
+                writer.invokeDefCall("gt", descriptor, DefBootstrap.BINARY_OPERATOR, 0);
+                writejump = false;
+            } else if (gte) {
+                writer.invokeDefCall("gte", descriptor, DefBootstrap.BINARY_OPERATOR, 0);
+                writejump = false;
+            } else {
+                throw createError(new IllegalStateException("Illegal tree structure."));
+            }
+        } else {
+            if (eq) {
+                if (right.isNull) {
+                    writer.ifNull(jump);
+                } else if (operation == Operation.EQ) {
+                    writer.invokeStatic(OBJECTS_TYPE, EQUALS);
+                    writejump = false;
+                } else {
+                    writer.ifCmp(promotedType.type, MethodWriter.EQ, jump);
+                }
+            } else if (ne) {
+                if (right.isNull) {
+                    writer.ifNonNull(jump);
+                } else if (operation == Operation.NE) {
+                    writer.invokeStatic(OBJECTS_TYPE, EQUALS);
+                    writer.ifZCmp(MethodWriter.EQ, jump);
+                } else {
+                    writer.ifCmp(promotedType.type, MethodWriter.NE, jump);
+                }
+            } else {
+                throw createError(new IllegalStateException("Illegal tree structure."));
+            }
         }
 
         if (writejump) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EConstant.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EConstant.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Globals;
-import org.elasticsearch.painless.Definition.Sort;
 
 import java.util.Set;
 
@@ -73,20 +72,17 @@ final class EConstant extends AExpression {
 
     @Override
     void write(MethodWriter writer, Globals globals) {
-        Sort sort = actual.sort;
-
-        switch (sort) {
-            case STRING: writer.push((String)constant);  break;
-            case DOUBLE: writer.push((double)constant);  break;
-            case FLOAT:  writer.push((float)constant);   break;
-            case LONG:   writer.push((long)constant);    break;
-            case INT:    writer.push((int)constant);     break;
-            case CHAR:   writer.push((char)constant);    break;
-            case SHORT:  writer.push((short)constant);   break;
-            case BYTE:   writer.push((byte)constant);    break;
-            case BOOL:   writer.push((boolean)constant); break;
-            default:
-                throw createError(new IllegalStateException("Illegal tree structure."));
+        if      (actual.clazz == String.class) writer.push((String)constant);
+        else if (actual.clazz == double.class) writer.push((double)constant);
+        else if (actual.clazz == float.class) writer.push((float)constant);
+        else if (actual.clazz == long.class) writer.push((long)constant);
+        else if (actual.clazz == int.class) writer.push((int)constant);
+        else if (actual.clazz == char.class) writer.push((char)constant);
+        else if (actual.clazz == short.class) writer.push((short)constant);
+        else if (actual.clazz == byte.class) writer.push((byte)constant);
+        else if (actual.clazz == boolean.class) writer.push((boolean)constant);
+        else {
+            throw createError(new IllegalStateException("Illegal tree structure."));
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EElvis.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EElvis.java
@@ -54,8 +54,8 @@ public class EElvis extends AExpression {
 
     @Override
     void analyze(Locals locals) {
-        if (expected != null && expected.sort.primitive) {
-            throw createError(new IllegalArgumentException("Evlis operator cannot return primitives"));
+        if (expected != null && expected.clazz.isPrimitive()) {
+            throw createError(new IllegalArgumentException("Elvis operator cannot return primitives"));
         }
         lhs.expected = expected;
         lhs.explicit = explicit;
@@ -73,7 +73,7 @@ public class EElvis extends AExpression {
         if (lhs.constant != null) {
             throw createError(new IllegalArgumentException("Extraneous elvis operator. LHS is a constant."));
         }
-        if (lhs.actual.sort.primitive) {
+        if (lhs.actual.clazz.isPrimitive()) {
             throw createError(new IllegalArgumentException("Extraneous elvis operator. LHS is a primitive."));
         }
         if (rhs.isNull) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EInstanceof.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EInstanceof.java
@@ -65,7 +65,7 @@ public final class EInstanceof extends AExpression {
         }
 
         // map to wrapped type for primitive types
-        resolvedType = type.sort.primitive ? type.sort.boxed : type.clazz;
+        resolvedType = type.clazz.isPrimitive() ? Definition.getBoxedType(type).clazz : type.clazz;
 
         // analyze and cast the expression
         expression.analyze(locals);
@@ -73,9 +73,9 @@ public final class EInstanceof extends AExpression {
         expression = expression.cast(locals);
 
         // record if the expression returns a primitive
-        primitiveExpression = expression.actual.sort.primitive;
+        primitiveExpression = expression.actual.clazz.isPrimitive();
         // map to wrapped type for primitive types
-        expressionType = expression.actual.sort.primitive ? expression.actual.sort.boxed : type.clazz;
+        expressionType = expression.actual.clazz.isPrimitive() ? Definition.getBoxedType(expression.actual).clazz : type.clazz;
 
         actual = Definition.BOOLEAN_TYPE;
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENull.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENull.java
@@ -52,7 +52,7 @@ public final class ENull extends AExpression {
         isNull = true;
 
         if (expected != null) {
-            if (expected.sort.primitive) {
+            if (expected.clazz.isPrimitive()) {
                 throw createError(new IllegalArgumentException("Cannot cast null to a primitive type [" + expected.name + "]."));
             }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENumeric.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENumeric.java
@@ -22,7 +22,6 @@ package org.elasticsearch.painless.node;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Location;
-import org.elasticsearch.painless.Definition.Sort;
 
 import java.util.Objects;
 import java.util.Set;
@@ -87,16 +86,16 @@ public final class ENumeric extends AExpression {
             }
         } else {
             try {
-                Sort sort = expected == null ? Sort.INT : expected.sort;
+                Class<?> sort = expected == null ? int.class : expected.clazz;
                 int integer = Integer.parseInt(value, radix);
 
-                if (sort == Sort.BYTE && integer >= Byte.MIN_VALUE && integer <= Byte.MAX_VALUE) {
+                if (sort == byte.class && integer >= Byte.MIN_VALUE && integer <= Byte.MAX_VALUE) {
                     constant = (byte)integer;
                     actual = Definition.BYTE_TYPE;
-                } else if (sort == Sort.CHAR && integer >= Character.MIN_VALUE && integer <= Character.MAX_VALUE) {
+                } else if (sort == char.class && integer >= Character.MIN_VALUE && integer <= Character.MAX_VALUE) {
                     constant = (char)integer;
                     actual = Definition.CHAR_TYPE;
-                } else if (sort == Sort.SHORT && integer >= Short.MIN_VALUE && integer <= Short.MAX_VALUE) {
+                } else if (sort == short.class && integer >= Short.MIN_VALUE && integer <= Short.MAX_VALUE) {
                     constant = (short)integer;
                     actual = Definition.SHORT_TYPE;
                 } else {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EUnary.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EUnary.java
@@ -22,7 +22,6 @@ package org.elasticsearch.painless.node;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Location;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.DefBootstrap;
@@ -101,18 +100,18 @@ public final class EUnary extends AExpression {
         child = child.cast(variables);
 
         if (child.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = ~(int)child.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = ~(long)child.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
             }
         }
 
-        if (promote.sort == Sort.DEF && expected != null) {
+        if (promote.dynamic && expected != null) {
             actual = expected;
         } else {
             actual = promote;
@@ -132,22 +131,22 @@ public final class EUnary extends AExpression {
         child = child.cast(variables);
 
         if (child.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = +(int)child.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = +(long)child.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = +(float)child.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = +(double)child.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
             }
         }
 
-        if (promote.sort == Sort.DEF && expected != null) {
+        if (promote.dynamic && expected != null) {
             actual = expected;
         } else {
             actual = promote;
@@ -167,22 +166,22 @@ public final class EUnary extends AExpression {
         child = child.cast(variables);
 
         if (child.constant != null) {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
 
-            if (sort == Sort.INT) {
+            if (sort == int.class) {
                 constant = -(int)child.constant;
-            } else if (sort == Sort.LONG) {
+            } else if (sort == long.class) {
                 constant = -(long)child.constant;
-            } else if (sort == Sort.FLOAT) {
+            } else if (sort == float.class) {
                 constant = -(float)child.constant;
-            } else if (sort == Sort.DOUBLE) {
+            } else if (sort == double.class) {
                 constant = -(double)child.constant;
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));
             }
         }
 
-        if (promote.sort == Sort.DEF && expected != null) {
+        if (promote.dynamic && expected != null) {
             actual = expected;
         } else {
             actual = promote;
@@ -206,7 +205,7 @@ public final class EUnary extends AExpression {
             writer.push(true);
             writer.mark(end);
         } else {
-            Sort sort = promote.sort;
+            Class<?> sort = promote.clazz;
             child.write(writer, globals);
 
             // Def calls adopt the wanted return value. If there was a narrowing cast,
@@ -218,13 +217,13 @@ public final class EUnary extends AExpression {
             }
 
             if (operation == Operation.BWNOT) {
-                if (sort == Sort.DEF) {
+                if (promote.dynamic) {
                     org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(actual.type, child.actual.type);
                     writer.invokeDefCall("not", descriptor, DefBootstrap.UNARY_OPERATOR, defFlags);
                 } else {
-                    if (sort == Sort.INT) {
+                    if (sort == int.class) {
                         writer.push(-1);
-                    } else if (sort == Sort.LONG) {
+                    } else if (sort == long.class) {
                         writer.push(-1L);
                     } else {
                         throw createError(new IllegalStateException("Illegal tree structure."));
@@ -233,14 +232,14 @@ public final class EUnary extends AExpression {
                     writer.math(MethodWriter.XOR, actual.type);
                 }
             } else if (operation == Operation.SUB) {
-                if (sort == Sort.DEF) {
+                if (promote.dynamic) {
                     org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(actual.type, child.actual.type);
                     writer.invokeDefCall("neg", descriptor, DefBootstrap.UNARY_OPERATOR, defFlags);
                 } else {
                     writer.math(MethodWriter.NEG, actual.type);
                 }
             } else if (operation == Operation.ADD) {
-                if (sort == Sort.DEF) {
+                if (promote.dynamic) {
                     org.objectweb.asm.Type descriptor = org.objectweb.asm.Type.getMethodType(actual.type, child.actual.type);
                     writer.invokeDefCall("plus", descriptor, DefBootstrap.UNARY_OPERATOR, defFlags);
                 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PBrace.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PBrace.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -58,11 +57,9 @@ public final class PBrace extends AStoreable {
         prefix.expected = prefix.actual;
         prefix = prefix.cast(locals);
 
-        Sort sort = prefix.actual.sort;
-
-        if (sort == Sort.ARRAY) {
+        if (prefix.actual.dimensions > 0) {
             sub = new PSubBrace(location, prefix.actual, index);
-        } else if (sort == Sort.DEF) {
+        } else if (prefix.actual.dynamic) {
             sub = new PSubDefArray(location, index);
         } else if (Map.class.isAssignableFrom(prefix.actual.clazz)) {
             sub = new PSubMapShortcut(location, prefix.actual.struct, index);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
@@ -22,7 +22,6 @@ package org.elasticsearch.painless.node;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Field;
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
@@ -63,11 +62,9 @@ public final class PField extends AStoreable {
         prefix.expected = prefix.actual;
         prefix = prefix.cast(locals);
 
-        Sort sort = prefix.actual.sort;
-
-        if (sort == Sort.ARRAY) {
+        if (prefix.actual.dimensions > 0) {
             sub = new PSubArrayLength(location, prefix.actual.name, value);
-        } else if (sort == Sort.DEF) {
+        } else if (prefix.actual.dynamic) {
             sub = new PSubDefField(location, value);
         } else {
             Struct struct = prefix.actual.struct;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
@@ -71,7 +71,7 @@ final class PSubCallInvoke extends AExpression {
     void write(MethodWriter writer, Globals globals) {
         writer.writeDebugInfo(location);
 
-        if (box.sort.primitive) {
+        if (box.clazz.isPrimitive()) {
             writer.box(box.type);
         }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
@@ -61,12 +60,12 @@ final class PSubListShortcut extends AStoreable {
         getter = struct.methods.get(new Definition.MethodKey("get", 1));
         setter = struct.methods.get(new Definition.MethodKey("set", 2));
 
-        if (getter != null && (getter.rtn.sort == Sort.VOID || getter.arguments.size() != 1 ||
-            getter.arguments.get(0).sort != Sort.INT)) {
+        if (getter != null && (getter.rtn.clazz == void.class || getter.arguments.size() != 1 ||
+            getter.arguments.get(0).clazz != int.class)) {
             throw createError(new IllegalArgumentException("Illegal list get shortcut for type [" + struct.name + "]."));
         }
 
-        if (setter != null && (setter.arguments.size() != 2 || setter.arguments.get(0).sort != Sort.INT)) {
+        if (setter != null && (setter.arguments.size() != 2 || setter.arguments.get(0).clazz != int.class)) {
             throw createError(new IllegalArgumentException("Illegal list set shortcut for type [" + struct.name + "]."));
         }
 
@@ -132,7 +131,7 @@ final class PSubListShortcut extends AStoreable {
 
         setter.write(writer);
 
-        writer.writePop(setter.rtn.sort.size);
+        writer.writePop(setter.rtn.type.getSize());
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
@@ -25,7 +25,6 @@ import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Location;
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.Sort;
 
 import java.util.Objects;
 import java.util.Set;
@@ -61,7 +60,7 @@ final class PSubMapShortcut extends AStoreable {
         getter = struct.methods.get(new Definition.MethodKey("get", 1));
         setter = struct.methods.get(new Definition.MethodKey("put", 2));
 
-        if (getter != null && (getter.rtn.sort == Sort.VOID || getter.arguments.size() != 1)) {
+        if (getter != null && (getter.rtn.clazz == void.class || getter.arguments.size() != 1)) {
             throw createError(new IllegalArgumentException("Illegal map get shortcut for type [" + struct.name + "]."));
         }
 
@@ -135,7 +134,7 @@ final class PSubMapShortcut extends AStoreable {
 
         setter.write(writer);
 
-        writer.writePop(setter.rtn.sort.size);
+        writer.writePop(setter.rtn.type.getSize());
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeCallInvoke.java
@@ -52,7 +52,7 @@ public class PSubNullSafeCallInvoke extends AExpression {
     void analyze(Locals locals) {
         guarded.analyze(locals);
         actual = guarded.actual;
-        if (actual.sort.primitive) {
+        if (actual.clazz.isPrimitive()) {
             throw new IllegalArgumentException("Result of null safe operator must be nullable");
         }
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubNullSafeField.java
@@ -52,7 +52,7 @@ public class PSubNullSafeField extends AStoreable {
         guarded.read = read;
         guarded.analyze(locals);
         actual = guarded.actual;
-        if (actual.sort.primitive) {
+        if (actual.clazz.isPrimitive()) {
             throw new IllegalArgumentException("Result of null safe operator must be nullable");
         }
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubShortcut.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -55,12 +54,12 @@ final class PSubShortcut extends AStoreable {
 
     @Override
     void analyze(Locals locals) {
-        if (getter != null && (getter.rtn.sort == Sort.VOID || !getter.arguments.isEmpty())) {
+        if (getter != null && (getter.rtn.clazz == void.class || !getter.arguments.isEmpty())) {
             throw createError(new IllegalArgumentException(
                 "Illegal get shortcut on field [" + value + "] for type [" + type + "]."));
         }
 
-        if (setter != null && (setter.rtn.sort != Sort.VOID || setter.arguments.size() != 1)) {
+        if (setter != null && (setter.rtn.clazz != void.class || setter.arguments.size() != 1)) {
             throw createError(new IllegalArgumentException(
                 "Illegal set shortcut on field [" + value + "] for type [" + type + "]."));
         }
@@ -124,7 +123,7 @@ final class PSubShortcut extends AStoreable {
 
         setter.write(writer);
 
-        writer.writePop(setter.rtn.sort.size);
+        writer.writePop(setter.rtn.type.getSize());
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SDeclaration.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SDeclaration.java
@@ -82,17 +82,19 @@ public final class SDeclaration extends AStatement {
         writer.writeStatementOffset(location);
 
         if (expression == null) {
-            switch (variable.type.sort) {
-                case VOID:   throw createError(new IllegalStateException("Illegal tree structure."));
-                case BOOL:
-                case BYTE:
-                case SHORT:
-                case CHAR:
-                case INT:    writer.push(0);    break;
-                case LONG:   writer.push(0L);   break;
-                case FLOAT:  writer.push(0.0F); break;
-                case DOUBLE: writer.push(0.0);  break;
-                default:     writer.visitInsn(Opcodes.ACONST_NULL);
+            Class<?> sort = variable.type.clazz;
+
+            if (sort == void.class || sort == boolean.class || sort == byte.class ||
+                sort == short.class || sort == char.class || sort == int.class) {
+                writer.push(0);
+            } else if (sort == long.class) {
+                writer.push(0L);
+            } else if (sort == float.class) {
+                writer.push(0F);
+            } else if (sort == double.class) {
+                writer.push(0D);
+            } else {
+                writer.visitInsn(Opcodes.ACONST_NULL);
             }
         } else {
             expression.write(writer, globals);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SEach.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SEach.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -79,9 +78,9 @@ public class SEach extends AStatement {
         locals = Locals.newLocalScope(locals);
         Variable variable = locals.addVariable(location, type, name, true);
 
-        if (expression.actual.sort == Sort.ARRAY) {
+        if (expression.actual.dimensions > 0) {
             sub = new SSubEachArray(location, variable, expression, block);
-        } else if (expression.actual.sort == Sort.DEF || Iterable.class.isAssignableFrom(expression.actual.clazz)) {
+        } else if (expression.actual.dynamic || Iterable.class.isAssignableFrom(expression.actual.clazz)) {
             sub = new SSubEachIterable(location, variable, expression, block);
         } else {
             throw createError(new IllegalArgumentException("Illegal for each type [" + expression.actual.name + "]."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SExpression.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SExpression.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -50,7 +49,7 @@ public final class SExpression extends AStatement {
     @Override
     void analyze(Locals locals) {
         Type rtnType = locals.getReturnType();
-        boolean isVoid = rtnType.sort == Sort.VOID;
+        boolean isVoid = rtnType.clazz == void.class;
 
         expression.read = lastSource && !isVoid;
         expression.analyze(locals);
@@ -59,7 +58,7 @@ public final class SExpression extends AStatement {
             throw createError(new IllegalArgumentException("Not a statement."));
         }
 
-        boolean rtn = lastSource && !isVoid && expression.actual.sort != Sort.VOID;
+        boolean rtn = lastSource && !isVoid && expression.actual.clazz != void.class;
 
         expression.expected = rtn ? rtnType : expression.actual;
         expression.internal = rtn;
@@ -79,7 +78,7 @@ public final class SExpression extends AStatement {
         if (methodEscape) {
             writer.returnValue();
         } else {
-            writer.writePop(expression.expected.sort.size);
+            writer.writePop(expression.expected.type.getSize());
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFor.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFor.java
@@ -161,7 +161,7 @@ public final class SFor extends AStatement {
             AExpression initializer = (AExpression)this.initializer;
 
             initializer.write(writer, globals);
-            writer.writePop(initializer.expected.sort.size);
+            writer.writePop(initializer.expected.type.getSize());
         }
 
         writer.mark(start);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFunction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFunction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.painless.Constant;
 import org.elasticsearch.painless.Def;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Method;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Definition.Type;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -163,7 +162,7 @@ public final class SFunction extends AStatement {
             allEscape = statement.allEscape;
         }
 
-        if (!methodEscape && rtnType.sort != Sort.VOID) {
+        if (!methodEscape && rtnType.clazz != void.class) {
             throw createError(new IllegalArgumentException("Not all paths provide a return value for method [" + name + "]."));
         }
 
@@ -198,7 +197,7 @@ public final class SFunction extends AStatement {
         }
 
         if (!methodEscape) {
-            if (rtnType.sort == Sort.VOID) {
+            if (rtnType.clazz == void.class) {
                 function.returnValue();
             } else {
                 throw createError(new IllegalStateException("Illegal tree structure."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
@@ -25,7 +25,6 @@ import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Definition.Method;
 import org.elasticsearch.painless.Definition.MethodKey;
-import org.elasticsearch.painless.Definition.Sort;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Variable;
@@ -74,7 +73,7 @@ final class SSubEachIterable extends AStatement {
         iterator = locals.addVariable(location, locals.getDefinition().getType("Iterator"),
                 "#itr" + location.getOffset(), true);
 
-        if (expression.actual.sort == Sort.DEF) {
+        if (expression.actual.dynamic) {
             method = null;
         } else {
             method = expression.actual.struct.methods.get(new MethodKey("iterator", 0));

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ElvisTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ElvisTests.java
@@ -142,6 +142,6 @@ public class ElvisTests extends ScriptTestCase {
 
     private void assertCannotReturnPrimitive(String script) {
         Exception e = expectScriptThrows(IllegalArgumentException.class, () -> exec(script));
-        assertEquals("Evlis operator cannot return primitives", e.getMessage());
+        assertEquals("Elvis operator cannot return primitives", e.getMessage());
     }
 }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessDocGenerator.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessDocGenerator.java
@@ -69,7 +69,7 @@ public class PainlessDocGenerator {
             emitGeneratedWarning(indexStream);
             List<Type> types = Definition.allSimpleTypes().stream().sorted(comparing(t -> t.name)).collect(toList());
             for (Type type : types) {
-                if (type.sort.primitive) {
+                if (type.clazz.isPrimitive()) {
                     // Primitives don't have methods to reference
                     continue;
                 }


### PR DESCRIPTION
As the title says.  All of the information contained in the Sort enum was redundant and can be obtained from the existing data structures members in slightly different ways.  This not only reduces the amount of code, but also is a major step in making Definition instanceable.  This change looks large, but it's impossible to remove sort without also modifying the majority of the AnalyzerCaster file, so in reality it's a lot of lines with minor changes.  @rjernst Please don't reject this outright!