### PR TITLE
Upgrade to forbiddenapis 2.4.1

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   compile 'com.netflix.nebula:gradle-info-plugin:3.0.3'
   compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
   compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
-  compile 'de.thetaphi:forbiddenapis:2.3'
+  compile 'de.thetaphi:forbiddenapis:2.4.1'
   compile 'org.apache.rat:apache-rat:0.11'
   compile "org.elasticsearch:jna:4.4.0-1"
 }


### PR DESCRIPTION
Update provides:
- Adds support for Gradle 4.0 (without deprecation warning)
- full Java 9 support through ASM 6.0

Version 2.4 was buggy (it broke Gradle dependencies on SourceSets), but this version fixes it.