### PR TITLE
Create keystore on RPM and Debian package install

### DIFF
--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -103,11 +103,17 @@ chown -R root:elasticsearch /etc/elasticsearch
 chmod 0750 /etc/elasticsearch
 
 if [ -f /etc/default/elasticsearch ]; then
-   chown root:elasticsearch /etc/default/elasticsearch
+    chown root:elasticsearch /etc/default/elasticsearch
 fi
 
 if [ -f /etc/sysconfig/elasticsearch ]; then
-   chown root:elasticsearch /etc/sysconfig/elasticsearch
+    chown root:elasticsearch /etc/sysconfig/elasticsearch
+fi
+
+if [ ! -f "$ES_PATH_CONF"/elasticsearch.keystore ]; then
+    /usr/share/elasticsearch/bin/elasticsearch-keystore create
+    chown root:elasticsearch "$ES_PATH_CONF"/elasticsearch.keystore
+    chmod 660 "$ES_PATH_CONF"/elasticsearch.keystore
 fi
 
 ${scripts.footer}


### PR DESCRIPTION
When Elasticsearch starts up, it tries to create a keystore if one does not exist; this is so the keystore can be seeded. With the RPM and Debian packages, the keystore would be located in /etc/elasticsearch. This configuration directory is typically not writable by the elasticsearch user so the Elasticsearch process will not have permission to create the keystore. Instead, the RPM and Debian packages should create the keystore (if it does not exist) on package installation. This commit enables these packages to do that in the post-install routines.
