### PR TITLE
Enable BWC testing against other remotes

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -472,28 +472,32 @@ is tested depends on the branch. On master, this will test against the current
 stable branch. On the stable branch, it will test against the latest release
 branch. Finally, on a release branch, it will test against the most recent release.
 
-=== BWC Testing against a specific branch
+=== BWC Testing against a specific remote/branch
 
 Sometimes a backward compatibility change spans two versions. A common case is a new functionality
 that needs a BWC bridge in and an unreleased versioned of a release branch (for example, 5.x).
-To test the changes, you can instruct gradle to build the BWC version from a local branch instead of
-pulling the release branch from GitHub. You do so using the `tests.bwc.refspec` system property:
+To test the changes, you can instruct gradle to build the BWC version from a another remote/branch combination instead of
+pulling the release branch from GitHub. You do so using the `tests.bwc.remote` and `tests.bwc.refspec` system properties:
 
 -------------------------------------------------
-gradle check -Dtests.bwc.refspec=origin/index_req_bwc_5.x
+gradle check -Dtests.bwc.remote=${remote} -Dtests.bwc.refspec=index_req_bwc_5.x
 -------------------------------------------------
 
-The branch needs to be available on the local clone that the BWC makes of the repository you run the
-tests from. Using the `origin` remote is a handy trick to make sure that a branch is available
-and is up to date in the case of multiple runs.
+The branch needs to be available on the remote that the BWC makes of the
+repository you run the tests from. Using the remote is a handy trick to make
+sure that a branch is available and is up to date in the case of multiple runs.
 
 Example:
 
-Say you need to make a change to `master` and have a BWC layer in `5.x`. You will need to:
-. Create a branch called `index_req_change` off `master`. This will contain your change.
-. Create a branch called `index_req_bwc_5.x` off `5.x`. This will contain your bwc layer.
-. If not running the tests locally, push both branches to your remote repository.
-. Run the tests with `gradle check -Dtests.bwc.refspec=origin/index_req_bwc_5.x`
+Say you need to make a change to `master` and have a BWC layer in `5.x`. You
+will need to:
+. Create a branch called `index_req_change` off your remote `${remote}`. This
+will contain your change.
+. Create a branch called `index_req_bwc_5.x` off `5.x`. This will contain your
+bwc layer.
+. Push both branches to your remote repository.
+. Run the tests with `gradle check -Dtests.bwc.remote=${remote}
+-Dtests.bwc.refspec=index_req_bwc_5.x`.
 
 == Coverage analysis
 

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -493,11 +493,9 @@ Say you need to make a change to `master` and have a BWC layer in `5.x`. You
 will need to:
 . Create a branch called `index_req_change` off your remote `${remote}`. This
 will contain your change.
-. Create a branch called `index_req_bwc_5.x` off `5.x`. This will contain your
-bwc layer.
+. Create a branch called `index_req_bwc_5.x` off `5.x`. This will contain your bwc layer.
 . Push both branches to your remote repository.
-. Run the tests with `gradle check -Dtests.bwc.remote=${remote}
--Dtests.bwc.refspec=index_req_bwc_5.x`.
+. Run the tests with `gradle check -Dtests.bwc.remote=${remote} -Dtests.bwc.refspec=index_req_bwc_5.x`.
 
 == Coverage analysis
 

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -63,42 +63,44 @@ if (enabled) {
   }
   File checkoutDir = file("${buildDir}/bwc/checkout-${bwcBranch}")
 
+  final String remote = System.getProperty("tests.bwc.remote", "elastic")
+
   task createClone(type: LoggedExec) {
     onlyIf { checkoutDir.exists() == false }
     commandLine = ['git', 'clone', rootDir, checkoutDir]
   }
 
-  task findUpstream(type: LoggedExec) {
+  task findRemote(type: LoggedExec) {
     dependsOn createClone
     workingDir = checkoutDir
     commandLine = ['git', 'remote', '-v']
     doLast {
-      project.ext.upstreamExists = false
+      project.ext.remoteExists = false
       output.toString('UTF-8').eachLine {
-        if (it.contains("upstream")) {
-          project.ext.upstreamExists = true
+        if (it.contains("${remote}\thttps://github.com/${remote}/elasticsearch.git")) {
+          project.ext.remoteExists = true
         }
       }
     }
   }
 
-  task addUpstream(type: LoggedExec) {
-    dependsOn findUpstream
-    onlyIf { project.ext.upstreamExists == false }
+  task addRemote(type: LoggedExec) {
+    dependsOn findRemote
+    onlyIf { project.ext.remoteExists == false }
     workingDir = checkoutDir
-    commandLine = ['git', 'remote', 'add', 'upstream', 'https://github.com/elastic/elasticsearch.git']
+    commandLine = ['git', 'remote', 'add', "${remote}", "https://github.com/${remote}/elasticsearch.git"]
   }
 
   task fetchLatest(type: LoggedExec) {
     onlyIf { project.gradle.startParameter.isOffline() == false }
-    dependsOn addUpstream
+    dependsOn addRemote
     workingDir = checkoutDir
     commandLine = ['git', 'fetch', '--all']
   }
 
   String buildMetadataKey = "bwc_refspec_${project.path.substring(1)}"
   task checkoutBwcBranch(type: LoggedExec) {
-    String refspec = System.getProperty("tests.bwc.refspec", buildMetadata.get(buildMetadataKey, "upstream/${bwcBranch}"))
+    String refspec = System.getProperty("tests.bwc.refspec", buildMetadata.get(buildMetadataKey, "${remote}/${bwcBranch}"))
     dependsOn fetchLatest
     workingDir = checkoutDir
     commandLine = ['git', 'checkout', refspec]


### PR DESCRIPTION
This commit enables BWC testing against remotes on GitHub other than elastic/elasticsearch.git.
