### PR TITLE
Loosen the restrictions on disabling _all in 6.x

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -254,15 +254,12 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
                     .field("enabled", true)
                 .endObject().endObject().bytes());
 
-        CompressedXContent disabledAll = new CompressedXContent(XContentFactory.jsonBuilder().startObject()
-                .startObject("_all")
-                    .field("enabled", false)
-                .endObject().endObject().bytes());
-
         Exception e = expectThrows(MapperParsingException.class,
                 () -> indexService.mapperService().merge(MapperService.DEFAULT_MAPPING, enabledAll,
                         MergeReason.MAPPING_UPDATE, random().nextBoolean()));
         assertThat(e.getMessage(), containsString("[_all] is disabled in 6.0"));
+        assertWarnings("[_all] is deprecated in 6.0+ and will be removed in 7.0. As a replacement, " +
+                        "you can use [copy_to] on mapping fields to create your own catch all field.");
     }
 
      public void testPartitionedConstraints() {


### PR DESCRIPTION
With 6.0+ we previously threw an exception when the `_all` field was configured
at all. This loosens that restriction a little bit so that the error is only
thrown when `_all` is enabled. A deprecation warning is returned/logged instead
if any `_all` configuration is found.

In 7.0, we retain the behavior of throwing an exception if `_all` is enabled at
all.