### PR TITLE
Add safer empty variable checking for Windows

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -29,14 +29,14 @@ if not exist %JAVA% (
 )
 
 rem do not let JAVA_TOOL_OPTIONS slip in (as the JVM does by default)
-if not "%JAVA_TOOL_OPTIONS%" == "" (
+if defined JAVA_TOOL_OPTIONS (
   echo warning: ignoring JAVA_TOOL_OPTIONS=%JAVA_TOOL_OPTIONS%
   set JAVA_TOOL_OPTIONS=
 )
 
 rem JAVA_OPTS is not a built-in JVM mechanism but some people think it is so we
 rem warn them that we are not observing the value of %JAVA_OPTS%
-if not "%JAVA_OPTS%" == "" (
+if defined JAVA_OPTS (
   (echo|set /p=warning: ignoring JAVA_OPTS=%JAVA_OPTS%; )
   echo pass JVM parameters via ES_JAVA_OPTS
 )
@@ -46,6 +46,6 @@ rem check the Java version
 
 set HOSTNAME=%COMPUTERNAME%
 
-if "%ES_PATH_CONF%" == "" (
+if not defined ES_PATH_CONF (
   set ES_PATH_CONF=!ES_HOME!\config
 )

--- a/distribution/src/main/resources/bin/elasticsearch-keystore.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-keystore.bat
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal enabledelayedexpansion
+setlocal enableextensions
 
 call "%~dp0elasticsearch-env.bat" || exit /b 1
 
@@ -12,4 +13,5 @@ call "%~dp0elasticsearch-env.bat" || exit /b 1
   org.elasticsearch.common.settings.KeyStoreCli ^
   %*
 
+endlocal
 endlocal

--- a/distribution/src/main/resources/bin/elasticsearch-plugin.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-plugin.bat
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal enabledelayedexpansion
+setlocal enableextensions
 
 call "%~dp0elasticsearch-env.bat" || exit /b 1
 
@@ -12,4 +13,5 @@ call "%~dp0elasticsearch-env.bat" || exit /b 1
   org.elasticsearch.plugins.PluginCli ^
   %*
 
+endlocal
 endlocal

--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal enabledelayedexpansion
+setlocal enableextensions
 
 call "%~dp0elasticsearch-env.bat" || exit /b 1
 
@@ -265,4 +266,5 @@ set /a conv=%conv% * 1024 * 1024
 set "%~2=%conv%"
 goto:eof
 
+endlocal
 endlocal

--- a/distribution/src/main/resources/bin/elasticsearch-translog.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-translog.bat
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal enabledelayedexpansion
+setlocal enableextensions
 
 call "%~dp0elasticsearch-env.bat" || exit /b 1
 
@@ -12,4 +13,5 @@ call "%~dp0elasticsearch-env.bat" || exit /b 1
   org.elasticsearch.index.translog.TranslogToolCli ^
   %*
 
+endlocal
 endlocal

--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -1,6 +1,7 @@
 @echo off
 
 setlocal enabledelayedexpansion
+setlocal enableextensions
 
 SET params='%*'
 
@@ -50,4 +51,5 @@ for /F "usebackq delims=" %%a in (`findstr /b \- "%ES_JVM_OPTIONS%"`) do set JVM
 
 %JAVA% %ES_JAVA_OPTS% -Delasticsearch -Des.path.home="%ES_HOME%" -Des.path.conf="%ES_PATH_CONF%" -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch" !newparams!
 
+endlocal
 endlocal


### PR DESCRIPTION
We need to check if JAVA_TOOL_OPTIONS, and JAVA_OPTS are set, and if ES_PATH_CONF is not set. However, if these variables are defined and contain quotes, the current mechanism busts on them. Instead, we should use safer mechanism for checking if these variable are defined or not. This commit does that.

Closes #26261
