### PR TITLE
Upgrade API: fix excessive logging and unnecessary template updates

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -26,7 +26,6 @@ import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -405,7 +404,7 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
                 builder.startObject("mappings");
                 for (ObjectObjectCursor<String, CompressedXContent> cursor : indexTemplateMetaData.mappings()) {
                     byte[] mappingSource = cursor.value.uncompressed();
-                    Map<String, Object> mapping = XContentHelper.convertToMap(new BytesArray(mappingSource), false).v2();
+                    Map<String, Object> mapping = XContentHelper.convertToMap(new BytesArray(mappingSource), true).v2();
                     if (mapping.size() == 1 && mapping.containsKey(cursor.key)) {
                         // the type name is the root value, reduce it
                         mapping = (Map<String, Object>) mapping.get(cursor.key);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/TemplateUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/TemplateUpgradeService.java
@@ -123,11 +123,11 @@ public class TemplateUpgradeService extends AbstractComponent implements Cluster
         lastTemplateMetaData = templates;
         Optional<Tuple<Map<String, BytesReference>, Set<String>>> changes = calculateTemplateChanges(templates);
         if (changes.isPresent()) {
-            logger.info("Starting template upgrade to version {}, {} templates will be updated and {} will be removed",
-                Version.CURRENT,
-                changes.get().v1().size(),
-                changes.get().v2().size());
             if (updatesInProgress.compareAndSet(0, changes.get().v1().size() + changes.get().v2().size())) {
+                logger.info("Starting template upgrade to version {}, {} templates will be updated and {} will be removed",
+                    Version.CURRENT,
+                    changes.get().v1().size(),
+                    changes.get().v2().size());
                 threadPool.generic().execute(() -> updateTemplates(changes.get().v1(), changes.get().v2()));
             }
         }

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaDataTests.java
@@ -20,9 +20,17 @@ package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -30,7 +38,9 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 
+import static java.util.Collections.singletonMap;
 import static org.elasticsearch.cluster.metadata.AliasMetaData.newAliasMetaDataBuilder;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 public class IndexTemplateMetaDataTests extends ESTestCase {
 
@@ -76,6 +86,38 @@ public class IndexTemplateMetaDataTests extends ESTestCase {
             multiMetaData.writeTo(output);
             assertEquals(bytes.toBytesRef(), output.bytes().toBytesRef());
         }
+    }
+
+    public void testIndexTemplateMetaDataXContentRoundTrip() throws Exception {
+        ToXContent.Params params = new ToXContent.MapParams(singletonMap("reduce_mappings", "true"));
+
+        String template = "{\"index_patterns\" : [ \".test-*\" ],\"order\" : 1000," +
+            "\"settings\" : {\"number_of_shards\" : 1,\"number_of_replicas\" : 0}," +
+            "\"mappings\" : {\"doc\" :" +
+            "{\"properties\":{\"" +
+            randomAlphaOfLength(10) + "\":{\"type\":\"text\"},\"" +
+            randomAlphaOfLength(10) + "\":{\"type\":\"keyword\"}}" +
+            "}}}";
+
+        BytesReference templateBytes = new BytesArray(template);
+        final IndexTemplateMetaData indexTemplateMetaData;
+        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, templateBytes, XContentType.JSON)) {
+            indexTemplateMetaData = IndexTemplateMetaData.Builder.fromXContent(parser, "test");
+        }
+
+        final BytesReference templateBytesRoundTrip;
+        try (XContentBuilder builder = XContentBuilder.builder(JsonXContent.jsonXContent)) {
+            builder.startObject();
+            IndexTemplateMetaData.Builder.toXContent(indexTemplateMetaData, builder, params);
+            builder.endObject();
+            templateBytesRoundTrip = builder.bytes();
+        }
+
+        final IndexTemplateMetaData indexTemplateMetaDataRoundTrip;
+        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, templateBytesRoundTrip, XContentType.JSON)) {
+            indexTemplateMetaDataRoundTrip = IndexTemplateMetaData.Builder.fromXContent(parser, "test");
+        }
+        assertThat(indexTemplateMetaData, equalTo(indexTemplateMetaDataRoundTrip));
     }
 
 }


### PR DESCRIPTION
TemplateUpgradeService might get stuck in repeatedly upgrading templates after upgrade to 5.6.0. This is caused by shuffling mappings definition in the template during template serialization. This commit makes the template serialization consistent.

Closes #26673
