### PR TITLE
Fix IndexOutOfBoundsException in histograms for NaN doubles (#26787)

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -321,8 +321,9 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
             do {
                 final IteratorAndCurrent top = pq.top();
 
-                if (top.current.key != key) {
-                    // the key changes, reduce what we already buffered and reset the buffer for current buckets
+                if (Double.compare(top.current.key, key) != 0) {
+                    // The key changes, reduce what we already buffered and reset the buffer for current buckets.
+                    // Using Double.compare instead of != to handle NaN correctly.
                     final Bucket reduced = currentBuckets.get(0).reduce(currentBuckets, reduceContext);
                     if (reduced.getDocCount() >= minDocCount || reduceContext.isFinalReduce() == false) {
                         reducedBuckets.add(reduced);
@@ -335,7 +336,7 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
 
                 if (top.iterator.hasNext()) {
                     final Bucket next = top.iterator.next();
-                    assert next.key > top.current.key : "shards must return data sorted by key";
+                    assert Double.compare(next.key, top.current.key) > 0 : "shards must return data sorted by key";
                     top.current = next;
                     pq.updateTop();
                 } else {


### PR DESCRIPTION
The [linked issue](https://github.com/elastic/elasticsearch/issues/26787) should contain all information necessary to review.

There might be better ways to test this change, my experience with the Elasticsearch test design is limited.

I also have a working patch against the 5.6 branch, which I care about more at this point (having the fix in a future 5.x release). Let me know if you'd like me to submit that one separately.

Thanks!