### PR TITLE
add top hits as a parsed aggregation to the rest high level client

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -120,6 +120,8 @@ import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStat
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ParsedExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.sum.ParsedSum;
 import org.elasticsearch.search.aggregations.metrics.sum.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.tophits.ParsedTopHits;
+import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.valuecount.ParsedValueCount;
 import org.elasticsearch.search.aggregations.metrics.valuecount.ValueCountAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValue;
@@ -602,6 +604,7 @@ public class RestHighLevelClient implements Closeable {
         map.put(SignificantLongTerms.NAME, (p, c) -> ParsedSignificantLongTerms.fromXContent(p, (String) c));
         map.put(SignificantStringTerms.NAME, (p, c) -> ParsedSignificantStringTerms.fromXContent(p, (String) c));
         map.put(ScriptedMetricAggregationBuilder.NAME, (p, c) -> ParsedScriptedMetric.fromXContent(p, (String) c));
+        map.put(TopHitsAggregationBuilder.NAME, (p, c) -> ParsedTopHits.fromXContent(p, (String) c));
         List<NamedXContentRegistry.Entry> entries = map.entrySet().stream()
                 .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue()))
                 .collect(Collectors.toList());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -628,7 +628,7 @@ public class RestHighLevelClientTests extends ESTestCase {
 
     public void testDefaultNamedXContents() {
         List<NamedXContentRegistry.Entry> namedXContents = RestHighLevelClient.getDefaultNamedXContents();
-        assertEquals(43, namedXContents.size());
+        assertEquals(44, namedXContents.size());
         Map<Class<?>, Integer> categories = new HashMap<>();
         for (NamedXContentRegistry.Entry namedXContent : namedXContents) {
             Integer counter = categories.putIfAbsent(namedXContent.categoryClass, 1);
@@ -637,7 +637,7 @@ public class RestHighLevelClientTests extends ESTestCase {
             }
         }
         assertEquals(2, categories.size());
-        assertEquals(Integer.valueOf(40), categories.get(Aggregation.class));
+        assertEquals(Integer.valueOf(41), categories.get(Aggregation.class));
         assertEquals(Integer.valueOf(3), categories.get(Suggest.Suggestion.class));
     }
 


### PR DESCRIPTION
Using a top hits aggregation with the REST high level client results in this error (ignore the 5.6 version, still happens on master)
```
Caused by: org.elasticsearch.common.xcontent.NamedXContentRegistry$UnknownNamedObjectException: Unknown Aggregation [top_hits]
	at org.elasticsearch.common.xcontent.NamedXContentRegistry.parseNamedObject(NamedXContentRegistry.java:135) ~[elasticsearch-5.6.0-SNAPSHOT.jar:5.6.0-SNAPSHOT]
	at org.elasticsearch.common.xcontent.support.AbstractXContentParser.namedObject(AbstractXContentParser.java:402) ~[elasticsearch-5.6.0-SNAPSHOT.jar:5.6.0-SNAPSHOT]
	at org.elasticsearch.common.xcontent.XContentParserUtils.parseTypedKeysObject(XContentParserUtils.java:144) ~[elasticsearch-5.6.0-SNAPSHOT.jar:5.6.0-SNAPSHOT]
	at org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms$ParsedBucket.parseTermsBucketXContent(ParsedTerms.java:144) ~[elasticsearch-5.6.0-SNAPSHOT.jar:5.6.0-SNAPSHOT]
	at org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms$ParsedBucket.fromXContent(ParsedStringTerms.java:82) ~[elasticsearch-5.6.0-SNAPSHOT.jar:5.6.0-SNAPSHOT]
```

Added the parser to the list to fix (pls backport it I want to use the 5.6 client when it's released)