### PR TITLE
Fix DiskThresholdMonitor flood warning

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -77,7 +77,7 @@ public class DiskThresholdMonitor extends AbstractComponent {
         }
 
         // Check percentage disk values
-        if (usage.getFreeDiskAsPercentage() < diskThresholdSettings.getFreeDiskThresholdHigh()) {
+        if (usage.getFreeDiskAsPercentage() < diskThresholdSettings.getFreeDiskThresholdFloodStage()) {
             logger.warn("flood stage disk watermark [{}] exceeded on {}, all indices on this node will marked read-only",
                 Strings.format1Decimals(100.0 - diskThresholdSettings.getFreeDiskThresholdFloodStage(), "%"), usage);
         } else if (usage.getFreeDiskAsPercentage() < diskThresholdSettings.getFreeDiskThresholdHigh()) {


### PR DESCRIPTION
The flood warning checks the wrong threshold, namely the high watermark. This would impact any node for which the disk usage is above the high watermark and below the flood stage watermark. This commit fixes this so that it compares to the flood threshold.


Closes #26201

