### PR TITLE
Fix default paths for Windows service

### DIFF
--- a/core/src/main/java/org/elasticsearch/cli/EnvironmentAwareCommand.java
+++ b/core/src/main/java/org/elasticsearch/cli/EnvironmentAwareCommand.java
@@ -59,6 +59,9 @@ public abstract class EnvironmentAwareCommand extends Command {
             settings.put(kvp.key, kvp.value);
         }
 
+        putSystemPropertyIfSettingIsMissing(settings, "default.path.conf", "es.default.path.conf");
+        putSystemPropertyIfSettingIsMissing(settings, "default.path.data", "es.default.path.data");
+        putSystemPropertyIfSettingIsMissing(settings, "default.path.logs", "es.default.path.logs");
         putSystemPropertyIfSettingIsMissing(settings, "path.conf", "es.path.conf");
         putSystemPropertyIfSettingIsMissing(settings, "path.data", "es.path.data");
         putSystemPropertyIfSettingIsMissing(settings, "path.home", "es.path.home");


### PR DESCRIPTION
The Windows service is a bit of an oddball in terms of how it starts Elasticsearch via procrun. This means there are not command line flags per se that we can use to pass default paths like is done with the Linux service files. Instead, we have been passing these via system properties. Sadly, the translation of these into settings was lost somewhere and without packaging tests for Windows, this was only recently detected. This commit fixes this issue by translating the system properties that Windows sets for default paths into the actual default settings that they are meant to be controlling. Note that this change targets the 5.6 branch only as default settings have been completely removed in 6.0 and later versions of Elasticsearch.

Closes #26873

