### PR TITLE
Remove deprecated `type` and `slop` field in `match` query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -35,7 +35,6 @@ import org.elasticsearch.index.search.MatchQuery;
 import org.elasticsearch.index.search.MatchQuery.ZeroTermsQuery;
 
 import java.io.IOException;
-import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -43,7 +42,6 @@ import java.util.Objects;
  * result of the analysis.
  */
 public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
-    public static final ParseField SLOP_FIELD = new ParseField("slop", "phrase_slop").withAllDeprecated("match_phrase query");
     public static final ParseField ZERO_TERMS_QUERY_FIELD = new ParseField("zero_terms_query");
     public static final ParseField CUTOFF_FREQUENCY_FIELD = new ParseField("cutoff_frequency");
     public static final ParseField LENIENT_FIELD = new ParseField("lenient");
@@ -54,7 +52,6 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     public static final ParseField MAX_EXPANSIONS_FIELD = new ParseField("max_expansions");
     public static final ParseField PREFIX_LENGTH_FIELD = new ParseField("prefix_length");
     public static final ParseField ANALYZER_FIELD = new ParseField("analyzer");
-    public static final ParseField TYPE_FIELD = new ParseField("type").withAllDeprecated("match_phrase and match_phrase_prefix query");
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField GENERATE_SYNONYMS_PHRASE_QUERY = new ParseField("auto_generate_synonyms_phrase_query");
 
@@ -64,23 +61,13 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     /** The default mode terms are combined in a match query */
     public static final Operator DEFAULT_OPERATOR = Operator.OR;
 
-    /** The default mode match query type */
-    @Deprecated
-    public static final MatchQuery.Type DEFAULT_TYPE = MatchQuery.Type.BOOLEAN;
-
     private final String fieldName;
 
     private final Object value;
 
-    @Deprecated
-    private MatchQuery.Type type = DEFAULT_TYPE;
-
     private Operator operator = DEFAULT_OPERATOR;
 
     private String analyzer;
-
-    @Deprecated
-    private int slop = MatchQuery.DEFAULT_PHRASE_SLOP;
 
     private Fuzziness fuzziness = null;
 
@@ -123,9 +110,15 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         super(in);
         fieldName = in.readString();
         value = in.readGenericValue();
-        type = MatchQuery.Type.readFromStream(in);
+        // TODO lower this version once this has been backported to 6.0.0
+        if (in.getVersion().before(Version.V_7_0_0_alpha1)) {
+            MatchQuery.Type.readFromStream(in);  // deprecated type
+        }
         operator = Operator.readFromStream(in);
-        slop = in.readVInt();
+        // TODO lower this version once this has been backported to 6.0.0
+        if (in.getVersion().before(Version.V_7_0_0_alpha1)) {
+            in.readVInt(); // deprecated slop
+        }
         prefixLength = in.readVInt();
         maxExpansions = in.readVInt();
         fuzzyTranspositions = in.readBoolean();
@@ -146,9 +139,15 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeString(fieldName);
         out.writeGenericValue(value);
-        type.writeTo(out);
+        // TODO lower this version once this has been backported to 6.0.0
+        if (out.getVersion().before(Version.V_7_0_0_alpha1)) {
+            MatchQuery.Type.BOOLEAN.writeTo(out); // deprecated type
+        }
         operator.writeTo(out);
-        out.writeVInt(slop);
+        // TODO lower this version once this has been backported to 6.0.0
+        if (out.getVersion().before(Version.V_7_0_0_alpha1)) {
+            out.writeVInt(MatchQuery.DEFAULT_PHRASE_SLOP); // deprecated slop
+        }
         out.writeVInt(prefixLength);
         out.writeVInt(maxExpansions);
         out.writeBoolean(fuzzyTranspositions);
@@ -173,34 +172,6 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     /** Returns the value used in this query. */
     public Object value() {
         return this.value;
-    }
-
-    /**
-     * Sets the type of the text query.
-     *
-     * @deprecated Use {@link MatchPhraseQueryBuilder} for <code>phrase</code>
-     *             queries and {@link MatchPhrasePrefixQueryBuilder} for
-     *             <code>phrase_prefix</code> queries
-     */
-    @Deprecated
-    public MatchQueryBuilder type(MatchQuery.Type type) {
-        if (type == null) {
-            throw new IllegalArgumentException("[" + NAME + "] requires type to be non-null");
-        }
-        this.type = type;
-        return this;
-    }
-
-    /**
-     * Get the type of the query.
-     *
-     * @deprecated Use {@link MatchPhraseQueryBuilder} for <code>phrase</code>
-     *             queries and {@link MatchPhrasePrefixQueryBuilder} for
-     *             <code>phrase_prefix</code> queries
-     */
-    @Deprecated
-    public MatchQuery.Type type() {
-        return this.type;
     }
 
     /** Sets the operator to use when using a boolean query. Defaults to <tt>OR</tt>. */
