### PR TITLE
[TEST] Added skipping the `headers` feature to the Bulk REST YAML test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/bulk/10_basic.yml
@@ -65,7 +65,8 @@
   - skip:
       version: " - 5.4.99"
       reason: confusing exception messaged caused by empty object fixed in 5.5.0
-      
+      features: ["headers"]
+
   - do:
       catch: /Malformed action\/metadata line \[3\], expected FIELD_NAME but found \[END_OBJECT\]/
       headers:


### PR DESCRIPTION
This test has been failing in th Ruby runner, since it assumed the `headers` feature,
but was not annotated accordingly.

This patch adds the `skip` clause with the `headers` feature.
