### PR TITLE
Docs: Add search response took time explanation

### DIFF
--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -155,6 +155,13 @@ be set to `true` in the response.
 --------------------------------------------------
 // TESTRESPONSE[s/"took": 3/"took": $body.took/]
 
+The `took` time in the response contains the milliseconds that this request
+took for processing, beginning quickly after the node received the query, up
+until all search related work is done and before the the above JSON is returned
+to the client. This means it includes the time spent waiting in thread pools,
+executing a distributed search across the whole cluster and gathering all the
+results.
+
 include::request/query.asciidoc[]
 
 include::request/from-size.asciidoc[]

--- a/docs/reference/search/request-body.asciidoc
+++ b/docs/reference/search/request-body.asciidoc
@@ -157,7 +157,7 @@ be set to `true` in the response.
 
 The `took` time in the response contains the milliseconds that this request
 took for processing, beginning quickly after the node received the query, up
-until all search related work is done and before the the above JSON is returned
+until all search related work is done and before the above JSON is returned
 to the client. This means it includes the time spent waiting in thread pools,
 executing a distributed search across the whole cluster and gathering all the
 results.


### PR DESCRIPTION
This is just to ensure that people understand this is not an average of all distributed search requests or something (and of course it cannot include the full cycle time as JSON gets rendered before the tcp connection is closed, but I really dont want to get into that...)