### PR TITLE
Fix filtering for ListSetting

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -309,6 +309,13 @@ public class Setting<T> extends ToXContentToBytes {
     }
 
     /**
+     * Returns <code>true</code> iff this setting is a list setting.
+     */
+    boolean isListSetting() {
+        return false;
+    }
+
+    /**
      * Returns the default value string representation for this setting.
      * @param settings a settings object for settings that has a default value depending on another setting if available
      */
@@ -760,6 +767,11 @@ public class Setting<T> extends ToXContentToBytes {
 
         @Override
         boolean hasComplexMatcher() {
+            return true;
+        }
+
+        @Override
+        boolean isListSetting() {
             return true;
         }
 

--- a/core/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
@@ -152,8 +152,12 @@ public class SettingsModule implements Module {
      */
     private void registerSetting(Setting<?> setting) {
         if (setting.isFiltered()) {
-            if (settingsFilterPattern.contains(setting.getKey()) == false) {
-                registerSettingsFilter(setting.getKey());
+            final String key = setting.getKey();
+            if (settingsFilterPattern.contains(key) == false) {
+                registerSettingsFilter(key);
+                if (setting.isListSetting()) {
+                    registerSettingsFilter(key + ".*");
+                }
             }
         }
         if (setting.hasNodeScope() || setting.hasIndexScope()) {

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsModuleTests.java
@@ -23,7 +23,11 @@ import org.elasticsearch.common.inject.ModuleTestCase;
 import org.elasticsearch.common.settings.Setting.Property;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsString;
 
 public class SettingsModuleTests extends ModuleTestCase {
@@ -116,6 +120,31 @@ public class SettingsModuleTests extends ModuleTestCase {
         assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).getAsMap().containsKey("bar.baz"));
         assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).getAsMap().get("bar.baz").equals("false"));
 
+    }
+
+    public void testRegisterListSettingsFilter() {
+        final Settings settings = Settings.builder()
+                                          .put("foo.bar", true)
+                                          .put("foo.baz", "one")
+                                          .putArray("foo.qux", Arrays.asList("two", "three", "four"))
+                                          .build();
+
+        final List<Setting<?>> additionalSettings = Arrays.asList(
+            Setting.simpleString("foo.bar", Property.NodeScope),
+            Setting.simpleString("foo.baz", Property.NodeScope, Property.Filtered),
+            Setting.listSetting("foo.qux", singletonList("default"), String::toString, Property.NodeScope, Property.Filtered)
+        );
+
+        final SettingsModule module = new SettingsModule(settings, additionalSettings, emptyList());
+
+        final Set<String> filters = module.getSettingsFilter().getPatterns();
+        assertEquals(3, filters.size());
+        assertTrue(filters.contains("foo.baz"));
+        assertTrue(filters.contains("foo.qux"));
+        assertTrue(filters.contains("foo.qux.*"));
+
+        assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).size() == 1);
+        assertInstanceBinding(module, SettingsFilter.class, (s) -> s.filter(settings).getAsMap().containsKey("foo.bar"));
     }
 
     public void testMutuallyExclusiveScopes() {


### PR DESCRIPTION
List settings are not correctly filtered out in 5.6 and 6.0. 
