### PR TITLE
Remove dead path conf BWC code in build

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -186,17 +186,6 @@ class NodeInfo {
         else {
             env.put('ES_PATH_CONF', pathConf)
         }
-        if (Version.fromString(nodeVersion).major == 5) {
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                /*
-                 * We have to delay building the string as the path will not exist during configuration which will fail on Windows due to
-                 * getting the short name requiring the path to already exist.
-                 */
-                args.addAll("-E", "path.conf=${-> getShortPathName(pathConf.toString())}")
-            } else {
-                args.addAll("-E", "path.conf=${pathConf}")
-            }
-        }
         if (!System.properties.containsKey("tests.es.path.data")) {
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 /*


### PR DESCRIPTION
When changing how the config path is configured (from a command-line flag to an environment variable) we had to add BWC code in the build so that we could form clusters with 5.x nodes in them. Now that this branch has moved to 7.x, we no longer need to be BWC with 5.x for starting nodes. This commit removes this dead BWC code.

