### PR TITLE
Settings: Move keystore creation to plugin installation

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesExtension.groovy
@@ -46,6 +46,10 @@ class PluginPropertiesExtension {
     @Input
     boolean hasClientJar = false
 
+    /** True if the plugin requires the elasticsearch keystore to exist, false otherwise. */
+    @Input
+    boolean requiresKeystore = false
+
     /** A license file that should be included in the built plugin zip. */
     @Input
     File licenseFile = null

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginPropertiesTask.groovy
@@ -80,7 +80,8 @@ class PluginPropertiesTask extends Copy {
             'elasticsearchVersion': stringSnap(VersionProperties.elasticsearch),
             'javaVersion': project.targetCompatibility as String,
             'classname': extension.classname,
-            'hasNativeController': extension.hasNativeController
+            'hasNativeController': extension.hasNativeController,
+            'requiresKeystore': extension.requiresKeystore
         ]
     }
 }

--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -42,3 +42,6 @@ elasticsearch.version=${elasticsearchVersion}
 #
 # 'has.native.controller': whether or not the plugin has a native controller
 has.native.controller=${hasNativeController}
+#
+# 'requires.keystore': whether or not the plugin needs the elasticsearch keystore be created
+requires.keystore=${requiresKeystore}

--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -226,16 +226,13 @@ final class Bootstrap {
         } catch (IOException e) {
             throw new BootstrapException(e);
         }
+        if (keystore == null) {
+            return null; // no keystore
+        }
 
         try {
-            if (keystore == null) {
-                // create it, we always want one! we use an empty passphrase, but a user can change this later if they want.
-                KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create(new char[0]);
-                keyStoreWrapper.save(initialEnv.configFile());
-                return keyStoreWrapper;
-            } else {
-                keystore.decrypt(new char[0] /* TODO: read password from stdin */);
-            }
+            KeyStoreWrapper.upgrade(keystore, initialEnv.configFile(), new char[0] /* TODO: read password from stdin */);
+            keystore.decrypt(new char[0] /* TODO: read password from stdin */);
         } catch (Exception e) {
             throw new BootstrapException(e);
         }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -231,8 +231,8 @@ final class Bootstrap {
         }
 
         try {
-            KeyStoreWrapper.upgrade(keystore, initialEnv.configFile(), new char[0] /* TODO: read password from stdin */);
             keystore.decrypt(new char[0] /* TODO: read password from stdin */);
+            KeyStoreWrapper.upgrade(keystore, initialEnv.configFile());
         } catch (Exception e) {
             throw new BootstrapException(e);
         }

--- a/core/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -229,12 +229,11 @@ public class KeyStoreWrapper implements SecureSettings {
     }
 
     /** Upgrades the format of the keystore, if necessary. */
