### PR TITLE
Reject the `index_options` parameter for numeric fields

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
@@ -102,6 +103,13 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return defaultOptions;
         }
 
+        /**
+         * @return if this {@link Builder} allows setting of `index_options`
+         */
+        protected boolean allowsIndexOptions() {
+            return true;
+        }
+
         public T store(boolean store) {
             this.fieldType.setStored(store);
             return builder;
@@ -161,6 +169,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         }
 
         public T indexOptions(IndexOptions indexOptions) {
+            if (allowsIndexOptions() == false) {
+                throw new UnsupportedOperationException(
+                        "index_options not allowed for field type [" + fieldType().typeName() + "]");
+            }
             this.fieldType.setIndexOptions(indexOptions);
             this.indexOptionsSet = true;
             return builder;

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -103,13 +103,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return defaultOptions;
         }
 
-        /**
-         * @return if this {@link Builder} allows setting of `index_options`
-         */
-        protected boolean allowsIndexOptions() {
-            return true;
-        }
-
         public T store(boolean store) {
             this.fieldType.setStored(store);
             return builder;
@@ -169,10 +162,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         }
 
         public T indexOptions(IndexOptions indexOptions) {
-            if (allowsIndexOptions() == false) {
-                throw new UnsupportedOperationException(
-                        "index_options not allowed for field type [" + fieldType().typeName() + "]");
-            }
             this.fieldType.setIndexOptions(indexOptions);
             this.indexOptionsSet = true;
             return builder;

--- a/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -85,6 +85,14 @@ public class NumberFieldMapper extends FieldMapper {
             return builder;
         }
 
+        /**
+         * Numeric field types no longer support `index_options`
+         */
+        @Override
+        protected boolean allowsIndexOptions() {
+            return false;
+        }
+
         protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
             if (ignoreMalformed != null) {
                 return new Explicit<>(ignoreMalformed, true);

--- a/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -85,12 +85,10 @@ public class NumberFieldMapper extends FieldMapper {
             return builder;
         }
 
-        /**
-         * Numeric field types no longer support `index_options`
-         */
         @Override
-        protected boolean allowsIndexOptions() {
-            return false;
+        public Builder indexOptions(IndexOptions indexOptions) {
+            throw new MapperParsingException(
+                    "index_options not allowed in field [" + name + "] of type [" + builder.fieldType().typeName() + "]");
         }
 
         protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -209,7 +209,12 @@ public class TypeParsers {
                 builder.boost(nodeFloatValue(propNode));
                 iterator.remove();
             } else if (propName.equals("index_options")) {
-                builder.indexOptions(nodeIndexOptionValue(propNode));
+                if (builder.allowsIndexOptions()) {
+                    builder.indexOptions(nodeIndexOptionValue(propNode));
+                } else {
+                    throw new MapperParsingException(
+                            "index_options not allowed in field [" + name + "] of type [" + builder.fieldType().typeName() + "]");
+                }
                 iterator.remove();
             } else if (propName.equals("similarity")) {
                 SimilarityProvider similarityProvider = resolveSimilarity(parserContext, name, propNode.toString());

--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -209,12 +209,7 @@ public class TypeParsers {
                 builder.boost(nodeFloatValue(propNode));
                 iterator.remove();
             } else if (propName.equals("index_options")) {
-                if (builder.allowsIndexOptions()) {
-                    builder.indexOptions(nodeIndexOptionValue(propNode));
-                } else {
-                    throw new MapperParsingException(
-                            "index_options not allowed in field [" + name + "] of type [" + builder.fieldType().typeName() + "]");
-                }
+                builder.indexOptions(nodeIndexOptionValue(propNode));
                 iterator.remove();
             } else if (propName.equals("similarity")) {
                 SimilarityProvider similarityProvider = resolveSimilarity(parserContext, name, propNode.toString());

--- a/core/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -283,7 +283,7 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
                 .startObject("properties")
                     .startObject("foo")
                         .field("type", type)
-                        .field("index_options", randomFrom(new String[]{"docs", "freqs", "positions", "offset"}))
+                    .field("index_options", randomFrom(new String[] { "docs", "freqs", "positions", "offsets" }))
                     .endObject()
                 .endObject().endObject().endObject().string();
             MapperParsingException e = expectThrows(MapperParsingException.class,

--- a/core/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -31,9 +31,9 @@ import org.elasticsearch.index.mapper.NumberFieldTypeTests.OutOfRangeSpec;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.List;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -41,7 +41,7 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
     @Override
     protected void setTypeList() {
-        TYPES = new HashSet<>(Arrays.asList("byte", "short", "integer", "long", "float", "double"));
+        TYPES = new HashSet<>(Arrays.asList("byte", "short", "integer", "long", "float", "double", "half_float"));
         WHOLE_TYPES = new HashSet<>(Arrays.asList("byte", "short", "integer", "long"));
     }
 
@@ -258,7 +258,7 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
     public void testRejectNorms() throws IOException {
         // not supported as of 5.0
-        for (String type : Arrays.asList("byte", "short", "integer", "long", "float", "double")) {
+        for (String type : TYPES) {
             DocumentMapperParser parser = createIndex("index-" + type).mapperService().documentMapperParser();
             String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties")
@@ -270,6 +270,25 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
             MapperParsingException e = expectThrows(MapperParsingException.class,
                     () -> parser.parse("type", new CompressedXContent(mapping)));
             assertThat(e.getMessage(), containsString("Mapping definition for [foo] has unsupported parameters:  [norms"));
+        }
+    }
+
+    /**
+     * `index_options` was deprecated and is rejected as of 7.0
+     */
+    public void testRejectIndexOptions() throws IOException {
+        for (String type : TYPES) {
+            DocumentMapperParser parser = createIndex("index-" + type).mapperService().documentMapperParser();
+            String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                    .startObject("foo")
+                        .field("type", type)
+                        .field("index_options", randomFrom(new String[]{"docs", "freqs", "positions", "offset"}))
+                    .endObject()
+                .endObject().endObject().endObject().string();
+            MapperParsingException e = expectThrows(MapperParsingException.class,
+                    () -> parser.parse("type", new CompressedXContent(mapping)));
+            assertThat(e.getMessage(), containsString("index_options not allowed in field [foo] of type [" + type +"]"));
         }
     }
 
@@ -296,7 +315,7 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
 
         Object missing;
-        if (Arrays.asList("float", "double").contains(type)) {
+        if (Arrays.asList("float", "double", "half_float").contains(type)) {
             missing = 123d;
         } else {
             missing = 123L;

--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -28,6 +28,8 @@ following settings:
     offsets (which map the term back to the original string) are indexed.
     Offsets are used by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
 
+NOTE: <<number,Numeric fields>> don't support the `index_options` parameter any longer.
+
 <<mapping-index,Analyzed>> string fields use `positions` as the default, and
 all other fields use `docs` as the default.
 

--- a/docs/reference/migration/migrate_7_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/mappings.asciidoc
@@ -4,3 +4,7 @@
 ==== The `_all` meta field is removed
 
 The `_all` field deprecated in 6 have now been removed.
+
+==== `index_options` for numeric fields has been removed
+
+The `index_options` field for numeric  fields has been deprecated in 6 and has now been removed.

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -88,12 +88,10 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             return builder;
         }
 
-        /**
-         * Scaled float types no longer support `index_options`
-         */
         @Override
-        protected boolean allowsIndexOptions() {
-            return false;
+        public Builder indexOptions(IndexOptions indexOptions) {
+            throw new MapperParsingException(
+                    "index_options not allowed in field [" + name + "] of type [" + builder.fieldType().typeName() + "]");
         }
 
         protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -88,6 +88,14 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             return builder;
         }
 
+        /**
+         * Scaled float types no longer support `index_options`
+         */
+        @Override
+        protected boolean allowsIndexOptions() {
+            return false;
+        }
+
         protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
             if (ignoreMalformed != null) {
                 return new Explicit<>(ignoreMalformed, true);

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -336,4 +336,19 @@ public class ScaledFloatFieldMapperTests extends ESSingleNodeTestCase {
         );
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
     }
+
+    /**
+     * `index_options` was deprecated and is rejected as of 7.0
+     */
+    public void testRejectIndexOptions() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties")
+                .startObject("foo")
+                    .field("type", "scaled_float")
+                    .field("index_options", randomFrom(new String[]{"docs", "freqs", "positions", "offset"}))
+                .endObject()
+            .endObject().endObject().endObject().string();
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> parser.parse("type", new CompressedXContent(mapping)));
+        assertThat(e.getMessage(), containsString("index_options not allowed in field [foo] of type [scaled_float]"));
+    }
 }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -345,7 +345,7 @@ public class ScaledFloatFieldMapperTests extends ESSingleNodeTestCase {
             .startObject("properties")
                 .startObject("foo")
                     .field("type", "scaled_float")
-                    .field("index_options", randomFrom(new String[]{"docs", "freqs", "positions", "offset"}))
+                .field("index_options", randomFrom(new String[] { "docs", "freqs", "positions", "offsets" }))
                 .endObject()
             .endObject().endObject().endObject().string();
         MapperParsingException e = expectThrows(MapperParsingException.class, () -> parser.parse("type", new CompressedXContent(mapping)));


### PR DESCRIPTION
Numeric fields no longer support the `index_options` parameter. This changes the parameter 
to be rejected in numeric field types after it was deprecated in 6.0.

Closes #21475 