### PR TITLE
Decouple BulkProcessor from ThreadPool

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -39,7 +39,6 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -50,7 +49,6 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -614,14 +612,14 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
             }
         };
 
-        ThreadPool threadPool = new ThreadPool(Settings.builder().put("node.name", getClass().getName()).build());
         // Pull the client to a variable to work around https://bugs.eclipse.org/bugs/show_bug.cgi?id=514884
         RestHighLevelClient hlClient = highLevelClient();
-        try(BulkProcessor processor = new BulkProcessor.Builder(hlClient::bulkAsync, listener, threadPool)
-            .setConcurrentRequests(0)
-            .setBulkSize(new ByteSizeValue(5, ByteSizeUnit.GB))
-            .setBulkActions(nbItems + 1)
-            .build()) {
+
+        try(BulkProcessor processor = BulkProcessor.builder(hlClient::bulkAsync, listener)
+                .setConcurrentRequests(0)
+                .setBulkSize(new ByteSizeValue(5, ByteSizeUnit.GB))
+                .setBulkActions(nbItems + 1)
+                .build()) {
             for (int i = 0; i < nbItems; i++) {
                 String id = String.valueOf(i);
                 boolean erroneous = randomBoolean();
@@ -631,7 +629,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
                 if (opType == DocWriteRequest.OpType.DELETE) {
                     if (erroneous == false) {
                         assertEquals(RestStatus.CREATED,
-                            highLevelClient().index(new IndexRequest("index", "test", id).source("field", -1)).status());
+                                highLevelClient().index(new IndexRequest("index", "test", id).source("field", -1)).status());
                     }
                     DeleteRequest deleteRequest = new DeleteRequest("index", "test", id);
                     processor.add(deleteRequest);
@@ -653,10 +651,10 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
 
                     } else if (opType == DocWriteRequest.OpType.UPDATE) {
                         UpdateRequest updateRequest = new UpdateRequest("index", "test", id)
-                            .doc(new IndexRequest().source(xContentType, "id", i));
+                                .doc(new IndexRequest().source(xContentType, "id", i));
                         if (erroneous == false) {
                             assertEquals(RestStatus.CREATED,
-                                highLevelClient().index(new IndexRequest("index", "test", id).source("field", -1)).status());
+                                    highLevelClient().index(new IndexRequest("index", "test", id).source("field", -1)).status());
                         }
                         processor.add(updateRequest);
                     }
@@ -676,8 +674,6 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         assertNull(error.get());
 
         validateBulkResponses(nbItems, errors, bulkResponse, bulkRequest);
-
-        terminate(threadPool);
     }
 
     private void validateBulkResponses(int nbItems, boolean[] errors, BulkResponse bulkResponse, BulkRequest bulkRequest) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -615,7 +615,7 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         // Pull the client to a variable to work around https://bugs.eclipse.org/bugs/show_bug.cgi?id=514884
         RestHighLevelClient hlClient = highLevelClient();
 
