### PR TITLE
add deleteByQuery and prepareDeleteByQuery method in Client

### DIFF
--- a/core/src/main/java/org/elasticsearch/client/Client.java
+++ b/core/src/main/java/org/elasticsearch/client/Client.java
@@ -67,6 +67,9 @@ import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.DeleteByQueryRequestBuilder;
 
 import java.util.Map;
 
@@ -208,6 +211,29 @@ public interface Client extends ElasticsearchClient, Releasable {
      * @param id    The id of the document to delete
      */
     DeleteRequestBuilder prepareDelete(String index, String type, String id);
+
+    /**
+     * Deletes a or some documents from the index based on the index.
+     *
+     * @param request The delete by query request
+     * @return The result future
+     * @see Requests#deleteByQueryRequest(String)
+     */
+    ActionFuture<BulkByScrollResponse> deleteByQuery(DeleteByQueryRequest request);
+
+    /**
+     * Deletes a or some documents from the index based on the index
+     *
+     * @param request  The delete request
+     * @param listener A listener to be notified with a result
+     * @see Requests#deleteByQueryRequest(String)
+     */
+    void deleteByQuery(DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener);
+
+    /**
+     * Deletes a or some documents from the index based on the index.
+     */
+    DeleteByQueryRequestBuilder prepareDeleteByQuery(String... source);
 
     /**
      * Executes a bulk of index / delete operations.

--- a/core/src/main/java/org/elasticsearch/client/Requests.java
+++ b/core/src/main/java/org/elasticsearch/client/Requests.java
@@ -63,6 +63,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 
 /**
  * A handy one stop shop for creating requests (make sure to import static this class).
@@ -105,6 +106,10 @@ public class Requests {
      */
     public static DeleteRequest deleteRequest(String index) {
         return new DeleteRequest(index);
+    }
+
+    public static DeleteByQueryRequest deleteByQueryRequest(String index) {
+        return new DeleteByQueryRequest(new SearchRequest(index));
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/core/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -348,6 +348,10 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.DeleteByQueryRequestBuilder;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -470,6 +474,21 @@ public abstract class AbstractClient extends AbstractComponent implements Client
     @Override
     public DeleteRequestBuilder prepareDelete(String index, String type, String id) {
         return prepareDelete().setIndex(index).setType(type).setId(id);
+    }
+
+    @Override
+    public ActionFuture<BulkByScrollResponse> deleteByQuery(DeleteByQueryRequest request) {
+        return execute(DeleteByQueryAction.INSTANCE, request);
+    }
+
+    @Override
+    public void deleteByQuery(DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
+        execute(DeleteByQueryAction.INSTANCE, request, listener);
+    }
+
+    @Override
+    public DeleteByQueryRequestBuilder prepareDeleteByQuery(String... source) {
+        return new DeleteByQueryRequestBuilder(this, DeleteByQueryAction.INSTANCE).source(source);
     }
 
     @Override


### PR DESCRIPTION
When I was using the deletebyquery test. I found the API somewhat different from the others. In order to maintain a unified style, I add some methods to the Client class.