### PR TITLE
Support distance units in GeoHashGrid aggregation precision

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
@@ -77,7 +77,7 @@ public class GeoGridAggregationBuilder extends ValuesSourceAggregationBuilder<Va
                         throw e2;
                     } catch (IllegalArgumentException e3) {
                         // this happens when distance too small, so precision > 12. We'd like to see the original string
-                        throw new IllegalArgumentException("precision too high [" + precision + "]");
+                        throw new IllegalArgumentException("precision too high [" + precision + "]", e3);
                     }
                 }
             }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParserTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParserTests.java
@@ -19,11 +19,14 @@
 package org.elasticsearch.search.aggregations.bucket.geogrid;
 
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class GeoHashGridParserTests extends ESTestCase {
     public void testParseValidFromInts() throws Exception {
@@ -44,6 +47,46 @@ public class GeoHashGridParserTests extends ESTestCase {
         assertSame(XContentParser.Token.START_OBJECT, token);
         // can create a factory
         assertNotNull(GeoGridAggregationBuilder.parse("geohash_grid", stParser));
+    }
+
+    public void testParseDistanceUnitPrecision() throws Exception {
+        double distance = randomDoubleBetween(10.0, 100.00, true);
+        DistanceUnit unit = randomFrom(DistanceUnit.values());
+        if (unit.equals(DistanceUnit.MILLIMETERS)) {
+            distance = 5600 + randomDouble(); // 5.6cm is approx. smallest distance represented by precision 12
+        }
+        String distanceString = distance + unit.toString();
+        XContentParser stParser = createParser(JsonXContent.jsonXContent,
+                "{\"field\":\"my_loc\", \"precision\": \"" + distanceString + "\", \"size\": \"500\", \"shard_size\": \"550\"}");
+        XContentParser.Token token = stParser.nextToken();
+        assertSame(XContentParser.Token.START_OBJECT, token);
+        // can create a factory
+        GeoGridAggregationBuilder builder = GeoGridAggregationBuilder.parse("geohash_grid", stParser);
+        assertNotNull(builder);
+        assertThat(builder.precision(), greaterThanOrEqualTo(0));
+        assertThat(builder.precision(), lessThanOrEqualTo(12));
+    }
+
+    public void testParseInvalidUnitPrecision() throws Exception {
+        XContentParser stParser = createParser(JsonXContent.jsonXContent,
+                "{\"field\":\"my_loc\", \"precision\": \"10kg\", \"size\": \"500\", \"shard_size\": \"550\"}");
+        XContentParser.Token token = stParser.nextToken();
+        assertSame(XContentParser.Token.START_OBJECT, token);
+        ParsingException ex = expectThrows(ParsingException.class, () -> GeoGridAggregationBuilder.parse("geohash_grid", stParser));
+        assertEquals("[geohash_grid] failed to parse field [precision]", ex.getMessage());
+        assertThat(ex.getCause(), instanceOf(NumberFormatException.class));
+        assertEquals("For input string: \"10kg\"", ex.getCause().getMessage());
+    }
+
+    public void testParseDistanceUnitPrecisionTooSmall() throws Exception {
+        XContentParser stParser = createParser(JsonXContent.jsonXContent,
+                "{\"field\":\"my_loc\", \"precision\": \"1cm\", \"size\": \"500\", \"shard_size\": \"550\"}");
+        XContentParser.Token token = stParser.nextToken();
+        assertSame(XContentParser.Token.START_OBJECT, token);
+        ParsingException ex = expectThrows(ParsingException.class, () -> GeoGridAggregationBuilder.parse("geohash_grid", stParser));
+        assertEquals("[geohash_grid] failed to parse field [precision]", ex.getMessage());
+        assertThat(ex.getCause(), instanceOf(IllegalArgumentException.class));
+        assertEquals("precision too high [1cm]", ex.getCause().getMessage());
     }
 
     public void testParseErrorOnBooleanPrecision() throws Exception {

--- a/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
@@ -149,6 +149,15 @@ field::         Mandatory. The name of the field indexed with GeoPoints.
 
 precision::     Optional. The string length of the geohashes used to define
                 cells/buckets in the results. Defaults to 5.
+                The precision can either be defined in terms of the integer
+                precision levels mentioned above. Values outside of [1,12] will
+                be rejected.
+                Alternatively, the precision level can be approximated from a
+                distance measure like "1km", "10m". The precision level is
+                calculate such that cells will not exceed the specified
+                size (diagonal) of the required precision. When this would lead
+                to precision levels higher than the supported 12 levels,
+                (e.g. for distances <5.6cm) the value is rejected.
 
 size::          Optional. The maximum number of geohash buckets to return
                 (defaults to 10,000). When results are trimmed, buckets are


### PR DESCRIPTION
Currently the `precision` parameter must be a precision level
in the range of [1,12]. In #5042 it was suggested also supporting
distance units like "1km" to automatically approcimate the needed
precision level. This change adds this support to the Rest API by
making use of GeoUtils#geoHashLevelsForPrecision.

Plain integer values without a unit are still treated as precision
levels like before. Distance values that are too small to be represented
by a precision level of 12 (values approx. less than 0.056m) are
rejected.

Closes #5042