### PR TITLE
Improve shard-failed log messages.

### DIFF
--- a/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/core/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -209,6 +209,19 @@ public final class ExceptionsHelper {
         return uniqueFailures.toArray(new ShardOperationFailedException[0]);
     }
 
+    /**
+     * Returns the message for the root cause (the innermost exception).
+     */
+    public static String rootCauseMessage(Exception failure) {
+        if (failure == null) {
+            return "no exception";
+        }
+        if (!(failure instanceof ElasticsearchException)) {
+            return failure.getMessage();
+        }
+        return ((ElasticsearchException) failure).getRootCause().getMessage();
+    }
+
     static class GroupBy {
         final String reason;
         final String index;

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -207,7 +207,7 @@ public class ShardStateAction extends AbstractComponent {
 
         @Override
         public void messageReceived(ShardEntry request, TransportChannel channel) throws Exception {
-            logger.warn((Supplier<?>) () -> new ParameterizedMessage("{} received shard failed for {}", request.shardId, request), request.failure);
+            logger.warn((Supplier<?>) () -> new ParameterizedMessage("{} received shard failed for {}", request.shardId, request.shortSummary()), request.failure);
             clusterService.submitStateUpdateTask(
                 "shard-failed " + request.shortSummary(),
                 request,

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -209,7 +209,7 @@ public class ShardStateAction extends AbstractComponent {
         public void messageReceived(ShardEntry request, TransportChannel channel) throws Exception {
             logger.warn((Supplier<?>) () -> new ParameterizedMessage("{} received shard failed for {}", request.shardId, request), request.failure);
             clusterService.submitStateUpdateTask(
-                "shard-failed " + request,
+                "shard-failed " + request.shortSummary(),
                 request,
                 ClusterStateTaskConfig.build(Priority.HIGH),
                 shardFailedClusterStateTaskExecutor,

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -497,13 +497,23 @@ public class ShardStateAction extends AbstractComponent {
             out.writeException(failure);
         }
 
-        @Override
-        public String toString() {
-            List<String> components = new ArrayList<>(4);
+        private void addSummaryComponents(List<String> components) {
             components.add("shard id [" + shardId + "]");
             components.add("allocation id [" + allocationId + "]");
             components.add("primary term [" + primaryTerm + "]");
             components.add("message [" + message + "]");
+        }
+
+        public String shortSummary() {
+            List<String>components = new ArrayList<>(4);
+            addSummaryComponents(components);
+            return String.join(", ", components);
+        }
+
+        @Override
+        public String toString() {
+            List<String> components = new ArrayList<>(5);
+            addSummaryComponents(components);
             if (failure != null) {
                 components.add("failure [" + ExceptionsHelper.detailedMessage(failure) + "]");
             }

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -207,7 +207,9 @@ public class ShardStateAction extends AbstractComponent {
 
         @Override
         public void messageReceived(ShardEntry request, TransportChannel channel) throws Exception {
-            logger.warn((Supplier<?>) () -> new ParameterizedMessage("{} received shard failed for {}", request.shardId, request.shortSummary()), request.failure);
+            logger.warn((Supplier<?>) () -> new ParameterizedMessage("{} received shard failed for {}",
+                                                                     request.shardId, request.shortSummary()),
+                        request.failure);
             clusterService.submitStateUpdateTask(
                 "shard-failed " + request.shortSummary(),
                 request,

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -499,27 +499,20 @@ public class ShardStateAction extends AbstractComponent {
             out.writeException(failure);
         }
 
-        private void addSummaryComponents(List<String> components) {
-            components.add("shard id [" + shardId + "]");
-            components.add("allocation id [" + allocationId + "]");
-            components.add("primary term [" + primaryTerm + "]");
-            components.add("message [" + message + "]");
-        }
-
         public String shortSummary() {
-            List<String>components = new ArrayList<>(4);
-            addSummaryComponents(components);
-            return String.join(", ", components);
+            return  "shard id [" + shardId
+                + "] allocation id [" + allocationId
+                + "] primary term [" + primaryTerm
+                + "] message [" + message + "]";
         }
 
         @Override
         public String toString() {
-            List<String> components = new ArrayList<>(5);
-            addSummaryComponents(components);
-            if (failure != null) {
-                components.add("failure [" + ExceptionsHelper.detailedMessage(failure) + "]");
-            }
-            return String.join(", ", components);
+            return  "shard id [" + shardId
+                + "] allocation id [" + allocationId
+                + "] primary term [" + primaryTerm
+                + "] message [" + message
+                + "] failure [" + ExceptionsHelper.detailedMessage(failure) + "]";
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/core/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -209,7 +209,7 @@ public class ShardStateAction extends AbstractComponent {
         public void messageReceived(ShardEntry request, TransportChannel channel) throws Exception {
             logger.warn((Supplier<?>) () -> new ParameterizedMessage("{} received shard failed for {}", request.shardId, request), request.failure);
             clusterService.submitStateUpdateTask(
-                "shard-failed",
+                "shard-failed " + request,
                 request,
                 ClusterStateTaskConfig.build(Priority.HIGH),
                 shardFailedClusterStateTaskExecutor,

--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -657,7 +657,9 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     }
 
     private synchronized void handleRecoveryFailure(ShardRouting shardRouting, boolean sendShardFailure, Exception failure) {
-        failAndRemoveShard(shardRouting, sendShardFailure, "failed recovery [" + ExceptionsHelper.rootCauseMessage(failure) + "]", failure, clusterService.state());
+        failAndRemoveShard(shardRouting, sendShardFailure,
+            "failed recovery [" + ExceptionsHelper.rootCauseMessage(failure) + "]",
+            failure, clusterService.state());
     }
 
     private void failAndRemoveShard(ShardRouting shardRouting, boolean sendShardFailure, String message, @Nullable Exception failure,

--- a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.apache.lucene.store.LockObtainFailedException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -656,7 +657,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     }
 
     private synchronized void handleRecoveryFailure(ShardRouting shardRouting, boolean sendShardFailure, Exception failure) {
-        failAndRemoveShard(shardRouting, sendShardFailure, "failed recovery", failure, clusterService.state());
+        failAndRemoveShard(shardRouting, sendShardFailure, "failed recovery [" + ExceptionsHelper.rootCauseMessage(failure) + "]", failure, clusterService.state());
     }
 
     private void failAndRemoveShard(ShardRouting shardRouting, boolean sendShardFailure, String message, @Nullable Exception failure,

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -252,7 +252,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
                 notifyListener(e, sendShardFailure);
             } finally {
                 try {
-                    cancellableThreads.cancel("failed recovery [" + ExceptionsHelper.stackTrace(e) + "]");
+                    cancellableThreads.cancel("failed recovery [" + ExceptionsHelper.rootCauseMessage(e) + "]");
                 } finally {
                     // release the initial reference. recovery files will be cleaned as soon as ref count goes to zero, potentially now
                     decRef();


### PR DESCRIPTION
Previously:

    [WARN ][o.e.i.c.IndicesClusterStateService] [node_td2] [[test][0]] marking
        and sending shard failed due to [failed recovery]
    [WARN ][o.e.c.a.s.ShardStateAction] [node_tm0] [test][0] received shard
        failed for shard id [[test][0]], allocation id [m7t1rFIHTIKCsiecyLYvXA],
        primary term [0], message [failed recovery], failure
        [RecoveryFailedException[[test][0]: Recovery failed from
        {node_td1}{UKtBYHLJTwGWJ-bbSHxy_A}{MFiPmyjATnWl4oqp81GRqQ}{127.0.0.1}{127.0.0.1:9402}
        into
        {node_td2}{waqqel-jSSK2222vUOBVdg}{ZvUuFoC7S5eY2p6UqR45iA}{127.0.0.1}{127.0.0.1:9401}];
        nested:
        RemoteTransportException[[node_td1][127.0.0.1:53995][internal:index/shard/recovery/start_recovery]];
        nested: RecoveryEngineException[Phase[1] phase1 failed]; nested:
        RecoverFilesRecoveryException[Failed to transfer [15] files with total size of
        [10.9kb]]; nested:
        SendRequestTransportException[[node_td2][127.0.0.1:9401][internal:index/shard/recovery/file_chunk]];
        nested: NotSerializableExceptionWrapper[runtime_exception: Caused some
        truncated files for fun and profit]; ]
    [DEBUG][o.e.c.s.MasterService    ] [node_tm0] processing
        [shard-failed[shard id [[test][0]], allocation id [m7t1rFIHTIKCsiecyLYvXA],
        primary term [0], message [failed recovery], failure
        [RecoveryFailedException[[test][0]: Recovery failed from
        {node_td1}{UKtBYHLJTwGWJ-bbSHxy_A}{MFiPmyjATnWl4oqp81GRqQ}{127.0.0.1}{127.0.0.1:9402}
        into
        {node_td2}{waqqel-jSSK2222vUOBVdg}{ZvUuFoC7S5eY2p6UqR45iA}{127.0.0.1}{127.0.0.1:9401}];
        nested:
        RemoteTransportException[[node_td1][127.0.0.1:53995][internal:index/shard/recovery/start_recovery]];
        nested: RecoveryEngineException[Phase[1] phase1 failed]; nested:
        RecoverFilesRecoveryException[Failed to transfer [15] files with total size of
        [10.9kb]]; nested:
        SendRequestTransportException[[node_td2][127.0.0.1:9401][internal:index/shard/recovery/file_chunk]];
        nested: NotSerializableExceptionWrapper[runtime_exception: Caused some
        truncated files for fun and profit]; ]]]: execute

now

    [WARN ][o.e.i.c.IndicesClusterStateService] [node_td2] [[test][1]] marking
        and sending shard failed due to [failed recovery [runtime_exception: Caused
        some truncated files for fun and profit]]
    [WARN ][o.e.c.a.s.ShardStateAction] [node_tm0] [test][1] received shard
        failed for shard id [[test][1]] allocation id [OLqdfDFPTcC_74128virZw] primary
        term [0] message [failed recovery [runtime_exception: Caused some truncated
        files for fun and profit]]
    [DEBUG][o.e.c.s.MasterService    ] [node_tm0] processing [shard-failed
        shard id [[test][1]] allocation id [OLqdfDFPTcC_74128virZw] primary term [0]
        message [failed recovery [runtime_exception: Caused some truncated files for
        fun and profit]][shard id [[test][1]] allocation id [OLqdfDFPTcC_74128virZw]
        primary term [0] message [failed recovery [runtime_exception: Caused some
        truncated files for fun and profit]] failure
        [RecoveryFailedException[[test][1]: Recovery failed from
        {node_td1}{xg_rYbgNRaiiGi1Uy4-dlw}{sbcTdJfjSO2iJakJi4-5PQ}{127.0.0.1}{127.0.0.1:9401}
        into
        {node_td2}{RJab72gkTgCiuqYuTUDrvw}{DIyt0KSbSPeutYzWqPLyGw}{127.0.0.1}{127.0.0.1:9402}];
        nested:
        RemoteTransportException[[node_td1][127.0.0.1:53949][internal:index/shard/recovery/start_recovery]];
        nested: RecoveryEngineException[Phase[1] phase1 failed]; nested:
        RecoverFilesRecoveryException[Failed to transfer [15] files with total size of
        [5.5kb]]; nested:
        SendRequestTransportException[[node_td2][127.0.0.1:9402][internal:index/shard/recovery/file_chunk]];
        nested: NotSerializableExceptionWrapper[runtime_exception: Caused some
        truncated files for fun and profit]; ]]]: execute
