### PR TITLE
Removes minimum master nodes default number

### DIFF
--- a/distribution/src/main/resources/config/elasticsearch.yml
+++ b/distribution/src/main/resources/config/elasticsearch.yml
@@ -69,7 +69,7 @@ ${path.logs}
 #
 # Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
 #
-#discovery.zen.minimum_master_nodes: CHANGE ME TO NUMBER_OF_MASTER_ELIGIBLE_NODES / 2 + 1
+#discovery.zen.minimum_master_nodes: 
 #
 # For more information, consult the zen discovery module documentation.
 #

--- a/distribution/src/main/resources/config/elasticsearch.yml
+++ b/distribution/src/main/resources/config/elasticsearch.yml
@@ -69,7 +69,7 @@ ${path.logs}
 #
 # Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
 #
-#discovery.zen.minimum_master_nodes: 3
+#discovery.zen.minimum_master_nodes: CHANGE ME TO NUMBER_OF_MASTER_ELIGIBLE_NODES / 2 + 1
 #
 # For more information, consult the zen discovery module documentation.
 #


### PR DESCRIPTION
At the moment the elasticsearch.yml contains the minimum master node setting commented out but with a value of 3. This has lead to users uncommenting the value and assuming it is a good default without reading that they need to change it to a quorum of master eligible nodes causing split brain in their cluster and defeating the point of the setting.

The default of 3 is not even a good default for our recommended setup of 3 dedicated master eligible nodes.

This changes the value o fthe commented out setting to something that will not produce valid config and should highlight that the value needs to be changed so users no longer uncomment the line without considering what the correct value for their setup should be.
