### PR TITLE
Remove creating keystore on package install

### DIFF
--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -103,17 +103,11 @@ chown -R root:elasticsearch /etc/elasticsearch
 chmod 0750 /etc/elasticsearch
 
 if [ -f /etc/default/elasticsearch ]; then
-    chown root:elasticsearch /etc/default/elasticsearch
+   chown root:elasticsearch /etc/default/elasticsearch
 fi
 
 if [ -f /etc/sysconfig/elasticsearch ]; then
-    chown root:elasticsearch /etc/sysconfig/elasticsearch
-fi
-
-if [ ! -f "$ES_PATH_CONF"/elasticsearch.keystore ]; then
-    /usr/share/elasticsearch/bin/elasticsearch-keystore create
-    chown root:elasticsearch "$ES_PATH_CONF"/elasticsearch.keystore
-    chmod 660 "$ES_PATH_CONF"/elasticsearch.keystore
+   chown root:elasticsearch /etc/sysconfig/elasticsearch
 fi
 
 ${scripts.footer}


### PR DESCRIPTION
This is no longer needed as we now create the keystore if needed by a plugin.

Relates #26309

