### PR TITLE
Internal: Add versionless alias for rest client codebase in policy files

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -205,6 +205,11 @@ final class Security {
                     }
                     String property = "codebase." + shortName;
                     if (shortName.startsWith("elasticsearch-rest-client")) {
+                        // The rest client is currently the only example where we have an elasticsearch built artifact
+                        // which needs special permissions in policy files when used. This temporary solution is to
+                        // pass in an extra system property that omits the -version.jar suffix the other properties have.
+                        // That allows the snapshots to reference snapshot builds of the client, and release builds to
+                        // referenced release builds of the client, all with the same grant statements.
                         final String esVersion = Version.CURRENT + (Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "");
                         final int index = property.indexOf("-" + esVersion + ".jar");
                         assert index >= 0;
@@ -222,7 +227,6 @@ final class Security {
             } finally {
                 // clear codebase properties
                 for (String property : propertiesSet) {
-                    System.out.println("Unsetting " + property);
                     System.clearProperty(property);
                 }
             }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -205,12 +205,11 @@ final class Security {
                     }
                     if (shortName.startsWith("elasticsearch-rest-client")) {
                         final String esVersion = Version.CURRENT + (Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "");
-                        System.setProperty("es.version", esVersion);
-                        propertiesSet.add("es.version");
-                        final String urlAsString = url.toString();
-                        final int index = urlAsString.indexOf("-" + System.getProperty("es.version") + ".jar");
+                        final int index = shortName.indexOf("-" + esVersion + ".jar");
                         assert index >= 0;
-                        shortName = urlAsString.substring(0, index);
+                        String restClientAlias = "codebase." + shortName.substring(0, index);
+                        propertiesSet.add(restClientAlias);
+                        System.setProperty(restClientAlias, url.toString());
                     }
                     String property = "codebase." + shortName;
                     propertiesSet.add(property);
@@ -223,6 +222,7 @@ final class Security {
             } finally {
                 // clear codebase properties
                 for (String property : propertiesSet) {
+                    System.out.println("Unsetting " + property);
                     System.clearProperty(property);
                 }
             }

--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -203,15 +203,15 @@ final class Security {
                     if (shortName.endsWith(".jar") == false) {
                         continue; // tests :(
                     }
+                    String property = "codebase." + shortName;
                     if (shortName.startsWith("elasticsearch-rest-client")) {
                         final String esVersion = Version.CURRENT + (Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "");
-                        final int index = shortName.indexOf("-" + esVersion + ".jar");
+                        final int index = property.indexOf("-" + esVersion + ".jar");
                         assert index >= 0;
-                        String restClientAlias = "codebase." + shortName.substring(0, index);
+                        String restClientAlias = property.substring(0, index);
                         propertiesSet.add(restClientAlias);
                         System.setProperty(restClientAlias, url.toString());
                     }
-                    String property = "codebase." + shortName;
                     propertiesSet.add(property);
                     String previous = System.setProperty(property, url.toString());
                     if (previous != null) {

--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -24,14 +24,14 @@
 //// SecurityManager impl:
 //// Must have all permissions to properly perform access checks
 
-grant codeBase "${codebase.securesm-1.1.jar}" {
+grant codeBase "${codebase.securesm.jar}" {
   permission java.security.AllPermission;
 };
 
 //// Very special jar permissions:
 //// These are dangerous permissions that we don't want to grant to everything.
 
-grant codeBase "${codebase.lucene-core-7.0.0-snapshot-d94a5f0.jar}" {
+grant codeBase "${codebase.lucene-core.jar}" {
   // needed to allow MMapDirectory's "unmap hack" (die unmap hack, die)
   // java 8 package
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
@@ -42,7 +42,7 @@ grant codeBase "${codebase.lucene-core-7.0.0-snapshot-d94a5f0.jar}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
-grant codeBase "${codebase.lucene-misc-7.0.0-snapshot-d94a5f0.jar}" {
+grant codeBase "${codebase.lucene-misc.jar}" {
   // needed to allow shard shrinking to use hard-links if possible via lucenes HardlinkCopyDirectoryWrapper
   permission java.nio.file.LinkPermission "hard";
 };

--- a/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -24,14 +24,14 @@
 //// SecurityManager impl:
 //// Must have all permissions to properly perform access checks
 
-grant codeBase "${codebase.securesm.jar}" {
+grant codeBase "${codebase.securesm-1.1.jar}" {
   permission java.security.AllPermission;
 };
 
 //// Very special jar permissions:
 //// These are dangerous permissions that we don't want to grant to everything.
 
-grant codeBase "${codebase.lucene-core.jar}" {
+grant codeBase "${codebase.lucene-core-7.0.0-snapshot-d94a5f0.jar}" {
   // needed to allow MMapDirectory's "unmap hack" (die unmap hack, die)
   // java 8 package
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
@@ -42,7 +42,7 @@ grant codeBase "${codebase.lucene-core.jar}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
-grant codeBase "${codebase.lucene-misc.jar}" {
+grant codeBase "${codebase.lucene-misc-7.0.0-snapshot-d94a5f0.jar}" {
   // needed to allow shard shrinking to use hard-links if possible via lucenes HardlinkCopyDirectoryWrapper
   permission java.nio.file.LinkPermission "hard";
 };

--- a/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -21,7 +21,7 @@
 //// These are mock objects and test management that we allow test framework libs
 //// to provide on our behalf. But tests themselves cannot do this stuff!
 
-grant codeBase "${codebase.securemock.jar}" {
+grant codeBase "${codebase.securemock-1.2.jar}" {
   // needed to access ReflectionFactory (see below)
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
   // needed for reflection in ibm jdk
@@ -33,7 +33,7 @@ grant codeBase "${codebase.securemock.jar}" {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
-grant codeBase "${codebase.lucene-test-framework.jar}" {
+grant codeBase "${codebase.lucene-test-framework-7.0.0-snapshot-d94a5f0.jar}" {
   // needed by RamUsageTester
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed for testing hardlinks in StoreRecoveryTests since we install MockFS
@@ -42,7 +42,7 @@ grant codeBase "${codebase.lucene-test-framework.jar}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
-grant codeBase "${codebase.randomizedtesting-runner.jar}" {
+grant codeBase "${codebase.randomizedtesting-runner-2.5.2.jar}" {
   // optionally needed for access to private test methods (e.g. beforeClass)
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed to fail tests on uncaught exceptions from other threads
@@ -53,29 +53,29 @@ grant codeBase "${codebase.randomizedtesting-runner.jar}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
-grant codeBase "${codebase.junit.jar}" {
+grant codeBase "${codebase.junit-4.12.jar}" {
   // needed for TestClass creation
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
-grant codeBase "${codebase.mocksocket.jar}" {
+grant codeBase "${codebase.mocksocket-1.2.jar}" {
   // mocksocket makes and accepts socket connections
   permission java.net.SocketPermission "*", "accept,connect";
 };
 
-grant codeBase "${codebase.elasticsearch-rest-client.jar}" {
+grant codeBase "${codebase.elasticsearch-rest-client}-${es.version}.jar" {
   // rest makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";
   // rest client uses system properties which gets the default proxy
   permission java.net.NetPermission "getProxySelector";
 };
 
-grant codeBase "${codebase.httpcore-nio.jar}" {
+grant codeBase "${codebase.httpcore-nio-4.4.5.jar}" {
   // httpcore makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";
 };
 
-grant codeBase "${codebase.httpasyncclient.jar}" {
+grant codeBase "${codebase.httpasyncclient-4.1.2.jar}" {
   // httpasyncclient makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";
   // rest client uses system properties which gets the default proxy

--- a/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -21,7 +21,7 @@
 //// These are mock objects and test management that we allow test framework libs
 //// to provide on our behalf. But tests themselves cannot do this stuff!
 
-grant codeBase "${codebase.securemock-1.2.jar}" {
+grant codeBase "${codebase.securemock.jar}" {
   // needed to access ReflectionFactory (see below)
   permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
   // needed for reflection in ibm jdk
@@ -33,7 +33,7 @@ grant codeBase "${codebase.securemock-1.2.jar}" {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };
 
-grant codeBase "${codebase.lucene-test-framework-7.0.0-snapshot-d94a5f0.jar}" {
+grant codeBase "${codebase.lucene-test-framework.jar}" {
   // needed by RamUsageTester
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed for testing hardlinks in StoreRecoveryTests since we install MockFS
@@ -42,7 +42,7 @@ grant codeBase "${codebase.lucene-test-framework-7.0.0-snapshot-d94a5f0.jar}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
-grant codeBase "${codebase.randomizedtesting-runner-2.5.2.jar}" {
+grant codeBase "${codebase.randomizedtesting-runner.jar}" {
   // optionally needed for access to private test methods (e.g. beforeClass)
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed to fail tests on uncaught exceptions from other threads
@@ -53,29 +53,29 @@ grant codeBase "${codebase.randomizedtesting-runner-2.5.2.jar}" {
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
-grant codeBase "${codebase.junit-4.12.jar}" {
+grant codeBase "${codebase.junit.jar}" {
   // needed for TestClass creation
   permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
 
-grant codeBase "${codebase.mocksocket-1.2.jar}" {
+grant codeBase "${codebase.mocksocket.jar}" {
   // mocksocket makes and accepts socket connections
   permission java.net.SocketPermission "*", "accept,connect";
 };
 
-grant codeBase "${codebase.elasticsearch-rest-client-7.0.0-alpha1-SNAPSHOT.jar}" {
+grant codeBase "${codebase.elasticsearch-rest-client.jar}" {
   // rest makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";
   // rest client uses system properties which gets the default proxy
   permission java.net.NetPermission "getProxySelector";
 };
 
-grant codeBase "${codebase.httpcore-nio-4.4.5.jar}" {
+grant codeBase "${codebase.httpcore-nio.jar}" {
   // httpcore makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";
 };
 
-grant codeBase "${codebase.httpasyncclient-4.1.2.jar}" {
+grant codeBase "${codebase.httpasyncclient.jar}" {
   // httpasyncclient makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";
   // rest client uses system properties which gets the default proxy

--- a/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/core/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -63,7 +63,7 @@ grant codeBase "${codebase.mocksocket-1.2.jar}" {
   permission java.net.SocketPermission "*", "accept,connect";
 };
 
-grant codeBase "${codebase.elasticsearch-rest-client}-${es.version}.jar" {
+grant codeBase "${codebase.elasticsearch-rest-client}" {
   // rest makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";
   // rest client uses system properties which gets the default proxy

--- a/modules/reindex/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/reindex/src/main/plugin-metadata/plugin-security.policy
@@ -22,7 +22,7 @@ grant {
    permission java.net.SocketPermission "*", "connect";
 };
 
-grant codeBase "${codebase.elasticsearch-rest-client-7.0.0-alpha1-SNAPSHOT.jar}" {
+grant codeBase "${codebase.elasticsearch-rest-client}-${es.version}.jar" {
   // rest client uses system properties which gets the default proxy
   permission java.net.NetPermission "getProxySelector";
 };

--- a/modules/reindex/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/reindex/src/main/plugin-metadata/plugin-security.policy
@@ -22,7 +22,7 @@ grant {
    permission java.net.SocketPermission "*", "connect";
 };
 
-grant codeBase "${codebase.elasticsearch-rest-client}-${es.version}.jar" {
+grant codeBase "${codebase.elasticsearch-rest-client}" {
   // rest client uses system properties which gets the default proxy
   permission java.net.NetPermission "getProxySelector";
 };


### PR DESCRIPTION
Security manager policy files contains grants for specific codebases,
where a codebase is a jar file. We use a system property containing the
name of the jar file to resolve the jar file location when parsing the
policy file. However, this means the version of the jars must be
modified when versions of dependencies change. This is particularly
messy for elasticsearch, where we now have a dependency on the rest
client, and need to support both a snapshot version for testing and non
snapshot for release.

This commit removes the version portion of the jar file name. The
implications are we will no longer need to edit policy files when
dependencies change, and do not need any special handling for snapshot
vs release builds and their internal policy files in the core
elasticsearch jar.