### PR TITLE
Add a `custom_double` field type.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/core/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -56,6 +56,7 @@ public final class QueryParserHelper {
         }
         ALLOWED_QUERY_MAPPER_TYPES.add("scaled_float");
         ALLOWED_QUERY_MAPPER_TYPES.add(TextFieldMapper.CONTENT_TYPE);
+        ALLOWED_QUERY_MAPPER_TYPES.add("custom_float");
     }
 
     private QueryParserHelper() {}

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -174,8 +174,8 @@ setting `num_significant_bits` to +10+ and `zero_exponent` to +8+.
 
 `zero_exponent`::
 
-    This setting is more expert and represents the exponent that should be used
-    to represent 0 in the float representation. Must be in -1023..1023, default
-    value is -1023.
+    This setting is more expert and represents the exponent that is represented
+    by 0 in the float representation. Must be in -1023..1023, default value is
+    -1023.
     Fields that will only store integers in practice can set this value to
     `num_significant_bits - 2` in order to save space.

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -12,6 +12,7 @@ The following numeric types are supported:
 `float`::        A single-precision 32-bit IEEE 754 floating point.
 `half_float`::   A half-precision 16-bit IEEE 754 floating point.
 `scaled_float`:: A floating point that is backed by a `long` and a fixed scaling factor.
+`custom_float`:: A floating-point number whose format is configurable.
 
 Below is an example of configuring a mapping with numeric fields:
 
@@ -140,3 +141,41 @@ The following parameters are accepted by numeric types:
     sorting) will behave as if the document had a value of +2.3+. High values
     of `scaling_factor` improve accuracy but also increase space requirements.
     This parameter is required.
+
+[[custom-float-params]]
+==== Parameters for `custom_float`
+
+experimental[The `custom_float` type is new and we'd like to get feedback about it before stabilizing the API.]
+
+`custom_float` uses a format that is similar to `float` and `double` except that
+the number of bits that you wish to spend on the mantissa and the exponent are
+configurable.
+
+One use-case that this field can help with is storing large numbers efficiently
+while only preserving the most significant bits. We believe that this may be
+useful for instance in order to store latencies or numbers of bytes, since the
+order of magnitude for these quantities is usually much more important than
+the accurate values. If this is your use-case, you could store such values
+efficiently while preserving 10 significant bits (\~3 significant digits) by
+setting `num_significant_bits` to +10+ and `zero_exponent` to +8+.
+
+`custom_float` accepts an additional parameter:
+
+[horizontal]
+
+`num_significant_bits`::
+
+    The number of significant bits to keep. Higher values increase accuracy of
+    the representation but also increase storage requirements. Must be in 1..53,
+    default value is 53.
+    If you want to preserve x significant digits, you will need about
+    ceil(log2(10x)) bits. For instance for 3 significant digits, this gives 10
+    significant bits.
+
+`zero_exponent`::
+
+    This setting is more expert and represents the exponent that should be used
+    to represent 0 in the float representation. Must be in -1023..1023, default
+    value is -1023.
+    Fields that will only store integers in practice can set this value to
+    `num_significant_bits - 2` in order to save space.

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/CustomFloat.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/CustomFloat.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.util.NumericUtils;
+
+import java.util.function.DoubleToLongFunction;
+import java.util.function.LongToDoubleFunction;
+
+class CustomFloat {
+
+    private CustomFloat() {}
+
+    private static void checkNumSigBits(int numSigBits) {
+        if (numSigBits < 1) {
+            throw new IllegalArgumentException("numSigBits must be >= 1, got " + numSigBits);
+        }
+        if (numSigBits > 53) {
+            throw new IllegalArgumentException("numSigBits must be <= 53, got " + numSigBits);
+        }
+    }
+
+    private static void checkZeroExponent(int zeroExponent) {
+        if (zeroExponent < -1023) {
+            throw new IllegalArgumentException("zeroExponent must be >= -1023, got " + zeroExponent);
+        }
+        if (zeroExponent > 1023) {
+            // we could support greater values in the future, but 0 looks like a good start
+            // for a max value to me
+            throw new IllegalArgumentException("zeroExponent must be <= 1023, got " + zeroExponent);
+        }
+    }
+
+    /**
+     * Get an encoder that preserves ordering and does not collapse -0 and +0.
+     * The encoder only supports finite values.
+     * @param numSigBits the number of significant bits, must be in 1..53
+     * @param zeroExponent the exponent that is used to represent 0, must be in -1023..0
+     */
+    public static DoubleToLongFunction getEncoder(int numSigBits, int zeroExponent) {
+        return new Encoder(numSigBits, zeroExponent)::encode;
+    }
+
+    /** Get a decoder of encoded values. */
+    public static LongToDoubleFunction getDecoder(int numSigBits, int zeroExponent) {
+        return new Decoder(numSigBits, zeroExponent)::decode;
+    }
+
+    private static class Encoder {
+        
+        private final int shift;
+        private final long expDelta;
+        
+        Encoder(int numSigBits, int zeroExponent) {
+            checkNumSigBits(numSigBits);
+            checkZeroExponent(zeroExponent);
+            this.shift = 53 - numSigBits;
+            this.expDelta = (zeroExponent - -1023L);
+        }
+        
+        long encode(double value) {
+            if (Double.isFinite(value) == false) {
+                throw new IllegalArgumentException("Cannot encode non-finite value: " + value);
+            }
+            long bits = Double.doubleToLongBits(value);
+            long mantissaAndExponent = bits & 0x7fffffffffffffffL;
+
+            long exponent = mantissaAndExponent >>> 52;
+            if (exponent > expDelta) {
+                // should be the common case
+                mantissaAndExponent -= expDelta << 52;
+            } else if (exponent != 0) {
+                // need to go from normal to subnormal
+                // restore the implicit bit
+                mantissaAndExponent = (1L << 52) | (mantissaAndExponent & ((1L << 52) - 1));
+                // and shift right, taking the min with 63 since shifts are mod 64
+                mantissaAndExponent >>>= Math.min(63, 1 + expDelta - exponent);
+            } else if (mantissaAndExponent != 0) {
+                // need to go from subnormal to subnormal with a different base
+                // taking the min with 63 since shifts are mod 64
+                mantissaAndExponent >>>= Math.min(63, expDelta);
+            }
+
+            if (shift > 0) {
+                // add 2^(shift-1) so that subsequent shift round rather than truncate
+                mantissaAndExponent += 1L << (shift - 1);
+                // and subtract the shift-th bit so that we round to even in case of tie
+                // just like casting from double to float does
+                mantissaAndExponent -= (mantissaAndExponent >>> shift) & 1;
+
+                // make sure the rounding does not make us encode infinities
+                long newExponent = (mantissaAndExponent >>> 52) + expDelta;
+                if (newExponent >= 0x7ff) {
+                    throw new IllegalArgumentException("Value " + value + " is too large and was rounded to +/-Infinity");
+                }
+
+                // clear trailing bits
+                mantissaAndExponent &= (~0L << shift);
+            }
+
+            bits = bits & 0x8000000000000000L; // take the sign
+            bits |= mantissaAndExponent; // and add bits back
+            
+            long encoded = NumericUtils.sortableDoubleBits(bits);
+            return encoded >> shift; // signed shift on purpose
+        }
+
+    }
+
+    private static class Decoder {
+
+        private final int shift;
+        private final long expDelta;
+        
+        Decoder(int numSigBits, int zeroExponent) {
+            checkNumSigBits(numSigBits);
+            checkZeroExponent(zeroExponent);
+            this.shift = 53 - numSigBits;
+            this.expDelta = (zeroExponent - -1023);
+        }
+
+        double decode(long bits) {
+            bits <<= shift;
+            if ((bits & 0x8000000000000000L) != 0) {
+                bits |= ((1L << shift) - 1);
+            }
+            bits = NumericUtils.sortableDoubleBits(bits);
+            long mantissaAndExponent = bits & 0x7fffffffffffffffL;
+            long exponent = mantissaAndExponent >>> 52;
+            if (exponent > 0) {
+                // common case: normal
+                bits += expDelta << 52;
+            } else if (mantissaAndExponent != 0) {
+                // non-zero subnormal
+                int numLeadingZeros = Long.numberOfLeadingZeros(mantissaAndExponent);
+                int s = numLeadingZeros - (64 - 53);
+                if (s > expDelta) {
+                    // remains subnormal
+                    bits = (bits & 0x8000000000000000L) // sign
+                            | (mantissaAndExponent << expDelta); // mantissa
+                } else {
+                    // becomes normal
+                    bits = (bits & 0x8000000000000000L) // sign
+                            | ((expDelta - s + 1) << 52) // exponent
+                            | ((mantissaAndExponent << s) & ((1L << 52) - 1)); // mantissa
+                }
+            }
+            return Double.longBitsToDouble(bits);
+        }
+
+    }
+
+}

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/CustomFloat.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/CustomFloat.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.util.NumericUtils;
+import org.apache.lucene.util.packed.PackedInts;
 
 import java.util.function.DoubleToLongFunction;
 import java.util.function.LongToDoubleFunction;
@@ -167,4 +168,12 @@ class CustomFloat {
 
     }
 
+    public static void main(String[] args) {
+        DoubleToLongFunction encoder = CustomFloat.getEncoder(10, 8);
+        LongToDoubleFunction decoder = CustomFloat.getDecoder(10, 8);
+        System.out.println(encoder.applyAsLong(Long.MAX_VALUE));
+        System.out.println(PackedInts.bitsRequired(Long.MAX_VALUE));
+        System.out.println(PackedInts.bitsRequired(encoder.applyAsLong(Long.MAX_VALUE)));
+        System.out.println(decoder.applyAsDouble(1<<14));
+    }
 }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/CustomFloat.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/CustomFloat.java
