### PR TITLE
Add MSI breaking change to release notes

### DIFF
--- a/docs/reference/release-notes/5.5.3.asciidoc
+++ b/docs/reference/release-notes/5.5.3.asciidoc
@@ -5,6 +5,14 @@ See https://www.elastic.co/blog/multi-data-path-bug-in-elasticsearch-5-3-0[Multi
 
 Also see <<breaking-changes-5.5>>.
 
+[[breaking-msi-5.5.3]]
+[float]
+=== Breaking MSI Windows Installer changes
+
+Upgrades from 5.5.0, 5.5.1, 5.5.2. See https://github.com/elastic/windows-installers/releases/tag/v5.5.3[release notes]::
+* `ES_HOME` and `ES_CONFIG` environment variables unset after successful upgrade
+* Windows Service stopped after successful upgrade
+
 [[deprecation-5.5.3]]
 [float]
 === Deprecations

--- a/docs/reference/release-notes/5.6.0.asciidoc
+++ b/docs/reference/release-notes/5.6.0.asciidoc
@@ -3,6 +3,14 @@
 
 Also see <<breaking-changes-5.6>>.
 
+[[breaking-msi-5.6.0]]
+[float]
+=== Breaking MSI Windows Installer changes
+
+Upgrades from 5.5.0, 5.5.1, 5.5.2. See https://github.com/elastic/windows-installers/releases/tag/v5.6.0[release notes]::
+* `ES_HOME` and `ES_CONFIG` environment variables unset after successful upgrade
+* Windows Service stopped after successful upgrade
+
 [[breaking-java-5.6.0]]
 [float]
 === Breaking Java changes


### PR DESCRIPTION
Add a section to the 5.5.3 and 5.6.0 release notes about upgrades using the MSI Windows Installer from 5.5.0, 5.5.1 and 5.5.2, pointing to the [Windows Installer releases](https://github.com/elastic/windows-installers/releases)