### PR TITLE
Remove deprecated parameters from `ids_query`

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/IdsQueryBuilder.java
@@ -51,7 +51,7 @@ import static org.elasticsearch.common.xcontent.ObjectParser.fromList;
 public class IdsQueryBuilder extends AbstractQueryBuilder<IdsQueryBuilder> {
     public static final String NAME = "ids";
 
-    private static final ParseField TYPE_FIELD = new ParseField("type", "types", "_type");
+    private static final ParseField TYPE_FIELD = new ParseField("type");
     private static final ParseField VALUES_FIELD = new ParseField("values");
 
     private final Set<String> ids = new HashSet<>();

--- a/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -149,35 +149,4 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
         assertThat(parsed.ids(), contains("1","100","4"));
         assertEquals(json, 0, parsed.types().length);
     }
-
-    public void testFromJsonDeprecatedSyntax() throws IOException {
-        IdsQueryBuilder testQuery = new IdsQueryBuilder().types("my_type");
-
-        //single value type can also be called _type
-        final String contentString = "{\n" +
-                "    \"ids\" : {\n" +
-                "        \"_type\" : \"my_type\",\n" +
-                "        \"values\" : [ ]\n" +
-                "    }\n" +
-                "}";
-
-        IdsQueryBuilder parsed = (IdsQueryBuilder) parseQuery(contentString);
-        assertEquals(testQuery, parsed);
-
-        parseQuery(contentString);
-        assertWarnings("Deprecated field [_type] used, expected [type] instead");
-
-        //array of types can also be called types rather than type
-        final String contentString2 = "{\n" +
-                "    \"ids\" : {\n" +
-                "        \"types\" : [\"my_type\"],\n" +
-                "        \"values\" : [ ]\n" +
-                "    }\n" +
-                "}";
-        parsed = (IdsQueryBuilder) parseQuery(contentString2);
-        assertEquals(testQuery, parsed);
-
-        parseQuery(contentString2);
-        assertWarnings("Deprecated field [types] used, expected [type] instead");
-    }
 }


### PR DESCRIPTION
The `_type` and `types` version of the current `type` parameter have been
deprecated since 5.0. We can remove support for them in 7.0 and also in 6.x and
6.0.