### PR TITLE
Correcting the value of swappiness

### DIFF
--- a/docs/reference/setup/sysconfig/swap.asciidoc
+++ b/docs/reference/setup/sysconfig/swap.asciidoc
@@ -38,7 +38,7 @@ via `System Properties → Advanced → Performance → Advanced → Virtual mem
 ==== Configure `swappiness`
 
 Another option available on Linux systems is to ensure that the sysctl value
-`vm.swappiness` is set to `1`. This reduces the kernel's tendency to swap and
+`vm.swappiness` is set to `0`. This reduces the kernel's tendency to swap and
 should not lead to swapping under normal circumstances, while still allowing the
 whole system to swap in emergency conditions.
 


### PR DESCRIPTION
To disable swap, vm.swappiness should be set to '0' and not '1'.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
