### PR TITLE
Clarify pure wilcard matching with `query_string`

### DIFF
--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -55,6 +55,24 @@ match the query string `"a* b* c*"`.
 
 [WARNING]
 =======
+Pure wildcards `\*` are rewritten to <<query-dsl-exists-query,`exists`>> queries for efficiency.
+As a consequence documents with an empty value on a `text` or a `keyword` field
+like below would match the wildcard `"field:*"`:
+```
+{
+  "field": ""
+}
+```
+\... and the following document would **not**:
+```
+{
+  "field": null
+}
+```
+=======
+
+[WARNING]
+=======
 Allowing a wildcard at the beginning of a word (eg `"*ing"`) is particularly
 heavy, because all terms in the index need to be examined, just in case
 they match.  Leading wildcards can be disabled by setting

--- a/docs/reference/query-dsl/query-string-syntax.asciidoc
+++ b/docs/reference/query-dsl/query-string-syntax.asciidoc
@@ -56,14 +56,15 @@ match the query string `"a* b* c*"`.
 [WARNING]
 =======
 Pure wildcards `\*` are rewritten to <<query-dsl-exists-query,`exists`>> queries for efficiency.
-As a consequence documents with an empty value on a `text` or a `keyword` field
-like below would match the wildcard `"field:*"`:
+As a consequence, the wildcard `"field:*"` would match documents with an emtpy value
+ like the following:
 ```
 {
   "field": ""
 }
 ```
-\... and the following document would **not**:
+\... and would **not** match if the field is missing or set with an explicit null
+value like the following:
 ```
 {
   "field": null


### PR DESCRIPTION
In 5.x pure wildcard queries `*` in `query_string` are rewritten to `exists` query for efficiency.
Though this introduced a change in the documents that match such queries because
`exists` query also return documents with an empty value for the field.
This commit clarifies this behavior for 5.x and beyond.

Closes #26801
