### PR TITLE
change the strategy about how shards select path from multi paths on one datanode

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexService.java
@@ -324,10 +324,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     }
                     dataPathToShardCount.put(dataPath, curCount + 1);
                 }
-                path = ShardPath.selectNewPathForShard(nodeEnv, shardId, this.indexSettings,
-                    routing.getExpectedShardSize() == ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE
-                        ? getAvgShardSizeInBytes() : routing.getExpectedShardSize(),
-                    dataPathToShardCount);
+                path = ShardPath.selectNewPathForShard(nodeEnv, shardId, this.indexSettings);
                 logger.debug("{} creating using a new path [{}]", shardId, path);
             } else {
                 logger.debug("{} creating using an existing path [{}]", shardId, path);

--- a/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -26,11 +26,10 @@ import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.index.IndexSettings;
 
 import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Random;
 
 public final class ShardPath {
     public static final String INDEX_FOLDER_NAME = "index";
@@ -40,6 +39,8 @@ public final class ShardPath {
     private final ShardId shardId;
     private final Path shardStatePath;
     private final boolean isCustomDataPath;
+
+    public static int shardRountBinNumber = -1;
 
     public ShardPath(boolean isCustomDataPath, Path dataPath, Path shardStatePath, ShardId shardId) {
         assert dataPath.getFileName().toString().equals(Integer.toString(shardId.id())) : "dataPath must end with the shard ID but didn't: " + dataPath.toString();
@@ -162,8 +163,7 @@ public final class ShardPath {
         }
     }
 
-    public static ShardPath selectNewPathForShard(NodeEnvironment env, ShardId shardId, IndexSettings indexSettings,
-                                                  long avgShardSizeInBytes, Map<Path,Integer> dataPathToShardCount) throws IOException {
+    public static ShardPath selectNewPathForShard(NodeEnvironment env, ShardId shardId, IndexSettings indexSettings) throws IOException {
 
         final Path dataPath;
         final Path statePath;
@@ -171,39 +171,15 @@ public final class ShardPath {
         if (indexSettings.hasCustomDataPath()) {
             dataPath = env.resolveCustomLocation(indexSettings, shardId);
             statePath = env.nodePaths()[0].resolve(shardId);
-        } else {
-            BigInteger totFreeSpace = BigInteger.ZERO;
-            for (NodeEnvironment.NodePath nodePath : env.nodePaths()) {
-                totFreeSpace = totFreeSpace.add(BigInteger.valueOf(nodePath.fileStore.getUsableSpace()));
-            }
-
-            // TODO: this is a hack!!  We should instead keep track of incoming (relocated) shards since we know
-            // how large they will be once they're done copying, instead of a silly guess for such cases:
-
-            // Very rough heuristic of how much disk space we expect the shard will use over its lifetime, the max of current average
-            // shard size across the cluster and 5% of the total available free space on this node:
-            BigInteger estShardSizeInBytes = BigInteger.valueOf(avgShardSizeInBytes).max(totFreeSpace.divide(BigInteger.valueOf(20)));
-
-            // TODO - do we need something more extensible? Yet, this does the job for now...
+        }  else {
             final NodeEnvironment.NodePath[] paths = env.nodePaths();
-            NodeEnvironment.NodePath bestPath = null;
-            BigInteger maxUsableBytes = BigInteger.valueOf(Long.MIN_VALUE);
-            for (NodeEnvironment.NodePath nodePath : paths) {
-                FileStore fileStore = nodePath.fileStore;
 
-                BigInteger usableBytes = BigInteger.valueOf(fileStore.getUsableSpace());
-                assert usableBytes.compareTo(BigInteger.ZERO) >= 0;
-
-                // Deduct estimated reserved bytes from usable space:
-                Integer count = dataPathToShardCount.get(nodePath.path);
-                if (count != null) {
-                    usableBytes = usableBytes.subtract(estShardSizeInBytes.multiply(BigInteger.valueOf(count)));
-                }
-                if (bestPath == null || usableBytes.compareTo(maxUsableBytes) > 0) {
-                    maxUsableBytes = usableBytes;
-                    bestPath = nodePath;
-                }
+            if (shardRountBinNumber == -1) {
+                shardRountBinNumber = new Random().nextInt(paths.length);
             }
+
+            NodeEnvironment.NodePath bestPath = paths[ShardPath.shardRountBinNumber];
+            ShardPath.shardRountBinNumber = ++ ShardPath.shardRountBinNumber % paths.length;
 
             statePath = bestPath.resolve(shardId);
             dataPath = statePath;

--- a/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/NewPathForShardTests.java
@@ -183,7 +183,7 @@ public class NewPathForShardTests extends ESTestCase {
         bFileStore.usableSpace = 1000;
 
         ShardId shardId = new ShardId("index", "_na_", 0);
-        ShardPath result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, Collections.<Path,Integer>emptyMap());
+        ShardPath result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS);
         assertTrue(result.getDataPath().toString().contains(aPathPart));
 
         // Test the reverse: b has lots of free space, but a has little, so new shard should go to b:
@@ -191,7 +191,7 @@ public class NewPathForShardTests extends ESTestCase {
         bFileStore.usableSpace = 100000;
 
         shardId = new ShardId("index", "_na_", 0);
-        result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, Collections.<Path,Integer>emptyMap());
+        result = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS);
         assertTrue(result.getDataPath().toString().contains(bPathPart));
 
         // Now a and be have equal usable space; we allocate two shards to the node, and each should go to different paths:
@@ -199,9 +199,9 @@ public class NewPathForShardTests extends ESTestCase {
         bFileStore.usableSpace = 100000;
 
         Map<Path,Integer> dataPathToShardCount = new HashMap<>();
-        ShardPath result1 = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, dataPathToShardCount);
+        ShardPath result1 = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS);
         dataPathToShardCount.put(NodeEnvironment.shardStatePathToDataPath(result1.getDataPath()), 1);
-        ShardPath result2 = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS, 100, dataPathToShardCount);
+        ShardPath result2 = ShardPath.selectNewPathForShard(nodeEnv, shardId, INDEX_SETTINGS);
 
         // #11122: this was the original failure: on a node with 2 disks that have nearly equal
         // free space, we would always allocate all N incoming shards to the one path that


### PR DESCRIPTION
In produce environment, every node has more than one disk.
In current strategy,we select the path mainly by the way whose usable space is most. but in reality it is not so good

First the path usable space is not equal the beginning, worsely there has a lot of difference about the usable space, as the result, all shards will be allocated to one path(it will be mounted to one disk). 

Second, the current strategy does well to select path for shard in the same index, how about different index. as we can see, when the first index is allocated to properly path, laterly the second index will be allocated to the same path,  when there's not enough time to write data to the first index(or the interval is very short), so the estShardSizeInBytes and aviable free space change little. especially at 00:00, almost all the needed indices are created(with no date writen into) at the moment. In produce environment, we has 12 disks ,only 4-6 diskes will be used.

      So we think of  six strategies for our environment:
            1. select the path that has the most free space
            2. select the path that use the least space
            3. random select shard path
            4. round-bin
            5. select the path that has the least shards
            6.select the path that depends on the history data traffic.
As we can say, 1th and 2th have same bug, we can deal with the shards with same index well, how about different index.1th is being using  6th is the the best strategy,but it it difficult to realize.

 Think out the other strategies, we select the 4th in our production, every path will be equally select to allocate shard, the above situation will be avoided, alse it is easy to realize, and as result, it work well too.