### PR TITLE
Optimize search_after when sorting in index sort order

### DIFF
--- a/core/src/main/java/org/apache/lucene/queries/SearchAfterSortedDocQuery.java
+++ b/core/src/main/java/org/apache/lucene/queries/SearchAfterSortedDocQuery.java
@@ -50,7 +50,7 @@ public class SearchAfterSortedDocQuery extends Query {
 
     public SearchAfterSortedDocQuery(Sort sort, FieldDoc after) {
         if (sort.getSort().length < after.fields.length) {
-            throw new IllegalArgumentException("after doc  has " + after.fields.length + " value(s) but sort has "
+            throw new IllegalArgumentException("after doc has " + after.fields.length + " value(s) but sort has "
                     + sort.getSort().length);
         }
         this.sort = sort;

--- a/core/src/main/java/org/apache/lucene/queries/SearchAfterSortedDocQuery.java
+++ b/core/src/main/java/org/apache/lucene/queries/SearchAfterSortedDocQuery.java
@@ -35,9 +35,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.Weight;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -51,13 +49,13 @@ public class SearchAfterSortedDocQuery extends Query {
     private final int[] reverseMuls;
 
     public SearchAfterSortedDocQuery(Sort sort, FieldDoc after) {
-        if (sort.getSort().length != after.fields.length) {
+        if (sort.getSort().length < after.fields.length) {
             throw new IllegalArgumentException("after doc  has " + after.fields.length + " value(s) but sort has "
-                    + sort.getSort().length + ".");
+                    + sort.getSort().length);
         }
         this.sort = sort;
         this.after = after;
-        int numFields = sort.getSort().length;
+        int numFields = after.fields.length;
         this.fieldComparators = new FieldComparator[numFields];
         this.reverseMuls = new int[numFields];
         for (int i = 0; i < numFields; i++) {
@@ -137,7 +135,7 @@ public class SearchAfterSortedDocQuery extends Query {
                 }
             }
 
-            if (topDoc <= doc) {
+            if (doc <= topDoc) {
                 return false;
             }
             return true;

--- a/core/src/main/java/org/elasticsearch/search/query/QueryCollectorContext.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QueryCollectorContext.java
@@ -31,6 +31,7 @@ import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.common.lucene.MinimumScoreCollector;
 import org.elasticsearch.common.lucene.search.FilteredCollector;
+import org.elasticsearch.search.internal.ScrollContext;
 import org.elasticsearch.search.profile.query.InternalProfileCollector;
 import org.elasticsearch.tasks.TaskCancelledException;
 
@@ -211,6 +212,7 @@ abstract class QueryCollectorContext {
      * The total hit count matching the query is also computed if <code>trackTotalHits</code> is true.
      */
     static QueryCollectorContext createEarlySortingTerminationCollectorContext(IndexReader reader,
+                                                                               ScrollContext scrollContext,
                                                                                Query query,
                                                                                Sort indexSort,
                                                                                int numHits,
@@ -247,6 +249,10 @@ abstract class QueryCollectorContext {
                     final TopDocs topDocs = result.topDocs();
                     topDocs.totalHits = countSupplier.getAsInt();
                     result.topDocs(topDocs, result.sortValueFormats());
+                    if (scrollContext != null) {
+                        // first round
+                        scrollContext.totalHits = topDocs.totalHits;
+                    }
                 }
             }
         };

--- a/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -139,43 +139,39 @@ public class QueryPhase implements SearchPhase {
             assert query == searcher.rewrite(query); // already rewritten
 
             final ScrollContext scrollContext = searchContext.scrollContext();
-            if (scrollContext != null) {
-                if (scrollContext.totalHits == -1) {
-                    // first round
-                    assert scrollContext.lastEmittedDoc == null;
-                    // there is not much that we can optimize here since we want to collect all
-                    // documents in order to get the total number of hits
-
-                } else {
-                    final ScoreDoc after = scrollContext.lastEmittedDoc;
-                    if (returnsDocsInOrder(query, searchContext.sort())) {
-                        // now this gets interesting: since we sort in index-order, we can directly
-                        // skip to the desired doc
-                        if (after != null) {
-                            BooleanQuery bq = new BooleanQuery.Builder()
-                                .add(query, BooleanClause.Occur.MUST)
-                                .add(new MinDocQuery(after.doc + 1), BooleanClause.Occur.FILTER)
-                                .build();
-                            query = bq;
-                        }
-                        // ... and stop collecting after ${size} matches
-                        searchContext.terminateAfter(searchContext.size());
-                        searchContext.trackTotalHits(false);
-                    } else if (canEarlyTerminate(indexSort, searchContext)) {
-                        // now this gets interesting: since the index sort matches the search sort, we can directly
-                        // skip to the desired doc
-                        if (after != null) {
-                            BooleanQuery bq = new BooleanQuery.Builder()
-                                .add(query, BooleanClause.Occur.MUST)
-                                .add(new SearchAfterSortedDocQuery(indexSort, (FieldDoc) after), BooleanClause.Occur.FILTER)
-                                .build();
-                            query = bq;
-                        }
-                        searchContext.trackTotalHits(false);
-                    }
+            final boolean isScrollContext = scrollContext != null && scrollContext.totalHits != -1;
+            final ScoreDoc after = isScrollContext ? scrollContext.lastEmittedDoc : searchContext.searchAfter();
+            if (returnsDocsInOrder(query, searchContext.sort())) {
+                // now this gets interesting: since we sort in index-order, we can directly
+                // skip to the desired doc
+                if (after != null &&
+                        (isScrollContext || searchContext.trackTotalHits() == false)) {
+                    BooleanQuery bq = new BooleanQuery.Builder()
+                        .add(query, BooleanClause.Occur.MUST)
+                        .add(new MinDocQuery(after.doc + 1), BooleanClause.Occur.FILTER)
+                        .build();
+                    query = bq;
+                }
+                if (isScrollContext || searchContext.trackTotalHits() == false) {
+                    // ... and stop collecting after ${size} matches
+                    searchContext.terminateAfter(searchContext.size());
+                    searchContext.trackTotalHits(false);
+                }
+            } else if (canEarlyTerminate(indexSort, searchContext)) {
+                // now this gets interesting: since the index sort matches the search sort, we can directly
+                // skip to the desired doc
+                if (after != null &&
+                        (isScrollContext || searchContext.trackTotalHits() == false)) {
+                    BooleanQuery bq = new BooleanQuery.Builder()
+                        .add(query, BooleanClause.Occur.MUST)
+                        .add(new SearchAfterSortedDocQuery(indexSort, (FieldDoc) after), BooleanClause.Occur.FILTER)
+                        .build();
+                    query = bq;
+                }
+                if (isScrollContext || searchContext.trackTotalHits() == false) {
+                    searchContext.trackTotalHits(false);
                 }
             }
-
             final LinkedList<QueryCollectorContext> collectors = new LinkedList<>();
             if (searchContext.parsedPostFilter() != null) {
                 // add post filters before aggregations
@@ -247,13 +243,12 @@ public class QueryPhase implements SearchPhase {
                 collectors.stream().anyMatch(QueryCollectorContext::shouldCollect));
             final boolean shouldCollect = topDocsFactory.shouldCollect();
 
-            if (topDocsFactory.numHits() > 0 &&
-                (scrollContext == null || scrollContext.totalHits != -1) &&
-                canEarlyTerminate(indexSort, searchContext)) {
+            if (canEarlyTerminate(indexSort, searchContext)) {
                 // top docs collection can be early terminated based on index sort
+                int numHits = Math.min(1, topDocsFactory.numHits());
                 // add the collector context first so we don't early terminate aggs but only top docs
-                collectors.addFirst(createEarlySortingTerminationCollectorContext(reader, searchContext.query(), indexSort,
-                    topDocsFactory.numHits(), searchContext.trackTotalHits(), shouldCollect));
+                collectors.addFirst(createEarlySortingTerminationCollectorContext(reader, scrollContext, searchContext.query(), indexSort,
+                    numHits, searchContext.trackTotalHits(), shouldCollect));
             }
             // add the top docs collector, the first collector context in the chain
             collectors.addFirst(topDocsFactory);

--- a/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -245,7 +245,7 @@ public class QueryPhase implements SearchPhase {
 
             if (canEarlyTerminate(indexSort, searchContext)) {
                 // top docs collection can be early terminated based on index sort
-                int numHits = Math.min(1, topDocsFactory.numHits());
+                int numHits = Math.max(1, topDocsFactory.numHits());
                 // add the collector context first so we don't early terminate aggs but only top docs
                 collectors.addFirst(createEarlySortingTerminationCollectorContext(reader, scrollContext, searchContext.query(), indexSort,
                     numHits, searchContext.trackTotalHits(), shouldCollect));

--- a/core/src/test/java/org/apache/lucene/queries/SearchAfterSortedDocQueryTests.java
+++ b/core/src/test/java/org/apache/lucene/queries/SearchAfterSortedDocQueryTests.java
@@ -73,7 +73,7 @@ public class SearchAfterSortedDocQueryTests extends ESTestCase {
         FieldDoc fieldDoc = new FieldDoc(0, 0f, new Object[] {4, 5});
         IllegalArgumentException ex =
             expectThrows(IllegalArgumentException.class, () -> new SearchAfterSortedDocQuery(sort, fieldDoc));
-        assertThat(ex.getMessage(), equalTo("after doc  has 2 value(s) but sort has 1"));
+        assertThat(ex.getMessage(), equalTo("after doc has 2 value(s) but sort has 1"));
     }
 
     public void testRandom() throws IOException {

--- a/core/src/test/java/org/apache/lucene/queries/SearchAfterSortedDocQueryTests.java
+++ b/core/src/test/java/org/apache/lucene/queries/SearchAfterSortedDocQueryTests.java
@@ -73,7 +73,7 @@ public class SearchAfterSortedDocQueryTests extends ESTestCase {
         FieldDoc fieldDoc = new FieldDoc(0, 0f, new Object[] {4, 5});
         IllegalArgumentException ex =
             expectThrows(IllegalArgumentException.class, () -> new SearchAfterSortedDocQuery(sort, fieldDoc));
-        assertThat(ex.getMessage(), equalTo("after doc  has 2 value(s) but sort has 1."));
+        assertThat(ex.getMessage(), equalTo("after doc  has 2 value(s) but sort has 1"));
     }
 
     public void testRandom() throws IOException {

--- a/core/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/core/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -532,11 +532,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
         context.trackTotalHits(false);
         QueryPhase.execute(context, contextSearcher, checkCancelled -> {}, sort);
         context.trackTotalHits(true);
-        assertThat(context.queryResult().topDocs().totalHits, equalTo(1L));
         assertTrue(collected.get());
         assertTrue(context.queryResult().terminatedEarly());
         assertThat(context.terminateAfter(), equalTo(0));
-        assertThat(context.queryResult().getTotalHits(), equalTo(1L));
 
         // Test with initial scroll context
         collected.set(false);
@@ -580,9 +578,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
         }
 
         // Test search after pagination
+        context.scrollContext(null);
         for (boolean trackTotalHits : new boolean[] {true, false}) {
             collected.set(false);
-            context.scrollContext(null);
             context.trackTotalHits(trackTotalHits);
             context.searchAfter(new FieldDoc(Integer.MAX_VALUE, Float.NaN, firstDoc.fields));
             QueryPhase.execute(context, contextSearcher, checkCancelled -> {


### PR DESCRIPTION
This commit automatically adds a special query that match document greater than the `search_after` values when
sorting on index sort order (using `_doc` sort or index sorting) using track_total_hits=false.
This is an optimization for search_after pagination queries that do not need to compute the total_hits for each page.