### PR TITLE
Build: Add git hashes used as build metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,16 @@ if (currentVersion.bugfix == 0) {
   }
 }
 
+// build metadata from previous build, contains eg hashes for bwc builds
+String buildMetadataValue = System.getenv('BUILD_METADATA')
+if (buildMetadataValue == null) {
+  buildMetadataValue = ''
+}
+Map<String,String> buildMetadataMap = buildMetadataValue.tokenize(';').collectEntries {
+  def (String key, String value) = it.split('=')
+  return [key: value]
+}
+
 // injecting groovy property variables into all projects
 allprojects {
   project.ext {
@@ -136,6 +146,7 @@ allprojects {
     // for backcompat testing
     indexCompatVersions = versions
     wireCompatVersions = versions.subList(prevMinorIndex, versions.size())
+    buildMetadata = buildMetadataMap
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -132,9 +132,9 @@ String buildMetadataValue = System.getenv('BUILD_METADATA')
 if (buildMetadataValue == null) {
   buildMetadataValue = ''
 }
-Map<String,String> buildMetadataMap = buildMetadataValue.tokenize(';').collectEntries {
+Map<String, String> buildMetadataMap = buildMetadataValue.tokenize(';').collectEntries {
   def (String key, String value) = it.split('=')
-  return [key: value]
+  return [key, value]
 }
 
 // injecting groovy property variables into all projects

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -105,18 +105,37 @@ if (enabled) {
   }
 
   // this is an Exec task so that the SHA that is checked out is logged
+  String buildMetadataKey = "bwc_refspec_${project.path.substring(1)}"
   task checkoutBwcBranch(type: Exec) {
-    def String refspec = System.getProperty("tests.bwc.refspec", "upstream/${bwcBranch}")
+    def String refspec = System.getProperty("tests.bwc.refspec", buildMetadata.get(buildMetadataKey, "upstream/${bwcBranch}"))
     dependsOn fetchLatest
     workingDir = checkoutDir
     commandLine = ['git', 'checkout', refspec]
+  }
+
+  File buildMetadataFile = project.file("build/${project.name}/build_metadata")
+  task writeBuildMetadata(type: LoggedExec) {
+    dependsOn checkoutBwcBranch
+    workingDir = checkoutDir
+    commandLine = ['git', 'rev-parse', 'HEAD']
+    ignoreExitValue = true
+    ByteArrayOutputStream output = new ByteArrayOutputStream()
+    standardOutput = output
+    doLast {
+      if (execResult.exitValue != 0) {
+        output.toString('UTF-8').eachLine { line -> logger.error(line) }
+        execResult.assertNormalExitValue()
+      }
+      project.mkdir(buildMetadataFile.parent)
+      buildMetadataFile.setText("${buildMetadataKey}=${output.toString('UTF-8')}", 'UTF-8')
+    }
   }
 
   File bwcDeb = file("${checkoutDir}/distribution/deb/build/distributions/elasticsearch-${bwcVersion}.deb")
   File bwcRpm = file("${checkoutDir}/distribution/rpm/build/distributions/elasticsearch-${bwcVersion}.rpm")
   File bwcZip = file("${checkoutDir}/distribution/zip/build/distributions/elasticsearch-${bwcVersion}.zip")
   task buildBwcVersion(type: GradleBuild) {
-    dependsOn checkoutBwcBranch
+    dependsOn checkoutBwcBranch, writeBuildMetadata
     dir = checkoutDir
     tasks = [':distribution:deb:assemble', ':distribution:rpm:assemble', ':distribution:zip:assemble']
     doLast {


### PR DESCRIPTION
This commit adds files to the build output called build_metadata which
contain key/value pairs of metadata associated with the build. The first
use of this metadata are the git hashes associated with bwc checkouts.
These metadata files will be picked up by CI intake jobs and stored
along with last-good-commit, and then passed back in through the
BUILD_METADATA env var on periodic jobs.