### PR TITLE
Drop upgrade from full cluster restart tests

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -165,7 +165,6 @@ public class FullClusterRestartIT extends ESRestTestCase {
         assertAllSearchWorks(count);
         assertBasicAggregationWorks();
         assertRealtimeGetWorks();
-        assertUpgradeWorks();
         assertStoredBinaryFields(count);
     }
 
@@ -529,75 +528,6 @@ public class FullClusterRestartIT extends ESRestTestCase {
         response = client().performRequest("PUT", "/" + index + "/_settings", Collections.emptyMap(),
                 new StringEntity(requestBody, ContentType.APPLICATION_JSON));
         assertEquals(200, response.getStatusLine().getStatusCode());
-    }
-
-    void assertUpgradeWorks() throws Exception {
-        if (runningAgainstOldCluster) {
-            Map<String, Object> rsp = toMap(client().performRequest("GET", "/_upgrade"));
-            Map<?, ?> indexUpgradeStatus = (Map<?, ?>) XContentMapValues.extractValue("indices." + index, rsp);
-            int totalBytes = (Integer) indexUpgradeStatus.get("size_in_bytes");
-            assertThat(totalBytes, greaterThan(0));
-            int toUpgradeBytes = (Integer) indexUpgradeStatus.get("size_to_upgrade_in_bytes");
-            assertEquals(0, toUpgradeBytes);
-        } else {
-            // Pre upgrade checks:
-            Map<String, Object> rsp = toMap(client().performRequest("GET", "/_upgrade"));
-            Map<?, ?> indexUpgradeStatus = (Map<?, ?>) XContentMapValues.extractValue("indices." + index, rsp);
-            int totalBytes = (Integer) indexUpgradeStatus.get("size_in_bytes");
-            assertThat(totalBytes, greaterThan(0));
-            int toUpgradeBytes = (Integer) indexUpgradeStatus.get("size_to_upgrade_in_bytes");
-            if (oldClusterVersion.luceneVersion.equals(Version.CURRENT.luceneVersion)) {
-                assertThat(toUpgradeBytes, equalTo(0));
-            } else {
-                assertThat(toUpgradeBytes, greaterThan(0));
-            }
-
-            Response r = client().performRequest("POST", "/" + index + "/_flush");
-            assertEquals(200, r.getStatusLine().getStatusCode());
-
-            // Upgrade segments:
-            r = client().performRequest("POST", "/" + index + "/_upgrade");
-            assertEquals(200, r.getStatusLine().getStatusCode());
-            rsp = toMap(r);
-            logger.info("upgrade api response: {}", rsp);
-            Map<?, ?>  versions = (Map<?, ?>) XContentMapValues.extractValue("upgraded_indices." + index, rsp);
-            assertNotNull(versions);
-            Version upgradeVersion = Version.fromString((String) versions.get("upgrade_version"));
-            assertEquals(Version.CURRENT, upgradeVersion);
-            org.apache.lucene.util.Version luceneVersion =
-                org.apache.lucene.util.Version.parse((String) versions.get("oldest_lucene_segment_version"));
-            assertEquals(Version.CURRENT.luceneVersion, luceneVersion);
-
-            r = client().performRequest("POST", "/" + index + "/_refresh");
-            assertEquals(200, r.getStatusLine().getStatusCode());
-
-            // Post upgrade checks:
-            rsp = toMap(client().performRequest("GET", "/_upgrade"));
-            logger.info("upgrade status api response: {}", rsp);
-            indexUpgradeStatus = (Map<?, ?>) XContentMapValues.extractValue("indices." + index, rsp);
-            assertNotNull(indexUpgradeStatus);
-            totalBytes = (Integer) indexUpgradeStatus.get("size_in_bytes");
-            assertThat(totalBytes, greaterThan(0));
-            toUpgradeBytes = (Integer) indexUpgradeStatus.get("size_to_upgrade_in_bytes");
-            assertEquals(0, toUpgradeBytes);
-
-            rsp = toMap(client().performRequest("GET", "/" + index + "/_segments"));
-            Map<?, ?> shards = (Map<?, ?>) XContentMapValues.extractValue("indices." + index + ".shards", rsp);
-            for (Object shard : shards.values()) {
-                List<?> shardSegments = (List<?>) shard;
-                for (Object shardSegment : shardSegments) {
-                    Map<?, ?> shardSegmentRsp = (Map<?, ?>) shardSegment;
-                    Map<?, ?> segments = (Map<?, ?>) shardSegmentRsp.get("segments");
-                    for (Object segment : segments.values()) {
-                        Map<?, ?> segmentRsp = (Map<?, ?>) segment;
-                        luceneVersion = org.apache.lucene.util.Version.parse((String) segmentRsp.get("version"));
-                        assertEquals("Un-upgraded segment " + segment, Version.CURRENT.luceneVersion.major, luceneVersion.major);
-                        assertEquals("Un-upgraded segment " + segment, Version.CURRENT.luceneVersion.minor, luceneVersion.minor);
-                        assertEquals("Un-upgraded segment " + segment, Version.CURRENT.luceneVersion.bugfix, luceneVersion.bugfix);
-                    }
-                }
-            }
-        }
     }
 
     void assertStoredBinaryFields(int count) throws Exception {


### PR DESCRIPTION
Our documentation for the API is:
```
The _upgrade API is no longer useful and will be removed.
Instead, see Reindex to upgrade.
```

Given that, I don't think we need to test the API anymore.

Closes #25311
