### PR TITLE
Export HOSTNAME environment variable

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -65,6 +65,8 @@ fi
 # check the Java version
 "$JAVA" -cp "$ES_CLASSPATH" org.elasticsearch.tools.JavaVersionChecker
 
+export HOSTNAME=$HOSTNAME
+
 ${source.path.env}
 
 if [ -z "$ES_PATH_CONF" ]; then

--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -44,6 +44,8 @@ if not "%JAVA_OPTS%" == "" (
 rem check the Java version
 %JAVA% -cp "%ES_CLASSPATH%" "org.elasticsearch.tools.JavaVersionChecker" || exit /b 1
 
+set HOSTNAME=%COMPUTERNAME%
+
 if "%ES_PATH_CONF%" == "" (
   set ES_PATH_CONF=!ES_HOME!\config
 )

--- a/qa/vagrant/src/test/resources/packaging/tests/module_and_plugin_test_cases.bash
+++ b/qa/vagrant/src/test/resources/packaging/tests/module_and_plugin_test_cases.bash
@@ -450,3 +450,15 @@ fi
 @test "[$GROUP] test umask" {
     install_jvm_example $(readlink -m jvm-example-*.zip) 0077
 }
+
+@test "[$GROUP] hostname" {
+    local temp=`mktemp -d`
+    cp "$ESCONFIG"/elasticsearch.yml "$temp"
+    echo 'node.name: ${HOSTNAME}' >> "$ESCONFIG"/elasticsearch.yml
+    start_elasticsearch_service
+    wait_for_elasticsearch_status
+    [ "$(curl -XGET localhost:9200/_cat/nodes?h=name)" == "$HOSTNAME" ]
+    stop_elasticsearch_service
+    cp "$temp"/elasticsearch.yml "$ESCONFIG"/elasticsearch.yml
+    rm -rf "$temp"
+}


### PR DESCRIPTION
We previously explicitly set the HOSTNAME environment variable so that ${HOSTNAME} could be used a placeholder for defining the node.name in elasticsearch.yml. We removed explicitly setting this because bash defines HOSTNAME. The problem is that bash defines HOSTNAME as a bash variable, not as an environment variable. Therefore, to restore the previous behavior, we export the bash value for HOSTNAME as an environment variable named HOSTNAME. For consistency between Windows and the Unix-like systems, we also define HOSTNAME with a value equal to the environment variable COMPUTERNAME on Windows.

Closes #26255, relates #25807
