### PR TITLE
Add documentation about disabling `_field_names`.

### DIFF
--- a/docs/reference/how-to/indexing-speed.asciidoc
+++ b/docs/reference/how-to/indexing-speed.asciidoc
@@ -115,6 +115,13 @@ The default is `10%` which is often plenty: for example, if you give the JVM
 two shards that are heavily indexing.
 
 [float]
+=== Disable `_field_names`
+
+The <<mapping-field-names-field,`_field_names` field>> introduces some
+index-time overhead, so you might want to disable it if you never need to
+run `exists` queries.
+
+[float]
 === Additional optimizations
 
 Many of the strategies outlined in <<tune-for-disk-usage>> also

--- a/docs/reference/mapping/fields/field-names-field.asciidoc
+++ b/docs/reference/mapping/fields/field-names-field.asciidoc
@@ -35,3 +35,25 @@ GET my_index/_search
 // CONSOLE
 
 <1> Querying on the `_field_names` field (also see the <<query-dsl-exists-query,`exists`>> query)
+
+
+==== Disabling `_field_names`
+
+Because `_field_names` introduce some index-time overhead, you might want to
+disable this field if you want to optimize for indexing speed and do not need
+`exists` queries.
+
+[source,js]
+--------------------------------------------------
+PUT tweets
+{
+  "mappings": {
+    "tweet": {
+      "_field_names": {
+        "enabled": false
+      }
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE


### PR DESCRIPTION
This field has significant index-time overhead.

Closes #26779
