### PR TITLE
Remove `Settings,put(Map<String,String>)`

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -1074,15 +1074,6 @@ public final class Settings implements ToXContentFragment {
         }
 
         /**
-         * Sets all the provided settings.
-         */
-        public Builder put(Map<String, String> settings) {
-            removeNonArraysFieldsIfNewSettingsContainsFieldAsArray(settings);
-            map.putAll(settings);
-            return this;
-        }
-
-        /**
          * Removes non array values from the existing map, if settings contains an array value instead
          *
          * Example:
@@ -1176,7 +1167,7 @@ public final class Settings implements ToXContentFragment {
         public Builder putProperties(final Map<String, String> esSettings, final Function<String, String> keyFunction) {
             for (final Map.Entry<String, String> esSetting : esSettings.entrySet()) {
                 final String key = esSetting.getKey();
-                map.put(keyFunction.apply(key), esSetting.getValue());
+                put(keyFunction.apply(key), esSetting.getValue());
             }
             return this;
         }

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/ListPluginsCommandTests.java
@@ -69,7 +69,9 @@ public class ListPluginsCommandTests extends ESTestCase {
         int status = new ListPluginsCommand() {
             @Override
             protected Environment createEnv(Terminal terminal, Map<String, String> settings) throws UserException {
-                final Settings realSettings = Settings.builder().put("path.home", home).put(settings).build();
+                Settings.Builder builder = Settings.builder().put("path.home", home);
+                settings.forEach((k,v) -> builder.put(k, v));
+                final Settings realSettings = builder.build();
                 return new Environment(realSettings, home.resolve("config"));
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/ESElasticsearchCliTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/ESElasticsearchCliTestCase.java
@@ -52,7 +52,9 @@ abstract class ESElasticsearchCliTestCase extends ESTestCase {
             final int status = Elasticsearch.main(args, new Elasticsearch() {
                 @Override
                 protected Environment createEnv(final Terminal terminal, final Map<String, String> settings) throws UserException {
-                    final Settings realSettings = Settings.builder().put("path.home", home).put(settings).build();
+                    Settings.Builder builder = Settings.builder().put("path.home", home);
+                    settings.forEach((k,v) -> builder.put(k, v));
+                    final Settings realSettings = builder.build();
                     return new Environment(realSettings, home.resolve("config"));
                 }
                 @Override


### PR DESCRIPTION
`Map<String,String>` is basically erasing the type while other methods on the `Settings.Builder` are type safe and have corresponding `get` methods.