### PR TITLE
Protect SortBuilder.toString() from JsonGenerationException.

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
@@ -34,7 +34,9 @@ public abstract class SortBuilder implements ToXContent {
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.prettyPrint();
+            builder.startObject();
             toXContent(builder, EMPTY_PARAMS);
+            builder.endObject();
             return builder.string();
         } catch (Exception e) {
             throw new ElasticsearchException("Failed to build query", e);

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -1,43 +1,18 @@
 package org.elasticsearch.search.sort;
 
-import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 
-import java.util.Arrays;
-
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 
 public class FieldSortBuilderTests extends ESTestCase {
 
-    private static final String FIELDNAME = "myfield";
-    private static final String QUOTES = "\"";
-
-    public void testToXContent() throws Exception {
-        FieldSortBuilder fieldSortBuilder = prepareFSB();
-        XContentBuilder xc = XContentFactory.contentBuilder(XContentType.JSON);
-        xc.startObject();
-        fieldSortBuilder.toXContent(xc, FieldSortBuilder.EMPTY_PARAMS);
-        xc.endObject();
-
-        assertThat(xc.string(), stringContainsInOrder(
-                Arrays.asList(QUOTES + FIELDNAME + QUOTES, QUOTES + "order" + QUOTES, QUOTES + SortOrder.ASC.toString() + QUOTES)));
-    }
-
     public void testToString() throws Exception {
-        FieldSortBuilder fsb = prepareFSB();
+        FieldSortBuilder fsb = SortBuilders.fieldSort("myfield");
+        fsb.order(SortOrder.ASC);
 
         String fsbPrint = fsb.toString();
 
-        assertThat(fsbPrint, stringContainsInOrder(
-                Arrays.asList(QUOTES + FIELDNAME + QUOTES, QUOTES + "order" + QUOTES, QUOTES + SortOrder.ASC.toString() + QUOTES)));
-    }
-
-    private FieldSortBuilder prepareFSB() {
-        FieldSortBuilder fieldSortBuilder = SortBuilders.fieldSort(FIELDNAME);
-        fieldSortBuilder.order(SortOrder.ASC);
-        return fieldSortBuilder;
+        assertThat(fsbPrint, equalToIgnoringWhiteSpace("{ \"myfield\" : { \"order\" : \"asc\" } }"));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.elasticsearch.search.sort;
 
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -1,0 +1,43 @@
+package org.elasticsearch.search.sort;
+
+import static org.hamcrest.Matchers.stringContainsInOrder;
+
+import java.util.Arrays;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.test.ESTestCase;
+
+public class FieldSortBuilderTests extends ESTestCase {
+
+    private static final String FIELDNAME = "myfield";
+    private static final String QUOTES = "\"";
+
+    public void testToXContent() throws Exception {
+        FieldSortBuilder fieldSortBuilder = prepareFSB();
+        XContentBuilder xc = XContentFactory.contentBuilder(XContentType.JSON);
+        xc.startObject();
+        fieldSortBuilder.toXContent(xc, FieldSortBuilder.EMPTY_PARAMS);
+        xc.endObject();
+
+        assertThat(xc.string(), stringContainsInOrder(
+                Arrays.asList(QUOTES + FIELDNAME + QUOTES, QUOTES + "order" + QUOTES, QUOTES + SortOrder.ASC.toString() + QUOTES)));
+    }
+
+    public void testToString() throws Exception {
+        FieldSortBuilder fsb = prepareFSB();
+
+        String fsbPrint = fsb.toString();
+
+        assertThat(fsbPrint, stringContainsInOrder(
+                Arrays.asList(QUOTES + FIELDNAME + QUOTES, QUOTES + "order" + QUOTES, QUOTES + SortOrder.ASC.toString() + QUOTES)));
+    }
+
+    private FieldSortBuilder prepareFSB() {
+        FieldSortBuilder fieldSortBuilder = SortBuilders.fieldSort(FIELDNAME);
+        fieldSortBuilder.order(SortOrder.ASC);
+        return fieldSortBuilder;
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.search.sort;
 
-import static org.hamcrest.Matchers.containsString;
-
 import java.util.Map;
 
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -66,7 +64,7 @@ public class ScriptSortBuilderTests extends ESTestCase {
 
         String ssbPrint = ssb.toString();
 
-        assertThat(ssbPrint, containsString("testtype"));
+        assertTrue(ssbPrint.contains("\"inline\" : \"testscript\""));
     }
     
 }

--- a/core/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.search.sort;
 
-import com.google.common.collect.ImmutableMap;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.Map;
 
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -29,7 +31,7 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
 
 public class ScriptSortBuilderTests extends ESTestCase {
 
@@ -58,4 +60,13 @@ public class ScriptSortBuilderTests extends ESTestCase {
         
         assertEquals(xcWith.string(), xcWithOut.string());
     }
+    
+    public void testToString() {
+        ScriptSortBuilder ssb = prepareSSB();
+
+        String ssbPrint = ssb.toString();
+
+        assertThat(ssbPrint, containsString("testtype"));
+    }
+    
 }


### PR DESCRIPTION
It fixes #20853. As @s1monw said in #20853 in 5.0 is been fixed and haven't been ported to 2.4 branch. 

SortBuilder.toString() throws an exception when tries to generate the Json equivalent string. Though is not a critical bug, the calls to this function must be protected in order to prevent the exception and the consecuent break.

I've added two test to ensure the right behaviour of the toString() function. 