### PR TITLE
Remove UnsortedNumericDoubleValues

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -43,8 +43,9 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.index.mapper.GeoPointFieldMapper.GeoPointFieldType;
+import org.elasticsearch.index.fielddata.SortingNumericDoubleValues;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.GeoPointFieldMapper.GeoPointFieldType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -346,22 +347,23 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         @Override
         protected NumericDoubleValues distance(LeafReaderContext context) {
             final MultiGeoPointValues geoPointValues = fieldData.load(context).getGeoPointValues();
-            return mode.select(new MultiValueMode.UnsortedNumericDoubleValues() {
-                @Override
-                public int docValueCount() {
-                    return geoPointValues.docValueCount();
-                }
-
+            return mode.select(new SortingNumericDoubleValues() {
                 @Override
                 public boolean advanceExact(int docId) throws IOException {
-                    return geoPointValues.advanceExact(docId);
-                }
-
-                @Override
-                public double nextValue() throws IOException {
-                    GeoPoint other = geoPointValues.nextValue();
-                    return Math.max(0.0d,
-                            distFunction.calculate(origin.lat(), origin.lon(), other.lat(), other.lon(), DistanceUnit.METERS) - offset);
+                    if (geoPointValues.advanceExact(docId)) {
+                        int n = geoPointValues.docValueCount();
+                        resize(n);
+                        for (int i = 0; i < n; i++) {
+                            GeoPoint other = geoPointValues.nextValue();
+                            double distance = distFunction.calculate(
+                                origin.lat(), origin.lon(), other.lat(), other.lon(), DistanceUnit.METERS);
+                            values[i] = Math.max(0.0d, distance - offset);
+                        }
+                        sort();
+                        return true;
+                    } else {
+                        return false;
+                    }
                 }
             }, 0.0);
         }
@@ -427,20 +429,20 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         @Override
         protected NumericDoubleValues distance(LeafReaderContext context) {
             final SortedNumericDoubleValues doubleValues = fieldData.load(context).getDoubleValues();
-            return mode.select(new MultiValueMode.UnsortedNumericDoubleValues() {
+            return mode.select(new SortingNumericDoubleValues() {
                 @Override
-                public int docValueCount() {
-                    return doubleValues.docValueCount();
-                }
-
-                @Override
-                public boolean advanceExact(int doc) throws IOException {
-                    return doubleValues.advanceExact(doc);
-                }
-
-                @Override
-                public double nextValue() throws IOException {
-                    return Math.max(0.0d, Math.abs(doubleValues.nextValue() - origin) - offset);
+                public boolean advanceExact(int docId) throws IOException {
+                    if (doubleValues.advanceExact(docId)) {
+                        int n = doubleValues.docValueCount();
+                        resize(n);
+                        for (int i = 0; i < n; i++) {
+                            values[i] = Math.max(0.0d, Math.abs(doubleValues.nextValue() - origin) - offset);
+                        }
+                        sort();
+                        return true;
+                    } else {
+                        return false;
+                    }
                 }
             }, 0.0);
         }

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -544,10 +544,11 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
                     if (distance.advanceExact(docId) == false) {
                         return Explanation.noMatch("No value for the distance");
                     }
+                    double value = distance.doubleValue();
                     return Explanation.match(
                             (float) score(docId, subQueryScore.getValue()),
                             "Function for field " + getFieldName() + ":",
-                            func.explainFunction(getDistanceString(ctx, docId), distance.doubleValue(), scale));
+                            func.explainFunction(getDistanceString(ctx, docId), value, scale));
                 }
             };
         }

--- a/core/src/main/java/org/elasticsearch/search/MultiValueMode.java
+++ b/core/src/main/java/org/elasticsearch/search/MultiValueMode.java
@@ -104,16 +104,6 @@ public enum MultiValueMode implements Writeable {
             }
             return totalCount > 0 ? totalValue : missingValue;
         }
-
-        @Override
-        protected double pick(UnsortedNumericDoubleValues values) throws IOException {
-            final int count = values.docValueCount();
-            double total = 0;
-            for (int index = 0; index < count; ++index) {
-                total += values.nextValue();
-            }
-            return total;
-        }
     },
 
     /**
@@ -176,16 +166,6 @@ public enum MultiValueMode implements Writeable {
                 return missingValue;
             }
             return totalValue/totalCount;
-        }
-
-        @Override
-        protected double pick(UnsortedNumericDoubleValues values) throws IOException {
-            final int count = values.docValueCount();
-            double total = 0;
-            for (int index = 0; index < count; ++index) {
-                total += values.nextValue();
-            }
-            return total/count;
         }
     },
 
@@ -303,16 +283,6 @@ public enum MultiValueMode implements Writeable {
             }
             return hasValue ? ord : -1;
         }
-
-        @Override
-        protected double pick(UnsortedNumericDoubleValues values) throws IOException {
-            int count = values.docValueCount();
-            double min = Double.POSITIVE_INFINITY;
-            for (int index = 0; index < count; ++index) {
-                min = Math.min(values.nextValue(), min);
-            }
-            return min;
-        }
     },
 
     /**
@@ -418,16 +388,6 @@ public enum MultiValueMode implements Writeable {
                 }
             }
             return ord;
-        }
-
-        @Override
-        protected double pick(UnsortedNumericDoubleValues values) throws IOException {
-            int count = values.docValueCount();
-            double max = Double.NEGATIVE_INFINITY;
-            for (int index = 0; index < count; ++index) {
-                max = Math.max(values.nextValue(), max);
-            }
-            return max;
         }
     };
 
@@ -903,43 +863,6 @@ public enum MultiValueMode implements Writeable {
 
     protected int pick(SortedDocValues values, DocIdSetIterator docItr, int startDoc, int endDoc) throws IOException {
         throw new IllegalArgumentException("Unsupported sort mode: " + this);
-    }
-
-    /**
-     * Return a {@link NumericDoubleValues} instance that can be used to sort documents
-     * with this mode and the provided values. When a document has no value,
-     * <code>missingValue</code> is returned.
-     *
-     * Allowed Modes: SUM, AVG, MIN, MAX
-     */
-    public NumericDoubleValues select(final UnsortedNumericDoubleValues values, final double missingValue) {
-        return new NumericDoubleValues() {
-            private boolean hasValue;
-
-            @Override
-            public boolean advanceExact(int doc) throws IOException {
-                hasValue = values.advanceExact(doc);
-                return true;
-            }
-            @Override
-            public double doubleValue() throws IOException {
-                return hasValue ? pick(values) : missingValue;
-            }
-        };
-    }
-
-    protected double pick(UnsortedNumericDoubleValues values) throws IOException {
-        throw new IllegalArgumentException("Unsupported sort mode: " + this);
-    }
-
-    /**
-     * Interface allowing custom value generators to be used in MultiValueMode.
-     */
-    // TODO: why do we need it???
-    public interface UnsortedNumericDoubleValues {
-        boolean advanceExact(int doc) throws IOException;
-        int docValueCount() throws IOException;
-        double nextValue() throws IOException;
     }
 
     @Override


### PR DESCRIPTION
Resolves #24086 

@jpountz Thanks for your patient for this fix. There still a test failed because the test expects the `nextValue()` of `NumericDoubleValues ` can be called several times. But the `SortingNumericDoubleValues ` cannot be reused. So I need to fix the test or allow reset the `SortingNumericDoubleValues`'s state? Thanks.
