### PR TITLE
Fix unmapped_type creation for indices created in 2.x 

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -724,7 +724,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             if (typeParser == null) {
                 throw new IllegalArgumentException("No mapper found for type [" + type + "]");
             }
-            final Mapper.Builder<?, ?> builder = typeParser.parse("__anonymous_" + type, emptyMap(), parserContext);
+            final Mapper.Builder<?, ?> builder = typeParser.parse("__anonymous_" + type, new HashMap<>(), parserContext);
             final BuilderContext builderContext = new BuilderContext(indexSettings.getSettings(), new ContentPath(1));
             fieldType = ((FieldMapper)builder.build(builderContext)).fieldType();
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -167,7 +167,16 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testUnmappedFieldType() {
-        Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT);
+        assertUnmappedFieldType(Version.CURRENT);
+    }
+
+    public void testUnmappedFieldTypeBWC() {
+        // test BWC with indices created in 2.x
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_4_6);
+        assertUnmappedFieldType(version);
+    }
+
+    private void assertUnmappedFieldType(Version version) {
         MapperService mapperService =
             createIndex("index", Settings.builder().put("index.version.created", version).build()).mapperService();
         assertThat(mapperService.unmappedFieldType("keyword"), instanceOf(KeywordFieldType.class));

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -29,13 +29,16 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.VersionUtils;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,6 +52,11 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 
 public class MapperServiceTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singletonList(InternalSettingsPlugin.class);
+    }
 
     public void testTypeNameStartsWithIllegalDot() {
         String index = "test-index";
@@ -179,10 +187,21 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
     private void assertUnmappedFieldType(Version version) {
         MapperService mapperService =
             createIndex("index", Settings.builder().put("index.version.created", version).build()).mapperService();
-        assertThat(mapperService.unmappedFieldType("keyword"), instanceOf(KeywordFieldType.class));
-        assertThat(mapperService.unmappedFieldType("long"), instanceOf(NumberFieldType.class));
-        // back compat
-        assertThat(mapperService.unmappedFieldType("string"), instanceOf(KeywordFieldType.class));
+        if (version.after(Version.V_2_4_6)) {
+            assertThat(mapperService.unmappedFieldType("keyword"), instanceOf(KeywordFieldType.class));
+        } else {
+            assertThat(mapperService.unmappedFieldType("keyword"), instanceOf(StringFieldType.class));
+        }
+        if (version.after(Version.V_2_4_6)) {
+            assertThat(mapperService.unmappedFieldType("long"), instanceOf(NumberFieldType.class));
+        } else {
+            assertThat(mapperService.unmappedFieldType("long"), instanceOf(LegacyLongFieldMapper.LongFieldType.class));
+        }
+        if (version.after(Version.V_2_4_6)) {
+            assertThat(mapperService.unmappedFieldType("string"), instanceOf(KeywordFieldType.class));
+        } else {
+            assertThat(mapperService.unmappedFieldType("string"), instanceOf(StringFieldType.class));
+        }
         assertWarnings("[unmapped_type:string] should be replaced with [unmapped_type:keyword]");
     }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -29,6 +30,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper.KeywordFieldType;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberFieldType;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.VersionUtils;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -165,7 +167,9 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testUnmappedFieldType() {
-        MapperService mapperService = createIndex("index").mapperService();
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT);
+        MapperService mapperService =
+            createIndex("index", Settings.builder().put("index.version.created", version).build()).mapperService();
         assertThat(mapperService.unmappedFieldType("keyword"), instanceOf(KeywordFieldType.class));
         assertThat(mapperService.unmappedFieldType("long"), instanceOf(NumberFieldType.class));
         // back compat

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -860,7 +860,16 @@ public class FieldSortIT extends ESIntegTestCase {
     }
 
     public void testIgnoreUnmapped() throws Exception {
-        Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT);
+        assertIgnoreUnmapped(Version.CURRENT);
+    }
+
+    public void testIgnoreUnmappedBWC() throws Exception{
+        // test BWC with indices created in 2.x
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.V_2_4_6);
+        assertIgnoreUnmapped(version);
+    }
+
+    private void assertIgnoreUnmapped(Version version) throws IOException {
         prepareCreate("test")
             .setSettings(Settings.builder().put(indexSettings()).put("index.version.created", version).build()).get();
 

--- a/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/core/src/test/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -23,12 +23,14 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
 import org.apache.lucene.util.UnicodeUtil;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -39,6 +41,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.test.VersionUtils;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -857,7 +860,9 @@ public class FieldSortIT extends ESIntegTestCase {
     }
 
     public void testIgnoreUnmapped() throws Exception {
-        createIndex("test");
+        Version version = VersionUtils.randomVersionBetween(random(), Version.V_2_0_0, Version.CURRENT);
+        prepareCreate("test")
+            .setSettings(Settings.builder().put(indexSettings()).put("index.version.created", version).build()).get();
 
         client().prepareIndex("test", "type1", "1").setSource(jsonBuilder().startObject()
                 .field("id", "1")


### PR DESCRIPTION
Setting unmapped_type to `keyword` to sort an index created in 2.x throws an UnsupportedOperationException.

Fixes #26162