### PR TITLE
Add friendlier message on bad keystore permissions

### DIFF
--- a/core/src/main/java/org/elasticsearch/cli/UserException.java
+++ b/core/src/main/java/org/elasticsearch/cli/UserException.java
@@ -32,4 +32,17 @@ public class UserException extends Exception {
         super(msg);
         this.exitCode = exitCode;
     }
+
+    /**
+     * Constructs a new user exception with specified exit status, message, and underlying cause.
+     *
+     * @param exitCode the exit code
+     * @param msg      the message
+     * @param cause    the underlying cause
+     */
+    public UserException(final int exitCode, final String msg, final Throwable cause) {
+        super(msg, cause);
+        this.exitCode = exitCode;
+    }
+
 }

--- a/core/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -59,6 +60,8 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.bootstrap.BootstrapSettings;
+import org.elasticsearch.cli.ExitCodes;
+import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.Randomness;
 
 /**
@@ -304,6 +307,12 @@ public class KeyStoreWrapper implements SecureSettings {
             output.writeInt(keystoreBytes.length);
             output.writeBytes(keystoreBytes, keystoreBytes.length);
             CodecUtil.writeFooter(output);
+        } catch (final AccessDeniedException e) {
+            final String message = String.format(
+                    Locale.ROOT,
+                    "unable to create temporary keystore at [%s], please check filesystem permissions",
+                    configDir.resolve(tmpFile));
+            throw new UserException(ExitCodes.CONFIG, message, e);
         }
 
         Path keystoreFile = keystorePath(configDir);


### PR DESCRIPTION
If we do not have permissions to write the keystore, an unclear access denied exception is thrown. This commit catches this exception so that we can decorate it with a friendlier error message.
