### PR TITLE
Tests: Add Fedora-26 to packaging tests

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -352,6 +352,7 @@ These are the linux flavors the Vagrantfile currently supports:
 * centos-6
 * centos-7
 * fedora-25
+* fedora-26
 * oel-6 aka Oracle Enterprise Linux 6
 * oel-7 aka Oracle Enterprise Linux 7
 * sles-12

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,6 +64,10 @@ Vagrant.configure(2) do |config|
     config.vm.box = "elastic/fedora-25-x86_64"
     dnf_common config
   end
+  config.vm.define "fedora-26" do |config|
+    config.vm.box = "elastic/fedora-26-x86_64"
+    dnf_common config
+  end
   config.vm.define "opensuse-42" do |config|
     config.vm.box = "elastic/opensuse-42-x86_64"
     opensuse_common config

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -20,6 +20,7 @@ class VagrantTestPlugin implements Plugin<Project> {
             'debian-8',
             'debian-9',
             'fedora-25',
+            'fedora-26',
             'oel-6',
             'oel-7',
             'opensuse-42',


### PR DESCRIPTION
Add Fedora-26 to packaging tests. Don't retire Fedora-25 yet, as it
will be EOL, one month after Fedora-27 is out.
