### PR TITLE
dont re-compute SortedSetDocValues for each segment when its not chan…

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalMapping.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalMapping.java
@@ -36,9 +36,9 @@ public class GlobalOrdinalMapping extends SortedSetDocValues {
     private final LongValues mapping;
     private final SortedSetDocValues[] bytesValues;
 
-    GlobalOrdinalMapping(OrdinalMap ordinalMap, SortedSetDocValues[] bytesValues, int segmentIndex) {
+    GlobalOrdinalMapping(OrdinalMap ordinalMap, SortedSetDocValues[] bytesValues, int segmentIndex, SortedSetDocValues segmentValues) {
         super();
-        this.values = bytesValues[segmentIndex];
+        this.values = segmentValues;
         this.bytesValues = bytesValues;
         this.ordinalMap = ordinalMap;
         this.mapping = ordinalMap.getGlobalOrds(segmentIndex);

--- a/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -149,7 +149,7 @@ public class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent impleme
                 // segment ordinals match global ordinals
                 return values;
             }
-            return new GlobalOrdinalMapping(ordinalMap, globalOrdinalValues.get(), segmentIndex);
+            return new GlobalOrdinalMapping(ordinalMap, globalOrdinalValues.get(), segmentIndex, values);
         }
 
         @Override


### PR DESCRIPTION
Yelp search uses elasticsearch version 5.1.1 for text searching and aggregations. Recently we started seeing very **high cpu** usage on some nodes (3-5% of total nodes). 

**Background**

- we do aggregations on our queries for a few keyword type fields of varying cardinality, such that num_cardinality varies from ~1000 to ~40,000 for different fields.

Although our sharding configuration is subject to change, the one at the time of the incident was:

- 25-30 segments per shard with the size of segments varying from 100Mb to 5Gb. 
- 30-40 shards per index 
- 8-10 shards per elasticsearch JVM (replicas included)

**Analysis**
- Upon some investigation ([_nodes/hot_threads](https://gist.github.com/umeshdangat/a2b30adb3401b9fd170daa93362784c5) and  jstack)the hotspot in code was revealed to be the **GlobalOrdinalsIndexFieldData.getOrdinalsValues**() call.  
- This call is made  for every segment. 
- Looks like we end up computing the SortedSetDocValues[] repeatedly for each segment even though they don't change in the scope of a single GlobalOrdinalsIndexFieldData instance?
- This object does get rebuilt upon adding new_segments, etc. (refresh_interval).

Reason for using threadLocal in the patch:  [From Lucene docs](https://lucene.apache.org/core/6_3_0/core/org/apache/lucene/index/LeafReader.html#getSortedDocValues-java.lang.String-)
```
/** Returns {@link SortedSetDocValues} for this field, or
*  null if no {@link SortedSetDocValues} were indexed for
*  this field.  The returned instance should only be
*  used by a single thread. */
public abstract SortedSetDocValues getSortedSetDocValues(String field) throws IOException;

```

We deployed this "fix" as an emergency patch and it did bring down our cpu usage drastically. I also see this issue mentioned on [discuss](http://elasticsearch-users.115913.n3.nabble.com/Elasticserach-High-CPU-td4075400.html).

<img width="588" alt="screen shot 2017-08-28 at 8 30 13 am 1" src="https://user-images.githubusercontent.com/4211071/29890648-3079b638-8d7d-11e7-909f-8d19e2a2ca23.png">

**Potential issues with the proposed patch**
- Hard to reproduce in 5.1.1 (outside of our prod env) I think it depends on the segment_size and number of segments amongst other factors(#cores, #shards per node )
- Also, As I understand this "fix" might increase the memory usage in order of:
   ` num_shards_per_node * num_search_threads_per_node * num_keyword_fields_aggregated_upon * maxOrd(unique_values) * size_of_each_SortedSetDocValueRow`
 Is this understanding correct? Having said that, the heap usage does not seem to be an issue for us post applying this change


Note: @Yelp we use 5.1.1 hence the change on our system looks more like [this](https://github.com/elastic/elasticsearch/compare/v5.1.1...umeshdangat:v5.1.1_dont_aggregate_segment_ordinals_for_each_segment)

Manual testing:

**Single threaded test:**

- mapping:
```
curl -XPUT localhost:9200/test_1 -d '{
  "mappings": {
    "my_type": {
      "properties": {
        "tags": {
          "type":  "keyword"
        }
      }
    }
  },
  "settings": {
    "index": {
         "number_of_shards": 2,
         "number_of_replicas": 0
     }
   }
}'
```

- Insert one doc

`curl -XPUT localhost:9200/test_1/my_type/1 -d '{"tags":["one", "two", "three"]}' -H 'Content-Type: application/json'
`

- Insert second doc

`curl -XPUT localhost:9200/test_1/my_type/2 -d '{"tags":["two", "three"]}' -H 'Content-Type: application/json`

- Insert third doc

`curl -XPUT localhost:9200/test_1/my_type/3 -d '{"tags":["three", "four"]}' -H 'Content-Type: application/json
`
- query using aggregations

```
curl localhost:9200/test_1/_search -d '{
  "query": {"match_all": {}} ,
"aggs":{
"places_stats": {
      "terms": {
        "field": "tags"
      },
      "aggs": {
        "weight": {
          "sum": {
            "script": {
              "inline": "1",
              "lang": "painless"
            }
          }
        }
      }
    }
}}'
```

**Multi threaded tests:**
Run in multiple terminals the following command
```
for i in `seq 1 1000`;do curl localhost:9200/test_1/_search -d@query_aggs.json; done
for i in `seq 1 1000`;do curl localhost:9200/test_1/_search -d@query_aggs.json; done

```
