### PR TITLE
Use the 6.6.1 Lucene version constant.

### DIFF
--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -93,11 +93,9 @@ public class Version implements Comparable<Version> {
     public static final int V_5_6_0_ID = 5060099;
     public static final Version V_5_6_0 = new Version(V_5_6_0_ID, org.apache.lucene.util.Version.LUCENE_6_6_0);
     public static final int V_5_6_1_ID = 5060199;
-    // TODO use proper Lucene constant once we are on a Lucene snapshot that knows about 6.6.1
-    public static final Version V_5_6_1 = new Version(V_5_6_1_ID, org.apache.lucene.util.Version.fromBits(6, 6, 1));
+    public static final Version V_5_6_1 = new Version(V_5_6_1_ID, org.apache.lucene.util.Version.LUCENE_6_6_1);
     public static final int V_5_6_2_ID = 5060299;
-    // TODO use proper Lucene constant once we are on a Lucene snapshot that knows about 6.6.1
-    public static final Version V_5_6_2 = new Version(V_5_6_2_ID, org.apache.lucene.util.Version.fromBits(6, 6, 1));
+    public static final Version V_5_6_2 = new Version(V_5_6_2_ID, org.apache.lucene.util.Version.LUCENE_6_6_1);
     public static final int V_6_0_0_alpha1_ID = 6000001;
     public static final Version V_6_0_0_alpha1 =
             new Version(V_6_0_0_alpha1_ID, org.apache.lucene.util.Version.LUCENE_7_0_0);


### PR DESCRIPTION
It is only possible since we moved to Lucene 7.0.0 GA. Previous snapshots did
not know about it.
