### PR TITLE
Change default value to true for transpositions parameter of fuzzy query

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -54,8 +54,8 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
     public static final int DEFAULT_MAX_EXPANSIONS = FuzzyQuery.defaultMaxExpansions;
 
     /** Default as to whether transpositions should be treated as a primitive edit operation,
-     * instead of classic Levenshtein algorithm. Defaults to false. */
-    public static final boolean DEFAULT_TRANSPOSITIONS = false;
+     * instead of classic Levenshtein algorithm. Defaults to true. */
+    public static final boolean DEFAULT_TRANSPOSITIONS = FuzzyQuery.defaultTranspositions;
 
     private static final ParseField TERM_FIELD = new ParseField("term");
     private static final ParseField VALUE_FIELD = new ParseField("value");

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -74,7 +74,6 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
 
     private int maxExpansions = DEFAULT_MAX_EXPANSIONS;
 
-    //LUCENE 4 UPGRADE  we need a testcase for this + documentation
     private boolean transpositions = DEFAULT_TRANSPOSITIONS;
 
     private String rewrite;

--- a/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/FuzzyQueryBuilderTests.java
@@ -241,6 +241,7 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
         checkGeneratedJson(json, parsed);
         assertEquals(json, 42.0, parsed.boost(), 0.00001);
         assertEquals(json, 2, parsed.fuzziness().asFloat(), 0f);
+        assertEquals(json, false, parsed.transpositions());
     }
 
     public void testParseFailsWithMultipleFields() throws IOException {
@@ -289,5 +290,20 @@ public class FuzzyQueryBuilderTests extends AbstractQueryTestCase<FuzzyQueryBuil
 
         ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(query));
         assertEquals("[fuzzy] unexpected token [START_ARRAY] after [value]", e.getMessage());
+    }
+
+    public void testToQueryWithTranspositions() throws Exception {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        Query query = new FuzzyQueryBuilder(STRING_FIELD_NAME, "text").toQuery(createShardContext());
+        assertThat(query, instanceOf(FuzzyQuery.class));
+        assertEquals(FuzzyQuery.defaultTranspositions, ((FuzzyQuery)query).getTranspositions());
+
+        query = new FuzzyQueryBuilder(STRING_FIELD_NAME, "text").transpositions(true).toQuery(createShardContext());
+        assertThat(query, instanceOf(FuzzyQuery.class));
+        assertEquals(true, ((FuzzyQuery)query).getTranspositions());
+
+        query = new FuzzyQueryBuilder(STRING_FIELD_NAME, "text").transpositions(false).toQuery(createShardContext());
+        assertThat(query, instanceOf(FuzzyQuery.class));
+        assertEquals(false, ((FuzzyQuery)query).getTranspositions());
     }
 }

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -1,5 +1,9 @@
 [[breaking_70_search_changes]]
-=== Search changes
+=== Search and Query DSL changes
+
+==== Changes to queries
+*   The default value for `transpositions` parameter of `fuzzy` query
+    has been changed to `true`.
 
 ==== Adaptive replica selection enabled by default
 

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -36,7 +36,8 @@ GET /_search
                     "boost" :         1.0,
                     "fuzziness" :     2,
                     "prefix_length" : 0,
-                    "max_expansions": 100
+                    "max_expansions": 100,
+                    "transpositions": false
             }
         }
     }
@@ -66,7 +67,7 @@ GET /_search
 `transpositions`::
 
     Whether fuzzy transpositions (`ab` -> `ba`) are supported.
-    Default is `false`.
+    Default is `true`.
 
 WARNING: This query can be very heavy if `prefix_length` is set to `0` and if
 `max_expansions` is set to a high number. It could result in every term in the


### PR DESCRIPTION
All other fuzzy queries (`match`, `multi_match`, `query_string` and `simple_query_string`) are using `true` as default value for `transpositions` parameter.
