### PR TITLE
Add note to docs on /etc/elasticsearch ownership

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -160,9 +160,7 @@ include::check-running.asciidoc[]
 [[deb-configuring]]
 ==== Configuring Elasticsearch
 
-Elasticsearch loads its configuration from the `/etc/elasticsearch/elasticsearch.yml`
-file by default.  The format of this config file is explained in
-<<settings>>.
+include::etc-elasticsearch.asciidoc[]
 
 The Debian package also has a system configuration file (`/etc/default/elasticsearch`),
 which allows you to set the following parameters:

--- a/docs/reference/setup/install/etc-elasticsearch.asciidoc
+++ b/docs/reference/setup/install/etc-elasticsearch.asciidoc
@@ -3,7 +3,7 @@ The ownership of this directory and all files in this directory are set to
 `root:elasticsearch` on package installation and the directory has the `setgid`
 flag set so that any files and subdirectories created under `/etc/elasticsearch`
 are created with this ownership as well (e.g., if a keystore is created using
-the <<secure-settings,keystore tool>>. It is expected that this be maintained so
+the <<secure-settings,keystore tool>>). It is expected that this be maintained so
 that the Elasticsearch process can read the files under this directory via the
 group permissions.
 

--- a/docs/reference/setup/install/etc-elasticsearch.asciidoc
+++ b/docs/reference/setup/install/etc-elasticsearch.asciidoc
@@ -7,6 +7,6 @@ the <<secure-settings,keystore tool>>). It is expected that this be maintained s
 that the Elasticsearch process can read the files under this directory via the
 group permissions.
 
-Elasticsearch loads its configuration from the `/etc/elasticsearch/elasticsearch.yml`
-file by default.  The format of this config file is explained in
-<<settings>>.
+Elasticsearch loads its configuration from the
+`/etc/elasticsearch/elasticsearch.yml` file by default.  The format of this
+config file is explained in <<settings>>.

--- a/docs/reference/setup/install/etc-elasticsearch.asciidoc
+++ b/docs/reference/setup/install/etc-elasticsearch.asciidoc
@@ -1,0 +1,12 @@
+Elasticsearch defaults to using `/etc/elasticsearch` for runtime configuration.
+The ownership of this directory and all files in this directory are set to
+`root:elasticsearch` on package installation and the directory has the `setgid`
+flag set so that any files and subdirectories created under `/etc/elasticsearch`
+are created with this ownership as well (e.g., if a keystore is created using
+the <<secure-settings,keystore tool>>. It is expected that this be maintained so
+that the Elasticsearch process can read the files under this directory via the
+group permissions.
+
+Elasticsearch loads its configuration from the `/etc/elasticsearch/elasticsearch.yml`
+file by default.  The format of this config file is explained in
+<<settings>>.

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -148,9 +148,7 @@ include::check-running.asciidoc[]
 [[rpm-configuring]]
 ==== Configuring Elasticsearch
 
-Elasticsearch loads its configuration from the `/etc/elasticsearch/elasticsearch.yml`
-file by default.  The format of this config file is explained in
-<<settings>>.
+include::etc-elasticsearch.asciidoc[]
 
 The RPM also has a system configuration file (`/etc/sysconfig/elasticsearch`),
 which allows you to set the following parameters:


### PR DESCRIPTION
This commit adds a note to the docs for the RPM and Debian installation regarding the expected permissions for /etc/elasticsearch.

