### PR TITLE
Split off command reference for elasticsearch-keystore

### DIFF
--- a/docs/reference/setup/elasticsearch-keystore.asciidoc
+++ b/docs/reference/setup/elasticsearch-keystore.asciidoc
@@ -1,0 +1,97 @@
+[[elasticsearch-keystore-command]]
+== Elasticsearch-keystore Command
+
+The `elasticsearch-keystore` command manages secure settings in the {es}
+keystore.
+
+[float]
+=== Synopsis
+
+[source,shell]
+--------------------------------------------------
+bin/elasticsearch-keystore
+([add] [--stdin <setting>]) |
+[add-file] |
+[create] |
+[list] |
+[remove])
+[-h, --help]
+[-s, --silent]
+[-v, --verbose]
+--------------------------------------------------
+
+[float]
+=== Description
+
+{es} provides a keystore that you can use to store settings that relate to
+sensitive information. The `elasticsearch-keystore create` command generates a
+`elasticsearch.keystore` file, which you can secure by using password
+protection. For more information about the location of config files, see
+<<config-files-location>>.
+
+Run the command as the user that will run {es}.
+
+[float]
+=== Parameters
+
+`add`:: Adds a string setting to the keystore.
+
+`add-file`:: Adds a file setting to the keystore.
+
+`create`:: Creates a new {es} keystore.
+
+`-h, --help`:: Shows help.
+
+`list`:: Lists entries in the keystore.
+
+`remove`:: Removes a setting from the keystore.
+
+`-s, --silent`:: Shows minimal output.
+
+`--stdin <setting>`:: Specifies the name of the setting to add to the keystore.
+If you specify the `add` parameter without the `--stdin` parameter, the command
+prompts you for the name of the setting.
+
+`-v, --verbose`:: Shows verbose output.
+
+[float]
+=== Examples
+
+To create the `elasticsearch.keystore`, use the `create` command:
+
+[source,sh]
+----------------------------------------------------------------
+bin/elasticsearch-keystore create
+----------------------------------------------------------------
+
+The file `elasticsearch.keystore` is created alongside `elasticsearch.yml`.
+
+To generate a list of the settings in the keystore, use the `list` command:
+
+[source,sh]
+----------------------------------------------------------------
+bin/elasticsearch-keystore list
+----------------------------------------------------------------
+
+You can add sensitive string settings, like authentication credentials for cloud
+plugins, by using the `add` command:
+
+[source,sh]
+----------------------------------------------------------------
+bin/elasticsearch-keystore add the.setting.name.to.set
+----------------------------------------------------------------
+
+The command prompts you for the value of the setting. To pass the value
+through stdin, use the `--stdin` flag:
+
+[source,sh]
+----------------------------------------------------------------
+cat /file/containing/setting/value | bin/elasticsearch-keystore add --stdin the.setting.name.to.set
+----------------------------------------------------------------
+
+To remove a setting from the keystore, use the `remove` command:
+
+[source,sh]
+----------------------------------------------------------------
+bin/elasticsearch-keystore remove the.setting.name.to.remove
+----------------------------------------------------------------

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -3,66 +3,11 @@
 
 Some settings are sensitive, and relying on filesystem permissions to protect
 their values is not sufficient. For this use case, elasticsearch provides a
-keystore, which may be password protected, and the `elasticsearch-keystore`
+keystore, which may be password protected, and the
+<<elasticsearch-keystore-command,`elasticsearch-keystore`>>
 tool to manage the settings in the keystore.
-
-NOTE: All commands here should be run as the user which will run elasticsearch.
 
 NOTE: Only some settings are designed to be read from the keystore. See
 documentation for each setting to see if it is supported as part of the keystore.
 
-[float]
-[[creating-keystore]]
-=== Creating the keystore
-
-To create the `elasticsearch.keystore`, use the `create` command:
-
-[source,sh]
-----------------------------------------------------------------
-bin/elasticsearch-keystore create
-----------------------------------------------------------------
-
-The file `elasticsearch.keystore` will be created alongside `elasticsearch.yml`.
-
-[float]
-[[list-settings]]
-=== Listing settings in the keystore
-
-A list of the settings in the keystore is available with the `list` command:
-
-[source,sh]
-----------------------------------------------------------------
-bin/elasticsearch-keystore list
-----------------------------------------------------------------
-
-[float]
-[[add-string-to-keystore]]
-=== Adding string settings
-
-Sensitive string settings, like authentication credentials for cloud
-plugins, can be added using the `add` command:
-
-[source,sh]
-----------------------------------------------------------------
-bin/elasticsearch-keystore add the.setting.name.to.set
-----------------------------------------------------------------
-
-The tool will prompt for the value of the setting. To pass the value
-through stdin, use the `--stdin` flag:
-
-[source,sh]
-----------------------------------------------------------------
-cat /file/containing/setting/value | bin/elasticsearch-keystore add --stdin the.setting.name.to.set
-----------------------------------------------------------------
-
-[float]
-[[remove-settings]]
-=== Removing settings
-
-To remove a setting from the keystore, use the `remove` command:
-
-[source,sh]
-----------------------------------------------------------------
-bin/elasticsearch-keystore remove the.setting.name.to.remove
-----------------------------------------------------------------
-
+include::elasticsearch-keystore.asciidoc[]


### PR DESCRIPTION
This pull request splits off a sub-page about the elasticsearch-keystore command usage, so that the original page can be focused on valid keystore settings. 

The layout for the command usage is aligned with the others done recently here: 
https://www.elastic.co/guide/en/elasticsearch/reference/master/xpack-commands.html