### PR TITLE
Detect modified keystore on package removal

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -382,6 +382,10 @@ configure(distributions.findAll { ['deb', 'rpm'].contains(it.name) }) {
       requires('bash')
     }
 
+    if (project.name == 'deb' || project.name == 'rpm') {
+      requires('coreutils')
+    }
+
     into '/usr/share/elasticsearch'
     fileMode 0644
     dirMode 0755

--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -99,8 +99,16 @@ fi
 
 chown -R elasticsearch:elasticsearch /var/lib/elasticsearch
 chown -R elasticsearch:elasticsearch /var/log/elasticsearch
+
+if [ ! -f "$ES_PATH_CONF"/elasticsearch.keystore ]; then
+    /usr/share/elasticsearch/bin/elasticsearch-keystore create
+    md5sum "$ES_PATH_CONF"/elasticsearch.keystore > "$ES_PATH_CONF"/elasticsearch.keystore.md5sum
+fi
+
 chown -R root:elasticsearch /etc/elasticsearch
 chmod 0750 /etc/elasticsearch
+chmod 660 "$ES_PATH_CONF"/elasticsearch.keystore
+[ -f "$ES_PATH_CONF"/elasticsearch.keystore.md5sum ] && chmod 660 "$ES_PATH_CONF"/elasticsearch.keystore.md5sum
 
 if [ -f /etc/default/elasticsearch ]; then
     chown root:elasticsearch /etc/default/elasticsearch
@@ -108,12 +116,6 @@ fi
 
 if [ -f /etc/sysconfig/elasticsearch ]; then
     chown root:elasticsearch /etc/sysconfig/elasticsearch
-fi
-
-if [ ! -f "$ES_PATH_CONF"/elasticsearch.keystore ]; then
-    /usr/share/elasticsearch/bin/elasticsearch-keystore create
-    chown root:elasticsearch "$ES_PATH_CONF"/elasticsearch.keystore
-    chmod 660 "$ES_PATH_CONF"/elasticsearch.keystore
 fi
 
 ${scripts.footer}

--- a/distribution/src/main/packaging/scripts/postrm
+++ b/distribution/src/main/packaging/scripts/postrm
@@ -85,6 +85,14 @@ if [ "$REMOVE_DIRS" = "true" ]; then
         rmdir --ignore-fail-on-non-empty "$DATA_DIR"
     fi
 
+    if [ -f "$ES_PATH_CONF"/elasticsearch.keystore.md5sum ]; then
+        if md5sum -c --quiet --status "$ES_PATH_CONF"/elasticsearch.keystore.md5sum; then
+          rm "$ES_PATH_CONF"/elasticsearch.keystore "$ES_PATH_CONF"/elasticsearch.keystore.md5sum
+        else
+          echo "warning: $ES_PATH_CONF/elasticsearch.keystore modified so not removed"
+        fi
+    fi
+
     # delete the conf directory if and only if empty
     if [ -d "$ES_PATH_CONF" ]; then
         rmdir --ignore-fail-on-non-empty "$ES_PATH_CONF"

--- a/qa/vagrant/src/test/resources/packaging/tests/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/30_deb_package.bats
@@ -149,6 +149,8 @@ setup() {
 
     # The configuration files are still here
     assert_file_exist "/etc/elasticsearch"
+    assert_file_exist "/etc/elsticsearch.keystore"
+    assert_file_exist "/etc/elsticsearch.keystore.md5sum"
     assert_file_exist "/etc/elasticsearch/elasticsearch.yml"
     assert_file_exist "/etc/elasticsearch/jvm.options"
     assert_file_exist "/etc/elasticsearch/log4j2.properties"
@@ -170,6 +172,8 @@ setup() {
 @test "[DEB] verify package purge" {
     # all remaining files are deleted by the purge
     assert_file_not_exist "/etc/elasticsearch"
+    assert_file_not_exist "/etc/elsticsearch.keystore"
+    assert_file_not_exist "/etc/elsticsearch.keystore.md5sum"
     assert_file_not_exist "/etc/elasticsearch/elasticsearch.yml"
     assert_file_not_exist "/etc/elasticsearch/jvm.options"
     assert_file_not_exist "/etc/elasticsearch/log4j2.properties"

--- a/qa/vagrant/src/test/resources/packaging/tests/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/30_deb_package.bats
@@ -149,8 +149,8 @@ setup() {
 
     # The configuration files are still here
     assert_file_exist "/etc/elasticsearch"
-    assert_file_exist "/etc/elsticsearch.keystore"
-    assert_file_exist "/etc/elsticsearch.keystore.md5sum"
+    assert_file_exist "/etc/elasticsearch.keystore"
+    assert_file_exist "/etc/elasticsearch.keystore.md5sum"
     assert_file_exist "/etc/elasticsearch/elasticsearch.yml"
     assert_file_exist "/etc/elasticsearch/jvm.options"
     assert_file_exist "/etc/elasticsearch/log4j2.properties"

--- a/qa/vagrant/src/test/resources/packaging/tests/40_rpm_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/40_rpm_package.bats
@@ -158,6 +158,7 @@ setup() {
     echo "# ping" >> "/etc/elasticsearch/elasticsearch.yml"
     echo "# ping" >> "/etc/elasticsearch/jvm.options"
     echo "# ping" >> "/etc/elasticsearch/log4j2.properties"
+    echo "baz.quux" | /usr/share/elasticsearch/bin/elasticsearch-keystore add foo.bar
     rpm -e 'elasticsearch'
 }
 
@@ -187,6 +188,7 @@ setup() {
     assert_file_exist "/etc/elasticsearch/jvm.options.rpmsave"
     assert_file_not_exist "/etc/elasticsearch/log4j2.properties"
     assert_file_exist "/etc/elasticsearch/log4j2.properties.rpmsave"
+    assert_file_exist "/etc/elasticsearch/elasticsearch.keystore"
 
     assert_file_not_exist "/etc/init.d/elasticsearch"
     assert_file_not_exist "/usr/lib/systemd/system/elasticsearch.service"

--- a/qa/vagrant/src/test/resources/packaging/utils/packages.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/packages.bash
@@ -95,6 +95,8 @@ verify_package_installation() {
     assert_file "$ESHOME/bin/elasticsearch-translog" f root root 755
     assert_file "$ESHOME/lib" d root root 755
     assert_file "$ESCONFIG" d root elasticsearch 750
+    assert_file "$ESCONFIG/elasticsearch.keystore" f root elasticsearch 660
+    assert_file "$ESCONFIG/elasticsearch.keystore.md5sum" f root elasticsearch 660
     assert_file "$ESCONFIG/elasticsearch.yml" f root elasticsearch 660
     assert_file "$ESCONFIG/jvm.options" f root elasticsearch 660
     assert_file "$ESCONFIG/log4j2.properties" f root elasticsearch 660


### PR DESCRIPTION
When we install the Debian or RPM package, we create an initial keystore with a random keystore.seed. If this keystore is never modified by the user, we should remove it on package cleanup. To do this, when creating the keystore we add an md5sum file so that on package removal we can compare the md5sum of the current keystore with that created on package installation. If the keystore has not changed, we remove the keystore otherwise we preserve it for the user.

