### PR TITLE
Close #26771: beider_morse phonetic encoder failure when languageset unspecified 

### DIFF
--- a/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/PhoneticTokenFilterFactory.java
+++ b/plugins/analysis-phonetic/src/main/java/org/elasticsearch/index/analysis/PhoneticTokenFilterFactory.java
@@ -116,7 +116,7 @@ public class PhoneticTokenFilterFactory extends AbstractTokenFilterFactory {
     public TokenStream create(TokenStream tokenStream) {
         if (encoder == null) {
             if (ruletype != null && nametype != null) {
-                if (languageset != null) {
+                if (languageset != null && languageset.length > 0) {
                     final LanguageSet languages = LanguageSet.from(new HashSet<>(Arrays.asList(languageset)));
                     return new BeiderMorseFilter(tokenStream, new PhoneticEngine(nametype, ruletype, true), languages);
                 }


### PR DESCRIPTION
This closes #26771. Based on jpountz's analysis: check languageset is neither null nor the empty array.

The previous behaviour was for an empty languageset array to cause the original tokens to be returned. Now, an empty languageset array will function the same as a non-existent languageset and trigger automatic language detection. This ensures that beider_morse phonetic encoder always returns a phonetic encoding of SOME sort, and that it matches the documented behavior.

