### PR TITLE
Change format how settings represent lists / array

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -86,7 +86,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
 
     protected void validateSettingKey(Setting setting) {
         if (isValidKey(setting.getKey()) == false && (setting.isGroupSetting() && isValidGroupKey(setting.getKey())
-            || isValidAffixKey(setting.getKey())) == false) {
+            || isValidAffixKey(setting.getKey())) == false || setting.getKey().endsWith(".0")) {
             throw new IllegalArgumentException("illegal settings key: [" + setting.getKey() + "]");
         }
     }

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -203,7 +203,7 @@ public final class Settings implements ToXContentFragment {
      * @param setting The setting key
      * @return The setting value, <tt>null</tt> if it does not exists.
      */
-    public final String get(String setting) {
+    public String get(String setting) {
         String s = settings.get(setting);
         if (isInternalList(s)) {
             return stripListMarker(s);

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -552,7 +552,7 @@ public final class Settings implements ToXContentFragment {
         if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             entries = settings.getAsMap().entrySet();
         } else {
-            Map<String, String> legacyEntries = new HashMap<>(settings.getAsMap().size());
+            Map<String, String> legacyEntries = new TreeMap<>();
             for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
                 String value = entry.getValue();
                 List<String> optional = maybeGetList(value);

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -71,7 +71,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/core/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/core/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -70,6 +70,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -106,7 +107,7 @@ public class Analysis {
                 return CharArraySet.EMPTY_SET;
             } else {
                 // LUCENE 4 UPGRADE: Should be settings.getAsBoolean("stem_exclusion_case", false)?
-                return new CharArraySet(Strings.commaDelimitedListToSet(value), false);
+                return new CharArraySet(new HashSet<>(Arrays.asList(settings.getAsArray("stem_exclusion"))), false);
             }
         }
         String[] stemExclusion = settings.getAsArray("stem_exclusion", null);
@@ -164,7 +165,7 @@ public class Analysis {
             if ("_none_".equals(value)) {
                 return CharArraySet.EMPTY_SET;
             } else {
-                return resolveNamedWords(Strings.commaDelimitedListToSet(value), namedWords, ignoreCase);
+                return resolveNamedWords(new HashSet<>(Arrays.asList(settings.getAsArray(name))), namedWords, ignoreCase);
             }
         }
         List<String> pathLoadedWords = getWordList(env, settings, name);

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -602,7 +602,7 @@ public class SettingTests extends ESTestCase {
         expectThrows(UnsupportedOperationException.class, () -> listAffixSetting.get(Settings.EMPTY));
         expectThrows(UnsupportedOperationException.class, () -> listAffixSetting.getRaw(Settings.EMPTY));
         assertEquals(Collections.singletonList("testelement"), listAffixSetting.getDefault(Settings.EMPTY));
-        assertEquals("[\"testelement\"]", listAffixSetting.getDefaultRaw(Settings.EMPTY));
+        assertEquals(Arrays.asList("testelement"), Settings.decodeList(listAffixSetting.getDefaultRaw(Settings.EMPTY)));
     }
 
     public void testMinMaxInt() {

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -579,7 +579,7 @@ public class SettingsTests extends ESTestCase {
                 .put("foobar.1", "baz")
                 .build();
         assertEquals(1, settings.size());
-        assertEquals(settings.get("foobar"), "[\"bar\",\"baz\"]");
+        assertArrayEquals(settings.getAsArray("foobar"), new String[] {"bar", "baz"});
     }
 
     public void testToXContent() throws IOException {
@@ -645,8 +645,9 @@ public class SettingsTests extends ESTestCase {
         for (int i = 0; i < 2; i++){
             keyValues.put(in.readString(), in.readOptionalString());
         }
-        assertEquals(keyValues.get("foo.bar"), "[\"0\",\"1\",\"2\",\"3\"]");
-        assertEquals(keyValues.get("foo.bar.baz"), "baz");
+        Settings build = Settings.builder().put(keyValues).build();
+        assertEquals(build.getAsArray("foo.bar"), new String[] {"0", "1", "2", "3"});
+        assertEquals(build.get("foo.bar.baz"), "baz");
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -26,11 +26,17 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.loader.YamlSettingsLoader;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -304,7 +310,7 @@ public class SettingsTests extends ESTestCase {
                 .put(Settings.builder().put("value.data", "1").build())
                 .build();
         assertThat(settings.get("value.data"), is("1"));
-        assertThat(settings.get("value"), is(nullValue()));
+        assertThat(settings.getAsArray("value"), is(new String[] {"4", "5"}));
     }
 
     public void testPrefixNormalization() {
@@ -551,15 +557,41 @@ public class SettingsTests extends ESTestCase {
         assertTrue(e.getMessage().contains("must be stored inside the Elasticsearch keystore"));
     }
 
-    public void testGetAsArrayFailsOnDuplicates() {
+    public void testConcreteWillOverrideLegacyArray() {
         final Settings settings =
                 Settings.builder()
                         .put("foobar.0", "bar")
                         .put("foobar.1", "baz")
                         .put("foobar", "foo")
                         .build();
-        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> settings.getAsArray("foobar"));
-        assertThat(e, hasToString(containsString("settings object contains values for [foobar=foo] and [foobar.0=bar]")));
+        assertEquals(1, settings.size());
+        assertEquals(settings.get("foobar"), "foo");
+    }
+
+    public void testLegacyArrayOverrideConcrete() {
+        final Settings settings =
+            Settings.builder()
+                .put("foobar", "foo")
+                .put("foobar.0", "bar")
+                .put("foobar.1", "baz")
+                .build();
+        assertEquals(1, settings.size());
+        assertEquals(settings.get("foobar"), "[\"bar\",\"baz\"]");
+    }
+
+    public void testToXContent() throws IOException {
+        Settings test = Settings.builder().putArray("foo.bar", "1", "2", "3").put("foo.bar.baz", "test").build();
+        XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        test.toXContent(builder, new ToXContent.MapParams(Collections.emptyMap()));
+        builder.endObject();
+        assertEquals("{\"foo\":{\"bar.baz\":\"test\",\"bar\":[\"1\",\"2\",\"3\"]}}", builder.string());
+
+        builder = XContentBuilder.builder(XContentType.JSON.xContent());
+        builder.startObject();
+        test.toXContent(builder, new ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
+        builder.endObject();
+        assertEquals("{\"foo.bar\":[\"1\",\"2\",\"3\"],\"foo.bar.baz\":\"test\"}", builder.string());
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/JsonSettingsLoaderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/JsonSettingsLoaderTests.java
@@ -42,8 +42,7 @@ public class JsonSettingsLoaderTests extends ESTestCase {
         assertThat(settings.getAsInt("test1.test2.value3", -1), equalTo(2));
 
         // check array
-        assertThat(settings.get("test1.test3.0"), equalTo("test3-1"));
-        assertThat(settings.get("test1.test3.1"), equalTo("test3-2"));
+        assertThat(settings.get("test1.test3"), equalTo("[\"test3-1\",\"test3-2\"]"));
         assertThat(settings.getAsArray("test1.test3").length, equalTo(2));
         assertThat(settings.getAsArray("test1.test3")[0], equalTo("test3-1"));
         assertThat(settings.getAsArray("test1.test3")[1], equalTo("test3-2"));

--- a/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/loader/YamlSettingsLoaderTests.java
@@ -46,8 +46,7 @@ public class YamlSettingsLoaderTests extends ESTestCase {
         assertThat(settings.getAsInt("test1.test2.value3", -1), equalTo(2));
 
         // check array
-        assertThat(settings.get("test1.test3.0"), equalTo("test3-1"));
-        assertThat(settings.get("test1.test3.1"), equalTo("test3-2"));
+        assertThat(settings.get("test1.test3"), equalTo("[\"test3-1\",\"test3-2\"]"));
         assertThat(settings.getAsArray("test1.test3").length, equalTo(2));
         assertThat(settings.getAsArray("test1.test3")[0], equalTo("test3-1"));
         assertThat(settings.getAsArray("test1.test3")[1], equalTo("test3-2"));

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MassiveWordListTest.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MassiveWordListTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.analysis.common;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class MassiveWordListTest extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return Collections.singleton(CommonAnalysisPlugin.class);
+    }
+
+    public void testCreateIndexWithMassiveWordList() {
+        String[] wordList = new String[100000];
+        for (int i = 0; i < wordList.length; i++) {
+            wordList[i] = "hello world";
+        }
+        client().admin().indices().prepareCreate("test").setSettings(Settings.builder()
+            .put("index.number_of_shards", 1)
+            .put("analysis.analyzer.test_analyzer.type", "custom")
+            .put("analysis.analyzer.test_analyzer.tokenizer", "standard")
+            .putArray("analysis.analyzer.test_analyzer.filter", "dictionary_decompounder", "lowercase")
+            .put("analysis.filter.dictionary_decompounder.type", "dictionary_decompounder")
+            .putArray("analysis.filter.dictionary_decompounder.word_list", wordList)
+        ).get();
+    }
+}

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MassiveWordListTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MassiveWordListTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 import java.util.Collection;
 import java.util.Collections;
 
-public class MassiveWordListTest extends ESSingleNodeTestCase {
+public class MassiveWordListTests extends ESSingleNodeTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2Service.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2Service.java
@@ -115,7 +115,9 @@ interface AwsEc2Service {
      * instances with a tag key set to stage, and a value of dev. Several tags set will require all of those tags to be set for the
      * instance to be included.
      */
-    Setting<Settings> TAG_SETTING = Setting.groupSetting("discovery.ec2.tag.", Property.NodeScope);
+    Setting.AffixSetting<List<String>> TAG_SETTING =
+        Setting.prefixKeySetting("discovery.ec2.tag.",
+            key -> Setting.listSetting(key, Collections.emptyList(), Function.identity(), Property.NodeScope));
 
     AmazonEC2 client();
 }


### PR DESCRIPTION
Today we represent each value of a list setting with it's own dedicated key that ends with the index of the value in the list. Aside of the obvious weirdness this has several issues especially if lists are massive since it causes massive runtime penalties when validating settings. Like a list of 100k words will literally cause a create index call to timeout and in-turn massive slowdown on all subsequent validations runs. 

This change moves away from the current internal representation towards a single decoded string representation. A list is encoded into a JSON list internally in a fully backwards compatible way. A list is then a single key value pair in settings and all prefix based settings are internally converted to the new representation in the settings builder. This change also forbids to add a settings that ends with a `.0` which was internally used to detect a list setting. Once this has been rolled out for an entire major version all the internal `.0` handling can be removed since all settings will be converted.
