### PR TITLE
Eliminate contention in LocalCheckpointTracker

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTrackerBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTrackerBenchmark.java
@@ -1,0 +1,117 @@
+package org.elasticsearch.index.seqno;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This benchmark measures throughput of <code>LocalCheckpointTracker</code> if it were used by a primary shard (get sequence number +
+ * mark it as completed) under contention. The benchmark also backs off in-between operations to avoid "hammering" counters in an
+ * unrealistic fashion (see parameter <code>backoff</code>).
+ *
+ * An additional optimization (in <code>LocalCheckpointTracker</code>) would be to implement a backoff in the atomic counters themselves
+ * as described in the paper
+ * <a href="https://arxiv.org/abs/1305.5800">Lightweight Contention Management for Efficient Compare-and-Swap Operations</a>.
+ */
+@Fork(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@SuppressWarnings("unused") //invoked by benchmarking framework
+public class LocalCheckpointTrackerBenchmark {
+    private LocalCheckpointTracker tracker;
+
+    @Param({"0", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192"})
+    int backoff;
+
+    @Setup
+    public void setUp() {
+        tracker = new LocalCheckpointTracker(SequenceNumbersService.NO_OPS_PERFORMED, SequenceNumbersService.NO_OPS_PERFORMED);
+    }
+
+    @Benchmark
+    @Group("seq_1")
+    @GroupThreads()
+    public long measureAdvance_1() {
+        Blackhole.consumeCPU(backoff);
+        long seqNo = tracker.generateSeqNo();
+        Blackhole.consumeCPU(backoff);
+        tracker.markSeqNoAsCompleted(seqNo);
+        return seqNo;
+    }
+
+
+    @Benchmark
+    @Group("seq_2")
+    @GroupThreads(2)
+    public long measureAdvance_2() {
+        Blackhole.consumeCPU(backoff);
+        long seqNo = tracker.generateSeqNo();
+        Blackhole.consumeCPU(backoff);
+        tracker.markSeqNoAsCompleted(seqNo);
+        return seqNo;
+    }
+
+
+    @Benchmark
+    @Group("seq_4")
+    @GroupThreads(4)
+    public long measureAdvance_4() {
+        Blackhole.consumeCPU(backoff);
+        long seqNo = tracker.generateSeqNo();
+        Blackhole.consumeCPU(backoff);
+        tracker.markSeqNoAsCompleted(seqNo);
+        return seqNo;
+    }
+
+
+    @Benchmark
+    @Group("seq_8")
+    @GroupThreads(8)
+    public long measureAdvance_8() {
+        Blackhole.consumeCPU(backoff);
+        long seqNo = tracker.generateSeqNo();
+        Blackhole.consumeCPU(backoff);
+        tracker.markSeqNoAsCompleted(seqNo);
+        return seqNo;
+    }
+
+
+    @Benchmark
+    @Group("seq_16")
+    @GroupThreads(16)
+    public long measureAdvance_16() {
+        Blackhole.consumeCPU(backoff);
+        long seqNo = tracker.generateSeqNo();
+        Blackhole.consumeCPU(backoff);
+        tracker.markSeqNoAsCompleted(seqNo);
+        return seqNo;
+    }
+
+
+    @Benchmark
+    @Group("seq_32")
+    @GroupThreads(32)
+    public long measureAdvance_32() {
+        Blackhole.consumeCPU(backoff);
+        long seqNo = tracker.generateSeqNo();
+        Blackhole.consumeCPU(backoff);
+        tracker.markSeqNoAsCompleted(seqNo);
+        return seqNo;
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -117,7 +117,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexSettings.QUERY_STRING_LENIENT_SETTING,
         IndexSettings.ALLOW_UNMAPPED,
         IndexSettings.INDEX_CHECK_ON_STARTUP,
-        LocalCheckpointTracker.SETTINGS_BIT_ARRAYS_SIZE,
         IndexSettings.MAX_REFRESH_LISTENERS_PER_SHARD,
         IndexSettings.MAX_SLICES_PER_SCROLL,
         ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING,

--- a/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
@@ -109,12 +109,12 @@ public class LocalCheckpointTracker {
     public void markSeqNoAsCompleted(final long seqNo) {
         // make sure we track highest seen sequence number
         nextSeqNo.updateAndGet((current) -> seqNo >= current ? seqNo + 1 : current);
-        if (seqNo <= checkpoint) {
-            // this is possible during recovery where we might replay an operation that was also replicated
-            return;
-        }
         // there is no need to hold the lock for the whole method as the code above is already lock-free.
         synchronized (this) {
+            if (seqNo <= checkpoint) {
+                // this is possible during recovery where we might replay an operation that was also replicated
+                return;
+            }
             final FixedBitSet bitSet = getBitSetForSeqNo(seqNo);
             final int offset = seqNoToBitSetOffset(seqNo);
             bitSet.set(offset);

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -69,7 +69,7 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
         final long localCheckpoint,
         final long globalCheckpoint) {
         super(shardId, indexSettings);
-        localCheckpointTracker = new LocalCheckpointTracker(indexSettings, maxSeqNo, localCheckpoint);
+        localCheckpointTracker = new LocalCheckpointTracker(maxSeqNo, localCheckpoint);
         globalCheckpointTracker = new GlobalCheckpointTracker(shardId, indexSettings, globalCheckpoint);
     }
 

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -235,7 +235,7 @@ public class RecoverySourceHandler {
 
             logger.trace("all operations up to [{}] completed, checking translog content", endingSeqNo);
 
-            final LocalCheckpointTracker tracker = new LocalCheckpointTracker(shard.indexSettings(), startingSeqNo, startingSeqNo - 1);
+            final LocalCheckpointTracker tracker = new LocalCheckpointTracker(startingSeqNo, startingSeqNo - 1);
             try (Translog.Snapshot snapshot = shard.getTranslog().newSnapshotFromMinSeqNo(startingSeqNo)) {
                 Translog.Operation operation;
                 while ((operation = snapshot.next()) != null) {


### PR DESCRIPTION
With this commit, we eliminate lock contention in `LocalCheckpointTracker`.

First, we use CAS instead of locking to guard the local sequence number
 counter. We do this to eliminate lock contention when a
large number of clients indexes data in Elasticsearch (to be clear: there 
is still contention but it's pushed down to the CPU's cache coherency layer).

Second, we also eliminate contention in `#markSeqNoAsCompleted()` 
with a lock-free implementation.

Relates #26339