### PR TITLE
Snapshot fallback should consider build.snapshot

### DIFF
--- a/core/src/main/java/org/elasticsearch/Build.java
+++ b/core/src/main/java/org/elasticsearch/Build.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch;
 
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -59,7 +60,18 @@ public class Build {
             // not running from the official elasticsearch jar file (unit tests, IDE, uber client jar, shadiness)
             shortHash = "Unknown";
             date = "Unknown";
-            isSnapshot = true;
+            final String buildSnapshot = System.getProperty("build.snapshot");
+            if (buildSnapshot != null) {
+                try {
+                    Class.forName("com.carrotsearch.randomizedtesting.RandomizedContext");
+                } catch (final ClassNotFoundException e) {
+                    // we are not in tests but build.snapshot is set, bail hard
+                    throw new IllegalStateException("build.snapshot set to [" + buildSnapshot + "] but not running tests");
+                }
+                isSnapshot = Booleans.parseBoolean(buildSnapshot);
+            } else {
+                isSnapshot = true;
+            }
         }
         if (shortHash == null) {
             throw new IllegalStateException("Error finding the build shortHash. " +

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -141,7 +141,7 @@ public class ReproduceInfoPrinter extends RunListener {
                 appendProperties(ESIntegTestCase.TESTS_ENABLE_MOCK_MODULES);
             }
             appendProperties("tests.assertion.disabled", "tests.security.manager", "tests.nightly", "tests.jvms",
-                             "tests.client.ratio", "tests.heap.size", "tests.bwc", "tests.bwc.version");
+                             "tests.client.ratio", "tests.heap.size", "tests.bwc", "tests.bwc.version", "build.snapshot");
             if (System.getProperty("tests.jvm.argline") != null && !System.getProperty("tests.jvm.argline").isEmpty()) {
                 appendOpt("tests.jvm.argline", "\"" + System.getProperty("tests.jvm.argline") + "\"");
             }


### PR DESCRIPTION
When determining if a build is a snapshot build, we look for a field in the JAR manifest. However, when running tests, we are not running with a compiled core Elasticsearch JAR, we are running with the compiled core classes on the classpath. We have a fallback for this, we always assume such a situation is a snapshot build. However, when running builds with -Dbuild.snapshot=false, this is not the case. As such, we need to fallback to the value of build.snapshot. However, there are cases where we are not running with a compiled core Elasticsearch JAR (e.g., when the transport client is embedded in a web container) so we should only do this fallback if we are in tests. To verify we are in tests, we check if randomized runner is on the classpath.

Closes #26546
