### PR TITLE
Handle point queries with 2 or more dimensions correctly

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
@@ -355,6 +355,10 @@ final class QueryAnalyzer {
     private static BiFunction<Query, Map<String, Float>, Result> pointRangeQuery() {
         return (query, boosts) -> {
             PointRangeQuery pointRangeQuery = (PointRangeQuery) query;
+            if (pointRangeQuery.getNumDims() != 1) {
+                throw new UnsupportedQueryException(query);
+            }
+
             byte[] lowerPoint = pointRangeQuery.getLowerPoint();
             byte[] upperPoint = pointRangeQuery.getUpperPoint();
             byte[] interval = new byte[16];

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.HalfFloatPoint;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.Term;
@@ -741,6 +742,15 @@ public class QueryAnalyzerTests extends ESTestCase {
         assertEquals("_field", ranges.get(0).range.fieldName);
         assertArrayEquals(ranges.get(0).range.lowerPoint, InetAddressPoint.encode(InetAddresses.forString("192.168.1.0")));
         assertArrayEquals(ranges.get(0).range.upperPoint, InetAddressPoint.encode(InetAddresses.forString("192.168.1.255")));
+    }
+
+    public void testTooManyPointDimensions() {
+        // For now no extraction support for geo queries:
+        Query query1 = LatLonPoint.newBoxQuery("_field", 0, 1, 0, 1);
+        expectThrows(UnsupportedQueryException.class, () -> analyze(query1, Collections.emptyMap()));
+
+        Query query2 = LongPoint.newRangeQuery("_field", new long[]{0, 0, 0}, new long[]{1, 1, 1});
+        expectThrows(UnsupportedQueryException.class, () -> analyze(query2, Collections.emptyMap()));
     }
 
     public void testIndexOrDocValuesQuery() {


### PR DESCRIPTION
The `QueryAnalyzer` can only handle point queries with a single dimension.
Non issue, because this fixes a bug in unreleased code.
This caused percolator queries with geo queries to never match in snapshot versions from 6.x branch and master branch.