### PR TITLE
Build: Ensure build metadata is written

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -106,11 +106,14 @@ if (enabled) {
 
   // this is an Exec task so that the SHA that is checked out is logged
   String buildMetadataKey = "bwc_refspec_${project.path.substring(1)}"
-  task checkoutBwcBranch(type: Exec) {
-    def String refspec = System.getProperty("tests.bwc.refspec", buildMetadata.get(buildMetadataKey, "upstream/${bwcBranch}"))
+  task checkoutBwcBranch(type: LoggedExec) {
+    String refspec = System.getProperty("tests.bwc.refspec", buildMetadata.get(buildMetadataKey, "upstream/${bwcBranch}"))
     dependsOn fetchLatest
     workingDir = checkoutDir
     commandLine = ['git', 'checkout', refspec]
+    doFirst {
+      println "Checking out elasticsearch ${refspec} for branch ${bwcBranch}"
+    }
   }
 
   File buildMetadataFile = project.file("build/${project.name}/build_metadata")
@@ -127,7 +130,9 @@ if (enabled) {
         execResult.assertNormalExitValue()
       }
       project.mkdir(buildMetadataFile.parent)
-      buildMetadataFile.setText("${buildMetadataKey}=${output.toString('UTF-8')}", 'UTF-8')
+      String commit = output.toString('UTF-8')
+      buildMetadataFile.setText("${buildMetadataKey}=${commit}", 'UTF-8')
+      println "Checked out elasticsearch commit ${commit}"
     }
   }
 
@@ -148,6 +153,8 @@ if (enabled) {
     }
   }
 
+  // ensure build metadata is written, even if nothing uses it in this build
+  check.dependsOn writeBuildMetadata
 
   artifacts {
     'default' file: bwcDeb, name: 'elasticsearch', type: 'deb', builtBy: buildBwcVersion

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -106,14 +106,11 @@ if (enabled) {
 
   // this is an Exec task so that the SHA that is checked out is logged
   String buildMetadataKey = "bwc_refspec_${project.path.substring(1)}"
-  task checkoutBwcBranch(type: LoggedExec) {
-    String refspec = System.getProperty("tests.bwc.refspec", buildMetadata.get(buildMetadataKey, "upstream/${bwcBranch}"))
+  task checkoutBwcBranch(type: Exec) {
+    def String refspec = System.getProperty("tests.bwc.refspec", buildMetadata.get(buildMetadataKey, "upstream/${bwcBranch}"))
     dependsOn fetchLatest
     workingDir = checkoutDir
     commandLine = ['git', 'checkout', refspec]
-    doFirst {
-      println "Checking out elasticsearch ${refspec} for branch ${bwcBranch}"
-    }
   }
 
   File buildMetadataFile = project.file("build/${project.name}/build_metadata")
@@ -130,9 +127,7 @@ if (enabled) {
         execResult.assertNormalExitValue()
       }
       project.mkdir(buildMetadataFile.parent)
-      String commit = output.toString('UTF-8')
-      buildMetadataFile.setText("${buildMetadataKey}=${commit}", 'UTF-8')
-      println "Checked out elasticsearch commit ${commit}"
+      buildMetadataFile.setText("${buildMetadataKey}=${output.toString('UTF-8')}", 'UTF-8')
     }
   }
 
@@ -153,8 +148,6 @@ if (enabled) {
     }
   }
 
-  // ensure build metadata is written, even if nothing uses it in this build
-  check.dependsOn writeBuildMetadata
 
   artifacts {
     'default' file: bwcDeb, name: 'elasticsearch', type: 'deb', builtBy: buildBwcVersion

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -89,7 +89,10 @@ test.enabled = false // no unit tests for rolling upgrades, only the rest integr
 // basic integ tests includes testing bwc against the most recent version
 task integTest {
   if (project.bwc_tests_enabled) {
-    dependsOn = ["v${indexCompatVersions[-1]}#bwcTest"]
+    dependsOn "v${indexCompatVersions[-1]}#bwcTest"
+    if (indexCompatVersions[-1].bugfix == 0) {
+      dependsOn "v${indexCompatVersions[-2]}#bwcTest"
+    }
   }
 }
 


### PR DESCRIPTION
This commit ensures build metadata is written for the release snapshot version. In later jobs like
bwcTest, the extra bwc-release-snapshot info is needed. Full cluster restart now runs against both bwc versions, if relevant for the given branch.