### PR TITLE
[Tests] Prevent test errors cause by empty field names

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
@@ -23,6 +23,8 @@ import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 
+import org.elasticsearch.common.Strings;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -59,7 +61,7 @@ public final class RandomDocumentPicks {
         String fieldName;
         do {
             fieldName = randomString(random);
-        } while (fieldName.contains("."));
+        } while (fieldName.contains(".") || Strings.hasText(fieldName) == false);
         return fieldName;
     }
 


### PR DESCRIPTION
When random document sources are generated and the field name is empty or a
whitespace-only name we can get MapperParsingExceptions in tests. This has been
fixed in master by using RandomStrings.randomAsciiAlphanumOfLengthBetween() for
the lead field name, but this method doesn't seem to be available on 5.x so this
change excludes whitespace-only fieldnames.

Closes #26736