### PR TITLE
Fix wrong indent in gateway documentation (minor)

### DIFF
--- a/docs/reference/modules/gateway.asciidoc
+++ b/docs/reference/modules/gateway.asciidoc
@@ -4,9 +4,9 @@
 The local gateway module stores the cluster state and shard data across full
 cluster restarts.
 
- The following _static_ settings, which must be set on every master node,
-  control how long a freshly elected master should wait before it tries to
-  recover the cluster state and the cluster's data:
+The following _static_ settings, which must be set on every master node,
+control how long a freshly elected master should wait before it tries to
+recover the cluster state and the cluster's data:
 
 `gateway.expected_nodes`::
 


### PR DESCRIPTION
This changeset fixes a spurious indent that causes a code block to be generated instead of a regular paragraph.