### PR TITLE
Shade only commons http and commons logging

### DIFF
--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -78,7 +78,8 @@ task shadeDeps(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar)
   destinationDir = shadedDir
   configurations = [project.configurations.shade]
   classifier = 'deps'
-  relocate 'org.apache', 'org.elasticsearch.client'
+  relocate 'org.apache.commons', 'org.elasticsearch.client.commons'
+  relocate 'org.apache.http', 'org.elasticsearch.client.http'
 
   doLast {
     shadedSrcDir.mkdir()


### PR DESCRIPTION
The current build shades everything o.a, including some log4j shim
classes. This fixes the build to only shade common logging and common
http.