@@ -167,13 +167,4 @@ class CustomFloat {
         }
 
     }
-
-    public static void main(String[] args) {
-        DoubleToLongFunction encoder = CustomFloat.getEncoder(10, 8);
-        LongToDoubleFunction decoder = CustomFloat.getDecoder(10, 8);
-        System.out.println(encoder.applyAsLong(Long.MAX_VALUE));
-        System.out.println(PackedInts.bitsRequired(Long.MAX_VALUE));
-        System.out.println(PackedInts.bitsRequired(encoder.applyAsLong(Long.MAX_VALUE)));
-        System.out.println(decoder.applyAsDouble(1<<14));
-    }
 }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/CustomFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/CustomFloatFieldMapper.java
@@ -1,0 +1,637 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
+import org.elasticsearch.index.fielddata.ScriptDocValues;
+import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.index.fielddata.fieldcomparator.DoubleValuesComparatorSource;
+import org.elasticsearch.index.fielddata.plain.DocValuesIndexFieldData;
+import org.elasticsearch.index.mapper.NumberFieldMapper.Defaults;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.MultiValueMode;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.DoubleToLongFunction;
+import java.util.function.LongToDoubleFunction;
+
+/** A {@link FieldMapper} for custom floats.  */
+public class CustomFloatFieldMapper extends FieldMapper {
+
+    public static final String CONTENT_TYPE = "custom_float";
+    // use the same default as numbers
+    private static final Setting<Boolean> COERCE_SETTING = NumberFieldMapper.COERCE_SETTING;
+    private static final int DEFAULT_NUM_SIG_BITS = 53;
+    private static final int DEFAULT_ZERO_EXPONENT = -1023;
+
+    public static class Builder extends FieldMapper.Builder<Builder, CustomFloatFieldMapper> {
+
+        private Boolean ignoreMalformed;
+        private Boolean coerce;
+
+        public Builder(String name) {
+            super(name, new CustomFloatFieldType(), new CustomFloatFieldType());
+            builder = this;
+        }
+
+        @Override
+        public CustomFloatFieldType fieldType() {
+            return (CustomFloatFieldType) super.fieldType();
+        }
+
+        public Builder ignoreMalformed(boolean ignoreMalformed) {
+            this.ignoreMalformed = ignoreMalformed;
+            return builder;
+        }
+
+        protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
+            if (ignoreMalformed != null) {
+                return new Explicit<>(ignoreMalformed, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(IGNORE_MALFORMED_SETTING.get(context.indexSettings()), false);
+            }
+            return Defaults.IGNORE_MALFORMED;
+        }
+
+        public Builder coerce(boolean coerce) {
+            this.coerce = coerce;
+            return builder;
+        }
+
+        public Builder numSigBits(int numSigBits) {
+            fieldType().setNumSigBits(numSigBits);
+            return this;
+        }
+
+        public Builder zeroExponent(int zeroExponent) {
+            fieldType().setZeroExponent(zeroExponent);
+            return this;
+        }
+
+        protected Explicit<Boolean> coerce(BuilderContext context) {
+            if (coerce != null) {
+                return new Explicit<>(coerce, true);
+            }
+            if (context.indexSettings() != null) {
+                return new Explicit<>(COERCE_SETTING.get(context.indexSettings()), false);
+            }
+            return Defaults.COERCE;
+        }
+
+        @Override
+        public CustomFloatFieldMapper build(BuilderContext context) {
+            setupFieldType(context);
+            return new CustomFloatFieldMapper(name, fieldType, defaultFieldType, ignoreMalformed(context),
+                    coerce(context), context.indexSettings(), multiFieldsBuilder.build(this, context), copyTo);
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+
+        @Override
+        public Mapper.Builder<?,?> parse(String name, Map<String, Object> node,
+                                         ParserContext parserContext) throws MapperParsingException {
+            Builder builder = new Builder(name);
+            TypeParsers.parseField(builder, name, node, parserContext);
+            for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
+                Map.Entry<String, Object> entry = iterator.next();
+                String propName = entry.getKey();
+                Object propNode = entry.getValue();
+                if (propName.equals("null_value")) {
+                    if (propNode == null) {
+                        throw new MapperParsingException("Property [null_value] cannot be null.");
+                    }
+                    builder.nullValue(CustomFloatFieldMapper.parse(propNode));
+                    iterator.remove();
+                } else if (propName.equals("ignore_malformed")) {
+                    builder.ignoreMalformed(TypeParsers.nodeBooleanValue(name, "ignore_malformed", propNode, parserContext));
+                    iterator.remove();
+                } else if (propName.equals("coerce")) {
+                    builder.coerce(TypeParsers.nodeBooleanValue(name, "coerce", propNode, parserContext));
+                    iterator.remove();
+                } else if (propName.equals("num_significant_bits")) {
+                    int numSigBits = XContentMapValues.nodeIntegerValue(propNode);
+                    if (numSigBits < 1 || numSigBits > 53) {
+                        throw new IllegalArgumentException("[num_significant_bits] must be in 1..53, got " + numSigBits);
+                    }
+                    builder.numSigBits(numSigBits);
+                    iterator.remove();
+                } else if (propName.equals("zero_exponent")) {
+                    int zeroExp = XContentMapValues.nodeIntegerValue(propNode);
+                    if (zeroExp < -1023 || zeroExp > 1023) {
+                        throw new IllegalArgumentException("[zero_exponent] must be in -1023..1023, got " + zeroExp);
+                    }
+                    builder.zeroExponent(zeroExp);
+                    iterator.remove();
+                }
+            }
+            return builder;
+        }
+    }
+
+    public static final class CustomFloatFieldType extends SimpleMappedFieldType {
+
+        private int numSigBits = DEFAULT_NUM_SIG_BITS;
+        private int zeroExp = DEFAULT_ZERO_EXPONENT;
+        private DoubleToLongFunction encoder;
+        private LongToDoubleFunction decoder;
+
+        public CustomFloatFieldType() {
+            super();
+            setTokenized(false);
+            setHasDocValues(true);
+            setOmitNorms(true);
+        }
+
+        CustomFloatFieldType(CustomFloatFieldType other) {
+            super(other);
+            this.numSigBits = other.numSigBits;
+            this.zeroExp = other.zeroExp;
+            this.encoder = CustomFloat.getEncoder(numSigBits, zeroExp);
+            this.decoder = CustomFloat.getDecoder(numSigBits, zeroExp);
+        }
+
+        @Override
+        public MappedFieldType clone() {
+            return new CustomFloatFieldType(this);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+
+        public int getNumSigBits() {
+            return numSigBits;
+        }
+
+        public void setNumSigBits(int numSigBits) {
+            checkIfFrozen();
+            this.encoder = CustomFloat.getEncoder(numSigBits, zeroExp);
+            this.decoder = CustomFloat.getDecoder(numSigBits, zeroExp);
+            this.numSigBits = numSigBits;
+        }
+
+        public int getZeroExp() {
+            return zeroExp;
+        }
+
+        public void setZeroExponent(int zeroExp) {
+            checkIfFrozen();
+            this.encoder = CustomFloat.getEncoder(numSigBits, zeroExp);
+            this.decoder = CustomFloat.getDecoder(numSigBits, zeroExp);
+            this.zeroExp = zeroExp;
+        }
+
+        @Override
+        public void checkCompatibility(MappedFieldType other, List<String> conflicts, boolean strict) {
+            super.checkCompatibility(other, conflicts, strict);
+            if (numSigBits != ((CustomFloatFieldType) other).numSigBits) {
+                conflicts.add("mapper [" + name() + "] has different [num_significant_bits] values");
+            }
+            if (zeroExp != ((CustomFloatFieldType) other).zeroExp) {
+                conflicts.add("mapper [" + name() + "] has different [zero_exponent] values");
+            }
+        }
+
+        @Override
+        public Query termQuery(Object value, QueryShardContext context) {
+            failIfNotIndexed();
+            double queryValue = parse(value);
+            long encodedValue = encoder.applyAsLong(queryValue);
+            Query query = NumberFieldMapper.NumberType.LONG.termQuery(name(), encodedValue);
+            if (boost() != 1f) {
+                query = new BoostQuery(query, boost());
+            }
+            return query;
+        }
+
+        @Override
+        public Query termsQuery(List<?> values, QueryShardContext context) {
+            failIfNotIndexed();
+            List<Long> encodedValues = new ArrayList<>(values.size());
+            for (Object value : values) {
+                double queryValue = parse(value);
+                long encodedValue = encoder.applyAsLong(queryValue);
+                encodedValues.add(encodedValue);
+            }
+            Query query = NumberFieldMapper.NumberType.LONG.termsQuery(name(), Collections.unmodifiableList(encodedValues));
+            if (boost() != 1f) {
+                query = new BoostQuery(query, boost());
+            }
+            return query;
+        }
+
+        @Override
+        public Query rangeQuery(Object lowerTerm, Object upperTerm, boolean includeLower, boolean includeUpper, QueryShardContext context) {
+            failIfNotIndexed();
+            Long lo = null;
+            if (lowerTerm != null) {
+                double dValue = parse(lowerTerm);
+                if (includeLower == false) {
+                    dValue = Math.nextUp(dValue);
+                }
+                lo = encoder.applyAsLong(dValue);
+                if (decoder.applyAsDouble(lo) < dValue) {
+                    // not subject to overflows since extreme values represent Infinities/Nan which we reject
+                    lo += 1;
+                }
+            }
+            Long hi = null;
+            if (upperTerm != null) {
+                double dValue = parse(upperTerm);
+                if (includeUpper == false) {
+                    dValue = Math.nextDown(dValue);
+                }
+                hi = encoder.applyAsLong(dValue);
+                if (decoder.applyAsDouble(hi) > dValue) {
+                    // not subject to overflows since extreme values represent Infinities/Nan which we reject
+                    hi -= 1;
+                }
+            }
+            Query query = NumberFieldMapper.NumberType.LONG.rangeQuery(name(), lo, hi, true, true, hasDocValues());
+            if (boost() != 1f) {
+                query = new BoostQuery(query, boost());
+            }
+            return query;
+        }
+
+        @Override
+        public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
+            failIfNoDocValues();
+            return new IndexFieldData.Builder() {
+                @Override
+                public IndexFieldData<?> build(IndexSettings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
+                        CircuitBreakerService breakerService, MapperService mapperService) {
+                    final IndexNumericFieldData encodedValues = (IndexNumericFieldData) new DocValuesIndexFieldData.Builder()
+                            .numericType(IndexNumericFieldData.NumericType.LONG)
+                            .build(indexSettings, fieldType, cache, breakerService, mapperService);
+                    return new CustomFloatIndexFieldData(encodedValues, decoder);
+                }
+            };
+        }
+
+        @Override
+        public Object valueForDisplay(Object value) {
+            if (value == null) {
+                return null;
+            }
+            return decoder.applyAsDouble(((Number) value).longValue());
+        }
+
+        @Override
+        public DocValueFormat docValueFormat(String format, DateTimeZone timeZone) {
+            if (timeZone != null) {
+                throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName()
+                    + "] does not support custom time zones");
+            }
+            if (format == null) {
+                return DocValueFormat.RAW;
+            } else {
+                return new DocValueFormat.Decimal(format);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (super.equals(o) == false) {
+                return false;
+            }
+            return numSigBits == ((CustomFloatFieldType) o).numSigBits
+                    && zeroExp == ((CustomFloatFieldType) o).zeroExp;
+        }
+
+        @Override
+        public int hashCode() {
+            int h = super.hashCode();
+            h = 31 * h + numSigBits;
+            h = 31 * h + zeroExp;
+            return h;
+        }
+    }
+
+    private Explicit<Boolean> ignoreMalformed;
+
+    private Explicit<Boolean> coerce;
+
+    private CustomFloatFieldMapper(
+            String simpleName,
+            MappedFieldType fieldType,
+            MappedFieldType defaultFieldType,
+            Explicit<Boolean> ignoreMalformed,
+            Explicit<Boolean> coerce,
+            Settings indexSettings,
+            MultiFields multiFields,
+            CopyTo copyTo) {
+        super(simpleName, fieldType, defaultFieldType, indexSettings, multiFields, copyTo);
+        this.ignoreMalformed = ignoreMalformed;
+        this.coerce = coerce;
+    }
+
+    @Override
+    public CustomFloatFieldType fieldType() {
+        return (CustomFloatFieldType) super.fieldType();
+    }
+
+    private CustomFloatFieldType defaultFieldType() {
+        return (CustomFloatFieldType) defaultFieldType;
+    }
+
+    @Override
+    protected String contentType() {
+        return fieldType.typeName();
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
+
+        XContentParser parser = context.parser();
+        Object value;
+        Number numericValue = null;
+        if (context.externalValueSet()) {
+            value = context.externalValue();
+        } else if (parser.currentToken() == Token.VALUE_NULL) {
+            value = null;
+        } else if (coerce.value()
+                && parser.currentToken() == Token.VALUE_STRING
+                && parser.textLength() == 0) {
+            value = null;
+        } else {
+            try {
+                numericValue = parse(parser, coerce.value());
+            } catch (IllegalArgumentException e) {
+                if (ignoreMalformed.value()) {
+                    return;
+                } else {
+                    throw e;
+                }
+            }
+            value = numericValue;
+        }
+
+        if (value == null) {
+            value = fieldType().nullValue();
+        }
+
+        if (value == null) {
+            return;
+        }
+
+        if (numericValue == null) {
+            numericValue = parse(value);
+        }
+
+        double doubleValue = numericValue.doubleValue();
+        if (Double.isFinite(doubleValue) == false) {
+            if (ignoreMalformed.value()) {
+                return;
+            } else {
+                // since we encode to a long, we have no way to carry NaNs and infinities
+                throw new IllegalArgumentException("[custom_float] only supports finite values, but got [" + doubleValue + "]");
+            }
+        }
+        long encodedValue = fieldType().encoder.applyAsLong(doubleValue);
+
+        boolean indexed = fieldType().indexOptions() != IndexOptions.NONE;
+        boolean docValued = fieldType().hasDocValues();
+        boolean stored = fieldType().stored();
+        fields.addAll(NumberFieldMapper.NumberType.LONG.createFields(fieldType().name(), encodedValue, indexed, docValued, stored));
+    }
+
+    @Override
+    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+        super.doMerge(mergeWith, updateAllTypes);
+        CustomFloatFieldMapper other = (CustomFloatFieldMapper) mergeWith;
+        if (other.ignoreMalformed.explicit()) {
+            this.ignoreMalformed = other.ignoreMalformed;
+        }
+        if (other.coerce.explicit()) {
+            this.coerce = other.coerce;
+        }
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults, Params params) throws IOException {
+        super.doXContentBody(builder, includeDefaults, params);
+
+        if (includeDefaults || fieldType().getNumSigBits() != defaultFieldType().getNumSigBits()) {
+            builder.field("num_significant_bits", fieldType().getNumSigBits());
+        }
+        if (includeDefaults || fieldType().getZeroExp() != defaultFieldType().getZeroExp()) {
+            builder.field("zero_exponent", fieldType().getZeroExp());
+        }
+
+        if (includeDefaults || ignoreMalformed.explicit()) {
+            builder.field("ignore_malformed", ignoreMalformed.value());
+        }
+        if (includeDefaults || coerce.explicit()) {
+            builder.field("coerce", coerce.value());
+        }
+
+        if (includeDefaults || fieldType().nullValue() != null) {
+            builder.field("null_value", fieldType().nullValue());
+        }
+    }
+
+    static Double parse(Object value) {
+        return objectToDouble(value);
+    }
+
+    private static Double parse(XContentParser parser, boolean coerce) throws IOException {
+        return parser.doubleValue(coerce);
+    }
+
+    /**
+     * Converts an Object to a double by checking it against known types first
+     */
+    private static double objectToDouble(Object value) {
+        double doubleValue;
+
+        if (value instanceof Number) {
+            doubleValue = ((Number) value).doubleValue();
+        } else if (value instanceof BytesRef) {
+            doubleValue = Double.parseDouble(((BytesRef) value).utf8ToString());
+        } else {
+            doubleValue = Double.parseDouble(value.toString());
+        }
+
+        return doubleValue;
+    }
+
+    private static class CustomFloatIndexFieldData implements IndexNumericFieldData {
+
+        private final IndexNumericFieldData encodedFieldData;
+        private final LongToDoubleFunction decoder;
+
+        CustomFloatIndexFieldData(IndexNumericFieldData encodedFieldData, LongToDoubleFunction decoder) {
+            this.encodedFieldData = encodedFieldData;
+            this.decoder = decoder;
+        }
+
+        @Override
+        public String getFieldName() {
+            return encodedFieldData.getFieldName();
+        }
+
+        @Override
+        public AtomicNumericFieldData load(LeafReaderContext context) {
+            return new CustomFloatLeafFieldData(encodedFieldData.load(context), decoder);
+        }
+
+        @Override
+        public AtomicNumericFieldData loadDirect(LeafReaderContext context) throws Exception {
+            return new CustomFloatLeafFieldData(encodedFieldData.loadDirect(context), decoder);
+        }
+
+        @Override
+        public SortField sortField(@Nullable Object missingValue, MultiValueMode sortMode, Nested nested, boolean reverse) {
+            final XFieldComparatorSource source = new DoubleValuesComparatorSource(this, missingValue, sortMode, nested);
+            return new SortField(getFieldName(), source, reverse);
+        }
+
+        @Override
+        public void clear() {
+            encodedFieldData.clear();
+        }
+
+        @Override
+        public Index index() {
+            return encodedFieldData.index();
+        }
+
+        @Override
+        public NumericType getNumericType() {
+            /**
+             * {@link CustomFloatLeafFieldData#getDoubleValues()} transforms the raw long values in decoded floats.
+             */
+            return NumericType.DOUBLE;
+        }
+
+    }
+
+    private static class CustomFloatLeafFieldData implements AtomicNumericFieldData {
+
+        private final AtomicNumericFieldData encodedFieldData;
+        private final LongToDoubleFunction decoder;
+
+        CustomFloatLeafFieldData(AtomicNumericFieldData encodedFieldData, LongToDoubleFunction decoder) {
+            this.encodedFieldData = encodedFieldData;
+            this.decoder = decoder;
+        }
+
+        @Override
+        public ScriptDocValues.Doubles getScriptValues() {
+            return new ScriptDocValues.Doubles(getDoubleValues());
+        }
+
+        @Override
+        public SortedBinaryDocValues getBytesValues() {
+            return FieldData.toString(getDoubleValues());
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return encodedFieldData.ramBytesUsed();
+        }
+
+        @Override
+        public void close() {
+            encodedFieldData.close();
+        }
+
+        @Override
+        public SortedNumericDocValues getLongValues() {
+            return FieldData.castToLong(getDoubleValues());
+        }
+
+        @Override
+        public SortedNumericDoubleValues getDoubleValues() {
+            final SortedNumericDocValues values = encodedFieldData.getLongValues();
+            final NumericDocValues singleValues = DocValues.unwrapSingleton(values);
+            if (singleValues != null) {
+                return FieldData.singleton(new NumericDoubleValues() {
+                    @Override
+                    public boolean advanceExact(int doc) throws IOException {
+                        return singleValues.advanceExact(doc);
+                    }
+                    @Override
+                    public double doubleValue() throws IOException {
+                        return decoder.applyAsDouble(singleValues.longValue());
+                    }
+                });
+            } else {
+                return new SortedNumericDoubleValues() {
+
+                    @Override
+                    public boolean advanceExact(int target) throws IOException {
+                        return values.advanceExact(target);
+                    }
+
+                    @Override
+                    public double nextValue() throws IOException {
+                        return decoder.applyAsDouble(values.nextValue());
+                    }
+
+                    @Override
+                    public int docValueCount() {
+                        return values.docValueCount();
+                    }
+                };
+            }
+        }
+
+    }
+}

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/MapperExtrasPlugin.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/MapperExtrasPlugin.java
@@ -32,6 +32,7 @@ public class MapperExtrasPlugin extends Plugin implements MapperPlugin {
     public Map<String, Mapper.TypeParser> getMappers() {
         Map<String, Mapper.TypeParser> mappers = new LinkedHashMap<>();
         mappers.put(ScaledFloatFieldMapper.CONTENT_TYPE, new ScaledFloatFieldMapper.TypeParser());
+        mappers.put(CustomFloatFieldMapper.CONTENT_TYPE, new CustomFloatFieldMapper.TypeParser());
         mappers.put(TokenCountFieldMapper.CONTENT_TYPE, new TokenCountFieldMapper.TypeParser());
         for (RangeFieldMapper.RangeType type : RangeFieldMapper.RangeType.values()) {
             mappers.put(type.typeName(), new RangeFieldMapper.TypeParser(type));

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/CustomFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/CustomFloatFieldMapperTests.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class CustomFloatFieldMapperTests extends ESSingleNodeTestCase {
+
+    IndexService indexService;
+    DocumentMapperParser parser;
+
+    @Before
+    public void setup() {
+        indexService = createIndex("test");
+        parser = indexService.mapperService().documentMapperParser();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, MapperExtrasPlugin.class);
+    }
+
+    public void testDefaults() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "custom_float")
+                .endObject().endObject().endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertFalse(pointField.fieldType().stored());
+        assertEquals(NumericUtils.doubleToSortableLong(123), pointField.numericValue().longValue());
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+        assertEquals(NumericUtils.doubleToSortableLong(123), dvField.numericValue().longValue());
+        assertFalse(dvField.fieldType().stored());
+    }
+
+    public void testCustomParams() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "custom_float")
+                .field("num_significant_bits", 10).field("zero_exponent", -2)
+                .endObject().endObject().endObject().endObject().string();
+        long encoded = CustomFloat.getEncoder(10, -2).applyAsLong(123);
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertFalse(pointField.fieldType().stored());
+        assertEquals(encoded, pointField.numericValue().longValue());
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+        assertEquals(encoded, dvField.numericValue().longValue());
+        assertFalse(dvField.fieldType().stored());
+    }
+
+    public void testIllegalNumBits() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "custom_float")
+                .field("num_significant_bits", 0).endObject().endObject()
+                .endObject().endObject().string();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> parser.parse("type", new CompressedXContent(mapping)));
+        assertEquals("[num_significant_bits] must be in 1..53, got 0", e.getMessage());
+    }
+
+    public void testIllegalZeroExp() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "custom_float")
+                .field("zero_exponent", -1024).endObject().endObject()
+                .endObject().endObject().string();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> parser.parse("type", new CompressedXContent(mapping)));
+        assertEquals("[zero_exponent] must be in -1023..1023, got -1024", e.getMessage());
+    }
+
+    public void testNotIndexed() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "custom_float")
+                .field("index", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        IndexableField dvField = fields[0];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+        assertEquals(NumericUtils.doubleToSortableLong(123), dvField.numericValue().longValue());
+    }
+
+    public void testNoDocValues() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "custom_float")
+                .field("doc_values", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertEquals(NumericUtils.doubleToSortableLong(123), pointField.numericValue().longValue());
+    }
+
+    public void testStore() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "custom_float")
+                .field("store", true).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", 123)
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(3, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertEquals(NumericUtils.doubleToSortableLong(123), pointField.numericValue().doubleValue(), 0d);
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+        IndexableField storedField = fields[2];
+        assertTrue(storedField.fieldType().stored());
+        assertEquals(NumericUtils.doubleToSortableLong(123), storedField.numericValue().longValue());
+    }
+
+    public void testCoerce() throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "custom_float")
+                .endObject().endObject().endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "123")
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertEquals(NumericUtils.doubleToSortableLong(123), pointField.numericValue().longValue());
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties").startObject("field").field("type", "custom_float")
+                .field("coerce", false).endObject().endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper2 = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper2.mappingSource().toString());
+
+        ThrowingRunnable runnable = () -> mapper2.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", "123")
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+        MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
+        assertThat(e.getCause().getMessage(), containsString("passed as String"));
+    }
+
+    public void testIgnoreMalformed() throws Exception {
+        doTestIgnoreMalformed("a", "For input string: \"a\"");
+
+        List<String> values = Arrays.asList("NaN", "Infinity", "-Infinity");
+        for (String value : values) {
+            doTestIgnoreMalformed(value, "[custom_float] only supports finite values, but got [" + value + "]");
+        }
+    }
+
+    private void doTestIgnoreMalformed(String value, String exceptionMessageContains) throws Exception {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("field").field("type", "custom_float")
+            .endObject().endObject().endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ThrowingRunnable runnable = () -> mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", value)
+                .endObject()
+                .bytes(),
+            XContentType.JSON));
+        MapperParsingException e = expectThrows(MapperParsingException.class, runnable);
+        assertThat(e.getCause().getMessage(), containsString(exceptionMessageContains));
+
+        mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("field").field("type", "custom_float")
+            .field("ignore_malformed", true).endObject().endObject()
+            .endObject().endObject().string();
+
+        DocumentMapper mapper2 = parser.parse("type", new CompressedXContent(mapping));
+
+        ParsedDocument doc = mapper2.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .field("field", value)
+                .endObject()
+                .bytes(),
+            XContentType.JSON));
+
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(0, fields.length);
+    }
+
+    public void testNullValue() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("field")
+                            .field("type", "custom_float")
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .nullField("field")
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+        assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+
+        mapping = XContentFactory.jsonBuilder().startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("field")
+                            .field("type", "custom_float")
+                            .field("null_value", 2.5)
+                        .endObject()
+                    .endObject()
+                .endObject().endObject().string();
+
+        mapper = parser.parse("type", new CompressedXContent(mapping));
+        assertEquals(mapping, mapper.mappingSource().toString());
+
+        doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                .nullField("field")
+                .endObject()
+                .bytes(),
+                XContentType.JSON));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        IndexableField pointField = fields[0];
+        assertEquals(1, pointField.fieldType().pointDimensionCount());
+        assertFalse(pointField.fieldType().stored());
+        assertEquals(NumericUtils.doubleToSortableLong(2.5), pointField.numericValue().longValue());
+        IndexableField dvField = fields[1];
+        assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
+        assertFalse(dvField.fieldType().stored());
+    }
+
+    public void testEmptyName() throws IOException {
+        // after 5.x
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("")
+            .field("type", "custom_float").endObject().endObject()
+            .endObject().endObject().string();
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> parser.parse("type", new CompressedXContent(mapping))
+        );
+        assertThat(e.getMessage(), containsString("name cannot be empty string"));
+    }
+}

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/CustomFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/CustomFloatFieldTypeTests.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fielddata.AtomicNumericFieldData;
+import org.elasticsearch.index.fielddata.IndexNumericFieldData;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.DoubleToLongFunction;
+import java.util.function.LongToDoubleFunction;
+
+public class CustomFloatFieldTypeTests extends FieldTypeTestCase {
+
+    @Override
+    protected MappedFieldType createDefaultFieldType() {
+        CustomFloatFieldMapper.CustomFloatFieldType ft = new CustomFloatFieldMapper.CustomFloatFieldType();
+        ft.setNumSigBits(10);
+        ft.setZeroExponent(-20);
+        return ft;
+    }
+
+    @Before
+    public void setupProperties() {
+        addModifier(new Modifier("num_significant_bits", false) {
+            @Override
+            public void modify(MappedFieldType ft) {
+                CustomFloatFieldMapper.CustomFloatFieldType tft = (CustomFloatFieldMapper.CustomFloatFieldType)ft;
+                tft.setNumSigBits(15);
+            }
+            @Override
+            public void normalizeOther(MappedFieldType other) {
+                super.normalizeOther(other);
+                ((CustomFloatFieldMapper.CustomFloatFieldType) other).setNumSigBits(10);
+            }
+        });
+        addModifier(new Modifier("zero_exponent", false) {
+            @Override
+            public void modify(MappedFieldType ft) {
+                CustomFloatFieldMapper.CustomFloatFieldType tft = (CustomFloatFieldMapper.CustomFloatFieldType)ft;
+                tft.setZeroExponent(10);
+            }
+            @Override
+            public void normalizeOther(MappedFieldType other) {
+                super.normalizeOther(other);
+                ((CustomFloatFieldMapper.CustomFloatFieldType) other).setZeroExponent(-20);
+            }
+        });
+    }
+
+    public void testTermQuery() {
+        CustomFloatFieldMapper.CustomFloatFieldType ft = new CustomFloatFieldMapper.CustomFloatFieldType();
+        ft.setName("custom_float");
+        ft.setNumSigBits(10);
+        ft.setZeroExponent(-20);
+        double value = (randomDouble() * 2 - 1) * 10000;
+        long encoded = CustomFloat.getEncoder(ft.getNumSigBits(), ft.getZeroExp()).applyAsLong(value);
+        assertEquals(LongPoint.newExactQuery("custom_float", encoded), ft.termQuery(value, null));
+    }
+
+    public void testTermsQuery() {
+        CustomFloatFieldMapper.CustomFloatFieldType ft = new CustomFloatFieldMapper.CustomFloatFieldType();
+        ft.setName("custom_float");
+        ft.setNumSigBits(10);
+        ft.setZeroExponent(-20);
+        double value1 = (randomDouble() * 2 - 1) * 10000;
+        long encoded1 = CustomFloat.getEncoder(ft.getNumSigBits(), ft.getZeroExp()).applyAsLong(value1);
+        double value2 = (randomDouble() * 2 - 1) * 10000;
+        long encoded2 = CustomFloat.getEncoder(ft.getNumSigBits(), ft.getZeroExp()).applyAsLong(value2);
+        assertEquals(
+                LongPoint.newSetQuery("custom_float", encoded1, encoded2),
+                ft.termsQuery(Arrays.asList(value1, value2), null));
+    }
+
+    public void testRangeQuery() throws IOException {
+        // make sure the accuracy loss of scaled floats only occurs at index time
+        // this test checks that searching custom floats yields the same results as
+        // searching doubles that are rounded to the closest half float
+        CustomFloatFieldMapper.CustomFloatFieldType ft = new CustomFloatFieldMapper.CustomFloatFieldType();
+        ft.setName("custom_float");
+        ft.setNumSigBits(randomIntBetween(2, 10));
+        ft.setZeroExponent(randomIntBetween(-10, 2));
+        DoubleToLongFunction encoder = CustomFloat.getEncoder(ft.getNumSigBits(), ft.getZeroExp());
+        LongToDoubleFunction decoder = CustomFloat.getDecoder(ft.getNumSigBits(), ft.getZeroExp());
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+        final int numDocs = 1000;
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+            double value = (randomDouble() * 2 - 1) * 10000;
+            long encodedValue = encoder.applyAsLong(value);
+            double rounded = decoder.applyAsDouble(encodedValue);
+            doc.add(new LongPoint("custom_float", encodedValue));
+            doc.add(new DoublePoint("double", rounded));
+            w.addDocument(doc);
+        }
+        final DirectoryReader reader = DirectoryReader.open(w);
+        w.close();
+        IndexSearcher searcher = newSearcher(reader);
+        final int numQueries = 1000;
+        for (int i = 0; i < numQueries; ++i) {
+            Double l = randomBoolean() ? null : (randomDouble() * 2 - 1) * 10000;
+            Double u = randomBoolean() ? null : (randomDouble() * 2 - 1) * 10000;
+            boolean includeLower = randomBoolean();
+            boolean includeUpper = randomBoolean();
+            Query doubleQ = NumberFieldMapper.NumberType.DOUBLE.rangeQuery("double", l, u, includeLower, includeUpper, false);
+            Query customFloatQ = ft.rangeQuery(l, u, includeLower, includeUpper, null);
+            assertEquals(searcher.count(doubleQ), searcher.count(customFloatQ));
+        }
+        IOUtils.close(reader, dir);
+    }
+
+    public void testValueForSearch() {
+        CustomFloatFieldMapper.CustomFloatFieldType ft = new CustomFloatFieldMapper.CustomFloatFieldType();
+        ft.setName("custom_float");
+        ft.setNumSigBits(randomIntBetween(2, 10));
+        ft.setZeroExponent(randomIntBetween(-10, 2));
+        LongToDoubleFunction decoder = CustomFloat.getDecoder(ft.getNumSigBits(), ft.getZeroExp());
+        assertNull(ft.valueForDisplay(null));
+        assertEquals(decoder.applyAsDouble(10L), ft.valueForDisplay(10L));
+    }
+
+    public void testFieldData() throws IOException {
+        CustomFloatFieldMapper.CustomFloatFieldType ft = new CustomFloatFieldMapper.CustomFloatFieldType();
+        ft.setNumSigBits(randomIntBetween(2, 10));
+        ft.setZeroExponent(randomIntBetween(-10, 2));
+        LongToDoubleFunction decoder = CustomFloat.getDecoder(ft.getNumSigBits(), ft.getZeroExp());
+        Directory dir = newDirectory();
+        IndexWriter w = new IndexWriter(dir, new IndexWriterConfig(null));
+        Document doc = new Document();
+        doc.add(new SortedNumericDocValuesField("custom_float1", 10));
+        doc.add(new SortedNumericDocValuesField("custom_float2", 5));
+        doc.add(new SortedNumericDocValuesField("custom_float2", 12));
+        w.addDocument(doc);
+        try (DirectoryReader reader = DirectoryReader.open(w)) {
+            IndexMetaData indexMetadata = new IndexMetaData.Builder("index").settings(
+                    Settings.builder()
+                    .put("index.version.created", Version.CURRENT)
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0).build()).build();
+            IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+
+            // single-valued
+            ft.setName("custom_float1");
+            IndexNumericFieldData fielddata = (IndexNumericFieldData) ft.fielddataBuilder("index")
+                .build(indexSettings, ft, null, null, null);
+            assertEquals(fielddata.getNumericType(), IndexNumericFieldData.NumericType.DOUBLE);
+            AtomicNumericFieldData leafFieldData = fielddata.load(reader.leaves().get(0));
+            SortedNumericDoubleValues values = leafFieldData.getDoubleValues();
+            assertTrue(values.advanceExact(0));
+            assertEquals(1, values.docValueCount());
+            assertEquals(decoder.applyAsDouble(10), values.nextValue(), 0d);
+
+            // multi-valued
+            ft.setName("custom_float2");
+            fielddata = (IndexNumericFieldData) ft.fielddataBuilder("index").build(indexSettings, ft, null, null, null);
+            leafFieldData = fielddata.load(reader.leaves().get(0));
+            values = leafFieldData.getDoubleValues();
+            assertTrue(values.advanceExact(0));
+            assertEquals(2, values.docValueCount());
+            assertEquals(decoder.applyAsDouble(5), values.nextValue(), 0d);
+            assertEquals(decoder.applyAsDouble(12), values.nextValue(), 0d);
+        }
+        IOUtils.close(w, dir);
+    }
+}

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/CustomFloatTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/CustomFloatTests.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matchers;
+
+import java.util.function.DoubleToLongFunction;
+import java.util.function.LongToDoubleFunction;
+
+public class CustomFloatTests extends ESTestCase {
+
+    public void testIllegalInput() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> CustomFloat.getEncoder(0, -100));
+        assertEquals("numSigBits must be >= 1, got 0", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class,
+                () -> CustomFloat.getEncoder(54, -100));
+        assertEquals("numSigBits must be <= 53, got 54", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class,
+                () -> CustomFloat.getEncoder(10, -1024));
+        assertEquals("zeroExponent must be >= -1023, got -1024", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class,
+                () -> CustomFloat.getEncoder(10, 1024));
+        assertEquals("zeroExponent must be <= 1023, got 1024", e.getMessage());
+
+        DoubleToLongFunction encoder = CustomFloat.getEncoder(randomIntBetween(1, 53), randomIntBetween(-1023, 0));
+        e = expectThrows(IllegalArgumentException.class,
+                () -> encoder.applyAsLong(Double.POSITIVE_INFINITY));
+        assertEquals("Cannot encode non-finite value: Infinity", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class,
+                () -> encoder.applyAsLong(Double.NEGATIVE_INFINITY));
+        assertEquals("Cannot encode non-finite value: -Infinity", e.getMessage());
+
+        e = expectThrows(IllegalArgumentException.class,
+                () -> encoder.applyAsLong(Double.NaN));
+        assertEquals("Cannot encode non-finite value: NaN", e.getMessage());
+
+        DoubleToLongFunction encoder2 = CustomFloat.getEncoder(randomIntBetween(1, 51), randomIntBetween(-1023, 0));
+        e = expectThrows(IllegalArgumentException.class,
+                () -> encoder2.applyAsLong(Math.nextDown(Double.POSITIVE_INFINITY)));
+        assertThat(e.getMessage(), Matchers.containsString("is too large and was rounded to +/-Infinity"));
+    }
+
+    public void testDuelFloat() {
+        DoubleToLongFunction encoder = CustomFloat.getEncoder(24, -127);
+        LongToDoubleFunction decoder = CustomFloat.getDecoder(24, -127);
+        for (int i = 0; i < 100; ++i) {
+            // Doubles that are likely normal
+            double d = (randomDouble() - 0.3) * 10000;
+            long encoded = encoder.applyAsLong(d);
+            double decoded = decoder.applyAsDouble(encoded);
+            assertEquals("" + (float) d + " != " + decoded,
+                    Double.doubleToLongBits((float) d), Double.doubleToLongBits(decoded));
+        }
+
+        for (int i = 0; i < 100; ++i) {
+            // Likely subnormal floats
+            double d = (randomDouble() - 0.3) * Float.MIN_VALUE * 100000;
+            long encoded = encoder.applyAsLong(d);
+            double decoded = decoder.applyAsDouble(encoded);
+            assertEquals("" + (double) (float) d + " != " + decoded,
+                    Double.doubleToLongBits((float) d), Double.doubleToLongBits(decoded));
+        }
+    }
+
+    public void testDuelDouble() {
+        DoubleToLongFunction encoder = CustomFloat.getEncoder(53, -1023);
+        LongToDoubleFunction decoder = CustomFloat.getDecoder(53, -1023);
+        for (int i = 0; i < 100; ++i) {
+            double d = (randomDouble() - 0.3) * 10000;
+            long encoded = encoder.applyAsLong(d);
+            double decoded = decoder.applyAsDouble(encoded);
+            assertEquals("" + d + " != " + decoded,
+                    Double.doubleToLongBits(d), Double.doubleToLongBits(decoded));
+        }
+
+        for (int i = 0; i < 100; ++i) {
+            // Likely subnormal doubles
+            double d = (randomDouble() - 0.3) * 100000 * Double.MIN_VALUE;
+            long encoded = encoder.applyAsLong(d);
+            double decoded = decoder.applyAsDouble(encoded);
+            assertEquals("" + d + " != " + decoded,
+                    Double.doubleToLongBits(d), Double.doubleToLongBits(decoded));
+        }
+    }
+
+    public void testEncodeLongs() {
+        for (int iter = 0; iter < 10; ++iter) {
+            int numSigBits = randomIntBetween(1, 53);
+            int zeroExp = numSigBits - 2;
+            DoubleToLongFunction encoder = CustomFloat.getEncoder(numSigBits, zeroExp);
+            LongToDoubleFunction decoder = CustomFloat.getDecoder(numSigBits, zeroExp);
+            for (int i = 0; i <= (1 << numSigBits); ++i) {
+                long encoded = encoder.applyAsLong(i);
+                double decoded = decoder.applyAsDouble(encoded);
+                assertEquals(i, decoded, 0d);
+                assertEquals(i, encoded);
+            }
+        }
+    }
+
+    public void testMaintainsOrder() {
+        int numSigBits = randomIntBetween(3, 10);
+        int zeroExp = randomIntBetween(-1023, numSigBits - 2);
+        DoubleToLongFunction encoder = CustomFloat.getEncoder(numSigBits, zeroExp);
+        assertTrue(encoder.applyAsLong(-2) < encoder.applyAsLong(-1));
+        assertTrue(encoder.applyAsLong(-1) < encoder.applyAsLong(0));
+        assertTrue(encoder.applyAsLong(0) < encoder.applyAsLong(1));
+        assertTrue(encoder.applyAsLong(1) < encoder.applyAsLong(2));
+        assertTrue(encoder.applyAsLong(3) <= encoder.applyAsLong(Math.PI));
+        assertTrue(encoder.applyAsLong(Math.PI) <= encoder.applyAsLong(4));
+    }
+}

