### PR TITLE
Fixed incomplete JSON body on count request making org.elasticsearch.rest.action.RestActions#parseTopLevelQueryBuilder go into endless loop

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/RestActions.java
@@ -243,6 +243,15 @@ public class RestActions {
     private static QueryBuilder parseTopLevelQueryBuilder(XContentParser parser) {
         try {
             QueryBuilder queryBuilder = null;
+            XContentParser.Token first = parser.nextToken();
+            if (first == null) {
+                return null;
+            } else if (first != XContentParser.Token.START_OBJECT) {
+                throw new ParsingException(
+                    parser.getTokenLocation(), "Expected [" + XContentParser.Token.START_OBJECT +
+                    "] but found [" + first + "]", parser.getTokenLocation()
+                );
+            }
             for (XContentParser.Token token = parser.nextToken(); token != XContentParser.Token.END_OBJECT; token = parser.nextToken()) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     String fieldName = parser.currentName();


### PR DESCRIPTION
Took a shot at #26083 here :) 

The problem is that `parser.nextToken()` will return `null` when hitting the end a JSON string. So if the String is partly valid like an empty string:

```java
for (XContentParser.Token token = parser.nextToken(); token != XContentParser.Token.END_OBJECT; token = parser.nextToken()) {
```

will loop forever because `nextToken()` will keep returning `null`.
You can see this by one core going to 100% load while a request like:

```sh
curl -XGET  -H 'Content-Type: application/json' http://localhost:9200/\*/_count -d '""'
```

blocks forever.

In `5.2` this seems to have been caught in the logic guessing the content type of the request and the above example returned:

```sh
{"error":{"root_cause":[{"type":"parse_exception","reason":"Failed to derive xcontent"}],"type":"parse_exception","reason":"Failed to derive xcontent"},"status":400}%
```

Since this is no longer the cause of the problem, I took a shot at a more appropriate error and it now returns:

```sh
"error":{"root_cause":[{"type":"parsing_exception","reason":"Failed to parse","line":1,"col":1}],"type":"parsing_exception","reason":"Failed to parse","line":1,"col":1,"caused_by":{"type":"e_o_f_exception","reason":"Unexpected end of JSON request body."}},"status":400}%
```

Fixes #26083