### PR TITLE
Added the `terminate_after` parameter to the REST spec for "Count" API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -67,6 +67,10 @@
         "lenient": {
           "type" : "boolean",
           "description" : "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
+        },
+        "terminate_after" : {
+          "type" : "number",
+          "description" : "The maximum count for each shard, upon reaching which the query execution will terminate early"
         }
       }
     },


### PR DESCRIPTION
The [`terminate_after`](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-count.html) parameter has been missing from the REST specification.