### PR TITLE
Throw a better error message for empty field names

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -175,14 +175,21 @@ final class DocumentParser {
     }
 
     private static String[] splitAndValidatePath(String fullFieldPath) {
-        String[] parts = fullFieldPath.split("\\.");
-        for (String part : parts) {
-            if (Strings.hasText(part) == false) {
-                throw new IllegalArgumentException(
-                    "object field starting or ending with a [.] makes object resolution ambiguous: [" + fullFieldPath + "]");
+        if (fullFieldPath.contains(".")) {
+            String[] parts = fullFieldPath.split("\\.");
+            for (String part : parts) {
+                if (Strings.hasText(part) == false) {
+                    throw new IllegalArgumentException(
+                            "object field starting or ending with a [.] makes object resolution ambiguous: [" + fullFieldPath + "]");
+                }
             }
+            return parts;
+        } else {
+            if (Strings.isEmpty(fullFieldPath)) {
+                throw new IllegalArgumentException("field name cannot be an empty string");
+            }
+            return new String[] {fullFieldPath};
         }
-        return parts;
     }
 
     /** Creates a Mapping containing any dynamically added fields, or returns null if there were no dynamic mappings. */

--- a/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/core/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -250,6 +250,6 @@ public class IndexActionIT extends ESIntegTestCase {
         );
         assertThat(e.getMessage(), containsString("failed to parse"));
         assertThat(e.getRootCause().getMessage(),
-                containsString("object field starting or ending with a [.] makes object resolution ambiguous: []"));
+                containsString("field name cannot be an empty string"));
     }
 }


### PR DESCRIPTION
When a document is parsed with a `""` for a field name, we currently throw a
confusing error about `.` being present in the field. This changes the error
message to be clearer about what's causing the problem.

Resolves #23348
