### PR TITLE
rest-client-sniffer: configurable threadfactory

### DIFF
--- a/client/sniffer/src/main/java/org/elasticsearch/client/sniff/Sniffer.java
+++ b/client/sniffer/src/main/java/org/elasticsearch/client/sniff/Sniffer.java
@@ -31,8 +31,10 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Class responsible for sniffing nodes from some source (default is elasticsearch itself) and setting them to a provided instance of
@@ -45,6 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class Sniffer implements Closeable {
 
     private static final Log logger = LogFactory.getLog(Sniffer.class);
+    private static final String SNIFFER_THREAD_NAME = "es_rest_client_sniffer";
 
     private final Task task;
 
@@ -79,7 +82,8 @@ public class Sniffer implements Closeable {
             this.restClient = restClient;
             this.sniffIntervalMillis = sniffIntervalMillis;
             this.sniffAfterFailureDelayMillis = sniffAfterFailureDelayMillis;
-            this.scheduledExecutorService = Executors.newScheduledThreadPool(1);
+            SnifferThreadFactory threadFactory = new SnifferThreadFactory(SNIFFER_THREAD_NAME);
+            this.scheduledExecutorService = Executors.newScheduledThreadPool(1, threadFactory);
             scheduleNextRun(0);
         }
 
@@ -150,5 +154,25 @@ public class Sniffer implements Closeable {
      */
     public static SnifferBuilder builder(RestClient restClient) {
         return new SnifferBuilder(restClient);
+    }
+
+    private static class SnifferThreadFactory implements ThreadFactory {
+
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final String namePrefix;
+        private final ThreadFactory originalThreadFactory;
+
+        private SnifferThreadFactory(String namePrefix) {
+            this.namePrefix = namePrefix;
+            this.originalThreadFactory = Executors.defaultThreadFactory();
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = this.originalThreadFactory.newThread(r);
+            t.setName(namePrefix + "[T#" + threadNumber.getAndIncrement() + "]");
+            t.setDaemon(true);
+            return t;
+        }
     }
 }


### PR DESCRIPTION
Make the sniffers threadfactory configurable. 

I.e. useful if you want to make the sniffer's thread daemonized.