### PR TITLE
Add a maximum search request size.

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.common.settings;
 
+import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.AutoCreateIndex;
@@ -410,6 +411,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING,
                     FastVectorHighlighter.SETTING_TV_HIGHLIGHT_MULTI_VALUE,
                     Node.BREAKER_TYPE_KEY,
-                    IndexGraveyard.SETTING_MAX_TOMBSTONES
+                    IndexGraveyard.SETTING_MAX_TOMBSTONES,
+                    ActionModule.SETTING_SEARCH_MAX_CONTENT_LENGTH
             )));
 }

--- a/core/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
@@ -85,7 +86,7 @@ public class MultiSearchRequestTests extends ESTestCase {
             "{\"query\" : {\"match_all\" :{}}}\r\n";
         FakeRestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withContent(new BytesArray(requestContent), XContentType.JSON).build();
-        MultiSearchRequest request = RestMultiSearchAction.parseRequest(restRequest, true);
+        MultiSearchRequest request = RestMultiSearchAction.parseRequest(restRequest, true, new ByteSizeValue(16_384));
         assertThat(request.requests().size(), equalTo(1));
         assertThat(request.requests().get(0).indices()[0], equalTo("test"));
         assertThat(request.requests().get(0).indicesOptions(),
@@ -177,13 +178,13 @@ public class MultiSearchRequestTests extends ESTestCase {
         RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
                 .withContent(new BytesArray(mserchAction.getBytes(StandardCharsets.UTF_8)), XContentType.JSON).build();
         IllegalArgumentException expectThrows = expectThrows(IllegalArgumentException.class,
-                () -> RestMultiSearchAction.parseRequest(restRequest, true));
+                () -> RestMultiSearchAction.parseRequest(restRequest, true, new ByteSizeValue(16_384)));
         assertEquals("The msearch request must be terminated by a newline [\n]", expectThrows.getMessage());
 
         String mserchActionWithNewLine = mserchAction + "\n";
         RestRequest restRequestWithNewLine = new FakeRestRequest.Builder(xContentRegistry())
                 .withContent(new BytesArray(mserchActionWithNewLine.getBytes(StandardCharsets.UTF_8)), XContentType.JSON).build();
-        MultiSearchRequest msearchRequest = RestMultiSearchAction.parseRequest(restRequestWithNewLine, true);
+        MultiSearchRequest msearchRequest = RestMultiSearchAction.parseRequest(restRequestWithNewLine, true, new ByteSizeValue(16_384));
         assertEquals(3, msearchRequest.requests().size());
     }
 
@@ -191,7 +192,7 @@ public class MultiSearchRequestTests extends ESTestCase {
         byte[] data = StreamsUtils.copyToBytesFromClasspath(sample);
         RestRequest restRequest = new FakeRestRequest.Builder(xContentRegistry())
             .withContent(new BytesArray(data), XContentType.JSON).build();
-        return RestMultiSearchAction.parseRequest(restRequest, true);
+        return RestMultiSearchAction.parseRequest(restRequest, true, new ByteSizeValue(16_384));
     }
 
     @Override

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -75,8 +76,10 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
             multiRequest.maxConcurrentSearchRequests(restRequest.paramAsInt("max_concurrent_searches", 0));
         }
 
+        // ignore the limit for now, we will evaluate it after the script is executed
+        ByteSizeValue limit = new ByteSizeValue(Long.MAX_VALUE);
         RestMultiSearchAction.parseMultiLineRequest(restRequest, multiRequest.indicesOptions(), allowExplicitIndex,
-                (searchRequest, bytes) -> {
+                limit, (searchRequest, bytes) -> {
                     try {
                         SearchTemplateRequest searchTemplateRequest = RestSearchTemplateAction.parse(bytes);
                         if (searchTemplateRequest.getScript() != null) {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/30_max_content_length.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/msearch/30_max_content_length.yml
@@ -1,0 +1,36 @@
+---
+setup:
+  - do:
+      index:
+        index:  test
+        type:   doc
+        id:     1
+        body:   {}
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            http.search.max_content_length: "30b"
+
+---
+teardown:
+
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            http.search.max_content_length: null
+
+---
+"Max content length limit":
+  - do:
+      catch: /Search request body .* is larger than the configured limit/
+      msearch:
+        body:
+          - index: test
+          - query:
+              term: { some_feld: "some_value" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_max_content_length.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_max_content_length.yml
@@ -1,0 +1,36 @@
+---
+setup:
+  - do:
+      index:
+        index:  test
+        type:   doc
+        id:     1
+        body:   {}
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            http.search.max_content_length: "10b"
+
+---
+teardown:
+
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            http.search.max_content_length: null
+
+---
+"Max content length limit":
+  - do:
+      catch: /Search request body .* is larger than the configured limit/
+      search:
+        index: test
+        body:
+          query:
+            match_all: {}


### PR DESCRIPTION
This commit adds the `http.search.max_content_length` setting that is a
safeguard against too large search requests. It applies to the search, msearch
and template search APIs.
