### PR TITLE
Deprecate the `index_options` parameter for numeric fields

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
@@ -101,6 +102,13 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
         protected IndexOptions getDefaultIndexOption() {
             return defaultOptions;
+        }
+
+        /**
+         * @return if this {@link Builder} allows setting of `index_options`
+         */
+        protected boolean allowsIndexOptions() {
+            return true;
         }
 
         public T store(boolean store) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -85,6 +85,14 @@ public class NumberFieldMapper extends FieldMapper {
             return builder;
         }
 
+        /**
+         * Numeric field types no longer support `index_options`
+         */
+        @Override
+        protected boolean allowsIndexOptions() {
+            return false;
+        }
+
         protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
             if (ignoreMalformed != null) {
                 return new Explicit<>(ignoreMalformed, true);

--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -241,7 +241,13 @@ public class TypeParsers {
                 && parseNorms(builder, name, propName, propNode, parserContext)) {
                 iterator.remove();
             } else if (propName.equals("index_options")) {
-                builder.indexOptions(nodeIndexOptionValue(propNode));
+                if (builder.allowsIndexOptions()) {
+                    builder.indexOptions(nodeIndexOptionValue(propNode));
+                } else {
+                    DEPRECATION_LOGGER.deprecated(
+                            "index_options are deprecated for field [{}] of type [{}] and will be removed in the next major version.",
+                            name, builder.fieldType.typeName());
+                }
                 iterator.remove();
             } else if (propName.equals("include_in_all")) {
                 if (parserContext.isWithinMultiField()) {

--- a/core/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -34,6 +34,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -41,7 +42,7 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
     @Override
     protected void setTypeList() {
-        TYPES = new HashSet<>(Arrays.asList("byte", "short", "integer", "long", "float", "double"));
+        TYPES = new HashSet<>(Arrays.asList("byte", "short", "integer", "long", "float", "double", "half_float"));
         WHOLE_TYPES = new HashSet<>(Arrays.asList("byte", "short", "integer", "long"));
     }
 
@@ -258,7 +259,7 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
 
     public void testRejectNorms() throws IOException {
         // not supported as of 5.0
-        for (String type : Arrays.asList("byte", "short", "integer", "long", "float", "double")) {
+        for (String type : TYPES) {
             DocumentMapperParser parser = createIndex("index-" + type).mapperService().documentMapperParser();
             String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties")
@@ -270,6 +271,25 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
             MapperParsingException e = expectThrows(MapperParsingException.class,
                     () -> parser.parse("type", new CompressedXContent(mapping)));
             assertThat(e.getMessage(), containsString("Mapping definition for [foo] has unsupported parameters:  [norms"));
+        }
+    }
+
+    /**
+     * `index_options` was deprecated and is rejected as of 7.0
+     */
+    public void testRejectIndexOptions() throws IOException {
+        for (String type : TYPES) {
+            DocumentMapperParser parser = createIndex("index-" + type).mapperService().documentMapperParser();
+            String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+                .startObject("properties")
+                    .startObject("foo")
+                        .field("type", type)
+                        .field("index_options", randomFrom(new String[]{"docs", "freqs", "positions", "offset"}))
+                    .endObject()
+                .endObject().endObject().endObject().string();
+            parser.parse("type", new CompressedXContent(mapping));
+            assertWarnings(
+                    "index_options are deprecated for field [foo] of type [" + type + "] and will be removed in the next major version.");
         }
     }
 
@@ -296,7 +316,7 @@ public class NumberFieldMapperTests extends AbstractNumericFieldMapperTestCase {
         assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
 
         Object missing;
-        if (Arrays.asList("float", "double").contains(type)) {
+        if (Arrays.asList("float", "double", "half_float").contains(type)) {
             missing = 123d;
         } else {
             missing = 123L;

--- a/docs/reference/mapping/params/index-options.asciidoc
+++ b/docs/reference/mapping/params/index-options.asciidoc
@@ -28,6 +28,8 @@ following settings:
     offsets (which map the term back to the original string) are indexed.
     Offsets are used by the <<unified-highlighter,unified highlighter>> to speed up highlighting.
 
+WARNING: The `index_options` parameter has been deprecated for <<number,Numeric fields>> in 6.0.0.
+
 <<mapping-index,Analyzed>> string fields use `positions` as the default, and
 all other fields use `docs` as the default.
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -88,6 +88,14 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             return builder;
         }
 
+        /**
+         * Scaled float types no longer support `index_options`
+         */
+        @Override
+        protected boolean allowsIndexOptions() {
+            return false;
+        }
+
         protected Explicit<Boolean> ignoreMalformed(BuilderContext context) {
             if (ignoreMalformed != null) {
                 return new Explicit<>(ignoreMalformed, true);

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapperTests.java
@@ -336,4 +336,21 @@ public class ScaledFloatFieldMapperTests extends ESSingleNodeTestCase {
         );
         assertThat(e.getMessage(), containsString("name cannot be empty string"));
     }
+
+    /**
+     * `index_options` was deprecated and is rejected as of 7.0
+     */
+    public void testRejectIndexOptions() throws IOException {
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties")
+                .startObject("foo")
+                    .field("type", "scaled_float")
+                    .field("scaling_factor", 10.0)
+                    .field("index_options", randomFrom(new String[]{"docs", "freqs", "positions", "offset"}))
+                .endObject()
+            .endObject().endObject().endObject().string();
+        parser.parse("type", new CompressedXContent(mapping));
+        assertWarnings(
+                "index_options are deprecated for field [foo] of type [scaled_float] and will be removed in the next major version.");
+    }
 }


### PR DESCRIPTION
This change deprecates the use of the `index_options` parameter for numeric
fields.

Relates to #21475