### PR TITLE
Remove Settings#getAsMap()

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -83,14 +83,8 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
             if (request.humanReadable()) {
                 settings = IndexMetaData.addHumanReadableSettings(settings);
             }
-            if (!CollectionUtils.isEmpty(request.names())) {
-                Settings.Builder settingsBuilder = Settings.builder();
-                for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
-                    if (Regex.simpleMatch(request.names(), entry.getKey())) {
-                        settingsBuilder.put(entry.getKey(), entry.getValue());
-                    }
-                }
-                settings = settingsBuilder.build();
+            if (CollectionUtils.isEmpty(request.names()) == false) {
+                settings = settings.filter(k -> Regex.simpleMatch(request.names(), k));
             }
             indexToSettingsBuilder.put(concreteIndex.getName(), settings);
         }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -1078,9 +1078,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
             boolean binary = params.paramAsBoolean("binary", false);
 
             builder.startObject(KEY_SETTINGS);
-            for (Map.Entry<String, String> entry : indexMetaData.getSettings().getAsMap().entrySet()) {
-                builder.field(entry.getKey(), entry.getValue());
-            }
+            indexMetaData.getSettings().toXContent(builder, new MapParams(Collections.singletonMap("flat_settings", "true")));
             builder.endObject();
 
             builder.startArray(KEY_MAPPINGS);

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -1000,17 +1000,13 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
 
             if (!metaData.persistentSettings().isEmpty()) {
                 builder.startObject("settings");
-                for (Map.Entry<String, String> entry : metaData.persistentSettings().getAsMap().entrySet()) {
-                    builder.field(entry.getKey(), entry.getValue());
-                }
+                metaData.persistentSettings().toXContent(builder, new MapParams(Collections.singletonMap("flat_settings", "true")));
                 builder.endObject();
             }
 
             if (context == XContentContext.API && !metaData.transientSettings().isEmpty()) {
                 builder.startObject("transient_settings");
-                for (Map.Entry<String, String> entry : metaData.transientSettings().getAsMap().entrySet()) {
-                    builder.field(entry.getKey(), entry.getValue());
-                }
+                metaData.transientSettings().toXContent(builder, new MapParams(Collections.singletonMap("flat_settings", "true")));
                 builder.endObject();
             }
 

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataUpdateSettingsService.java
@@ -165,7 +165,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
 
         indexScopedSettings.validate(normalizedSettings);
         // never allow to change the number of shards
-        for (String key : normalizedSettings.getKeys()) {
+        for (String key : normalizedSettings.keySet()) {
             Setting setting = indexScopedSettings.get(key);
             assert setting != null; // we already validated the normalized settings
             settingsForClosedIndices.copy(key, normalizedSettings);
@@ -211,8 +211,7 @@ public class MetaDataUpdateSettingsService extends AbstractComponent implements 
 
                 if (!skippedSettings.isEmpty() && !openIndices.isEmpty()) {
                     throw new IllegalArgumentException(String.format(Locale.ROOT,
-                            "Can't update non dynamic settings [%s] for open indices %s", skippedSettings, openIndices
-                    ));
+                            "Can't update non dynamic settings [%s] for open indices %s", skippedSettings, openIndices));
                 }
 
                 int updatedNumberOfReplicas = openSettings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, -1);

--- a/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/core/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.transport.TransportAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 public class DiscoveryNodeFilters {
 
@@ -55,10 +54,6 @@ public class DiscoveryNodeFilters {
             }
         }
     };
