### PR TITLE
Make RestHighLevelClient Closeable and simplify its creation

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -197,8 +197,8 @@ public class RestHighLevelClient implements Closeable {
      */
     protected RestHighLevelClient(RestClient restClient, CheckedConsumer<RestClient, IOException> doClose,
                                   List<NamedXContentRegistry.Entry> namedXContentEntries) {
-        this.client = Objects.requireNonNull(restClient);
-        this.doClose = doClose;
+        this.client = Objects.requireNonNull(restClient, "restClient must not be null");
+        this.doClose = Objects.requireNonNull(doClose, "doClose consumer must not be null");
         this.registry = new NamedXContentRegistry(
                 Stream.of(getDefaultNamedXContents().stream(), getProvidedNamedXContents().stream(), namedXContentEntries.stream())
                     .flatMap(Function.identity()).collect(toList()));

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -184,7 +184,7 @@ public class RestHighLevelClient implements Closeable {
      * Creates a {@link RestHighLevelClient} given the low level {@link RestClient} that it should use to perform requests and
      * a list of entries that allow to parse custom response sections added to Elasticsearch through plugins.
      * This constructor can be called by subclasses in case an externally created low-level REST client needs to be provided.
-     * The consumer argument allows to control what needs to be done when the {@link #close()} method is called.a
+     * The consumer argument allows to control what needs to be done when the {@link #close()} method is called.
      * Also subclasses can provide parsers for custom response sections added to Elasticsearch through plugins.
      */
     protected RestHighLevelClient(RestClient restClient, CheckedConsumer<RestClient, IOException> doClose,

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -177,7 +177,15 @@ public class RestHighLevelClient implements Closeable {
      * {@link RestClient} to be used to perform requests.
      */
     public RestHighLevelClient(RestClientBuilder restClientBuilder) {
-        this(restClientBuilder.build(), RestClient::close, Collections.emptyList());
+        this(restClientBuilder, Collections.emptyList());
+    }
+
+    /**
+     * Creates a {@link RestHighLevelClient} given the low level {@link RestClientBuilder} that allows to build the
+     * {@link RestClient} to be used to perform requests and parsers for custom response sections added to Elasticsearch through plugins.
+     */
+    protected RestHighLevelClient(RestClientBuilder restClientBuilder, List<NamedXContentRegistry.Entry> namedXContentEntries) {
+        this(restClientBuilder.build(), RestClient::close, namedXContentEntries);
     }
 
     /**

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
@@ -59,6 +59,7 @@ import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test and demonstrates how {@link RestHighLevelClient} can be extended to support custom endpoints.
@@ -74,7 +75,9 @@ public class CustomRestHighLevelClientTests extends ESTestCase {
     public void initClients() throws IOException {
         if (restHighLevelClient == null) {
             final RestClient restClient = mock(RestClient.class);
-            restHighLevelClient = new CustomRestClient(restClient);
+            final RestClientBuilder restClientBuilder = mock(RestClientBuilder.class);
+            when(restClientBuilder.build()).thenReturn(restClient);
+            restHighLevelClient = new CustomRestClient(restClientBuilder);
 
             doAnswer(mock -> mockPerformRequest((Header) mock.getArguments()[4]))
                     .when(restClient)
@@ -150,8 +153,8 @@ public class CustomRestHighLevelClientTests extends ESTestCase {
      */
     static class CustomRestClient extends RestHighLevelClient {
 
-        private CustomRestClient(RestClient restClient) {
-            super(restClient);
+        private CustomRestClient(RestClientBuilder restClientBuilder) {
+            super(restClientBuilder);
         }
 
         MainResponse custom(MainRequest mainRequest, Header... headers) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
@@ -19,6 +19,12 @@
 
 package org.elasticsearch.client;
 
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.main.MainRequest;
+import org.elasticsearch.action.main.MainResponse;
 import org.elasticsearch.client.http.Header;
 import org.elasticsearch.client.http.HttpEntity;
 import org.elasticsearch.client.http.HttpHost;
@@ -32,12 +38,6 @@ import org.elasticsearch.client.http.message.BasicHeader;
 import org.elasticsearch.client.http.message.BasicHttpResponse;
 import org.elasticsearch.client.http.message.BasicRequestLine;
 import org.elasticsearch.client.http.message.BasicStatusLine;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Build;
-import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.main.MainRequest;
-import org.elasticsearch.action.main.MainResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -48,6 +48,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -59,7 +60,6 @@ import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Test and demonstrates how {@link RestHighLevelClient} can be extended to support custom endpoints.
@@ -75,9 +75,7 @@ public class CustomRestHighLevelClientTests extends ESTestCase {
     public void initClients() throws IOException {
         if (restHighLevelClient == null) {
             final RestClient restClient = mock(RestClient.class);
-            final RestClientBuilder restClientBuilder = mock(RestClientBuilder.class);
-            when(restClientBuilder.build()).thenReturn(restClient);
-            restHighLevelClient = new CustomRestClient(restClientBuilder);
+            restHighLevelClient = new CustomRestClient(restClient);
 
             doAnswer(mock -> mockPerformRequest((Header) mock.getArguments()[4]))
                     .when(restClient)
@@ -153,8 +151,8 @@ public class CustomRestHighLevelClientTests extends ESTestCase {
      */
     static class CustomRestClient extends RestHighLevelClient {
 
-        private CustomRestClient(RestClientBuilder restClientBuilder) {
-            super(restClientBuilder);
+        private CustomRestClient(RestClient restClient) {
+            super(restClient, RestClient::close, Collections.emptyList());
         }
 
         MainResponse custom(MainRequest mainRequest, Header... headers) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
@@ -41,7 +41,8 @@ public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
     }
 
     @AfterClass
-    public static void cleanupClient() {
+    public static void cleanupClient() throws IOException {
+        restHighLevelClient.close();
         restHighLevelClient = null;
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
@@ -19,14 +19,15 @@
 
 package org.elasticsearch.client;
 
-import org.elasticsearch.client.http.Header;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.http.Header;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.AfterClass;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.Collections;
 
 public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
 
@@ -36,7 +37,7 @@ public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
     public void initHighLevelClient() throws IOException {
         super.initClient();
         if (restHighLevelClient == null) {
-            restHighLevelClient = new RestHighLevelClient(client());
+            restHighLevelClient = new HighLevelClient(client());
         }
     }
 
@@ -72,5 +73,17 @@ public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
     @FunctionalInterface
     protected interface AsyncMethod<Request, Response> {
         void execute(Request request, ActionListener<Response> listener, Header... headers);
+    }
+
+    private static class HighLevelClient extends RestHighLevelClient {
+
+        private HighLevelClient(RestClient restClient) {
+            super(restClient, Collections.emptyList());
+        }
+
+        @Override
+        public void close() throws IOException {
+            //no-op: the low-level client gets closed externally
+        }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ESRestHighLevelClientTestCase.java
@@ -76,14 +76,8 @@ public abstract class ESRestHighLevelClientTestCase extends ESRestTestCase {
     }
 
     private static class HighLevelClient extends RestHighLevelClient {
-
         private HighLevelClient(RestClient restClient) {
-            super(restClient, Collections.emptyList());
-        }
-
-        @Override
-        public void close() throws IOException {
-            //no-op: the low-level client gets closed externally
+            super(restClient, (client) -> {}, Collections.emptyList());
         }
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * This test works against a {@link RestHighLevelClient} subclass that simulats how custom response sections returned by
@@ -46,7 +47,9 @@ public class RestHighLevelClientExtTests extends ESTestCase {
     @Before
     public void initClient() throws IOException {
         RestClient restClient = mock(RestClient.class);
-        restHighLevelClient = new RestHighLevelClientExt(restClient);
+        final RestClientBuilder restClientBuilder = mock(RestClientBuilder.class);
+        when(restClientBuilder.build()).thenReturn(restClient);
+        restHighLevelClient = new RestHighLevelClientExt(restClientBuilder);
     }
 
     public void testParseEntityCustomResponseSection() throws IOException {
@@ -68,8 +71,8 @@ public class RestHighLevelClientExtTests extends ESTestCase {
 
     private static class RestHighLevelClientExt extends RestHighLevelClient {
 
-        private RestHighLevelClientExt(RestClient restClient) {
-            super(restClient, RestClient::close, getNamedXContentsExt());
+        private RestHighLevelClientExt(RestClientBuilder restClientBuilder) {
+            super(restClientBuilder, getNamedXContentsExt());
         }
 
         private static List<NamedXContentRegistry.Entry> getNamedXContentsExt() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
@@ -69,7 +69,7 @@ public class RestHighLevelClientExtTests extends ESTestCase {
     private static class RestHighLevelClientExt extends RestHighLevelClient {
 
         private RestHighLevelClientExt(RestClient restClient) {
-            super(restClient, getNamedXContentsExt());
+            super(restClient, RestClient::close, getNamedXContentsExt());
         }
 
         private static List<NamedXContentRegistry.Entry> getNamedXContentsExt() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
@@ -34,7 +34,6 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * This test works against a {@link RestHighLevelClient} subclass that simulats how custom response sections returned by
@@ -47,9 +46,7 @@ public class RestHighLevelClientExtTests extends ESTestCase {
     @Before
     public void initClient() throws IOException {
         RestClient restClient = mock(RestClient.class);
-        final RestClientBuilder restClientBuilder = mock(RestClientBuilder.class);
-        when(restClientBuilder.build()).thenReturn(restClient);
-        restHighLevelClient = new RestHighLevelClientExt(restClientBuilder);
+        restHighLevelClient = new RestHighLevelClientExt(restClient);
     }
 
     public void testParseEntityCustomResponseSection() throws IOException {
@@ -71,8 +68,8 @@ public class RestHighLevelClientExtTests extends ESTestCase {
 
     private static class RestHighLevelClientExt extends RestHighLevelClient {
 
-        private RestHighLevelClientExt(RestClientBuilder restClientBuilder) {
-            super(restClientBuilder, getNamedXContentsExt());
+        private RestHighLevelClientExt(RestClient restClient) {
+            super(restClient, RestClient::close, getNamedXContentsExt());
         }
 
         private static List<NamedXContentRegistry.Entry> getNamedXContentsExt() {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -105,7 +105,9 @@ public class RestHighLevelClientTests extends ESTestCase {
     @Before
     public void initClient() {
         restClient = mock(RestClient.class);
-        restHighLevelClient = new RestHighLevelClient(restClient);
+        final RestClientBuilder restClientBuilder = mock(RestClientBuilder.class);
+        when(restClientBuilder.build()).thenReturn(restClient);
+        restHighLevelClient = new RestHighLevelClient(restClientBuilder);
     }
 
     public void testPingSuccessful() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -91,6 +91,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNotNull;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -105,9 +106,16 @@ public class RestHighLevelClientTests extends ESTestCase {
     @Before
     public void initClient() {
         restClient = mock(RestClient.class);
-        final RestClientBuilder restClientBuilder = mock(RestClientBuilder.class);
-        when(restClientBuilder.build()).thenReturn(restClient);
-        restHighLevelClient = new RestHighLevelClient(restClientBuilder);
+        restHighLevelClient = new RestHighLevelClient(restClient, RestClient::close, Collections.emptyList());
+    }
+
+    public void testCloseIsIdempotent() throws IOException {
+        restHighLevelClient.close();
+        verify(restClient, times(1)).close();
+        restHighLevelClient.close();
+        verify(restClient, times(2)).close();
+        restHighLevelClient.close();
+        verify(restClient, times(3)).close();
     }
 
     public void testPingSuccessful() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MainDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MainDocumentationIT.java
@@ -23,7 +23,9 @@ import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.main.MainResponse;
 import org.elasticsearch.client.ESRestHighLevelClientTestCase;
+import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.http.HttpHost;
 import org.elasticsearch.cluster.ClusterName;
 
 import java.io.IOException;
@@ -64,5 +66,29 @@ public class MainDocumentationIT extends ESRestHighLevelClientTestCase {
             assertNotNull(version);
             assertNotNull(build);
         }
+    }
+
+    public void testInitializationFromHosts() throws IOException {
+        //tag::rest-high-level-client-init-hosts
+        RestHighLevelClient restHighLevelClient = new RestHighLevelClient(
+                new HttpHost("localhost", 9200, "http"),
+                new HttpHost("localhost", 9201, "http"));
+        //end::rest-high-level-client-init-hosts
+
+        //tag::rest-high-level-client-close
+        restHighLevelClient.close();
+        //end::rest-high-level-client-close
+    }
+
+    public void testInitializationFromClient() throws IOException {
+        //tag::rest-high-level-client-init-client
+        RestClient lowLevelClient = RestClient.builder(new HttpHost("localhost", 9200))
+                .setRequestConfigCallback(
+                        requestConfigBuilder -> requestConfigBuilder.setConnectTimeout(5000).setSocketTimeout(60000))
+                .setMaxRetryTimeoutMillis(60000).build();
+        RestHighLevelClient restHighLevelClient = new RestHighLevelClient(lowLevelClient);
+        //end::rest-high-level-client-init-client
+
+        restHighLevelClient.close();
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MainDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MainDocumentationIT.java
@@ -68,27 +68,16 @@ public class MainDocumentationIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    public void testInitializationFromHosts() throws IOException {
-        //tag::rest-high-level-client-init-hosts
-        RestHighLevelClient restHighLevelClient = new RestHighLevelClient(
-                new HttpHost("localhost", 9200, "http"),
-                new HttpHost("localhost", 9201, "http"));
-        //end::rest-high-level-client-init-hosts
+    public void testInitializationFromClientBuilder() throws IOException {
+        //tag::rest-high-level-client-init
+        RestHighLevelClient client = new RestHighLevelClient(
+                RestClient.builder(
+                        new HttpHost("localhost", 9200, "http"),
+                        new HttpHost("localhost", 9201, "http")));
+        //end::rest-high-level-client-init
 
         //tag::rest-high-level-client-close
-        restHighLevelClient.close();
+        client.close();
         //end::rest-high-level-client-close
-    }
-
-    public void testInitializationFromClient() throws IOException {
-        //tag::rest-high-level-client-init-client
-        RestClient lowLevelClient = RestClient.builder(new HttpHost("localhost", 9200))
-                .setRequestConfigCallback(
-                        requestConfigBuilder -> requestConfigBuilder.setConnectTimeout(5000).setSocketTimeout(60000))
-                .setMaxRetryTimeoutMillis(60000).build();
-        RestHighLevelClient restHighLevelClient = new RestHighLevelClient(lowLevelClient);
-        //end::rest-high-level-client-init-client
-
-        restHighLevelClient.close();
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MigrationDocumentationIT.java
@@ -23,11 +23,9 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.ESRestHighLevelClientTestCase;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.http.HttpEntity;
 import org.elasticsearch.client.http.HttpStatus;
@@ -67,7 +65,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
 
     public void testCreateIndex() throws IOException {
-        RestClient restClient = client();
+        RestHighLevelClient client = highLevelClient();
         {
             //tag::migration-create-inded
             Settings indexSettings = Settings.builder() // <1>
@@ -93,7 +91,7 @@ public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
 
             HttpEntity entity = new NStringEntity(payload, ContentType.APPLICATION_JSON); // <5>
 
-            Response response = restClient.performRequest("PUT", "my-index", emptyMap(), entity); // <6>
+            Response response = client.getLowLevelClient().performRequest("PUT", "my-index", emptyMap(), entity); // <6>
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
                 // <7>
             }
@@ -103,10 +101,10 @@ public class MigrationDocumentationIT extends ESRestHighLevelClientTestCase {
     }
 
     public void testClusterHealth() throws IOException {
-        RestClient restClient = client();
+        RestHighLevelClient client = highLevelClient();
         {
             //tag::migration-cluster-health
-            Response response = restClient.performRequest("GET", "/_cluster/health"); // <1>
+            Response response = client.getLowLevelClient().performRequest("GET", "/_cluster/health"); // <1>
 
             ClusterHealthStatus healthStatus;
             try (InputStream is = response.getEntity().getContent()) { // <2>

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -66,7 +66,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -100,7 +99,6 @@ public class RestClient implements Closeable {
     private volatile HostTuple<Set<HttpHost>> hostTuple;
     private final ConcurrentMap<HttpHost, DeadHostState> blacklist = new ConcurrentHashMap<>();
     private final FailureListener failureListener;
-    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     RestClient(CloseableHttpAsyncClient client, long maxRetryTimeoutMillis, Header[] defaultHeaders,
                HttpHost[] hosts, String pathPrefix, FailureListener failureListener) {
@@ -496,11 +494,7 @@ public class RestClient implements Closeable {
 
     @Override
     public final void close() throws IOException {
-        if (closed.compareAndSet(false, true)) {
-            client.close();
-        } else {
-            throw new IllegalStateException("RestClient is already closed");
-        }
+        client.close();
     }
 
     private static boolean isSuccessfulResponse(int statusCode) {

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -493,7 +493,7 @@ public class RestClient implements Closeable {
     }
 
     @Override
-    public final void close() throws IOException {
+    public void close() throws IOException {
         client.close();
     }
 

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -112,6 +112,7 @@ public class RestClient implements Closeable {
 
     /**
      * Returns a new {@link RestClientBuilder} to help with {@link RestClient} creation.
+     * Creates a new builder instance and sets the hosts that the client will send requests to.
      */
     public static RestClientBuilder builder(HttpHost... hosts) {
         return new RestClientBuilder(hosts);

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -706,7 +706,7 @@ public class RestClient implements Closeable {
      * {@code HostTuple} enables the {@linkplain HttpHost}s and {@linkplain AuthCache} to be set together in a thread
      * safe, volatile way.
      */
-    protected static class HostTuple<T> {
+    private static class HostTuple<T> {
         final T hosts;
         final AuthCache authCache;
 

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
@@ -23,19 +23,34 @@ import org.elasticsearch.client.http.Header;
 import org.elasticsearch.client.http.HttpHost;
 import org.elasticsearch.client.http.impl.nio.client.CloseableHttpAsyncClient;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class RestClientTests extends RestClientTestCase {
+
+    public void testCloseIsIdempotent() throws IOException {
+        HttpHost[] hosts = new HttpHost[]{new HttpHost("localhost", 9200)};
+        CloseableHttpAsyncClient closeableHttpAsyncClient = mock(CloseableHttpAsyncClient.class);
+        RestClient restClient =  new RestClient(closeableHttpAsyncClient, 1_000, new Header[0], hosts, null, null);
+        restClient.close();
+        verify(closeableHttpAsyncClient, times(1)).close();
+        restClient.close();
+        verify(closeableHttpAsyncClient, times(2)).close();
+        restClient.close();
+        verify(closeableHttpAsyncClient, times(3)).close();
+    }
 
     public void testPerformAsyncWithUnsupportedMethod() throws Exception {
         RestClient.SyncResponseListener listener = new RestClient.SyncResponseListener(10000);
         try (RestClient restClient = createRestClient()) {
-            restClient.performRequestAsync("unsupported", randomAsciiOfLength(5), listener);
+            restClient.performRequestAsync("unsupported", randomAsciiLettersOfLength(5), listener);
             listener.get();
 
             fail("should have failed because of unsupported method");
@@ -47,7 +62,7 @@ public class RestClientTests extends RestClientTestCase {
     public void testPerformAsyncWithNullParams() throws Exception {
         RestClient.SyncResponseListener listener = new RestClient.SyncResponseListener(10000);
         try (RestClient restClient = createRestClient()) {
-            restClient.performRequestAsync(randomAsciiOfLength(5), randomAsciiOfLength(5), null, listener);
+            restClient.performRequestAsync(randomAsciiLettersOfLength(5), randomAsciiLettersOfLength(5), null, listener);
             listener.get();
 
             fail("should have failed because of null parameters");
@@ -59,7 +74,7 @@ public class RestClientTests extends RestClientTestCase {
     public void testPerformAsyncWithNullHeaders() throws Exception {
         RestClient.SyncResponseListener listener = new RestClient.SyncResponseListener(10000);
         try (RestClient restClient = createRestClient()) {
-            restClient.performRequestAsync("GET", randomAsciiOfLength(5), listener, (Header) null);
+            restClient.performRequestAsync("GET", randomAsciiLettersOfLength(5), listener, (Header) null);
             listener.get();
 
             fail("should have failed because of null headers");

--- a/docs/java-rest/high-level/migration.asciidoc
+++ b/docs/java-rest/high-level/migration.asciidoc
@@ -54,52 +54,44 @@ Settings settings = Settings.builder()
         .put("cluster.name", "prod").build();
 
 TransportClient transportClient = new PreBuiltTransportClient(settings)
-        .addTransportAddress(new TransportAddress(InetAddress.getByName("host"), 9300));
+        .addTransportAddress(new TransportAddress(InetAddress.getByName("localhost"), 9300))
+        .addTransportAddress(new TransportAddress(InetAddress.getByName("localhost"), 9301));
 --------------------------------------------------
 
-The initialization of a `RestHighLevelClient` is different. It first requires the initialization
-of a <<java-rest-low-usage-initialization,low-level client>>:
+The initialization of a `RestHighLevelClient` is different. It requires to provide
+a <<java-rest-low-usage-initialization,low-level client builder>> as a constructor
+argument:
 
-[source,java]
+["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-RestClient lowLevelRestClient = RestClient.builder(
-                new HttpHost("host", 9200, "http")).build();
+include-tagged::{doc-tests}/MainDocumentationIT.java[rest-high-level-client-init]
 --------------------------------------------------
 
 NOTE: The `RestClient` uses Elasticsearch's HTTP service which is
  bounded by default on `9200`. This port is different from the port
  used to connect to Elasticsearch with a `TransportClient`.
 
-Which is then passed to the constructor of the `RestHighLevelClient`:
+The `RestHighLevelClient` is thread-safe. It is typically instantiated by the
+application at startup time or when the first request is executed.
 
-[source,java]
---------------------------------------------------
-RestHighLevelClient client =
-    new RestHighLevelClient(lowLevelRestClient);
---------------------------------------------------
+Once the `RestHighLevelClient` is initialized, it can be used to execute any
+of the <<java-rest-high-supported-apis,supported APIs>>.
 
-Both `RestClient` and `RestHighLevelClient` are thread safe. They are
- typically instantiated by the application at startup time or when the
- first request is executed.
-
-Once the `RestHighLevelClient` is initialized, it can then be used to
-execute any of the <<java-rest-high-supported-apis,supported APIs>>.
-
-As with the `TransportClient`, the `RestClient` must be closed when it
+As with the `TransportClient`, the `RestHighLevelClient` must be closed when it
 is not needed anymore or when the application is stopped.
 
-So the code that closes the `TransportClient`:
+The code that closes the `TransportClient`:
 
 [source,java]
 --------------------------------------------------
 transportClient.close();
 --------------------------------------------------
 
-Must be replaced with:
+must be replaced with:
 
-[source,java]
+["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-lowLevelRestClient.close();
+include-tagged::{doc-tests}/MainDocumentationIT.java[rest-high-level-client-close]
 --------------------------------------------------
 
 === Changing the application's code
@@ -309,7 +301,8 @@ include-tagged::{doc-tests}/MigrationDocumentationIT.java[migration-create-inded
 set its content type (here, JSON)
 <6> Execute the request using the low-level client. The execution is synchronous
 and blocks on the `performRequest()` method until the remote cluster returns
-a response.
+a response. The low-level client can be retrieved from an existing `RestHighLevelClient`
+instance through the `getLowLevelClient` getter method.
 <7> Handle the situation where the index has not been created
 
 
@@ -339,7 +332,7 @@ With the low-level client, the code can be changed to:
 include-tagged::{doc-tests}/MigrationDocumentationIT.java[migration-cluster-health]
 --------------------------------------------------
 <1> Call the cluster's health REST endpoint using the default paramaters
-and gets back a `Response` object
+and gets back a `Response` object.
 <2> Retrieve an `InputStream` object in order to read the response's content
 <3> Parse the response's content using Elasticsearch's helper class `XContentHelper`. This
  helper requires the content type of the response to be passed as an argument and returns

--- a/docs/java-rest/high-level/usage.asciidoc
+++ b/docs/java-rest/high-level/usage.asciidoc
@@ -118,15 +118,35 @@ transitive dependencies:
 [[java-rest-high-usage-initialization]]
 === Initialization
 
-A `RestHighLevelClient` instance needs a <<java-rest-low-usage-initialization,REST low-level client>>
-to be built as follows:
+A `RestHighLevelClient` instance can be created by providing the host that it
+needs to communicate with as follows. In such case a new instance of the
+low-level Rest Client will be automatically created:
 
-[source,java]
+["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-RestHighLevelClient client =
-    new RestHighLevelClient(lowLevelRestClient); <1>
+include-tagged::{doc-tests}/MainDocumentationIT.java[rest-high-level-client-init-hosts]
 --------------------------------------------------
-<1> We pass the <<java-rest-low-usage-initialization,REST low-level client>> instance
+
+Another way to create a `RestHighLevelClient` instance is by  providing a
+<<java-rest-low-usage-initialization,REST low-level client>> instance. This is
+needed when the connections settings (e.g. timeouts, authentication) need to be
+configured, which can only be done by creating a custom low-level client instance
+and providing it at `RestHighLevelClient` initialization:
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/MainDocumentationIT.java[rest-high-level-client-init-client]
+--------------------------------------------------
+
+The high-level client instance needs to be closed when no longer needed so that
+all the resources used by it get properly released, as well as the underlying
+http client instance and its threads. This can be done through the `close`
+method, which will close the internal `RestClient` instance.
+
+["source","java",subs="attributes,callouts,macros"]
+--------------------------------------------------
+include-tagged::{doc-tests}/MainDocumentationIT.java[rest-high-level-client-close]
+--------------------------------------------------
 
 In the rest of this documentation about the Java High Level Client, the `RestHighLevelClient` instance
 will be referenced as `client`.

--- a/docs/java-rest/high-level/usage.asciidoc
+++ b/docs/java-rest/high-level/usage.asciidoc
@@ -118,25 +118,16 @@ transitive dependencies:
 [[java-rest-high-usage-initialization]]
 === Initialization
 
-A `RestHighLevelClient` instance can be created by providing the host that it
-needs to communicate with as follows. In such case a new instance of the
-low-level Rest Client will be automatically created:
+A `RestHighLevelClient` instance needs a <<java-rest-low-usage-initialization,REST low-level client builder>>
+to be built as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/MainDocumentationIT.java[rest-high-level-client-init-hosts]
+include-tagged::{doc-tests}/MainDocumentationIT.java[rest-high-level-client-init]
 --------------------------------------------------
 
-Another way to create a `RestHighLevelClient` instance is by  providing a
-<<java-rest-low-usage-initialization,REST low-level client>> instance. This is
-needed when the connections settings (e.g. timeouts, authentication) need to be
-configured, which can only be done by creating a custom low-level client instance
-and providing it at `RestHighLevelClient` initialization:
-
-["source","java",subs="attributes,callouts,macros"]
---------------------------------------------------
-include-tagged::{doc-tests}/MainDocumentationIT.java[rest-high-level-client-init-client]
---------------------------------------------------
+The high-level client will internally create the low-level client used to
+perform requests based on the provided builder, and manage its lifecycle.
 
 The high-level client instance needs to be closed when no longer needed so that
 all the resources used by it get properly released, as well as the underlying

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
@@ -28,7 +28,6 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.seqno.SeqNoStats;
-import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.yaml.ObjectPath;
 


### PR DESCRIPTION
By making RestHighLevelClient Closeable, its close method will close the internal low-level REST client instance, which simplifies the way users interact with the high-level client as they no longer need to keep track of the low-level client provided at initialization time.

Also, a new constructor that accepts HttpHosts is added to RestHighLevelClient, so that there is a way to create such client without specifying the underlying RestClient instance. The advantage is that users do not always have to create two clients. The disadvantage is that the dependency on apache http client is exposed through this constructor, but that is already exposed anyway by the low-level client which the high-level client uses.

Closes #26086