### PR TITLE
Catch exceptions and inform handler in RemoteClusterConnection#collectNodes

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
+++ b/core/src/main/java/org/elasticsearch/transport/RemoteClusterConnection.java
@@ -230,15 +230,19 @@ final class RemoteClusterConnection extends AbstractComponent implements Transpo
                     }
                 });
         };
-        if (connectedNodes.size() == 0) {
-            // just in case if we are not connected for some reason we try to connect and if we fail we have to notify the listener
-            // this will cause some back pressure on the search end and eventually will cause rejections but that's fine
-            // we can't proceed with a search on a cluster level.
-            // in the future we might want to just skip the remote nodes in such a case but that can already be implemented on the
-            // caller end since they provide the listener.
-            ensureConnected(ActionListener.wrap((x) -> runnable.run(), listener::onFailure));
-        } else {
-            runnable.run();
+        try {
+            if (connectedNodes.size() == 0) {
+                // just in case if we are not connected for some reason we try to connect and if we fail we have to notify the listener
+                // this will cause some back pressure on the search end and eventually will cause rejections but that's fine
+                // we can't proceed with a search on a cluster level.
+                // in the future we might want to just skip the remote nodes in such a case but that can already be implemented on the
+                // caller end since they provide the listener.
+                ensureConnected(ActionListener.wrap((x) -> runnable.run(), listener::onFailure));
+            } else {
+                runnable.run();
+            }
+        } catch (Exception ex) {
+            listener.onFailure(ex);
         }
     }
 


### PR DESCRIPTION

This adds a missing catch block to invoke the action listener instead of bubbling up the exception.

Closes #26700