### PR TITLE
setgid on /etc/elasticearch on package install

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -330,7 +330,7 @@ public class KeyStoreWrapper implements SecureSettings {
         PosixFileAttributeView attrs = Files.getFileAttributeView(keystoreFile, PosixFileAttributeView.class);
         if (attrs != null) {
             // don't rely on umask: ensure the keystore has minimal permissions
-            attrs.setPermissions(PosixFilePermissions.fromString("rw-------"));
+            attrs.setPermissions(PosixFilePermissions.fromString("rw-rw----"));
         }
     }
 

--- a/distribution/src/main/packaging/scripts/postinst
+++ b/distribution/src/main/packaging/scripts/postinst
@@ -100,6 +100,7 @@ fi
 chown -R elasticsearch:elasticsearch /var/lib/elasticsearch
 chown -R elasticsearch:elasticsearch /var/log/elasticsearch
 chown -R root:elasticsearch /etc/elasticsearch
+chmod g+s /etc/elasticsearch
 chmod 0750 /etc/elasticsearch
 
 if [ -f /etc/default/elasticsearch ]; then

--- a/qa/vagrant/src/test/resources/packaging/utils/packages.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/packages.bash
@@ -94,7 +94,7 @@ verify_package_installation() {
     assert_file "$ESHOME/bin/elasticsearch-plugin" f root root 755
     assert_file "$ESHOME/bin/elasticsearch-translog" f root root 755
     assert_file "$ESHOME/lib" d root root 755
-    assert_file "$ESCONFIG" d root elasticsearch 750
+    assert_file "$ESCONFIG" d root elasticsearch 2750
     assert_file "$ESCONFIG/elasticsearch.yml" f root elasticsearch 660
     assert_file "$ESCONFIG/jvm.options" f root elasticsearch 660
     assert_file "$ESCONFIG/log4j2.properties" f root elasticsearch 660


### PR DESCRIPTION
When creating the keystore explicitly (from executing elasticsearch-keystore create) or implicitly (for plugins that require the keystore to be created on install) on an Elasticsearch package installation, we are running as the root user. This leaves /etc/elasticsearch/elasticsearch.keystore having the wrong ownership (root:root) so that the elasticsearch user can not read the keystore on startup. This commit adds setgid to /etc/elasticsearch on package installation so that when executing this directory (as we would when creating the keystore), we will end up with the correct ownership (root:elasticsearch). Additionally, we set the permissions on the keystore to be 660 so that the elasticsearch user via its group can read this file on startup.

Closes #26410
