### PR TITLE
Reindex API: Disambiguation of requests_per_second

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -535,14 +535,20 @@ shards to become available. Both work exactly how they work in the
 <<docs-bulk,Bulk API>>.
 
 `requests_per_second` can be set to any positive decimal number (`1.4`, `6`,
-`1000`, etc) and throttles the number of requests per second that the reindex
-issues or it can be set to `-1` to disabled throttling. The throttling is done
-waiting between bulk batches so that it can manipulate the scroll timeout. The
-wait time is the difference between the time it took the batch to complete and
-the time `requests_per_second * requests_in_the_batch`. Since the batch isn't
-broken into multiple bulk requests large batch sizes will cause Elasticsearch
-to create many requests and then wait for a while before starting the next set.
-This is "bursty" instead of "smooth". The default is `-1`.
+`1000`, etc) and throttles the number of batches that the reindex issues by 
+padding each batch with a wait time. The throttling can be disabled by 
+setting `requests_per_second` to `-1`.
+
+The throttling is done waiting between bulk batches so that it can manipulate the 
+scroll timeout. The wait time is calculated by dividing the request scroll search
+size by the `requests_per_second`. By default the scroll batch size is `1000`, so 
+if the `requests_per_second` is set to `500`:
+
+`wait_time_in_seconds` = `1000` / `500` = `2` seconds
+
+Since the batch isn't broken into multiple bulk requests large batch sizes will 
+cause Elasticsearch to create many requests and then wait for a while before 
+starting the next set. This is "bursty" instead of "smooth". The default is `-1`.
 
 [float]
 [[docs-reindex-response-body]]

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -540,11 +540,12 @@ padding each batch with a wait time. The throttling can be disabled by
 setting `requests_per_second` to `-1`.
 
 The throttling is done waiting between bulk batches so that it can manipulate the 
-scroll timeout. The wait time is calculated by dividing the request scroll search
-size by the `requests_per_second`. By default the scroll batch size is `1000`, so 
-if the `requests_per_second` is set to `500`:
+scroll timeout. The wait time is the difference between the request scroll search
+size divided by the `requests_per_second` and the `batch_write_time`. By default 
+the scroll batch size is `1000`, so if the `requests_per_second` is set to `500`:
 
-`wait_time_in_seconds` = `1000` / `500` = `2` seconds
+`target_total_time` = `1000` / `500 per second` = `2 seconds` +
+`wait_time` = `target_total_time` - `batch_write_time` = `2 seconds` - `.5 seconds` = `1.5 seconds`
 
 Since the batch isn't broken into multiple bulk requests large batch sizes will 
 cause Elasticsearch to create many requests and then wait for a while before 