-    public static void upgrade(KeyStoreWrapper wrapper, Path configDir, char[] password) throws Exception {
+    public static void upgrade(KeyStoreWrapper wrapper, Path configDir) throws Exception {
         // ensure keystore.seed exists
         if (wrapper.getSettingNames().contains(SEED_SETTING.getKey())) {
             return;
         }
-        wrapper.decrypt(password);
         addBootstrapSeed(wrapper);
         wrapper.save(configDir);
     }

--- a/core/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -154,7 +154,7 @@ public class KeyStoreWrapper implements SecureSettings {
     }
 
     /** Returns a path representing the ES keystore in the given config dir. */
-    static Path keystorePath(Path configDir) {
+    public static Path keystorePath(Path configDir) {
         return configDir.resolve(KEYSTORE_FILENAME);
     }
 

--- a/core/src/main/java/org/elasticsearch/plugins/DummyPluginInfo.java
+++ b/core/src/main/java/org/elasticsearch/plugins/DummyPluginInfo.java
@@ -21,7 +21,7 @@ package org.elasticsearch.plugins;
 public class DummyPluginInfo extends PluginInfo {
 
     private DummyPluginInfo(String name, String description, String version, String classname) {
-        super(name, description, version, classname, false);
+        super(name, description, version, classname, false, false);
     }
 
     public static final DummyPluginInfo INSTANCE =

--- a/core/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -21,6 +21,7 @@ package org.elasticsearch.plugins;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.JarHell;
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -48,6 +49,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
     private final String version;
     private final String classname;
     private final boolean hasNativeController;
+    private final boolean requiresKeystore;
 
     /**
      * Construct plugin info.
@@ -57,18 +59,16 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param version             the version of Elasticsearch the plugin is built for
      * @param classname           the entry point to the plugin
      * @param hasNativeController whether or not the plugin has a native controller
+     * @param requiresKeystore    whether or not the plugin requires the elasticsearch keystore to be created
      */
-    public PluginInfo(
-            final String name,
-            final String description,
-            final String version,
-            final String classname,
-            final boolean hasNativeController) {
+    public PluginInfo(String name, String description, String version, String classname,
+                      boolean hasNativeController, boolean requiresKeystore) {
         this.name = name;
         this.description = description;
         this.version = version;
         this.classname = classname;
         this.hasNativeController = hasNativeController;
+        this.requiresKeystore = requiresKeystore;
     }
 
     /**
@@ -87,6 +87,11 @@ public class PluginInfo implements Writeable, ToXContentObject {
         } else {
             hasNativeController = false;
         }
+        if (in.getVersion().onOrAfter(Version.V_6_0_0_beta2)) {
+            requiresKeystore = in.readBoolean();
+        } else {
+            requiresKeystore = false;
+        }
     }
 
     @Override
@@ -97,6 +102,9 @@ public class PluginInfo implements Writeable, ToXContentObject {
         out.writeString(classname);
         if (out.getVersion().onOrAfter(Version.V_5_4_0)) {
             out.writeBoolean(hasNativeController);
+        }
+        if (out.getVersion().onOrAfter(Version.V_6_0_0_beta2)) {
+            out.writeBoolean(requiresKeystore);
         }
     }
 
@@ -173,17 +181,26 @@ public class PluginInfo implements Writeable, ToXContentObject {
                     break;
                 default:
                     final String message = String.format(
-                            Locale.ROOT,
-                            "property [%s] must be [%s], [%s], or unspecified but was [%s]",
-                            "has_native_controller",
-                            "true",
-                            "false",
-                            hasNativeControllerValue);
+                        Locale.ROOT,
+                        "property [%s] must be [%s], [%s], or unspecified but was [%s]",
+                        "has_native_controller",
+                        "true",
+                        "false",
+                        hasNativeControllerValue);
                     throw new IllegalArgumentException(message);
             }
         }
 
-        return new PluginInfo(name, description, version, classname, hasNativeController);
+        final String requiresKeystoreValue = props.getProperty("requires.keystore", "false");
+        final boolean requiresKeystore;
+        try {
+            requiresKeystore = Booleans.parseBoolean(requiresKeystoreValue);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("property [requires.keystore] must be [true] or [false]," +
+                                               " but was [" + requiresKeystoreValue + "]", e);
+        }
+
+        return new PluginInfo(name, description, version, classname, hasNativeController, requiresKeystore);
     }
 
     /**
@@ -231,6 +248,15 @@ public class PluginInfo implements Writeable, ToXContentObject {
         return hasNativeController;
     }
 
+    /**
+     * Whether or not the plugin requires the elasticsearch keystore to exist.
+     *
+     * @return {@code true} if the plugin requires a keystore, {@code false} otherwise
+     */
+    public boolean requiresKeystore() {
+        return requiresKeystore;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -240,6 +266,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             builder.field("description", description);
             builder.field("classname", classname);
             builder.field("has_native_controller", hasNativeController);
+            builder.field("requires_keystore", requiresKeystore);
         }
         builder.endObject();
 
@@ -272,6 +299,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
                 .append("Description: ").append(description).append("\n")
                 .append("Version: ").append(version).append("\n")
                 .append("Native Controller: ").append(hasNativeController).append("\n")
+                .append("Requires Keystore: ").append(requiresKeystore).append("\n")
                 .append(" * Classname: ").append(classname);
         return information.toString();
     }

--- a/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -102,7 +102,7 @@ public class PluginsService extends AbstractComponent {
         // first we load plugins that are on the classpath. this is for tests and transport clients
         for (Class<? extends Plugin> pluginClass : classpathPlugins) {
             Plugin plugin = loadPlugin(pluginClass, settings, configPath);
-            PluginInfo pluginInfo = new PluginInfo(pluginClass.getName(), "classpath plugin", "NA", pluginClass.getName(), false);
+            PluginInfo pluginInfo = new PluginInfo(pluginClass.getName(), "classpath plugin", "NA", pluginClass.getName(), false, false);
             if (logger.isTraceEnabled()) {
                 logger.trace("plugin loaded from classpath [{}]", pluginInfo);
             }

--- a/core/src/test/java/org/elasticsearch/bootstrap/BootstrapTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/BootstrapTests.java
@@ -50,13 +50,6 @@ public class BootstrapTests extends ESTestCase {
         env = KeyStoreCommandTestCase.setupEnv(true, fileSystems);
     }
 
-    public void testLoadSecureSettingsCreatesKeystore() throws BootstrapException {
-        final Path configPath = env.configFile();
-        assertFalse(Files.exists(configPath.resolve("elasticsearch.keystore")));
-        Bootstrap.loadSecureSettings(env);
-        assertTrue(Files.exists(configPath.resolve("elasticsearch.keystore")));
-    }
-
     public void testLoadSecureSettings() throws Exception {
         final Path configPath = env.configFile();
         final SecureString seed;

--- a/core/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
@@ -77,20 +77,24 @@ public class KeyStoreWrapperTests extends ESTestCase {
     public void testUpgradeNoop() throws Exception {
         KeyStoreWrapper keystore = KeyStoreWrapper.create(new char[0]);
         SecureString seed = keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey());
+        keystore.save(env.configFile());
         // upgrade does not overwrite seed
-        KeyStoreWrapper.upgrade(keystore, env.configFile(), new char[0]);
+        KeyStoreWrapper.upgrade(keystore, env.configFile());
         assertEquals(seed.toString(), keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey()).toString());
         keystore = KeyStoreWrapper.load(env.configFile());
+        keystore.decrypt(new char[0]);
         assertEquals(seed.toString(), keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey()).toString());
     }
 
     public void testUpgradeAddsSeed() throws Exception {
         KeyStoreWrapper keystore = KeyStoreWrapper.create(new char[0]);
         keystore.remove(KeyStoreWrapper.SEED_SETTING.getKey());
-        KeyStoreWrapper.upgrade(keystore, env.configFile(), new char[0]);
+        keystore.save(env.configFile());
+        KeyStoreWrapper.upgrade(keystore, env.configFile());
         SecureString seed = keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey());
         assertNotNull(seed);
         keystore = KeyStoreWrapper.load(env.configFile());
+        keystore.decrypt(new char[0]);
         assertEquals(seed.toString(), keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey()).toString());
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
@@ -69,8 +69,28 @@ public class KeyStoreWrapperTests extends ESTestCase {
         }
     }
 
-    public void testKeystoreSeed() throws Exception {
+    public void testCreate() throws Exception {
         KeyStoreWrapper keystore = KeyStoreWrapper.create(new char[0]);
         assertTrue(keystore.getSettingNames().contains(KeyStoreWrapper.SEED_SETTING.getKey()));
+    }
+
+    public void testUpgradeNoop() throws Exception {
+        KeyStoreWrapper keystore = KeyStoreWrapper.create(new char[0]);
+        SecureString seed = keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey());
+        // upgrade does not overwrite seed
+        KeyStoreWrapper.upgrade(keystore, env.configFile(), new char[0]);
+        assertEquals(seed.toString(), keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey()).toString());
+        keystore = KeyStoreWrapper.load(env.configFile());
+        assertEquals(seed.toString(), keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey()).toString());
+    }
+
+    public void testUpgradeAddsSeed() throws Exception {
+        KeyStoreWrapper keystore = KeyStoreWrapper.create(new char[0]);
+        keystore.remove(KeyStoreWrapper.SEED_SETTING.getKey());
+        KeyStoreWrapper.upgrade(keystore, env.configFile(), new char[0]);
+        SecureString seed = keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey());
+        assertNotNull(seed);
+        keystore = KeyStoreWrapper.load(env.configFile());
+        assertEquals(seed.toString(), keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey()).toString());
     }
 }

