### PR TITLE
added WARN level logging if an exception occurs in  org.elasticsearch…

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/core/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -1486,6 +1486,10 @@ public abstract class TcpTransport<Channel> extends AbstractLifecycleComponent i
             // the circuit breaker tripped
             if (transportChannel == null) {
                 transportChannel = new TcpTransportChannel<>(this, channel, transportName, action, requestId, version, profileName, 0);
+            } else {
+                logger.warn(
+                    (Supplier<?>) () -> new ParameterizedMessage(
+                        "Sending error message back to client for action [{}] and requestId [{}]", action, requestId), e);
             }
             try {
                 transportChannel.sendResponse(e);


### PR DESCRIPTION
This P.R. introduces WARN level logging if an exception occurs in  org.elasticsearch.transport.TcpTransport.handleRequest().
This is my first dive into the Elasticsearch code base, so I was a little unsure  about what to do with respect to the check of transportChannel == null. I log at WARN level only if transportChannel != null, but maybe that is too conservative.

Why This May Be Helpful

In some instances when shards get stuck in INITIALIZING state, the only evidence of the problem
appears in the log files of the  _recipient_ side of the peer-to-peer exchange.  This happens
even in cases  where the problem arises on the sender side of the exchange. This can make debugging
tricky. When you look at the only stack trace available (on the node running the recipient code) you
see a stack dump that mixes in what was happening on the sender side (when the sender side produced the error) together with the recipient part of the  stack trace, which tops out at the point where
the recipient was waiting for the client's response.

An example is shown below (see: Example Stack Trace.)


An example of where it would have been really useful to have both the sender and  recipient log the
error arose in the course of investigating this bug:
    https://github.com/elastic/elasticsearch/issues/26293



Example Stack Trace
-------------------

[2017-08-18T17:02:57,201][DEBUG][o.e.c.s.ClusterService   ] [node_az1_006a1fb63b6] applying cluster state version 1171
[2017-08-18T17:02:57,201][DEBUG][o.e.c.s.ClusterService   ] [node_az1_006a1fb63b6] set local cluster state to version 1171
[2017-08-18T17:02:57,212][DEBUG][o.e.c.s.ClusterService   ] [node_az1_006a1fb63b6] processing [zen-disco-receive(from master [master {node_az2_084354b0d5}{86-R436YR56aHOtxCptzjg}{YSViwD-tQhSJqe3y9w6dWw}{100.0.0.2}{100.0.0.2:9002}{rack_id=az2} committed version [1171]])]: took [11ms] done applying updated cluster_state (version: 1171, uuid: -U_RCKbTSIG6kiRDtuWSmg)
[2017-08-18T17:17:55,337][TRACE][o.e.t.T.tracer           ] [node_az1_006a1fb63b6] [3262984][internal:index/shard/recovery/start_recovery] received response from [{node_az2_f79f3497d0}{CTBV-A2tT5ysQ7uVX1vjPw}{4IMXO6pHQ_SNQS5mSzF6kg}{100.0.0.3}{100.0.0.3:9002}{rack_id=az2}]
[2017-08-18T17:17:55,338][WARN ][o.e.i.c.IndicesClusterStateService] [node_az1_006a1fb63b6] [[test360_19][143]] marking and sending shard failed due to [failed recovery]
org.elasticsearch.indices.recovery.RecoveryFailedException: [test360_19][143]: Recovery failed from {node_az2_f79f3497d0}{CTBV-A2tT5ysQ7uVX1vjPw}{4IMXO6pHQ_SNQS5mSzF6kg}{100.0.0.3}{100.0.0.3:9002}{rack_id=az2} into {node_az1_006a1fb63b6}{b-sQwH5dQQixJ9fN27l2eA}{NBnUGKW7R2CUXlI7byGm5g}{100.0.0.1}{100.0.0.1:9002}{rack_id=az3}
        at org.elasticsearch.indices.recovery.PeerRecoveryTargetService.doRecovery(PeerRecoveryTargetService.java:314) [elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoveryTargetService.access$900(PeerRecoveryTargetService.java:73) [elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoveryTargetService$RecoveryRunner.doRun(PeerRecoveryTargetService.java:556) [elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:638) [elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) [elasticsearch-5.5.1.jar:5.5.1]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_144]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_144]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
Caused by: org.elasticsearch.transport.RemoteTransportException: [node_az2_0ff81340d0bc][100.0.0.3:9002][internal:index/shard/recovery/start_recovery]
Caused by: org.elasticsearch.index.engine.RecoveryEngineException: Phase[1] phase1 failed
        at org.elasticsearch.indices.recovery.RecoverySourceHandler.recoverToTarget(RecoverySourceHandler.java:140) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoverySourceService.recover(PeerRecoverySourceService.java:132) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoverySourceService.access$100(PeerRecoverySourceService.java:54) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoverySourceService$StartRecoveryTransportRequestHandler.messageReceived(PeerRecoverySourceService.java:141) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoverySourceService$StartRecoveryTransportRequestHandler.messageReceived(PeerRecoverySourceService.java:138) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.transport.TransportRequestHandler.messageReceived(TransportRequestHandler.java:33) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:69) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.transport.TcpTransport$RequestHandler.doRun(TcpTransport.java:1544) ~[elasticsearch-5.5.1.jar:5.5.1]
        ... 5 more
