### PR TITLE
Check channel is open before setting SO_LINGER

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -338,7 +338,9 @@ public class Netty4Transport extends TcpTransport<Channel> {
                  * side otherwise the client (node) initiates the TCP closing sequence which doesn't cause these issues. Setting this
                  * by default from the beginning can have unexpected side-effects an should be avoided, our protocol is designed
                  * in a way that clients close connection which is how it should be*/
-                channel.config().setOption(ChannelOption.SO_LINGER, 0);
+                if (channel.isOpen()) {
+                    channel.config().setOption(ChannelOption.SO_LINGER, 0);
+                }
             }
         }
         if (blocking) {

--- a/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/MockTcpTransport.java
@@ -251,7 +251,9 @@ public class MockTcpTransport extends TcpTransport<MockTcpTransport.MockChannel>
                      * side otherwise the client (node) initiates the TCP closing sequence which doesn't cause these issues. Setting this
                      * by default from the beginning can have unexpected side-effects an should be avoided, our protocol is designed
                      * in a way that clients close connection which is how it should be*/
-                    channel.activeChannel.setSoLinger(true, 0);
+                    if (channel.isOpen.get()) {
+                        channel.activeChannel.setSoLinger(true, 0);
+                    }
                 }
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/NioTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/NioTransport.java
@@ -107,7 +107,9 @@ public class NioTransport extends TcpTransport<NioChannel> {
                  * side otherwise the client (node) initiates the TCP closing sequence which doesn't cause these issues. Setting this
                  * by default from the beginning can have unexpected side-effects an should be avoided, our protocol is designed
                  * in a way that clients close connection which is how it should be*/
-                channel.getRawChannel().setOption(StandardSocketOptions.SO_LINGER, 0);
+                if (channel.isOpen()) {
+                    channel.getRawChannel().setOption(StandardSocketOptions.SO_LINGER, 0);
+                }
             }
         }
         ArrayList<CloseFuture> futures = new ArrayList<>(channels.size());


### PR DESCRIPTION
This commit fixes a #26855. Right now we set SO_LINGER to 0 if we are
stopping the transport. This can throw a ChannelClosedException if the
raw channel is already closed. We have a number of scenarios where it is
possible this could be called with a channel that is already closed.
This commit fixes the issue be checking that the channel is not closed
before attempting to set the socket option.