### PR TITLE
[Docs] Add description for missing fields in Reindex/Update/Delete By Query

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -212,6 +212,7 @@ The JSON response looks like this:
 {
   "took" : 147,
   "timed_out": false,
+  "total": 119,
   "deleted": 119,
   "batches": 1,
   "version_conflicts": 0,
@@ -223,7 +224,6 @@ The JSON response looks like this:
   "throttled_millis": 0,
   "requests_per_second": -1.0,
   "throttled_until_millis": 0,
-  "total": 119,
   "failures" : [ ]
 }
 --------------------------------------------------
@@ -233,25 +233,48 @@ The JSON response looks like this:
 
 The number of milliseconds from start to end of the whole operation.
 
+`timed_out`::
+
+This flag is set to `true` if any of the requests executed during the
+delete by query execution has timed out.
+
+`total`::
+
+The number of documents that were successfully processed.
+
 `deleted`::
 
 The number of documents that were successfully deleted.
 
 `batches`::
 
-The number of scroll responses pulled back by the the delete by query.
+The number of scroll responses pulled back by the delete by query.
 
 `version_conflicts`::
 
 The number of version conflicts that the delete by query hit.
 
+`noops`::
+
+The number of documents that were ignored because the script used for
+the delete by query returned a `noop` value for `ctx.op`.
+
 `retries`::
 
-The number of retries that the delete by query did in response to a full queue.
+The number of retries attempted by delete by query. `bulk` is the number
+of bulk actions retried and `search` is the number of search actions retried.
 
 `throttled_millis`::
 
 Number of milliseconds the request slept to conform to `requests_per_second`.
+
+`requests_per_second`::
+
+The number of requests per second effectively executed during the delete by query.
+
+`throttled_until_millis`::
+
+Ask Nik. He knows, as always.
 
 `failures`::
 

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -256,8 +256,9 @@ The number of version conflicts that the delete by query hit.
 
 `noops`::
 
-The number of documents that were ignored because the script used for
-the delete by query returned a `noop` value for `ctx.op`.
+This field is always equal to zero for delete by query. It only exists
+so that delete by query, update by query and reindex APIs return responses
+ with the same structure.
 
 `retries`::
 
@@ -274,7 +275,10 @@ The number of requests per second effectively executed during the delete by quer
 
 `throttled_until_millis`::
 
-Ask Nik. He knows, as always.
+This field should always be equal to zero in a delete by query response. It only
+has meaning when using the <<docs-delete-by-query-task-api, Task API>>, where it
+indicates the next time (in milliseconds since epoch) a throttled request will be
+executed again in order to conform to `requests_per_second`.
 
 `failures`::
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -655,7 +655,10 @@ The number of requests per second effectively executed during the reindex.
 
 `throttled_until_millis`::
 
-Ask Nik. He knows, as always.
+This field should always be equal to zero in a delete by query response. It only
+has meaning when using the <<docs-reindex-task-api, Task API>>, where it
+indicates the next time (in milliseconds since epoch) a throttled request will be
+executed again in order to conform to `requests_per_second`.
 
 `failures`::
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -585,7 +585,7 @@ The JSON response looks like this:
   "timed_out": false,
   "total": 5,
   "updated": 0,
-  "created": 123,
+  "created": 5,
   "deleted": 0,
   "batches": 1,
   "noops": 0,
@@ -606,6 +606,15 @@ The JSON response looks like this:
 
 The number of milliseconds from start to end of the whole operation.
 
+`timed_out`::
+
+This flag is set to `true` if any of the requests executed during the
+reindex has timed out.
+
+`total`::
+
+The number of documents that were successfully processed.
+
 `updated`::
 
 The number of documents that were successfully updated.
@@ -614,9 +623,18 @@ The number of documents that were successfully updated.
 
 The number of documents that were successfully created.
 
+`deleted`::
+
+The number of documents that were successfully deleted.
+
 `batches`::
 
 The number of scroll responses pulled back by the the reindex.
+
+`noops`::
+
+The number of documents that were ignored because the script used for
+the reindex returned a `noop` value for `ctx.op`.
 
 `version_conflicts`::
 
@@ -630,6 +648,14 @@ actions retried and `search` is the number of search actions retried.
 `throttled_millis`::
 
 Number of milliseconds the request slept to conform to `requests_per_second`.
+
+`requests_per_second`::
+
+The number of requests per second effectively executed during the reindex.
+
+`throttled_until_millis`::
+
+Ask Nik. He knows, as always.
 
 `failures`::
 

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -262,6 +262,7 @@ The JSON response looks like this:
 {
   "took" : 147,
   "timed_out": false,
+  "total": 5,
   "updated": 5,
   "deleted": 0,
   "batches": 1,
@@ -274,7 +275,6 @@ The JSON response looks like this:
   "throttled_millis": 0,
   "requests_per_second": -1.0,
   "throttled_until_millis": 0,
-  "total": 5,
   "failures" : [ ]
 }
 --------------------------------------------------
@@ -284,9 +284,22 @@ The JSON response looks like this:
 
 The number of milliseconds from start to end of the whole operation.
 
+`timed_out`::
+
+This flag is set to `true` if any of the requests executed during the
+update by query execution has timed out.
+
+`total`::
+
+The number of documents that were successfully processed.
+
 `updated`::
 
 The number of documents that were successfully updated.
+
+`deleted`::
+
+The number of documents that were successfully deleted.
 
 `batches`::
 
@@ -296,6 +309,11 @@ The number of scroll responses pulled back by the the update by query.
 
 The number of version conflicts that the update by query hit.
 
+`noops`::
+
+The number of documents that were ignored because the script used for
+the update by query returned a `noop` value for `ctx.op`.
+
 `retries`::
 
 The number of retries attempted by update-by-query. `bulk` is the number of bulk
@@ -304,6 +322,14 @@ actions retried and `search` is the number of search actions retried.
 `throttled_millis`::
 
 Number of milliseconds the request slept to conform to `requests_per_second`.
+
+`requests_per_second`::
+
+The number of requests per second effectively executed during the update by query.
+
+`throttled_until_millis`::
+
+Ask Nik. He knows, as always.
 
 `failures`::
 

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -329,7 +329,10 @@ The number of requests per second effectively executed during the update by quer
 
 `throttled_until_millis`::
 
-Ask Nik. He knows, as always.
+This field should always be equal to zero in a delete by query response. It only
+has meaning when using the <<docs-update-by-query-task-api, Task API>>, where it
+indicates the next time (in milliseconds since epoch) a throttled request will be
+executed again in order to conform to `requests_per_second`.
 
 `failures`::
 


### PR DESCRIPTION
Some fields lack of a description, I don't think it is intentional.