### PR TITLE
[DOCS] Clarify compatibility and relation between high level REST client and core version

### DIFF
--- a/docs/java-rest/high-level/usage.asciidoc
+++ b/docs/java-rest/high-level/usage.asciidoc
@@ -9,15 +9,25 @@ getting the artifact to using it in an application.
 The Java High Level REST Client requires Java 1.8 and depends on the Elasticsearch
 core project. The client version is the same as the Elasticsearch version that the
 client was developed for. It accepts the same request arguments as the `TransportClient`
-and returns the same response objects.
+and returns the same response objects. See the <<java-rest-high-level-migration>>
+if you are needing to migrate an application from `TransportClient` to the
+new REST client.
 
-The High Level Client is backwards compatible but can only communicate with Elasticsearch
-version 5.5 and onwards. The High Level Client is forward compatible as well, meaning that
-it supports communicating with a later version of Elasticsearch than the one it was developed
-for. It is recommended to upgrade the High Level Client when upgrading the Elasticsearch
-cluster to a new major version, as REST API breaking changes may cause unexpected results,
-and newly added APIs will only be supported by the newer version of the client. The client
-should be updated last, once all of the nodes in the cluster have been upgraded.
+The High Level Client is guaranteed to be able to communicate with any Elasticsearch
+node running on the same major version and greater or equal minor version. It
+doesn't need to be in the same minor version as the Elasticsearch nodes it
+communicates with, as it is forward compatible meaning that it supports
+communicating with later versions of Elasticsearch than the one it was developed for.
+That means that the 6.0 client is able to communicate with any 6.x Elasticsearch node,
+while the 6.1 client is for sure able to communicate with 6.1, 6.2 and any later 6.x
+version, but there may be incompatibility issues when communicating with a previous
+Elasticsearch node version, for instance between 6.1 and 6.0, in case 6.1 supports
+new request body fields for some APIs that are not known by 6.0.
+It is recommended to upgrade the High Level Client when upgrading the Elasticsearch
+cluster to a new major version, as REST API breaking changes cause unexpected results,
+and newly added APIs will only be supported by the newer version of the client.
+The client should always be updated last, once all of the nodes in the cluster have
+been upgraded to the new major version.
 
 [[java-rest-high-javadoc]]
 === Javadoc

--- a/docs/java-rest/high-level/usage.asciidoc
+++ b/docs/java-rest/high-level/usage.asciidoc
@@ -10,24 +10,26 @@ The Java High Level REST Client requires Java 1.8 and depends on the Elasticsear
 core project. The client version is the same as the Elasticsearch version that the
 client was developed for. It accepts the same request arguments as the `TransportClient`
 and returns the same response objects. See the <<java-rest-high-level-migration>>
-if you are needing to migrate an application from `TransportClient` to the
-new REST client.
+if you need to migrate an application from `TransportClient` to the new REST client.
 
 The High Level Client is guaranteed to be able to communicate with any Elasticsearch
 node running on the same major version and greater or equal minor version. It
 doesn't need to be in the same minor version as the Elasticsearch nodes it
 communicates with, as it is forward compatible meaning that it supports
 communicating with later versions of Elasticsearch than the one it was developed for.
-That means that the 6.0 client is able to communicate with any 6.x Elasticsearch node,
-while the 6.1 client is for sure able to communicate with 6.1, 6.2 and any later 6.x
-version, but there may be incompatibility issues when communicating with a previous
-Elasticsearch node version, for instance between 6.1 and 6.0, in case the 6.1 client
-supports new request body fields for some APIs that are not known by the 6.0 node.
+
+The 6.0 client is able to communicate with any 6.x Elasticsearch node, while the 6.1
+client is for sure able to communicate with 6.1, 6.2 and any later 6.x version, but
+there may be incompatibility issues when communicating with a previous Elasticsearch
+node version, for instance between 6.1 and 6.0, in case the 6.1 client supports new
+request body fields for some APIs that are not known by the 6.0 node(s).
+
 It is recommended to upgrade the High Level Client when upgrading the Elasticsearch
-cluster to a new major version, as REST API breaking changes cause unexpected results,
-and newly added APIs will only be supported by the newer version of the client.
-The client should always be updated last, once all of the nodes in the cluster have
-been upgraded to the new major version.
+cluster to a new major version, as REST API breaking changes may cause unexpected
+results depending on the node that is hit by the request, and newly added APIs will
+only be supported by the newer version of the client. The client should always be
+updated last, once all of the nodes in the cluster have been upgraded to the new
+major version.
 
 [[java-rest-high-javadoc]]
 === Javadoc

--- a/docs/java-rest/high-level/usage.asciidoc
+++ b/docs/java-rest/high-level/usage.asciidoc
@@ -21,8 +21,8 @@ communicating with later versions of Elasticsearch than the one it was developed
 That means that the 6.0 client is able to communicate with any 6.x Elasticsearch node,
 while the 6.1 client is for sure able to communicate with 6.1, 6.2 and any later 6.x
 version, but there may be incompatibility issues when communicating with a previous
-Elasticsearch node version, for instance between 6.1 and 6.0, in case 6.1 supports
-new request body fields for some APIs that are not known by 6.0.
+Elasticsearch node version, for instance between 6.1 and 6.0, in case the 6.1 client
+supports new request body fields for some APIs that are not known by the 6.0 node.
 It is recommended to upgrade the High Level Client when upgrading the Elasticsearch
 cluster to a new major version, as REST API breaking changes cause unexpected results,
 and newly added APIs will only be supported by the newer version of the client.


### PR DESCRIPTION
The client is forward compatible, while there may be bw comp issues even for non breaking changes made to ES core. That is why it's recommended to upgrade the client last and always have it in a version that's less or equal than the smallest node version.

Closes #26142