### PR TITLE
[DOCS] Add more instructions about jar hell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,16 @@ then `File->New Project From Existing Sources`. Point to the root of
 the source directory, select
 `Import project from external model->Gradle`, enable
 `Use auto-import`. Additionally, in order to run tests directly from 
-IDEA 2017.2 and above it is required to disable IDEA run launcher, 
-which can be achieved by adding `-Didea.no.launcher=true` 
-[JVM option](https://intellij-support.jetbrains.com/hc/en-us/articles/206544869-Configuring-JVM-options-and-platform-properties) 
+IDEA 2017.2 and above it is required to disable IDEA run launcher to avoid
+finding yourself in "jar hell", which can be achieved by adding the
+`-Didea.no.launcher=true` [JVM
+option](https://intellij-support.jetbrains.com/hc/en-us/articles/206544869-Configuring-JVM-options-and-platform-properties)
+or by adding `idea.no.launcher=true` to the
+`idea.properties`[https://www.jetbrains.com/help/idea/file-idea-properties.html]
+file which can be accessed under Help > Edit Custom Properties within IDEA. You
+may also need to [remove `ant-javafx.jar` from your
+classpath][https://github.com/elastic/elasticsearch/issues/14348] if that is
+reported as a source of jar hell.
 
 The Elasticsearch codebase makes heavy use of Java `assert`s and the
 test runner requires that assertions be enabled within the JVM. This


### PR DESCRIPTION
Including the fact that IntelliJ 2017.2 seems to have a spurious jar on its classpath, and an alternative location for the `idea.no.launcher=true` setting.
