### PR TITLE
Allow copying from a field to another field that belongs to the same nested object.

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
@@ -568,4 +568,95 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
         assertArrayEquals(expected, actual);
     }
 
+    public void testCopyToMultiField() throws Exception {
+        String mapping = jsonBuilder().startObject().startObject("doc")
+                .startObject("properties")
+                    .startObject("my_field")
+                        .field("type", "keyword")
+                        .field("copy_to", "my_field.bar")
+                        .startObject("fields")
+                            .startObject("bar")
+                                .field("type", "text")
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .endObject().endObject().string();
+
+        MapperService mapperService = createIndex("test").mapperService();
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> mapperService.merge("doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean()));
+        assertEquals("[copy_to] may not be used to copy to a multi-field: [my_field.bar]", e.getMessage());
+    }
+
+    public void testNestedCopyTo() throws Exception {
+        String mapping = jsonBuilder().startObject().startObject("doc")
+                .startObject("properties")
+                    .startObject("n")
+                        .field("type", "nested")
+                        .startObject("properties")
+                            .startObject("foo")
+                                .field("type", "keyword")
+                                .field("copy_to", "n.bar")
+                            .endObject()
+                            .startObject("bar")
+                                .field("type", "text")
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .endObject().endObject().string();
+
+        MapperService mapperService = createIndex("test").mapperService();
+        mapperService.merge("doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean()); // no exception
+    }
+
+    public void testNestedCopyToMultiField() throws Exception {
+        String mapping = jsonBuilder().startObject().startObject("doc")
+                .startObject("properties")
+                    .startObject("n")
+                        .field("type", "nested")
+                        .startObject("properties")
+                            .startObject("my_field")
+                                .field("type", "keyword")
+                                .field("copy_to", "n.my_field.bar")
+                                .startObject("fields")
+                                    .startObject("bar")
+                                        .field("type", "text")
+                                    .endObject()
+                                .endObject()
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .endObject().endObject().string();
+
+        MapperService mapperService = createIndex("test").mapperService();
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> mapperService.merge("doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean()));
+        assertEquals("[copy_to] may not be used to copy to a multi-field: [n.my_field.bar]", e.getMessage());
+    }
+
+    public void testCopyFromMultiField() throws Exception {
+        String mapping = jsonBuilder().startObject().startObject("doc")
+                .startObject("properties")
+                    .startObject("my_field")
+                        .field("type", "keyword")
+                        .startObject("fields")
+                            .startObject("bar")
+                                .field("type", "text")
+                                .field("copy_to", "my_field.baz")
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endObject()
+                .endObject().endObject().string();
+
+        MapperService mapperService = createIndex("test").mapperService();
+        MapperParsingException e = expectThrows(MapperParsingException.class,
+                () -> mapperService.merge("doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean()));
+        assertThat(e.getMessage(),
+                Matchers.containsString("copy_to in multi fields is not allowed. Found the copy_to in field [bar] " +
+                        "which is within a multi field."));
+    }
 }


### PR DESCRIPTION
The previous test was too strict and enforced that the target object was a
parent. It has been relaxed so that fields that belong to the same nested
object can copy to each other.

The commit also improves error handling in case of multi-fields. The current
validation works but may throw confusing error messages since it assumes that
only object fields may introduce dots in fields names while multi fields may
too.

Closes #26763