### PR TITLE
Remove MapperService#dynamic.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -97,6 +97,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     public static final Setting<Long> INDEX_MAPPING_DEPTH_LIMIT_SETTING =
             Setting.longSetting("index.mapping.depth.limit", 20L, 1, Property.Dynamic, Property.IndexScope);
     public static final boolean INDEX_MAPPER_DYNAMIC_DEFAULT = true;
+    @Deprecated
     public static final Setting<Boolean> INDEX_MAPPER_DYNAMIC_SETTING =
         Setting.boolSetting("index.mapper.dynamic", INDEX_MAPPER_DYNAMIC_DEFAULT,
                 Property.Dynamic, Property.IndexScope, Property.Deprecated);

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -50,7 +50,6 @@ import org.elasticsearch.index.mapper.Mapper.BuilderContext;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.InvalidTypeNameException;
-import org.elasticsearch.indices.TypeMissingException;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 
 import java.io.Closeable;
@@ -99,7 +98,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             Setting.longSetting("index.mapping.depth.limit", 20L, 1, Property.Dynamic, Property.IndexScope);
     public static final boolean INDEX_MAPPER_DYNAMIC_DEFAULT = true;
     public static final Setting<Boolean> INDEX_MAPPER_DYNAMIC_SETTING =
-        Setting.boolSetting("index.mapper.dynamic", INDEX_MAPPER_DYNAMIC_DEFAULT, Property.Dynamic, Property.IndexScope);
+        Setting.boolSetting("index.mapper.dynamic", INDEX_MAPPER_DYNAMIC_DEFAULT,
+                Property.Dynamic, Property.IndexScope, Property.Deprecated);
 
     private static ObjectHashSet<String> META_FIELDS = ObjectHashSet.from(
             "_uid", "_id", "_type", "_parent", "_routing", "_index",
@@ -109,11 +109,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(MapperService.class));
 
     private final IndexAnalyzers indexAnalyzers;
-
-    /**
-     * Will create types automatically if they do not exists in the mapping definition yet
-     */
-    private final boolean dynamic;
 
     private volatile String defaultMappingSource;
 
@@ -148,24 +143,15 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         this.searchQuoteAnalyzer = new MapperAnalyzerWrapper(indexAnalyzers.getDefaultSearchQuoteAnalyzer(), p -> p.searchQuoteAnalyzer());
         this.mapperRegistry = mapperRegistry;
 
-        if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_6_0_0_alpha1)) {
-            if (INDEX_MAPPER_DYNAMIC_SETTING.exists(indexSettings.getSettings())) {
-                if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_7_0_0_alpha1)) {
-                    throw new IllegalArgumentException("Setting " + INDEX_MAPPER_DYNAMIC_SETTING.getKey() + " was removed after version 6.0.0");
-                } else {
-                    DEPRECATION_LOGGER.deprecated("Setting " + INDEX_MAPPER_DYNAMIC_SETTING.getKey() + " is deprecated since indices may not have more than one type anymore.");
-                }
-            }
-            this.dynamic = INDEX_MAPPER_DYNAMIC_DEFAULT;
-        } else {
-            this.dynamic = this.indexSettings.getValue(INDEX_MAPPER_DYNAMIC_SETTING);
+        if (INDEX_MAPPER_DYNAMIC_SETTING.exists(indexSettings.getSettings()) &&
+                indexSettings.getIndexVersionCreated().onOrAfter(Version.V_7_0_0_alpha1)) {
+            throw new IllegalArgumentException("Setting " + INDEX_MAPPER_DYNAMIC_SETTING.getKey() + " was removed after version 6.0.0");
         }
+
         defaultMappingSource = "{\"_default_\":{}}";
 
         if (logger.isTraceEnabled()) {
-            logger.trace("using dynamic[{}], default mapping source[{}]", dynamic, defaultMappingSource);
-        } else if (logger.isDebugEnabled()) {
-            logger.debug("using dynamic[{}]", dynamic);
+            logger.trace("default mapping source[{}]", defaultMappingSource);
         }
     }
 
@@ -738,10 +724,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         DocumentMapper mapper = mappers.get(type);
         if (mapper != null) {
             return new DocumentMapperForType(mapper, null);
-        }
-        if (!dynamic) {
-            throw new TypeMissingException(index(),
-                    new IllegalStateException("trying to auto create mapping, but dynamic mapping is disabled"), type);
         }
         mapper = parse(type, null, true);
         return new DocumentMapperForType(mapper, mapper.mapping());

--- a/core/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
@@ -108,16 +108,6 @@ public class AutoCreateIndexTests extends ESTestCase {
                 buildClusterState("index1", "index2", "index3")), equalTo(false));
     }
 
-    public void testDynamicMappingDisabled() {
-        Settings settings = Settings.builder().put(AutoCreateIndex.AUTO_CREATE_INDEX_SETTING.getKey(), randomFrom(true,
-                randomAlphaOfLengthBetween(1, 10)))
-            .put(MapperService.INDEX_MAPPER_DYNAMIC_SETTING.getKey(), false).build();
-        AutoCreateIndex autoCreateIndex = newAutoCreateIndex(settings);
-        IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () ->
-            autoCreateIndex.shouldAutoCreate(randomAlphaOfLengthBetween(1, 10), buildClusterState()));
-        assertEquals("no such index and [index.mapper.dynamic] is [false]", e.getMessage());
-    }
-
     public void testAutoCreationPatternEnabled() {
         Settings settings = Settings.builder().put(AutoCreateIndex.AUTO_CREATE_INDEX_SETTING.getKey(), randomFrom("+index*", "index*"))
                 .build();

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingVersionTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingVersionTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -62,6 +63,7 @@ public class DynamicMappingVersionTests extends ESSingleNodeTestCase {
             .build();
         Exception e = expectThrows(IllegalArgumentException.class, () -> createIndex("test-index", settings));
         assertEquals(e.getMessage(), "Setting index.mapper.dynamic was removed after version 6.0.0");
+        assertSettingDeprecationsAndWarnings(new Setting[] { MapperService.INDEX_MAPPER_DYNAMIC_SETTING });
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingVersionTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DynamicMappingVersionTests.java
@@ -19,12 +19,9 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.indices.TypeMissingException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
@@ -67,14 +64,4 @@ public class DynamicMappingVersionTests extends ESSingleNodeTestCase {
         assertEquals(e.getMessage(), "Setting index.mapper.dynamic was removed after version 6.0.0");
     }
 
-    public void testDynamicMappingDisablePreEs6() {
-        Settings settingsPreEs6 = Settings.builder()
-            .put(MapperService.INDEX_MAPPER_DYNAMIC_SETTING.getKey(), false)
-            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_5_0_0)
-            .build();
-        MapperService preEs6MapperService = createIndex("pre-es6-index", settingsPreEs6).mapperService();
-        Exception e = expectThrows(TypeMissingException.class,
-            () -> preEs6MapperService.documentMapperWithAutoCreate("pre-es6-type"));
-        assertEquals(e.getMessage(), "type[pre-es6-type] missing");
-    }
 }


### PR DESCRIPTION
We ignore it as of 6.0 and forbid it as of 7.0.