### PR TITLE
Fix http publish host

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
@@ -115,12 +115,12 @@ public final class NetworkAddress {
         return format(address, port, null);
     }
     // note, we don't validate port, because we only allow InetSocketAddress
-    static String format(InetAddress address, int port, String verbatimAddress) {
+    static String format(InetAddress address, int port, String verbatimHost) {
         Objects.requireNonNull(address);
 
         StringBuilder builder = new StringBuilder();
-        if (verbatimAddress != null && !verbatimAddress.isEmpty()) {
-            builder.append(verbatimAddress);
+        if (verbatimHost != null && !verbatimHost.isEmpty()) {
+            builder.append(verbatimHost);
         }
         else if (port != -1 && address instanceof Inet6Address) {
             builder.append(InetAddresses.toUriString(address));

--- a/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/network/NetworkAddress.java
@@ -88,13 +88,41 @@ public final class NetworkAddress {
         return format(address.getAddress(), address.getPort());
     }
 
-    // note, we don't validate port, because we only allow InetSocketAddress
+    /**
+     * Formats a network address and port for display purposes.
+     * Allowing the hostname to be passed verbatim as configured externally.
+     * <p>
+     * When {@code verbatimHost} is not null or empty it will be used as the hostname.
+     * </p>
+     * Otherwise this formats the address with {@link #format(InetAddress)}
+     * and appends the port number. IPv6 addresses will be bracketed.
+     * <p>
+     * Example output:
+     * <ul>
+     *   <li>With hostname: {@code elastic.co:9300}</li>
+     *   <li>IPv4: {@code 127.0.0.1:9300}</li>
+     *   <li>IPv6: {@code [::1]:9300}</li>
+     * </ul>
+     * @param address IPv4 or IPv6 address with port
+     * @param verbatimHost String representing the host name.
+     * @return formatted string
+     */
+    public static String format(InetSocketAddress address, String verbatimHost) {
+        return format(address.getAddress(), address.getPort(), verbatimHost);
+    }
+
     static String format(InetAddress address, int port) {
+        return format(address, port, null);
+    }
+    // note, we don't validate port, because we only allow InetSocketAddress
+    static String format(InetAddress address, int port, String verbatimAddress) {
         Objects.requireNonNull(address);
 
         StringBuilder builder = new StringBuilder();
-
-        if (port != -1 && address instanceof Inet6Address) {
+        if (verbatimAddress != null && !verbatimAddress.isEmpty()) {
+            builder.append(verbatimAddress);
+        }
+        else if (port != -1 && address instanceof Inet6Address) {
             builder.append(InetAddresses.toUriString(address));
         } else {
             builder.append(InetAddresses.toAddrString(address));

--- a/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
@@ -22,9 +22,11 @@ package org.elasticsearch.common.transport;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkAddress;
 
 import java.io.IOException;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -49,12 +51,17 @@ public final class TransportAddress implements Writeable {
     }
 
     private final InetSocketAddress address;
+    private final String verbatimAddress;
 
     public TransportAddress(InetAddress address, int port) {
         this(new InetSocketAddress(address, port));
     }
 
     public TransportAddress(InetSocketAddress address) {
+        this(address, null);
+    }
+
+    public TransportAddress(InetSocketAddress address, String verbatimAddress) {
         if (address == null) {
             throw new IllegalArgumentException("InetSocketAddress must not be null");
         }
@@ -62,6 +69,7 @@ public final class TransportAddress implements Writeable {
             throw new IllegalArgumentException("Address must be resolved but wasn't - InetSocketAddress#getAddress() returned null");
         }
         this.address = address;
+        this.verbatimAddress = verbatimAddress;
     }
 
     /**
@@ -75,7 +83,9 @@ public final class TransportAddress implements Writeable {
         final InetAddress inetAddress = InetAddress.getByAddress(host, a);
         int port = in.readInt();
         this.address = new InetSocketAddress(inetAddress, port);
+        this.verbatimAddress = null;
     }
+
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
@@ -126,6 +136,6 @@ public final class TransportAddress implements Writeable {
 
     @Override
     public String toString() {
-        return NetworkAddress.format(address);
+        return NetworkAddress.format(address, this.verbatimAddress);
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
+++ b/core/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
@@ -83,9 +83,8 @@ public final class TransportAddress implements Writeable {
         final InetAddress inetAddress = InetAddress.getByAddress(host, a);
         int port = in.readInt();
         this.address = new InetSocketAddress(inetAddress, port);
-        this.verbatimAddress = null;
+        this.verbatimAddress = in.readOptionalString();
     }
-
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
@@ -97,6 +96,7 @@ public final class TransportAddress implements Writeable {
         // these only make sense with respect to the local machine, and will only formulate
         // the address incorrectly remotely.
         out.writeInt(address.getPort());
+        out.writeOptionalString(this.verbatimAddress);
     }
 
     /**

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -80,6 +80,7 @@ import org.elasticsearch.transport.netty4.Netty4Utils;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -328,10 +329,12 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
         } catch (Exception e) {
             throw new BindTransportException("Failed to resolve publish address", e);
         }
-
         final int publishPort = resolvePublishPort(settings, boundAddresses, publishInetAddress);
         final InetSocketAddress publishAddress = new InetSocketAddress(publishInetAddress, publishPort);
-        return new BoundTransportAddress(boundAddresses.toArray(new TransportAddress[0]), new TransportAddress(publishAddress));
+        List<String> publishHosts = SETTING_HTTP_PUBLISH_HOST.get(settings);
+        final String verbatimPublishAdress = publishHosts.isEmpty() ? null : publishHosts.get(0);
+
+        return new BoundTransportAddress(boundAddresses.toArray(new TransportAddress[0]), new TransportAddress(publishAddress, verbatimPublishAdress));
     }
 
     // package private for tests

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -334,7 +334,8 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
         List<String> publishHosts = SETTING_HTTP_PUBLISH_HOST.get(settings);
         final String verbatimPublishAdress = publishHosts.isEmpty() ? null : publishHosts.get(0);
 
-        return new BoundTransportAddress(boundAddresses.toArray(new TransportAddress[0]), new TransportAddress(publishAddress, verbatimPublishAdress));
+        final TransportAddress publishTransportAdress = new TransportAddress(publishAddress, verbatimPublishAdress);
+        return new BoundTransportAddress(boundAddresses.toArray(new TransportAddress[0]), publishTransportAdress);
     }
 
     // package private for tests

--- a/qa/smoke-test-http-publish-host/build.gradle
+++ b/qa/smoke-test-http-publish-host/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.rest-test'
+
+integTest {
+}
+
+integTestCluster {
+    numNodes = 2
+    // localhost should be available to all and not be resolved
+    setting 'http.publish_host', 'localhost'
+}
+

--- a/qa/smoke-test-http-publish-host/src/test/java/org/elasticsearch/smoketest/SmokeTestHttpPublishHostClientYamlTestSuiteIT.java
+++ b/qa/smoke-test-http-publish-host/src/test/java/org/elasticsearch/smoketest/SmokeTestHttpPublishHostClientYamlTestSuiteIT.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.smoketest;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+import org.apache.lucene.util.TimeUnits;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+
+@TimeoutSuite(millis = 40 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
+public class SmokeTestHttpPublishHostClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    public SmokeTestHttpPublishHostClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return ESClientYamlSuiteTestCase.createParameters();
+    }
+}
+

--- a/qa/smoke-test-http-publish-host/src/test/resources/rest-api-spec/test/smoke_test_http_publish_host/10_should_return_verbatim.yml
+++ b/qa/smoke-test-http-publish-host/src/test/resources/rest-api-spec/test/smoke_test_http_publish_host/10_should_return_verbatim.yml
@@ -1,0 +1,40 @@
+# Integration tests for smoke testing multi-node IT
+# If the local machine which is running the test is low on disk space
+# We can have one unassigned shard
+---
+"cluster health basic test, wait for both nodes to join":
+  - do:
+      cluster.health:
+        wait_for_nodes: 2
+
+  - is_true:   cluster_name
+  - is_false:  timed_out
+  - gte:       { number_of_nodes:         2 }
+  - gte:       { number_of_data_nodes:    2 }
+
+  - do:
+      cluster.state: {}
+
+  - set: { master_node: master }
+
+  - do:
+      nodes.info:
+        metric: [ http ]
+
+  - is_true: nodes.$master.http.publish_address
+  - set: { nodes.$master.http.publish_address: host_name_master }
+
+  - match:
+      $host_name_master : |
+          /^localhost:\d+$/
+
+  # Can only reliably get the long node id for the master node from the cluster.state API
+  # All the cat API's return a truncated version
+
+  # The YAML tests will need a foreach(key in path) construct to test all the publish_address's for each node
+  #
+  #- is_true: nodes.1.http.publish_address
+  #- set: { nodes.1.http.publish_address: host_name_1 }
+  #- match:
+  #    $host_name_1 : |
+  #        /^localhost:\d+$/

--- a/qa/smoke-test-http-publish-host/src/test/resources/rest-api-spec/test/smoke_test_http_publish_host/10_should_return_verbatim.yml
+++ b/qa/smoke-test-http-publish-host/src/test/resources/rest-api-spec/test/smoke_test_http_publish_host/10_should_return_verbatim.yml
@@ -1,8 +1,5 @@
-# Integration tests for smoke testing multi-node IT
-# If the local machine which is running the test is low on disk space
-# We can have one unassigned shard
 ---
-"cluster health basic test, wait for both nodes to join":
+"nodes info http publish host should be verbatim":
   - do:
       cluster.health:
         wait_for_nodes: 2

--- a/settings.gradle
+++ b/settings.gradle
@@ -75,6 +75,7 @@ List projects = [
   'qa:smoke-test-ingest-with-all-dependencies',
   'qa:smoke-test-ingest-disabled',
   'qa:smoke-test-multinode',
+  'qa:smoke-test-http-publish-host',
   'qa:smoke-test-plugins',
   'qa:smoke-test-reindex-with-all-modules',
   'qa:smoke-test-tribe-node',


### PR DESCRIPTION
Fix #22029 report configured `http.publish_host` unresolved and verbatim to user. 

The node still needs to be able to resolve the host name at startup so for certain network topologies this could still not be a solution. I think we'd need a `publish_host_unresolved` setting for that that sidesteps `InetAddress` all together, but will park that for a new issue. 

The verbatim `publish_host` now shows up both on startup in console: 

> publish_address {elastic.co:9200}, bound_addresses {127.0.0.1:9200}, {[::1]:9200}

and in the Nodes Info Api used by clients for sniffing (response truncated).

```json
{
	"cluster_name": "qa_smoke-test-http-publish-host_integTestCluster",
	"nodes": {
		"1TrB9eQlQmm_9qHHqGoagA": {
			"name": "node-1",
			"http": {
				"bound_address": [
					"127.0.0.1:52922",
					"[::1]:52923"
				],
				"publish_address": "localhost:52922"
			}
		},
		"g-hAtMH_QcypO3OUO13lSg": {
			"name": "node-0",
			"http": {
				"bound_address": [
					"127.0.0.1:52808",
					"[::1]:52809"
				],
				"publish_address": "localhost:52808"
			}
		}
	}
}
```

Run new YAML test only:

> gradle :qa:smoke-test-http-publish-host:integTestRunner -Dtests.class=org.elasticsearch.smoketest.SmokeTestHttpPublishHostClientYamlTestSuiteIT -Dtests.method="test {yaml=smoke_test_http_publish_host/10_should_return_verbatim/nodes info http publish host should be verbatim}"




