### PR TITLE
[Tests] Check that quoteAnalyzer overrides analyzer in `query_string` query

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -63,6 +63,11 @@ with default operator of `AND`, the same query is translated to
 
 |`analyzer` |The analyzer name used to analyze the query string.
 
+|`quote_analyzer` |The name of the analyzer that is used to analyze
+quoted phrases in the query string. For those parts, it overrides other
+analyzers that are set using the `analyzer` parameter or the
+<<search-quote-analyzer,`search_quote_analyzer`>> setting.
+
 |`allow_leading_wildcard` |When set, `*` or `?` are allowed as the first
 character. Defaults to `true`.
 
@@ -73,7 +78,7 @@ increments in result queries. Defaults to `true`.
 expand to. Defaults to `50`
 
 |`fuzziness` |Set the fuzziness for fuzzy queries. Defaults
-to `AUTO`. See  <<fuzziness>> for allowed settings.
+to `AUTO`. See <<fuzziness>> for allowed settings.
 
 |`fuzzy_prefix_length` |Set the prefix length for fuzzy queries. Default
 is `0`.


### PR DESCRIPTION
Adding a check to QueryStringQueryBuilderTests that checks the override
behaviour of `quote_analyzer`, also adding documentation explaining the use of
this parameter in `query_string` query.

Closes #25417