### PR DESCRIPTION
Proposal for disambiguation of `requests_per_second` as discussed in [Reindex API: Reindex task es_rejected_execution_exception search queue failure #26153](https://github.com/elastic/elasticsearch/issues/26153#issuecomment-321828792).

@nik9000 As per our discussion in the aforementioned elasticsearch issue, I am looking to disambiguate the `requests_per_second` wait function. I compared some of my results and have a proposal for updating the instructions to reflect my experience and your brief explanation. Here are the results of this unsuccessful scroll batch size of `10000`, `requests_per_second` of `10000` Reindex task:

Item | Result
:---:|:---
Total Docs | 26690000
Total Batches | 2669
Task Completion Time | 6195 s
Time per Batch | 2.32s
Overall EPS | 4308
Time Throttled | 2668 s
Time Throttled per Batch | 1s
Time Working | 3527 s
Time Working per Scroll | 1.32 s
Working EPS | 7567.3
Time Throttle to Work Ratio | 0.75

>**@nik9000** So `.5` would write all `10000` documents and then sleep `20000` seconds - the amount of time that the write took.

I interpret this formula as `size` / `requests_per_second` = `wait_time` in seconds. This indeed kind of matches the time in the original post.

So in this case I perform the `wait_time` calculation and append it to the `Time Working per Scroll`:
```
1. 10000 / 10000 = 1 s
2. 1 s + 1.32 s = 2.32 s 
```
That fits nicely. So now I will try how I interpret the documentation:

>The wait time is the difference between the time it took the batch to complete and the time `requests_per_second` * `requests_in_the_batch`

I interpret this formula as either:

1. `batch_time_read_write` - (`requests_per_second` * `requests_in_the_batch`) 
2. (`requests_per_second` * `requests_in_the_batch`) - `batch_time_read_write`

```
1. 1.32 - (10000 * 10000) = −99999998.68
2. (10000 * 10000) - 1.32 = 99999998.68
```
Neither of these really match, even converting the seconds to nano, it doesn't produce anything meaningful. Of course, this will be different if you are indeed timing the bulk write (~as you may of suggested~ You definitely said this was the case).

**10000 Failed Task Output**
```javascript
{
  "completed": true,
  "task": {
    "node": "fmVI6xlZQCmhqZqVPIjfXA",
    "id": 84157930,
    "type": "transport",
    "action": "indices:data/write/reindex",
    "status": {
      "total": 279063633,
      "updated": 0,
      "created": 26690000,
      "deleted": 0,
      "batches": 2669,
      "version_conflicts": 0,
      "noops": 0,
      "retries": {
        "bulk": 0,
        "search": 0
      },
      "throttled_millis": 2667995,
      "requests_per_second": 10000,
      "throttled_until_millis": 0
    },
    "description": "reindex from [largeindex] to [largeindex.es5]",
    "start_time_in_millis": 1502431979655,
    "running_time_in_nanos": 6195367033709,
    "cancellable": true
  },
  "response": {
    "took": 6195366,
    "timed_out": false,
    "total": 279063633,
    "updated": 0,
    "created": 26690000,
    "deleted": 0,
    "batches": 2669,
    "version_conflicts": 0,
    "noops": 0,
    "retries": {
      "bulk": 0,
      "search": 0
    },
    "throttled_millis": 2667995,
    "requests_per_second": 10000,
    "throttled_until_millis": 0,
    "failures": [
      {
        "shard": -1,
        "reason": {
          "type": "es_rejected_execution_exception",
          "reason": "rejected execution of org.elasticsearch.transport.TransportService$7@48752bce on EsThreadPoolExecutor[search, queue capacity = 1000, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@53fe6f13[Running, pool size = 49, active threads = 49, queued tasks = 999, completed tasks = 7727372]]"
        }
      }
    ]
  }
}
```
So lets consider the results of a successful scroll batch size of `10000` and `requests_per_second` of `5000` Reindex task:

Item | Result
---:|:---
Total Docs | 133317017
Total Batches | 13332
Task Completion Time | 44458.6 s
Time per Batch | 3.33s
Overall EPS | 2998.7
Time Throttled | 26663 s
Time Throttled per Batch | 1.99s
Time Working | 17795 s
Time Working per Batch | 1.33 s
Working EPS | 7491.6
Time Throttle to Work Ratio | 1.49

`size` / `requests_per_second` = `wait_time` in seconds between each `bulk`:
```
1. 10000 / 5000 = 2 s
2. 2 s + 1.33 s = 3.33 s 
```
Again, the formula suits the metrics perfectly. You'll also notice the Working EPS is very similar as you'd expect with the same scroll size of `10000`. However, when applying my interpretation of the formula in the documentation:

1. `batch_time_read_write` - (`requests_per_second` * `requests_in_the_batch`) 
2. (`requests_per_second` * `requests_in_the_batch`) - `batch_time_read_write`

```
1. 1.33 - (5000 * 10000) = −49999998.67
2. (5000 * 10000) - 1.33 = 49999998.67
```
Same kind of result again, not what I am experiencing.

**5000 Successful Task Output**
```javascript
{
  "_index": ".tasks",
  "_type": "task",
  "_id": "fmVI6xlZQCmhqZqVPIjfXA:81294668",
  "_score": 1,
  "_source": {
    "completed": true,
    "task": {
      "node": "fmVI6xlZQCmhqZqVPIjfXA",
      "id": 81294668,
      "type": "transport",
      "action": "indices:data/write/reindex",
      "status": {
        "total": 133317017,
        "updated": 0,
        "created": 133317017,
        "deleted": 0,
        "batches": 13332,
        "version_conflicts": 0,
        "noops": 0,
        "retries": {
          "bulk": 0,
          "search": 0
        },
        "throttled_millis": 26663379,
        "requests_per_second": 5000,
        "throttled_until_millis": 0
      },
      "description": "reindex from [largeindex] to [largeindex.es5]",
      "start_time_in_millis": 1502414174752,
      "running_time_in_nanos": 44458656303656,
      "cancellable": true
    },
    "response": {
      "took": 44458656,
      "timed_out": false,
      "total": 133317017,
      "updated": 0,
      "created": 133317017,
      "deleted": 0,
      "batches": 13332,
      "version_conflicts": 0,
      "noops": 0,
      "retries": {
        "bulk": 0,
        "search": 0
      },
      "throttled_millis": 26663379,
      "requests_per_second": 5000,
      "throttled_until_millis": 0,
      "failures": []
    }
  }
}
```