### PR TITLE
Fix daemonization command status test

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -27,7 +27,7 @@ ES_JVM_OPTIONS="$CONF_DIR"/jvm.options
 ES_JAVA_OPTS="`parse_jvm_options "$ES_JVM_OPTIONS"` $ES_JAVA_OPTS"
 
 # manual parsing to find out, if process should be detached
-if [ ! `echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )'` ]; then
+if ! echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )' > /dev/null; then
   exec \
     "$JAVA" \
     $ES_JAVA_OPTS \


### PR DESCRIPTION
In bin/elasticsearch, we grep the command line looking for various flags that indicate the process should be daemonized. To do this, we simply test command status from the grep. Sadly, this is utterly broken (unreleased) as instead we are testing the output of the command, not the command status. This commit fixes this issue.

Closes #26080

