### PR TITLE
Prohibit using `nested_filter`, `nested_path` and new `nested` Option at the same time in FieldSortBuilder

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -91,7 +91,9 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         }
         this.setNestedFilter(template.getNestedFilter());
         this.setNestedPath(template.getNestedPath());
-        this.setNestedSort(template.getNestedSort());
+        if (template.getNestedSort() != null) {
+            this.setNestedSort(template.getNestedSort());
+        };
     }
 
     /**
@@ -207,6 +209,9 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      */
     @Deprecated
     public FieldSortBuilder setNestedFilter(QueryBuilder nestedFilter) {
+        if (this.nestedSort != null) {
+            throw new IllegalArgumentException("Setting both nested_path/nested_filter and nested not allowed");
+        }
         this.nestedFilter = nestedFilter;
         return this;
     }
@@ -231,6 +236,9 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      */
     @Deprecated
     public FieldSortBuilder setNestedPath(String nestedPath) {
+        if (this.nestedSort != null) {
+            throw new IllegalArgumentException("Setting both nested_path/nested_filter and nested not allowed");
+        }
         this.nestedPath = nestedPath;
         return this;
     }
@@ -259,6 +267,9 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      * order to be taken into account for sorting.
      */
     public FieldSortBuilder setNestedSort(final NestedSortBuilder nestedSort) {
+        if (this.nestedFilter != null || this.nestedPath != null) {
+            throw new IllegalArgumentException("Setting both nested_path/nested_filter and nested not allowed");
+        }
         this.nestedSort = nestedSort;
         return this;
     }

--- a/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.search.sort;
 
-import static org.elasticsearch.search.sort.NestedSortBuilder.NESTED_FIELD;
-
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
@@ -45,6 +43,8 @@ import org.elasticsearch.search.MultiValueMode;
 
 import java.io.IOException;
 import java.util.Objects;
+
+import static org.elasticsearch.search.sort.NestedSortBuilder.NESTED_FIELD;
 
 /**
  * A sort builder to sort based on a document field.
@@ -203,9 +203,9 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      * Sets the nested filter that the nested objects should match with in order
      * to be taken into account for sorting.
      *
-     * TODO should the above getters and setters be deprecated/ changed in
-     * favour of real getters and setters?
+     * @deprecated set nested sort with {@link #setNestedSort(NestedSortBuilder)} and retrieve with {@link #getNestedSort()}
      */
+    @Deprecated
     public FieldSortBuilder setNestedFilter(QueryBuilder nestedFilter) {
         this.nestedFilter = nestedFilter;
         return this;
@@ -214,7 +214,10 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     /**
      * Returns the nested filter that the nested objects should match with in
      * order to be taken into account for sorting.
+     *
+     * @deprecated set nested sort with {@link #setNestedSort(NestedSortBuilder)} and retrieve with {@link #getNestedSort()}
      */
+    @Deprecated
     public QueryBuilder getNestedFilter() {
         return this.nestedFilter;
     }
@@ -223,7 +226,10 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
      * Sets the nested path if sorting occurs on a field that is inside a nested
      * object. By default when sorting on a field inside a nested object, the
      * nearest upper nested object is selected as nested path.
+     *
+     * @deprecated set nested sort with {@link #setNestedSort(NestedSortBuilder)} and retrieve with {@link #getNestedSort()}
      */
+    @Deprecated
     public FieldSortBuilder setNestedPath(String nestedPath) {
         this.nestedPath = nestedPath;
         return this;
@@ -232,15 +238,26 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     /**
      * Returns the nested path if sorting occurs in a field that is inside a
      * nested object.
+     * @deprecated set nested sort with {@link #setNestedSort(NestedSortBuilder)} and retrieve with {@link #getNestedSort()}
      */
+    @Deprecated
     public String getNestedPath() {
         return this.nestedPath;
     }
 
+    /**
+     * Returns the {@link NestedSortBuilder}
+     */
     public NestedSortBuilder getNestedSort() {
         return this.nestedSort;
     }
 
+    /**
+     * Sets the {@link NestedSortBuilder} to be used for fields that are inside a nested
+     * object. The {@link NestedSortBuilder} takes a `path` argument and an optional
+     * nested filter that the nested objects should match with in
+     * order to be taken into account for sorting.
+     */
     public FieldSortBuilder setNestedSort(final NestedSortBuilder nestedSort) {
         this.nestedSort = nestedSort;
         return this;

--- a/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -134,7 +134,12 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
             assertNotSame(testItem, parsedItem);
             assertEquals(testItem, parsedItem);
             assertEquals(testItem.hashCode(), parsedItem.hashCode());
+            assertWarnings(testItem);
         }
+    }
+
+    protected void assertWarnings(T testItem) {
+        // assert potential warnings based on the test sort configuration. Do nothing by default, subtests can overwrite
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -85,14 +85,17 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
             builder.sortMode(randomFrom(SortMode.values()));
         }
         if (randomBoolean()) {
-            builder.setNestedSort(createRandomNestedSort(3));
-        }
-        // the following are alternative ways to setNestedSort for nested sorting
-        if (randomBoolean()) {
-            builder.setNestedFilter(randomNestedFilter());
-        }
-        if (randomBoolean()) {
-            builder.setNestedPath(randomAlphaOfLengthBetween(1, 10));
+            if (randomBoolean()) {
+                builder.setNestedSort(createRandomNestedSort(3));
+            } else {
+                // the following are alternative ways to setNestedSort for nested sorting
+                if (randomBoolean()) {
+                    builder.setNestedFilter(randomNestedFilter());
+                }
+                if (randomBoolean()) {
+                    builder.setNestedPath(randomAlphaOfLengthBetween(1, 10));
+                }
+            }
         }
         return builder;
     }


### PR DESCRIPTION
Currently we allow both "old" and "new" way of setting nested sorts on the 
FieldSortBuilder at the same time. This should throw an error, instead the user
should choose one of the two possible options.

Also adding testing for the now deprecated nestedPath/nestedFilter parameters,
inlcuding checks that they emmit warnings on parsing and that the new
NestetedSortBuilder overwrites the deprecated parameters when building the
SortField.

Relates to #17286