### PR TITLE
Add packaging test for systemd runtime directive

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/tests/60_systemd.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/60_systemd.bats
@@ -236,3 +236,12 @@ setup() {
     [ "$max_address_space" == "unlimited" ]
     systemctl stop elasticsearch.service
 }
+
+@test "[SYSTEMD] test runtime directory" {
+    clean_before_test
+    install_package
+    sudo rm -rf /var/run/elasticsearch
+    systemctl start elasticsearch.service
+    wait_for_elasticsearch_status
+    systemctl stop elasticsearch.service
+}

--- a/qa/vagrant/src/test/resources/packaging/tests/60_systemd.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/60_systemd.bats
@@ -243,5 +243,6 @@ setup() {
     sudo rm -rf /var/run/elasticsearch
     systemctl start elasticsearch.service
     wait_for_elasticsearch_status
+    [ -d /var/run/elasticsearch ]
     systemctl stop elasticsearch.service
 }


### PR DESCRIPTION
We previously added a RuntimeDirectory directive to the systemd service file for Elasticsearch. This commit adds a packaging test for the situation that this directive was intended to address.

Relates #23526
