### PR TITLE
Docs: Use single-node discovery.type for dev example

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -49,7 +49,7 @@ Elasticsearch can be quickly started for development or testing use with the fol
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
-docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" {docker-image}
+docker run -p 9200:9200 -e "discovery.type=single-node" {docker-image}
 --------------------------------------------
 
 endif::[]

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -49,7 +49,7 @@ Elasticsearch can be quickly started for development or testing use with the fol
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
-docker run -p 9200:9200 -e "discovery.type=single-node" {docker-image}
+docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" {docker-image}
 --------------------------------------------
 
 endif::[]


### PR DESCRIPTION
For the single node, dev example, the `discovery.type=single-node`[1] is
a perfect fit and makes the example shorter and more self explanatory.

[1] https://github.com/elastic/elasticsearch/pull/23595
[2] https://github.com/elastic/elasticsearch/pull/23598
