### PR TITLE
Add missing script contexts and types allowed settings

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.common.settings;
 
 import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
+import org.elasticsearch.script.ScriptModes;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.action.search.TransportSearchAction;
@@ -316,6 +317,8 @@ public final class ClusterSettings extends AbstractScopedSettings {
                     IndexSettings.QUERY_STRING_ANALYZE_WILDCARD,
                     IndexSettings.QUERY_STRING_ALLOW_LEADING_WILDCARD,
                     PrimaryShardAllocator.NODE_INITIAL_SHARDS_SETTING,
+                    ScriptModes.TYPES_ALLOWED_SETTING,
+                    ScriptModes.CONTEXTS_ALLOWED_SETTING,
                     ScriptService.SCRIPT_CACHE_SIZE_SETTING,
                     ScriptService.SCRIPT_CACHE_EXPIRE_SETTING,
                     ScriptService.SCRIPT_AUTO_RELOAD_ENABLED_SETTING,

--- a/core/src/main/java/org/elasticsearch/script/ScriptModes.java
+++ b/core/src/main/java/org/elasticsearch/script/ScriptModes.java
@@ -44,9 +44,9 @@ public class ScriptModes {
 
     private static final String NONE = "none";
 
-    private static final Setting<List<String>> TYPES_ALLOWED_SETTING =
+    public static final Setting<List<String>> TYPES_ALLOWED_SETTING =
         Setting.listSetting("script.allowed_types", Collections.emptyList(), Function.identity(), Setting.Property.NodeScope);
-    private static final Setting<List<String>> CONTEXTS_ALLOWED_SETTING =
+    public static final Setting<List<String>> CONTEXTS_ALLOWED_SETTING =
         Setting.listSetting("script.allowed_contexts", Collections.emptyList(), Function.identity(), Setting.Property.NodeScope);
 
     private final Set<String> typesAllowed;


### PR DESCRIPTION
As the title says.

Relates to (https://github.com/elastic/elasticsearch/issues/26651)