### PR TITLE
Add skip version to rolling upgrade test

### DIFF
--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,6 +1,8 @@
 ---
 "Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
   - skip:
+      version: " - 5.5.99"
+      reason: stored search template API is deprecated in 5.6.0
       features: "warnings"
 
   - do:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,10 +1,5 @@
 ---
 "Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
-  - skip:
-      version: " - 5.5.99"
-      reason: stored search template API is deprecated in 5.6.0
-      features: "warnings"
-
   - do:
       indices.create:
         index: test_index
@@ -87,6 +82,35 @@
           }
   - match: { "acknowledged": true }
 
+---
+"Put a template before 5.6.0":
+  - skip:
+      version: "5.6.0 - "
+      reason: stored search template API is deprecated in 5.6.0
+
+  - do:
+      put_template:
+        id: test_search_template
+        body:
+          query:
+            match:
+              f1: "{{f1}}"
+  - match: { acknowledged: true }
+
+  - do:
+      search_template:
+        body:
+          id: test_search_template
+          params:
+            f1: v5_old
+  - match: { hits.total: 1 }
+---
+"Put a template 5.6.0 and beyond":
+  - skip:
+      version: " - 5.5.99"
+      reason: stored search template API is deprecated in 5.6.0
+      features: "warnings"
+
   - do:
       warnings:
         - "The stored search template API is deprecated. Use stored scripts instead."
@@ -105,4 +129,3 @@
           params:
             f1: v5_old
   - match: { hits.total: 1 }
-


### PR DESCRIPTION
The stored search template API became deprecated in 5.6.0 so the
version max should be added.
