### PR TITLE
Add missing catch arguments to the rest api spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -163,12 +163,16 @@ be caught and tested.  For instance:
 The argument to `catch` can be any of:
 
 [horizontal]
-`missing`::     a 404 response from ES
-`conflict`::    a 409 response from ES
-`request`::     a generic error response from ES
-`param`::       a client-side error indicating an unknown parameter has been passed
-                to the method
-`/foo bar/`::   the text of the error message matches this regular expression
+`unauthorized`::    a 401 response from ES
+`forbidden`::       a 403 response from ES
+`missing`::         a 404 response from ES
+`request_timeout`:: a 408 response from ES
+`conflict`::        a 409 response from ES
+`unavailable`::     a 503 response from ES
+`request`::         a generic error response from ES
+`param`::           a client-side error indicating an unknown parameter has been passed
+                    to the method
+`/foo bar/`::       the text of the error message matches this regular expression
 
 If `catch` is specified, then the `response` var must be cleared, and the test
 should fail if no error is thrown.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -168,8 +168,9 @@ The argument to `catch` can be any of:
 `missing`::         a 404 response from ES
 `request_timeout`:: a 408 response from ES
 `conflict`::        a 409 response from ES
+`request`::         a 4xx-5xx error response from ES, not equal to any named response
+                    above
 `unavailable`::     a 503 response from ES
-`request`::         a generic error response from ES
 `param`::           a client-side error indicating an unknown parameter has been passed
                     to the method
 `/foo bar/`::       the text of the error message matches this regular expression


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/613352/30171875-bb990278-93b8-11e7-98cb-97af21d94b1d.png)
