### PR TITLE
Define a templated systemd instance service unit in distribution packaging

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -422,6 +422,11 @@ configure(distributions.findAll { ['deb', 'rpm'].contains(it.name) }) {
       fileType CONFIG | NOREPLACE
       from "${packagingFiles}/systemd/elasticsearch.service"
     }
+    configurationFile '/usr/lib/systemd/system/elasticsearch@.service'
+    into('/usr/lib/systemd/system') {
+      fileType CONFIG | NOREPLACE
+      from "${packagingFiles}/systemd/elasticsearch@.service"
+    }
     into('/usr/lib/sysctl.d') {
       fileType CONFIG | NOREPLACE
       from "${packagingFiles}/systemd/sysctl/elasticsearch.conf"

--- a/distribution/src/main/packaging/systemd/elasticsearch@.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Elasticsearch Instance %i
+Description=Elasticsearch Instance %I
 Documentation=http://www.elastic.co
 Wants=network-online.target
 After=network-online.target

--- a/distribution/src/main/packaging/systemd/elasticsearch@.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch@.service
@@ -1,0 +1,60 @@
+[Unit]
+Description=Elasticsearch Instance %i
+Documentation=http://www.elastic.co
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+RuntimeDirectory=elasticsearch
+Environment=ES_HOME=/usr/share/elasticsearch
+Environment=ES_PATH_CONF=${path.conf}/%i
+Environment=PID_DIR=/var/run/elasticsearch
+EnvironmentFile=-${path.env}-%i
+
+WorkingDirectory=/usr/share/elasticsearch
+
+User=elasticsearch
+Group=elasticsearch
+
+ExecStart=/usr/share/elasticsearch/bin/elasticsearch -p ${PID_DIR}/elasticsearch-%i.pid --quiet
+
+# StandardOutput is configured to redirect to journalctl since
+# some error messages may be logged in standard output before
+# elasticsearch logging system is initialized. Elasticsearch
+# stores its logs in /var/log/elasticsearch and does not use
+# journalctl by default. If you also want to enable journalctl
+# logging, you can simply remove the "quiet" option from ExecStart.
+StandardOutput=journal
+StandardError=inherit
+
+# Specifies the maximum file descriptor number that can be opened by this process
+LimitNOFILE=65536
+
+# Specifies the maximum number of processes
+LimitNPROC=4096
+
+# Specifies the maximum size of virtual memory
+LimitAS=infinity
+
+# Specifies the maximum file size
+LimitFSIZE=infinity
+
+# Disable timeout logic and wait until process is stopped
+TimeoutStopSec=0
+
+# SIGTERM signal is used to stop the Java process
+KillSignal=SIGTERM
+
+# Send the signal only to the JVM rather than its control group
+KillMode=process
+
+# Java process is never killed
+SendSIGKILL=no
+
+# When a JVM receives a SIGTERM signal it exits with code 143
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target
+
+# Built for ${project.name}-${project.version} (${project.name})

--- a/docs/reference/setup/install/systemd.asciidoc
+++ b/docs/reference/setup/install/systemd.asciidoc
@@ -51,3 +51,25 @@ sudo journalctl --unit elasticsearch --since  "2016-10-30 18:17:16"
 
 Check `man journalctl` or https://www.freedesktop.org/software/systemd/man/journalctl.html for
 more command line options.
+
+===== Managing Multiple Instances
+
+Optional systemd service templates are included to better aid in running more
+than one instance on a host.
+This is an non-standard configuration scenario intended for advanced users.
+
+In order to do so, necessary directories and configuration files must be
+created to manage separate instances of Elasticsearch.
+The following bash commands will start three local instances sharing a data
+directory:
+
+[source,sh]
+--------------------------------------------
+sudo echo node.max_local_storage_nodes: 3 >> /etc/elasticsearch/elasticsearch.yml
+sudo echo discovery.zen.minimum_master_nodes: 2 >> /etc/elasticsearch/elasticsearch.yml
+for instance in 1 2 3 ; do
+  sudo mkdir /etc/elasticsearch/$instance
+  sudo cp -p /etc/elasticsearch/*.* /etc/elasticsearch/$instance
+  sudo systemctl start elasticsearch@$instance.service
+done
+--------------------------------------------


### PR DESCRIPTION
This is an attempt to illustrate the proposed changes in #24867. I'm gradle-dumb so there may very well be a better way to drop this new file, but the changeset gets the point across (it's also unfortunate that the service file is a copypasta from the default one, but I'm not sure if there's a good way to resolve that in gradle either).

The intent here is not to expose an entirely fully-fledged alternative method of running Elasticsearch, but rather to provide the templated service unit for power users/administrators who know what they're doing to avoid manually writing service files in downstream processes (which is the current approach by ansible/puppet/chef/etc.). Keeping the service file contents in sync saves everyone from a ton of problems.

The instance-specific parts of the templated unit are 1) a custom `ES_PATH_CONF`, `EnvironmentFile`, and PID file. This should be enough to create a separate environment for an instance of Elasticsearch if someone wants to run it that way, and should hopefully avoid be trappy by failing fast unless an administrator has taken specific actions to create `ES_PATH_CONF` (which doesn't exist by default) and optionally the instance-specific defaults file. This is going to be hard to bump into and start by accident since it requires a special `systemctl start elasticsearch@master.service` invocation and will simply fail since no instance-specific directory in `/etc/elasticsearch/master` has been created. 

I've built and tested this, and was able to get the templated service to work by copying `/etc/elasticsearch/*.*` into `/etc/elasticsearch/01` and then starting `systemctl start elasticsearch@01.service`.  It's not perfect, and does require manual steps to setup the instance-specific configuration files, but that's the intent of providing the unit: make the functionality available if needed.

(I'm not sure whether this should be PRd against a different branch, but master seems safe). I can provide a small snippet somewhere in the docs if this ends up getting the greenlight, depending on the amount of visibility it should have.