-        try(BulkProcessor processor = BulkProcessor.builder(hlClient::bulkAsync, listener)
+        try (BulkProcessor processor = BulkProcessor.builder(hlClient::bulkAsync, listener)
                 .setConcurrentRequests(0)
                 .setBulkSize(new ByteSizeValue(5, ByteSizeUnit.GB))
                 .setBulkActions(nbItems + 1)

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequestHandler.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequestHandler.java
@@ -25,7 +25,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.Scheduler;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
@@ -44,14 +44,13 @@ public final class BulkRequestHandler {
     private final int concurrentRequests;
 
     BulkRequestHandler(BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer, BackoffPolicy backoffPolicy,
-                       BulkProcessor.Listener listener, ThreadPool threadPool,
-                       int concurrentRequests) {
+                       BulkProcessor.Listener listener, Scheduler scheduler, int concurrentRequests) {
         assert concurrentRequests >= 0;
         this.logger = Loggers.getLogger(getClass());
         this.consumer = consumer;
         this.listener = listener;
         this.concurrentRequests = concurrentRequests;
-        this.retry = new Retry(EsRejectedExecutionException.class, backoffPolicy, threadPool);
+        this.retry = new Retry(EsRejectedExecutionException.class, backoffPolicy, scheduler);
         this.semaphore = new Semaphore(concurrentRequests > 0 ? concurrentRequests : 1);
     }
 

--- a/core/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
@@ -36,7 +36,7 @@ import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Cancellable;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 
 import java.io.Closeable;

--- a/core/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
+++ b/core/src/main/java/org/elasticsearch/monitor/jvm/JvmGcMonitorService.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.monitor.jvm.JvmStats.GarbageCollector;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Cancellable;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 
 import java.util.HashMap;

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -93,7 +93,7 @@ import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Cancellable;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.TransportRequest;
 

--- a/core/src/main/java/org/elasticsearch/threadpool/Scheduler.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/Scheduler.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.threadpool;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Scheduler that allows to schedule one-shot and periodic commands.
+ */
+public interface Scheduler {
+
+    static ScheduledThreadPoolExecutor initScheduler(Settings settings) {
+        ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(1,
+                EsExecutors.daemonThreadFactory(settings, "scheduler"), new EsAbortPolicy());
+        scheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+        scheduler.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+        scheduler.setRemoveOnCancelPolicy(true);
+        return scheduler;
+    }
+
+    static boolean terminate(ScheduledThreadPoolExecutor scheduledThreadPoolExecutor, long timeout, TimeUnit timeUnit) {
+        scheduledThreadPoolExecutor.shutdown();
+        if (awaitTermination(scheduledThreadPoolExecutor, timeout, timeUnit)) {
+            return true;
+        }
+        // last resort
+        scheduledThreadPoolExecutor.shutdownNow();
+        return awaitTermination(scheduledThreadPoolExecutor, timeout, timeUnit);
+    }
+
+    static boolean awaitTermination(final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor,
+            final long timeout, final TimeUnit timeUnit) {
+        try {
+            if (scheduledThreadPoolExecutor.awaitTermination(timeout, timeUnit)) {
+                return true;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return false;
+    }
+
+    /**
+     * Does nothing by default but can be used by subclasses to save the current thread context and wraps the command in a Runnable
+     * that restores that context before running the command.
+     */
+    default Runnable preserveContext(Runnable command) {
+        return command;
+    }
+
+    /**
+     * Schedules a one-shot command to be run after a given delay. The command is not run in the context of the calling thread.
+     * To preserve the context of the calling thread you may call {@link #preserveContext(Runnable)} on the runnable before passing
+     * it to this method.
+     * The command runs on scheduler thread. Do not run blocking calls on the scheduler thread. Subclasses may allow
+     * to execute on a different executor, in which case blocking calls are allowed.
+     *
+     * @param delay delay before the task executes
+     * @param executor the name of the executor that has to execute this task. Ignored in the default implementation but can be used
+     *                 by subclasses that support multiple executors.
+     * @param command the command to run
+     * @return a ScheduledFuture who's get will return when the task has been added to its target thread pool and throws an exception if
+     *         the task is canceled before it was added to its target thread pool. Once the task has been added to its target thread pool
+     *         the ScheduledFuture cannot interact with it.
+     * @throws EsRejectedExecutionException if the task cannot be scheduled for execution
+     */
+    ScheduledFuture<?> schedule(TimeValue delay, String executor, Runnable command);
+
+    /**
+     * Schedules a periodic action that runs on scheduler thread. Do not run blocking calls on the scheduler thread. Subclasses may allow
+     * to execute on a different executor, in which case blocking calls are allowed.
+     *
+     * @param command the action to take
+     * @param interval the delay interval
+     * @param executor the name of the executor that has to execute this task. Ignored in the default implementation but can be used
+     *                 by subclasses that support multiple executors.
+     * @return a {@link Cancellable} that can be used to cancel the subsequent runs of the command. If the command is running, it will
+     *         not be interrupted.
+     */
+    default Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, String executor) {
+        return new ReschedulingRunnable(command, interval, executor, this, (e) -> {}, (e) -> {});
+    }
+
+    /**
+     * This interface represents an object whose execution may be cancelled during runtime.
+     */
+    interface Cancellable {
+
+        /**
+         * Cancel the execution of this object. This method is idempotent.
+         */
+        void cancel();
+
+        /**
+         * Check if the execution has been cancelled
+         * @return true if cancelled
+         */
+        boolean isCancelled();
+    }
+
+    /**
+     * This class encapsulates the scheduling of a {@link Runnable} that needs to be repeated on a interval. For example, checking a value
+     * for cleanup every second could be done by passing in a Runnable that can perform the check and the specified interval between
+     * executions of this runnable. <em>NOTE:</em> the runnable is only rescheduled to run again after completion of the runnable.
+     *
+     * For this class, <i>completion</i> means that the call to {@link Runnable#run()} returned or an exception was thrown and caught. In
+     * case of an exception, this class will log the exception and reschedule the runnable for its next execution. This differs from the
+     * {@link ScheduledThreadPoolExecutor#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)} semantics as an exception there would
+     * terminate the rescheduling of the runnable.
+     */
+    final class ReschedulingRunnable extends AbstractRunnable implements Cancellable {
+
+        private final Runnable runnable;
+        private final TimeValue interval;
+        private final String executor;
+        private final Scheduler scheduler;
+        private final Consumer<Exception> rejectionConsumer;
+        private final Consumer<Exception> failureConsumer;
+
+        private volatile boolean run = true;
+
+        /**
+         * Creates a new rescheduling runnable and schedules the first execution to occur after the interval specified
+         *
+         * @param runnable the {@link Runnable} that should be executed periodically
+         * @param interval the time interval between executions
+         * @param executor the executor where this runnable should be scheduled to run
+         * @param scheduler the {@link Scheduler} instance to use for scheduling
+         */
+        ReschedulingRunnable(Runnable runnable, TimeValue interval, String executor, Scheduler scheduler,
+                             Consumer<Exception> rejectionConsumer, Consumer<Exception> failureConsumer) {
+            this.runnable = runnable;
+            this.interval = interval;
+            this.executor = executor;
+            this.scheduler = scheduler;
+            this.rejectionConsumer = rejectionConsumer;
+            this.failureConsumer = failureConsumer;
+            scheduler.schedule(interval, executor, this);
+        }
+
+        @Override
+        public void cancel() {
+            run = false;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return run == false;
+        }
+
+        @Override
+        public void doRun() {
+            // always check run here since this may have been cancelled since the last execution and we do not want to run
+            if (run) {
+                runnable.run();
+            }
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            failureConsumer.accept(e);
+        }
+
+        @Override
+        public void onRejection(Exception e) {
+            run = false;
+            rejectionConsumer.accept(e);
+        }
+
+        @Override
+        public void onAfter() {
+            // if this has not been cancelled reschedule it to run again
+            if (run) {
+                try {
+                    scheduler.schedule(interval, executor, this);
+                } catch (final EsRejectedExecutionException e) {
+                    onRejection(e);
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -33,10 +33,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.SizeValue;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.concurrent.XRejectedExecutionHandler;
@@ -64,7 +61,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.unmodifiableMap;
 
-public class ThreadPool extends AbstractComponent implements Closeable {
+public class ThreadPool extends AbstractComponent implements Scheduler, Closeable {
 
     public static class Names {
         public static final String SAME = "same";
@@ -143,8 +140,6 @@ public class ThreadPool extends AbstractComponent implements Closeable {
 
     private Map<String, ExecutorHolder> executors = new HashMap<>();
 
-    private final ScheduledThreadPoolExecutor scheduler;
-
     private final CachedTimeThread cachedTimeThread;
 
     static final ExecutorService DIRECT_EXECUTOR = EsExecutors.newDirectExecutorService();
@@ -152,6 +147,8 @@ public class ThreadPool extends AbstractComponent implements Closeable {
     private final ThreadContext threadContext;
 
     private final Map<String, ExecutorBuilder> builders;
+
+    private final ScheduledThreadPoolExecutor scheduler;
 
     public Collection<ExecutorBuilder> builders() {
         return Collections.unmodifiableCollection(builders.values());
@@ -210,12 +207,7 @@ public class ThreadPool extends AbstractComponent implements Closeable {
 
         executors.put(Names.SAME, new ExecutorHolder(DIRECT_EXECUTOR, new Info(Names.SAME, ThreadPoolType.DIRECT)));
         this.executors = unmodifiableMap(executors);
-
-        this.scheduler = new ScheduledThreadPoolExecutor(1, EsExecutors.daemonThreadFactory(settings, "scheduler"), new EsAbortPolicy());
-        this.scheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-        this.scheduler.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
-        this.scheduler.setRemoveOnCancelPolicy(true);
-
+        this.scheduler = Scheduler.initScheduler(settings);
         TimeValue estimatedTimeInterval = ESTIMATED_TIME_INTERVAL_SETTING.get(settings);
         this.cachedTimeThread = new CachedTimeThread(EsExecutors.threadName(settings, "[timer]"), estimatedTimeInterval.millis());
         this.cachedTimeThread.start();
@@ -329,25 +321,6 @@ public class ThreadPool extends AbstractComponent implements Closeable {
         return holder.executor();
     }
 
-    public ScheduledExecutorService scheduler() {
-        return this.scheduler;
-    }
-
-    /**
-     * Schedules a periodic action that runs on the specified thread pool.
-     *
-     * @param command the action to take
-     * @param interval the delay interval
-     * @param executor The name of the thread pool on which to execute this task. {@link Names#SAME} means "execute on the scheduler thread",
-     *             which there is only one of. Executing blocking or long running code on the {@link Names#SAME} thread pool should never
-     *             be done as it can cause issues with the cluster
-     * @return a {@link Cancellable} that can be used to cancel the subsequent runs of the command. If the command is running, it will
-     *         not be interrupted.
-     */
-    public Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, String executor) {
-        return new ReschedulingRunnable(command, interval, executor, this);
-    }
-
     /**
      * Schedules a one-shot command to run after a given delay. The command is not run in the context of the calling thread. To preserve the
      * context of the calling thread you may call <code>threadPool.getThreadContext().preserveContext</code> on the runnable before passing
@@ -361,13 +334,30 @@ public class ThreadPool extends AbstractComponent implements Closeable {
      * @return a ScheduledFuture who's get will return when the task is has been added to its target thread pool and throw an exception if
      *         the task is canceled before it was added to its target thread pool. Once the task has been added to its target thread pool
      *         the ScheduledFuture will cannot interact with it.
-     * @throws EsRejectedExecutionException if the task cannot be scheduled for execution
+     * @throws org.elasticsearch.common.util.concurrent.EsRejectedExecutionException if the task cannot be scheduled for execution
      */
     public ScheduledFuture<?> schedule(TimeValue delay, String executor, Runnable command) {
         if (!Names.SAME.equals(executor)) {
             command = new ThreadedRunnable(command, executor(executor));
         }
-        return scheduler.schedule(new LoggingRunnable(command), delay.millis(), TimeUnit.MILLISECONDS);
+        return scheduler.schedule(new ThreadPool.LoggingRunnable(command), delay.millis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public Cancellable scheduleWithFixedDelay(Runnable command, TimeValue interval, String executor) {
+        return new ReschedulingRunnable(command, interval, executor, this,
+                (e) -> {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug((Supplier<?>) () -> new ParameterizedMessage("scheduled task [{}] was rejected on thread pool [{}]",
+                                command, executor), e);
+                    }
+                },
+                (e) -> logger.warn((Supplier<?>) () -> new ParameterizedMessage("failed to run scheduled task [{}] on thread pool [{}]",
+                        command.toString(), executor), e));
+    }
+
+    public Runnable preserveContext(Runnable command) {
+        return getThreadContext().preserveContext(command);
     }
 
     public void shutdown() {
@@ -376,7 +366,7 @@ public class ThreadPool extends AbstractComponent implements Closeable {
         scheduler.shutdown();
         for (ExecutorHolder executor : executors.values()) {
             if (executor.executor() instanceof ThreadPoolExecutor) {
-                ((ThreadPoolExecutor) executor.executor()).shutdown();
+                executor.executor().shutdown();
             }
         }
     }
@@ -387,7 +377,7 @@ public class ThreadPool extends AbstractComponent implements Closeable {
         scheduler.shutdownNow();
         for (ExecutorHolder executor : executors.values()) {
             if (executor.executor() instanceof ThreadPoolExecutor) {
-                ((ThreadPoolExecutor) executor.executor()).shutdownNow();
+                executor.executor().shutdownNow();
             }
         }
     }
@@ -396,12 +386,15 @@ public class ThreadPool extends AbstractComponent implements Closeable {
         boolean result = scheduler.awaitTermination(timeout, unit);
         for (ExecutorHolder executor : executors.values()) {
             if (executor.executor() instanceof ThreadPoolExecutor) {
-                result &= ((ThreadPoolExecutor) executor.executor()).awaitTermination(timeout, unit);
+                result &= executor.executor().awaitTermination(timeout, unit);
             }
         }
-
         cachedTimeThread.join(unit.toMillis(timeout));
         return result;
+    }
+
+    public ScheduledExecutorService scheduler() {
+        return this.scheduler;
     }
 
     /**
@@ -722,27 +715,29 @@ public class ThreadPool extends AbstractComponent implements Closeable {
      * Returns <code>true</code> if the given pool was terminated successfully. If the termination timed out,
      * the service is <code>null</code> this method will return <code>false</code>.
      */
-    public static boolean terminate(ThreadPool pool, long timeout, TimeUnit timeUnit) {
-        if (pool != null) {
+    public static boolean terminate(ThreadPool threadPool, long timeout, TimeUnit timeUnit) {
+        if (threadPool != null) {
             try {
-                pool.shutdown();
-                if (awaitTermination(pool, timeout, timeUnit)) return true;
+                threadPool.shutdown();
+                if (awaitTermination(threadPool, timeout, timeUnit)) {
+                    return true;
+                }
                 // last resort
-                pool.shutdownNow();
-                return awaitTermination(pool, timeout, timeUnit);
+                threadPool.shutdownNow();
+                return awaitTermination(threadPool, timeout, timeUnit);
             } finally {
-                IOUtils.closeWhileHandlingException(pool);
+                IOUtils.closeWhileHandlingException(threadPool);
             }
         }
         return false;
     }
 
     private static boolean awaitTermination(
-            final ThreadPool pool,
+            final ThreadPool threadPool,
             final long timeout,
             final TimeUnit timeUnit) {
         try {
-            if (pool.awaitTermination(timeout, timeUnit)) {
+            if (threadPool.awaitTermination(timeout, timeUnit)) {
                 return true;
             }
         } catch (InterruptedException e) {
@@ -758,102 +753,6 @@ public class ThreadPool extends AbstractComponent implements Closeable {
 
     public ThreadContext getThreadContext() {
         return threadContext;
-    }
-
-    /**
-     * This interface represents an object whose execution may be cancelled during runtime.
-     */
-    public interface Cancellable {
-
-        /**
-         * Cancel the execution of this object. This method is idempotent.
-         */
-        void cancel();
-
-        /**
-         * Check if the execution has been cancelled
-         * @return true if cancelled
-         */
-        boolean isCancelled();
-    }
-
-    /**
-     * This class encapsulates the scheduling of a {@link Runnable} that needs to be repeated on a interval. For example, checking a value
-     * for cleanup every second could be done by passing in a Runnable that can perform the check and the specified interval between
-     * executions of this runnable. <em>NOTE:</em> the runnable is only rescheduled to run again after completion of the runnable.
-     *
-     * For this class, <i>completion</i> means that the call to {@link Runnable#run()} returned or an exception was thrown and caught. In
-     * case of an exception, this class will log the exception and reschedule the runnable for its next execution. This differs from the
-     * {@link ScheduledThreadPoolExecutor#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)} semantics as an exception there would
-     * terminate the rescheduling of the runnable.
-     */
-    static final class ReschedulingRunnable extends AbstractRunnable implements Cancellable {
-
-        private final Runnable runnable;
-        private final TimeValue interval;
-        private final String executor;
-        private final ThreadPool threadPool;
-
-        private volatile boolean run = true;
-
-        /**
-         * Creates a new rescheduling runnable and schedules the first execution to occur after the interval specified
-         *
-         * @param runnable the {@link Runnable} that should be executed periodically
-         * @param interval the time interval between executions
-         * @param executor the executor where this runnable should be scheduled to run
-         * @param threadPool the {@link ThreadPool} instance to use for scheduling
-         */
-        ReschedulingRunnable(Runnable runnable, TimeValue interval, String executor, ThreadPool threadPool) {
-            this.runnable = runnable;
-            this.interval = interval;
-            this.executor = executor;
-            this.threadPool = threadPool;
-            threadPool.schedule(interval, executor, this);
-        }
-
-        @Override
-        public void cancel() {
-            run = false;
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return run == false;
-        }
-
-        @Override
-        public void doRun() {
-            // always check run here since this may have been cancelled since the last execution and we do not want to run
-            if (run) {
-                runnable.run();
-            }
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            threadPool.logger.warn((Supplier<?>) () -> new ParameterizedMessage("failed to run scheduled task [{}] on thread pool [{}]", runnable.toString(), executor), e);
-        }
-
-        @Override
-        public void onRejection(Exception e) {
-            run = false;
-            if (threadPool.logger.isDebugEnabled()) {
-                threadPool.logger.debug((Supplier<?>) () -> new ParameterizedMessage("scheduled task [{}] was rejected on thread pool [{}]", runnable, executor), e);
-            }
-        }
-
-        @Override
-        public void onAfter() {
-            // if this has not been cancelled reschedule it to run again
-            if (run) {
-                try {
-                    threadPool.schedule(interval, executor, this);
-                } catch (final EsRejectedExecutionException e) {
-                    onRejection(e);
-                }
-            }
-        }
     }
 
     public static boolean assertNotScheduleThread(String reason) {

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -715,18 +715,18 @@ public class ThreadPool extends AbstractComponent implements Scheduler, Closeabl
      * Returns <code>true</code> if the given pool was terminated successfully. If the termination timed out,
      * the service is <code>null</code> this method will return <code>false</code>.
      */
-    public static boolean terminate(ThreadPool threadPool, long timeout, TimeUnit timeUnit) {
-        if (threadPool != null) {
+    public static boolean terminate(ThreadPool pool, long timeout, TimeUnit timeUnit) {
+        if (pool != null) {
             try {
-                threadPool.shutdown();
-                if (awaitTermination(threadPool, timeout, timeUnit)) {
+                pool.shutdown();
+                if (awaitTermination(pool, timeout, timeUnit)) {
                     return true;
                 }
                 // last resort
-                threadPool.shutdownNow();
-                return awaitTermination(threadPool, timeout, timeUnit);
+                pool.shutdownNow();
+                return awaitTermination(pool, timeout, timeUnit);
             } finally {
-                IOUtils.closeWhileHandlingException(threadPool);
+                IOUtils.closeWhileHandlingException(pool);
             }
         }
         return false;

--- a/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/core/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -353,7 +353,7 @@ public class ThreadPool extends AbstractComponent implements Scheduler, Closeabl
                     }
                 },
                 (e) -> logger.warn((Supplier<?>) () -> new ParameterizedMessage("failed to run scheduled task [{}] on thread pool [{}]",
-                        command.toString(), executor), e));
+                        command, executor), e));
     }
 
     public Runnable preserveContext(Runnable command) {

--- a/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
+++ b/core/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
@@ -25,7 +25,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Cancellable;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 
 import java.io.IOException;

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
@@ -67,7 +67,7 @@ public class BulkProcessorTests extends ESTestCase {
         final BulkProcessor bulkProcessor;
         assertNull(threadPool.getThreadContext().getHeader(headerKey));
         assertNull(threadPool.getThreadContext().getTransient(transientKey));
-        try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
+        try (ThreadContext.StoredContext ignore = threadPool.getThreadContext().stashContext()) {
             threadPool.getThreadContext().putHeader(headerKey, headerValue);
             threadPool.getThreadContext().putTransient(transientKey, transientValue);
             bulkProcessor = new BulkProcessor(consumer, BackoffPolicy.noBackoff(), new BulkProcessor.Listener() {
@@ -82,7 +82,7 @@ public class BulkProcessorTests extends ESTestCase {
                 @Override
                 public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
                 }
-            }, 1, bulkSize, new ByteSizeValue(5, ByteSizeUnit.MB), flushInterval, threadPool);
+            }, 1, bulkSize, new ByteSizeValue(5, ByteSizeUnit.MB), flushInterval, threadPool, () -> {});
         }
         assertNull(threadPool.getThreadContext().getHeader(headerKey));
         assertNull(threadPool.getThreadContext().getTransient(transientKey));

--- a/core/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -56,7 +56,7 @@ import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Cancellable;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.junit.After;
 import org.junit.Before;

--- a/core/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -35,7 +35,7 @@ import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Cancellable;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/core/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceSettingsTests.java
@@ -22,9 +22,9 @@ package org.elasticsearch.monitor.jvm;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPool.Cancellable;
 
 import java.util.AbstractMap;
 import java.util.HashSet;

--- a/core/src/test/java/org/elasticsearch/threadpool/ScheduleWithFixedDelayTests.java
+++ b/core/src/test/java/org/elasticsearch/threadpool/ScheduleWithFixedDelayTests.java
@@ -26,9 +26,9 @@ import org.elasticsearch.common.util.concurrent.BaseFuture;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.threadpool.ThreadPool.Cancellable;
+import org.elasticsearch.threadpool.Scheduler.Cancellable;
 import org.elasticsearch.threadpool.ThreadPool.Names;
-import org.elasticsearch.threadpool.ThreadPool.ReschedulingRunnable;
+import org.elasticsearch.threadpool.Scheduler.ReschedulingRunnable;
 import org.junit.After;
 import org.junit.Before;
 
@@ -80,7 +80,8 @@ public class ScheduleWithFixedDelayTests extends ESTestCase {
                 Thread.currentThread().interrupt();
             }
         };
-        ReschedulingRunnable reschedulingRunnable = new ReschedulingRunnable(runnable, delay, Names.GENERIC, threadPool);
+        ReschedulingRunnable reschedulingRunnable = new ReschedulingRunnable(runnable, delay, Names.GENERIC, threadPool,
+                (e) -> {}, (e) -> {});
         // this call was made during construction of the runnable
         verify(threadPool, times(1)).schedule(delay, Names.GENERIC, reschedulingRunnable);
 
@@ -260,7 +261,8 @@ public class ScheduleWithFixedDelayTests extends ESTestCase {
             }
         };
         Runnable runnable = () -> {};
-        ReschedulingRunnable reschedulingRunnable = new ReschedulingRunnable(runnable, delay, Names.GENERIC, threadPool);
+        ReschedulingRunnable reschedulingRunnable = new ReschedulingRunnable(runnable, delay, Names.GENERIC,
+                threadPool, (e) -> {}, (e) -> {});
         assertTrue(reschedulingRunnable.isCancelled());
     }
 

--- a/docs/java-rest/high-level/apis/bulk.asciidoc
+++ b/docs/java-rest/high-level/apis/bulk.asciidoc
@@ -125,27 +125,24 @@ The `BulkProcessor` simplifies the usage of the Bulk API by providing
 a utility class that allows index/update/delete operations to be
 transparently executed as they are added to the processor.
 
-In order to execute the requests, the `BulkProcessor` requires 3 components:
+In order to execute the requests, the `BulkProcessor` requires the following
+components:
 
 `RestHighLevelClient`:: This client is used to execute the `BulkRequest`
 and to retrieve the `BulkResponse`
 `BulkProcessor.Listener`:: This listener is called before and after
 every `BulkRequest` execution or when a `BulkRequest` failed
-`ThreadPool`:: The `BulkRequest` executions are done using threads from this
-pool, allowing the `BulkProcessor` to work in a non-blocking manner and to
-accept new index/update/delete requests while bulk requests are executing.
 
-Then the `BulkProcessor.Builder` class can be used to build a new `BulkProcessor`:
+Then the `BulkProcessor.builder` method can be used to build a new `BulkProcessor`:
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
 include-tagged::{doc-tests}/CRUDDocumentationIT.java[bulk-processor-init]
 --------------------------------------------------
-<1> Create the `ThreadPool` using the given `Settings`
-<2> Create the `BulkProcessor.Listener`
-<3> This method is called before each execution of a `BulkRequest`
-<4> This method is called after each execution of a `BulkRequest`
-<5> This method is called when a `BulkRequest` failed
-<6> Create the `BulkProcessor` by calling the `build()` method from
+<1> Create the `BulkProcessor.Listener`
+<2> This method is called before each execution of a `BulkRequest`
+<3> This method is called after each execution of a `BulkRequest`
+<4> This method is called when a `BulkRequest` failed
+<5> Create the `BulkProcessor` by calling the `build()` method from
 the `BulkProcessor.Builder`. The `RestHighLevelClient.bulkAsync()`
 method will be used to execute the `BulkRequest` under the hood.
 
@@ -190,7 +187,7 @@ to know if the `BulkResponse` contains errors
 the failure
 
 Once all requests have been added to the `BulkProcessor`, its instance needs to
-be closed closed using one of the two available closing methods.
+be closed using one of the two available closing methods.
 
 The `awaitClose()` method can be used to wait until all requests have been processed
  or the specified waiting time elapses:
@@ -209,3 +206,4 @@ include-tagged::{doc-tests}/CRUDDocumentationIT.java[bulk-processor-close]
 
 Both methods flush the requests added to the processor before closing the processor
 and also forbid any new request to be added to it.
+

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -765,8 +765,8 @@ public abstract class ESTestCase extends LuceneTestCase {
         return terminated;
     }
 
-    public static boolean terminate(ThreadPool service) throws InterruptedException {
-        return ThreadPool.terminate(service, 10, TimeUnit.SECONDS);
+    public static boolean terminate(ThreadPool threadPool) throws InterruptedException {
+        return ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
The goal of this PR is to not require to provide a `ThreadPool` when creating a `BulkProcessor`. This way, we make it easier to use the `BulkProcessor` from the high-level REST client.

The initial [idea](https://github.com/elastic/elasticsearch/issues/26028#issuecomment-325412254) around removing the need for passing in a `ThreadPool` to `BulkProcessor` was to require two functions: `BiFunction<Runnable, TimeValue, ScheduledFuture<?>>` to schedule a task and `Function<Runnable, Runnable>` to wrap the command into one that preserves the thread context. When trying that approach, a few issues came up. The flush task is a periodic task (scheduled through `scheduleWithFixedDelay`) and gets executed on the `GENERIC` thread pool rather than `SAME`. Also the `ThreadPool#scheduleWithFixedDelay` method has different semantics compared to the standard `ScheduledThreadPoolExecutor#scheduleWithFixedDelay` when it comes to failures.

The approach I went for in this PR is based on extracting the minimal code that allows to schedule tasks into a new base interface called `Scheduler` which the `BulkProcessor` depends on. `ThreadPool` implements `Scheduler` and enhances it, so that all of the components that already used `BulkProcessor` and had a `ThreadPool` available can keep on doing the same exactly the same way, while the high-level REST client internally creates its own instance of the `Scheduler` (users don't even have to provide it while they previously needed to create the `ThreadPool`), which works exactly as the `ThreadPool` but it doesn't support multiple executors, and shuts it down on close (also it doesn't log anything in case of failures).

This approach allows to not have to reinvent the wheel in the high-level REST client and use the same code that we already have to schedule one-shot and periodic tasks, all without requiring an entire `ThreadPool` which the high-level REST client doesn't need.

Closes #26028