@@ -229,30 +200,6 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     /** Get the analyzer to use, if previously set, otherwise <tt>null</tt> */
     public String analyzer() {
         return this.analyzer;
-    }
-
-    /**
-     * Sets a slop factor for phrase queries
-     *
-     * @deprecated for phrase queries use {@link MatchPhraseQueryBuilder}
-     */
-    @Deprecated
-    public MatchQueryBuilder slop(int slop) {
-        if (slop < 0 ) {
-            throw new IllegalArgumentException("No negative slop allowed.");
-        }
-        this.slop = slop;
-        return this;
-    }
-
-    /**
-     * Get the slop factor for phrase queries.
-     *
-     * @deprecated for phrase queries use {@link MatchPhraseQueryBuilder}
-     */
-    @Deprecated
-    public int slop() {
-        return this.slop;
     }
 
     /** Sets the fuzziness used when evaluated to a fuzzy query type. Defaults to "AUTO". */
@@ -425,17 +372,9 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         builder.startObject(fieldName);
 
         builder.field(QUERY_FIELD.getPreferredName(), value);
-        // this is deprecated so only output the value if its not the default value (for bwc)
-        if (type != MatchQuery.Type.BOOLEAN) {
-            builder.field(TYPE_FIELD.getPreferredName(), type.toString().toLowerCase(Locale.ENGLISH));
-        }
         builder.field(OPERATOR_FIELD.getPreferredName(), operator.toString());
         if (analyzer != null) {
             builder.field(ANALYZER_FIELD.getPreferredName(), analyzer);
-        }
-        // this is deprecated so only output the value if its not the default value (for bwc)
-        if (slop != MatchQuery.DEFAULT_PHRASE_SLOP) {
-            builder.field(SLOP_FIELD.getPreferredName(), slop);
         }
         if (fuzziness != null) {
             fuzziness.toXContent(builder, params);
@@ -473,7 +412,6 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         if (analyzer != null) {
             matchQuery.setAnalyzer(analyzer);
         }
-        matchQuery.setPhraseSlop(slop);
         matchQuery.setFuzziness(fuzziness);
         matchQuery.setFuzzyPrefixLength(prefixLength);
         matchQuery.setMaxExpansions(maxExpansions);
@@ -484,7 +422,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
         matchQuery.setZeroTermsQuery(zeroTermsQuery);
         matchQuery.setAutoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery);
 
-        Query query = matchQuery.parse(type, fieldName, value);
+        Query query = matchQuery.parse(MatchQuery.Type.BOOLEAN, fieldName, value);
         return Queries.maybeApplyMinimumShouldMatch(query, minimumShouldMatch);
     }
 
