### PR TITLE
Fix discovery-file plugin to use custom config path

### DIFF
--- a/plugins/discovery-file/src/main/java/org/elasticsearch/discovery/file/FileBasedDiscoveryPlugin.java
+++ b/plugins/discovery-file/src/main/java/org/elasticsearch/discovery/file/FileBasedDiscoveryPlugin.java
@@ -42,6 +42,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -61,10 +62,12 @@ public class FileBasedDiscoveryPlugin extends Plugin implements DiscoveryPlugin 
     private static final DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
 
     private final Settings settings;
+    private final Path configPath;
     private ExecutorService fileBasedDiscoveryExecutorService;
 
-    public FileBasedDiscoveryPlugin(Settings settings) {
+    public FileBasedDiscoveryPlugin(Settings settings, Path configPath) {
         this.settings = settings;
+        this.configPath = configPath;
     }
 
     @Override
@@ -96,7 +99,8 @@ public class FileBasedDiscoveryPlugin extends Plugin implements DiscoveryPlugin 
                                                                             NetworkService networkService) {
         return Collections.singletonMap(
             "file",
-            () -> new FileBasedUnicastHostsProvider(settings, transportService, fileBasedDiscoveryExecutorService));
+            () -> new FileBasedUnicastHostsProvider(
+                    new Environment(settings, configPath), transportService, fileBasedDiscoveryExecutorService));
     }
 
     @Override

--- a/plugins/discovery-file/src/main/java/org/elasticsearch/discovery/file/FileBasedUnicastHostsProvider.java
+++ b/plugins/discovery-file/src/main/java/org/elasticsearch/discovery/file/FileBasedUnicastHostsProvider.java
@@ -71,11 +71,11 @@ class FileBasedUnicastHostsProvider extends AbstractComponent implements Unicast
 
     private final TimeValue resolveTimeout;
 
-    FileBasedUnicastHostsProvider(Settings settings, TransportService transportService, ExecutorService executorService) {
-        super(settings);
+    FileBasedUnicastHostsProvider(Environment environment, TransportService transportService, ExecutorService executorService) {
+        super(environment.settings());
         this.transportService = transportService;
         this.executorService = executorService;
-        this.unicastHostsFilePath = new Environment(settings).configFile().resolve("discovery-file").resolve(UNICAST_HOSTS_FILE);
+        this.unicastHostsFilePath = environment.configFile().resolve("discovery-file").resolve(UNICAST_HOSTS_FILE);
         this.resolveTimeout = DISCOVERY_ZEN_PING_UNICAST_HOSTS_RESOLVE_TIMEOUT.get(settings);
     }
 

--- a/plugins/discovery-file/src/test/java/org/elasticsearch/discovery/file/FileBasedDiscoveryPluginTests.java
+++ b/plugins/discovery-file/src/test/java/org/elasticsearch/discovery/file/FileBasedDiscoveryPluginTests.java
@@ -24,11 +24,12 @@ import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.nio.file.Path;
 
 public class FileBasedDiscoveryPluginTests extends ESTestCase {
 
     public void testHostsProviderBwc() {
-        FileBasedDiscoveryPlugin plugin = new FileBasedDiscoveryPlugin(Settings.EMPTY);
+        FileBasedDiscoveryPlugin plugin = new FileBasedDiscoveryPlugin(Settings.EMPTY, createTempDir());
         Settings additionalSettings = plugin.additionalSettings();
         assertEquals("file", additionalSettings.get(DiscoveryModule.DISCOVERY_HOSTS_PROVIDER_SETTING.getKey()));
         assertWarnings("Using discovery.type setting to set hosts provider is deprecated. " +
@@ -37,9 +38,10 @@ public class FileBasedDiscoveryPluginTests extends ESTestCase {
 
     public void testHostsProviderExplicit() {
         Settings settings = Settings.builder().put(DiscoveryModule.DISCOVERY_HOSTS_PROVIDER_SETTING.getKey(), "foo").build();
-        FileBasedDiscoveryPlugin plugin = new FileBasedDiscoveryPlugin(settings);
+        FileBasedDiscoveryPlugin plugin = new FileBasedDiscoveryPlugin(settings, createTempDir());
         assertEquals(Settings.EMPTY, plugin.additionalSettings());
         assertWarnings("Using discovery.type setting to set hosts provider is deprecated. " +
                 "Set \"discovery.zen.hosts_provider: file\" instead");
     }
+
 }


### PR DESCRIPTION
The discovery-file plugin was not config path aware, so it always picked up the default config path (from Elasticsearch home) rather than a custom config path. This commit fixes the discovery-file plugin to respect a custom config path.

Closes #26660

