### PR TITLE
Close the light connection when removing an address from TransportClient

### DIFF
--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -210,7 +210,8 @@ final class TransportClientNodesService extends AbstractComponent implements Clo
                 if (!otherNode.getAddress().equals(transportAddress)) {
                     listNodesBuilder.add(otherNode);
                 } else {
-                    logger.debug("removing address [{}] from listed nodes", otherNode);
+                    logger.debug("disconnecting from listed node with address [{}]", otherNode);
+                    transportService.disconnectFromNode(otherNode);
                 }
             }
             listedNodes = Collections.unmodifiableList(listNodesBuilder);


### PR DESCRIPTION
There seems to be a connection leak in the TransportClient when using removeTransportAddress()

## Stating the problem

When adding an address with `TransportClient.addTransportAddresses()`, the `TransportClientNodesService` adds a DiscoveryNode to listedNodes and ends up calling `nodeSampler.sample()`. In my case I have the `SimpleNodeSampler`. 
For the new address (not already connected), the sampling is doing a 'light connection' with `TransportService.connectToNodeLight()`, which delegates to an instance of `Transport`. In my case, the Transport impl is a NettyTransport, which will open a Channel to the target node.

So here we have the newly created DiscoveryNode referenced in the listedNodes List of the TransportClientNodesService and a Channel cached in the NettyTransport
's connectedNodes map.

When removing an address from the `TransportClient`, the TransportClientNodesService is doing the following:
1) removing the address from the listedNodes
2) removing the address from the nodes and disconnecting
3) calling the NodeSampler to refresh

What I believe is missing is closing the connection when removing the node from listedNodes, because we have an opened Channel cached in NettyTransport.
This PR fixes this by asking the Transport to disconnect from the listed node upon removal to close the light connection.

## How to reproduce

I am using an Elastic Cloud cluster, doing periodically a DNS resolution of the name and adding/removing addresses from the TransportClient accordingly. 
For each address removed, a connection is leaked, and is visible with tools like lsof or with a debugger.

## Closing note

I am using Elasticsearch 2.4, and while I know that upgrading to 5 is the way froward, I don't have time to do it right now, so I would appreciate a backport of this fix to the 2.4 branch to avoid having to build and deploy a fork of the client.