### PR TITLE
Introduce sorted_after query for sorted index

### DIFF
--- a/core/src/main/java/org/apache/lucene/queries/SearchAfterSortedDocQuery.java
+++ b/core/src/main/java/org/apache/lucene/queries/SearchAfterSortedDocQuery.java
@@ -35,9 +35,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.Weight;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -51,13 +49,13 @@ public class SearchAfterSortedDocQuery extends Query {
     private final int[] reverseMuls;
 
     public SearchAfterSortedDocQuery(Sort sort, FieldDoc after) {
-        if (sort.getSort().length != after.fields.length) {
+        if (sort.getSort().length < after.fields.length) {
             throw new IllegalArgumentException("after doc  has " + after.fields.length + " value(s) but sort has "
-                    + sort.getSort().length + ".");
+                    + sort.getSort().length);
         }
         this.sort = sort;
         this.after = after;
-        int numFields = sort.getSort().length;
+        int numFields = after.fields.length;
         this.fieldComparators = new FieldComparator[numFields];
         this.reverseMuls = new int[numFields];
         for (int i = 0; i < numFields; i++) {
@@ -137,7 +135,7 @@ public class SearchAfterSortedDocQuery extends Query {
                 }
             }
 
-            if (topDoc <= doc) {
+            if (doc <= topDoc) {
                 return false;
             }
             return true;

--- a/core/src/main/java/org/elasticsearch/index/query/SortedAfterQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SortedAfterQueryBuilder.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.queries.SearchAfterSortedDocQuery;
+import org.apache.lucene.search.FieldDoc;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.IndexSortConfig;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.searchafter.SearchAfterBuilder;
+import org.elasticsearch.search.sort.SortAndFormats;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A {@link QueryBuilder} that only matches documents which sort fields are greater than the provided values.
+ * This works only if the index is sorted and the provided values match the sort field types.
+ */
+public class SortedAfterQueryBuilder extends AbstractQueryBuilder<SortedAfterQueryBuilder> {
+    public static final String NAME = "sorted_after";
+
+    private static final ObjectParser<SortedAfterQueryBuilder, Void> PARSER;
+    static {
+        PARSER = new ObjectParser<>(NAME);
+        PARSER.declareField(SortedAfterQueryBuilder::setSortValues, (parser, context) -> SearchAfterBuilder.fromXContent(parser),
+            new ParseField("values"), ObjectParser.ValueType.OBJECT_ARRAY);
+        PARSER.declareString(SortedAfterQueryBuilder::queryName, AbstractQueryBuilder.NAME_FIELD);
+        PARSER.declareFloat(SortedAfterQueryBuilder::boost, AbstractQueryBuilder.BOOST_FIELD);
+    }
+    public static SortedAfterQueryBuilder fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, new SortedAfterQueryBuilder(), null);
+    }
+
+    private final SearchAfterBuilder builder;
+
+    public SortedAfterQueryBuilder() {
+        this.builder = new SearchAfterBuilder();
+    }
+
+    public SortedAfterQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.builder = new SearchAfterBuilder(in);
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        builder.writeTo(out);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return "sorted_after";
+    }
+
+    public SortedAfterQueryBuilder setSortValues(Object[] values) {
+        builder.setSortValues(values);
+        return this;
+    }
+
+    SortedAfterQueryBuilder setSortValues(SearchAfterBuilder other) {
+        builder.setSortValues(other.getSortValues());
+        return this;
+    }
+
+    public Object[] getSortValues() {
+        return builder.getSortValues();
+    }
+
+    @Override
+    public Query doToQuery(QueryShardContext context) throws IOException {
+        IndexSortConfig indexSortConfig = context.getMapperService().getIndexSettings().getIndexSortConfig();
+        if (indexSortConfig.hasIndexSort() == false) {
+            throw new IllegalArgumentException("[after] query cannot be applied on non-sorted index [" + context.index().getName() + "]");
+        }
+        Sort indexSort = indexSortConfig.buildIndexSort(context.getMapperService()::fullName, context::getForField);
+        DocValueFormat[] docValueFormats= new DocValueFormat[indexSort.getSort().length];
+        for (int i = 0; i < docValueFormats.length; i++) {
+            SortField sortField = indexSort.getSort()[i];
+            MappedFieldType ft = context.getMapperService().fullName(sortField.getField());
+            assert (ft != null);
+            docValueFormats[i] = ft.docValueFormat(null, null);
+        }
+        FieldDoc fieldDoc = SearchAfterBuilder.buildFieldDoc(new SortAndFormats(indexSort, docValueFormats), builder.getSortValues());
+        return new SearchAfterSortedDocQuery(indexSort, fieldDoc);
+    }
+
+    @Override
+    protected boolean doEquals(SortedAfterQueryBuilder other) {
+        return Objects.equals(builder, other.builder);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(getClass(), builder);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.array("values", this.builder.getSortValues());
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+}

--- a/core/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ParseFieldRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.SortedAfterQueryBuilder;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoostingQueryBuilder;
 import org.elasticsearch.index.query.CommonTermsQueryBuilder;
@@ -739,6 +740,7 @@ public class SearchModule {
         registerQuery(new QuerySpec<>(GeoPolygonQueryBuilder.NAME, GeoPolygonQueryBuilder::new, GeoPolygonQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(ExistsQueryBuilder.NAME, ExistsQueryBuilder::new, ExistsQueryBuilder::fromXContent));
         registerQuery(new QuerySpec<>(MatchNoneQueryBuilder.NAME, MatchNoneQueryBuilder::new, MatchNoneQueryBuilder::fromXContent));
+        registerQuery(new QuerySpec<>(SortedAfterQueryBuilder.NAME, SortedAfterQueryBuilder::new, SortedAfterQueryBuilder::fromXContent));
 
         if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {
             registerQuery(new QuerySpec<>(GeoShapeQueryBuilder.NAME, GeoShapeQueryBuilder::new, GeoShapeQueryBuilder::fromXContent));

--- a/core/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -105,17 +104,17 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
 
     public static FieldDoc buildFieldDoc(SortAndFormats sort, Object[] values) {
         if (sort == null || sort.sort.getSort() == null || sort.sort.getSort().length == 0) {
-            throw new IllegalArgumentException("Sort must contain at least one field.");
+            throw new IllegalArgumentException("Sort must contain at least one field");
         }
 
         SortField[] sortFields = sort.sort.getSort();
-        if (sortFields.length != values.length) {
+        if (sortFields.length < values.length) {
             throw new IllegalArgumentException(
                     SEARCH_AFTER.getPreferredName() + " has " + values.length + " value(s) but sort has "
-                            + sort.sort.getSort().length + ".");
+                            + sort.sort.getSort().length);
         }
-        Object[] fieldValues = new Object[sortFields.length];
-        for (int i = 0; i < sortFields.length; i++) {
+        Object[] fieldValues = new Object[values.length];
+        for (int i = 0; i < fieldValues.length; i++) {
             SortField sortField = sortFields[i];
             DocValueFormat format = sort.formats[i];
             if (values[i] != null) {
@@ -195,11 +194,11 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
 
                 default:
                     throw new IllegalArgumentException("Comparator type [" + sortType.name() + "] for field [" + fieldName
-                            + "] is not supported.");
+                            + "] is not supported");
             }
         } catch(NumberFormatException e) {
             throw new IllegalArgumentException(
-                    "Failed to parse " + SEARCH_AFTER.getPreferredName() + " value for field [" + fieldName + "].", e);
+                    "Failed to parse " + SEARCH_AFTER.getPreferredName() + " value for field [" + fieldName + "]", e);
         }
     }
 
@@ -251,7 +250,7 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "Expected [" + XContentParser.Token.VALUE_STRING + "] or ["
                             + XContentParser.Token.VALUE_NUMBER + "] or [" + XContentParser.Token.VALUE_BOOLEAN + "] or ["
-                            + XContentParser.Token.VALUE_NULL + "] but found [" + token + "] inside search_after.");
+                            + XContentParser.Token.VALUE_NULL + "] but found [" + token + "] inside search_after");
                 }
             }
         } else {
@@ -264,7 +263,7 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
 
     @Override
     public boolean equals(Object other) {
-        if (! (other instanceof SearchAfterBuilder)) {
+        if (other instanceof SearchAfterBuilder == false) {
             return false;
         }
         return Arrays.equals(sortValues, ((SearchAfterBuilder) other).sortValues);
@@ -283,7 +282,7 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
             toXContent(builder, EMPTY_PARAMS);
             return builder.string();
         } catch (Exception e) {
-            throw new ElasticsearchException("Failed to build xcontent.", e);
+            throw new ElasticsearchException("Failed to build xcontent", e);
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/query/SortedAfterQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/SortedAfterQueryBuilderTests.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.apache.lucene.queries.SearchAfterSortedDocQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.test.AbstractQueryTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class SortedAfterQueryBuilderTests extends AbstractQueryTestCase<SortedAfterQueryBuilder> {
+    private static final String[] FIELD_NAMES = new String[] { STRING_FIELD_NAME_2, INT_FIELD_NAME, DATE_FIELD_NAME };
+    private static String[] RANDOM_SORT_FIELDS;
+
+    @BeforeClass
+    private static void setRandomSortFields() {
+        int numFields = randomIntBetween(1, 5);
+        RANDOM_SORT_FIELDS = new String[numFields];
+        for (int i = 0; i < numFields; i++) {
+            RANDOM_SORT_FIELDS[i] = randomFrom(FIELD_NAMES);
+        }
+    }
+
+    @AfterClass
+    private static void unsetRandomSortFields() {
+        RANDOM_SORT_FIELDS = null;
+    }
+
+    @Override
+    protected Settings indexSettings() {
+        return Settings.builder().putArray("index.sort.field", RANDOM_SORT_FIELDS).build();
+    }
+
+    @Override
+    protected SortedAfterQueryBuilder doCreateTestQueryBuilder() {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        SortedAfterQueryBuilder builder = new SortedAfterQueryBuilder();
+        Object[] values = new Object[RANDOM_SORT_FIELDS.length];
+        for (int i = 0; i < values.length; i++) {
+            switch (RANDOM_SORT_FIELDS[i]) {
+                case STRING_FIELD_NAME_2:
+                    values[i] = randomAlphaOfLengthBetween(1, 35);
+                    break;
+                case INT_FIELD_NAME:
+                    values[i] = randomIntBetween(-10000, 10000);
+                    break;
+                case DATE_FIELD_NAME:
+                    values[i] = randomNonNegativeLong();
+                    break;
+                default:
+                    assert (false);
+            }
+        }
+        builder.setSortValues(values);
+        return builder;
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(SortedAfterQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {
+        assertThat(query, instanceOf(SearchAfterSortedDocQuery.class));
+    }
+
+    @Override
+    public void testUnknownField() {
+        String marker = "#marker#";
+        SortedAfterQueryBuilder testQuery;
+        do {
+            testQuery = createTestQueryBuilder();
+        } while (testQuery.toString().contains(marker));
+        testQuery.queryName(marker); // to find root query to add additional bogus field there
+        String queryAsString = testQuery.toString().replace("\"" + marker + "\"", "\"" + marker + "\", \"bogusField\" : \"someValue\"");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> parseQuery(queryAsString));
+        assertThat(e.getMessage(), containsString("bogusField"));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -263,6 +263,7 @@ public class SearchModuleTests extends ModuleTestCase {
     }
 
     private static final String[] NON_DEPRECATED_QUERIES = new String[] {
+            "after",
             "bool",
             "boosting",
             "common",

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -506,8 +506,7 @@ public class FieldSortIT extends ESIntegTestCase {
 
     public void testSimpleSorts() throws Exception {
         Random random = random();
-        assertAcked(prepareCreate("test")
-.addMapping("type1",
+        assertAcked(prepareCreate("test").addMapping("type1",
                 XContentFactory.jsonBuilder().startObject().startObject("type1").startObject("properties").startObject("str_value")
                         .field("type", "keyword").endObject().startObject("boolean_value").field("type", "boolean").endObject()
                         .startObject("byte_value").field("type", "byte").endObject().startObject("short_value").field("type", "short")


### PR DESCRIPTION
This change introduces a new query called `sorted_after`. This query matches document
in a sorted index that are greater than the provided values.
It is similar to the `search_after` option except that the comparaison between documents
is based on the index sort and not the search sort. As a query it also filters all documents rather than
just the top hits.

Example:

````
# Defines a sorted index
PUT twitter
{
    "settings" : {
        "index" : {
            "sort.field" : ["user_name", "date"] <1>
        }
    },
    "mappings": {
        "tweet": {
            "properties": {
                "date": {
                    "type": "date"
                },
                "user_name": {
                    "type": "keyword"
                },
                "tweet": {
                    "type": "text"
                }
            }
        }
    }
}

# sorted_after query on this index
GET twitter/_search
{
    "query": {
        "sorted_after" : {
            "values": ["@elastic", 1503568658000]
        }
    }
}

# Can also work on a prefix of the index sort (e.g. only user_name)
GET twitter/_search
{
    "query": {
        "sorted_after" : {
            "values": ["@elastic"]
        }
    }
}
````
