### PR TITLE
Add global checkpoint tracking on the primary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 allprojects {
-  ext.bwc_tests_enabled = true
+  ext.bwc_tests_enabled = false
 }
 
 task verifyBwcTestsEnabled {

--- a/core/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -93,7 +93,8 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
         if (node.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
             super.sendReplicaRequest(replicaRequest, node, listener);
         } else {
-            listener.onResponse(new ReplicaResponse(SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT));
+            final long pre60NodeCheckpoint = SequenceNumbersService.PRE_60_NODE_CHECKPOINT;
+            listener.onResponse(new ReplicaResponse(pre60NodeCheckpoint, pre60NodeCheckpoint));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.index.seqno.SequenceNumbersService;
 import org.elasticsearch.index.shard.ReplicationGroup;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
@@ -173,6 +174,7 @@ public class ReplicationOperation<
                 successfulShards.incrementAndGet();
                 try {
                     primary.updateLocalCheckpointForShard(shard.allocationId().getId(), response.localCheckpoint());
+                    primary.updateGlobalCheckpointForShard(shard.allocationId().getId(), response.globalCheckpoint());
                 } catch (final AlreadyClosedException e) {
                     // okay, the index was deleted or this shard was never activated after a relocation; fall through and finish normally
                 } catch (final Exception e) {
@@ -316,6 +318,14 @@ public class ReplicationOperation<
         void updateLocalCheckpointForShard(String allocationId, long checkpoint);
 
         /**
+         * Update the local knowledge of the global checkpoint for the specified allocation ID.
+         *
+         * @param allocationId     the allocation ID to update the global checkpoint for
+         * @param globalCheckpoint the global checkpoint
+         */
+        void updateGlobalCheckpointForShard(String allocationId, long globalCheckpoint);
+
+        /**
          * Returns the local checkpoint on the primary shard.
          *
          * @return the local checkpoint
@@ -385,12 +395,24 @@ public class ReplicationOperation<
     }
 
     /**
-     * An interface to encapsulate the metadata needed from replica shards when they respond to operations performed on them
+     * An interface to encapsulate the metadata needed from replica shards when they respond to operations performed on them.
      */
     public interface ReplicaResponse {
 
-        /** the local check point for the shard. see {@link org.elasticsearch.index.seqno.SequenceNumbersService#getLocalCheckpoint()} */
+        /**
+         * The local checkpoint for the shard. See {@link SequenceNumbersService#getLocalCheckpoint()}.
+         *
+         * @return the local checkpoint
+         **/
         long localCheckpoint();
+
+        /**
+         * The global checkpoint for the shard. See {@link SequenceNumbersService#getGlobalCheckpoint()}.
+         *
+         * @return the global checkpoint
+         **/
+        long globalCheckpoint();
+
     }
 
     public static class RetryOnPrimaryException extends ElasticsearchException {

--- a/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -1039,7 +1039,7 @@ public abstract class TransportReplicationAction<
 
         public ReplicaResponse(long localCheckpoint, long globalCheckpoint) {
             /*
-             * A replica should always know its own local checkpoints so this should always be valida  sequence number or the pre-6.0
+             * A replica should always know its own local checkpoints so this should always be a valid sequence number or the pre-6.0
              * checkpoint value when simulating responses to replication actions that pre-6.0 nodes are not aware of (e.g., the global
              * checkpoint background sync, and the primary/replica resync).
              */

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
@@ -89,7 +89,8 @@ public class GlobalCheckpointSyncAction extends TransportReplicationAction<
         if (node.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
             super.sendReplicaRequest(replicaRequest, node, listener);
         } else {
-            listener.onResponse(new ReplicaResponse(SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT));
+            final long pre60NodeCheckpoint = SequenceNumbersService.PRE_60_NODE_CHECKPOINT;
+            listener.onResponse(new ReplicaResponse(pre60NodeCheckpoint, pre60NodeCheckpoint));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -358,12 +358,10 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
          * information is lagging compared to a replica (e.g., if a replica is promoted to primary but has stale info relative to other
          * replica shards). In these cases, the local knowledge of the global checkpoint could be higher than sync from the lagging primary.
          */
-        final long currentGlobalCheckpoint = getGlobalCheckpoint();
-        if (currentGlobalCheckpoint <= globalCheckpoint) {
-            logger.trace("updating global checkpoint from [{}] to [{}] due to [{}]", currentGlobalCheckpoint, globalCheckpoint, reason);
-            final long unassignedSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
-            final CheckpointState cps =
-                    checkpoints.computeIfAbsent(allocationId, k -> new CheckpointState(unassignedSeqNo, unassignedSeqNo, true));
+        final CheckpointState cps = checkpoints.get(allocationId);
+        assert cps != null;
+        if (cps.globalCheckpoint <= globalCheckpoint) {
+            logger.trace("updating global checkpoint from [{}] to [{}] due to [{}]", cps.globalCheckpoint, globalCheckpoint, reason);
             cps.globalCheckpoint = globalCheckpoint;
         }
         assert invariant();

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -38,14 +38,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
-import java.util.function.LongFunction;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 /**
  * This class is responsible of tracking the global checkpoint. The global checkpoint is the highest sequence number for which all lower (or

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -864,7 +864,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
 
         @Override
         public int hashCode() {
-            int result = (int) (clusterStateVersion ^ (clusterStateVersion >>> 32));
+            int result = Long.hashCode(clusterStateVersion);
             result = 31 * result + checkpoints.hashCode();
             result = 31 * result + routingTable.hashCode();
             return result;

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -673,7 +673,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         assert handoffInProgress;
         primaryMode = false;
         handoffInProgress = false;
-        // forget all checkpoint information except for current shard (should we forget local checkpoint for current shard as well?)
+        // forget all checkpoint information except for global checkpoint of current shard
         checkpoints.entrySet().stream().forEach(e -> {
             final CheckpointState cps = e.getValue();
             if (cps.localCheckpoint != SequenceNumbers.UNASSIGNED_SEQ_NO &&

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -392,8 +392,8 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
 
     private void updateGlobalCheckpoint(final String allocationId, final long globalCheckpoint, LongConsumer ifUpdated) {
         final CheckpointState cps = checkpoints.get(allocationId);
-        assert cps != null;
-        if (globalCheckpoint > cps.globalCheckpoint) {
+        assert !this.allocationId.equals(allocationId) || cps != null;
+        if (cps != null && globalCheckpoint > cps.globalCheckpoint) {
             ifUpdated.accept(cps.globalCheckpoint);
             cps.globalCheckpoint = globalCheckpoint;
         }

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -36,8 +36,15 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongFunction;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 /**
  * This class is responsible of tracking the global checkpoint. The global checkpoint is the highest sequence number for which all lower (or
@@ -50,7 +57,7 @@ import java.util.stream.Collectors;
  */
 public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
 
-    private final String allocationId;
+    final String allocationId;
 
     /**
      * The global checkpoint tracker can operate in two modes:
@@ -103,9 +110,9 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
     /**
      * Local checkpoint information for all shard copies that are tracked. Has an entry for all shard copies that are either initializing
      * and / or in-sync, possibly also containing information about unassigned in-sync shard copies. The information that is tracked for
-     * each shard copy is explained in the docs for the {@link LocalCheckpointState} class.
+     * each shard copy is explained in the docs for the {@link CheckpointState} class.
      */
-    final Map<String, LocalCheckpointState> localCheckpoints;
+    final Map<String, CheckpointState> checkpoints;
 
     /**
      * This set contains allocation IDs for which there is a thread actively waiting for the local checkpoint to advance to at least the
@@ -114,59 +121,66 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
     final Set<String> pendingInSync;
 
     /**
-     * The global checkpoint:
-     * - computed based on local checkpoints, if the tracker is in primary mode
-     * - received from the primary, if the tracker is in replica mode
-     */
-    volatile long globalCheckpoint;
-
-    /**
      * Cached value for the last replication group that was computed
      */
     volatile ReplicationGroup replicationGroup;
 
-    public static class LocalCheckpointState implements Writeable {
+    public static class CheckpointState implements Writeable {
 
         /**
          * the last local checkpoint information that we have for this shard
          */
         long localCheckpoint;
+
+        /**
+         * the last global checkpoint information that we have for this shard. This information is computed for the primary if
+         * the tracker is in primary mode and received from the primary if in replica mode.
+         */
+        long globalCheckpoint;
         /**
          * whether this shard is treated as in-sync and thus contributes to the global checkpoint calculation
          */
         boolean inSync;
 
-        public LocalCheckpointState(long localCheckpoint, boolean inSync) {
+        public CheckpointState(long localCheckpoint, long globalCheckpoint, boolean inSync) {
             this.localCheckpoint = localCheckpoint;
+            this.globalCheckpoint = globalCheckpoint;
             this.inSync = inSync;
         }
 
-        public LocalCheckpointState(StreamInput in) throws IOException {
+        public CheckpointState(StreamInput in) throws IOException {
             this.localCheckpoint = in.readZLong();
+            this.globalCheckpoint = in.readZLong();
             this.inSync = in.readBoolean();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeZLong(localCheckpoint);
+            out.writeZLong(globalCheckpoint);
             out.writeBoolean(inSync);
         }
 
         /**
          * Returns a full copy of this object
          */
-        public LocalCheckpointState copy() {
-            return new LocalCheckpointState(localCheckpoint, inSync);
+        public CheckpointState copy() {
+            return new CheckpointState(localCheckpoint, globalCheckpoint, inSync);
         }
 
         public long getLocalCheckpoint() {
             return localCheckpoint;
         }
 
+        public long getGlobalCheckpoint() {
+            return globalCheckpoint;
+        }
+
         @Override
         public String toString() {
             return "LocalCheckpointState{" +
                 "localCheckpoint=" + localCheckpoint +
+                ", globalCheckpoint=" + globalCheckpoint +
                 ", inSync=" + inSync +
                 '}';
         }
@@ -176,16 +190,18 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
-            LocalCheckpointState that = (LocalCheckpointState) o;
+            CheckpointState that = (CheckpointState) o;
 
             if (localCheckpoint != that.localCheckpoint) return false;
+            if (globalCheckpoint != that.globalCheckpoint) return false;
             return inSync == that.inSync;
         }
 
         @Override
         public int hashCode() {
-            int result = (int) (localCheckpoint ^ (localCheckpoint >>> 32));
-            result = 31 * result + (inSync ? 1 : 0);
+            int result = Long.hashCode(localCheckpoint);
+            result = 31 * result + Long.hashCode(globalCheckpoint);
+            result = 31 * result + Boolean.hashCode(inSync);
             return result;
         }
     }
@@ -195,20 +211,34 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
      * as a logical operator, many of the invariants are written under the form (!A || B), they should be read as (A implies B) however.
      */
     private boolean invariant() {
+        assert checkpoints.get(allocationId) != null :
+            "checkpoints map should always have an entry for the current shard";
+
         // local checkpoints only set during primary mode
-        assert primaryMode || localCheckpoints.values().stream()
+        assert primaryMode || checkpoints.values().stream()
             .allMatch(lcps -> lcps.localCheckpoint == SequenceNumbers.UNASSIGNED_SEQ_NO ||
-                lcps.localCheckpoint == SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT);
+                lcps.localCheckpoint == SequenceNumbersService.PRE_60_NODE_CHECKPOINT);
+
+        // global checkpoints for other shards only set during primary mode
+        assert primaryMode || checkpoints.entrySet().stream().filter(e -> e.getKey().equals(allocationId) == false).map(Map.Entry::getValue)
+            .allMatch(cps ->
+                (cps.globalCheckpoint == SequenceNumbers.UNASSIGNED_SEQ_NO ||
+                    cps.globalCheckpoint == SequenceNumbersService.PRE_60_NODE_CHECKPOINT));
 
         // relocation handoff can only occur in primary mode
         assert !handoffInProgress || primaryMode;
 
-        // there is at least one in-sync shard copy when the global checkpoint tracker operates in primary mode (i.e. the shard itself)
-        assert !primaryMode || localCheckpoints.values().stream().anyMatch(lcps -> lcps.inSync);
+        // the current shard is marked as in-sync when the global checkpoint tracker operates in primary mode
+        assert !primaryMode || checkpoints.get(allocationId).inSync;
 
         // the routing table and replication group is set when the global checkpoint tracker operates in primary mode
         assert !primaryMode || (routingTable != null && replicationGroup != null) :
             "primary mode but routing table is " + routingTable + " and replication group is " + replicationGroup;
+
+        // when in primary mode, the current allocation ID is the allocation ID of the primary or the relocation allocation ID
+        assert !primaryMode
+                || (routingTable.primaryShard().allocationId().getId().equals(allocationId)
+                || routingTable.primaryShard().allocationId().getRelocationId().equals(allocationId));
 
         // during relocation handoff there are no entries blocking global checkpoint advancement
         assert !handoffInProgress || pendingInSync.isEmpty() :
@@ -218,9 +248,18 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         assert pendingInSync.isEmpty() || (primaryMode && !handoffInProgress);
 
         // the computed global checkpoint is always up-to-date
-        assert !primaryMode || globalCheckpoint == computeGlobalCheckpoint(pendingInSync, localCheckpoints.values(), globalCheckpoint) :
-            "global checkpoint is not up-to-date, expected: " +
-                computeGlobalCheckpoint(pendingInSync, localCheckpoints.values(), globalCheckpoint) + " but was: " + globalCheckpoint;
+        assert !primaryMode
+                || getGlobalCheckpoint() == computeGlobalCheckpoint(pendingInSync, checkpoints.values(), getGlobalCheckpoint())
+                : "global checkpoint is not up-to-date, expected: " +
+                computeGlobalCheckpoint(pendingInSync, checkpoints.values(), getGlobalCheckpoint()) + " but was: " + getGlobalCheckpoint();
+
+        // when in primary mode, the global checkpoint is at most the minimum local checkpoint on all in-sync shard copies
+        assert !primaryMode
+                || getGlobalCheckpoint() <= inSyncCheckpointStates(checkpoints, CheckpointState::getLocalCheckpoint, LongStream::min);
+
+        // when in primary mode, the local knowledge of the global checkpoints on shard copies is bounded by the global checkpoint
+        assert !primaryMode
+                || getGlobalCheckpoint() >= inSyncCheckpointStates(checkpoints, CheckpointState::getGlobalCheckpoint, LongStream::max);
 
         // we have a routing table iff we have a replication group
         assert (routingTable == null) == (replicationGroup == null) :
@@ -230,16 +269,25 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
             "cached replication group out of sync: expected: " + calculateReplicationGroup() + " but was: " + replicationGroup;
 
         // all assigned shards from the routing table are tracked
-        assert routingTable == null || localCheckpoints.keySet().containsAll(routingTable.getAllAllocationIds()) :
-            "local checkpoints " + localCheckpoints + " not in-sync with routing table " + routingTable;
+        assert routingTable == null || checkpoints.keySet().containsAll(routingTable.getAllAllocationIds()) :
+            "local checkpoints " + checkpoints + " not in-sync with routing table " + routingTable;
 
-        for (Map.Entry<String, LocalCheckpointState> entry : localCheckpoints.entrySet()) {
+        for (Map.Entry<String, CheckpointState> entry : checkpoints.entrySet()) {
             // blocking global checkpoint advancement only happens for shards that are not in-sync
             assert !pendingInSync.contains(entry.getKey()) || !entry.getValue().inSync :
                 "shard copy " + entry.getKey() + " blocks global checkpoint advancement but is in-sync";
         }
 
         return true;
+    }
+
+    private static long inSyncCheckpointStates(
+            final Map<String, CheckpointState> checkpoints,
+            ToLongFunction<CheckpointState> function,
+            Function<LongStream, OptionalLong> reducer) {
+        final OptionalLong value = reducer.apply(checkpoints.values().stream().filter(cps -> cps.inSync).mapToLong(function));
+        assert value.isPresent();
+        return value.getAsLong();
     }
 
     /**
@@ -262,8 +310,8 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         this.primaryMode = false;
         this.handoffInProgress = false;
         this.appliedClusterStateVersion = -1L;
-        this.globalCheckpoint = globalCheckpoint;
-        this.localCheckpoints = new HashMap<>(1 + indexSettings.getNumberOfReplicas());
+        this.checkpoints = new HashMap<>(1 + indexSettings.getNumberOfReplicas());
+        checkpoints.put(allocationId, new CheckpointState(SequenceNumbers.UNASSIGNED_SEQ_NO, globalCheckpoint, false));
         this.pendingInSync = new HashSet<>();
         this.routingTable = null;
         this.replicationGroup = null;
@@ -282,7 +330,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
 
     private ReplicationGroup calculateReplicationGroup() {
         return new ReplicationGroup(routingTable,
-            localCheckpoints.entrySet().stream().filter(e -> e.getValue().inSync).map(Map.Entry::getKey).collect(Collectors.toSet()));
+            checkpoints.entrySet().stream().filter(e -> e.getValue().inSync).map(Map.Entry::getKey).collect(Collectors.toSet()));
     }
 
     /**
@@ -290,8 +338,10 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
      *
      * @return the global checkpoint
      */
-    public long getGlobalCheckpoint() {
-        return globalCheckpoint;
+    public synchronized long getGlobalCheckpoint() {
+        final CheckpointState cps = checkpoints.get(allocationId);
+        assert cps != null;
+        return cps.globalCheckpoint;
     }
 
     /**
@@ -308,9 +358,12 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
          * information is lagging compared to a replica (e.g., if a replica is promoted to primary but has stale info relative to other
          * replica shards). In these cases, the local knowledge of the global checkpoint could be higher than sync from the lagging primary.
          */
-        if (this.globalCheckpoint <= globalCheckpoint) {
-            logger.trace("updating global checkpoint from [{}] to [{}] due to [{}]", this.globalCheckpoint, globalCheckpoint, reason);
-            this.globalCheckpoint = globalCheckpoint;
+        if (getGlobalCheckpoint() <= globalCheckpoint) {
+            logger.trace("updating global checkpoint from [{}] to [{}] due to [{}]", getGlobalCheckpoint(), globalCheckpoint, reason);
+            final long unassignedSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
+            final CheckpointState cps =
+                    checkpoints.computeIfAbsent(allocationId, k -> new CheckpointState(unassignedSeqNo, unassignedSeqNo, true));
+            cps.globalCheckpoint = globalCheckpoint;
         }
         assert invariant();
     }
@@ -321,12 +374,12 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
     public synchronized void activatePrimaryMode(final long localCheckpoint) {
         assert invariant();
         assert primaryMode == false;
-        assert localCheckpoints.get(allocationId) != null && localCheckpoints.get(allocationId).inSync &&
-            localCheckpoints.get(allocationId).localCheckpoint == SequenceNumbers.UNASSIGNED_SEQ_NO :
-            "expected " + allocationId + " to have initialized entry in " + localCheckpoints + " when activating primary";
+        assert checkpoints.get(allocationId) != null && checkpoints.get(allocationId).inSync &&
+            checkpoints.get(allocationId).localCheckpoint == SequenceNumbers.UNASSIGNED_SEQ_NO :
+            "expected " + allocationId + " to have initialized entry in " + checkpoints + " when activating primary";
         assert localCheckpoint >= SequenceNumbers.NO_OPS_PERFORMED;
         primaryMode = true;
-        updateLocalCheckpoint(allocationId, localCheckpoints.get(allocationId), localCheckpoint);
+        updateLocalCheckpoint(allocationId, checkpoints.get(allocationId), localCheckpoint);
         updateGlobalCheckpointOnPrimary();
         assert invariant();
     }
@@ -345,37 +398,47 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         if (applyingClusterStateVersion > appliedClusterStateVersion) {
             // check that the master does not fabricate new in-sync entries out of thin air once we are in primary mode
             assert !primaryMode || inSyncAllocationIds.stream().allMatch(
-                inSyncId -> localCheckpoints.containsKey(inSyncId) && localCheckpoints.get(inSyncId).inSync) :
+                inSyncId -> checkpoints.containsKey(inSyncId) && checkpoints.get(inSyncId).inSync) :
                 "update from master in primary mode contains in-sync ids " + inSyncAllocationIds +
-                    " that have no matching entries in " + localCheckpoints;
+                    " that have no matching entries in " + checkpoints;
             // remove entries which don't exist on master
             Set<String> initializingAllocationIds = routingTable.getAllInitializingShards().stream()
                 .map(ShardRouting::allocationId).map(AllocationId::getId).collect(Collectors.toSet());
-            boolean removedEntries = localCheckpoints.keySet().removeIf(
+            boolean removedEntries = checkpoints.keySet().removeIf(
                 aid -> !inSyncAllocationIds.contains(aid) && !initializingAllocationIds.contains(aid));
 
             if (primaryMode) {
                 // add new initializingIds that are missing locally. These are fresh shard copies - and not in-sync
                 for (String initializingId : initializingAllocationIds) {
-                    if (localCheckpoints.containsKey(initializingId) == false) {
+                    if (checkpoints.containsKey(initializingId) == false) {
                         final boolean inSync = inSyncAllocationIds.contains(initializingId);
                         assert inSync == false : "update from master in primary mode has " + initializingId +
                             " as in-sync but it does not exist locally";
                         final long localCheckpoint = pre60AllocationIds.contains(initializingId) ?
-                            SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT : SequenceNumbers.UNASSIGNED_SEQ_NO;
-                        localCheckpoints.put(initializingId, new LocalCheckpointState(localCheckpoint, inSync));
+                            SequenceNumbersService.PRE_60_NODE_CHECKPOINT : SequenceNumbers.UNASSIGNED_SEQ_NO;
+                        final long globalCheckpoint = localCheckpoint;
+                        checkpoints.put(initializingId, new CheckpointState(localCheckpoint, globalCheckpoint, inSync));
                     }
                 }
             } else {
                 for (String initializingId : initializingAllocationIds) {
-                    final long localCheckpoint = pre60AllocationIds.contains(initializingId) ?
-                        SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT : SequenceNumbers.UNASSIGNED_SEQ_NO;
-                    localCheckpoints.put(initializingId, new LocalCheckpointState(localCheckpoint, false));
+                    if (allocationId.equals(initializingId) == false) {
+                        final long localCheckpoint = pre60AllocationIds.contains(initializingId) ?
+                            SequenceNumbersService.PRE_60_NODE_CHECKPOINT : SequenceNumbers.UNASSIGNED_SEQ_NO;
+                        final long globalCheckpoint = localCheckpoint;
+                        checkpoints.put(initializingId, new CheckpointState(localCheckpoint, globalCheckpoint, false));
+                    }
                 }
                 for (String inSyncId : inSyncAllocationIds) {
-                    final long localCheckpoint = pre60AllocationIds.contains(inSyncId) ?
-                        SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT : SequenceNumbers.UNASSIGNED_SEQ_NO;
-                    localCheckpoints.put(inSyncId, new LocalCheckpointState(localCheckpoint, true));
+                    if (allocationId.equals(inSyncId)) {
+                        // current shard is initially marked as not in-sync because we don't know better at that point
+                        checkpoints.get(allocationId).inSync = true;
+                    } else {
+                        final long localCheckpoint = pre60AllocationIds.contains(inSyncId) ?
+                            SequenceNumbersService.PRE_60_NODE_CHECKPOINT : SequenceNumbers.UNASSIGNED_SEQ_NO;
+                        final long globalCheckpoint = localCheckpoint;
+                        checkpoints.put(inSyncId, new CheckpointState(localCheckpoint, globalCheckpoint, true));
+                    }
                 }
             }
             appliedClusterStateVersion = applyingClusterStateVersion;
@@ -397,8 +460,8 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
     public synchronized void initiateTracking(final String allocationId) {
         assert invariant();
         assert primaryMode;
-        LocalCheckpointState lcps = localCheckpoints.get(allocationId);
-        if (lcps == null) {
+        CheckpointState cps = checkpoints.get(allocationId);
+        if (cps == null) {
             // can happen if replica was removed from cluster but recovery process is unaware of it yet
             throw new IllegalStateException("no local checkpoint tracking information available");
         }
@@ -416,21 +479,21 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         assert invariant();
         assert primaryMode;
         assert handoffInProgress == false;
-        LocalCheckpointState lcps = localCheckpoints.get(allocationId);
-        if (lcps == null) {
+        CheckpointState cps = checkpoints.get(allocationId);
+        if (cps == null) {
             // can happen if replica was removed from cluster but recovery process is unaware of it yet
             throw new IllegalStateException("no local checkpoint tracking information available for " + allocationId);
         }
         assert localCheckpoint >= SequenceNumbers.NO_OPS_PERFORMED :
             "expected known local checkpoint for " + allocationId + " but was " + localCheckpoint;
         assert pendingInSync.contains(allocationId) == false : "shard copy " + allocationId + " is already marked as pending in-sync";
-        updateLocalCheckpoint(allocationId, lcps, localCheckpoint);
+        updateLocalCheckpoint(allocationId, cps, localCheckpoint);
         // if it was already in-sync (because of a previously failed recovery attempt), global checkpoint must have been
         // stuck from advancing
-        assert !lcps.inSync || (lcps.localCheckpoint >= globalCheckpoint) :
-            "shard copy " + allocationId + " that's already in-sync should have a local checkpoint " + lcps.localCheckpoint +
-                " that's above the global checkpoint " + globalCheckpoint;
-        if (lcps.localCheckpoint < globalCheckpoint) {
+        assert !cps.inSync || (cps.localCheckpoint >= getGlobalCheckpoint()) :
+            "shard copy " + allocationId + " that's already in-sync should have a local checkpoint " + cps.localCheckpoint +
+                " that's above the global checkpoint " + getGlobalCheckpoint();
+        if (cps.localCheckpoint < getGlobalCheckpoint()) {
             pendingInSync.add(allocationId);
             try {
                 while (true) {
@@ -444,7 +507,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
                 pendingInSync.remove(allocationId);
             }
         } else {
-            lcps.inSync = true;
+            cps.inSync = true;
             replicationGroup = calculateReplicationGroup();
             logger.trace("marked [{}] as in-sync", allocationId);
             updateGlobalCheckpointOnPrimary();
@@ -453,23 +516,40 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         assert invariant();
     }
 
-    private boolean updateLocalCheckpoint(String allocationId, LocalCheckpointState lcps, long localCheckpoint) {
-        // a local checkpoint of PRE_60_NODE_LOCAL_CHECKPOINT cannot be overridden
-        assert lcps.localCheckpoint != SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT ||
-            localCheckpoint == SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT :
+    private boolean updateLocalCheckpoint(String allocationId, CheckpointState cps, long localCheckpoint) {
+        // a local checkpoint of PRE_60_NODE_CHECKPOINT cannot be overridden
+        assert cps.localCheckpoint != SequenceNumbersService.PRE_60_NODE_CHECKPOINT ||
+            localCheckpoint == SequenceNumbersService.PRE_60_NODE_CHECKPOINT :
             "pre-6.0 shard copy " + allocationId + " unexpected to send valid local checkpoint " + localCheckpoint;
         // a local checkpoint for a shard copy should be a valid sequence number or the pre-6.0 sequence number indicator
         assert localCheckpoint != SequenceNumbers.UNASSIGNED_SEQ_NO :
                 "invalid local checkpoint for shard copy [" + allocationId + "]";
-        if (localCheckpoint > lcps.localCheckpoint) {
-            logger.trace("updated local checkpoint of [{}] from [{}] to [{}]", allocationId, lcps.localCheckpoint, localCheckpoint);
-            lcps.localCheckpoint = localCheckpoint;
+        if (localCheckpoint > cps.localCheckpoint) {
+            logger.trace("updated local checkpoint of [{}] from [{}] to [{}]", allocationId, cps.localCheckpoint, localCheckpoint);
+            cps.localCheckpoint = localCheckpoint;
             return true;
         } else {
             logger.trace("skipped updating local checkpoint of [{}] from [{}] to [{}], current checkpoint is higher", allocationId,
-                lcps.localCheckpoint, localCheckpoint);
+                cps.localCheckpoint, localCheckpoint);
             return false;
         }
+    }
+
+    /**
+     * Update the local knowledge of the global checkpoint for the specified allocation ID.
+     *
+     * @param allocationId     the allocation ID to update the global checkpoint for
+     * @param globalCheckpoint the global checkpoint
+     */
+    public synchronized void updateGlobalCheckpointForShard(final String allocationId, final long globalCheckpoint) {
+        assert primaryMode;
+        assert handoffInProgress == false;
+        assert invariant();
+        final CheckpointState cps = checkpoints.get(allocationId);
+        if (cps != null && globalCheckpoint > cps.globalCheckpoint) {
+            cps.globalCheckpoint = globalCheckpoint;
+        }
+        assert invariant();
     }
 
     /**
@@ -483,17 +563,17 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         assert invariant();
         assert primaryMode;
         assert handoffInProgress == false;
-        LocalCheckpointState lcps = localCheckpoints.get(allocationId);
-        if (lcps == null) {
+        CheckpointState cps = checkpoints.get(allocationId);
+        if (cps == null) {
             // can happen if replica was removed from cluster but replication process is unaware of it yet
             return;
         }
-        boolean increasedLocalCheckpoint = updateLocalCheckpoint(allocationId, lcps, localCheckpoint);
+        boolean increasedLocalCheckpoint = updateLocalCheckpoint(allocationId, cps, localCheckpoint);
         boolean pending = pendingInSync.contains(allocationId);
-        if (pending && lcps.localCheckpoint >= globalCheckpoint) {
+        if (pending && cps.localCheckpoint >= getGlobalCheckpoint()) {
             pendingInSync.remove(allocationId);
             pending = false;
-            lcps.inSync = true;
+            cps.inSync = true;
             replicationGroup = calculateReplicationGroup();
             logger.trace("marked [{}] as in-sync", allocationId);
             notifyAllWaiters();
@@ -508,21 +588,21 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
      * Computes the global checkpoint based on the given local checkpoints. In case where there are entries preventing the
      * computation to happen (for example due to blocking), it returns the fallback value.
      */
-    private static long computeGlobalCheckpoint(final Set<String> pendingInSync, final Collection<LocalCheckpointState> localCheckpoints,
+    private static long computeGlobalCheckpoint(final Set<String> pendingInSync, final Collection<CheckpointState> localCheckpoints,
                                                 final long fallback) {
         long minLocalCheckpoint = Long.MAX_VALUE;
         if (pendingInSync.isEmpty() == false) {
             return fallback;
         }
-        for (final LocalCheckpointState lcps : localCheckpoints) {
-            if (lcps.inSync) {
-                if (lcps.localCheckpoint == SequenceNumbers.UNASSIGNED_SEQ_NO) {
+        for (final CheckpointState cps : localCheckpoints) {
+            if (cps.inSync) {
+                if (cps.localCheckpoint == SequenceNumbers.UNASSIGNED_SEQ_NO) {
                     // unassigned in-sync replica
                     return fallback;
-                } else if (lcps.localCheckpoint == SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT) {
+                } else if (cps.localCheckpoint == SequenceNumbersService.PRE_60_NODE_CHECKPOINT) {
                     // 5.x replica, ignore for global checkpoint calculation
                 } else {
-                    minLocalCheckpoint = Math.min(lcps.localCheckpoint, minLocalCheckpoint);
+                    minLocalCheckpoint = Math.min(cps.localCheckpoint, minLocalCheckpoint);
                 }
             }
         }
@@ -535,12 +615,14 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
      */
     private synchronized void updateGlobalCheckpointOnPrimary() {
         assert primaryMode;
-        final long computedGlobalCheckpoint = computeGlobalCheckpoint(pendingInSync, localCheckpoints.values(), globalCheckpoint);
+        final CheckpointState cps = checkpoints.get(allocationId);
+        final long globalCheckpoint = cps.globalCheckpoint;
+        final long computedGlobalCheckpoint = computeGlobalCheckpoint(pendingInSync, checkpoints.values(), getGlobalCheckpoint());
         assert computedGlobalCheckpoint >= globalCheckpoint : "new global checkpoint [" + computedGlobalCheckpoint +
             "] is lower than previous one [" + globalCheckpoint + "]";
         if (globalCheckpoint != computedGlobalCheckpoint) {
             logger.trace("global checkpoint updated to [{}]", computedGlobalCheckpoint);
-            globalCheckpoint = computedGlobalCheckpoint;
+            cps.globalCheckpoint = computedGlobalCheckpoint;
         }
     }
 
@@ -553,13 +635,13 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         assert handoffInProgress == false;
         assert pendingInSync.isEmpty() : "relocation handoff started while there are still shard copies pending in-sync: " + pendingInSync;
         handoffInProgress = true;
-        // copy clusterStateVersion and localCheckpoints and return
-        // all the entries from localCheckpoints that are inSync: the reason we don't need to care about initializing non-insync entries
+        // copy clusterStateVersion and checkpoints and return
+        // all the entries from checkpoints that are inSync: the reason we don't need to care about initializing non-insync entries
         // is that they will have to undergo a recovery attempt on the relocation target, and will hence be supplied by the cluster state
         // update on the relocation target once relocation completes). We could alternatively also copy the map as-is (it’s safe), and it
         // would be cleaned up on the target by cluster state updates.
-        Map<String, LocalCheckpointState> localCheckpointsCopy = new HashMap<>();
-        for (Map.Entry<String, LocalCheckpointState> entry : localCheckpoints.entrySet()) {
+        Map<String, CheckpointState> localCheckpointsCopy = new HashMap<>();
+        for (Map.Entry<String, CheckpointState> entry : checkpoints.entrySet()) {
             localCheckpointsCopy.put(entry.getKey(), entry.getValue().copy());
         }
         assert invariant();
@@ -586,11 +668,19 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         assert handoffInProgress;
         primaryMode = false;
         handoffInProgress = false;
-        // forget all checkpoint information
-        localCheckpoints.values().stream().forEach(lcps -> {
-            if (lcps.localCheckpoint != SequenceNumbers.UNASSIGNED_SEQ_NO &&
-                lcps.localCheckpoint != SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT) {
-                lcps.localCheckpoint = SequenceNumbers.UNASSIGNED_SEQ_NO;
+        // forget all checkpoint information except for current shard (should we forget local checkpoint for current shard as well?)
+        checkpoints.entrySet().stream().forEach(e -> {
+            final CheckpointState cps = e.getValue();
+            if (cps.localCheckpoint != SequenceNumbers.UNASSIGNED_SEQ_NO &&
+                cps.localCheckpoint != SequenceNumbersService.PRE_60_NODE_CHECKPOINT) {
+                cps.localCheckpoint = SequenceNumbers.UNASSIGNED_SEQ_NO;
+            }
+            if (e.getKey().equals(allocationId) == false) {
+                // don't throw global checkpoint information of current shard away
+                if (cps.globalCheckpoint != SequenceNumbers.UNASSIGNED_SEQ_NO &&
+                    cps.globalCheckpoint != SequenceNumbersService.PRE_60_NODE_CHECKPOINT) {
+                    cps.globalCheckpoint = SequenceNumbers.UNASSIGNED_SEQ_NO;
+                }
             }
         });
         assert invariant();
@@ -609,9 +699,9 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         primaryMode = true;
         // capture current state to possibly replay missed cluster state update
         appliedClusterStateVersion = primaryContext.clusterStateVersion();
-        localCheckpoints.clear();
-        for (Map.Entry<String, LocalCheckpointState> entry : primaryContext.localCheckpoints.entrySet()) {
-            localCheckpoints.put(entry.getKey(), entry.getValue().copy());
+        checkpoints.clear();
+        for (Map.Entry<String, CheckpointState> entry : primaryContext.localCheckpoints.entrySet()) {
+            checkpoints.put(entry.getKey(), entry.getValue().copy());
         }
         routingTable = primaryContext.getRoutingTable();
         replicationGroup = calculateReplicationGroup();
@@ -628,11 +718,11 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         final long lastAppliedClusterStateVersion = appliedClusterStateVersion;
         final Set<String> inSyncAllocationIds = new HashSet<>();
         final Set<String> pre60AllocationIds = new HashSet<>();
-        localCheckpoints.entrySet().forEach(entry -> {
+        checkpoints.entrySet().forEach(entry -> {
             if (entry.getValue().inSync) {
                 inSyncAllocationIds.add(entry.getKey());
             }
-            if (entry.getValue().getLocalCheckpoint() == SequenceNumbersService.PRE_60_NODE_LOCAL_CHECKPOINT) {
+            if (entry.getValue().getLocalCheckpoint() == SequenceNumbersService.PRE_60_NODE_CHECKPOINT) {
                 pre60AllocationIds.add(entry.getKey());
             }
         });
@@ -651,9 +741,9 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
     /**
      * Returns the local checkpoint information tracked for a specific shard. Used by tests.
      */
-    public synchronized LocalCheckpointState getTrackedLocalCheckpointForShard(String allocationId) {
+    public synchronized CheckpointState getTrackedLocalCheckpointForShard(String allocationId) {
         assert primaryMode;
-        return localCheckpoints.get(allocationId);
+        return checkpoints.get(allocationId);
     }
 
     /**
@@ -682,10 +772,10 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
     public static class PrimaryContext implements Writeable {
 
         private final long clusterStateVersion;
-        private final Map<String, LocalCheckpointState> localCheckpoints;
+        private final Map<String, CheckpointState> localCheckpoints;
         private final IndexShardRoutingTable routingTable;
 
-        public PrimaryContext(long clusterStateVersion, Map<String, LocalCheckpointState> localCheckpoints,
+        public PrimaryContext(long clusterStateVersion, Map<String, CheckpointState> localCheckpoints,
                               IndexShardRoutingTable routingTable) {
             this.clusterStateVersion = clusterStateVersion;
             this.localCheckpoints = localCheckpoints;
@@ -694,7 +784,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
 
         public PrimaryContext(StreamInput in) throws IOException {
             clusterStateVersion = in.readVLong();
-            localCheckpoints = in.readMap(StreamInput::readString, LocalCheckpointState::new);
+            localCheckpoints = in.readMap(StreamInput::readString, CheckpointState::new);
             routingTable = IndexShardRoutingTable.Builder.readFrom(in);
         }
 
@@ -702,7 +792,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
             return clusterStateVersion;
         }
 
-        public Map<String, LocalCheckpointState> getLocalCheckpoints() {
+        public Map<String, CheckpointState> getLocalCheckpoints() {
             return localCheckpoints;
         }
 
@@ -713,7 +803,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVLong(clusterStateVersion);
-            out.writeMap(localCheckpoints, (streamOutput, s) -> out.writeString(s), (streamOutput, lcps) -> lcps.writeTo(out));
+            out.writeMap(localCheckpoints, (streamOutput, s) -> out.writeString(s), (streamOutput, cps) -> cps.writeTo(out));
             IndexShardRoutingTable.Builder.writeTo(routingTable, out);
         }
 
@@ -721,7 +811,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         public String toString() {
             return "PrimaryContext{" +
                     "clusterStateVersion=" + clusterStateVersion +
-                    ", localCheckpoints=" + localCheckpoints +
+                    ", checkpoints=" + localCheckpoints +
                     ", routingTable=" + routingTable +
                     '}';
         }

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -300,8 +300,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
                                 .filter(cps -> cps.inSync)
                                 .mapToLong(function)
                                 .filter(v -> v != SequenceNumbers.UNASSIGNED_SEQ_NO));
-        assert value.isPresent();
-        return value.getAsLong();
+        return value.isPresent() ? value.getAsLong() : SequenceNumbers.UNASSIGNED_SEQ_NO;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -358,8 +358,9 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
          * information is lagging compared to a replica (e.g., if a replica is promoted to primary but has stale info relative to other
          * replica shards). In these cases, the local knowledge of the global checkpoint could be higher than sync from the lagging primary.
          */
-        if (getGlobalCheckpoint() <= globalCheckpoint) {
-            logger.trace("updating global checkpoint from [{}] to [{}] due to [{}]", getGlobalCheckpoint(), globalCheckpoint, reason);
+        final long currentGlobalCheckpoint = getGlobalCheckpoint();
+        if (currentGlobalCheckpoint <= globalCheckpoint) {
+            logger.trace("updating global checkpoint from [{}] to [{}] due to [{}]", currentGlobalCheckpoint, globalCheckpoint, reason);
             final long unassignedSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
             final CheckpointState cps =
                     checkpoints.computeIfAbsent(allocationId, k -> new CheckpointState(unassignedSeqNo, unassignedSeqNo, true));

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -292,7 +292,14 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
             final Map<String, CheckpointState> checkpoints,
             ToLongFunction<CheckpointState> function,
             Function<LongStream, OptionalLong> reducer) {
-        final OptionalLong value = reducer.apply(checkpoints.values().stream().filter(cps -> cps.inSync).mapToLong(function));
+        final OptionalLong value =
+                reducer.apply(
+                        checkpoints
+                                .values()
+                                .stream()
+                                .filter(cps -> cps.inSync)
+                                .mapToLong(function)
+                                .filter(v -> v != SequenceNumbers.UNASSIGNED_SEQ_NO));
         assert value.isPresent();
         return value.getAsLong();
     }

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -256,11 +256,17 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
 
         // when in primary mode, the global checkpoint is at most the minimum local checkpoint on all in-sync shard copies
         assert !primaryMode
-                || getGlobalCheckpoint() <= inSyncCheckpointStates(checkpoints, CheckpointState::getLocalCheckpoint, LongStream::min);
+                || getGlobalCheckpoint() <= inSyncCheckpointStates(checkpoints, CheckpointState::getLocalCheckpoint, LongStream::min)
+                : "global checkpoint [" + getGlobalCheckpoint() + "] "
+                + "for primary mode allocation ID [" + allocationId + "] "
+                + "more than in-sync local checkpoints [" + checkpoints + "]";
 
         // when in primary mode, the local knowledge of the global checkpoints on shard copies is bounded by the global checkpoint
         assert !primaryMode
-                || getGlobalCheckpoint() >= inSyncCheckpointStates(checkpoints, CheckpointState::getGlobalCheckpoint, LongStream::max);
+                || getGlobalCheckpoint() >= inSyncCheckpointStates(checkpoints, CheckpointState::getGlobalCheckpoint, LongStream::max)
+                : "global checkpoint [" + getGlobalCheckpoint() + "] "
+                + "for primary mode allocation ID [" + allocationId + "] "
+                + "less than in-sync global checkpoints [" + checkpoints + "]";
 
         // we have a routing table iff we have a replication group
         assert (routingTable == null) == (replicationGroup == null) :

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -406,7 +406,14 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
         assert primaryMode;
         assert handoffInProgress == false;
         assert invariant();
-        updateGlobalCheckpoint(allocationId, globalCheckpoint, current -> {});
+        updateGlobalCheckpoint(
+                allocationId,
+                globalCheckpoint,
+                current -> logger.trace(
+                        "updating local knowledge for [{}] on the primary of the global checkpoint from [{}] to [{}]",
+                        allocationId,
+                        current,
+                        globalCheckpoint));
         assert invariant();
     }
 

--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointTracker.java
@@ -797,7 +797,7 @@ public class GlobalCheckpointTracker extends AbstractIndexShardComponent {
             return clusterStateVersion;
         }
 
-        public Map<String, CheckpointState> getLocalCheckpoints() {
+        public Map<String, CheckpointState> getCheckpointStates() {
             return localCheckpoints;
         }
 

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -211,7 +211,7 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
      * Activates the global checkpoint tracker in primary mode (see {@link GlobalCheckpointTracker#primaryMode}.
      * Called on primary activation or promotion.
      */
-    public void activatePrimaryMode(final String allocationId, final long localCheckpoint) {
+    public void activatePrimaryMode(final long localCheckpoint) {
         globalCheckpointTracker.activatePrimaryMode(localCheckpoint);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.seqno;
 
+import com.carrotsearch.hppc.ObjectLongMap;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
@@ -140,6 +141,10 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
      */
     public void updateGlobalCheckpointForShard(final String allocationId, final long globalCheckpoint) {
         globalCheckpointTracker.updateGlobalCheckpointForShard(allocationId, globalCheckpoint);
+    }
+
+    public ObjectLongMap<String> getGlobalCheckpoints() {
+        return globalCheckpointTracker.getGlobalCheckpoints();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbersService.java
@@ -35,7 +35,7 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
     /**
      * Represents a local checkpoint coming from a pre-6.0 node
      */
-    public static final long PRE_60_NODE_LOCAL_CHECKPOINT = -3L;
+    public static final long PRE_60_NODE_CHECKPOINT = -3L;
 
     private final LocalCheckpointTracker localCheckpointTracker;
     private final GlobalCheckpointTracker globalCheckpointTracker;
@@ -130,6 +130,16 @@ public class SequenceNumbersService extends AbstractIndexShardComponent {
      */
     public void updateLocalCheckpointForShard(final String allocationId, final long checkpoint) {
         globalCheckpointTracker.updateLocalCheckpoint(allocationId, checkpoint);
+    }
+
+    /**
+     * Update the local knowledge of the global checkpoint for the specified allocation ID.
+     *
+     * @param allocationId     the allocation ID to update the global checkpoint for
+     * @param globalCheckpoint the global checkpoint
+     */
+    public void updateGlobalCheckpointForShard(final String allocationId, final long globalCheckpoint) {
+        globalCheckpointTracker.updateGlobalCheckpointForShard(allocationId, globalCheckpoint);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1791,9 +1791,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     public void activateWithPrimaryContext(final GlobalCheckpointTracker.PrimaryContext primaryContext) {
         verifyPrimary();
         assert shardRouting.isRelocationTarget() : "only relocation target can update allocation IDs from primary context: " + shardRouting;
-        assert primaryContext.getLocalCheckpoints().containsKey(routingEntry().allocationId().getId()) &&
+        assert primaryContext.getCheckpointStates().containsKey(routingEntry().allocationId().getId()) &&
             getEngine().seqNoService().getLocalCheckpoint() ==
-                primaryContext.getLocalCheckpoints().get(routingEntry().allocationId().getId()).getLocalCheckpoint();
+                primaryContext.getCheckpointStates().get(routingEntry().allocationId().getId()).getLocalCheckpoint();
         getEngine().seqNoService().activateWithPrimaryContext(primaryContext);
     }
 

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1670,6 +1670,18 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
+     * Update the local knowledge of the global checkpoint for the specified allocation ID.
+     *
+     * @param allocationId     the allocation ID to update the global checkpoint for
+     * @param globalCheckpoint the global checkpoint
+     */
+    public void updateGlobalCheckpointForShard(final String allocationId, final long globalCheckpoint) {
+        verifyPrimary();
+        verifyNotClosed();
+        getEngine().seqNoService().updateGlobalCheckpointForShard(allocationId, globalCheckpoint);
+    }
+
+    /**
      * Waits for all operations up to the provided sequence number to complete.
      *
      * @param seqNo the sequence number that the checkpoint must advance to before this method returns

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.shard;
 
+import com.carrotsearch.hppc.ObjectLongMap;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.IndexCommit;
@@ -1745,6 +1746,12 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      */
     public long getGlobalCheckpoint() {
         return getEngine().seqNoService().getGlobalCheckpoint();
+    }
+
+    public ObjectLongMap<String> getGlobalCheckpoints() {
+        verifyPrimary();
+        verifyNotClosed();
+        return getEngine().seqNoService().getGlobalCheckpoints();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -401,7 +401,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     final DiscoveryNode recoverySourceNode = recoveryState.getSourceNode();
                     if (currentRouting.isRelocationTarget() == false || recoverySourceNode.getVersion().before(Version.V_6_0_0_alpha1)) {
                         // there was no primary context hand-off in < 6.0.0, need to manually activate the shard
-                        getEngine().seqNoService().activatePrimaryMode(currentRouting.allocationId().getId(), getEngine().seqNoService().getLocalCheckpoint());
+                        getEngine().seqNoService().activatePrimaryMode(getEngine().seqNoService().getLocalCheckpoint());
                     }
                 }
 
@@ -498,7 +498,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                             }
                         },
                         e -> failShard("exception during primary term transition", e));
-                    getEngine().seqNoService().activatePrimaryMode(currentRouting.allocationId().getId(), getEngine().seqNoService().getLocalCheckpoint());
+                    getEngine().seqNoService().activatePrimaryMode(getEngine().seqNoService().getLocalCheckpoint());
                     primaryTerm = newPrimaryTerm;
                     latch.countDown();
                 }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -467,7 +467,9 @@ public class RecoverySourceHandler {
          * the permit then the state of the shard will be relocated and this recovery will fail.
          */
         runUnderPrimaryPermit(() -> shard.markAllocationIdAsInSync(request.targetAllocationId(), targetLocalCheckpoint));
-        cancellableThreads.execute(() -> recoveryTarget.finalizeRecovery(shard.getGlobalCheckpoint()));
+        final long globalCheckpoint = shard.getGlobalCheckpoint();
+        cancellableThreads.execute(() -> recoveryTarget.finalizeRecovery(globalCheckpoint));
+        shard.updateGlobalCheckpointForShard(request.targetAllocationId(), globalCheckpoint);
 
         if (request.isPrimaryRelocation()) {
             logger.trace("performing relocation hand-off");

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -639,7 +639,8 @@ public class TransportReplicationActionTests extends ESTestCase {
         CapturingTransport.CapturedRequest[] captures = transport.getCapturedRequestsAndClear();
         assertThat(captures, arrayWithSize(1));
         if (randomBoolean()) {
-            final TransportReplicationAction.ReplicaResponse response = new TransportReplicationAction.ReplicaResponse(randomLong());
+            final TransportReplicationAction.ReplicaResponse response =
+                    new TransportReplicationAction.ReplicaResponse(randomLong(), randomLong());
             transport.handleResponse(captures[0].requestId, response);
             assertTrue(listener.isDone());
             assertThat(listener.get(), equalTo(response));

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
@@ -289,7 +289,8 @@ public class TransportWriteActionTests extends ESTestCase {
         CapturingTransport.CapturedRequest[] captures = transport.getCapturedRequestsAndClear();
         assertThat(captures, arrayWithSize(1));
         if (randomBoolean()) {
-            final TransportReplicationAction.ReplicaResponse response = new TransportReplicationAction.ReplicaResponse(randomLong());
+            final TransportReplicationAction.ReplicaResponse response =
+                    new TransportReplicationAction.ReplicaResponse(randomLong(), randomLong());
             transport.handleResponse(captures[0].requestId, response);
             assertTrue(listener.isDone());
             assertThat(listener.get(), equalTo(response));

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2028,7 +2028,7 @@ public class InternalEngineTests extends ESTestCase {
         final Set<String> indexedIds = new HashSet<>();
         long localCheckpoint = SequenceNumbers.NO_OPS_PERFORMED;
         long replicaLocalCheckpoint = SequenceNumbers.NO_OPS_PERFORMED;
-        long globalCheckpoint = SequenceNumbers.UNASSIGNED_SEQ_NO;
+        long globalCheckpoint;
         long maxSeqNo = SequenceNumbers.NO_OPS_PERFORMED;
         InternalEngine initialEngine = null;
 

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2028,7 +2028,7 @@ public class InternalEngineTests extends ESTestCase {
         final Set<String> indexedIds = new HashSet<>();
         long localCheckpoint = SequenceNumbers.NO_OPS_PERFORMED;
         long replicaLocalCheckpoint = SequenceNumbers.NO_OPS_PERFORMED;
-        long globalCheckpoint;
+        final long globalCheckpoint;
         long maxSeqNo = SequenceNumbers.NO_OPS_PERFORMED;
         InternalEngine initialEngine = null;
 

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -82,7 +82,6 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
@@ -2039,7 +2038,7 @@ public class InternalEngineTests extends ESTestCase {
             initialEngine.seqNoService().updateAllocationIdsFromMaster(1L, new HashSet<>(Arrays.asList(primary.allocationId().getId(),
                 replica.allocationId().getId())),
                 new IndexShardRoutingTable.Builder(shardId).addShard(primary).addShard(replica).build(), Collections.emptySet());
-            initialEngine.seqNoService().activatePrimaryMode(primary.allocationId().getId(), primarySeqNo);
+            initialEngine.seqNoService().activatePrimaryMode(primarySeqNo);
             for (int op = 0; op < opCount; op++) {
                 final String id;
                 // mostly index, sometimes delete

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -482,6 +482,11 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             }
 
             @Override
+            public void updateGlobalCheckpointForShard(String allocationId, long globalCheckpoint) {
+                replicationGroup.getPrimary().updateGlobalCheckpointForShard(allocationId, globalCheckpoint);
+            }
+
+            @Override
             public long localCheckpoint() {
                 return replicationGroup.getPrimary().getLocalCheckpoint();
             }
@@ -518,7 +523,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                                 try {
                                     performOnReplica(request, replica);
                                     releasable.close();
-                                    listener.onResponse(new ReplicaResponse(replica.getLocalCheckpoint()));
+                                    listener.onResponse(new ReplicaResponse(replica.getLocalCheckpoint(), replica.getGlobalCheckpoint()));
                                 } catch (final Exception e) {
                                     Releasables.closeWhileHandlingException(releasable);
                                     listener.onFailure(e);

--- a/core/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
@@ -293,7 +293,6 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
 
             final IndexShard oldPrimary = shards.getPrimary();
             final IndexShard newPrimary = shards.getReplicas().get(0);
-            final IndexShard otherReplica = shards.getReplicas().get(1);
 
             // simulate docs that were inflight when primary failed
             final int extraDocs = randomIntBetween(0, 5);

--- a/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTrackerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTrackerTests.java
@@ -622,10 +622,11 @@ public class GlobalCheckpointTrackerTests extends ESTestCase {
         final ShardId shardId = new ShardId("test", "_na_", 0);
 
         FakeClusterState clusterState = initialState();
+        final AllocationId primaryAllocationId = clusterState.routingTable.primaryShard().allocationId();
         GlobalCheckpointTracker oldPrimary =
-                new GlobalCheckpointTracker(shardId, clusterState.routingTable.primaryShard().allocationId().getId(), indexSettings, UNASSIGNED_SEQ_NO);
+                new GlobalCheckpointTracker(shardId, primaryAllocationId.getId(), indexSettings, UNASSIGNED_SEQ_NO);
         GlobalCheckpointTracker newPrimary =
-                new GlobalCheckpointTracker(shardId, clusterState.routingTable.primaryShard().allocationId().getRelocationId(), indexSettings, UNASSIGNED_SEQ_NO);
+                new GlobalCheckpointTracker(shardId, primaryAllocationId.getRelocationId(), indexSettings, UNASSIGNED_SEQ_NO);
 
         Set<String> allocationIds = new HashSet<>(Arrays.asList(oldPrimary.allocationId, newPrimary.allocationId));
 
@@ -650,7 +651,10 @@ public class GlobalCheckpointTrackerTests extends ESTestCase {
         }
 
         // simulate transferring the global checkpoint to the new primary after finalizing recovery before the handoff
-        markAllocationIdAsInSyncQuietly(oldPrimary, newPrimary.allocationId, Math.max(SequenceNumbers.NO_OPS_PERFORMED, oldPrimary.getGlobalCheckpoint() + randomInt(5)));
+        markAllocationIdAsInSyncQuietly(
+                oldPrimary,
+                newPrimary.allocationId,
+                Math.max(SequenceNumbers.NO_OPS_PERFORMED, oldPrimary.getGlobalCheckpoint() + randomInt(5)));
         oldPrimary.updateGlobalCheckpointForShard(newPrimary.allocationId, oldPrimary.getGlobalCheckpoint());
         GlobalCheckpointTracker.PrimaryContext primaryContext = oldPrimary.startRelocationHandoff();
 
@@ -796,7 +800,8 @@ public class GlobalCheckpointTrackerTests extends ESTestCase {
         activeAllocationIds.add(relocatingId);
         final ShardId shardId = new ShardId("test", "_na_", 0);
         final ShardRouting primaryShard =
-                TestShardRouting.newShardRouting(shardId, randomAlphaOfLength(10), randomAlphaOfLength(10), true, ShardRoutingState.RELOCATING, relocatingId);
+                TestShardRouting.newShardRouting(
+                        shardId, randomAlphaOfLength(10), randomAlphaOfLength(10), true, ShardRoutingState.RELOCATING, relocatingId);
 
         return new FakeClusterState(
                 initialClusterStateVersion,

--- a/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTrackerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTrackerTests.java
@@ -92,10 +92,6 @@ public class GlobalCheckpointTrackerTests extends ESTestCase {
 
         builder.addShard(primaryShard);
 
-        if (primaryShard.relocating()) {
-           // builder.addShard(primaryShard.getTargetRelocatingShard());
-        }
-
         return builder.build();
     }
 

--- a/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTrackerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTrackerTests.java
@@ -624,7 +624,7 @@ public class GlobalCheckpointTrackerTests extends ESTestCase {
         GlobalCheckpointTracker newPrimary =
                 new GlobalCheckpointTracker(shardId, primaryAllocationId.getRelocationId(), indexSettings, UNASSIGNED_SEQ_NO);
 
-        Set<String> allocationIds = new HashSet<>(Arrays.asList(oldPrimary.allocationId, newPrimary.allocationId));
+        Set<String> allocationIds = new HashSet<>(Arrays.asList(oldPrimary.shardAllocationId, newPrimary.shardAllocationId));
 
         clusterState.apply(oldPrimary);
         clusterState.apply(newPrimary);
@@ -649,9 +649,9 @@ public class GlobalCheckpointTrackerTests extends ESTestCase {
         // simulate transferring the global checkpoint to the new primary after finalizing recovery before the handoff
         markAllocationIdAsInSyncQuietly(
                 oldPrimary,
-                newPrimary.allocationId,
+                newPrimary.shardAllocationId,
                 Math.max(SequenceNumbers.NO_OPS_PERFORMED, oldPrimary.getGlobalCheckpoint() + randomInt(5)));
-        oldPrimary.updateGlobalCheckpointForShard(newPrimary.allocationId, oldPrimary.getGlobalCheckpoint());
+        oldPrimary.updateGlobalCheckpointForShard(newPrimary.shardAllocationId, oldPrimary.getGlobalCheckpoint());
         GlobalCheckpointTracker.PrimaryContext primaryContext = oldPrimary.startRelocationHandoff();
 
         if (randomBoolean()) {
@@ -731,25 +731,25 @@ public class GlobalCheckpointTrackerTests extends ESTestCase {
          * global checkpoint state after the primary context was transferred.
          */
         Map<String, GlobalCheckpointTracker.CheckpointState> oldPrimaryCheckpointsCopy = new HashMap<>(oldPrimary.checkpoints);
-        oldPrimaryCheckpointsCopy.remove(oldPrimary.allocationId);
-        oldPrimaryCheckpointsCopy.remove(newPrimary.allocationId);
+        oldPrimaryCheckpointsCopy.remove(oldPrimary.shardAllocationId);
+        oldPrimaryCheckpointsCopy.remove(newPrimary.shardAllocationId);
         Map<String, GlobalCheckpointTracker.CheckpointState> newPrimaryCheckpointsCopy = new HashMap<>(newPrimary.checkpoints);
-        newPrimaryCheckpointsCopy.remove(oldPrimary.allocationId);
-        newPrimaryCheckpointsCopy.remove(newPrimary.allocationId);
+        newPrimaryCheckpointsCopy.remove(oldPrimary.shardAllocationId);
+        newPrimaryCheckpointsCopy.remove(newPrimary.shardAllocationId);
         assertThat(newPrimaryCheckpointsCopy, equalTo(oldPrimaryCheckpointsCopy));
         // we can however assert that shared knowledge of the local checkpoint and in-sync status is equal
         assertThat(
-                oldPrimary.checkpoints.get(oldPrimary.allocationId).localCheckpoint,
-                equalTo(newPrimary.checkpoints.get(oldPrimary.allocationId).localCheckpoint));
+                oldPrimary.checkpoints.get(oldPrimary.shardAllocationId).localCheckpoint,
+                equalTo(newPrimary.checkpoints.get(oldPrimary.shardAllocationId).localCheckpoint));
         assertThat(
-                oldPrimary.checkpoints.get(newPrimary.allocationId).localCheckpoint,
-                equalTo(newPrimary.checkpoints.get(newPrimary.allocationId).localCheckpoint));
+                oldPrimary.checkpoints.get(newPrimary.shardAllocationId).localCheckpoint,
+                equalTo(newPrimary.checkpoints.get(newPrimary.shardAllocationId).localCheckpoint));
         assertThat(
-                oldPrimary.checkpoints.get(oldPrimary.allocationId).inSync,
-                equalTo(newPrimary.checkpoints.get(oldPrimary.allocationId).inSync));
+                oldPrimary.checkpoints.get(oldPrimary.shardAllocationId).inSync,
+                equalTo(newPrimary.checkpoints.get(oldPrimary.shardAllocationId).inSync));
         assertThat(
-                oldPrimary.checkpoints.get(newPrimary.allocationId).inSync,
-                equalTo(newPrimary.checkpoints.get(newPrimary.allocationId).inSync));
+                oldPrimary.checkpoints.get(newPrimary.shardAllocationId).inSync,
+                equalTo(newPrimary.checkpoints.get(newPrimary.shardAllocationId).inSync));
         assertThat(newPrimary.getGlobalCheckpoint(), equalTo(oldPrimary.getGlobalCheckpoint()));
         assertThat(newPrimary.routingTable, equalTo(oldPrimary.routingTable));
         assertThat(newPrimary.replicationGroup, equalTo(oldPrimary.replicationGroup));

--- a/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTrackerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/seqno/GlobalCheckpointTrackerTests.java
@@ -741,6 +741,19 @@ public class GlobalCheckpointTrackerTests extends ESTestCase {
         newPrimaryCheckpointsCopy.remove(oldPrimary.allocationId);
         newPrimaryCheckpointsCopy.remove(newPrimary.allocationId);
         assertThat(newPrimaryCheckpointsCopy, equalTo(oldPrimaryCheckpointsCopy));
+        // we can however assert that shared knowledge of the local checkpoint and in-sync status is equal
+        assertThat(
+                oldPrimary.checkpoints.get(oldPrimary.allocationId).localCheckpoint,
+                equalTo(newPrimary.checkpoints.get(oldPrimary.allocationId).localCheckpoint));
+        assertThat(
+                oldPrimary.checkpoints.get(newPrimary.allocationId).localCheckpoint,
+                equalTo(newPrimary.checkpoints.get(newPrimary.allocationId).localCheckpoint));
+        assertThat(
+                oldPrimary.checkpoints.get(oldPrimary.allocationId).inSync,
+                equalTo(newPrimary.checkpoints.get(oldPrimary.allocationId).inSync));
+        assertThat(
+                oldPrimary.checkpoints.get(newPrimary.allocationId).inSync,
+                equalTo(newPrimary.checkpoints.get(newPrimary.allocationId).inSync));
         assertThat(newPrimary.getGlobalCheckpoint(), equalTo(oldPrimary.getGlobalCheckpoint()));
         assertThat(newPrimary.routingTable, equalTo(oldPrimary.routingTable));
         assertThat(newPrimary.replicationGroup, equalTo(oldPrimary.replicationGroup));

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -128,8 +128,7 @@ public class RelocationIT extends ESIntegTestCase {
                     final DiscoveryNode node = clusterService().state().nodes().get(primaryShardRouting.currentNodeId());
                     final IndicesService indicesService =
                             internalCluster().getInstance(IndicesService.class, node.getName());
-                    final IndexService indexService = indicesService.indexService(primaryShardRouting.index());
-                    final IndexShard indexShard = indexService.getShardOrNull(primaryShardRouting.id());
+                    final IndexShard indexShard = indicesService.getShardOrNull(primaryShardRouting.shardId());
                     final ObjectLongMap<String> globalCheckpoints = indexShard.getGlobalCheckpoints();
                     for (ShardStats shardStats : indexShardStats) {
                         final SeqNoStats seqNoStats = shardStats.getSeqNoStats();

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -139,7 +139,7 @@ public class RelocationIT extends ESIntegTestCase {
                             seqNoStats.getGlobalCheckpoint(), equalTo(primarySeqNoStats.getGlobalCheckpoint()));
                         assertThat(shardStats.getShardRouting() + " max seq no mismatch",
                             seqNoStats.getMaxSeqNo(), equalTo(primarySeqNoStats.getMaxSeqNo()));
-                        // the local knowledge on the primary of the global checkpoint equals the global checkpoints on the shard
+                        // the local knowledge on the primary of the global checkpoint equals the global checkpoint on the shard
                         assertThat(
                                 seqNoStats.getGlobalCheckpoint(),
                                 equalTo(globalCheckpoints.get(shardStats.getShardRouting().allocationId().getId())));

--- a/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/RelocationIT.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.recovery;
 
 import com.carrotsearch.hppc.IntHashSet;
+import com.carrotsearch.hppc.ObjectLongMap;
 import com.carrotsearch.hppc.procedures.IntProcedure;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.util.English;
@@ -34,6 +35,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
@@ -44,12 +46,14 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryFileChunkRequest;
 import org.elasticsearch.plugins.Plugin;
@@ -118,8 +122,15 @@ public class RelocationIT extends ESIntegTestCase {
                     }
                     ShardStats primary = maybePrimary.get();
                     final SeqNoStats primarySeqNoStats = primary.getSeqNoStats();
-                    assertThat(primary.getShardRouting() + " should have set the global checkpoint",
+                    final ShardRouting primaryShardRouting = primary.getShardRouting();
+                    assertThat(primaryShardRouting + " should have set the global checkpoint",
                         primarySeqNoStats.getGlobalCheckpoint(), not(equalTo(SequenceNumbers.UNASSIGNED_SEQ_NO)));
+                    final DiscoveryNode node = clusterService().state().nodes().get(primaryShardRouting.currentNodeId());
+                    final IndicesService indicesService =
+                            internalCluster().getInstance(IndicesService.class, node.getName());
+                    final IndexService indexService = indicesService.indexService(primaryShardRouting.index());
+                    final IndexShard indexShard = indexService.getShardOrNull(primaryShardRouting.id());
+                    final ObjectLongMap<String> globalCheckpoints = indexShard.getGlobalCheckpoints();
                     for (ShardStats shardStats : indexShardStats) {
                         final SeqNoStats seqNoStats = shardStats.getSeqNoStats();
                         assertThat(shardStats.getShardRouting() + " local checkpoint mismatch",
@@ -128,6 +139,10 @@ public class RelocationIT extends ESIntegTestCase {
                             seqNoStats.getGlobalCheckpoint(), equalTo(primarySeqNoStats.getGlobalCheckpoint()));
                         assertThat(shardStats.getShardRouting() + " max seq no mismatch",
                             seqNoStats.getMaxSeqNo(), equalTo(primarySeqNoStats.getMaxSeqNo()));
+                        // the local knowledge on the primary of the global checkpoint equals the global checkpoints on the shard
+                        assertThat(
+                                seqNoStats.getGlobalCheckpoint(),
+                                equalTo(globalCheckpoints.get(shardStats.getShardRouting().allocationId().getId())));
                     }
                 }
             }


### PR DESCRIPTION
This commit adds local tracking of the global checkpoints on all shard copies when a global checkpoint tracker is operating in primary mode. With this, we relay the global checkpoint on a shard copy back to the primary shard during replication operations. This serves as another step towards adding a background sync of the global checkpoint to the shard copies.

Relates #26591