--- a/core/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/core/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -143,13 +143,13 @@ public class NodeInfoStreamingTests extends ESTestCase {
             List<PluginInfo> plugins = new ArrayList<>();
             for (int i = 0; i < numPlugins; i++) {
                 plugins.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
-                        randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10), randomBoolean()));
+                        randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10), randomBoolean(), randomBoolean()));
             }
             int numModules = randomIntBetween(0, 5);
             List<PluginInfo> modules = new ArrayList<>();
             for (int i = 0; i < numModules; i++) {
                 modules.add(new PluginInfo(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10),
-                        randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10), randomBoolean()));
+                        randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10), randomBoolean(), randomBoolean()));
             }
             pluginsAndModules = new PluginsAndModules(plugins, modules);
         }

--- a/core/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
+++ b/core/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
@@ -209,11 +209,11 @@ public class PluginInfoTests extends ESTestCase {
 
     public void testPluginListSorted() {
         List<PluginInfo> plugins = new ArrayList<>();
-        plugins.add(new PluginInfo("c", "foo", "dummy", "dummyclass", randomBoolean()));
-        plugins.add(new PluginInfo("b", "foo", "dummy", "dummyclass", randomBoolean()));
-        plugins.add(new PluginInfo("e", "foo", "dummy", "dummyclass", randomBoolean()));
-        plugins.add(new PluginInfo("a", "foo", "dummy", "dummyclass", randomBoolean()));
-        plugins.add(new PluginInfo("d", "foo", "dummy", "dummyclass", randomBoolean()));
+        plugins.add(new PluginInfo("c", "foo", "dummy", "dummyclass", randomBoolean(), randomBoolean()));
+        plugins.add(new PluginInfo("b", "foo", "dummy", "dummyclass", randomBoolean(), randomBoolean()));
+        plugins.add(new PluginInfo("e", "foo", "dummy", "dummyclass", randomBoolean(), randomBoolean()));
+        plugins.add(new PluginInfo("a", "foo", "dummy", "dummyclass", randomBoolean(), randomBoolean()));
+        plugins.add(new PluginInfo("d", "foo", "dummy", "dummyclass", randomBoolean(), randomBoolean()));
         PluginsAndModules pluginsInfo = new PluginsAndModules(plugins, Collections.emptyList());
 
 

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.io.FileSystemUtils;
+import org.elasticsearch.common.settings.KeyStoreWrapper;
 import org.elasticsearch.env.Environment;
 
 import java.io.BufferedReader;
@@ -571,6 +572,15 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
                     return FileVisitResult.CONTINUE;
                 }
             });
