### PR TITLE
[Docs] Add note about maximum token length for whitespace tokenizer

### DIFF
--- a/docs/reference/analysis/tokenizers/whitespace-tokenizer.asciidoc
+++ b/docs/reference/analysis/tokenizers/whitespace-tokenizer.asciidoc
@@ -17,6 +17,11 @@ POST _analyze
 ---------------------------
 // CONSOLE
 
+[NOTE]
+=============================================
+The maximum token length is 255. If a token is seen that exceeds this length, then it is split at 255 characters.
+=============================================
+
 /////////////////////
 
 [source,js]


### PR DESCRIPTION
The whitespace tokenizer splits tokens longer than 255 characters into multiple tokens, 
which can lead to confusing search matches like the one observed in #26601. This adds
a note to the documentation to make this clearer.

Closes #26641