### PR TITLE
Scripting: Deprecate scripts.max_compilation_per_minute setting

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/ScriptService.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptService.java
@@ -90,7 +90,7 @@ public class ScriptService extends AbstractComponent implements Closeable, Clust
     public static final Setting<Integer> SCRIPT_MAX_SIZE_IN_BYTES =
         Setting.intSetting("script.max_size_in_bytes", 65535, Property.NodeScope);
     public static final Setting<Integer> SCRIPT_MAX_COMPILATIONS_PER_MINUTE =
-        Setting.intSetting("script.max_compilations_per_minute", 15, 0, Property.Dynamic, Property.NodeScope);
+        Setting.intSetting("script.max_compilations_per_minute", 15, 0, Property.Dynamic, Property.NodeScope, Property.Deprecated);
 
     private final Collection<ScriptEngineService> scriptEngines;
     private final Map<String, ScriptEngineService> scriptEnginesByLang;

--- a/docs/reference/cluster/update-settings.asciidoc
+++ b/docs/reference/cluster/update-settings.asciidoc
@@ -15,6 +15,7 @@ PUT /_cluster/settings
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 Or:
 
@@ -28,6 +29,7 @@ PUT /_cluster/settings?flat_settings=true
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 The cluster responds with the settings updated. So the response for the
 last example will be:
@@ -60,6 +62,8 @@ PUT /_cluster/settings
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[s/^/PUT _cluster\/settings\n{ "transient" : { "indices.recovery.max_bytes_per_sec" : "20mb" } }\n/]
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 Reset settings will not be included in the cluster response. So
 the response for the last example will be:
@@ -87,6 +91,8 @@ PUT /_cluster/settings
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[s/^/PUT _cluster\/settings\n{ "transient" : { "indices.recovery.max_bytes_per_sec" : "20mb" } }\n/]
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 Cluster wide settings can be returned using:
 

--- a/docs/reference/modules/cluster/allocation_filtering.asciidoc
+++ b/docs/reference/modules/cluster/allocation_filtering.asciidoc
@@ -22,6 +22,7 @@ PUT _cluster/settings
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 NOTE: Shards will only be relocated if it is possible to do so without
 breaking another routing constraint, such as never allocating a primary and

--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -66,6 +66,7 @@ PUT _cluster/settings
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 NOTE: Prior to 2.0.0, when using multiple data paths, the disk threshold
 decider only factored in the usage across all data paths (if you had two

--- a/docs/reference/modules/cluster/misc.asciidoc
+++ b/docs/reference/modules/cluster/misc.asciidoc
@@ -56,3 +56,4 @@ PUT /_cluster/settings
 }
 -------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]

--- a/docs/reference/modules/cross-cluster-search.asciidoc
+++ b/docs/reference/modules/cross-cluster-search.asciidoc
@@ -78,6 +78,7 @@ PUT _cluster/settings
 }
 --------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 A remote cluster can be deleted from the cluster settings by setting its seeds to `null`:
 

--- a/docs/reference/modules/indices/circuit_breaker.asciidoc
+++ b/docs/reference/modules/indices/circuit_breaker.asciidoc
@@ -87,3 +87,5 @@ documentation for more information.
 
     Limit for the number of unique dynamic scripts within a minute that are
     allowed to be compiled. Defaults to 15.
+
+deprecated[5.6.0 This parameter is deprecated and will be replaced with `script.max_compilation_rate` in Elasticsearch 6.0]

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -168,6 +168,7 @@ PUT _cluster/settings
 ----------------------------
 // CONSOLE
 // TEST[catch:/cannot set discovery.zen.minimum_master_nodes to more than the current master nodes/]
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 TIP: An advantage of splitting the master and data roles between dedicated
 nodes is that you can have just three master-eligible nodes and set

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -96,6 +96,7 @@ PUT _cluster/settings
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 You can also control which actions will be traced, using a set of include and exclude wildcard patterns. By default every request will be traced
 except for fault detection pings:
@@ -111,5 +112,6 @@ PUT _cluster/settings
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 

--- a/docs/reference/setup/cluster_restart.asciidoc
+++ b/docs/reference/setup/cluster_restart.asciidoc
@@ -125,6 +125,7 @@ PUT _cluster/settings
 }
 ------------------------------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 The cluster will now start allocating replica shards to all data nodes. At this
 point it is safe to resume indexing and searching, but your cluster will

--- a/docs/reference/setup/configuration.asciidoc
+++ b/docs/reference/setup/configuration.asciidoc
@@ -216,6 +216,7 @@ PUT /_cluster/settings
 }
 -------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 
 This is most appropriate when you need to dynamically need to adjust a logging
 level on an actively-running cluster.

--- a/docs/reference/setup/rolling_upgrade.asciidoc
+++ b/docs/reference/setup/rolling_upgrade.asciidoc
@@ -138,6 +138,7 @@ PUT _cluster/settings
 }
 --------------------------------------------------
 // CONSOLE
+// TEST[warning:[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.]
 --
 
 . *Wait for the node to recover*

--- a/modules/lang-groovy/src/test/resources/rest-api-spec/test/lang_groovy/30_compile_limit.yaml
+++ b/modules/lang-groovy/src/test/resources/rest-api-spec/test/lang_groovy/30_compile_limit.yaml
@@ -11,14 +11,6 @@ setup:
           refresh: wait_for
 
 ---
-teardown:
-  - do:
-      cluster.put_settings:
-        body:
-          transient:
-            script.max_compilations_per_minute: null
-
----
 "circuit breaking with too many scripts":
 
   - skip:
@@ -27,6 +19,8 @@ teardown:
         - warnings
 
   - do:
+      warnings:
+        - "[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
       cluster.put_settings:
         body:
           transient:
@@ -60,6 +54,15 @@ teardown:
               script:
                 source: "\"aoeuaoeu\""
                 lang: groovy
+
+  - do:
+      warnings:
+        - "[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
+      cluster.put_settings:
+        body:
+          transient:
+            script.max_compilations_per_minute: null
+
 
 ---
 "no bad settings":

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RetryTests.java
@@ -86,6 +86,12 @@ public class RetryTests extends ESSingleNodeTestCase {
         }
     }
 
+    // disabling, this one conflicts with the executor blocking
+    @Override
+    protected boolean enableWarningsCheck() {
+        return false;
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
         return pluginList(

--- a/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/60_pipeline_timestamp_date_mapping.yaml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/test/resources/rest-api-spec/test/ingest/60_pipeline_timestamp_date_mapping.yaml
@@ -80,6 +80,7 @@
             ingest.new_date_format: true
       warnings:
         - "[ingest.new_date_format] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
+        - "[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
 
   - match: {transient: {ingest: {new_date_format: "true"}}}
 
@@ -115,5 +116,6 @@
             ingest.new_date_format: false
       warnings:
         - "[ingest.new_date_format] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
+        - "[script.max_compilations_per_minute] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version."
 
   - match: {transient: {ingest: {new_date_format: "false"}}}


### PR DESCRIPTION
This setting will be replaced with script.max_compilation_rate in
Elasticsearch 6.0, thus it can be marked as deprecated in 5.6.

The REST tests that delete a setting, ensure that this setting exists
before, as otherwise a bug is hit, that the required header is not
returned (see #26419).

Note: This is just an extension of #26402 with fixed tests.