### PR TITLE
Use short name for invoking wrapper script

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -152,6 +152,10 @@ class NodeInfo {
         }
         if (config.daemonize) {
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                /*
+                 * We have to delay building the string as the path will not exist during configuration which will fail on Windows due to
+                 * getting the short name requiring the path to already exist.
+                 */
                 args.add("${-> getShortPathName(wrapperScript.toString())}")
             } else {
                 args.add("${wrapperScript}")
@@ -176,17 +180,31 @@ class NodeInfo {
         }
         final File jvmOptionsFile = new File(confDir, 'jvm.options')
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            /*
+             * We have to delay building the string as the path will not exist during configuration which will fail on Windows due to
+             * getting the short name requiring the path to already exist.
+             */
             env.put('ES_JVM_OPTIONS', "${-> getShortPathName(jvmOptionsFile.toString())}")
         } else {
             env.put('ES_JVM_OPTIONS', jvmOptionsFile)
         }
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            /*
+             * We have to delay building the string as the path will not exist during configuration which will fail on Windows due to
+             * getting the short name requiring the path to already exist.
+             */
             args.addAll("-E", "path.conf=${-> getShortPathName(confDir.toString())}")
         } else {
             args.addAll("-E", "path.conf=${confDir}")
         }
         if (!System.properties.containsKey("tests.es.path.data")) {
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                /*
+                 * We have to delay building the string as the path will not exist during configuration which will fail on Windows due to
+                 * getting the short name requiring the path to already exist. This one is extra tricky because usually we rely on the node
+                 * creating its data directory on startup but we simply can not do that here because getting the short path name requires
+                 * the directory to already exist. Therefore, we create this directory immediately before getting the short name.
+                 */
                 args.addAll("-E", "path.data=${-> Files.createDirectories(Paths.get(dataDir.toString())); getShortPathName(dataDir.toString())}")
             } else {
                 args.addAll("-E", "path.data=${-> dataDir.toString()}")


### PR DESCRIPTION
When starting a node in standalone tests, we sometimes use a wrapper script as opposed to starting Elasticsearch directly (this is used for backgrounding). On Windows, the path to this wrapper script can be exceptionally long, exceeding the length of a batch script that cmd.exe will invoke without whining. This commit replaces using the full path name for this wrapper script by the short name for the wrapper script.

Additionally, the data, configuration, and jvm.options paths can also end up being too long so we shorten those too. Care has to be taken with the data directory because we usually rely on the node creating it on startup but doing that will not be compatible with getting the short name as that requires the directory already existing. Therefore, we create that directory on-demand immediately before actually resolving the short name.

Relates #26365 