### PR TITLE
Fix serialization errors when cross cluster search goes to a single shard

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -322,7 +322,7 @@ public class SearchTransportService extends AbstractComponent {
                 }
             });
         TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_SCROLL_ACTION_NAME,
-                (request) -> new SearchFreeContextResponse());
+                (Supplier<TransportResponse>) SearchFreeContextResponse::new);
         transportService.registerRequestHandler(FREE_CONTEXT_ACTION_NAME, ThreadPool.Names.SAME, SearchFreeContextRequest::new,
             new TaskAwareTransportRequestHandler<SearchFreeContextRequest>() {
                 @Override
@@ -331,7 +331,8 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(new SearchFreeContextResponse(freed));
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_ACTION_NAME, (request) -> new SearchFreeContextResponse());
+        TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_ACTION_NAME,
+                (Supplier<TransportResponse>) SearchFreeContextResponse::new);
         transportService.registerRequestHandler(CLEAR_SCROLL_CONTEXTS_ACTION_NAME, () -> TransportRequest.Empty.INSTANCE,
             ThreadPool.Names.SAME, new TaskAwareTransportRequestHandler<TransportRequest.Empty>() {
                 @Override
@@ -341,7 +342,7 @@ public class SearchTransportService extends AbstractComponent {
                 }
             });
         TransportActionProxy.registerProxyAction(transportService, CLEAR_SCROLL_CONTEXTS_ACTION_NAME,
-            (request) -> TransportResponse.Empty.INSTANCE);
+                () -> TransportResponse.Empty.INSTANCE);
 
         transportService.registerRequestHandler(DFS_ACTION_NAME, ThreadPool.Names.SAME, ShardSearchTransportRequest::new,
             new TaskAwareTransportRequestHandler<ShardSearchTransportRequest>() {
@@ -369,7 +370,7 @@ public class SearchTransportService extends AbstractComponent {
 
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, DFS_ACTION_NAME, (request) -> new DfsSearchResult());
+        TransportActionProxy.registerProxyAction(transportService, DFS_ACTION_NAME, DfsSearchResult::new);
 
         transportService.registerRequestHandler(QUERY_ACTION_NAME, ThreadPool.Names.SAME, ShardSearchTransportRequest::new,
             new TaskAwareTransportRequestHandler<ShardSearchTransportRequest>() {
@@ -397,7 +398,7 @@ public class SearchTransportService extends AbstractComponent {
                 }
             });
         TransportActionProxy.registerProxyAction(transportService, QUERY_ACTION_NAME,
-                (request) -> ((ShardSearchRequest)request).numberOfShards() == 1 ? new QueryFetchSearchResult() : new QuerySearchResult());
+                (request) -> ((ShardSearchRequest)request).numberOfShards() == 1 ? QueryFetchSearchResult::new : QuerySearchResult::new);
 
         transportService.registerRequestHandler(QUERY_ID_ACTION_NAME, ThreadPool.Names.SEARCH, QuerySearchRequest::new,
             new TaskAwareTransportRequestHandler<QuerySearchRequest>() {
@@ -407,7 +408,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_ID_ACTION_NAME, (request) -> new QuerySearchResult());
+        TransportActionProxy.registerProxyAction(transportService, QUERY_ID_ACTION_NAME, QuerySearchResult::new);
 
         transportService.registerRequestHandler(QUERY_SCROLL_ACTION_NAME, ThreadPool.Names.SEARCH, InternalScrollSearchRequest::new,
             new TaskAwareTransportRequestHandler<InternalScrollSearchRequest>() {
@@ -417,7 +418,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_SCROLL_ACTION_NAME, (request) -> new ScrollQuerySearchResult());
+        TransportActionProxy.registerProxyAction(transportService, QUERY_SCROLL_ACTION_NAME, ScrollQuerySearchResult::new);
 
         transportService.registerRequestHandler(QUERY_FETCH_SCROLL_ACTION_NAME, ThreadPool.Names.SEARCH, InternalScrollSearchRequest::new,
             new TaskAwareTransportRequestHandler<InternalScrollSearchRequest>() {
@@ -427,8 +428,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_FETCH_SCROLL_ACTION_NAME,
-                (request) -> new ScrollQueryFetchSearchResult());
+        TransportActionProxy.registerProxyAction(transportService, QUERY_FETCH_SCROLL_ACTION_NAME, ScrollQueryFetchSearchResult::new);
 
         transportService.registerRequestHandler(FETCH_ID_SCROLL_ACTION_NAME, ThreadPool.Names.SEARCH, ShardFetchRequest::new,
             new TaskAwareTransportRequestHandler<ShardFetchRequest>() {
@@ -438,7 +438,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, FETCH_ID_SCROLL_ACTION_NAME, (request) -> new FetchSearchResult());
+        TransportActionProxy.registerProxyAction(transportService, FETCH_ID_SCROLL_ACTION_NAME, FetchSearchResult::new);
 
         transportService.registerRequestHandler(FETCH_ID_ACTION_NAME, ThreadPool.Names.SEARCH, ShardFetchSearchRequest::new,
             new TaskAwareTransportRequestHandler<ShardFetchSearchRequest>() {
@@ -448,7 +448,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, FETCH_ID_ACTION_NAME, (request) -> new FetchSearchResult());
+        TransportActionProxy.registerProxyAction(transportService, FETCH_ID_ACTION_NAME, FetchSearchResult::new);
 
         // this is cheap, it does not fetch during the rewrite phase, so we can let it quickly execute on a networking thread
         transportService.registerRequestHandler(QUERY_CAN_MATCH_NAME, ThreadPool.Names.SAME, ShardSearchTransportRequest::new,
@@ -459,7 +459,8 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(new CanMatchResponse(canMatch));
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_CAN_MATCH_NAME, (request) -> new CanMatchResponse());
+        TransportActionProxy.registerProxyAction(transportService, QUERY_CAN_MATCH_NAME,
+                (Supplier<TransportResponse>) CanMatchResponse::new);
     }
 
     public static final class CanMatchResponse extends SearchPhaseResult {

--- a/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -40,6 +40,7 @@ import org.elasticsearch.search.fetch.ScrollQueryFetchSearchResult;
 import org.elasticsearch.search.fetch.ShardFetchRequest;
 import org.elasticsearch.search.fetch.ShardFetchSearchRequest;
 import org.elasticsearch.search.internal.InternalScrollSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.internal.ShardSearchTransportRequest;
 import org.elasticsearch.search.query.QuerySearchRequest;
 import org.elasticsearch.search.query.QuerySearchResult;
@@ -320,7 +321,8 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(new SearchFreeContextResponse(freed));
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_SCROLL_ACTION_NAME, SearchFreeContextResponse::new);
+        TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_SCROLL_ACTION_NAME,
+                (request) -> new SearchFreeContextResponse());
         transportService.registerRequestHandler(FREE_CONTEXT_ACTION_NAME, ThreadPool.Names.SAME, SearchFreeContextRequest::new,
             new TaskAwareTransportRequestHandler<SearchFreeContextRequest>() {
                 @Override
@@ -329,7 +331,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(new SearchFreeContextResponse(freed));
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_ACTION_NAME, SearchFreeContextResponse::new);
+        TransportActionProxy.registerProxyAction(transportService, FREE_CONTEXT_ACTION_NAME, (request) -> new SearchFreeContextResponse());
         transportService.registerRequestHandler(CLEAR_SCROLL_CONTEXTS_ACTION_NAME, () -> TransportRequest.Empty.INSTANCE,
             ThreadPool.Names.SAME, new TaskAwareTransportRequestHandler<TransportRequest.Empty>() {
                 @Override
@@ -339,7 +341,7 @@ public class SearchTransportService extends AbstractComponent {
                 }
             });
         TransportActionProxy.registerProxyAction(transportService, CLEAR_SCROLL_CONTEXTS_ACTION_NAME,
-            () -> TransportResponse.Empty.INSTANCE);
+            (request) -> TransportResponse.Empty.INSTANCE);
 
         transportService.registerRequestHandler(DFS_ACTION_NAME, ThreadPool.Names.SAME, ShardSearchTransportRequest::new,
             new TaskAwareTransportRequestHandler<ShardSearchTransportRequest>() {
@@ -367,7 +369,7 @@ public class SearchTransportService extends AbstractComponent {
 
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, DFS_ACTION_NAME, DfsSearchResult::new);
+        TransportActionProxy.registerProxyAction(transportService, DFS_ACTION_NAME, (request) -> new DfsSearchResult());
 
         transportService.registerRequestHandler(QUERY_ACTION_NAME, ThreadPool.Names.SAME, ShardSearchTransportRequest::new,
             new TaskAwareTransportRequestHandler<ShardSearchTransportRequest>() {
@@ -394,7 +396,8 @@ public class SearchTransportService extends AbstractComponent {
                     });
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_ACTION_NAME, QuerySearchResult::new);
+        TransportActionProxy.registerProxyAction(transportService, QUERY_ACTION_NAME,
+                (request) -> ((ShardSearchRequest)request).numberOfShards() == 1 ? new QueryFetchSearchResult() : new QuerySearchResult());
 
         transportService.registerRequestHandler(QUERY_ID_ACTION_NAME, ThreadPool.Names.SEARCH, QuerySearchRequest::new,
             new TaskAwareTransportRequestHandler<QuerySearchRequest>() {
@@ -404,7 +407,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_ID_ACTION_NAME, QuerySearchResult::new);
+        TransportActionProxy.registerProxyAction(transportService, QUERY_ID_ACTION_NAME, (request) -> new QuerySearchResult());
 
         transportService.registerRequestHandler(QUERY_SCROLL_ACTION_NAME, ThreadPool.Names.SEARCH, InternalScrollSearchRequest::new,
             new TaskAwareTransportRequestHandler<InternalScrollSearchRequest>() {
@@ -414,7 +417,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_SCROLL_ACTION_NAME, ScrollQuerySearchResult::new);
+        TransportActionProxy.registerProxyAction(transportService, QUERY_SCROLL_ACTION_NAME, (request) -> new ScrollQuerySearchResult());
 
         transportService.registerRequestHandler(QUERY_FETCH_SCROLL_ACTION_NAME, ThreadPool.Names.SEARCH, InternalScrollSearchRequest::new,
             new TaskAwareTransportRequestHandler<InternalScrollSearchRequest>() {
@@ -424,7 +427,8 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_FETCH_SCROLL_ACTION_NAME, ScrollQueryFetchSearchResult::new);
+        TransportActionProxy.registerProxyAction(transportService, QUERY_FETCH_SCROLL_ACTION_NAME,
+                (request) -> new ScrollQueryFetchSearchResult());
 
         transportService.registerRequestHandler(FETCH_ID_SCROLL_ACTION_NAME, ThreadPool.Names.SEARCH, ShardFetchRequest::new,
             new TaskAwareTransportRequestHandler<ShardFetchRequest>() {
@@ -434,7 +438,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, FETCH_ID_SCROLL_ACTION_NAME, FetchSearchResult::new);
+        TransportActionProxy.registerProxyAction(transportService, FETCH_ID_SCROLL_ACTION_NAME, (request) -> new FetchSearchResult());
 
         transportService.registerRequestHandler(FETCH_ID_ACTION_NAME, ThreadPool.Names.SEARCH, ShardFetchSearchRequest::new,
             new TaskAwareTransportRequestHandler<ShardFetchSearchRequest>() {
@@ -444,7 +448,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(result);
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, FETCH_ID_ACTION_NAME, FetchSearchResult::new);
+        TransportActionProxy.registerProxyAction(transportService, FETCH_ID_ACTION_NAME, (request) -> new FetchSearchResult());
 
         // this is cheap, it does not fetch during the rewrite phase, so we can let it quickly execute on a networking thread
         transportService.registerRequestHandler(QUERY_CAN_MATCH_NAME, ThreadPool.Names.SAME, ShardSearchTransportRequest::new,
@@ -455,7 +459,7 @@ public class SearchTransportService extends AbstractComponent {
                     channel.sendResponse(new CanMatchResponse(canMatch));
                 }
             });
-        TransportActionProxy.registerProxyAction(transportService, QUERY_CAN_MATCH_NAME, CanMatchResponse::new);
+        TransportActionProxy.registerProxyAction(transportService, QUERY_CAN_MATCH_NAME, (request) -> new CanMatchResponse());
     }
 
     public static final class CanMatchResponse extends SearchPhaseResult {

--- a/core/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -94,7 +94,7 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_A";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceA, "/test", SimpleTestResponse::new);
+        TransportActionProxy.registerProxyAction(serviceA, "/test", (request) -> new SimpleTestResponse());
         serviceA.connectToNode(nodeB);
 
         serviceB.registerRequestHandler("/test", SimpleTestRequest::new, ThreadPool.Names.SAME,
@@ -104,7 +104,7 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_B";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceB, "/test", SimpleTestResponse::new);
+        TransportActionProxy.registerProxyAction(serviceB, "/test", (request) -> new SimpleTestResponse());
         serviceB.connectToNode(nodeC);
         serviceC.registerRequestHandler("/test", SimpleTestRequest::new, ThreadPool.Names.SAME,
             (request, channel) -> {
@@ -113,7 +113,7 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_C";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceC, "/test", SimpleTestResponse::new);
+        TransportActionProxy.registerProxyAction(serviceC, "/test", (request) -> new SimpleTestResponse());
 
         CountDownLatch latch = new CountDownLatch(1);
         serviceA.sendRequest(nodeB, TransportActionProxy.getProxyAction("/test"), TransportActionProxy.wrapRequest(nodeC,
@@ -157,7 +157,7 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_A";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceA, "/test", SimpleTestResponse::new);
+        TransportActionProxy.registerProxyAction(serviceA, "/test", (request) -> new SimpleTestResponse());
         serviceA.connectToNode(nodeB);
 
         serviceB.registerRequestHandler("/test", SimpleTestRequest::new, ThreadPool.Names.SAME,
@@ -167,13 +167,13 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_B";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceB, "/test", SimpleTestResponse::new);
+        TransportActionProxy.registerProxyAction(serviceB, "/test", (request) -> new SimpleTestResponse());
         serviceB.connectToNode(nodeC);
         serviceC.registerRequestHandler("/test", SimpleTestRequest::new, ThreadPool.Names.SAME,
             (request, channel) -> {
                 throw new ElasticsearchException("greetings from TS_C");
             });
-        TransportActionProxy.registerProxyAction(serviceC, "/test", SimpleTestResponse::new);
+        TransportActionProxy.registerProxyAction(serviceC, "/test", (request) -> new SimpleTestResponse());
 
         CountDownLatch latch = new CountDownLatch(1);
         serviceA.sendRequest(nodeB, TransportActionProxy.getProxyAction("/test"), TransportActionProxy.wrapRequest(nodeC,

--- a/core/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -94,7 +94,7 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_A";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceA, "/test", (request) -> new SimpleTestResponse());
+        TransportActionProxy.registerProxyAction(serviceA, "/test", SimpleTestResponse::new);
         serviceA.connectToNode(nodeB);
 
         serviceB.registerRequestHandler("/test", SimpleTestRequest::new, ThreadPool.Names.SAME,
@@ -104,7 +104,7 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_B";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceB, "/test", (request) -> new SimpleTestResponse());
+        TransportActionProxy.registerProxyAction(serviceB, "/test", SimpleTestResponse::new);
         serviceB.connectToNode(nodeC);
         serviceC.registerRequestHandler("/test", SimpleTestRequest::new, ThreadPool.Names.SAME,
             (request, channel) -> {
@@ -113,7 +113,7 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_C";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceC, "/test", (request) -> new SimpleTestResponse());
+        TransportActionProxy.registerProxyAction(serviceC, "/test", SimpleTestResponse::new);
 
         CountDownLatch latch = new CountDownLatch(1);
         serviceA.sendRequest(nodeB, TransportActionProxy.getProxyAction("/test"), TransportActionProxy.wrapRequest(nodeC,
@@ -157,7 +157,7 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_A";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceA, "/test", (request) -> new SimpleTestResponse());
+        TransportActionProxy.registerProxyAction(serviceA, "/test", SimpleTestResponse::new);
         serviceA.connectToNode(nodeB);
 
         serviceB.registerRequestHandler("/test", SimpleTestRequest::new, ThreadPool.Names.SAME,
@@ -167,13 +167,13 @@ public class TransportActionProxyTests extends ESTestCase {
                 response.targetNode = "TS_B";
                 channel.sendResponse(response);
             });
-        TransportActionProxy.registerProxyAction(serviceB, "/test", (request) -> new SimpleTestResponse());
+        TransportActionProxy.registerProxyAction(serviceB, "/test", SimpleTestResponse::new);
         serviceB.connectToNode(nodeC);
         serviceC.registerRequestHandler("/test", SimpleTestRequest::new, ThreadPool.Names.SAME,
             (request, channel) -> {
                 throw new ElasticsearchException("greetings from TS_C");
             });
-        TransportActionProxy.registerProxyAction(serviceC, "/test", (request) -> new SimpleTestResponse());
+        TransportActionProxy.registerProxyAction(serviceC, "/test", SimpleTestResponse::new);
 
         CountDownLatch latch = new CountDownLatch(1);
         serviceA.sendRequest(nodeB, TransportActionProxy.getProxyAction("/test"), TransportActionProxy.wrapRequest(nodeC,

--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/10_basic.yml
@@ -165,3 +165,14 @@
   - match: { hits.total: 2 }
   - match: { hits.hits.0._source.filter_field: 1 }
   - match: { hits.hits.0._index: "my_remote_cluster:test_index" }
+
+---
+"Single shard search gets properly proxied":
+
+  - do:
+      search:
+        index: "my_remote_cluster:single_doc_index"
+
+  - match: { _shards.total: 1 }
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._index: "my_remote_cluster:single_doc_index"}


### PR DESCRIPTION
The single shard optimization that we have in our search api changes the type of response returned by the query transport action name based on the shard search request. if the request goes to one shard, we will do query and fetch at the same time, hence the response will be different. The proxying layer used in cross cluster search was not aware of this distinction, which causes serialization issues every time a cross cluster search request goes to a single shard and goes through a gateway node which has to forward the shard request to a data node. The coordinating node would then expect a `QueryFetchSearchResult` while the gateway would return a `QuerySearchResult`.

Closes #26833