### PR TITLE
Add boolean similarity to built in similarity types

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -46,32 +46,32 @@ public final class SimilarityService extends AbstractIndexComponent {
     public static final Map<String, SimilarityProvider.Factory> BUILT_IN;
     static {
         Map<String, SimilarityProvider.Factory> defaults = new HashMap<>();
-        Map<String, SimilarityProvider.Factory> buildIn = new HashMap<>();
+        Map<String, SimilarityProvider.Factory> builtIn = new HashMap<>();
         defaults.put("classic",
                 (name, settings, indexSettings, scriptService) -> new ClassicSimilarityProvider(name, settings, indexSettings));
         defaults.put("BM25",
                 (name, settings, indexSettings, scriptService) -> new BM25SimilarityProvider(name, settings, indexSettings));
         defaults.put("boolean",
                 (name, settings, indexSettings, scriptService) -> new BooleanSimilarityProvider(name, settings, indexSettings));
-        buildIn.put("classic",
+        builtIn.put("classic",
                 (name, settings, indexSettings, scriptService) -> new ClassicSimilarityProvider(name, settings, indexSettings));
-        buildIn.put("BM25",
+        builtIn.put("BM25",
                 (name, settings, indexSettings, scriptService) -> new BM25SimilarityProvider(name, settings, indexSettings));
-        buildIn.put("boolean",
+        builtIn.put("boolean",
                 (name, settings, indexSettings, scriptService) -> new BooleanSimilarityProvider(name, settings, indexSettings));
-        buildIn.put("DFR",
+        builtIn.put("DFR",
                 (name, settings, indexSettings, scriptService) -> new DFRSimilarityProvider(name, settings, indexSettings));
-        buildIn.put("IB",
+        builtIn.put("IB",
                 (name, settings, indexSettings, scriptService) -> new IBSimilarityProvider(name, settings, indexSettings));
-        buildIn.put("LMDirichlet",
+        builtIn.put("LMDirichlet",
                 (name, settings, indexSettings, scriptService) -> new LMDirichletSimilarityProvider(name, settings, indexSettings));
-        buildIn.put("LMJelinekMercer",
+        builtIn.put("LMJelinekMercer",
                 (name, settings, indexSettings, scriptService) -> new LMJelinekMercerSimilarityProvider(name, settings, indexSettings));
-        buildIn.put("DFI",
+        builtIn.put("DFI",
                 (name, settings, indexSettings, scriptService) -> new DFISimilarityProvider(name, settings, indexSettings));
-        buildIn.put("scripted", ScriptedSimilarityProvider::new);
+        builtIn.put("scripted", ScriptedSimilarityProvider::new);
         DEFAULTS = Collections.unmodifiableMap(defaults);
-        BUILT_IN = Collections.unmodifiableMap(buildIn);
+        BUILT_IN = Collections.unmodifiableMap(builtIn);
     }
 
     public SimilarityService(IndexSettings indexSettings, ScriptService scriptService,

--- a/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -46,19 +46,14 @@ public final class SimilarityService extends AbstractIndexComponent {
     public static final Map<String, SimilarityProvider.Factory> BUILT_IN;
     static {
         Map<String, SimilarityProvider.Factory> defaults = new HashMap<>();
-        Map<String, SimilarityProvider.Factory> builtIn = new HashMap<>();
         defaults.put("classic",
                 (name, settings, indexSettings, scriptService) -> new ClassicSimilarityProvider(name, settings, indexSettings));
         defaults.put("BM25",
                 (name, settings, indexSettings, scriptService) -> new BM25SimilarityProvider(name, settings, indexSettings));
         defaults.put("boolean",
                 (name, settings, indexSettings, scriptService) -> new BooleanSimilarityProvider(name, settings, indexSettings));
-        builtIn.put("classic",
-                (name, settings, indexSettings, scriptService) -> new ClassicSimilarityProvider(name, settings, indexSettings));
-        builtIn.put("BM25",
-                (name, settings, indexSettings, scriptService) -> new BM25SimilarityProvider(name, settings, indexSettings));
-        builtIn.put("boolean",
-                (name, settings, indexSettings, scriptService) -> new BooleanSimilarityProvider(name, settings, indexSettings));
+
+        Map<String, SimilarityProvider.Factory> builtIn = new HashMap<>(defaults);
         builtIn.put("DFR",
                 (name, settings, indexSettings, scriptService) -> new DFRSimilarityProvider(name, settings, indexSettings));
         builtIn.put("IB",

--- a/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/core/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -57,6 +57,8 @@ public final class SimilarityService extends AbstractIndexComponent {
                 (name, settings, indexSettings, scriptService) -> new ClassicSimilarityProvider(name, settings, indexSettings));
         buildIn.put("BM25",
                 (name, settings, indexSettings, scriptService) -> new BM25SimilarityProvider(name, settings, indexSettings));
+        buildIn.put("boolean",
+                (name, settings, indexSettings, scriptService) -> new BooleanSimilarityProvider(name, settings, indexSettings));
         buildIn.put("DFR",
                 (name, settings, indexSettings, scriptService) -> new DFRSimilarityProvider(name, settings, indexSettings));
         buildIn.put("IB",


### PR DESCRIPTION
The new boolean similarity is not added to the builtin similarities, so trying to use it will fail:

```
PUT /test_sim_boolean
{
  "settings": {
    "index": {
      "similarity": {
        "default": {
          "type": "boolean"
        }
      }
    }
  }
}
```

```
PUT test_sim_boolean
{
  "settings": {
    "similarity": {
      "boolean_sim": {
        "type": "boolean"
      }
    }
  }
}
```
```
{
   "error": {
      "root_cause": [
         {
            "type": "illegal_argument_exception",
            "reason": "Unknown Similarity type [boolean] for [default]"
         }
      ],
      "type": "illegal_argument_exception",
      "reason": "Unknown Similarity type [boolean] for [default]"
   },
   "status": 400
}
```

The workaround is to simply use the similarity directly in every field that requires it

```
PUT /test_sim_boolean
{
    "mappings": {
      "foo": {
        "properties": {
          "bar": {
            "type": "text",
            "similarity": "boolean"
          }
        }
      }
    }
  }
}
```

* First commit contains the fix.
* Second commit is a simple rename of the local variable. I can remove this commit if you really like the previous name or I can squash it.
* Third commit: after analyzing the code in order to future proof it, it is clear based on the three data points that built-in similarities include all of the default ones