### PR TITLE
Confusion between dispatcher and worker threads

### DIFF
--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -27,11 +27,9 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-time
 
 === Number of threads
 
-The Apache Http Async Client starts by default one dispatcher thread, and a
-number of worker threads used by the connection manager, as many as the number
-of locally detected processors (depending on what
-`Runtime.getRuntime().availableProcessors()` returns). The number of threads
-can be modified as follows:
+The Apache Http Async Client starts by default one dispatcher thread for each
+locally detected processor (using `Runtime.getRuntime().availableProcessors()`), and a
+number of worker threads. The number of dispatcher threads can be modified as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------


### PR DESCRIPTION
The documentation says there is just 1 dispatcher thread and a configurable number of worker threads.
Actually there is one dispatcher per processor (which is configurable) and the worker threads are pooled