### PR TITLE
Use holder pattern for lazy deprecation loggers

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.common.settings;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.ToXContentToBytes;
@@ -355,23 +354,13 @@ public class Setting<T> extends ToXContentToBytes {
         return settings.get(getKey(), defaultValue.apply(settings));
     }
 
-    private static SetOnce<DeprecationLogger> deprecationLogger = new SetOnce<>();
-
-    // we have to initialize lazily otherwise a logger would be constructed before logging is initialized
-    private static synchronized DeprecationLogger getDeprecationLogger() {
-        if (deprecationLogger.get() == null) {
-            deprecationLogger.set(new DeprecationLogger(Loggers.getLogger(Settings.class)));
-        }
-        return deprecationLogger.get();
-    }
-
     /** Logs a deprecation warning if the setting is deprecated and used. */
     void checkDeprecation(Settings settings) {
         // They're using the setting, so we need to tell them to stop
         if (this.isDeprecated() && this.exists(settings)) {
             // It would be convenient to show its replacement key, but replacement is often not so simple
             final String key = getKey();
-            getDeprecationLogger().deprecatedAndMaybeLog(
+            Settings.DeprecationLoggerHolder.deprecationLogger.deprecatedAndMaybeLog(
                     key,
                     "[{}] setting was deprecated in Elasticsearch and will be removed in a future release! "
                             + "See the breaking changes documentation for the next major version.",

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.loader.SettingsLoader;
 import org.elasticsearch.common.settings.loader.SettingsLoaderFactory;
@@ -63,7 +64,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -321,6 +321,15 @@ public final class Settings implements ToXContent {
     }
 
     /**
+     * We have to lazy initialize the deprecation logger as otherwise a static logger here would be constructed before logging is configured
+     * leading to a runtime failure (see {@link LogConfigurator#checkErrorListener()} ). The premature construction would come from any
+     * {@link Setting} object constructed in, for example, {@link org.elasticsearch.env.Environment}.
+     */
+    static class DeprecationLoggerHolder {
+        static DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(Settings.class));
+    }
+
+    /**
      * Returns the setting value (as boolean) associated with the setting key. If it does not exists,
      * returns the default value provided.
      */
@@ -328,7 +337,7 @@ public final class Settings implements ToXContent {
         String rawValue = get(setting);
         Boolean booleanValue = Booleans.parseBooleanExact(rawValue, defaultValue);
         if (rawValue != null && Booleans.isStrictlyBoolean(rawValue) == false) {
-            DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(Settings.class));
+            final DeprecationLogger deprecationLogger = DeprecationLoggerHolder.deprecationLogger;
             deprecationLogger.deprecated("Expected a boolean [true/false] for setting [{}] but got [{}]", setting, rawValue);
         }
         return booleanValue;

--- a/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -61,7 +61,7 @@ public abstract class AbstractXContentParser implements XContentParser {
      * leading to a runtime failure (see {@link LogConfigurator#checkErrorListener()} ). The premature construction would come from any
      * {@link Setting} object constructed in, for example, {@link org.elasticsearch.env.Environment}.
      */
-    static class DeprecationLoggerHolder {
+    private static class DeprecationLoggerHolder {
         static DeprecationLogger deprecationLogger = new DeprecationLogger(Loggers.getLogger(AbstractXContentParser.class));
     }
 


### PR DESCRIPTION
In a few places we need to lazy initialize static deprecation loggers. This is needed to avoid touching logging before logging is configured, but deprecation loggers that are used in foundational classes like settings and parsers would be initialized before logging is configured. Previously we used a lazy set once pattern which is fine, but there's a simpler approach: the holder pattern.

Relates #26210
