### PR TITLE
ICU plugin: use root locale by default for collators

### DIFF
--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuCollationTokenFilterFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuCollationTokenFilterFactory.java
@@ -84,7 +84,7 @@ public class IcuCollationTokenFilterFactory extends AbstractTokenFilterFactory {
                 }
                 collator = Collator.getInstance(locale);
             } else {
-                collator = Collator.getInstance();
+                collator = Collator.getInstance(ULocale.ROOT);
             }
         }
 

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -389,7 +389,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
                     }
                     collator = Collator.getInstance(locale);
                 } else {
-                    collator = Collator.getInstance();
+                    collator = Collator.getInstance(ULocale.ROOT);
                 }
             }
 

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/analysis/SimpleIcuCollationTokenFilterTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/analysis/SimpleIcuCollationTokenFilterTests.java
@@ -39,6 +39,19 @@ import static org.hamcrest.Matchers.equalTo;
 // Tests borrowed from Solr's Icu collation key filter factory test.
 public class SimpleIcuCollationTokenFilterTests extends ESTestCase {
     /*
+     * Tests usage where we do not provide a language or locale
+     */
+    public void testDefaultUsage() throws Exception {
+        Settings settings = Settings.builder()
+                .put("index.analysis.filter.myCollator.type", "icu_collation")
+                .put("index.analysis.filter.myCollator.strength", "primary")
+                .build();
+        TestAnalysis analysis = createTestAnalysis(new Index("test", "_na_"), settings, new AnalysisICUPlugin());
+
+        TokenFilterFactory filterFactory = analysis.tokenFilter.get("myCollator");
+        assertCollatesToSame(filterFactory, "FOO", "foo");
+    }
+    /*
     * Turkish has some funny casing.
     * This test shows how you can solve this kind of thing easily with collation.
     * Instead of using LowerCaseFilter, use a turkish collator with primary strength.

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/CollationFieldTypeTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/CollationFieldTypeTests.java
@@ -78,7 +78,7 @@ public class CollationFieldTypeTests extends FieldTypeTestCase {
         ft.setName("field");
         ft.setIndexOptions(IndexOptions.DOCS);
 
-        Collator collator = Collator.getInstance().freeze();
+        Collator collator = Collator.getInstance(ULocale.ROOT).freeze();
         ((CollationFieldType) ft).setCollator(collator);
 
         RawCollationKey fooKey = collator.getRawCollationKey("foo", null);
@@ -126,7 +126,7 @@ public class CollationFieldTypeTests extends FieldTypeTestCase {
         ft.setName("field");
         ft.setIndexOptions(IndexOptions.DOCS);
 
-        Collator collator = Collator.getInstance().freeze();
+        Collator collator = Collator.getInstance(ULocale.ROOT).freeze();
         ((CollationFieldType) ft).setCollator(collator);
 
         RawCollationKey aKey = collator.getRawCollationKey("a", null);

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
@@ -82,7 +82,7 @@ public class ICUCollationKeywordFieldMapperTests extends ESSingleNodeTestCase {
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(2, fields.length);
 
-        Collator collator = Collator.getInstance();
+        Collator collator = Collator.getInstance(ULocale.ROOT);
         RawCollationKey key = collator.getRawCollationKey("1234", null);
         BytesRef expected = new BytesRef(key.bytes, 0, key.size);
 
@@ -126,7 +126,7 @@ public class ICUCollationKeywordFieldMapperTests extends ESSingleNodeTestCase {
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(2, fields.length);
 
-        Collator collator = Collator.getInstance();
+        Collator collator = Collator.getInstance(ULocale.ROOT);
         RawCollationKey key = collator.getRawCollationKey("1234", null);
         BytesRef expected = new BytesRef(key.bytes, 0, key.size);
 
@@ -189,7 +189,7 @@ public class ICUCollationKeywordFieldMapperTests extends ESSingleNodeTestCase {
                 .bytes(),
             XContentType.JSON));
 
-        Collator collator = Collator.getInstance();
+        Collator collator = Collator.getInstance(ULocale.ROOT);
         RawCollationKey key = collator.getRawCollationKey("1234", null);
         BytesRef expected = new BytesRef(key.bytes, 0, key.size);
 
@@ -284,7 +284,7 @@ public class ICUCollationKeywordFieldMapperTests extends ESSingleNodeTestCase {
         IndexableField[] fields = doc.rootDoc().getFields("field");
         assertEquals(4, fields.length);
 
-        Collator collator = Collator.getInstance();
+        Collator collator = Collator.getInstance(ULocale.ROOT);
         RawCollationKey key = collator.getRawCollationKey("1234", null);
         BytesRef expected = new BytesRef(key.bytes, 0, key.size);
 
@@ -305,7 +305,7 @@ public class ICUCollationKeywordFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(fieldType.indexOptions(), equalTo(IndexOptions.NONE));
         assertEquals(DocValuesType.SORTED_SET, fieldType.docValuesType());
 
-        collator = Collator.getInstance();
+        collator = Collator.getInstance(ULocale.ROOT);
         key = collator.getRawCollationKey("5678", null);
         expected = new BytesRef(key.bytes, 0, key.size);
 


### PR DESCRIPTION
Calls to Collator.getInstance without arguments returns a
collator that uses the system's default locale, which we don't
want because it makes behavior harder to reproduce. Change it
to always use the root locale instead.

For #25587

The original issue just mentioned ICUCollationKeywordFieldMapper, I went ahead and fixed the usage in IcuCollationTokenFilterFactory as well. I believe that's all the usages of this API.

I considered adding this method to the forbidden APIs, but after looking at what's already listed I wasn't sure if this was important/common enough to make the cut. Will gladly add that in if that's what we want.