### PR TITLE
[DOCS] Add documentation for adaptive replica selection

### DIFF
--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -368,3 +368,12 @@ So what is the right number of replicas? If you have a cluster that has
 be able to cope with `max_failures` node failures at once at most, then the
 right number of replicas for you is
 `max(max_failures, ceil(num_nodes / num_primaries) - 1)`.
+
+[float]
+=== Turn on adaptive replica selection
+
+When multiple copies of data are present, elasticsearch can use a set of
+criteria called <<search-adaptive-replica,adaptive replica selection>> to select
+the best copy of the data based on response time, service time, and queue size
+of the node containing each copy of the shard. This can improve query throughput
+and reduce latency for search-heavy applications.

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -57,6 +57,34 @@ separated string. This will result in hitting the relevant shards where
 the routing values match to.
 
 [float]
+[[search-adaptive-replica]]
+== Adaptive Replica Selection
+
+As an alternative to requests being sent to copies of the data in a round robin
+fashion, you may enable adaptive replica selection. This allows the coordinating
+node to send the request to the copy deemed "best" based on a number of
+criteria:
+
+- Response time of past requests between the coordinating node and the node
+  containing the copy of the data
+- Time past search requests took to execute on the node containing the data
+- The queue size of the search threadpool on the node containing the data
+
+This can be turned on by changing the dynamic cluster setting
+`cluster.routing.use_adaptive_replica_selection` from `false` to `true`:
+
+[source,js]
+--------------------------------------------------
+PUT /_cluster/settings
+{
+    "transient": {
+        "cluster.routing.use_adaptive_replica_selection": true
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
 [[stats-groups]]
 == Stats Groups
 


### PR DESCRIPTION
This adds a blurb for adaptive replica selection since it was previously
undocumented.

Relates to #24915
