### PR TITLE
Accept an array of field names and boosts in the index.query.default_field setting

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -151,8 +151,12 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeRe
                 }
             }
             if (field == null) {
+                /**
+                 * TODO: _all is disabled by default and index.query.default_field can define multiple fields or pattterns so we should
+                 * probably makes the field name mandatory in analyze query.
+                 **/
                 if (indexService != null) {
-                    field = indexService.getIndexSettings().getDefaultField();
+                    field = indexService.getIndexSettings().getDefaultField().get(0);
                 } else {
                     field = AllFieldMapper.NAME;
                 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/analyze/TransportAnalyzeAction.java
@@ -61,7 +61,6 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.analysis.AnalysisModule;
-import org.elasticsearch.indices.analysis.PreBuiltTokenizers;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -156,7 +155,7 @@ public class TransportAnalyzeAction extends TransportSingleShardAction<AnalyzeRe
                  * probably makes the field name mandatory in analyze query.
                  **/
                 if (indexService != null) {
-                    field = indexService.getIndexSettings().getDefaultField().get(0);
+                    field = indexService.getIndexSettings().getDefaultFields().get(0);
                 } else {
                     field = AllFieldMapper.NAME;
                 }

--- a/core/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.MergePolicy;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.lucene.all.AllField;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -32,7 +31,6 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.mapper.AllFieldMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.node.Node;
 
@@ -245,11 +243,11 @@ public final class IndexSettings {
     /**
      * Returns the default search fields for this index.
      */
-    public List<String> getDefaultField() {
+    public List<String> getDefaultFields() {
         return defaultFields;
     }
 
-    private void setDefaultField(List<String> defaultFields) {
+    private void setDefaultFields(List<String> defaultFields) {
         this.defaultFields = defaultFields;
     }
 
@@ -367,7 +365,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_REFRESH_INTERVAL_SETTING, this::setRefreshInterval);
         scopedSettings.addSettingsUpdateConsumer(MAX_REFRESH_LISTENERS_PER_SHARD, this::setMaxRefreshListeners);
         scopedSettings.addSettingsUpdateConsumer(MAX_SLICES_PER_SCROLL, this::setMaxSlicesPerScroll);
-        scopedSettings.addSettingsUpdateConsumer(DEFAULT_FIELD_SETTING, this::setDefaultField);
+        scopedSettings.addSettingsUpdateConsumer(DEFAULT_FIELD_SETTING, this::setDefaultFields);
     }
 
     private void setTranslogFlushThresholdSize(ByteSizeValue byteSizeValue) {

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -59,7 +59,6 @@ import org.elasticsearch.index.mapper.UidFieldMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -1033,7 +1032,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         boolean useDefaultField = (fields == null);
         List<String> moreLikeFields = new ArrayList<>();
         if (useDefaultField) {
-            moreLikeFields = context.defaultField();
+            moreLikeFields = context.defaultFields();
         } else {
             for (String field : fields) {
                 MappedFieldType fieldType = context.fieldMapper(field);

--- a/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -1033,7 +1033,7 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         boolean useDefaultField = (fields == null);
         List<String> moreLikeFields = new ArrayList<>();
         if (useDefaultField) {
-            moreLikeFields = Collections.singletonList(context.defaultField());
+            moreLikeFields = context.defaultField();
         } else {
             for (String field : fields) {
                 MappedFieldType fieldType = context.fieldMapper(field);

--- a/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -144,7 +145,7 @@ public class QueryShardContext extends QueryRewriteContext {
         return similarityService != null ? similarityService.similarity(mapperService) : null;
     }
 
-    public String defaultField() {
+    public List<String> defaultField() {
         return indexSettings.getDefaultField();
     }
 

--- a/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -40,14 +40,11 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.fielddata.IndexFieldData;
-import org.elasticsearch.index.fielddata.plain.ConstantIndexFieldData;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.IndexFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
-import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.ObjectMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.query.support.NestedScope;
@@ -64,7 +61,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.function.LongSupplier;
 
 import static java.util.Collections.unmodifiableMap;
@@ -145,8 +141,8 @@ public class QueryShardContext extends QueryRewriteContext {
         return similarityService != null ? similarityService.similarity(mapperService) : null;
     }
 
-    public List<String> defaultField() {
-        return indexSettings.getDefaultField();
+    public List<String> defaultFields() {
+        return indexSettings.getDefaultFields();
     }
 
     public boolean queryStringLenient() {

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -43,7 +43,6 @@ import org.joda.time.DateTimeZone;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -933,7 +932,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
             final Map<String, Float> resolvedFields = QueryParserHelper.resolveMappingFields(context, fieldsAndWeights);
             queryParser = new QueryStringQueryParser(context, resolvedFields, isLenient);
         } else {
-            List<String> defaultFields = context.defaultField();
+            List<String> defaultFields = context.defaultFields();
             if (context.getMapperService().allEnabled() == false &&
                     defaultFields.size() == 1 && AllFieldMapper.NAME.equals(defaultFields.get(0))) {
                 // For indices created before 6.0 with _all disabled

--- a/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -404,7 +404,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
         if (fieldsAndWeights.isEmpty() == false) {
             resolvedFieldsAndWeights = QueryParserHelper.resolveMappingFields(context, fieldsAndWeights);
         } else {
-            List<String> defaultFields = context.defaultField();
+            List<String> defaultFields = context.defaultFields();
             if (context.getMapperService().allEnabled() == false &&
                     defaultFields.size() == 1 && AllFieldMapper.NAME.equals(defaultFields.get(0))) {
                 // For indices created before 6.0 with _all disabled

--- a/core/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/core/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -35,11 +35,12 @@ import org.elasticsearch.index.query.QueryShardContext;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Helpers to extract and expand field names from a mapping
+ * Helpers to extract and expand field names and boosts
  */
 public final class QueryParserHelper {
     // Mapping types the "all-ish" query can be executed against
@@ -58,6 +59,29 @@ public final class QueryParserHelper {
     }
 
     private QueryParserHelper() {}
+
+    /**
+     * Convert a list of field names encoded with optional boosts to a map that associates
+     * the field name and its boost.
+     * @param fields The list of fields encoded with optional boosts (e.g. ^0.35).
+     * @return The converted map with field names and associated boosts.
+     */
+    public static Map<String, Float> parseFieldsAndWeights(List<String> fields) {
+        final Map<String, Float> fieldsAndWeights = new HashMap<>();
+        for (String field : fields) {
+            int boostIndex = field.indexOf('^');
+            String fieldName;
+            float boost = 1.0f;
+            if (boostIndex != -1) {
+                fieldName = field.substring(0, boostIndex);
+                boost = Float.parseFloat(field.substring(boostIndex+1, field.length()));
+            } else {
+                fieldName = field;
+            }
+            fieldsAndWeights.put(fieldName, boost);
+        }
+        return fieldsAndWeights;
+    }
 
     /**
      * Get a {@link FieldMapper} associated with a field name or null.

--- a/core/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
+++ b/core/src/main/java/org/elasticsearch/index/search/QueryStringQueryParser.java
@@ -610,12 +610,13 @@ public class QueryStringQueryParser extends XQueryParser {
 
     @Override
     protected Query getWildcardQuery(String field, String termStr) throws ParseException {
-        if (termStr.equals("*") && field != null) {
+        if (termStr.equals("*") && (field != null || AllFieldMapper.NAME.equals(this.field))) {
             /**
              * We rewrite _all:* to a match all query.
              * TODO: We can remove this special case when _all is completely removed.
              */
-            if (Regex.isMatchAllPattern(field) || AllFieldMapper.NAME.equals(field)) {
+            if (AllFieldMapper.NAME.equals(this.field) ||
+                    Regex.isMatchAllPattern(field) || AllFieldMapper.NAME.equals(field)) {
                 return newMatchAllDocsQuery();
             }
             String actualField = field;

--- a/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -485,14 +485,14 @@ public class IndexSettingsTests extends ESTestCase {
         IndexSettings index = newIndexSettings(
             newIndexMeta("index", Settings.EMPTY), Settings.EMPTY
         );
-        assertThat(index.getDefaultField(), equalTo(Collections.singletonList("*")));
+        assertThat(index.getDefaultFields(), equalTo(Collections.singletonList("*")));
         index = newIndexSettings(
             newIndexMeta("index", Settings.EMPTY), Settings.builder().put("index.query.default_field", "body").build()
         );
-        assertThat(index.getDefaultField(), equalTo(Collections.singletonList("body")));
+        assertThat(index.getDefaultFields(), equalTo(Collections.singletonList("body")));
         index.updateIndexMetaData(
             newIndexMeta("index", Settings.builder().putArray("index.query.default_field", "body", "title").build())
         );
-        assertThat(index.getDefaultField(), equalTo(Arrays.asList("body", "title")));
+        assertThat(index.getDefaultFields(), equalTo(Arrays.asList("body", "title")));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -478,5 +479,20 @@ public class IndexSettingsTests extends ESTestCase {
                 // all is well
             }
         }
+    }
+
+    public void testQueryDefaultField() {
+        IndexSettings index = newIndexSettings(
+            newIndexMeta("index", Settings.EMPTY), Settings.EMPTY
+        );
+        assertThat(index.getDefaultField(), equalTo(Collections.singletonList("*")));
+        index = newIndexSettings(
+            newIndexMeta("index", Settings.EMPTY), Settings.builder().put("index.query.default_field", "body").build()
+        );
+        assertThat(index.getDefaultField(), equalTo(Collections.singletonList("body")));
+        index.updateIndexMetaData(
+            newIndexMeta("index", Settings.builder().putArray("index.query.default_field", "body", "title").build())
+        );
+        assertThat(index.getDefaultField(), equalTo(Arrays.asList("body", "title")));
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -78,7 +78,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStringQueryBuilder> {
-
     @Override
     protected QueryStringQueryBuilder doCreateTestQueryBuilder() {
         int numTerms = randomIntBetween(0, 5);

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -1008,6 +1008,11 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             ), 0.0f
         );
         assertEquals(expected, query);
+        // Reset the default value
+        context.getIndexSettings().updateIndexMetaData(
+            newIndexMeta("index",
+                context.getIndexSettings().getSettings(), Settings.builder().putArray("index.query.default_field", "*").build())
+        );
     }
 
     private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {

--- a/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SimpleQueryStringBuilderTests.java
@@ -40,6 +40,7 @@ import org.apache.lucene.search.spans.SpanTermQuery;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.lucene.all.AllTermQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.search.SimpleQueryStringQueryParser;
 import org.elasticsearch.search.internal.SearchContext;
@@ -268,7 +269,7 @@ public class SimpleQueryStringBuilderTests extends AbstractQueryTestCase<SimpleQ
             }
         } else if (queryBuilder.fields().size() == 0) {
             assertThat(query, either(instanceOf(DisjunctionMaxQuery.class))
-                .or(instanceOf(MatchNoDocsQuery.class)).or(instanceOf(TermQuery.class)));
+                .or(instanceOf(MatchNoDocsQuery.class)).or(instanceOf(TermQuery.class)).or(instanceOf(AllTermQuery.class)));
             if (query instanceof DisjunctionMaxQuery) {
                 for (Query disjunct : (DisjunctionMaxQuery) query) {
                     assertThat(disjunct, either(instanceOf(TermQuery.class)).or(instanceOf(MatchNoDocsQuery.class)));

--- a/docs/reference/query-dsl/simple-query-string-query.asciidoc
+++ b/docs/reference/query-dsl/simple-query-string-query.asciidoc
@@ -116,7 +116,7 @@ documents that contain "baz".
 ==== Default Field
 When not explicitly specifying the field to search on in the query
 string syntax, the `index.query.default_field` will be used to derive
-which field to search on. It defaults to `*` and the query will automatically
+which fields to search on. It defaults to `*` and the query will automatically
 attempt to determine the existing fields in the index's mapping that are queryable,
 and perform the search on those fields.
 


### PR DESCRIPTION
This commit allows to define an array of field names and boosts for the index setting `index.query.default_field`.
The format is equivalent to the `fields` options of the full text search queries (e.g. field_name^boost).
This commit also makes this setting dynamically updatable.

Fixes #25946