### PR TITLE
Prevent cluster internal `ClusterState.Custom` impls to leak to a client

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
@@ -69,6 +69,15 @@ public class ClusterStateRequestBuilder extends MasterNodeReadOperationRequestBu
     }
 
     /**
+     * Should the cluster state result include the {@link org.elasticsearch.cluster.ClusterState.Custom}. Defaults
+     * to <tt>true</tt>.
+     */
+    public ClusterStateRequestBuilder setCustoms(boolean filter) {
+        request.customs(filter);
+        return this;
+    }
+
+    /**
      * Should the cluster state result include the {@link org.elasticsearch.cluster.routing.RoutingTable}. Defaults
      * to <tt>true</tt>.
      */

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -126,7 +126,11 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
             builder.metaData(mdBuilder);
         }
         if (request.customs()) {
-            builder.customs(currentState.customs());
+            for (ObjectObjectCursor<String, ClusterState.Custom> custom : currentState.customs()) {
+                if (custom.value.isPrivate() == false) {
+                    builder.putCustom(custom.key, custom.value);
+                }
+            }
         }
         listener.onResponse(new ClusterStateResponse(currentState.getClusterName(), builder.build(),
                                                         serializeFullClusterState(currentState, Version.CURRENT).length()));

--- a/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -92,6 +92,14 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
     public static final ClusterState EMPTY_STATE = builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)).build();
 
     public interface Custom extends NamedDiffable<Custom>, ToXContent {
+
+        /**
+         * Returns <code>true</code> iff this {@link Custom} is private to the cluster and should never be send to a client.
+         * The default is <code>false</code>;
+         */
+        default boolean isPrivate() {
+            return false;
+        }
     }
 
     private static final NamedDiffableValueSerializer<Custom> CUSTOM_VALUE_SERIALIZER = new NamedDiffableValueSerializer<>(Custom.class);

--- a/core/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -286,15 +286,15 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         assertTrue(state.customs().containsKey("test"));
     }
 
-    private static class TestCustom  extends AbstractNamedDiffable<ClusterState.Custom> implements ClusterState.Custom {
+    private static class TestCustom extends AbstractNamedDiffable<ClusterState.Custom> implements ClusterState.Custom {
 
         private final int value;
 
-        public TestCustom(int value) {
+        TestCustom(int value) {
             this.value = value;
         }
 
-        public TestCustom(StreamInput in) throws IOException {
+        TestCustom(StreamInput in) throws IOException {
             this.value = in.readInt();
         }
         @Override
@@ -312,7 +312,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
             return builder;
         }
 
-        public static NamedDiff<ClusterState.Custom> readDiffFrom(StreamInput in) throws IOException {
+        static NamedDiff<ClusterState.Custom> readDiffFrom(StreamInput in) throws IOException {
             return readDiffFrom(ClusterState.Custom.class, "test", in);
         }
 

--- a/core/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -28,19 +28,32 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.plugins.ClusterPlugin;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.hamcrest.CollectionAssertions;
 import org.junit.Before;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertIndexTemplateExists;
@@ -53,6 +66,11 @@ import static org.hamcrest.Matchers.is;
  *
  */
 public class SimpleClusterStateIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(PrivateCustomPlugin.class);
+    }
 
     @Before
     public void indexData() throws Exception {
@@ -256,6 +274,69 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
             fail("Expected IndexNotFoundException");
         } catch (IndexNotFoundException e) {
             assertThat(e.getMessage(), is("no such index"));
+        }
+    }
+
+    public void testPrivateCustomsAreExcluded() {
+        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().setCustoms(true).get();
+        assertFalse(clusterStateResponse.getState().customs().containsKey("test"));
+        // just to make sure there is something
+        assertTrue(clusterStateResponse.getState().customs().containsKey(SnapshotDeletionsInProgress.TYPE));
+        ClusterState state = internalCluster().getInstance(ClusterService.class).state();
+        assertTrue(state.customs().containsKey("test"));
+    }
+
+    private static class TestCustom  extends AbstractNamedDiffable<ClusterState.Custom> implements ClusterState.Custom {
+
+        private final int value;
+
+        public TestCustom(int value) {
+            this.value = value;
+        }
+
+        public TestCustom(StreamInput in) throws IOException {
+            this.value = in.readInt();
+        }
+        @Override
+        public String getWriteableName() {
+            return "test";
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeInt(value);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder;
+        }
+
+        public static NamedDiff<ClusterState.Custom> readDiffFrom(StreamInput in) throws IOException {
+            return readDiffFrom(ClusterState.Custom.class, "test", in);
+        }
+
+        @Override
+        public boolean isPrivate() {
+            return true;
+        }
+    }
+
+    public static class PrivateCustomPlugin extends Plugin implements ClusterPlugin {
+
+        public PrivateCustomPlugin() {}
+
+        @Override
+        public Map<String, Supplier<ClusterState.Custom>> getInitialClusterStateCustomSupplier() {
+            return Collections.singletonMap("test", () -> new TestCustom(1));
+        }
+
+        @Override
+        public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+            List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
+            entries.add(new NamedWriteableRegistry.Entry(ClusterState.Custom.class, "test", TestCustom::new));
+            entries.add(new NamedWriteableRegistry.Entry(NamedDiff.class, "test", TestCustom::readDiffFrom));
+            return entries;
         }
     }
 }


### PR DESCRIPTION
Today a `ClusterState.Custom` can be fetched by a transport client and
leaks to the user even if the classes are private etc since the serialized
bytes can be reconstructed. This change adds an option to customs to mark
them as private such that our clusterstate action will never leak it.