+
+            if (info.requiresKeystore()) {
+                KeyStoreWrapper keystore = KeyStoreWrapper.load(env.configFile());
+                if (keystore == null) {
+                    terminal.println("Elasticsearch keystore is required by plugin [" + info.getName() + "], creating...");
+                    keystore = KeyStoreWrapper.create(new char[0]);
+                    keystore.save(env.configFile());
+                }
+            }
 
             terminal.println("-> Installed " + info.getName());
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/PluginSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/PluginSecurityTests.java
@@ -48,7 +48,7 @@ public class PluginSecurityTests extends ESTestCase {
                 "test cannot run with security manager enabled",
                 System.getSecurityManager() == null);
         final PluginInfo info =
-                new PluginInfo("fake", "fake", Version.CURRENT.toString(), "Fake", true);
+                new PluginInfo("fake", "fake", Version.CURRENT.toString(), "Fake", true, false);
         final MockTerminal terminal = new MockTerminal();
         terminal.addTextInput("y");
         terminal.addTextInput("y");
@@ -63,7 +63,7 @@ public class PluginSecurityTests extends ESTestCase {
                 "test cannot run with security manager enabled",
                 System.getSecurityManager() == null);
         final PluginInfo info =
-                new PluginInfo("fake", "fake", Version.CURRENT.toString(), "Fake", true);
+                new PluginInfo("fake", "fake", Version.CURRENT.toString(), "Fake", true, false);
         final MockTerminal terminal = new MockTerminal();
         terminal.addTextInput("y");
         terminal.addTextInput("n");
@@ -79,7 +79,7 @@ public class PluginSecurityTests extends ESTestCase {
                 "test cannot run with security manager enabled",
                 System.getSecurityManager() == null);
         final PluginInfo info =
-                new PluginInfo("fake", "fake", Version.CURRENT.toString(), "Fake", false);
+                new PluginInfo("fake", "fake", Version.CURRENT.toString(), "Fake", false, false);
         final MockTerminal terminal = new MockTerminal();
         terminal.addTextInput("y");
         final Path policyFile = this.getDataPath("security/simple-plugin-security.policy");


### PR DESCRIPTION
This commit removes the keystore creation on elasticsearch startup, and
instead adds a plugin property which indicates the plugin needs the
keystore to exist. It does still make sure the keystore.seed exists on
ES startup, but through an "upgrade" method that loading the keystore in
Bootstrap calls.

closes #26309