### PR TITLE
Add setup and teardown for old cluster tests

### DIFF
--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,5 +1,5 @@
 ---
-setup:
+"Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
   - do:
       indices.create:
         index: test_index
@@ -49,18 +49,6 @@ setup:
   - do:
       indices.flush:
         index: test_index,index_with_replicas
-
----
-teardown:
-  - do:
-      indices.delete:
-          index: test_index
-  - do:
-      indices.delete:
-          index: index_with_replicas
-
----
-"Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
 
   - do:
       search:
@@ -116,7 +104,6 @@ teardown:
           params:
             f1: v5_old
   - match: { hits.total: 1 }
-
 ---
 "Put a template 5.6.0 and beyond":
   - skip:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,35 +1,4 @@
 ---
-setup:
-  - do:
-      indices.create:
-        index: test_search_index
-        body:
-          settings:
-            index:
-              number_of_replicas: 0
-
-  - do:
-      bulk:
-        refresh: true
-        body:
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v1_old", "s2": 0}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v2_old", "s2": 1}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v3_old", "s2": 2}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v4_old", "s2": 3}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v5_old", "s2": 4}'
-
----
-teardown:
-  - do:
-      indices.delete:
-          index: test_search_index
-
----
 "Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
   - do:
       indices.create:
@@ -125,7 +94,7 @@ teardown:
         body:
           query:
             match:
-              s1: "{{s1}}"
+              f1: "{{f1}}"
   - match: { acknowledged: true }
 
   - do:
@@ -133,9 +102,8 @@ teardown:
         body:
           id: test_search_template
           params:
-            s1: v5_old
+            f1: v5_old
   - match: { hits.total: 1 }
-
 ---
 "Put a template 5.6.0 and beyond":
   - skip:
@@ -151,7 +119,7 @@ teardown:
         body:
           query:
             match:
-              s1: "{{s1}}"
+              f1: "{{f1}}"
   - match: { acknowledged: true }
 
   - do:
@@ -159,5 +127,5 @@ teardown:
         body:
           id: test_search_template
           params:
-            s1: v5_old
+            f1: v5_old
   - match: { hits.total: 1 }

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,5 +1,5 @@
 ---
-"Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
+setup:
   - do:
       indices.create:
         index: test_index
@@ -49,6 +49,18 @@
   - do:
       indices.flush:
         index: test_index,index_with_replicas
+
+---
+teardown:
+  - do:
+      indices.delete:
+          index: test_index
+  - do:
+      indices.delete:
+          index: index_with_replicas
+
+---
+"Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
 
   - do:
       search:
@@ -104,6 +116,7 @@
           params:
             f1: v5_old
   - match: { hits.total: 1 }
+
 ---
 "Put a template 5.6.0 and beyond":
   - skip:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,4 +1,35 @@
 ---
+setup:
+  - do:
+      indices.create:
+        index: test_search_index
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v1_old", "s2": 0}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v2_old", "s2": 1}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v3_old", "s2": 2}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v4_old", "s2": 3}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v5_old", "s2": 4}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+          index: test_search_index
+
+---
 "Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
   - do:
       indices.create:
@@ -89,29 +120,6 @@
       reason: stored search template API is deprecated in 5.6.0
 
   - do:
-      indices.create:
-        index: test_search_index
-        body:
-          settings:
-            index:
-              number_of_replicas: 0
-
-  - do:
-      bulk:
-        refresh: true
-        body:
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v1_old", "s2": 0}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v2_old", "s2": 1}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v3_old", "s2": 2}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v4_old", "s2": 3}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v5_old", "s2": 4}'
-
-  - do:
       put_template:
         id: test_search_template
         body:
@@ -128,38 +136,12 @@
             s1: v5_old
   - match: { hits.total: 1 }
 
-  - do:
-      indices.delete:
-          index: test_search_index
-
 ---
 "Put a template 5.6.0 and beyond":
   - skip:
       version: " - 5.5.99"
       reason: stored search template API is deprecated in 5.6.0
       features: "warnings"
-  - do:
-      indices.create:
-        index: test_search_index
-        body:
-          settings:
-            index:
-              number_of_replicas: 0
-
-  - do:
-      bulk:
-        refresh: true
-        body:
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v1_old", "s2": 0}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v2_old", "s2": 1}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v3_old", "s2": 2}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v4_old", "s2": 3}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v5_old", "s2": 4}'
 
   - do:
       warnings:
@@ -179,7 +161,3 @@
           params:
             s1: v5_old
   - match: { hits.total: 1 }
-
-  - do:
-      indices.delete:
-          index: test_search_index

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,6 +1,8 @@
 ---
-"Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
+"Index data, search, and create things in the cluster state that we'll validate are there after the ugprade 5.6.0 and beyond":
   - skip:
+      version: " - 5.5.99"
+      reason: stored search template API is deprecated in 5.6.0
       features: "warnings"
 
   - do:
@@ -88,6 +90,111 @@
   - do:
       warnings:
         - "The stored search template API is deprecated. Use stored scripts instead."