--- a/modules/mapper-extras/src/test/resources/rest-api-spec/test/custom_float/10_basic.yml
+++ b/modules/mapper-extras/src/test/resources/rest-api-spec/test/custom_float/10_basic.yml
@@ -1,0 +1,105 @@
+setup:
+  - do:
+      indices.create:
+          index: test
+          body:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              doc:
+                "properties":
+                  "number":
+                     "type" : "custom_float"
+                     "num_significant_bits": 10
+
+  - do:
+      index:
+        index: test
+        type: doc
+        id: 1
+        body: { "number" : 1 }
+
+  - do:
+      index:
+        index: test
+        type: doc
+        id: 2
+        body: { "number" : 1.5 }
+
+  - do:
+      index:
+        index: test
+        type: doc
+        id: 3
+        body: { "number" : -2.25 }
+
+  - do:
+      index:
+        index: test
+        type: doc
+        id: 4
+        body: { "number" : 1.5 }
+
+  - do:
+      indices.refresh: {}
+
+---
+"Aggregations":
+
+  - do:
+      search:
+        body: { "size" : 0, "aggs" : { "my_terms" : { "terms" : { "field" : "number" } } } }
+
+  - match: { hits.total: 4 }
+
+  - length: { aggregations.my_terms.buckets: 3 }
+
+  - match: { aggregations.my_terms.buckets.0.key: 1.5 }
+
+  - is_false: aggregations.my_terms.buckets.0.key_as_string
+
+  - match: { aggregations.my_terms.buckets.0.doc_count: 2 }
+
+  - match: { aggregations.my_terms.buckets.1.key: -2.25 }
+
+  - is_false: aggregations.my_terms.buckets.1.key_as_string
+
+  - match: { aggregations.my_terms.buckets.1.doc_count: 1 }
+
+  - match: { aggregations.my_terms.buckets.2.key: 1 }
+
+  - is_false: aggregations.my_terms.buckets.2.key_as_string
+
+  - match: { aggregations.my_terms.buckets.2.doc_count: 1 }
+
+---
+"Search":
+
+  - do:
+      search:
+        body: { "size" : 0, "query" : { "range" : { "number" : { "gte" : -2 } } } }
+
+  - match: { hits.total: 3 }
+
+  - do:
+      search:
+        body: { "size" : 0, "query" : { "range" : { "number" : { "gte" : 0 } } } }
+
+  - match: { hits.total: 3 }
+
+  - do:
+      search:
+        body: { "size" : 0, "query" : { "range" : { "number" : { "lt" : 1.5 } } } }
+
+  - match: { hits.total: 2 }
+
+---
+"Sort":
+
+  - do:
+      search:
+        body: { "size" : 1, "sort" : { "number" : { "order" : "asc" } } }
+
+  - match: { hits.total: 4 }
+  - match: { hits.hits.0._id: "3" }
+


### PR DESCRIPTION
This field exposes new trade-offs in order to optimize storage. It uses a format
that is very similar to `double` and `float` except that you can configure the
number of significant bits to maintain and the minimum exponent that may be
used to represent a value.

For instance configured with `num_significant_bits=10` and `zero_exponent=8`, it
can help preserve 10 significant bits (about 3 significant digits) and would use
at most 16 bits to represent numbers that cover the entire `long` range where
the `long` field would use 64 bits. I believe this can be interesting in order
to represent eg. query latencies or numbers of bytes per request, since we do not
care about the seconds for latencies that are in the order of hours, and we
don't care about a couple bytes more or less for amounts that are in the order
of megabytes.

It uses an approach that is slightly different from the one that was initially outlined
on #22886 but addresses the same problem.

Closes #22886