### PR TITLE
Update cluster_restart.asciidoc

### DIFF
--- a/docs/reference/setup/cluster_restart.asciidoc
+++ b/docs/reference/setup/cluster_restart.asciidoc
@@ -53,7 +53,48 @@ multiple times if necessary.
 --
 
 Stop all Elasticsearch services on all nodes in the cluster. Each node can be
-upgraded following the same procedure described in <<upgrade-node>>.
+upgraded following the same procedure described in upgrade-node.
+
+Shut down one of the nodes in the cluster *before* starting the upgrade.
+
+[TIP]
+================================================
+
+When using the zip or tarball packages, the `config`, `data`, `logs` and
+`plugins` directories are placed within the Elasticsearch home directory by
+default.
+
+It is a good idea to place these directories in a different location so that
+there is no chance of deleting them when upgrading Elasticsearch.  These
+custom paths can be <<path-settings,configured>> with the `path.conf`,
+`path.logs`, and `path.data` settings, and using `ES_JVM_OPTIONS` to specify
+the location of the `jvm.options` file.
+
+The <<deb,Debian>> and <<rpm,RPM>> packages place these directories in the
+appropriate place for each operating system.
+
+================================================
+
+To upgrade using a <<deb,Debian>> or <<rpm,RPM>> package:
+
+*   Use `rpm` or `dpkg` to install the new package.  All files should be
+    placed in their proper locations, and config files should not be
+    overwritten.
+
+To upgrade using a zip or compressed tarball:
+
+*   Extract the zip or tarball to a new directory, to be sure that you don't
+    overwrite the `config` or `data` directories.
+
+*   Either copy the files in the `config` directory from your old installation
+    to your new installation, or set the environment variable `ES_JVM_OPTIONS`
+    to the location of the `jvm.options` file and use the `-E path.conf=`
+    option on the command line to point to an external config directory.
+
+*   Either copy the files in the `data` directory from your old installation
+    to your new installation, or configure the location of the data directory
+    in the `config/elasticsearch.yml` file, with the `path.data` setting.
+    
 --
 
 . *Upgrade any plugins*


### PR DESCRIPTION
Propose to copy upgrade node section of the rolling restart guide section from the rolling guide to the full cluster restart guide, instead of linking

Relates #25175