### PR TITLE
Disallow : in cluster and index/alias names

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterName.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterName.java
@@ -34,6 +34,9 @@ public class ClusterName implements Writeable {
         if (s.isEmpty()) {
             throw new IllegalArgumentException("[cluster.name] must not be empty");
         }
+        if (s.contains(":")) {
+            throw new IllegalArgumentException("[cluster.name] must not contain ':'");
+        }
         return new ClusterName(s);
     }, Setting.Property.NodeScope);
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -165,6 +165,9 @@ public class MetaDataCreateIndexService extends AbstractComponent {
         if (index.contains("#")) {
             throw exceptionCtor.apply(index, "must not contain '#'");
         }
+        if (index.contains(":")) {
+            throw exceptionCtor.apply(index, "must not contain ':'");
+        }
         if (index.charAt(0) == '_' || index.charAt(0) == '-' || index.charAt(0) == '+') {
             throw exceptionCtor.apply(index, "must not start with '_', '-', or '+'");
         }

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
@@ -212,6 +212,7 @@ public class MetaDataCreateIndexServiceTests extends ESTestCase {
 
         validateIndexName("..", "must not be '.' or '..'");
 
+        validateIndexName("foo:bar", "must not contain ':'");
     }
 
     private void validateIndexName(String indexName, String errorMessage) {

--- a/docs/reference/migration/migrate_7_0.asciidoc
+++ b/docs/reference/migration/migrate_7_0.asciidoc
@@ -21,3 +21,11 @@ way to reindex old indices is to use the `reindex` API.
 
 =========================================
 
+[float]
+=== Also see:
+
+* <<breaking_70_cluster_changes>>
+* <<breaking_70_indices_changes>>
+
+include::migrate_7_0/cluster.asciidoc[]
+include::migrate_7_0/indices.asciidoc[]

--- a/docs/reference/migration/migrate_7_0/cluster.asciidoc
+++ b/docs/reference/migration/migrate_7_0/cluster.asciidoc
@@ -1,0 +1,7 @@
+[[breaking_70_cluster_changes]]
+=== Cluster changes
+
+==== `:` is no longer allowed in cluster name
+
+Due to cross-cluster search using `:` to separate a cluster and index name,
+cluster names may no longer contain `:`.

--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -1,0 +1,7 @@
+[[breaking_70_indices_changes]]
+=== Indices changes
+
+==== `:` is no longer allowed in index name
+
+Due to cross-cluster search using `:` to separate a cluster and index name,
+index names may no longer contain `:`.


### PR DESCRIPTION
We use `:` for cross-cluster search (eg `cluster:index`), therefore, we should
not allow the ambiguity when allowing cluster or index names.

Relates to #23892

This is for master (7.0+) with the intent to change it to deprecation warning/logging when backporting to the 6.0 and 6.x branches.