### PR TITLE
Fix percolator highlight sub fetch phase to not highlight query twice

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -909,7 +909,7 @@ Response:
                 },
                 "highlight": {
                     "message": [
-                        "some message with the <em>number</em> <em>1</em>"
+                        " with the <em>number</em> <em>1</em>"
                     ]
                 }
             }

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorHighlightSubFetchPhase.java
@@ -53,12 +53,12 @@ import java.util.Map;
  * Highlighting in the case of the percolate query is a bit different, because the PercolateQuery itself doesn't get highlighted,
  * but the source of the PercolateQuery gets highlighted by each hit containing a query.
  */
-final class PercolatorHighlightSubFetchPhase extends HighlightPhase {
+final class PercolatorHighlightSubFetchPhase implements FetchSubPhase {
+    private final HighlightPhase highlightPhase;
 
     PercolatorHighlightSubFetchPhase(Settings settings, Map<String, Highlighter> highlighters) {
-        super(settings, highlighters);
+        this.highlightPhase = new HighlightPhase(settings, highlighters);
     }
-
 
     boolean hitsExecutionNeeded(SearchContext context) { // for testing
         return context.highlight() != null && locatePercolatorQuery(context.query()).isEmpty() == false;
@@ -109,7 +109,7 @@ final class PercolatorHighlightSubFetchPhase extends HighlightPhase {
                             percolatorLeafReaderContext, slot, percolatorIndexSearcher
                         );
                         hitContext.cache().clear();
-                        super.hitExecute(subSearchContext, hitContext);
+                        highlightPhase.hitExecute(subSearchContext, hitContext);
                         for (Map.Entry<String, HighlightField> entry : hitContext.hit().getHighlightFields().entrySet()) {
                             if (percolateQuery.getDocuments().size() == 1) {
                                 String hlFieldName;


### PR DESCRIPTION
The `PercolatorHighlightSubFetchPhase` does not override hitExecute and since it extends HighlightPhase the search hits
are highlighted twice (by the highlight phase and then by the percolator). This does not alter the results, the second highlighting
just overrides the first one but this slow down the request because it duplicates the work.