@@ -492,10 +430,8 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
     protected boolean doEquals(MatchQueryBuilder other) {
         return Objects.equals(fieldName, other.fieldName) &&
                Objects.equals(value, other.value) &&
-               Objects.equals(type, other.type) &&
                Objects.equals(operator, other.operator) &&
                Objects.equals(analyzer, other.analyzer) &&
-               Objects.equals(slop, other.slop) &&
                Objects.equals(fuzziness, other.fuzziness) &&
                Objects.equals(prefixLength, other.prefixLength) &&
                Objects.equals(maxExpansions, other.maxExpansions) &&
@@ -510,7 +446,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
 
     @Override
     protected int doHashCode() {
-        return Objects.hash(fieldName, value, type, operator, analyzer, slop,
+        return Objects.hash(fieldName, value, operator, analyzer,
                 fuzziness, prefixLength, maxExpansions, minimumShouldMatch,
                 fuzzyRewrite, lenient, fuzzyTranspositions, zeroTermsQuery, cutoffFrequency, autoGenerateSynonymsPhraseQuery);
     }
@@ -522,13 +458,11 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
 
     public static MatchQueryBuilder fromXContent(XContentParser parser) throws IOException {
         String fieldName = null;
-        MatchQuery.Type type = MatchQuery.Type.BOOLEAN;
         Object value = null;
         float boost = AbstractQueryBuilder.DEFAULT_BOOST;
         String minimumShouldMatch = null;
         String analyzer = null;
         Operator operator = MatchQueryBuilder.DEFAULT_OPERATOR;
-        int slop = MatchQuery.DEFAULT_PHRASE_SLOP;
         Fuzziness fuzziness = null;
         int prefixLength = FuzzyQuery.defaultPrefixLength;
         int maxExpansion = FuzzyQuery.defaultMaxExpansions;
@@ -553,23 +487,10 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
                     } else if (token.isValue()) {
                         if (QUERY_FIELD.match(currentFieldName)) {
                             value = parser.objectText();
-                        } else if (TYPE_FIELD.match(currentFieldName)) {
-                            String tStr = parser.text();
-                            if ("boolean".equals(tStr)) {
-                                type = MatchQuery.Type.BOOLEAN;
-                            } else if ("phrase".equals(tStr)) {
-                                type = MatchQuery.Type.PHRASE;
-                            } else if ("phrase_prefix".equals(tStr) || ("phrasePrefix".equals(tStr))) {
-                                type = MatchQuery.Type.PHRASE_PREFIX;
-                            } else {
-                                throw new ParsingException(parser.getTokenLocation(), "[" + NAME + "] query does not support type " + tStr);
-                            }
                         } else if (ANALYZER_FIELD.match(currentFieldName)) {
                             analyzer = parser.text();
                         } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
                             boost = parser.floatValue();
-                        } else if (SLOP_FIELD.match(currentFieldName)) {
-                            slop = parser.intValue();
                         } else if (Fuzziness.FIELD.match(currentFieldName)) {
                             fuzziness = Fuzziness.parse(parser);
                         } else if (PREFIX_LENGTH_FIELD.match(currentFieldName)) {
@@ -624,9 +545,7 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
 
         MatchQueryBuilder matchQuery = new MatchQueryBuilder(fieldName, value);
         matchQuery.operator(operator);
-        matchQuery.type(type);
         matchQuery.analyzer(analyzer);
-        matchQuery.slop(slop);
         matchQuery.minimumShouldMatch(minimumShouldMatch);
         if (fuzziness != null) {
             matchQuery.fuzziness(fuzziness);

--- a/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.fetch.subphase.highlight;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -39,7 +40,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.index.query.functionscore.RandomScoreFunctionBuilder;
-import org.elasticsearch.index.search.MatchQuery;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
@@ -79,7 +79,6 @@ import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.regexpQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static org.elasticsearch.index.query.QueryBuilders.typeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.wildcardQuery;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.highlight;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
@@ -1474,7 +1473,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
-                .setQuery(QueryBuilders.matchQuery("tags", "long tag").type(MatchQuery.Type.PHRASE))
+                .setQuery(QueryBuilders.matchPhraseQuery("tags", "long tag"))
                 .highlighter(
                         new HighlightBuilder().field(new HighlightBuilder.Field("tags")
                             .highlighterType("plain").fragmentSize(-1).numOfFragments(2).fragmenter("simple")))
@@ -1485,7 +1484,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 equalTo("here is another one that is very <em>long</em> <em>tag</em> and has the tag token near the end"));
 
         response = client().prepareSearch("test")
-                .setQuery(QueryBuilders.matchQuery("tags", "long tag").type(MatchQuery.Type.PHRASE))
+                .setQuery(QueryBuilders.matchPhraseQuery("tags", "long tag"))
                 .highlighter(
                         new HighlightBuilder().field(new Field("tags").highlighterType("plain").fragmentSize(-1).numOfFragments(2)
                                 .fragmenter("span"))).get();
@@ -1496,7 +1495,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
                 equalTo("here is another one that is very <em>long</em> <em>tag</em> and has the tag token near the end"));
 
         assertFailures(client().prepareSearch("test")
-                        .setQuery(QueryBuilders.matchQuery("tags", "long tag").type(MatchQuery.Type.PHRASE))
+                        .setQuery(QueryBuilders.matchPhraseQuery("tags", "long tag"))
                         .highlighter(
                                 new HighlightBuilder().field(new Field("tags").highlighterType("plain").fragmentSize(-1).numOfFragments(2)
                                         .fragmenter("invalid"))),
@@ -1554,7 +1553,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
         // This query used to fail when the field to highlight was absent
         SearchResponse response = client().prepareSearch("test")
-            .setQuery(QueryBuilders.matchQuery("field", "highlight").type(MatchQuery.Type.BOOLEAN))
+            .setQuery(QueryBuilders.matchQuery("field", "highlight"))
             .highlighter(
                 new HighlightBuilder().field(new HighlightBuilder.Field("highlight_field").fragmentSize(-1).numOfFragments(1)
                     .fragmenter("simple"))).get();
@@ -1579,7 +1578,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
-                .setQuery(QueryBuilders.matchQuery("text", "test").type(MatchQuery.Type.BOOLEAN))
+                .setQuery(QueryBuilders.matchQuery("text", "test"))
                 .highlighter(
                         new HighlightBuilder().field("text").field("byte").field("short").field("int").field("long").field("float")
                                 .field("double"))
@@ -1604,7 +1603,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse response = client().prepareSearch("test")
-            .setQuery(QueryBuilders.matchQuery("text", "test").type(MatchQuery.Type.BOOLEAN))
+            .setQuery(QueryBuilders.matchQuery("text", "test"))
             .highlighter(new HighlightBuilder().field("text")).execute().actionGet();
         // PatternAnalyzer will throw an exception if it is resetted twice
         assertHitCount(response, 1L);

--- a/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
@@ -179,7 +179,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
     }
 
     public void testDefaults() throws ExecutionException, InterruptedException {
-        MatchQuery.Type type = randomBoolean() ? MatchQueryBuilder.DEFAULT_TYPE : MatchQuery.Type.BOOLEAN;
+        MatchQuery.Type type = MatchQuery.Type.BOOLEAN;
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero captain america", "full_name", "first_name", "last_name", "category")
                         .operator(Operator.OR))).get();
@@ -270,9 +270,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                     .addSort("_id", SortOrder.ASC)
                     .setQuery(multiMatchQueryBuilder).get();
             MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery(field, builder.toString());
-            if (multiMatchQueryBuilder.getType() != null) {
-                matchQueryBuilder.type(MatchQuery.Type.valueOf(multiMatchQueryBuilder.getType().matchQueryType().toString()));
-            }
+
             SearchResponse matchResp = client().prepareSearch("test")
                     // _id tie sort
                     .addSort("_score", SortOrder.DESC)
@@ -294,7 +292,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
     public void testCutoffFreq() throws ExecutionException, InterruptedException {
         final long numDocs = client().prepareSearch("test").setSize(0)
                 .setQuery(matchAllQuery()).get().getHits().getTotalHits();
-        MatchQuery.Type type = randomBoolean() ? MatchQueryBuilder.DEFAULT_TYPE : MatchQuery.Type.BOOLEAN;
+        MatchQuery.Type type = MatchQuery.Type.BOOLEAN;
         Float cutoffFrequency = randomBoolean() ? Math.min(1, numDocs * 1.f / between(10, 20)) : 1.f / between(10, 20);
         SearchResponse searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("marvel hero captain america", "full_name", "first_name", "last_name", "category")
@@ -357,7 +355,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
         int numIters = scaledRandomIntBetween(5, 10);
         for (int i = 0; i < numIters; i++) {
             {
-                MatchQuery.Type type = randomBoolean() ? MatchQueryBuilder.DEFAULT_TYPE : MatchQuery.Type.BOOLEAN;
+                MatchQuery.Type type = MatchQuery.Type.BOOLEAN;
                 MultiMatchQueryBuilder multiMatchQueryBuilder = randomBoolean() ? multiMatchQuery("marvel hero captain america", "full_name", "first_name", "last_name", "category") :
                         multiMatchQuery("marvel hero captain america", "*_name", randomBoolean() ? "category" : "categ*");
                 SearchResponse left = client().prepareSearch("test").setSize(numDocs)
@@ -377,7 +375,7 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
             }
 
             {
-                MatchQuery.Type type = randomBoolean() ? MatchQueryBuilder.DEFAULT_TYPE : MatchQuery.Type.BOOLEAN;
+                MatchQuery.Type type = MatchQuery.Type.BOOLEAN;
                 String minShouldMatch = randomBoolean() ? null : "" + between(0, 1);
                 Operator op = randomBoolean() ? Operator.AND : Operator.OR;
                 MultiMatchQueryBuilder multiMatchQueryBuilder = randomBoolean() ? multiMatchQuery("captain america", "full_name", "first_name", "last_name", "category") :


### PR DESCRIPTION
The `type` field has been deprecated in 5.0 and can be removed. It has been
replaced by using the `phrase` or the `phrase_prefix` query. The `slop` field has 
also been deprecated and can be removed. The `phrase` and `phrase_prefix` 
query still support this parameter.