-
-    public static DiscoveryNodeFilters buildFromSettings(OpType opType, String prefix, Settings settings) {
-        return buildFromKeyValue(opType, settings.getByPrefix(prefix).getAsMap());
-    }
 
     public static DiscoveryNodeFilters buildFromKeyValue(OpType opType, Map<String, String> filters) {
         Map<String, String[]> bFilters = new HashMap<>();

--- a/core/src/main/java/org/elasticsearch/common/logging/ESLoggerFactory.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/ESLoggerFactory.java
@@ -37,7 +37,7 @@ public final class ESLoggerFactory {
 
     public static final Setting<Level> LOG_DEFAULT_LEVEL_SETTING =
         new Setting<>("logger.level", Level.INFO.name(), Level::valueOf, Property.NodeScope);
-    public static final Setting<Level> LOG_LEVEL_SETTING =
+    public static final Setting.AffixSetting<Level> LOG_LEVEL_SETTING =
         Setting.prefixKeySetting("logger.", (key) -> new Setting<>(key, Level.INFO.name(), Level::valueOf, Property.Dynamic,
             Property.NodeScope));
 

--- a/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -52,7 +52,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -182,15 +181,12 @@ public class LogConfigurator {
             final Level level = ESLoggerFactory.LOG_DEFAULT_LEVEL_SETTING.get(settings);
             Loggers.setLevel(ESLoggerFactory.getRootLogger(), level);
         }
-
-        final Map<String, String> levels = settings.filter(ESLoggerFactory.LOG_LEVEL_SETTING::match).getAsMap();
-        for (final String key : levels.keySet()) {
+        ESLoggerFactory.LOG_LEVEL_SETTING.getAllConcreteSettings(settings)
             // do not set a log level for a logger named level (from the default log setting)
-            if (!key.equals(ESLoggerFactory.LOG_DEFAULT_LEVEL_SETTING.getKey())) {
-                final Level level = ESLoggerFactory.LOG_LEVEL_SETTING.getConcreteSetting(key).get(settings);
-                Loggers.setLevel(ESLoggerFactory.getLogger(key.substring("logger.".length())), level);
-            }
-        }
+            .filter(s -> s.getKey().equals(ESLoggerFactory.LOG_DEFAULT_LEVEL_SETTING.getKey()) == false).forEach(s -> {
+            final Level level = s.get(settings);
+            Loggers.setLevel(ESLoggerFactory.getLogger(s.getKey().substring("logger.".length())), level);
+        });
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -601,7 +601,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
                          * settings. The setting can remain there but we want users to be aware that some of their setting are invalid and
                          * they can research why and what they need to do to replace them.
                          */
-                        builder.copy(ARCHIVED_SETTINGS_PREFIX + key, settings);
+                        builder.copy(ARCHIVED_SETTINGS_PREFIX + key, key, settings);
                     }
                 }
             } catch (IllegalArgumentException ex) {
@@ -612,7 +612,7 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
                  * setting can remain there but we want users to be aware that some of their setting are invalid and they can research why
                  * and what they need to do to replace them.
                  */
-                builder.copy(ARCHIVED_SETTINGS_PREFIX + key, settings);
+                builder.copy(ARCHIVED_SETTINGS_PREFIX + key, key, settings);
             }
         }
         if (changed) {

--- a/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -503,24 +503,25 @@ public abstract class AbstractScopedSettings extends AbstractComponent {
                 (onlyDynamic && isDynamicSetting(key)  // it's a dynamicSetting and we only do dynamic settings
                 || get(key) == null && key.startsWith(ARCHIVED_SETTINGS_PREFIX) // the setting is not registered AND it's been archived
                 || (onlyDynamic == false && get(key) != null))); // if it's not dynamic AND we have a key
-        for (Map.Entry<String, String> entry : toApply.getAsMap().entrySet()) {
-            if (entry.getValue() == null && (canRemove.test(entry.getKey()) || entry.getKey().endsWith("*"))) {
+        for (String key : toApply.keySet()) {
+            boolean isNull = toApply.get(key) == null;
+            if (isNull && (canRemove.test(key) || key.endsWith("*"))) {
                 // this either accepts null values that suffice the canUpdate test OR wildcard expressions (key ends with *)
                 // we don't validate if there is any dynamic setting with that prefix yet we could do in the future
-                toRemove.add(entry.getKey());
+                toRemove.add(key);
                 // we don't set changed here it's set after we apply deletes below if something actually changed
-            } else if (get(entry.getKey()) == null) {
-                throw new IllegalArgumentException(type + " setting [" + entry.getKey() + "], not recognized");
-            } else if (entry.getValue() != null && canUpdate.test(entry.getKey())) {
-                validate(entry.getKey(), toApply);
-                settingsBuilder.put(entry.getKey(), entry.getValue());
-                updates.put(entry.getKey(), entry.getValue());
+            } else if (get(key) == null) {
+                throw new IllegalArgumentException(type + " setting [" + key + "], not recognized");
+            } else if (isNull == false && canUpdate.test(key)) {
+                validate(key, toApply);
+                settingsBuilder.copy(key, toApply);
+                updates.copy(key, toApply);
                 changed = true;
             } else {
-                if (isFinalSetting(entry.getKey())) {
-                    throw new IllegalArgumentException("final " + type + " setting [" + entry.getKey() + "], not updateable");
+                if (isFinalSetting(key)) {
+                    throw new IllegalArgumentException("final " + type + " setting [" + key + "], not updateable");
                 } else {
-                    throw new IllegalArgumentException(type + " setting [" + entry.getKey() + "], not dynamically updateable");
+                    throw new IllegalArgumentException(type + " setting [" + key + "], not dynamically updateable");
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -119,14 +119,14 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
         @Override
         public boolean hasChanged(Settings current, Settings previous) {
-            return current.filter(loggerPredicate).getAsMap().equals(previous.filter(loggerPredicate).getAsMap()) == false;
+            return current.filter(loggerPredicate).equals(previous.filter(loggerPredicate)) == false;
         }
 
         @Override
         public Settings getValue(Settings current, Settings previous) {
             Settings.Builder builder = Settings.builder();
             builder.put(current.filter(loggerPredicate));
-            for (String key : previous.getAsMap().keySet()) {
+            for (String key : previous.keySet()) {
                 if (loggerPredicate.test(key) && builder.internalMap().containsKey(key) == false) {
                     if (ESLoggerFactory.LOG_LEVEL_SETTING.getConcreteSetting(key).exists(settings) == false) {
                         builder.putNull(key);
@@ -140,7 +140,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
         @Override
         public void apply(Settings value, Settings current, Settings previous) {
-            for (String key : value.getAsMap().keySet()) {
+            for (String key : value.keySet()) {
                 assert loggerPredicate.test(key);
                 String component = key.substring("logger.".length());
                 if ("level".equals(component)) {

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -328,7 +328,7 @@ public class Setting<T> implements ToXContentObject {
      * Returns <code>true</code> iff this setting is present in the given settings object. Otherwise <code>false</code>
      */
     public boolean exists(Settings settings) {
-        return settings.getAsMap().containsKey(getKey());
+        return settings.keySet().contains(getKey());
     }
 
     /**
@@ -529,7 +529,7 @@ public class Setting<T> implements ToXContentObject {
         }
 
         private Stream<String> matchStream(Settings settings) {
-            return settings.getAsMap().keySet().stream().filter((key) -> match(key)).map(settingKey -> key.getConcreteString(settingKey));
+            return settings.keySet().stream().filter((key) -> match(key)).map(settingKey -> key.getConcreteString(settingKey));
         }
 
         AbstractScopedSettings.SettingUpdater<Map<AbstractScopedSettings.SettingUpdater<T>, T>> newAffixUpdater(
@@ -736,8 +736,8 @@ public class Setting<T> implements ToXContentObject {
 
         @Override
         public boolean exists(Settings settings) {
-            for (Map.Entry<String, String> entry : settings.getAsMap().entrySet()) {
-                if (entry.getKey().startsWith(key)) {
+            for (String settingsKey : settings.keySet()) {
+                if (settingsKey.startsWith(key)) {
                     return true;
                 }
             }

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -47,6 +47,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -746,13 +747,11 @@ public class Setting<T> implements ToXContentObject {
 
         @Override
         public void diff(Settings.Builder builder, Settings source, Settings defaultSettings) {
-            Map<String, String> leftGroup = get(source).getAsMap();
+            Set<String> leftGroup = get(source).keySet();
             Settings defaultGroup = get(defaultSettings);
-            for (Map.Entry<String, String> entry : defaultGroup.getAsMap().entrySet()) {
-                if (leftGroup.containsKey(entry.getKey()) == false) {
-                    builder.put(getKey() + entry.getKey(), entry.getValue());
-                }
-            }
+
+            builder.put(Settings.builder().put(defaultGroup.filter(k -> leftGroup.contains(k) == false), false)
+                    .normalizePrefix(getKey()).build(), false);
         }
 
         @Override
@@ -779,7 +778,7 @@ public class Setting<T> implements ToXContentObject {
                         validator.accept(currentSettings);
                     } catch (Exception | AssertionError e) {
                         throw new IllegalArgumentException("illegal value can't update [" + key + "] from ["
-                                + previousSettings.getAsMap() + "] to [" + currentSettings.getAsMap() + "]", e);
+                                + previousSettings + "] to [" + currentSettings+ "]", e);
                     }
                     return currentSettings;
                 }

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -84,7 +84,7 @@ import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 /**
  * An immutable settings implementation.
  */
-public final class Settings implements ToXContentFragment, Iterable<String> {
+public final class Settings implements ToXContentFragment {
 
     public static final Settings EMPTY = new Builder().build();
     private static final Pattern ARRAY_PATTERN = Pattern.compile("(.*)\\.\\d+$");
@@ -320,11 +320,6 @@ public final class Settings implements ToXContentFragment, Iterable<String> {
         } catch (NumberFormatException e) {
             throw new SettingsException("Failed to parse long setting [" + setting + "] with value [" + sValue + "]", e);
         }
-    }
-
-    @Override
-    public Iterator<String> iterator() {
-        return settings.keySet().iterator();
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -906,6 +906,9 @@ public final class Settings implements ToXContentFragment, Iterable<String> {
         }
 
         public Builder copy(String key, String sourceKey, Settings source) {
+            if (source.keySet().contains(sourceKey) == false) {
+                throw new IllegalArgumentException("source key not found in the source settings");
+            }
             return put(key, source.get(sourceKey));
         }
 

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -118,15 +118,6 @@ public final class Settings implements ToXContentFragment {
         return secureSettings;
     }
 
-    /**
-     * The settings as a flat {@link java.util.Map}.
-     * @return an unmodifiable map of settings
-     */
-    public Map<String, String> getAsMap() {
-        // settings is always unmodifiable
-        return this.settings;
-    }
-
     private Map<String, Object> getAsStructuredMap() {
         Map<String, Object> map = new HashMap<>(2);
         for (Map.Entry<String, String> entry : settings.entrySet()) {

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -1440,7 +1440,6 @@ public final class Settings implements ToXContentFragment, Iterable<String> {
     @Override
     public String toString() {
         try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
-            builder.prettyPrint();
             builder.startObject();
             toXContent(builder, new MapParams(Collections.singletonMap("flat_settings", "true")));
             builder.endObject();

--- a/core/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -506,7 +506,8 @@ public final class IndexSettings {
         }
         this.indexMetaData = indexMetaData;
         final Settings existingSettings = this.settings;
-        if (existingSettings.filter(IndexScopedSettings.INDEX_SETTINGS_KEY_PREDICATE).getAsMap().equals(newSettings.filter(IndexScopedSettings.INDEX_SETTINGS_KEY_PREDICATE).getAsMap())) {
+        if (existingSettings.filter(IndexScopedSettings.INDEX_SETTINGS_KEY_PREDICATE)
+            .equals(newSettings.filter(IndexScopedSettings.INDEX_SETTINGS_KEY_PREDICATE))) {
             // nothing to update, same settings
             return false;
         }

--- a/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/core/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -186,7 +186,7 @@ public class PluginsService extends AbstractComponent {
         final Settings.Builder builder = Settings.builder();
         for (Tuple<PluginInfo, Plugin> plugin : plugins) {
             Settings settings = plugin.v2().additionalSettings();
-            for (String setting : settings.getAsMap().keySet()) {
+            for (String setting : settings.keySet()) {
                 String oldPlugin = foundSettings.put(setting, plugin.v1().getName());
                 if (oldPlugin != null) {
                     throw new IllegalArgumentException("Cannot have additional setting [" + setting + "] " +

--- a/core/src/test/java/org/elasticsearch/bootstrap/ElasticsearchCliTests.java
+++ b/core/src/test/java/org/elasticsearch/bootstrap/ElasticsearchCliTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.bootstrap;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.cli.ExitCodes;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 
 import java.nio.file.Path;
@@ -150,9 +151,9 @@ public class ElasticsearchCliTests extends ESElasticsearchCliTestCase {
                 true,
                 output -> {},
                 (foreground, pidFile, quiet, env) -> {
-                    Map<String, String> settings = env.settings().getAsMap();
-                    assertThat(settings, hasEntry("foo", "bar"));
-                    assertThat(settings, hasEntry("baz", "qux"));
+                    Settings settings = env.settings();
+                    assertEquals("bar", settings.get("foo"));
+                    assertEquals("qux", settings.get("baz"));
                 },
                 "-Efoo=bar", "-E", "baz=qux");
     }

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
@@ -278,7 +278,7 @@ public class IndexCreationTaskTests extends ESTestCase {
 
         assertThat(result.metaData().index("test").getAliases(), not(hasKey("alias1")));
         assertThat(result.metaData().index("test").getCustoms(), not(hasKey("custom1")));
-        assertThat(result.metaData().index("test").getSettings().getAsMap(), not(Matchers.hasKey("key1")));
+        assertThat(result.metaData().index("test").getSettings().keySet(), not(Matchers.contains("key1")));
         assertThat(getMappingsFromResponse(), not(Matchers.hasKey("mapping1")));
     }
 

--- a/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -269,10 +269,10 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
 
     private Settings shuffleSettings(Settings source) {
         Settings.Builder settings = Settings.builder();
-        List<String> keys = new ArrayList<>(source.getAsMap().keySet());
+        List<String> keys = new ArrayList<>(source.keySet());
         Collections.shuffle(keys, random());
         for (String o : keys) {
-            settings.put(o, source.getAsMap().get(o));
+            settings.put(o, source.get(o));
         }
         return settings.build();
     }

--- a/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.node;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
@@ -59,7 +60,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put("xxx.name", "name1")
                 .build();
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("name1", "id1", buildNewFakeTransportAddress(), emptyMap(), emptySet(),
             Version.CURRENT);
@@ -73,7 +74,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put("xxx._id", "id1")
                 .build();
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("name1", "id1", buildNewFakeTransportAddress(), emptyMap(), emptySet(),
             Version.CURRENT);
@@ -88,7 +89,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx._id", "id1,blah")
                 .put("xxx.name", "blah,name2")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
         final Version version = Version.CURRENT;
         DiscoveryNode node = new DiscoveryNode("name1", "id1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), version);
@@ -106,7 +107,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx.tag", "A")
                 .put("xxx.group", "B")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(AND, "xxx.", settings);
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put("tag", "A");
@@ -139,7 +140,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         Settings settings = Settings.builder()
                 .put("xxx.name", "*")
                 .build();
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("name1", "id1", buildNewFakeTransportAddress(), emptyMap(), emptySet(),
             Version.CURRENT);
@@ -151,7 +152,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx.tag", "A")
                 .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "192.1.1.54")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(AND, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, singletonMap("tag", "A"), emptySet(), null);
         assertThat(filters.match(node), equalTo(true));
@@ -162,7 +163,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx.tag", "B")
                 .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "192.1.1.54")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(AND, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, singletonMap("tag", "A"), emptySet(), null);
         assertThat(filters.match(node), equalTo(false));
@@ -173,7 +174,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx.tag", "A")
                 .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "8.8.8.8")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(AND, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, singletonMap("tag", "A"), emptySet(), null);
         assertThat(filters.match(node), equalTo(false));
@@ -184,7 +185,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "192.1.1.54")
                 .put("xxx.tag", "A")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, singletonMap("tag", "A"), emptySet(), null);
         assertThat(filters.match(node), equalTo(true));
@@ -195,7 +196,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx.tag", "A")
                 .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "8.8.8.8")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, singletonMap("tag", "A"), emptySet(), null);
         assertThat(filters.match(node), equalTo(true));
@@ -206,7 +207,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx.tag", "A")
                 .put("xxx._publish_ip", "192.1.1.54")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(AND, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, singletonMap("tag", "A"), emptySet(), null);
         assertThat(filters.match(node), equalTo(true));
@@ -217,7 +218,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx.tag", "A")
                 .put("xxx._publish_ip", "8.8.8.8")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(AND, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(AND, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, singletonMap("tag", "A"), emptySet(), null);
         assertThat(filters.match(node), equalTo(false));
@@ -228,7 +229,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx._publish_ip", "192.1.1.54")
                 .put("xxx.tag", "A")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, singletonMap("tag", "A"), emptySet(), null);
         assertThat(filters.match(node), equalTo(true));
@@ -239,7 +240,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
                 .put("xxx.tag", "A")
                 .put("xxx._publish_ip", "8.8.8.8")
                 .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, singletonMap("tag", "A"), emptySet(), null);
         assertThat(filters.match(node), equalTo(true));
@@ -250,7 +251,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         Settings settings = shuffleSettings(Settings.builder()
             .put("xxx._publish_ip", matches ? "192.1.*" : "192.2.*")
             .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
 
         DiscoveryNode node = new DiscoveryNode("", "", "", "", "192.1.1.54", localAddress, emptyMap(), emptySet(), null);
         assertThat(filters.match(node), equalTo(matches));
@@ -263,7 +264,7 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
             .put("xxx." + randomFrom("_ip", "_host_ip", "_publish_ip"), "192.1.1.1, 192.1.1.54")
             .put("xxx.tag", "A, B")
             .build());
-        DiscoveryNodeFilters filters = DiscoveryNodeFilters.buildFromSettings(OR, "xxx.", settings);
+        DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);
         assertTrue(filters.match(node));
     }
 
@@ -275,5 +276,10 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
             settings.put(o, source.get(o));
         }
         return settings.build();
+    }
+
+    public static DiscoveryNodeFilters buildFromSettings(DiscoveryNodeFilters.OpType opType, String prefix, Settings settings) {
+        Setting.AffixSetting<String> setting = Setting.prefixKeySetting(prefix, key -> Setting.simpleString(key));
+        return DiscoveryNodeFilters.buildFromKeyValue(opType, setting.getAsMap(settings));
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -78,7 +78,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             .get();
 
         assertAcked(response);
-        assertEquals(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), "1s");
+        assertEquals(response.getTransientSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), "1s");
         assertTrue(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.get(Settings.EMPTY));
         assertFalse(response.getTransientSettings().getAsBoolean(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.getKey(), null));
 
@@ -86,7 +86,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             .prepareUpdateSettings()
             .setTransientSettings(Settings.builder().putNull((randomBoolean() ? "discovery.zen.*" : "*")).put(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey(), "2s"))
             .get();
-        assertEquals(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), "2s");
+        assertEquals(response.getTransientSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), "2s");
         assertNull(response.getTransientSettings().getAsBoolean(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.getKey(), null));
     }
 
@@ -102,7 +102,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 .get();
 
         assertAcked(response);
-        assertThat(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
+        assertThat(response.getTransientSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
         assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
         assertThat(discoverySettings.getPublishDiff(), equalTo(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.get(Settings.EMPTY)));
 
@@ -113,7 +113,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 .get();
 
         assertAcked(response);
-        assertNull(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()));
+        assertNull(response.getTransientSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()));
         assertThat(discoverySettings.getPublishTimeout(), equalTo(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.get(Settings.EMPTY)));
         assertThat(discoverySettings.getPublishDiff(), equalTo(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.get(Settings.EMPTY)));
 
@@ -125,7 +125,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 .get();
 
         assertAcked(response);
-        assertThat(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
+        assertThat(response.getTransientSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
         assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
         assertFalse(discoverySettings.getPublishDiff());
         response = client().admin().cluster()
@@ -133,8 +133,8 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 .setTransientSettings(Settings.builder().putNull((randomBoolean() ? "discovery.zen.*" : "*")))
                 .get();
 
-        assertNull(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()));
-        assertNull(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.getKey()));
+        assertNull(response.getTransientSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()));
+        assertNull(response.getTransientSettings().get(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.getKey()));
         assertThat(discoverySettings.getPublishTimeout(), equalTo(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.get(Settings.EMPTY)));
         assertThat(discoverySettings.getPublishDiff(), equalTo(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.get(Settings.EMPTY)));
 
@@ -145,7 +145,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 .get();
 
         assertAcked(response);
-        assertThat(response.getPersistentSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
+        assertThat(response.getPersistentSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
         assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
         assertThat(discoverySettings.getPublishDiff(), equalTo(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.get(Settings.EMPTY)));
 
@@ -156,7 +156,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 .get();
 
         assertAcked(response);
-        assertNull(response.getPersistentSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()));
+        assertNull(response.getPersistentSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()));
         assertThat(discoverySettings.getPublishTimeout(), equalTo(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.get(Settings.EMPTY)));
         assertThat(discoverySettings.getPublishDiff(), equalTo(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.get(Settings.EMPTY)));
 
@@ -169,7 +169,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 .get();
 
         assertAcked(response);
-        assertThat(response.getPersistentSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
+        assertThat(response.getPersistentSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
         assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
         assertFalse(discoverySettings.getPublishDiff());
         response = client().admin().cluster()
@@ -177,8 +177,8 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 .setPersistentSettings(Settings.builder().putNull((randomBoolean() ? "discovery.zen.*" : "*")))
                 .get();
 
-        assertNull(response.getPersistentSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()));
-        assertNull(response.getPersistentSettings().getAsMap().get(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.getKey()));
+        assertNull(response.getPersistentSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()));
+        assertNull(response.getPersistentSettings().get(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.getKey()));
         assertThat(discoverySettings.getPublishTimeout(), equalTo(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.get(Settings.EMPTY)));
         assertThat(discoverySettings.getPublishDiff(), equalTo(DiscoverySettings.PUBLISH_DIFF_ENABLE_SETTING.get(Settings.EMPTY)));
     }
@@ -261,7 +261,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 .get();
 
         assertAcked(response);
-        assertThat(response.getTransientSettings().getAsMap().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
+        assertThat(response.getTransientSettings().get(DiscoverySettings.PUBLISH_TIMEOUT_SETTING.getKey()), equalTo("1s"));
         assertThat(discoverySettings.getPublishTimeout().seconds(), equalTo(1L));
 
         try {

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -337,7 +337,7 @@ public class SettingTests extends ESTestCase {
                     Settings.EMPTY);
             fail("not accepted");
         } catch (IllegalArgumentException ex) {
-            assertEquals(ex.getMessage(), "illegal value can't update [foo.bar.] from [{}] to [{1.value=1, 2.value=2}]");
+            assertEquals(ex.getMessage(), "illegal value can't update [foo.bar.] from [{}] to [{\"1.value\":\"1\",\"2.value\":\"2\"}]");
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
@@ -108,7 +108,7 @@ public class SettingsFilterTests extends ESTestCase {
 
         // Test using direct filtering
         Settings filteredSettings = settingsFilter.filter(source);
-        assertThat(filteredSettings.getAsMap().entrySet(), equalTo(filtered.getAsMap().entrySet()));
+        assertThat(filteredSettings, equalTo(filtered));
 
         // Test using toXContent filtering
         RestRequest request = new FakeRestRequest();
@@ -119,6 +119,6 @@ public class SettingsFilterTests extends ESTestCase {
         xContentBuilder.endObject();
         String filteredSettingsString = xContentBuilder.string();
         filteredSettings = Settings.builder().loadFromSource(filteredSettingsString, xContentBuilder.contentType()).build();
-        assertThat(filteredSettings.getAsMap().entrySet(), equalTo(filtered.getAsMap().entrySet()));
+        assertThat(filteredSettings, equalTo(filtered));
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
@@ -113,8 +113,8 @@ public class SettingsModuleTests extends ModuleTestCase {
             Setting.boolSetting("bar.baz", true, Property.NodeScope)), Arrays.asList("foo.*"));
         assertInstanceBinding(module, Settings.class, (s) -> s == settings);
         assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).size() == 1);
-        assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).getAsMap().containsKey("bar.baz"));
-        assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).getAsMap().get("bar.baz").equals("false"));
+        assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).keySet().contains("bar.baz"));
+        assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).get("bar.baz").equals("false"));
 
     }
 

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -303,34 +303,27 @@ public class SettingsTests extends ESTestCase {
         builder.put("a.b.c.d", "ab3");
 
 
-        Map<String, String> fiteredMap = builder.build().filter((k) -> k.startsWith("a.b")).getAsMap();
-        assertEquals(3, fiteredMap.size());
+        Settings filteredSettings = builder.build().filter((k) -> k.startsWith("a.b"));
+        assertEquals(3, filteredSettings.size());
         int numKeys = 0;
-        for (String k : fiteredMap.keySet()) {
+        for (String k : filteredSettings.keySet()) {
             numKeys++;
             assertTrue(k.startsWith("a.b"));
         }
 
         assertEquals(3, numKeys);
-        int numValues = 0;
-
-        for (String v : fiteredMap.values()) {
-            numValues++;
-            assertTrue(v.startsWith("ab"));
-        }
-        assertEquals(3, numValues);
-        assertFalse(fiteredMap.containsKey("a.c"));
-        assertFalse(fiteredMap.containsKey("a"));
-        assertTrue(fiteredMap.containsKey("a.b"));
-        assertTrue(fiteredMap.containsKey("a.b.c"));
-        assertTrue(fiteredMap.containsKey("a.b.c.d"));
+        assertFalse(filteredSettings.keySet().contains("a.c"));
+        assertFalse(filteredSettings.keySet().contains("a"));
+        assertTrue(filteredSettings.keySet().contains("a.b"));
+        assertTrue(filteredSettings.keySet().contains("a.b.c"));
+        assertTrue(filteredSettings.keySet().contains("a.b.c.d"));
         expectThrows(UnsupportedOperationException.class, () ->
-            fiteredMap.remove("a.b"));
-        assertEquals("ab1", fiteredMap.get("a.b"));
-        assertEquals("ab2", fiteredMap.get("a.b.c"));
-        assertEquals("ab3", fiteredMap.get("a.b.c.d"));
+            filteredSettings.keySet().remove("a.b"));
+        assertEquals("ab1", filteredSettings.get("a.b"));
+        assertEquals("ab2", filteredSettings.get("a.b.c"));
+        assertEquals("ab3", filteredSettings.get("a.b.c.d"));
 
-        Iterator<String> iterator = fiteredMap.keySet().iterator();
+        Iterator<String> iterator = filteredSettings.keySet().iterator();
         for (int i = 0; i < 10; i++) {
             assertTrue(iterator.hasNext());
         }
@@ -356,7 +349,7 @@ public class SettingsTests extends ESTestCase {
         builder.put("a.c", "ac1");
         builder.put("a.b.c.d", "ab3");
 
-        Map<String, String> prefixMap = builder.build().getByPrefix("a.").getAsMap();
+        Settings prefixMap = builder.build().getByPrefix("a.");
         assertEquals(4, prefixMap.size());
         int numKeys = 0;
         for (String k : prefixMap.keySet()) {
@@ -365,20 +358,14 @@ public class SettingsTests extends ESTestCase {
         }
 
         assertEquals(4, numKeys);
-        int numValues = 0;
 
-        for (String v : prefixMap.values()) {
-            numValues++;
-            assertTrue(v, v.startsWith("ab") || v.startsWith("ac"));
-        }
-        assertEquals(4, numValues);
-        assertFalse(prefixMap.containsKey("a"));
-        assertTrue(prefixMap.containsKey("c"));
-        assertTrue(prefixMap.containsKey("b"));
-        assertTrue(prefixMap.containsKey("b.c"));
-        assertTrue(prefixMap.containsKey("b.c.d"));
+        assertFalse(prefixMap.keySet().contains("a"));
+        assertTrue(prefixMap.keySet().contains("c"));
+        assertTrue(prefixMap.keySet().contains("b"));
+        assertTrue(prefixMap.keySet().contains("b.c"));
+        assertTrue(prefixMap.keySet().contains("b.c.d"));
         expectThrows(UnsupportedOperationException.class, () ->
-            prefixMap.remove("a.b"));
+            prefixMap.keySet().remove("a.b"));
         assertEquals("ab1", prefixMap.get("b"));
         assertEquals("ab2", prefixMap.get("b.c"));
         assertEquals("ab3", prefixMap.get("b.c.d"));
@@ -444,27 +431,24 @@ public class SettingsTests extends ESTestCase {
         builder.put("a.c", "ac1");
         builder.put("a.b.c.d", "ab3");
 
-        Map<String, String> fiteredMap = builder.build().filter((k) -> false).getAsMap();
-        assertEquals(0, fiteredMap.size());
-        for (String k : fiteredMap.keySet()) {
+        Settings filteredSettings = builder.build().filter((k) -> false);
+        assertEquals(0, filteredSettings.size());
+        for (String k : filteredSettings.keySet()) {
             fail("no element");
 
         }
-        for (String v : fiteredMap.values()) {
-            fail("no element");
-        }
-        assertFalse(fiteredMap.containsKey("a.c"));
-        assertFalse(fiteredMap.containsKey("a"));
-        assertFalse(fiteredMap.containsKey("a.b"));
-        assertFalse(fiteredMap.containsKey("a.b.c"));
-        assertFalse(fiteredMap.containsKey("a.b.c.d"));
+        assertFalse(filteredSettings.keySet().contains("a.c"));
+        assertFalse(filteredSettings.keySet().contains("a"));
+        assertFalse(filteredSettings.keySet().contains("a.b"));
+        assertFalse(filteredSettings.keySet().contains("a.b.c"));
+        assertFalse(filteredSettings.keySet().contains("a.b.c.d"));
         expectThrows(UnsupportedOperationException.class, () ->
-            fiteredMap.remove("a.b"));
-        assertNull(fiteredMap.get("a.b"));
-        assertNull(fiteredMap.get("a.b.c"));
-        assertNull(fiteredMap.get("a.b.c.d"));
+            filteredSettings.keySet().remove("a.b"));
+        assertNull(filteredSettings.get("a.b"));
+        assertNull(filteredSettings.get("a.b.c"));
+        assertNull(filteredSettings.get("a.b.c.d"));
 
-        Iterator<String> iterator = fiteredMap.keySet().iterator();
+        Iterator<String> iterator = filteredSettings.keySet().iterator();
         for (int i = 0; i < 10; i++) {
             assertFalse(iterator.hasNext());
         }

--- a/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -191,7 +191,7 @@ public class IndexModuleTests extends ESTestCase {
         module.addIndexEventListener(eventListener);
         IndexService indexService = newIndexService(module);
         IndexSettings x = indexService.getIndexSettings();
-        assertEquals(x.getSettings().getAsMap(), indexSettings.getSettings().getAsMap());
+        assertEquals(x.getSettings(), indexSettings.getSettings());
         assertEquals(x.getIndex(), index);
         indexService.getIndexEventListener().beforeIndexRemoved(null, null);
         assertTrue(atomicBoolean.get());

--- a/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -60,7 +60,7 @@ public class IndexSettingsTests extends ESTestCase {
         assertEquals("0xdeadbeef", settings.getUUID());
 
         assertFalse(settings.updateIndexMetaData(metaData));
-        assertEquals(metaData.getSettings().getAsMap(), settings.getSettings().getAsMap());
+        assertEquals(metaData.getSettings(), settings.getSettings());
         assertEquals(0, integer.get());
         assertTrue(settings.updateIndexMetaData(newIndexMeta("index", Settings.builder().put(theSettings).put("index.test.setting.int", 42)
             .build())));
@@ -83,7 +83,7 @@ public class IndexSettingsTests extends ESTestCase {
         assertEquals("0xdeadbeef", settings.getUUID());
 
         assertFalse(settings.updateIndexMetaData(metaData));
-        assertEquals(metaData.getSettings().getAsMap(), settings.getSettings().getAsMap());
+        assertEquals(metaData.getSettings(), settings.getSettings());
         assertEquals(0, integer.get());
         expectThrows(IllegalArgumentException.class, () -> settings.updateIndexMetaData(newIndexMeta("index",
             Settings.builder().put(theSettings).put("index.test.setting.int", 42).build())));
@@ -156,7 +156,7 @@ public class IndexSettingsTests extends ESTestCase {
         } catch (IllegalArgumentException ex) {
             assertEquals("uuid mismatch on settings update expected: 0xdeadbeef but was: _na_", ex.getMessage());
         }
-        assertEquals(metaData.getSettings().getAsMap(), settings.getSettings().getAsMap());
+        assertEquals(metaData.getSettings(), settings.getSettings());
     }
 
     public IndexSettings newIndexSettings(IndexMetaData metaData, Settings nodeSettings, Setting<?>... settings) {

--- a/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -123,7 +123,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
                 .put(EXCEPTION_TOP_LEVEL_RATIO_KEY, topLevelRate)
                 .put(EXCEPTION_LOW_LEVEL_RATIO_KEY, lowLevelRate)
                 .put(MockEngineSupport.WRAP_READER_RATIO.getKey(), 1.0d);
-        logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
+        logger.info("creating index: [test] using settings: [{}]", settings.build());
         CreateIndexResponse response = client().admin().indices().prepareCreate("test")
                 .setSettings(settings)
                 .addMapping("type", mapping, XContentType.JSON).execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -376,7 +376,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         createIndex("test");
 
         GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
-        assertNull(getSettingsResponse.getIndexToSettings().get("test").getAsMap().get("index.does_not_exist"));
+        assertNull(getSettingsResponse.getIndexToSettings().get("test").get("index.does_not_exist"));
     }
 
     public void testIndexTemplateWithAliases() throws Exception {
@@ -852,6 +852,6 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
             .get();
 
         GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("test_good").get();
-        assertEquals("6", getSettingsResponse.getIndexToSettings().get("test_good").getAsMap().get("index.routing_partition_size"));
+        assertEquals("6", getSettingsResponse.getIndexToSettings().get("test_good").get("index.routing_partition_size"));
     }
 }

--- a/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -107,7 +107,7 @@ public class SearchWithRandomExceptionsIT extends ESIntegTestCase {
                 .put(EXCEPTION_TOP_LEVEL_RATIO_KEY, topLevelRate)
                 .put(EXCEPTION_LOW_LEVEL_RATIO_KEY, lowLevelRate)
             .put(MockEngineSupport.WRAP_READER_RATIO.getKey(), 1.0d);
-        logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
+        logger.info("creating index: [test] using settings: [{}]", settings.build());
         assertAcked(prepareCreate("test")
                 .setSettings(settings)
                 .addMapping("type", mapping, XContentType.JSON));

--- a/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -90,7 +90,7 @@ public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
         if (createIndexWithoutErrors) {
             Settings.Builder settings = Settings.builder()
                 .put("index.number_of_replicas", numberOfReplicas());
-            logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
+            logger.info("creating index: [test] using settings: [{}]", settings.build());
             client().admin().indices().prepareCreate("test")
                 .setSettings(settings)
                 .addMapping("type", mapping, XContentType.JSON).execute().actionGet();
@@ -112,7 +112,7 @@ public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
                 .put(MockFSIndexStore.INDEX_CHECK_INDEX_ON_CLOSE_SETTING.getKey(), false)
                 .put(MockFSDirectoryService.RANDOM_IO_EXCEPTION_RATE_SETTING.getKey(), exceptionRate)
                 .put(MockFSDirectoryService.RANDOM_IO_EXCEPTION_RATE_ON_OPEN_SETTING.getKey(), exceptionOnOpenRate); // we cannot expect that the index will be valid
-            logger.info("creating index: [test] using settings: [{}]", settings.build().getAsMap());
+            logger.info("creating index: [test] using settings: [{}]", settings.build());
             client().admin().indices().prepareCreate("test")
                 .setSettings(settings)
                 .addMapping("type", mapping, XContentType.JSON).execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -1949,7 +1949,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 initialSettingsBuilder.put(blockSetting, true);
             }
             Settings initialSettings = initialSettingsBuilder.build();
-            logger.info("--> using initial block settings {}", initialSettings.getAsMap());
+            logger.info("--> using initial block settings {}", initialSettings);
 
             if (!initialSettings.isEmpty()) {
                 logger.info("--> apply initial blocks to index");
@@ -1978,7 +1978,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                 changedSettingsBuilder.put(blockSetting, randomBoolean());
             }
             Settings changedSettings = changedSettingsBuilder.build();
-            logger.info("--> applying changed block settings {}", changedSettings.getAsMap());
+            logger.info("--> applying changed block settings {}", changedSettings);
 
             RestoreSnapshotResponse restoreSnapshotResponse = client.admin().cluster()
                     .prepareRestoreSnapshot("test-repo", "test-snap")
@@ -1992,7 +1992,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                     .put(initialSettings)
                     .put(changedSettings)
                     .build();
-            logger.info("--> merged block settings {}", mergedSettings.getAsMap());
+            logger.info("--> merged block settings {}", mergedSettings);
 
             logger.info("--> checking consistency between settings and blocks");
             assertThat(mergedSettings.getAsBoolean(IndexMetaData.SETTING_BLOCKS_METADATA, false),

--- a/modules/tribe/src/main/java/org/elasticsearch/tribe/TribePlugin.java
+++ b/modules/tribe/src/main/java/org/elasticsearch/tribe/TribePlugin.java
@@ -137,7 +137,7 @@ public class TribePlugin extends Plugin implements DiscoveryPlugin, ClusterPlugi
 
             return sb.build();
         } else {
-            for (String s : settings.getAsMap().keySet()) {
+            for (String s : settings.keySet()) {
                 if (s.startsWith("tribe.") && !s.equals(TribeService.TRIBE_NAME_SETTING.getKey())) {
                     throw new IllegalArgumentException("tribe cannot contain inner tribes: " + s);
                 }

--- a/modules/tribe/src/main/java/org/elasticsearch/tribe/TribeService.java
+++ b/modules/tribe/src/main/java/org/elasticsearch/tribe/TribeService.java
@@ -195,7 +195,7 @@ public class TribeService extends AbstractLifecycleComponent {
      * combined with tribe specific settings.
      */
     static Settings buildClientSettings(String tribeName, String parentNodeId, Settings globalSettings, Settings tribeSettings) {
-        for (String tribeKey : tribeSettings.getAsMap().keySet()) {
+        for (String tribeKey : tribeSettings.keySet()) {
             if (tribeKey.startsWith("path.")) {
                 throw new IllegalArgumentException("Setting [" + tribeKey + "] not allowed in tribe client [" + tribeName + "]");
             }

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -120,8 +120,9 @@ public final class HdfsRepository extends BlobStoreRepository {
         hadoopConfiguration.setClassLoader(HdfsRepository.class.getClassLoader());
         hadoopConfiguration.reloadConfiguration();
 
-        for (String key : repositorySettings.getByPrefix("conf.").keySet()) {
-            hadoopConfiguration.set(key, repositorySettings.get(key));
+        final Settings confSettings = repositorySettings.getByPrefix("conf.");
+        for (String key : confSettings.keySet()) {
+            hadoopConfiguration.set(key, confSettings.get(key));
         }
 
         // Create a hadoop user

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsRepository.java
@@ -120,9 +120,8 @@ public final class HdfsRepository extends BlobStoreRepository {
         hadoopConfiguration.setClassLoader(HdfsRepository.class.getClassLoader());
         hadoopConfiguration.reloadConfiguration();
 
-        Map<String, String> map = repositorySettings.getByPrefix("conf.").getAsMap();
-        for (Entry<String, String> entry : map.entrySet()) {
-            hadoopConfiguration.set(entry.getKey(), entry.getValue());
+        for (String key : repositorySettings.getByPrefix("conf.").keySet()) {
+            hadoopConfiguration.set(key, repositorySettings.get(key));
         }
 
         // Create a hadoop user

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilElasticsearchCliTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilElasticsearchCliTests.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.common.SuppressForbidden;
+import org.elasticsearch.common.settings.Settings;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -41,10 +42,10 @@ public class EvilElasticsearchCliTests extends ESElasticsearchCliTestCase {
                 true,
                 output -> {},
                 (foreground, pidFile, quiet, esSettings) -> {
-                    Map<String, String> settings = esSettings.settings().getAsMap();
+                    Settings settings = esSettings.settings();
                     assertThat(settings.size(), equalTo(2));
-                    assertThat(settings, hasEntry("path.home", value));
-                    assertThat(settings, hasKey("path.logs")); // added by env initialization
+                    assertEquals(value, settings.get("path.home"));
+                    assertTrue(settings.keySet().contains("path.logs")); // added by env initialization
                 });
 
         System.clearProperty("es.path.home");
@@ -54,10 +55,10 @@ public class EvilElasticsearchCliTests extends ESElasticsearchCliTestCase {
                 true,
                 output -> {},
                 (foreground, pidFile, quiet, esSettings) -> {
-                    Map<String, String> settings = esSettings.settings().getAsMap();
+                    Settings settings = esSettings.settings();
                     assertThat(settings.size(), equalTo(2));
-                    assertThat(settings, hasEntry("path.home", commandLineValue));
-                    assertThat(settings, hasKey("path.logs")); // added by env initialization
+                    assertEquals(commandLineValue, settings.get("path.home"));
+                    assertTrue(settings.keySet().contains("path.logs")); // added by env initialization
                 },
                 "-Epath.home=" + commandLineValue);
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -548,15 +548,15 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 if (cluster() != null) {
                     if (currentClusterScope != Scope.TEST) {
                         MetaData metaData = client().admin().cluster().prepareState().execute().actionGet().getState().getMetaData();
-                        final Map<String, String> persistent = metaData.persistentSettings().getAsMap();
+                        final Set<String> persistent = metaData.persistentSettings().keySet();
                         assertThat("test leaves persistent cluster metadata behind: " + persistent, persistent.size(), equalTo(0));
-                        final Map<String, String> transientSettings =  new HashMap<>(metaData.transientSettings().getAsMap());
+                        final Set<String> transientSettings =  new HashSet<>(metaData.transientSettings().keySet());
                         if (isInternalCluster() && internalCluster().getAutoManageMinMasterNode()) {
                             // this is set by the test infra
                             transientSettings.remove(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey());
                         }
                         assertThat("test leaves transient cluster metadata behind: " + transientSettings,
-                            transientSettings.keySet(), empty());
+                            transientSettings, empty());
                     }
                     ensureClusterSizeConsistency();
                     ensureClusterStateConsistency();

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -112,9 +112,9 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
         super.tearDown();
         assertAcked(client().admin().indices().prepareDelete("*").get());
         MetaData metaData = client().admin().cluster().prepareState().get().getState().getMetaData();
-        assertThat("test leaves persistent cluster metadata behind: " + metaData.persistentSettings().getAsMap(),
+        assertThat("test leaves persistent cluster metadata behind: " + metaData.persistentSettings().keySet(),
                 metaData.persistentSettings().size(), equalTo(0));
-        assertThat("test leaves transient cluster metadata behind: " + metaData.transientSettings().getAsMap(),
+        assertThat("test leaves transient cluster metadata behind: " + metaData.transientSettings().keySet(),
                 metaData.transientSettings().size(), equalTo(0));
         if (resetNodeAfterTest()) {
             assert NODE != null;

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -124,7 +124,7 @@ public class InternalTestClusterTests extends ESTestCase {
             if (clusterUniqueSettings.contains(key) && checkClusterUniqueSettings == false) {
                 continue;
             }
-            assertEquals(keys1, keys1.contains(key));
+            assertTrue("key [" + key + "] is missing in " + keys1, keys1.contains(key));
             assertEquals(right.get(key), left.get(key));
         }
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -116,15 +116,16 @@ public class InternalTestClusterTests extends ESTestCase {
     }
 
     public static void assertSettings(Settings left, Settings right, boolean checkClusterUniqueSettings) {
-        Set<Map.Entry<String, String>> entries0 = left.getAsMap().entrySet();
-        Map<String, String> entries1 = right.getAsMap();
+        Set<String> keys0 = left.keySet();
+        Set<String> keys1 = right.keySet();
         assertThat("--> left:\n" + left.toDelimitedString('\n') +  "\n-->right:\n" + right.toDelimitedString('\n'),
-            entries0.size(), equalTo(entries1.size()));
-        for (Map.Entry<String, String> entry : entries0) {
-            if (clusterUniqueSettings.contains(entry.getKey()) && checkClusterUniqueSettings == false) {
+            keys0.size(), equalTo(keys1.size()));
+        for (String key : keys0) {
+            if (clusterUniqueSettings.contains(key) && checkClusterUniqueSettings == false) {
                 continue;
             }
-            assertThat(entries1, hasEntry(entry.getKey(), entry.getValue()));
+            assertEquals(keys1, keys1.contains(key));
+            assertEquals(right.get(key), left.get(key));
         }
     }
 
@@ -137,10 +138,9 @@ public class InternalTestClusterTests extends ESTestCase {
     private void assertMMNinNodeSetting(String node, InternalTestCluster cluster, int masterNodes) {
         final int minMasterNodes = masterNodes / 2 + 1;
         Settings nodeSettings = cluster.client(node).admin().cluster().prepareNodesInfo(node).get().getNodes().get(0).getSettings();
-        assertThat("node setting of node [" + node + "] has the wrong min_master_node setting: ["
+        assertEquals("node setting of node [" + node + "] has the wrong min_master_node setting: ["
             + nodeSettings.get(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey()) + "]",
-            nodeSettings.getAsMap(),
-            hasEntry(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), Integer.toString(minMasterNodes)));
+            DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.get(nodeSettings).intValue(), minMasterNodes);
     }
 
     private void assertMMNinClusterSetting(InternalTestCluster cluster, int masterNodes) {
@@ -149,10 +149,9 @@ public class InternalTestClusterTests extends ESTestCase {
             Settings stateSettings = cluster.client(node).admin().cluster().prepareState().setLocal(true)
                 .get().getState().getMetaData().settings();
 
-            assertThat("dynamic setting for node [" + node + "] has the wrong min_master_node setting : ["
+            assertEquals("dynamic setting for node [" + node + "] has the wrong min_master_node setting : ["
                     + stateSettings.get(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey()) + "]",
-                stateSettings.getAsMap(),
-                hasEntry(DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), Integer.toString(minMasterNodes)));
+                DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.get(stateSettings).intValue(), minMasterNodes);
         }
     }
 


### PR DESCRIPTION
Since `#getAsMap` exposes internal representation we are tryting to remove it
step by step. This commit is cleaning up some xcontent writing as awell as
usage in tests