+      put_template:
+        id: test_search_template
+        body:
+          query:
+            match:
+              f1: "{{f1}}"
+  - match: { acknowledged: true }
+
+  - do:
+      search_template:
+        body:
+          id: test_search_template
+          params:
+            f1: v5_old
+  - match: { hits.total: 1 }
+
+---
+"Index data, search, and create things in the cluster state that we'll validate are there after the ugprade before 5.6.0":
+  - skip:
+      version: "5.6.0 - "
+      reason: stored search template API is deprecated in 5.6.0
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      indices.create:
+        index: index_with_replicas # dummy index to ensure we can recover indices with replicas just fine
+        body:
+          # if the node with the replica is the first to be restarted, then delayed
+          # allocation will kick in, and the cluster health won't return to GREEN
+          # before timing out
+          index.unassigned.node_left.delayed_timeout: "100ms"
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v1_old", "f2": 0}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v2_old", "f2": 1}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v3_old", "f2": 2}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v4_old", "f2": 3}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v5_old", "f2": 4}'
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+          - '{"index": {"_index": "index_with_replicas", "_type": "doc"}}'
+          - '{"f1": "d_old"}'
+
+  - do:
+      indices.flush:
+        index: test_index,index_with_replicas
+
+  - do:
+      search:
+        index: test_index
+
+  - match: { hits.total: 5 }
+
+  - do:
+      search:
+        index: index_with_replicas
+
+  - match: { hits.total: 5 }
+
+  - do:
+      snapshot.create_repository:
+        repository: my_repo
+        body:
+          type: url
+          settings:
+            url: "http://snapshot.test"
+  - match: { "acknowledged": true }
+
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [
+            ]
+          }
+  - match: { "acknowledged": true }
+
+  - do:
       put_template:
         id: test_search_template
         body:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,35 +1,4 @@
 ---
-setup:
-  - do:
-      indices.create:
-        index: test_search_index
-        body:
-          settings:
-            index:
-              number_of_replicas: 0
-
-  - do:
-      bulk:
-        refresh: true
-        body:
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v1_old", "s2": 0}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v2_old", "s2": 1}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v3_old", "s2": 2}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v4_old", "s2": 3}'
-          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
-          - '{"s1": "v5_old", "s2": 4}'
-
----
-teardown:
-  - do:
-      indices.delete:
-          index: test_search_index
-
----
 "Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
   - do:
       indices.create:
@@ -120,6 +89,29 @@ teardown:
       reason: stored search template API is deprecated in 5.6.0
 
   - do:
+      indices.create:
+        index: test_search_index
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v1_old", "s2": 0}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v2_old", "s2": 1}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v3_old", "s2": 2}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v4_old", "s2": 3}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v5_old", "s2": 4}'
+
+  - do:
       put_template:
         id: test_search_template
         body:
@@ -136,12 +128,38 @@ teardown:
             s1: v5_old
   - match: { hits.total: 1 }
 
+  - do:
+      indices.delete:
+          index: test_search_index
+
 ---
 "Put a template 5.6.0 and beyond":
   - skip:
       version: " - 5.5.99"
       reason: stored search template API is deprecated in 5.6.0
       features: "warnings"
+  - do:
+      indices.create:
+        index: test_search_index
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v1_old", "s2": 0}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v2_old", "s2": 1}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v3_old", "s2": 2}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v4_old", "s2": 3}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v5_old", "s2": 4}'
 
   - do:
       warnings:
@@ -161,3 +179,7 @@ teardown:
           params:
             s1: v5_old
   - match: { hits.total: 1 }
+
+  - do:
+      indices.delete:
+          index: test_search_index

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,4 +1,35 @@
 ---
+setup:
+  - do:
+      indices.create:
+        index: test_search_index
+        body:
+          settings:
+            index:
+              number_of_replicas: 0
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v1_old", "s2": 0}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v2_old", "s2": 1}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v3_old", "s2": 2}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v4_old", "s2": 3}'
+          - '{"index": {"_index": "test_search_index", "_type": "doc"}}'
+          - '{"s1": "v5_old", "s2": 4}'
+
+---
+teardown:
+  - do:
+      indices.delete:
+          index: test_search_index
+
+---
 "Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
   - do:
       indices.create:
@@ -94,7 +125,7 @@
         body:
           query:
             match:
-              f1: "{{f1}}"
+              s1: "{{s1}}"
   - match: { acknowledged: true }
 
   - do:
@@ -102,8 +133,9 @@
         body:
           id: test_search_template
           params:
-            f1: v5_old
+            s1: v5_old
   - match: { hits.total: 1 }
+
 ---
 "Put a template 5.6.0 and beyond":
   - skip:
@@ -119,7 +151,7 @@
         body:
           query:
             match:
-              f1: "{{f1}}"
+              s1: "{{s1}}"
   - match: { acknowledged: true }
 
   - do:
@@ -127,5 +159,5 @@
         body:
           id: test_search_template
           params:
-            f1: v5_old
+            s1: v5_old
   - match: { hits.total: 1 }

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yaml
@@ -1,5 +1,8 @@
 ---
 "Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
+  - skip:
+      features: "warnings"
+
   - do:
       indices.create:
         index: test_index
@@ -82,35 +85,6 @@
           }
   - match: { "acknowledged": true }
 
----
-"Put a template before 5.6.0":
-  - skip:
-      version: "5.6.0 - "
-      reason: stored search template API is deprecated in 5.6.0
-
-  - do:
-      put_template:
-        id: test_search_template
-        body:
-          query:
-            match:
-              f1: "{{f1}}"
-  - match: { acknowledged: true }
-
-  - do:
-      search_template:
-        body:
-          id: test_search_template
-          params:
-            f1: v5_old
-  - match: { hits.total: 1 }
----
-"Put a template 5.6.0 and beyond":
-  - skip:
-      version: " - 5.5.99"
-      reason: stored search template API is deprecated in 5.6.0
-      features: "warnings"
-
   - do:
       warnings:
         - "The stored search template API is deprecated. Use stored scripts instead."
@@ -129,3 +103,4 @@
           params:
             f1: v5_old
   - match: { hits.total: 1 }
+


### PR DESCRIPTION
The tests recently got refactored to add a few tests depending on the
version the tests are run against. But since the tests are not run in
order, the writes that were in one test caused failures in others if run
out of order. The indices that this test use are also important as they
are validated post upgrade. The only thing we can do is create a new
index that can be setup and torn down, and can be what the other two
tests validate against.