### PR TITLE
Migrate Search requests to use Writeable reading strategies

### DIFF
--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/search/TransportNoopSearchAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/search/TransportNoopSearchAction.java
@@ -42,8 +42,8 @@ public class TransportNoopSearchAction extends HandledTransportAction<SearchRequ
     @Inject
     public TransportNoopSearchAction(Settings settings, ThreadPool threadPool, TransportService transportService, ActionFilters
         actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(settings, NoopSearchAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver,
-            SearchRequest::new);
+        super(settings, NoopSearchAction.NAME, threadPool, transportService, actionFilters, SearchRequest::new,
+            indexNameExpressionResolver);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -117,8 +117,7 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
         maxConcurrentSearchRequests = in.readVInt();
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {
-            SearchRequest request = new SearchRequest();
-            request.readFrom(in);
+            SearchRequest request = new SearchRequest(in);
             requests.add(request);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -109,6 +109,33 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         this.source = source;
     }
 
+    /**
+     * Constructs a new search request from reading the specified stream.
+     *
+     * @param in The stream the request is read from
+     * @throws IOException if there is an issue reading the stream
+     */
+    public SearchRequest(StreamInput in) throws IOException {
+        super(in);
+        searchType = SearchType.fromId(in.readByte());
+        indices = new String[in.readVInt()];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = in.readString();
+        }
+        routing = in.readOptionalString();
+        preference = in.readOptionalString();
+        scroll = in.readOptionalWriteable(Scroll::new);
+        source = in.readOptionalWriteable(SearchSourceBuilder::new);
+        types = in.readStringArray();
+        indicesOptions = IndicesOptions.readIndicesOptions(in);
+        requestCache = in.readOptionalBoolean();
+        batchedReduceSize = in.readVInt();
+        if (in.getVersion().onOrAfter(Version.V_5_6_0)) {
+            maxConcurrentShardRequests = in.readVInt();
+            preFilterShardSize = in.readVInt();
+        }
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
@@ -385,7 +412,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
                 sb.append("], ");
                 sb.append("search_type[").append(searchType).append("], ");
                 if (source != null) {
-                    
+
                     sb.append("source[").append(source.toString(FORMAT_PARAMS)).append("]");
                 } else {
                     sb.append("source[]");
@@ -397,24 +424,7 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        searchType = SearchType.fromId(in.readByte());
-        indices = new String[in.readVInt()];
-        for (int i = 0; i < indices.length; i++) {
-            indices[i] = in.readString();
-        }
-        routing = in.readOptionalString();
-        preference = in.readOptionalString();
-        scroll = in.readOptionalWriteable(Scroll::new);
-        source = in.readOptionalWriteable(SearchSourceBuilder::new);
-        types = in.readStringArray();
-        indicesOptions = IndicesOptions.readIndicesOptions(in);
-        requestCache = in.readOptionalBoolean();
-        batchedReduceSize = in.readVInt();
-        if (in.getVersion().onOrAfter(Version.V_5_6_0)) {
-            maxConcurrentShardRequests = in.readVInt();
-            preFilterShardSize = in.readVInt();
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -137,6 +137,28 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     }
 
     @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeByte(searchType.id());
+        out.writeVInt(indices.length);
+        for (String index : indices) {
+            out.writeString(index);
+        }
+        out.writeOptionalString(routing);
+        out.writeOptionalString(preference);
+        out.writeOptionalWriteable(scroll);
+        out.writeOptionalWriteable(source);
+        out.writeStringArray(types);
+        indicesOptions.writeIndicesOptions(out);
+        out.writeOptionalBoolean(requestCache);
+        out.writeVInt(batchedReduceSize);
+        if (out.getVersion().onOrAfter(Version.V_5_6_0)) {
+            out.writeVInt(maxConcurrentShardRequests);
+            out.writeVInt(preFilterShardSize);
+        }
+    }
+
+    @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (source != null && source.trackTotalHits() == false && scroll() != null) {
@@ -425,28 +447,6 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     @Override
     public void readFrom(StreamInput in) throws IOException {
         throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeByte(searchType.id());
-        out.writeVInt(indices.length);
-        for (String index : indices) {
-            out.writeString(index);
-        }
-        out.writeOptionalString(routing);
-        out.writeOptionalString(preference);
-        out.writeOptionalWriteable(scroll);
-        out.writeOptionalWriteable(source);
-        out.writeStringArray(types);
-        indicesOptions.writeIndicesOptions(out);
-        out.writeOptionalBoolean(requestCache);
-        out.writeVInt(batchedReduceSize);
-        if (out.getVersion().onOrAfter(Version.V_5_6_0)) {
-            out.writeVInt(maxConcurrentShardRequests);
-            out.writeVInt(preFilterShardSize);
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
@@ -48,6 +48,12 @@ public class SearchScrollRequest extends ActionRequest implements ToXContentObje
         this.scrollId = scrollId;
     }
 
+    public SearchScrollRequest(StreamInput in) throws IOException {
+        super(in);
+        scrollId = in.readString();
+        scroll = in.readOptionalWriteable(Scroll::new);
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
@@ -100,9 +106,7 @@ public class SearchScrollRequest extends ActionRequest implements ToXContentObje
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        scrollId = in.readString();
-        scroll = in.readOptionalWriteable(Scroll::new);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
@@ -55,6 +55,13 @@ public class SearchScrollRequest extends ActionRequest implements ToXContentObje
     }
 
     @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(scrollId);
+        out.writeOptionalWriteable(scroll);
+    }
+
+    @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (scrollId == null) {
@@ -107,13 +114,6 @@ public class SearchScrollRequest extends ActionRequest implements ToXContentObje
     @Override
     public void readFrom(StreamInput in) throws IOException {
         throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeString(scrollId);
-        out.writeOptionalWriteable(scroll);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -203,14 +203,18 @@ public class SearchTransportService extends AbstractComponent {
             this.id = id;
         }
 
+        ScrollFreeContextRequest(StreamInput in) throws IOException {
+            super(in);
+            id = in.readLong();
+        }
+
         public long id() {
             return this.id;
         }
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            id = in.readLong();
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -231,6 +235,11 @@ public class SearchTransportService extends AbstractComponent {
             this.originalIndices = originalIndices;
         }
 
+        SearchFreeContextRequest(StreamInput in) throws IOException {
+            super(in);
+            originalIndices = OriginalIndices.readOriginalIndices(in);
+        }
+
         @Override
         public String[] indices() {
             if (originalIndices == null) {
@@ -249,8 +258,7 @@ public class SearchTransportService extends AbstractComponent {
 
         @Override
         public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
-            originalIndices = OriginalIndices.readOriginalIndices(in);
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override
@@ -289,7 +297,7 @@ public class SearchTransportService extends AbstractComponent {
     }
 
     public static void registerRequestHandler(TransportService transportService, SearchService searchService) {
-        transportService.registerRequestHandler(FREE_CONTEXT_SCROLL_ACTION_NAME, ScrollFreeContextRequest::new, ThreadPool.Names.SAME,
+        transportService.registerRequestHandler(FREE_CONTEXT_SCROLL_ACTION_NAME, ThreadPool.Names.SAME, ScrollFreeContextRequest::new,
             new TaskAwareTransportRequestHandler<ScrollFreeContextRequest>() {
                 @Override
                 public void messageReceived(ScrollFreeContextRequest request, TransportChannel channel, Task task) throws Exception {
@@ -298,7 +306,7 @@ public class SearchTransportService extends AbstractComponent {
                 }
             });
         TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_SCROLL_ACTION_NAME, SearchFreeContextResponse::new);
-        transportService.registerRequestHandler(FREE_CONTEXT_ACTION_NAME, SearchFreeContextRequest::new, ThreadPool.Names.SAME,
+        transportService.registerRequestHandler(FREE_CONTEXT_ACTION_NAME, ThreadPool.Names.SAME, SearchFreeContextRequest::new,
             new TaskAwareTransportRequestHandler<SearchFreeContextRequest>() {
                 @Override
                 public void messageReceived(SearchFreeContextRequest request, TransportChannel channel, Task task) throws Exception {
@@ -318,7 +326,7 @@ public class SearchTransportService extends AbstractComponent {
         TransportActionProxy.registerProxyAction(transportService, CLEAR_SCROLL_CONTEXTS_ACTION_NAME,
             () -> TransportResponse.Empty.INSTANCE);
 
-        transportService.registerRequestHandler(DFS_ACTION_NAME, ShardSearchTransportRequest::new, ThreadPool.Names.SAME,
+        transportService.registerRequestHandler(DFS_ACTION_NAME, ThreadPool.Names.SAME, ShardSearchTransportRequest::new,
             new TaskAwareTransportRequestHandler<ShardSearchTransportRequest>() {
                 @Override
                 public void messageReceived(ShardSearchTransportRequest request, TransportChannel channel, Task task) throws Exception {
@@ -346,7 +354,7 @@ public class SearchTransportService extends AbstractComponent {
             });
         TransportActionProxy.registerProxyAction(transportService, DFS_ACTION_NAME, DfsSearchResult::new);
 
-        transportService.registerRequestHandler(QUERY_ACTION_NAME, ShardSearchTransportRequest::new, ThreadPool.Names.SAME,
+        transportService.registerRequestHandler(QUERY_ACTION_NAME, ThreadPool.Names.SAME, ShardSearchTransportRequest::new,
             new TaskAwareTransportRequestHandler<ShardSearchTransportRequest>() {
                 @Override
                 public void messageReceived(ShardSearchTransportRequest request, TransportChannel channel, Task task) throws Exception {
@@ -373,7 +381,7 @@ public class SearchTransportService extends AbstractComponent {
             });
         TransportActionProxy.registerProxyAction(transportService, QUERY_ACTION_NAME, QuerySearchResult::new);
 
-        transportService.registerRequestHandler(QUERY_ID_ACTION_NAME, QuerySearchRequest::new, ThreadPool.Names.SEARCH,
+        transportService.registerRequestHandler(QUERY_ID_ACTION_NAME, ThreadPool.Names.SEARCH, QuerySearchRequest::new,
             new TaskAwareTransportRequestHandler<QuerySearchRequest>() {
                 @Override
                 public void messageReceived(QuerySearchRequest request, TransportChannel channel, Task task) throws Exception {
@@ -383,7 +391,7 @@ public class SearchTransportService extends AbstractComponent {
             });
         TransportActionProxy.registerProxyAction(transportService, QUERY_ID_ACTION_NAME, QuerySearchResult::new);
 
-        transportService.registerRequestHandler(QUERY_SCROLL_ACTION_NAME, InternalScrollSearchRequest::new, ThreadPool.Names.SEARCH,
+        transportService.registerRequestHandler(QUERY_SCROLL_ACTION_NAME, ThreadPool.Names.SEARCH, InternalScrollSearchRequest::new,
             new TaskAwareTransportRequestHandler<InternalScrollSearchRequest>() {
                 @Override
                 public void messageReceived(InternalScrollSearchRequest request, TransportChannel channel, Task task) throws Exception {
@@ -393,7 +401,7 @@ public class SearchTransportService extends AbstractComponent {
             });
         TransportActionProxy.registerProxyAction(transportService, QUERY_SCROLL_ACTION_NAME, ScrollQuerySearchResult::new);
 
-        transportService.registerRequestHandler(QUERY_FETCH_SCROLL_ACTION_NAME, InternalScrollSearchRequest::new, ThreadPool.Names.SEARCH,
+        transportService.registerRequestHandler(QUERY_FETCH_SCROLL_ACTION_NAME, ThreadPool.Names.SEARCH, InternalScrollSearchRequest::new,
             new TaskAwareTransportRequestHandler<InternalScrollSearchRequest>() {
                 @Override
                 public void messageReceived(InternalScrollSearchRequest request, TransportChannel channel, Task task) throws Exception {
@@ -403,7 +411,7 @@ public class SearchTransportService extends AbstractComponent {
             });
         TransportActionProxy.registerProxyAction(transportService, QUERY_FETCH_SCROLL_ACTION_NAME, ScrollQueryFetchSearchResult::new);
 
-        transportService.registerRequestHandler(FETCH_ID_SCROLL_ACTION_NAME, ShardFetchRequest::new, ThreadPool.Names.SEARCH,
+        transportService.registerRequestHandler(FETCH_ID_SCROLL_ACTION_NAME, ThreadPool.Names.SEARCH, ShardFetchRequest::new,
             new TaskAwareTransportRequestHandler<ShardFetchRequest>() {
                 @Override
                 public void messageReceived(ShardFetchRequest request, TransportChannel channel, Task task) throws Exception {
@@ -413,7 +421,7 @@ public class SearchTransportService extends AbstractComponent {
             });
         TransportActionProxy.registerProxyAction(transportService, FETCH_ID_SCROLL_ACTION_NAME, FetchSearchResult::new);
 
-        transportService.registerRequestHandler(FETCH_ID_ACTION_NAME, ShardFetchSearchRequest::new, ThreadPool.Names.SEARCH,
+        transportService.registerRequestHandler(FETCH_ID_ACTION_NAME, ThreadPool.Names.SEARCH, ShardFetchSearchRequest::new,
             new TaskAwareTransportRequestHandler<ShardFetchSearchRequest>() {
                 @Override
                 public void messageReceived(ShardFetchSearchRequest request, TransportChannel channel, Task task) throws Exception {
@@ -424,7 +432,7 @@ public class SearchTransportService extends AbstractComponent {
         TransportActionProxy.registerProxyAction(transportService, FETCH_ID_ACTION_NAME, FetchSearchResult::new);
 
         // this is super cheap and should not hit thread-pool rejections
-        transportService.registerRequestHandler(QUERY_CAN_MATCH_NAME, ShardSearchTransportRequest::new, ThreadPool.Names.SAME,
+        transportService.registerRequestHandler(QUERY_CAN_MATCH_NAME, ThreadPool.Names.SAME, ShardSearchTransportRequest::new,
             new TaskAwareTransportRequestHandler<ShardSearchTransportRequest>() {
                 @Override
                 public void messageReceived(ShardSearchTransportRequest request, TransportChannel channel, Task task) throws Exception {

--- a/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -208,6 +208,12 @@ public class SearchTransportService extends AbstractComponent {
             id = in.readLong();
         }
 
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeLong(id);
+        }
+
         public long id() {
             return this.id;
         }
@@ -215,12 +221,6 @@ public class SearchTransportService extends AbstractComponent {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
-            out.writeLong(id);
         }
     }
 
@@ -238,6 +238,12 @@ public class SearchTransportService extends AbstractComponent {
         SearchFreeContextRequest(StreamInput in) throws IOException {
             super(in);
             originalIndices = OriginalIndices.readOriginalIndices(in);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            OriginalIndices.writeOriginalIndices(originalIndices, out);
         }
 
         @Override
@@ -259,12 +265,6 @@ public class SearchTransportService extends AbstractComponent {
         @Override
         public void readFrom(StreamInput in) throws IOException {
             throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
-            OriginalIndices.writeOriginalIndices(originalIndices, out);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -82,7 +82,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                                  SearchTransportService searchTransportService, SearchPhaseController searchPhaseController,
                                  ClusterService clusterService, ActionFilters actionFilters,
                                  IndexNameExpressionResolver indexNameExpressionResolver) {
-        super(settings, SearchAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver, SearchRequest::new);
+        super(settings, SearchAction.NAME, threadPool, transportService, actionFilters, SearchRequest::new, indexNameExpressionResolver);
         this.searchPhaseController = searchPhaseController;
         this.searchTransportService = searchTransportService;
         this.remoteClusterService = searchTransportService.getRemoteClusterService();

--- a/core/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
@@ -45,8 +45,8 @@ public class TransportSearchScrollAction extends HandledTransportAction<SearchSc
                                        ClusterService clusterService, ActionFilters actionFilters,
                                        IndexNameExpressionResolver indexNameExpressionResolver,
                                        SearchTransportService searchTransportService, SearchPhaseController searchPhaseController) {
-        super(settings, SearchScrollAction.NAME, threadPool, transportService, actionFilters, indexNameExpressionResolver,
-                SearchScrollRequest::new);
+        super(settings, SearchScrollAction.NAME, threadPool, transportService, actionFilters, SearchScrollRequest::new,
+            indexNameExpressionResolver);
         this.clusterService = clusterService;
         this.searchTransportService = searchTransportService;
         this.searchPhaseController = searchPhaseController;

--- a/core/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/core/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -399,8 +399,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        searchRequest = new SearchRequest();
-        searchRequest.readFrom(in);
+        searchRequest = new SearchRequest(in);
         abortOnVersionConflict = in.readBoolean();
         size = in.readVInt();
         refresh = in.readBoolean();

--- a/core/src/main/java/org/elasticsearch/search/fetch/ShardFetchRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/ShardFetchRequest.java
@@ -56,6 +56,24 @@ public class ShardFetchRequest extends TransportRequest {
         this.lastEmittedDoc = lastEmittedDoc;
     }
 
+    public ShardFetchRequest(StreamInput in) throws IOException {
+        super(in);
+        id = in.readLong();
+        size = in.readVInt();
+        docIds = new int[size];
+        for (int i = 0; i < size; i++) {
+            docIds[i] = in.readVInt();
+        }
+        byte flag = in.readByte();
+        if (flag == 1) {
+            lastEmittedDoc = Lucene.readFieldDoc(in);
+        } else if (flag == 2) {
+            lastEmittedDoc = Lucene.readScoreDoc(in);
+        } else if (flag != 0) {
+            throw new IOException("Unknown flag: " + flag);
+        }
+    }
+
     public long id() {
         return id;
     }
@@ -74,21 +92,7 @@ public class ShardFetchRequest extends TransportRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        id = in.readLong();
-        size = in.readVInt();
-        docIds = new int[size];
-        for (int i = 0; i < size; i++) {
-            docIds[i] = in.readVInt();
-        }
-        byte flag = in.readByte();
-        if (flag == 1) {
-            lastEmittedDoc = Lucene.readFieldDoc(in);
-        } else if (flag == 2) {
-            lastEmittedDoc = Lucene.readScoreDoc(in);
-        } else if (flag != 0) {
-            throw new IOException("Unknown flag: " + flag);
-        }
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/fetch/ShardFetchRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/ShardFetchRequest.java
@@ -74,6 +74,25 @@ public class ShardFetchRequest extends TransportRequest {
         }
     }
 
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeLong(id);
+        out.writeVInt(size);
+        for (int i = 0; i < size; i++) {
+            out.writeVInt(docIds[i]);
+        }
+        if (lastEmittedDoc == null) {
+            out.writeByte((byte) 0);
+        } else if (lastEmittedDoc instanceof FieldDoc) {
+            out.writeByte((byte) 1);
+            Lucene.writeFieldDoc(out, (FieldDoc) lastEmittedDoc);
+        } else {
+            out.writeByte((byte) 2);
+            Lucene.writeScoreDoc(out, lastEmittedDoc);
+        }
+    }
+
     public long id() {
         return id;
     }
@@ -93,25 +112,6 @@ public class ShardFetchRequest extends TransportRequest {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeLong(id);
-        out.writeVInt(size);
-        for (int i = 0; i < size; i++) {
-            out.writeVInt(docIds[i]);
-        }
-        if (lastEmittedDoc == null) {
-            out.writeByte((byte) 0);
-        } else if (lastEmittedDoc instanceof FieldDoc) {
-            out.writeByte((byte) 1);
-            Lucene.writeFieldDoc(out, (FieldDoc) lastEmittedDoc);
-        } else {
-            out.writeByte((byte) 2);
-            Lucene.writeScoreDoc(out, lastEmittedDoc);
-        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/fetch/ShardFetchSearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/ShardFetchSearchRequest.java
@@ -46,6 +46,11 @@ public class ShardFetchSearchRequest extends ShardFetchRequest implements Indice
         this.originalIndices = originalIndices;
     }
 
+    public ShardFetchSearchRequest(StreamInput in) throws IOException {
+        super(in);
+        originalIndices = OriginalIndices.readOriginalIndices(in);
+    }
+
     @Override
     public String[] indices() {
         if (originalIndices == null) {
@@ -64,8 +69,7 @@ public class ShardFetchSearchRequest extends ShardFetchRequest implements Indice
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        originalIndices = OriginalIndices.readOriginalIndices(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/fetch/ShardFetchSearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/ShardFetchSearchRequest.java
@@ -52,6 +52,12 @@ public class ShardFetchSearchRequest extends ShardFetchRequest implements Indice
     }
 
     @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        OriginalIndices.writeOriginalIndices(originalIndices, out);
+    }
+
+    @Override
     public String[] indices() {
         if (originalIndices == null) {
             return null;
@@ -70,11 +76,5 @@ public class ShardFetchSearchRequest extends ShardFetchRequest implements Indice
     @Override
     public void readFrom(StreamInput in) throws IOException {
         throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        OriginalIndices.writeOriginalIndices(originalIndices, out);
     }
 }

--- a/core/src/main/java/org/elasticsearch/search/internal/InternalScrollSearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalScrollSearchRequest.java
@@ -44,6 +44,12 @@ public class InternalScrollSearchRequest extends TransportRequest {
         this.scroll = request.scroll();
     }
 
+    public InternalScrollSearchRequest(StreamInput in) throws IOException {
+        super(in);
+        id = in.readLong();
+        scroll = in.readOptionalWriteable(Scroll::new);
+    }
+
     public long id() {
         return id;
     }
@@ -59,9 +65,7 @@ public class InternalScrollSearchRequest extends TransportRequest {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        id = in.readLong();
-        scroll = in.readOptionalWriteable(Scroll::new);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/InternalScrollSearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/InternalScrollSearchRequest.java
@@ -50,6 +50,13 @@ public class InternalScrollSearchRequest extends TransportRequest {
         scroll = in.readOptionalWriteable(Scroll::new);
     }
 
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeLong(id);
+        out.writeOptionalWriteable(scroll);
+    }
+
     public long id() {
         return id;
     }
@@ -66,13 +73,6 @@ public class InternalScrollSearchRequest extends TransportRequest {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeLong(id);
-        out.writeOptionalWriteable(scroll);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -62,6 +62,13 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
         this.originalIndices = originalIndices;
     }
 
+    public ShardSearchTransportRequest(StreamInput in) throws IOException {
+        super(in);
+        shardSearchLocalRequest = new ShardSearchLocalRequest();
+        shardSearchLocalRequest.innerReadFrom(in);
+        originalIndices = OriginalIndices.readOriginalIndices(in);
+    }
+
     public void searchType(SearchType searchType) {
         shardSearchLocalRequest.setSearchType(searchType);
     }
@@ -144,12 +151,9 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        shardSearchLocalRequest = new ShardSearchLocalRequest();
-        shardSearchLocalRequest.innerReadFrom(in);
-        originalIndices = OriginalIndices.readOriginalIndices(in);
-
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
+
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {

--- a/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/internal/ShardSearchTransportRequest.java
@@ -69,6 +69,13 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
         originalIndices = OriginalIndices.readOriginalIndices(in);
     }
 
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        shardSearchLocalRequest.innerWriteTo(out, false);
+        OriginalIndices.writeOriginalIndices(originalIndices, out);
+    }
+
     public void searchType(SearchType searchType) {
         shardSearchLocalRequest.setSearchType(searchType);
     }
@@ -152,14 +159,6 @@ public class ShardSearchTransportRequest extends TransportRequest implements Sha
     @Override
     public void readFrom(StreamInput in) throws IOException {
         throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        shardSearchLocalRequest.innerWriteTo(out, false);
-        OriginalIndices.writeOriginalIndices(originalIndices, out);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
@@ -52,6 +52,13 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
         this.originalIndices = originalIndices;
     }
 
+    public QuerySearchRequest(StreamInput in) throws IOException {
+        super(in);
+        id = in.readLong();
+        dfs = readAggregatedDfs(in);
+        originalIndices = OriginalIndices.readOriginalIndices(in);
+    }
+
     public long id() {
         return id;
     }
@@ -72,10 +79,7 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        id = in.readLong();
-        dfs = readAggregatedDfs(in);
-        originalIndices = OriginalIndices.readOriginalIndices(in);
+        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/search/query/QuerySearchRequest.java
@@ -59,6 +59,14 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
         originalIndices = OriginalIndices.readOriginalIndices(in);
     }
 
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeLong(id);
+        dfs.writeTo(out);
+        OriginalIndices.writeOriginalIndices(originalIndices, out);
+    }
+
     public long id() {
         return id;
     }
@@ -80,14 +88,6 @@ public class QuerySearchRequest extends TransportRequest implements IndicesReque
     @Override
     public void readFrom(StreamInput in) throws IOException {
         throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeLong(id);
-        dfs.writeTo(out);
-        OriginalIndices.writeOriginalIndices(originalIndices, out);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
@@ -46,8 +46,7 @@ public class SearchScrollRequestTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             searchScrollRequest.writeTo(output);
             try (StreamInput in = output.bytes().streamInput()) {
-                SearchScrollRequest deserializedRequest = new SearchScrollRequest();
-                deserializedRequest.readFrom(in);
+                SearchScrollRequest deserializedRequest = new SearchScrollRequest(in);
                 assertEquals(deserializedRequest, searchScrollRequest);
                 assertEquals(deserializedRequest.hashCode(), searchScrollRequest.hashCode());
                 assertNotSame(deserializedRequest, searchScrollRequest);
@@ -61,8 +60,7 @@ public class SearchScrollRequestTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             internalScrollSearchRequest.writeTo(output);
             try (StreamInput in = output.bytes().streamInput()) {
-                InternalScrollSearchRequest deserializedRequest = new InternalScrollSearchRequest();
-                deserializedRequest.readFrom(in);
+                InternalScrollSearchRequest deserializedRequest = new InternalScrollSearchRequest(in);
                 assertEquals(deserializedRequest.id(), internalScrollSearchRequest.id());
                 assertEquals(deserializedRequest.scroll(), internalScrollSearchRequest.scroll());
                 assertNotSame(deserializedRequest, internalScrollSearchRequest);

--- a/core/src/test/java/org/elasticsearch/search/SearchRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/search/SearchRequestTests.java
@@ -43,8 +43,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             searchRequest.writeTo(output);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
-                SearchRequest deserializedRequest = new SearchRequest();
-                deserializedRequest.readFrom(in);
+                SearchRequest deserializedRequest = new SearchRequest(in);
                 assertEquals(deserializedRequest, searchRequest);
                 assertEquals(deserializedRequest.hashCode(), searchRequest.hashCode());
                 assertNotSame(deserializedRequest, searchRequest);

--- a/core/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
@@ -61,8 +61,7 @@ public class ShardSearchTransportRequestTests extends AbstractSearchTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             shardSearchTransportRequest.writeTo(output);
             try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
-                ShardSearchTransportRequest deserializedRequest = new ShardSearchTransportRequest();
-                deserializedRequest.readFrom(in);
+                ShardSearchTransportRequest deserializedRequest = new ShardSearchTransportRequest(in);
                 assertEquals(deserializedRequest.scroll(), shardSearchTransportRequest.scroll());
                 assertEquals(deserializedRequest.getAliasFilter(), shardSearchTransportRequest.getAliasFilter());
                 assertArrayEquals(deserializedRequest.indices(), shardSearchTransportRequest.indices());

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequest.java
@@ -137,7 +137,7 @@ public class SearchTemplateRequest extends ActionRequest implements CompositeInd
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        request = in.readOptionalStreamable(SearchRequest::new);
+        request = in.readOptionalWriteable(SearchRequest::new);
         simulate = in.readBoolean();
         explain = in.readBoolean();
         profile = in.readBoolean();

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -755,15 +755,27 @@ public class ElasticsearchAssertions {
         }
     }
 
+    /**
+     * This attemps to construct a new {@link Streamable} object that is in the process of
+     * being converted from {@link Streamable} to {@link Writeable}. Assuming this constructs
+     * the object successfully, #readFrom should not be called on the constructed object.
+     *
+     * @param streamable the object to retrieve the type of class to construct the new instance from
+     * @param in the stream to read the object from
+     * @return the newly constructed object from reading the stream
+     * @throws NoSuchMethodException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
     private static Streamable tryCreateFromStream(Streamable streamable, StreamInput in) throws NoSuchMethodException,
-        InstantiationException, IllegalAccessException, InvocationTargetException {
+            InstantiationException, IllegalAccessException, InvocationTargetException {
         try {
             Class<? extends Streamable> clazz = streamable.getClass();
             Constructor<? extends Streamable> constructor = clazz.getConstructor(StreamInput.class);
             assertThat(constructor, Matchers.notNullValue());
-            Streamable newInstance = constructor.newInstance(in);
-            return newInstance;
-        } catch (Exception e) {
+            return constructor.newInstance(in);
+        } catch (NoSuchMethodException e) {
             return null;
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -776,7 +776,6 @@ public class ElasticsearchAssertions {
         try {
             Class<? extends Streamable> clazz = streamable.getClass();
             Constructor<? extends Streamable> constructor = clazz.getConstructor(StreamInput.class);
-            assertThat(constructor, Matchers.notNullValue());
             return constructor.newInstance(in);
         } catch (NoSuchMethodException e) {
             return null;

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -763,10 +763,13 @@ public class ElasticsearchAssertions {
      * @param streamable the object to retrieve the type of class to construct the new instance from
      * @param in the stream to read the object from
      * @return the newly constructed object from reading the stream
-     * @throws NoSuchMethodException
-     * @throws InstantiationException
-     * @throws IllegalAccessException
-     * @throws InvocationTargetException
+     * @throws NoSuchMethodException if constuctor cannot be found
+     * @throws InstantiationException if the class represents an abstract class
+     * @throws IllegalAccessException if this {@code Constructor} object
+     *              is enforcing Java language access control and the underlying
+     *              constructor is inaccessible.
+     * @throws InvocationTargetException if the underlying constructor
+     *              throws an exception.
      */
     private static Streamable tryCreateFromStream(Streamable streamable, StreamInput in) throws NoSuchMethodException,
             InstantiationException, IllegalAccessException, InvocationTargetException {


### PR DESCRIPTION
This is a continuation of the Streamable -> Writeable migration. This PR focuses on 
a few of the SearchRequest-related actions.