Caused by: org.elasticsearch.indices.recovery.RecoverFilesRecoveryException: Failed to transfer [1] files with total size of [162b]
        at org.elasticsearch.indices.recovery.RecoverySourceHandler.phase1(RecoverySourceHandler.java:337) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.RecoverySourceHandler.recoverToTarget(RecoverySourceHandler.java:138) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoverySourceService.recover(PeerRecoverySourceService.java:132) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoverySourceService.access$100(PeerRecoverySourceService.java:54) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoverySourceService$StartRecoveryTransportRequestHandler.messageReceived(PeerRecoverySourceService.java:141) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.indices.recovery.PeerRecoverySourceService$StartRecoveryTransportRequestHandler.messageReceived(PeerRecoverySourceService.java:138) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.transport.TransportRequestHandler.messageReceived(TransportRequestHandler.java:33) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:69) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.transport.TcpTransport$RequestHandler.doRun(TcpTransport.java:1544) ~[elasticsearch-5.5.1.jar:5.5.1]
        ... 5 more
Caused by: org.elasticsearch.transport.ReceiveTimeoutTransportException: [node_az1_006a1fb63b6][100.0.0.1:9002][internal:index/shard/recovery/prepare_translog] request_id [1106203] timed out after [900000ms]
        at org.elasticsearch.transport.TransportService$TimeoutHandler.run(TransportService.java:951) ~[elasticsearch-5.5.1.jar:5.5.1]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:569) ~[elasticsearch-5.5.1.jar:5.5.1]
        ... 3 more
[2017-08-18T17:17:55,339][DEBUG][o.e.c.a.s.ShardStateAction] [node_az1_006a1fb63b6] [test360_19][143] sending [internal:cluster/shard/failure] to [86-R436YR56aHOtxCptzjg] for shard entry [shard id [[test360_19][143]], allocation id [uLI9lUk3To2entCZ-KQcAw], primary term [0], message [failed recovery], failure [RecoveryFailedException[[test360_19][143]: Recovery failed from {node_az2_f79f3497d0}{CTBV-A2tT5ysQ7uVX1vjPw}{4IMXO6pHQ_SNQS5mSzF6kg}{100.0.0.3}{100.0.0.3:9002}{rack_id=az2} into {node_az1_006a1fb63b6}{b-sQwH5dQQixJ9fN27l2eA}{NBnUGKW7R2CUXlI7byGm5g}{100.0.0.1}{100.0.0.1:9002}{rack_id=az3}]; nested: RemoteTransportException[[node_az2_f79f3497d0][100.0.0.3:9002][internal:index/shard/recovery/start_recovery]]; nested: RecoveryEngineException[Phase[1] phase1 failed]; nested: RecoverFilesRecoveryException[Failed to transfer [1] files with total size of [162b]]; nested: ReceiveTimeoutTransportException[[node_az1_006a1fb63b6][100.0.0.1:9002][internal:index/shard/recovery/prepare_translog] request_id [1106203] timed out after [900000ms]]; ]]
[2017-08-18T17:17:55,619][DEBUG][o.e.c.s.ClusterService   ] [node_az1_006a1fb63b6] processing [zen-disco-receive(from master [master {node_az2_084354b0d5}{86-R436YR56aHOtxCptzjg}{YSViwD-tQhSJqe3y9w6dWw}{100.0.0.2}{100.0.0.2:9002}{rack_id=az2} committed version [1172]])]: execute
