### PR TITLE
date_index_name processor should not fail if timestamp is specified as json number

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateIndexNameProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateIndexNameProcessor.java
@@ -25,6 +25,7 @@ import java.util.IllformedLocaleException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.elasticsearch.ExceptionsHelper;
@@ -61,7 +62,8 @@ public final class DateIndexNameProcessor extends AbstractProcessor {
 
     @Override
     public void execute(IngestDocument ingestDocument) throws Exception {
-        String date = ingestDocument.getFieldValue(field, String.class);
+        // Date can be specified as a string or long:
+        String date = Objects.toString(ingestDocument.getFieldValue(field, Object.class));
 
         DateTime dateTime = null;
         Exception lastException = null;

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateIndexNameProcessorTests.java
@@ -62,6 +62,11 @@ public class DateIndexNameProcessorTests extends ESTestCase {
                 Collections.singletonMap("_field", "1000500"));
         dateProcessor.execute(document);
         assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|UTC}}>"));
+
+        document = new IngestDocument("_index", "_type", "_id", null, null,
+                Collections.singletonMap("_field", 1000500L));
+        dateProcessor.execute(document);
+        assertThat(document.getSourceAndMetadata().get("_index"), equalTo("<events-{19700101||/m{yyyyMMdd|UTC}}>"));
     }
 
     public void testUnix()throws Exception {


### PR DESCRIPTION
PR for #26890