### PR TITLE
[Tests] Improve testing of FieldSortBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldData.java
@@ -100,6 +100,24 @@ public interface IndexFieldData<FD extends AtomicFieldData> extends IndexCompone
     // on another node (we don't have the custom source them...)
     abstract class XFieldComparatorSource extends FieldComparatorSource {
 
+        protected final MultiValueMode sortMode;
+        protected final Object missingValue;
+        protected final Nested nested;
+
+        public XFieldComparatorSource(Object missingValue, MultiValueMode sortMode, Nested nested) {
+            this.sortMode = sortMode;
+            this.missingValue = missingValue;
+            this.nested = nested;
+        }
+
+        public MultiValueMode sortMode() {
+            return this.sortMode;
+        }
+
+        public Nested nested() {
+            return this.nested;
+        }
+
         /**
          * Simple wrapper class around a filter that matches parent documents
          * and a filter that matches child documents. For every root document R,

--- a/core/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/BytesRefFieldComparatorSource.java
@@ -43,15 +43,10 @@ import java.io.IOException;
 public class BytesRefFieldComparatorSource extends IndexFieldData.XFieldComparatorSource {
 
     private final IndexFieldData<?> indexFieldData;
-    private final MultiValueMode sortMode;
-    private final Object missingValue;
-    private final Nested nested;
 
     public BytesRefFieldComparatorSource(IndexFieldData<?> indexFieldData, Object missingValue, MultiValueMode sortMode, Nested nested) {
+        super(missingValue, sortMode, nested);
         this.indexFieldData = indexFieldData;
-        this.sortMode = sortMode;
-        this.missingValue = missingValue;
-        this.nested = nested;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
@@ -41,15 +41,10 @@ import java.io.IOException;
 public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparatorSource {
 
     private final IndexNumericFieldData indexFieldData;
-    private final Object missingValue;
-    private final MultiValueMode sortMode;
-    private final Nested nested;
 
     public DoubleValuesComparatorSource(IndexNumericFieldData indexFieldData, @Nullable Object missingValue, MultiValueMode sortMode, Nested nested) {
+        super(missingValue, sortMode, nested);
         this.indexFieldData = indexFieldData;
-        this.missingValue = missingValue;
-        this.sortMode = sortMode;
-        this.nested = nested;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
@@ -39,15 +39,10 @@ import java.io.IOException;
 public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparatorSource {
 
     private final IndexNumericFieldData indexFieldData;
-    private final Object missingValue;
-    private final MultiValueMode sortMode;
-    private final Nested nested;
 
     public FloatValuesComparatorSource(IndexNumericFieldData indexFieldData, @Nullable Object missingValue, MultiValueMode sortMode, Nested nested) {
+        super(missingValue, sortMode, nested);
         this.indexFieldData = indexFieldData;
-        this.missingValue = missingValue;
-        this.sortMode = sortMode;
-        this.nested = nested;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
@@ -38,15 +38,10 @@ import java.io.IOException;
 public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorSource {
 
     private final IndexNumericFieldData indexFieldData;
-    private final Object missingValue;
-    private final MultiValueMode sortMode;
-    private final Nested nested;
 
     public LongValuesComparatorSource(IndexNumericFieldData indexFieldData, @Nullable Object missingValue, MultiValueMode sortMode, Nested nested) {
+        super(missingValue, sortMode, nested);
         this.indexFieldData = indexFieldData;
-        this.missingValue = missingValue;
-        this.sortMode = sortMode;
-        this.nested = nested;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -588,7 +588,8 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
                     DocValueFormat.RAW);
         }
 
-        IndexFieldData.XFieldComparatorSource geoDistanceComparatorSource = new IndexFieldData.XFieldComparatorSource() {
+        IndexFieldData.XFieldComparatorSource geoDistanceComparatorSource = new IndexFieldData.XFieldComparatorSource(null, finalSortMode,
+                nested) {
 
             @Override
             public SortField.Type reducedType() {
@@ -599,11 +600,10 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
             public FieldComparator<?> newComparator(String fieldname, int numHits, int sortPos, boolean reversed) {
                 return new FieldComparator.DoubleComparator(numHits, null, null) {
                     @Override
-                    protected NumericDocValues getNumericDocValues(LeafReaderContext context, String field)
-                        throws IOException {
+                    protected NumericDocValues getNumericDocValues(LeafReaderContext context, String field) throws IOException {
                         final MultiGeoPointValues geoPointValues = geoIndexFieldData.load(context).getGeoPointValues();
-                        final SortedNumericDoubleValues distanceValues = GeoUtils.distanceValues(geoDistance, unit,
-                            geoPointValues, localPoints);
+                        final SortedNumericDoubleValues distanceValues = GeoUtils.distanceValues(geoDistance, unit, geoPointValues,
+                                localPoints);
                         final NumericDoubleValues selectedValues;
                         if (nested == null) {
                             selectedValues = finalSortMode.select(distanceValues, Double.POSITIVE_INFINITY);
@@ -617,7 +617,6 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
                     }
                 };
             }
-
         };
 
         return new SortFieldAndFormat(new SortField(fieldName, geoDistanceComparatorSource, reverse),

--- a/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.search.sort;
 
 import org.apache.lucene.search.SortField;
-import org.apache.lucene.util.Accountable;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -35,7 +34,8 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
-import org.elasticsearch.index.fielddata.IndexFieldDataService;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper.BuilderContext;
@@ -47,8 +47,6 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
-import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptModule;
@@ -59,16 +57,19 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 
 public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends ESTestCase {
+
     private static final int NUMBER_OF_TESTBUILDERS = 20;
 
     protected static NamedWriteableRegistry namedWriteableRegistry;
@@ -77,7 +78,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
     private static ScriptService scriptService;
 
     @BeforeClass
-    public static void init() throws IOException {
+    public static void init() {
         Settings baseSettings = Settings.builder()
                 .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())
                 .build();
@@ -166,7 +167,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
     /**
      * Test equality and hashCode properties
      */
-    public void testEqualsAndHashcode() throws IOException {
+    public void testEqualsAndHashcode() {
         for (int runs = 0; runs < NUMBER_OF_TESTBUILDERS; runs++) {
             checkEqualsAndHashCode(createTestItem(), this::copy, this::mutate);
         }
@@ -176,22 +177,14 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
         Index index = new Index(randomAlphaOfLengthBetween(1, 10), "_na_");
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings(index,
             Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build());
-        IndicesFieldDataCache cache = new IndicesFieldDataCache(Settings.EMPTY, null);
-        IndexFieldDataService ifds = new IndexFieldDataService(IndexSettingsModule.newIndexSettings("test", Settings.EMPTY),
-                cache, null, null);
-        BitsetFilterCache bitsetFilterCache = new BitsetFilterCache(idxSettings, new BitsetFilterCache.Listener() {
+        BitsetFilterCache bitsetFilterCache = new BitsetFilterCache(idxSettings, Mockito.mock(BitsetFilterCache.Listener.class));
+        BiFunction<MappedFieldType, String, IndexFieldData<?>> indexFieldDataLookup = (fieldType, fieldIndexName) -> {
+            IndexFieldData.Builder builder = fieldType.fielddataBuilder(fieldIndexName);
+            return builder.build(idxSettings, fieldType, new IndexFieldDataCache.None(), null, null);
+        };
+        return new QueryShardContext(0, idxSettings, bitsetFilterCache, indexFieldDataLookup, null, null, scriptService,
+                xContentRegistry(), namedWriteableRegistry, null, null, () -> randomNonNegativeLong(), null) {
 
-            @Override
-            public void onRemoval(ShardId shardId, Accountable accountable) {
-            }
-
-            @Override
-            public void onCache(ShardId shardId, Accountable accountable) {
-            }
-        });
-        long nowInMillis = randomNonNegativeLong();
-        return new QueryShardContext(0, idxSettings, bitsetFilterCache, ifds::getForField, null, null, scriptService,
-                xContentRegistry(), namedWriteableRegistry, null, null, () -> nowInMillis, null) {
             @Override
             public MappedFieldType fieldMapper(String name) {
                 return provideMappedFieldType(name);
@@ -207,7 +200,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
 
     /**
      * Return a field type. We use {@link NumberFieldMapper.NumberFieldType} by default since it is compatible with all sort modes
-     * Tests that require other field type than double can override this.
+     * Tests that require other field types can override this.
      */
     protected MappedFieldType provideMappedFieldType(String name) {
         NumberFieldMapper.NumberFieldType doubleFieldType = new NumberFieldMapper.NumberFieldType(NumberFieldMapper.NumberType.DOUBLE);
@@ -237,7 +230,7 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
     private T copy(T original) throws IOException {
         /* The cast below is required to make Java 9 happy. Java 8 infers the T in copyWriterable to be the same as AbstractSortTestCase's
          * T but Java 9 infers it to be SortBuilder. */
-        return (T) copyWriteable(original, namedWriteableRegistry,
+        return copyWriteable(original, namedWriteableRegistry,
                 namedWriteableRegistry.getReader(SortBuilder.class, original.getWriteableName()));
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -20,15 +20,33 @@ x * Licensed to Elasticsearch under one or more contributor
 package org.elasticsearch.search.sort;
 
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSelector;
+import org.apache.lucene.search.SortedNumericSortField;
+import org.apache.lucene.search.SortedSetSelector;
+import org.apache.lucene.search.SortedSetSortField;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.Matchers.instanceOf;
+
 public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder> {
+
+    /**
+     * {@link #provideMappedFieldType(String)} will return a
+     */
+    private static String MAPPED_STRING_FIELDNAME = "_stringField";
 
     @Override
     protected FieldSortBuilder createTestItem() {
@@ -125,7 +143,136 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         assertEquals(DocValueFormat.RAW, format);
     }
 
-    public void testReverseOptionFails() throws IOException {
+    /**
+     * Test that missing values get transfered correctly to the SortField
+     */
+    public void testBuildSortFieldMissingValue() throws IOException {
+        QueryShardContext shardContextMock = createMockShardContext();
+        FieldSortBuilder fieldSortBuilder = new FieldSortBuilder("value").missing("_first");
+        SortField sortField = fieldSortBuilder.build(shardContextMock).field;
+        SortedNumericSortField expectedSortField = new SortedNumericSortField("value", SortField.Type.DOUBLE);
+        expectedSortField.setMissingValue(Double.NEGATIVE_INFINITY);
+        assertEquals(expectedSortField, sortField);
+
+        fieldSortBuilder = new FieldSortBuilder("value").missing("_last");
+        sortField = fieldSortBuilder.build(shardContextMock).field;
+        expectedSortField = new SortedNumericSortField("value", SortField.Type.DOUBLE);
+        expectedSortField.setMissingValue(Double.POSITIVE_INFINITY);
+        assertEquals(expectedSortField, sortField);
+
+        Double randomDouble = randomDouble();
+        fieldSortBuilder = new FieldSortBuilder("value").missing(randomDouble);
+        sortField = fieldSortBuilder.build(shardContextMock).field;
+        expectedSortField = new SortedNumericSortField("value", SortField.Type.DOUBLE);
+        expectedSortField.setMissingValue(randomDouble);
+        assertEquals(expectedSortField, sortField);
+
+        fieldSortBuilder = new FieldSortBuilder("value").missing(randomDouble.toString());
+        sortField = fieldSortBuilder.build(shardContextMock).field;
+        expectedSortField = new SortedNumericSortField("value", SortField.Type.DOUBLE);
+        expectedSortField.setMissingValue(randomDouble);
+        assertEquals(expectedSortField, sortField);
+    }
+
+    /**
+     * Test that the sort builder order gets transfered correctly to the SortField
+     */
+    public void testBuildSortFieldOrder() throws IOException {
+        QueryShardContext shardContextMock = createMockShardContext();
+        FieldSortBuilder fieldSortBuilder = new FieldSortBuilder("value");
+        SortField sortField = fieldSortBuilder.build(shardContextMock).field;
+        SortedNumericSortField expectedSortField = new SortedNumericSortField("value", SortField.Type.DOUBLE, false);
+        expectedSortField.setMissingValue(Double.POSITIVE_INFINITY);
+        assertEquals(expectedSortField, sortField);
+
+        fieldSortBuilder = new FieldSortBuilder("value").order(SortOrder.ASC);
+        sortField = fieldSortBuilder.build(shardContextMock).field;
+        expectedSortField = new SortedNumericSortField("value", SortField.Type.DOUBLE, false);
+        expectedSortField.setMissingValue(Double.POSITIVE_INFINITY);
+        assertEquals(expectedSortField, sortField);
+
+        fieldSortBuilder = new FieldSortBuilder("value").order(SortOrder.DESC);
+        sortField = fieldSortBuilder.build(shardContextMock).field;
+        expectedSortField = new SortedNumericSortField("value", SortField.Type.DOUBLE, true, SortedNumericSelector.Type.MAX);
+        expectedSortField.setMissingValue(Double.NEGATIVE_INFINITY);
+        assertEquals(expectedSortField, sortField);
+    }
+
+    /**
+     * Test that the sort builder mode gets transfered correctly to the SortField
+     */
+    public void testMultiValueMode() throws IOException {
+        QueryShardContext shardContextMock = createMockShardContext();
+
+        FieldSortBuilder sortBuilder = new FieldSortBuilder("value").sortMode(SortMode.MIN);
+        SortField sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField, instanceOf(SortedNumericSortField.class));
+        SortedNumericSortField numericSortField = (SortedNumericSortField) sortField;
+        assertEquals(SortedNumericSelector.Type.MIN, numericSortField.getSelector());
+
+        sortBuilder = new FieldSortBuilder("value").sortMode(SortMode.MAX);
+        sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField, instanceOf(SortedNumericSortField.class));
+        numericSortField = (SortedNumericSortField) sortField;
+        assertEquals(SortedNumericSelector.Type.MAX, numericSortField.getSelector());
+
+        sortBuilder = new FieldSortBuilder("value").sortMode(SortMode.SUM);
+        sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
+        XFieldComparatorSource comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
+        assertEquals(MultiValueMode.SUM, comparatorSource.sortMode());
+
+        sortBuilder = new FieldSortBuilder("value").sortMode(SortMode.AVG);
+        sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
+        comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
+        assertEquals(MultiValueMode.AVG, comparatorSource.sortMode());
+
+        sortBuilder = new FieldSortBuilder("value").sortMode(SortMode.MEDIAN);
+        sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
+        comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
+        assertEquals(MultiValueMode.MEDIAN, comparatorSource.sortMode());
+
+        // sort mode should also be set by build() implicitely to MIN or MAX if not set explicitely on builder
+        sortBuilder = new FieldSortBuilder("value");
+        sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField, instanceOf(SortedNumericSortField.class));
+        numericSortField = (SortedNumericSortField) sortField;
+        assertEquals(SortedNumericSelector.Type.MIN, numericSortField.getSelector());
+
+        sortBuilder = new FieldSortBuilder("value").order(SortOrder.DESC);
+        sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField, instanceOf(SortedNumericSortField.class));
+        numericSortField = (SortedNumericSortField) sortField;
+        assertEquals(SortedNumericSelector.Type.MAX, numericSortField.getSelector());
+    }
+
+    /**
+     * Test that the sort builder nested object gets created in the SortField
+     */
+    public void testBuildNested() throws IOException {
+        QueryShardContext shardContextMock = createMockShardContext();
+
+        FieldSortBuilder sortBuilder = new FieldSortBuilder("value").setNestedPath("path");
+        SortField sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
+        XFieldComparatorSource comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
+        assertNotNull(comparatorSource.nested());
+
+        sortBuilder = new FieldSortBuilder("value").setNestedPath("path").setNestedFilter(QueryBuilders.termQuery("field", 10.0));
+        sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField.getComparatorSource(), instanceOf(XFieldComparatorSource.class));
+        comparatorSource = (XFieldComparatorSource) sortField.getComparatorSource();
+        assertNotNull(comparatorSource.nested());
+
+        // if nested path is missing, we omit any filter and return a SortedNumericSortField
+        sortBuilder = new FieldSortBuilder("value").setNestedFilter(QueryBuilders.termQuery("field", 10.0));
+        sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField, instanceOf(SortedNumericSortField.class));
+    }
+
+    public void testUnknownOptionFails() throws IOException {
         String json = "{ \"post_date\" : {\"reverse\" : true} },\n";
 
         XContentParser parser = createParser(JsonXContent.jsonXContent, json);
@@ -134,14 +281,51 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         parser.nextToken();
         parser.nextToken();
 
-        try {
-          FieldSortBuilder.fromXContent(parser, "");
-          fail("adding reverse sorting option should fail with an exception");
-        } catch (IllegalArgumentException e) {
-            // all good
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> FieldSortBuilder.fromXContent(parser, ""));
+        assertEquals("[field_sort] unknown field [reverse], parser not found", e.getMessage());
+    }
+
+    @Override
+    protected MappedFieldType provideMappedFieldType(String name) {
+        if (name.equals(MAPPED_STRING_FIELDNAME)) {
+            KeywordFieldMapper.KeywordFieldType fieldType = new KeywordFieldMapper.KeywordFieldType();
+            fieldType.setName(name);
+            fieldType.setHasDocValues(true);
+            return fieldType;
+        } else {
+            return super.provideMappedFieldType(name);
         }
     }
 
+    /**
+     * Test that MIN, MAX mode work on non-numeric fields, but other modes throw exception
+     */
+    public void testModeNonNumericField() throws IOException {
+        QueryShardContext shardContextMock = createMockShardContext();
+
+        FieldSortBuilder sortBuilder = new FieldSortBuilder(MAPPED_STRING_FIELDNAME).sortMode(SortMode.MIN);
+        SortField sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField, instanceOf(SortedSetSortField.class));
+        assertEquals(SortedSetSelector.Type.MIN, ((SortedSetSortField) sortField).getSelector());
+
+        sortBuilder = new FieldSortBuilder(MAPPED_STRING_FIELDNAME).sortMode(SortMode.MAX);
+        sortField = sortBuilder.build(shardContextMock).field;
+        assertThat(sortField, instanceOf(SortedSetSortField.class));
+        assertEquals(SortedSetSelector.Type.MAX, ((SortedSetSortField) sortField).getSelector());
+
+        String expectedError = "we only support AVG, MEDIAN and SUM on number based fields";
+        QueryShardException e = expectThrows(QueryShardException.class,
+                () -> new FieldSortBuilder(MAPPED_STRING_FIELDNAME).sortMode(SortMode.AVG).build(shardContextMock));
+        assertEquals(expectedError, e.getMessage());
+
+        e = expectThrows(QueryShardException.class,
+                () -> new FieldSortBuilder(MAPPED_STRING_FIELDNAME).sortMode(SortMode.SUM).build(shardContextMock));
+        assertEquals(expectedError, e.getMessage());
+
+        e = expectThrows(QueryShardException.class,
+                () -> new FieldSortBuilder(MAPPED_STRING_FIELDNAME).sortMode(SortMode.MEDIAN).build(shardContextMock));
+        assertEquals(expectedError, e.getMessage());
+    }
 
     @Override
     protected FieldSortBuilder fromXContent(XContentParser parser, String fieldName) throws IOException {


### PR DESCRIPTION
Currently we don't do much unit testing about the SortField that is created then calling the
SortBuilders `build` method. Most of this is covered by integration tests somewhere but it 
would be good to have some basic checks in FieldSortBuilderTest as well. 

This adds testing for the sort order, mode, missing values and checks that `nested` gets set
in the XFieldComparatorSource when `nestedPath` and `nestedFilter` are set on the builder.
Also it is simplifying the setup of the mocked QueryShardContext a bit.

Relates to #17286