### PR TITLE
Fix the mention of split_on_whitespace's default value in query_string query docs

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -85,7 +85,7 @@ for exact matching. Look <<mixing-exact-search-with-stemming,here>> for a
 comprehensive example.
 
 |`split_on_whitespace` |Whether query text should be split on whitespace prior to analysis.
-Instead  the queryparser would parse around only real 'operators'. Default to `false`.
+Instead  the queryparser would parse around only real 'operators'. Defaults to `true`.
 It is not allowed to set this option to `false` if `auto_generate_phrase_queries` is already set to `true`.
 
 |`all_fields` | Perform the query on all fields detected in the mapping that can


### PR DESCRIPTION
As far as I can tell, split_on_whitespace's default value [is true](https://github.com/elastic/elasticsearch/blob/5.6/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java#L88), not false as the docs indicate.