### PR TITLE
Enable adaptive replica selection by default

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 public class OperationRouting extends AbstractComponent {
 
     public static final Setting<Boolean> USE_ADAPTIVE_REPLICA_SELECTION_SETTING =
-            Setting.boolSetting("cluster.routing.use_adaptive_replica_selection", false,
+            Setting.boolSetting("cluster.routing.use_adaptive_replica_selection", true,
                     Setting.Property.Dynamic, Setting.Property.NodeScope);
 
     private String[] awarenessAttributes;

--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -368,12 +368,3 @@ So what is the right number of replicas? If you have a cluster that has
 be able to cope with `max_failures` node failures at once at most, then the
 right number of replicas for you is
 `max(max_failures, ceil(num_nodes / num_primaries) - 1)`.
-
-[float]
-=== Turn on adaptive replica selection
-
-When multiple copies of data are present, elasticsearch can use a set of
-criteria called <<search-adaptive-replica,adaptive replica selection>> to select
-the best copy of the data based on response time, service time, and queue size
-of the node containing each copy of the shard. This can improve query throughput
-and reduce latency for search-heavy applications.

--- a/docs/reference/migration/migrate_7_0.asciidoc
+++ b/docs/reference/migration/migrate_7_0.asciidoc
@@ -28,8 +28,10 @@ way to reindex old indices is to use the `reindex` API.
 * <<breaking_70_cluster_changes>>
 * <<breaking_70_indices_changes>>
 * <<breaking_70_mappings_changes>>
+* <<breaking_70_search_changes>>
 
 include::migrate_7_0/aggregations.asciidoc[]
 include::migrate_7_0/cluster.asciidoc[]
 include::migrate_7_0/indices.asciidoc[]
 include::migrate_7_0/mappings.asciidoc[]
+include::migrate_7_0/search.asciidoc[]

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -1,0 +1,20 @@
+[[breaking_70_search_changes]]
+=== Search changes
+
+==== Adaptive replica selection enabled by default
+
+Adaptive replica selection has been enabled by default. If you wish to return to
+the older round robin of search requests, you can use the
+`cluster.routing.use_adaptive_replica_selection` setting:
+
+[source,js]
+--------------------------------------------------
+PUT /_cluster/settings
+{
+    "transient": {
+        "cluster.routing.use_adaptive_replica_selection": false
+    }
+}
+--------------------------------------------------
+// CONSOLE
+

--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -11,10 +11,11 @@ exception of the <<search-explain>> endpoints.
 [[search-routing]]
 == Routing
 
-When executing a search, it will be broadcast to all the index/indices
-shards (round robin between replicas). Which shards will be searched on
-can be controlled by providing the `routing` parameter. For example,
-when indexing tweets, the routing value can be the user name:
+When executing a search, Elasticsearch will pick the "best" copy of the data
+based on the <<search-adaptive-replica,adaptive replica selection>> formula.
+Which shards will be searched on can also be controlled by providing the
+`routing` parameter. For example, when indexing tweets, the routing value can be
+the user name:
 
 [source,js]
 --------------------------------------------------
@@ -60,29 +61,32 @@ the routing values match to.
 [[search-adaptive-replica]]
 == Adaptive Replica Selection
 
-As an alternative to requests being sent to copies of the data in a round robin
-fashion, you may enable adaptive replica selection. This allows the coordinating
-node to send the request to the copy deemed "best" based on a number of
-criteria:
+By default, Elasticsearch will use what is called adaptive replica selection.
+This allows the coordinating node to send the request to the copy deemed "best"
+based on a number of criteria:
 
 - Response time of past requests between the coordinating node and the node
   containing the copy of the data
 - Time past search requests took to execute on the node containing the data
 - The queue size of the search threadpool on the node containing the data
 
-This can be turned on by changing the dynamic cluster setting
-`cluster.routing.use_adaptive_replica_selection` from `false` to `true`:
+This can be turned off by changing the dynamic cluster setting
+`cluster.routing.use_adaptive_replica_selection` from `true` to `false`:
 
 [source,js]
 --------------------------------------------------
 PUT /_cluster/settings
 {
     "transient": {
-        "cluster.routing.use_adaptive_replica_selection": true
+        "cluster.routing.use_adaptive_replica_selection": false
     }
 }
 --------------------------------------------------
 // CONSOLE
+
+If adaptive replica selection is turned off, searches are sent to the
+index/indices shards in a round robin fashion between all copies of the data
+(primaries and replicas).
 
 [float]
 [[stats-groups]]


### PR DESCRIPTION
Relates to #24915

This is only for 7.0 only, as this is a breaking change.