### PR TITLE
Forbid negative values for index.unassigned.node_left.delayed_timeout

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -50,7 +50,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
     public static final FormatDateTimeFormatter DATE_TIME_FORMATTER = Joda.forPattern("dateOptionalTime");
 
     public static final Setting<TimeValue> INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING =
-        Setting.timeSetting("index.unassigned.node_left.delayed_timeout", TimeValue.timeValueMinutes(1), Property.Dynamic,
+        Setting.positiveTimeSetting("index.unassigned.node_left.delayed_timeout", TimeValue.timeValueMinutes(1), Property.Dynamic,
             Property.IndexScope);
     /**
      * Reason why the shard is in unassigned state.

--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -5,3 +5,8 @@
 
 Due to cross-cluster search using `:` to separate a cluster and index name,
 index names may no longer contain `:`.
+
+==== `index.unassigned.node_left.delayed_timeout` may no longer be negative
+
+Negative values were interpreted as zero in earlier versions but are no
+longer accepted.


### PR DESCRIPTION
Negative values for `index.unassigned.node_left.delayed_timeout` could be expected to mean "never" whereas in fact they mean "0". "Never" is not a useful value for this, so we should just reject negative values here.