### PR TITLE
Update by Query is modified to accept short `script` parameter.

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
@@ -67,7 +67,7 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
 
         Map<String, Consumer<Object>> consumers = new HashMap<>();
         consumers.put("conflicts", o -> internal.setConflicts((String) o));
-        consumers.put("script", o -> internal.setScript(parseScript((Map<String, Object>)o)));
+        consumers.put("script", o -> internal.setScript(parseScript(o)));
 
         parseInternalRequest(internal, request, consumers);
 
@@ -76,49 +76,59 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
     }
 
     @SuppressWarnings("unchecked")
-    private static Script parseScript(Map<String, Object> config) {
-        String script = null;
-        ScriptType type = null;
-        String lang = DEFAULT_SCRIPT_LANG;
-        Map<String, Object> params = Collections.emptyMap();
-        for (Iterator<Map.Entry<String, Object>> itr = config.entrySet().iterator(); itr.hasNext();) {
-            Map.Entry<String, Object> entry = itr.next();
-            String parameterName = entry.getKey();
-            Object parameterValue = entry.getValue();
-            if (Script.LANG_PARSE_FIELD.match(parameterName)) {
-                if (parameterValue instanceof String || parameterValue == null) {
-                    lang = (String) parameterValue;
-                } else {
-                    throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
-                }
-            } else if (Script.PARAMS_PARSE_FIELD.match(parameterName)) {
-                if (parameterValue instanceof Map || parameterValue == null) {
-                    params = (Map<String, Object>) parameterValue;
-                } else {
-                    throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
-                }
-            } else if (ScriptType.INLINE.getParseField().match(parameterName)) {
-                if (parameterValue instanceof String || parameterValue == null) {
-                    script = (String) parameterValue;
-                    type = ScriptType.INLINE;
-                } else {
-                    throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
-                }
-            } else if (ScriptType.STORED.getParseField().match(parameterName)) {
-                if (parameterValue instanceof String || parameterValue == null) {
-                    script = (String) parameterValue;
-                    type = ScriptType.STORED;
-                } else {
-                    throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
+    private static Script parseScript(Object config) {
+        assert config != null : "Script should not be null";
+
+        if (config instanceof String) { 
+                return new Script((String) config);
+        } else if (config instanceof Map) {
+            Map<String,Object> configMap = (Map<String, Object>) config;
+            String script = null;
+            ScriptType type = null;
+            String lang = DEFAULT_SCRIPT_LANG;
+            Map<String, Object> params = Collections.emptyMap();
+            for (Iterator<Map.Entry<String, Object>> itr = configMap.entrySet().iterator(); itr.hasNext();) {
+                Map.Entry<String, Object> entry = itr.next();
+                String parameterName = entry.getKey();
+                Object parameterValue = entry.getValue();
+                if (Script.LANG_PARSE_FIELD.match(parameterName)) {
+                    if (parameterValue instanceof String || parameterValue == null) {
+                        lang = (String) parameterValue;
+                    } else {
+                        throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
+                    }
+                } else if (Script.PARAMS_PARSE_FIELD.match(parameterName)) {
+                    if (parameterValue instanceof Map || parameterValue == null) {
+                        params = (Map<String, Object>) parameterValue;
+                    } else {
+                        throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
+                    }
+                } else if (ScriptType.INLINE.getParseField().match(parameterName)) {
+                    if (parameterValue instanceof String || parameterValue == null) {
+                        script = (String) parameterValue;
+                        type = ScriptType.INLINE;
+                    } else {
+                        throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
+                    }
+                } else if (ScriptType.STORED.getParseField().match(parameterName)) {
+                    if (parameterValue instanceof String || parameterValue == null) {
+                        script = (String) parameterValue;
+                        type = ScriptType.STORED;
+                    } else {
+                        throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
+                    }
                 }
             }
-        }
-        if (script == null) {
-            throw new ElasticsearchParseException("expected one of [{}] or [{}] fields, but found none",
+            if (script == null) {
+                throw new ElasticsearchParseException("expected one of [{}] or [{}] fields, but found none",
                     ScriptType.INLINE.getParseField().getPreferredName(), ScriptType.STORED.getParseField().getPreferredName());
-        }
-        assert type != null : "if script is not null, type should definitely not be null";
+            }
+            assert type != null : "if script is not null, type should definitely not be null";
 
-        return new Script(type, lang, script, params);
+            return new Script(type, lang, script, params);
+        }
+        else {
+            throw new IllegalArgumentException("Script value should be a String or a Map");
+        }
     }
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
@@ -79,8 +79,8 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
     private static Script parseScript(Object config) {
         assert config != null : "Script should not be null";
 
-        if (config instanceof String) { 
-                return new Script((String) config);
+        if (config instanceof String) {
+            return new Script((String) config);
         } else if (config instanceof Map) {
             Map<String,Object> configMap = (Map<String, Object>) config;
             String script = null;
@@ -126,8 +126,7 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
             assert type != null : "if script is not null, type should definitely not be null";
 
             return new Script(type, lang, script, params);
-        }
-        else {
+        } else {
             throw new IllegalArgumentException("Script value should be a String or a Map");
         }
     }

--- a/qa/smoke-test-reindex-with-all-modules/src/test/resources/rest-api-spec/test/update_by_query/10_script.yml
+++ b/qa/smoke-test-reindex-with-all-modules/src/test/resources/rest-api-spec/test/update_by_query/10_script.yml
@@ -30,6 +30,34 @@
   - match: { hits.total: 1 }
 
 ---
+"Update document using short `script` form":
+  - do:
+      index:
+        index:  twitter
+        type:   tweet
+        id:     1
+        body:   { "user": "kimchy" }
+  - do:
+        indices.refresh: {}
+
+  - do:
+      update_by_query:
+        index:   twitter
+        refresh: true
+        body:    { "script": "ctx._source.user = \"not\" + ctx._source.user" }
+  - match: {updated: 1}
+  - match: {noops: 0}
+
+  - do:
+      search:
+        index: twitter
+        body:
+          query:
+            match:
+              user: notkimchy
+  - match: { hits.total: 1 }
+
+---
 "Noop one doc":
   - do:
       index:


### PR DESCRIPTION
This change adding support of both long and short form of `script` parameter to `_update_by_query` request.
It should close the issue #24898 .

Changes in code:
static function `RestUpdateByQueryAction:parseScript()` is modified to accept `Object` parameter.
If `Object` is an instance of `Map` then it is a long form of `script` and old version of this function will be executed.
If `Object` is an instance of `String` then `Script` object will be created by using `Script(String)` constructor.

All tests are passed or ignored. However, `gradle check` is failed with the next message (I think it is not connected with my changes`
`* What went wrong:
Execution failed for task ':docs:integTestCluster#installAnalysisIcuPlugin'.
> A problem occurred starting process 'command '/Users/anton/Private/Coding/elasticsearch/docs/build/cluster/integTestCluster node0/elasticsearch-7.0.0-alpha1-SNAPSHOT/bin/elasticsearch-plugin''
`
