### PR TITLE
Build: Make bwc builds always use snapshot=false

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -134,6 +134,7 @@ if (enabled) {
     dependsOn checkoutBwcBranch, writeBuildMetadata
     dir = checkoutDir
     tasks = [':distribution:deb:assemble', ':distribution:rpm:assemble', ':distribution:zip:assemble']
+    startParameter.systemPropertiesArgs = ['build.snapshot': 'true']
     doLast {
       List missing = [bwcDeb, bwcRpm, bwcZip].grep { file ->
         false == file.exists() }


### PR DESCRIPTION
This commit makes the bwc builds use Exec instead of GradleBuild when
doing a release build. This is only relevant in the case of running
tests with a release build, which is only done by CI, so the sub build
in that case is run with info logging.

closes #26702