### PR TITLE
Enhances exists queries to reduce need for `_field_names`

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  */
 public final class RestClientBuilder {
     public static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 1000;
-    public static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 30000;
+    public static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 3000000;
     public static final int DEFAULT_MAX_RETRY_TIMEOUT_MILLIS = DEFAULT_SOCKET_TIMEOUT_MILLIS;
     public static final int DEFAULT_CONNECTION_REQUEST_TIMEOUT_MILLIS = 500;
     public static final int DEFAULT_MAX_CONN_PER_ROUTE = 10;

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  */
 public final class RestClientBuilder {
     public static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 1000;
-    public static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 3000000;
+    public static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 30000;
     public static final int DEFAULT_MAX_RETRY_TIMEOUT_MILLIS = DEFAULT_SOCKET_TIMEOUT_MILLIS;
     public static final int DEFAULT_CONNECTION_REQUEST_TIMEOUT_MILLIS = 500;
     public static final int DEFAULT_MAX_CONN_PER_ROUTE = 10;

--- a/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectArrayList;
+
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;

--- a/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -24,14 +24,15 @@ import com.carrotsearch.hppc.ObjectArrayList;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -134,14 +135,7 @@ public class BinaryFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -166,6 +166,8 @@ public class BinaryFieldMapper extends FieldMapper {
             } else {
                 field.add(value);
             }
+        } else {
+            createFieldNamesField(context, fields);
         }
 
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -24,12 +24,14 @@ import com.carrotsearch.hppc.ObjectArrayList;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -125,6 +127,22 @@ public class BinaryFieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new BytesBinaryDVIndexFieldData.Builder();
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            if (hasDocValues()) {
+                return new DocValuesFieldExistsQuery(name());
+            } else {
+                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
+                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
+                if (fieldNamesFieldType == null) {
+                    // can only happen when no types exist, so no docs exist
+                    // either
+                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
+                }
+                return fieldNamesFieldType.termQuery(name(), context);
+            }
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -179,6 +179,9 @@ public class BinaryFieldMapper extends FieldMapper {
                 field.add(value);
             }
         } else {
+            // Only add an entry to the field names field if the field is stored
+            // but has no doc values so exists query will work on a field with
+            // no doc values
             createFieldNamesField(context, fields);
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -221,6 +221,9 @@ public class BooleanFieldMapper extends FieldMapper {
 
     @Override
     protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
+        if (fieldType().hasDocValues() == false) {
+            createFieldNamesField(context, fields);
+        }
         if (fieldType().indexOptions() == IndexOptions.NONE && !fieldType().stored() && !fieldType().hasDocValues()) {
             return;
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -23,8 +23,10 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
@@ -32,7 +34,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -143,14 +144,7 @@ public class BooleanFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -21,8 +21,8 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.suggest.document.Completion50PostingsFormat;
 import org.apache.lucene.search.suggest.document.CompletionAnalyzer;
 import org.apache.lucene.search.suggest.document.CompletionQuery;
@@ -33,7 +33,6 @@ import org.apache.lucene.search.suggest.document.SuggestField;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.util.set.Sets;
@@ -264,18 +263,7 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
 
         @Override
         public Query existsQuery(QueryShardContext context) {
-            if (hasDocValues()) {
-                return new DocValuesFieldExistsQuery(name());
-            } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
-            }
+            return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
         }
 
         /**

--- a/core/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -26,10 +26,12 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
@@ -38,7 +40,6 @@ import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.joda.DateMathParser;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -252,14 +253,7 @@ public class DateFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -451,6 +451,8 @@ public class DateFieldMapper extends FieldMapper {
         }
         if (fieldType().hasDocValues()) {
             fields.add(new SortedNumericDocValuesField(fieldType().name(), timestamp));
+        } else {
+            createFieldNamesField(context, fields);
         }
         if (fieldType().stored()) {
             fields.add(new StoredField(fieldType().name(), timestamp));

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
@@ -33,6 +34,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper.FieldNamesFieldType;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.index.similarity.SimilarityService;
 
@@ -284,6 +286,18 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
      * Parse the field value and populate <code>fields</code>.
      */
     protected abstract void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException;
+
+    protected void createFieldNamesField(ParseContext context, List<IndexableField> fields) {
+        FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context.docMapper()
+                .metadataMapper(FieldNamesFieldMapper.class).fieldType();
+        if (fieldNamesFieldType != null && fieldNamesFieldType.isEnabled()) {
+            for (String fieldName : FieldNamesFieldMapper.extractFieldNames(fieldType().name())) {
+                if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
+                    fields.add(new Field(FieldNamesFieldMapper.NAME, fieldName, fieldNamesFieldType));
+                }
+            }
+        }
+    }
 
     @Override
     public Iterator<Mapper> iterator() {

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -292,9 +292,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                 .metadataMapper(FieldNamesFieldMapper.class).fieldType();
         if (fieldNamesFieldType != null && fieldNamesFieldType.isEnabled()) {
             for (String fieldName : FieldNamesFieldMapper.extractFieldNames(fieldType().name())) {
-                if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
                     fields.add(new Field(FieldNamesFieldMapper.NAME, fieldName, fieldNamesFieldType));
-                }
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -292,7 +292,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                 .metadataMapper(FieldNamesFieldMapper.class).fieldType();
         if (fieldNamesFieldType != null && fieldNamesFieldType.isEnabled()) {
             for (String fieldName : FieldNamesFieldMapper.extractFieldNames(fieldType().name())) {
-                    fields.add(new Field(FieldNamesFieldMapper.NAME, fieldName, fieldNamesFieldType));
+                fields.add(new Field(FieldNamesFieldMapper.NAME, fieldName, fieldNamesFieldType));
             }
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -179,6 +179,11 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
+        public Query existsQuery(QueryShardContext context) {
+            throw new UnsupportedOperationException("Cannot run exists query on _field_names");
+        }
+
+        @Override
         public Query termQuery(Object value, QueryShardContext context) {
             if (isEnabled() == false) {
                 throw new IllegalStateException("Cannot run [exists] queries if the [_field_names] field is disabled");

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -206,7 +206,6 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
 
     @Override
     public void postParse(ParseContext context) throws IOException {
-        super.parse(context);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -210,7 +210,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
 
     @Override
     public Mapper parse(ParseContext context) throws IOException {
-        // we parse in post parse
+        // Adding values to the _field_names field is handled by the mappers for each field type
         return null;
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -23,9 +23,11 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
@@ -188,7 +190,11 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
             if (isEnabled() == false) {
                 throw new IllegalStateException("Cannot run [exists] queries if the [_field_names] field is disabled");
             }
-            return super.termQuery(value, context);
+            try {
+                return new ExistsQueryBuilder(indexedValueForSearch(value).utf8ToString()).toQuery(context);
+            } catch (IOException e) {
+                throw new ElasticsearchException("Cannot build term query for [{}]", e, name());
+            }
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -23,11 +23,13 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -182,6 +184,22 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
         }
 
         @Override
+        public Query existsQuery(QueryShardContext context) {
+            if (hasDocValues()) {
+                return new DocValuesFieldExistsQuery(name());
+            } else {
+                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
+                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
+                if (fieldNamesFieldType == null) {
+                    // can only happen when no types exist, so no docs exist
+                    // either
+                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
+                }
+                return fieldNamesFieldType.termQuery(name(), context);
+            }
+        }
+
+        @Override
         public Query termQuery(Object value, QueryShardContext context) {
             throw new QueryShardException(context, "Geo fields do not support exact searching, use dedicated geo queries instead: ["
                 + name() + "]");
@@ -208,7 +226,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
         }
         if (fieldType.hasDocValues()) {
             context.doc().add(new LatLonDocValuesField(fieldType().name(), point.lat(), point.lon()));
-        } else {
+        } else if (fieldType().stored() || fieldType().indexOptions() != IndexOptions.NONE) {
             List<IndexableField> fields = new ArrayList<>(1);
             createFieldNamesField(context, fields);
             for (IndexableField field : fields) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -23,13 +23,14 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -188,14 +189,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -37,6 +37,7 @@ import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -207,6 +208,12 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
         }
         if (fieldType.hasDocValues()) {
             context.doc().add(new LatLonDocValuesField(fieldType().name(), point.lat(), point.lon()));
+        } else {
+            List<IndexableField> fields = new ArrayList<>(1);
+            createFieldNamesField(context, fields);
+            for (IndexableField field : fields) {
+                context.doc().add(field);
+            }
         }
         // if the mapping contains multifields then use the geohash string
         if (multiFields.iterator().hasNext()) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
@@ -29,6 +28,7 @@ import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.PackedQuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.SpatialStrategy;
@@ -44,6 +44,8 @@ import org.locationtech.spatial4j.shape.Shape;
 import org.locationtech.spatial4j.shape.jts.JtsGeometry;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -123,6 +125,11 @@ public class GeoShapeFieldMapper extends FieldMapper {
         public Builder coerce(boolean coerce) {
             this.coerce = coerce;
             return builder;
+        }
+
+        @Override
+        protected boolean defaultDocValues(Version indexCreated) {
+            return false;
         }
 
         protected Explicit<Boolean> coerce(BuilderContext context) {
@@ -440,11 +447,9 @@ public class GeoShapeFieldMapper extends FieldMapper {
                 throw new MapperParsingException("[{" + fieldType().name() + "}] is configured for points only but a " +
                         ((shape instanceof JtsGeometry) ? ((JtsGeometry)shape).getGeom().getGeometryType() : shape.getClass()) + " was found");
             }
-            Field[] fields = fieldType().defaultStrategy().createIndexableFields(shape);
-            if (fields == null || fields.length == 0) {
-                return null;
-            }
-            for (Field field : fields) {
+            List<IndexableField> fields = new ArrayList<>(Arrays.asList(fieldType().defaultStrategy().createIndexableFields(shape)));
+            createFieldNamesField(context, fields);
+            for (IndexableField field : fields) {
                 context.doc().add(field);
             }
         } catch (Exception e) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -20,6 +20,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
 import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
@@ -34,6 +35,7 @@ import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -411,6 +413,22 @@ public class GeoShapeFieldMapper extends FieldMapper {
                 return termStrategy;
             }
             throw new IllegalArgumentException("Unknown prefix tree strategy [" + strategyName + "]");
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            if (hasDocValues()) {
+                return new DocValuesFieldExistsQuery(name());
+            } else {
+                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
+                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
+                if (fieldNamesFieldType == null) {
+                    // can only happen when no types exist, so no docs exist
+                    // either
+                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
+                }
+                return fieldNamesFieldType.termQuery(name(), context);
+            }
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -20,8 +20,10 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
 import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
 import org.apache.lucene.spatial.prefix.TermQueryPrefixTreeStrategy;
@@ -35,7 +37,6 @@ import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -417,18 +418,7 @@ public class GeoShapeFieldMapper extends FieldMapper {
 
         @Override
         public Query existsQuery(QueryShardContext context) {
-            if (hasDocValues()) {
-                return new DocValuesFieldExistsQuery(name());
-            } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
-            }
+            return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -23,6 +23,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermInSetQuery;
@@ -36,10 +37,10 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.AtomicFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
-import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.fieldcomparator.BytesRefFieldComparatorSource;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -124,6 +125,11 @@ public class IdFieldMapper extends MetadataFieldMapper {
         @Override
         public Query termQuery(Object value, QueryShardContext context) {
             return termsQuery(Arrays.asList(value), context);
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new MatchAllDocsQuery();
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -21,9 +21,9 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -109,6 +109,11 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         public boolean isSearchable() {
             // The _index field is always searchable.
             return true;
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new MatchAllDocsQuery();
         }
 
         /**

--- a/core/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -369,6 +369,8 @@ public class IpFieldMapper extends FieldMapper {
         }
         if (fieldType().hasDocValues()) {
             fields.add(new SortedSetDocValuesField(fieldType().name(), new BytesRef(InetAddressPoint.encode(address))));
+        } else {
+            createFieldNamesField(context, fields);
         }
         if (fieldType().stored()) {
             fields.add(new StoredField(fieldType().name(), new BytesRef(InetAddressPoint.encode(address))));

--- a/core/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -25,15 +25,16 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -160,14 +161,7 @@ public class IpFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -328,6 +328,8 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
         if (fieldType().hasDocValues()) {
             fields.add(new SortedSetDocValuesField(fieldType().name(), binaryValue));
+        } else {
+            createFieldNamesField(context, fields);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -25,11 +25,12 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -218,14 +219,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -29,7 +29,6 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermInSetQuery;
@@ -38,7 +37,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.joda.DateMathParser;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -381,19 +379,7 @@ public abstract class MappedFieldType extends FieldType {
         return new ConstantScoreQuery(termQuery(nullValue, null));
     }
 
-    public Query existsQuery(QueryShardContext context) {
-        if (hasDocValues()) {
-            return new DocValuesFieldExistsQuery(name());
-        } else {
-            final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                    .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-            if (fieldNamesFieldType == null) {
-                // can only happen when no types exist, so no docs exist either
-                return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-            }
-            return fieldNamesFieldType.termQuery(name(), context);
-        }
-    }
+    public abstract Query existsQuery(QueryShardContext context);
 
     /**
      * An enum used to describe the relation between the range of terms in a

--- a/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -29,11 +29,13 @@ import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Explicit;
@@ -873,14 +875,7 @@ public class NumberFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1001,6 +1001,9 @@ public class NumberFieldMapper extends FieldMapper {
         boolean docValued = fieldType().hasDocValues();
         boolean stored = fieldType().stored();
         fields.addAll(fieldType().type.createFields(fieldType().name(), numericValue, indexed, docValued, stored));
+        if (docValued == false) {
+            createFieldNamesField(context, fields);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.DocValuesTermsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -176,6 +177,11 @@ public class ParentFieldMapper extends MetadataFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new DocValuesFieldExistsQuery(name());
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -166,6 +166,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
             if (fieldType().indexOptions() != IndexOptions.NONE || fieldType().stored()) {
                 fields.add(new Field(fieldType().name(), routing, fieldType()));
             }
+            createFieldNamesField(context, fields);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -22,10 +22,10 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -128,18 +128,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
 
         @Override
         public Query existsQuery(QueryShardContext context) {
-            if (hasDocValues()) {
-                return new DocValuesFieldExistsQuery(name());
-            } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
-            }
+            return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -24,6 +24,7 @@ import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -160,6 +161,11 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
                 value = ((BytesRef) value).utf8ToString();
             }
             return Long.parseLong(value.toString());
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new DocValuesFieldExistsQuery(name());
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -24,7 +24,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
@@ -160,6 +159,11 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            throw new QueryShardException(context, "The _source field is not searchable");
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -22,9 +22,10 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.lucene.search.Queries;
+import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -282,14 +283,7 @@ public class TextFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -333,6 +333,7 @@ public class TextFieldMapper extends FieldMapper {
             Field field = new Field(fieldType().name(), value, fieldType());
             fields.add(field);
         }
+        createFieldNamesField(context, fields);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
@@ -133,6 +133,11 @@ public class TypeFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new MatchAllDocsQuery();
+        }
+
+        @Override
         public Query termQuery(Object value, QueryShardContext context) {
             return termsQuery(Arrays.asList(value), context);
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermInSetQuery;
@@ -131,6 +132,11 @@ public class UidFieldMapper extends MetadataFieldMapper {
                         TextFieldMapper.Defaults.FIELDDATA_MAX_FREQUENCY,
                         TextFieldMapper.Defaults.FIELDDATA_MIN_SEGMENT_SIZE);
             }
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new MatchAllDocsQuery();
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
@@ -24,6 +24,7 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -85,6 +86,11 @@ public class VersionFieldMapper extends MetadataFieldMapper {
         @Override
         public String typeName() {
             return CONTENT_TYPE;
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new DocValuesFieldExistsQuery(name());
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
@@ -32,10 +33,14 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Objects;
 
 /**
@@ -126,8 +131,9 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     public static Query newFilter(QueryShardContext context, String fieldPattern) {
-        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType =
-                (FieldNamesFieldMapper.FieldNamesFieldType) context.getMapperService().fullName(FieldNamesFieldMapper.NAME);
+        
+        final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
+                .getMapperService().fullName(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldType == null) {
             // can only happen when no types exist, so no docs exist either
             return Queries.newMatchNoDocsQuery("Missing types in \"" + NAME + "\" query.");
@@ -143,16 +149,47 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
         }
 
         if (fields.size() == 1) {
-            Query filter = fieldNamesFieldType.termQuery(fields.iterator().next(), context);
+            String field = fields.iterator().next();
+            MappedFieldType fieldType = context.getMapperService().fullName(field);
+            if (fieldType == null) {
+                // The field does not exist as a leaf but could be an object so check for an object mapper
+                if (context.getObjectMapper(field) != null) {
+                    return newObjectFieldExistsQuery(context, field);
+                }
+                return Queries.newMatchNoDocsQuery("No field \"" + field + "\" exists in mappings.");
+            }
+            Query filter = fieldType.existsQuery(context);
             return new ConstantScoreQuery(filter);
         }
 
         BooleanQuery.Builder boolFilterBuilder = new BooleanQuery.Builder();
         for (String field : fields) {
-            Query filter = fieldNamesFieldType.termQuery(field, context);
-            boolFilterBuilder.add(filter, BooleanClause.Occur.SHOULD);
+            MappedFieldType fieldType = context.getMapperService().fullName(field);
+            if (fieldType == null) {
+                // The field does not exist as a leaf but could be an object so check for an object mapper
+                if (context.getObjectMapper(field) != null) {
+                    boolFilterBuilder.add(newObjectFieldExistsQuery(context, field), BooleanClause.Occur.SHOULD);
+                }
+            } else {
+                Query filter = fieldType.existsQuery(context);
+                boolFilterBuilder.add(filter, BooleanClause.Occur.SHOULD);
+            }
         }
         return new ConstantScoreQuery(boolFilterBuilder.build());
+    }
+
+    private static Query newObjectFieldExistsQuery(QueryShardContext context, String field) {
+        BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
+        for (Iterator<Mapper> itr = context.getObjectMapper(field).iterator(); itr.hasNext();) {
+            Mapper childField = itr.next();
+            if (childField instanceof ObjectMapper) {
+                booleanQuery.add(newObjectFieldExistsQuery(context, childField.name()), Occur.SHOULD);
+            } else {
+                Query existsQuery = context.getMapperService().fullName(childField.name()).existsQuery(context);
+                booleanQuery.add(existsQuery, Occur.SHOULD);
+            }
+        }
+        return new ConstantScoreQuery(booleanQuery.build());
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -24,12 +24,13 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
@@ -96,14 +97,7 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -20,12 +20,16 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexableField;
-import org.locationtech.spatial4j.shape.Point;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.Query;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.builders.ShapeBuilders;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.locationtech.spatial4j.shape.Point;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -127,6 +131,22 @@ public class ExternalMapper extends FieldMapper {
         @Override
         public String typeName() {
             return "faketype";
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            if (hasDocValues()) {
+                return new DocValuesFieldExistsQuery(name());
+            } else {
+                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
+                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
+                if (fieldNamesFieldType == null) {
+                    // can only happen when no types exist, so no docs exist
+                    // either
+                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
+                }
+                return fieldNamesFieldType.termQuery(name(), context);
+            }
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -20,12 +20,13 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.builders.ShapeBuilders;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -138,14 +139,7 @@ public class ExternalMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -23,10 +23,11 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -117,14 +118,7 @@ public class FakeStringFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
@@ -19,29 +19,16 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.indices.IndicesModule;
-import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
-import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.function.Supplier;
 
 public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
 
@@ -100,12 +87,13 @@ public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
                 .bytes(),
                 XContentType.JSON));
 
-        assertFieldNames(set("a", "a.keyword", "b", "b.c", "_id", "_version", "_seq_no", "_primary_term", "_source"), doc);
+        assertFieldNames(set("a"), doc);
     }
 
     public void testExplicitEnabled() throws Exception {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
             .startObject("_field_names").field("enabled", true).endObject()
+                .startObject("properties").startObject("field").field("type", "keyword").field("doc_values", false).endObject().endObject()
             .endObject().endObject().string();
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
         FieldNamesFieldMapper fieldNamesMapper = docMapper.metadataMapper(FieldNamesFieldMapper.class);
@@ -118,27 +106,7 @@ public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
             .bytes(),
             XContentType.JSON));
 
-        assertFieldNames(set("field", "field.keyword", "_id", "_version", "_seq_no", "_primary_term", "_source"), doc);
-    }
-
-    public void testDedup() throws Exception {
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
-            .startObject("_field_names").field("enabled", true).endObject()
-            .endObject().endObject().string();
-        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        FieldNamesFieldMapper fieldNamesMapper = docMapper.metadataMapper(FieldNamesFieldMapper.class);
-        assertTrue(fieldNamesMapper.fieldType().isEnabled());
-
-        ParsedDocument doc = docMapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
-            .startObject()
-            .field("field", 3) // will create 2 lucene fields under the hood: index and doc values
-            .endObject()
-            .bytes(),
-            XContentType.JSON));
-
-        Set<String> fields = set("field", "_id", "_version", "_seq_no", "_primary_term", "_source");
-        assertFieldNames(fields, doc);
-        assertEquals(fields.size(), doc.rootDoc().getValues("_field_names").length);
+        assertFieldNames(set("field"), doc);
     }
 
     public void testDisabled() throws Exception {
@@ -174,111 +142,5 @@ public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
 
         mapperEnabled = mapperService.merge("type", new CompressedXContent(enabledMapping), MapperService.MergeReason.MAPPING_UPDATE, false);
         assertTrue(mapperEnabled.metadataMapper(FieldNamesFieldMapper.class).fieldType().isEnabled());
-    }
-
-    private static class DummyMetadataFieldMapper extends MetadataFieldMapper {
-
-        public static class TypeParser implements MetadataFieldMapper.TypeParser {
-
-            @Override
-            public Builder<?, ?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-                return new MetadataFieldMapper.Builder<Builder, DummyMetadataFieldMapper>("_dummy", FIELD_TYPE, FIELD_TYPE) {
-                    @Override
-                    public DummyMetadataFieldMapper build(BuilderContext context) {
-                        return new DummyMetadataFieldMapper(context.indexSettings());
-                    }
-                };
-            }
-
-            @Override
-            public MetadataFieldMapper getDefault(MappedFieldType fieldType, ParserContext context) {
-                final Settings indexSettings = context.mapperService().getIndexSettings().getSettings();
-                return new DummyMetadataFieldMapper(indexSettings);
-            }
-
-        }
-
-        private static class DummyFieldType extends TermBasedFieldType {
-
-            DummyFieldType() {
-                super();
-            }
-
-            private DummyFieldType(MappedFieldType other) {
-                super(other);
-            }
-
-            @Override
-            public MappedFieldType clone() {
-                return new DummyFieldType(this);
-            }
-
-            @Override
-            public String typeName() {
-                return "_dummy";
-            }
-
-        }
-
-        private static final MappedFieldType FIELD_TYPE = new DummyFieldType();
-        static {
-            FIELD_TYPE.setTokenized(false);
-            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
-            FIELD_TYPE.setName("_dummy");
-            FIELD_TYPE.freeze();
-        }
-
-        protected DummyMetadataFieldMapper(Settings indexSettings) {
-            super("_dummy", FIELD_TYPE, FIELD_TYPE, indexSettings);
-        }
-
-        @Override
-        public void preParse(ParseContext context) throws IOException {
-        }
-
-        @Override
-        public void postParse(ParseContext context) throws IOException {
-            context.doc().add(new Field("_dummy", "dummy", FIELD_TYPE));
-        }
-
-        @Override
-        protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
-        }
-
-        @Override
-        protected String contentType() {
-            return "_dummy";
-        }
-
-    }
-
-    public void testSeesFieldsFromPlugins() throws IOException {
-        IndexService indexService = createIndex("test");
-        IndicesModule indicesModule = newTestIndicesModule(
-            Collections.emptyMap(),
-            Collections.singletonMap("_dummy", new DummyMetadataFieldMapper.TypeParser())
-        );
-        final MapperRegistry mapperRegistry = indicesModule.getMapperRegistry();
-        Supplier<QueryShardContext> queryShardContext = () -> {
-            return indexService.newQueryShardContext(0, null, () -> { throw new UnsupportedOperationException(); }, null);
-        };
-        MapperService mapperService = new MapperService(indexService.getIndexSettings(), indexService.getIndexAnalyzers(),
-                indexService.xContentRegistry(), indexService.similarityService(), mapperRegistry, queryShardContext);
-        DocumentMapperParser parser = new DocumentMapperParser(indexService.getIndexSettings(), mapperService,
-                indexService.getIndexAnalyzers(), indexService.xContentRegistry(), indexService.similarityService(), mapperRegistry,
-                queryShardContext);
-        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").endObject().endObject().string();
-        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
-        ParsedDocument parsedDocument = mapper.parse(SourceToParse.source("index", "type", "id", new BytesArray("{}"),
-                XContentType.JSON));
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(FieldNamesFieldMapper.NAME);
-        boolean found = false;
-        for (IndexableField f : fields) {
-            if ("_dummy".equals(f.stringValue())) {
-                found = true;
-                break;
-            }
-        }
-        assertTrue("Could not find the dummy field among " + Arrays.toString(fields), found);
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -19,11 +19,20 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.junit.Before;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FieldNamesFieldTypeTests extends FieldTypeTestCase {
     @Override
@@ -43,13 +52,27 @@ public class FieldNamesFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testTermQuery() {
-        FieldNamesFieldMapper.FieldNamesFieldType type = new FieldNamesFieldMapper.FieldNamesFieldType();
-        type.setName(FieldNamesFieldMapper.CONTENT_TYPE);
-        type.setEnabled(true);
-        Query termQuery = type.termQuery("field_name", null);
-        assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name")), termQuery);
-        type.setEnabled(false);
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> type.termQuery("field_name", null));
+
+        FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = new FieldNamesFieldMapper.FieldNamesFieldType();
+        fieldNamesFieldType.setName(FieldNamesFieldMapper.CONTENT_TYPE);
+        KeywordFieldMapper.KeywordFieldType fieldType = new KeywordFieldMapper.KeywordFieldType();
+        fieldType.setName("field_name");
+
+        Settings settings = Settings.builder().put("index.version.created", Version.CURRENT).build();
+        IndexSettings indexSettings = new IndexSettings(
+                new IndexMetaData.Builder("foo").settings(settings).numberOfShards(1).numberOfReplicas(0).build(), settings);
+        MapperService mapperService = mock(MapperService.class);
+        when(mapperService.fullName("_field_names")).thenReturn(fieldNamesFieldType);
+        when(mapperService.fullName("field_name")).thenReturn(fieldType);
+        when(mapperService.simpleMatchToIndexNames("field_name")).thenReturn(Collections.singletonList("field_name"));
+
+        QueryShardContext queryShardContext = new QueryShardContext(0,
+                indexSettings, null, null, mapperService, null, null, null, null, null, null, () -> 0L, null);
+        fieldNamesFieldType.setEnabled(true);
+        Query termQuery = fieldNamesFieldType.termQuery("field_name", queryShardContext);
+        assertEquals(new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name"))), termQuery);
+        fieldNamesFieldType.setEnabled(false);
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> fieldNamesFieldType.termQuery("field_name", null));
         assertEquals("Cannot run [exists] queries if the [_field_names] field is disabled", e.getMessage());
     }
 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.Version;
@@ -58,7 +57,7 @@ public class FieldNamesFieldTypeTests extends FieldTypeTestCase {
         KeywordFieldMapper.KeywordFieldType fieldType = new KeywordFieldMapper.KeywordFieldType();
         fieldType.setName("field_name");
 
-        Settings settings = Settings.builder().put("index.version.created", Version.CURRENT).build();
+        Settings settings = settings(Version.CURRENT).build();
         IndexSettings indexSettings = new IndexSettings(
                 new IndexMetaData.Builder("foo").settings(settings).numberOfShards(1).numberOfReplicas(0).build(), settings);
         MapperService mapperService = mock(MapperService.class);
@@ -70,7 +69,8 @@ public class FieldNamesFieldTypeTests extends FieldTypeTestCase {
                 indexSettings, null, null, mapperService, null, null, null, null, null, null, () -> 0L, null);
         fieldNamesFieldType.setEnabled(true);
         Query termQuery = fieldNamesFieldType.termQuery("field_name", queryShardContext);
-        assertEquals(new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name"))), termQuery);
+        assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name")), termQuery);
+        assertWarnings("terms query on the _field_names field is deprecated and will be removed, use exists query instead");
         fieldNamesFieldType.setEnabled(false);
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> fieldNamesFieldType.termQuery("field_name", null));
         assertEquals("Cannot run [exists] queries if the [_field_names] field is disabled", e.getMessage());

--- a/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -19,9 +19,10 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.lucene.search.Queries;
+import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.test.ESTestCase;
 
@@ -233,14 +234,7 @@ public class FieldTypeLookupTests extends ESTestCase {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
     }

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
@@ -70,6 +71,25 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
             MatchNoDocsQuery matchNoDocsQuery = (MatchNoDocsQuery) query;
             assertThat(matchNoDocsQuery.toString(null), containsString("Missing types in \"exists\" query."));
+        } else if (context.mapperService().getIndexSettings().getIndexVersionCreated().before(Version.V_6_1_0)) {
+            if (fields.size() == 1) {
+                assertThat(query, instanceOf(ConstantScoreQuery.class));
+                ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
+                String field = fields.iterator().next();
+                assertThat(constantScoreQuery.getQuery(), instanceOf(TermQuery.class));
+                TermQuery termQuery = (TermQuery) constantScoreQuery.getQuery();
+                assertEquals(field, termQuery.getTerm().text());
+            } else {
+                assertThat(query, instanceOf(ConstantScoreQuery.class));
+                ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
+                assertThat(constantScoreQuery.getQuery(), instanceOf(BooleanQuery.class));
+                BooleanQuery booleanQuery = (BooleanQuery) constantScoreQuery.getQuery();
+                assertThat(booleanQuery.clauses().size(), equalTo(mappedFields.size()));
+                for (int i = 0; i < mappedFields.size(); i++) {
+                    BooleanClause booleanClause = booleanQuery.clauses().get(i);
+                    assertThat(booleanClause.getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+                }
+            }
         } else if (fields.size() == 1 && mappedFields.size() == 0) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
             MatchNoDocsQuery matchNoDocsQuery = (MatchNoDocsQuery) query;

--- a/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/ExistsQueryBuilderTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -30,7 +31,10 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -60,23 +64,47 @@ public class ExistsQueryBuilderTests extends AbstractQueryTestCase<ExistsQueryBu
     protected void doAssertLuceneQuery(ExistsQueryBuilder queryBuilder, Query query, SearchContext context) throws IOException {
         String fieldPattern = queryBuilder.fieldName();
         Collection<String> fields = context.getQueryShardContext().simpleMatchToIndexNames(fieldPattern);
+        Collection<String> mappedFields = fields.stream().filter((field) -> context.getQueryShardContext().getObjectMapper(field) != null
+                || context.getQueryShardContext().getMapperService().fullName(field) != null).collect(Collectors.toList());
         if (getCurrentTypes().length == 0) {
             assertThat(query, instanceOf(MatchNoDocsQuery.class));
             MatchNoDocsQuery matchNoDocsQuery = (MatchNoDocsQuery) query;
             assertThat(matchNoDocsQuery.toString(null), containsString("Missing types in \"exists\" query."));
+        } else if (fields.size() == 1 && mappedFields.size() == 0) {
+            assertThat(query, instanceOf(MatchNoDocsQuery.class));
+            MatchNoDocsQuery matchNoDocsQuery = (MatchNoDocsQuery) query;
+            assertThat(matchNoDocsQuery.toString(null),
+                    containsString("No field \"" + fields.iterator().next() + "\" exists in mappings."));
         } else if (fields.size() == 1) {
             assertThat(query, instanceOf(ConstantScoreQuery.class));
             ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
-            assertThat(constantScoreQuery.getQuery(), instanceOf(TermQuery.class));
-            TermQuery termQuery = (TermQuery) constantScoreQuery.getQuery();
-            assertEquals(fields.iterator().next(), termQuery.getTerm().text());
+            String field = fields.iterator().next();
+            if (context.getQueryShardContext().getObjectMapper(field) != null) {
+                assertThat(constantScoreQuery.getQuery(), instanceOf(BooleanQuery.class));
+                BooleanQuery booleanQuery = (BooleanQuery) constantScoreQuery.getQuery();
+                List<String> childFields = new ArrayList<>();
+                context.getQueryShardContext().getObjectMapper(field).forEach(mapper -> childFields.add(mapper.name()));
+                assertThat(booleanQuery.clauses().size(), equalTo(childFields.size()));
+                for (int i = 0; i < childFields.size(); i++) {
+                    BooleanClause booleanClause = booleanQuery.clauses().get(i);
+                    assertThat(booleanClause.getOccur(), equalTo(BooleanClause.Occur.SHOULD));
+                }
+            } else if (context.getQueryShardContext().getMapperService().fullName(field).hasDocValues()) {
+                assertThat(constantScoreQuery.getQuery(), instanceOf(DocValuesFieldExistsQuery.class));
+                DocValuesFieldExistsQuery dvExistsQuery = (DocValuesFieldExistsQuery) constantScoreQuery.getQuery();
+                assertEquals(field, dvExistsQuery.getField());
+            } else {
+                assertThat(constantScoreQuery.getQuery(), instanceOf(TermQuery.class));
+                TermQuery termQuery = (TermQuery) constantScoreQuery.getQuery();
+                assertEquals(field, termQuery.getTerm().text());
+            }
         } else {
             assertThat(query, instanceOf(ConstantScoreQuery.class));
             ConstantScoreQuery constantScoreQuery = (ConstantScoreQuery) query;
             assertThat(constantScoreQuery.getQuery(), instanceOf(BooleanQuery.class));
             BooleanQuery booleanQuery = (BooleanQuery) constantScoreQuery.getQuery();
-            assertThat(booleanQuery.clauses().size(), equalTo(fields.size()));
-            for (int i = 0; i < fields.size(); i++) {
+            assertThat(booleanQuery.clauses().size(), equalTo(mappedFields.size()));
+            for (int i = 0; i < mappedFields.size(); i++) {
                 BooleanClause booleanClause = booleanQuery.clauses().get(i);
                 assertThat(booleanClause.getOccur(), equalTo(BooleanClause.Occur.SHOULD));
             }

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -801,11 +801,11 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
     public void testExistsFieldQuery() throws Exception {
         QueryShardContext context = createShardContext();
-        QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder("foo:*");
+        QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder(STRING_FIELD_NAME + ":*");
         Query query = queryBuilder.toQuery(context);
         Query expected;
         if (getCurrentTypes().length > 0) {
-            expected = new ConstantScoreQuery(new TermQuery(new Term("_field_names", "foo")));
+            expected = new ConstantScoreQuery(new TermQuery(new Term("_field_names", STRING_FIELD_NAME)));
         } else {
             expected = new MatchNoDocsQuery();
         }

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -23,6 +23,7 @@ import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PointRangeQuery;
@@ -124,7 +125,11 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         if (queryBuilder.from() == null && queryBuilder.to() == null) {
             final Query expectedQuery;
             if (getCurrentTypes().length > 0) {
-                expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, queryBuilder.fieldName())));
+                if (context.mapperService().fullName(queryBuilder.fieldName()).hasDocValues()) {
+                    expectedQuery = new ConstantScoreQuery(new DocValuesFieldExistsQuery(queryBuilder.fieldName()));
+                } else {
+                    expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, queryBuilder.fieldName())));
+                }
             } else {
                 expectedQuery = new MatchNoDocsQuery("no mappings yet");
             }
@@ -385,7 +390,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testRewriteDateToMatchAll() throws IOException {
-        String fieldName = randomAlphaOfLengthBetween(1, 20);
+        String fieldName = DATE_FIELD_NAME;
         RangeQueryBuilder query = new RangeQueryBuilder(fieldName) {
             @Override
             protected MappedFieldType.Relation getRelation(QueryRewriteContext queryRewriteContext) {
@@ -408,7 +413,11 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         final Query luceneQuery = rewrittenRange.toQuery(queryShardContext);
         final Query expectedQuery;
         if (getCurrentTypes().length > 0) {
-            expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, query.fieldName())));
+            if (queryShardContext.fieldMapper(query.fieldName()).hasDocValues()) {
+                expectedQuery = new ConstantScoreQuery(new DocValuesFieldExistsQuery(query.fieldName()));
+            } else {
+                expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, query.fieldName())));
+            }
         } else {
             expectedQuery = new MatchNoDocsQuery("no mappings yet");
         }
@@ -416,7 +425,7 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
     }
 
     public void testRewriteDateToMatchAllWithTimezoneAndFormat() throws IOException {
-        String fieldName = randomAlphaOfLengthBetween(1, 20);
+        String fieldName = DATE_FIELD_NAME;
         RangeQueryBuilder query = new RangeQueryBuilder(fieldName) {
             @Override
             protected MappedFieldType.Relation getRelation(QueryRewriteContext queryRewriteContext) {

--- a/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/RangeQueryBuilderTests.java
@@ -31,6 +31,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -125,7 +126,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         if (queryBuilder.from() == null && queryBuilder.to() == null) {
             final Query expectedQuery;
             if (getCurrentTypes().length > 0) {
-                if (context.mapperService().fullName(queryBuilder.fieldName()).hasDocValues()) {
+                if (context.mapperService().getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_1_0)
+                        && context.mapperService().fullName(queryBuilder.fieldName()).hasDocValues()) {
                     expectedQuery = new ConstantScoreQuery(new DocValuesFieldExistsQuery(queryBuilder.fieldName()));
                 } else {
                     expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, queryBuilder.fieldName())));
@@ -413,7 +415,8 @@ public class RangeQueryBuilderTests extends AbstractQueryTestCase<RangeQueryBuil
         final Query luceneQuery = rewrittenRange.toQuery(queryShardContext);
         final Query expectedQuery;
         if (getCurrentTypes().length > 0) {
-            if (queryShardContext.fieldMapper(query.fieldName()).hasDocValues()) {
+            if (queryShardContext.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_1_0)
+                    && queryShardContext.fieldMapper(query.fieldName()).hasDocValues()) {
                 expectedQuery = new ConstantScoreQuery(new DocValuesFieldExistsQuery(query.fieldName()));
             } else {
                 expectedQuery = new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, query.fieldName())));

--- a/core/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -210,6 +210,10 @@ public class CollapseBuilderTests extends AbstractSerializingTestCase<CollapseBu
                 public Query termQuery(Object value, QueryShardContext context) {
                     return null;
                 }
+
+                public Query existsQuery(QueryShardContext context) {
+                    return null;
+                }
             };
             fieldType.setName("field");
             fieldType.setHasDocValues(true);

--- a/core/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
@@ -153,6 +153,10 @@ public class SliceBuilderTests extends ESTestCase {
                 public Query termQuery(Object value, @Nullable QueryShardContext context) {
                     return null;
                 }
+
+                public Query existsQuery(QueryShardContext context) {
+                    return null;
+                }
             };
             fieldType.setName(UidFieldMapper.NAME);
             fieldType.setHasDocValues(false);
@@ -191,6 +195,10 @@ public class SliceBuilderTests extends ESTestCase {
 
                 @Override
                 public Query termQuery(Object value, @Nullable QueryShardContext context) {
+                    return null;
+                }
+
+                public Query existsQuery(QueryShardContext context) {
                     return null;
                 }
             };
@@ -287,6 +295,10 @@ public class SliceBuilderTests extends ESTestCase {
 
                 @Override
                 public Query termQuery(Object value, @Nullable QueryShardContext context) {
+                    return null;
+                }
+
+                public Query existsQuery(QueryShardContext context) {
                     return null;
                 }
             };

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -28,12 +28,14 @@ import org.apache.lucene.document.LongRange;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.BinaryDocValuesRangeQuery;
 import org.apache.lucene.queries.BinaryDocValuesRangeQuery.QueryType;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.ByteArrayDataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
@@ -43,7 +45,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.joda.DateMathParser;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -294,14 +295,7 @@ public class RangeFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -25,14 +25,15 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -218,14 +219,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/MetaJoinFieldMapper.java
@@ -21,6 +21,7 @@ package org.elasticsearch.join.mapper;
 
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -29,6 +30,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
 import java.util.List;
@@ -104,6 +106,11 @@ public class MetaJoinFieldMapper extends FieldMapper {
 
         public ParentJoinFieldMapper getMapper() {
             return mapper;
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            throw new UnsupportedOperationException("Exists query not supported for fields of type" + typeName());
         }
     }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
@@ -39,6 +40,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -123,6 +125,11 @@ public final class ParentIdFieldMapper extends FieldMapper {
             }
             BytesRef binaryValue = (BytesRef) value;
             return binaryValue.utf8ToString();
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new DocValuesFieldExistsQuery(name());
         }
     }
 

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -23,6 +23,8 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
@@ -40,6 +42,7 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.StringFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -235,6 +238,11 @@ public final class ParentJoinFieldMapper extends FieldMapper {
             }
             BytesRef binaryValue = (BytesRef) value;
             return binaryValue.utf8ToString();
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new DocValuesFieldExistsQuery(name());
         }
     }
 

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -48,7 +48,6 @@ import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -238,14 +237,7 @@ public class PercolatorFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -29,14 +29,15 @@ import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -130,14 +131,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
 

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -19,14 +19,11 @@
 
 package org.elasticsearch.index.mapper.murmur3;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
@@ -43,6 +40,10 @@ import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.TypeParsers;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.QueryShardException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 public class Murmur3FieldMapper extends FieldMapper {
 
@@ -125,6 +126,11 @@ public class Murmur3FieldMapper extends FieldMapper {
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             failIfNoDocValues();
             return new DocValuesIndexFieldData.Builder().numericType(NumericType.LONG);
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            return new DocValuesFieldExistsQuery(name());
         }
 
         @Override

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query.yml
@@ -1,4 +1,7 @@
 setup:
+  - skip:
+      features: ["headers"]
+
   - do:
       indices.create:
           index:  test
@@ -9,6 +12,7 @@ setup:
                 properties:
                   binary:
                     type: binary
+                    doc_values: true
                   boolean:
                     type: boolean
                   date:
@@ -46,12 +50,14 @@ setup:
                     type: text
   
   - do:
+      headers:
+        Content-Type: application/json
       index:
           index:  "test"
           type:   "test"
           id:     1
           body:
-            binary: "abcd1234"
+            binary: "YWJjZGUxMjM0"
             boolean: true
             date: "2017-01-01"
             geo_point: [0.0, 20.0]
@@ -73,12 +79,14 @@ setup:
             text: "foo bar"
   
   - do:
+      headers:
+        Content-Type: application/json
       index:
           index:  "test"
           type:   "test"
           id:     2
           body:
-            binary: "abcd1234"
+            binary: "YWJjZGUxMjM0"
             boolean: false
             date: "2017-01-01"
             geo_point: [0.0, 20.0]
@@ -99,13 +107,15 @@ setup:
             text: "foo bar"
   
   - do:
+      headers:
+        Content-Type: application/json
       index:
           index:  "test"
           type:   "test"
           id:     3
           routing: "route_me"
           body:
-            binary: "abcd1234"
+            binary: "YWJjZGUxMjM0"
             boolean: true
             date: "2017-01-01"
             geo_point: [0.0, 20.0]
@@ -143,6 +153,7 @@ setup:
                   binary:
                     type: binary
                     doc_values: false
+                    store: true
                   boolean:
                     type: boolean
                     doc_values: false
@@ -195,12 +206,14 @@ setup:
                     doc_values: false
   
   - do:
+      headers:
+        Content-Type: application/json
       index:
           index:  "test-no-dv"
           type:   "test"
           id:     1
           body:
-            binary: "abcd1234"
+            binary: "YWJjZGUxMjM0"
             boolean: true
             date: "2017-01-01"
             geo_point: [0.0, 20.0]
@@ -222,12 +235,14 @@ setup:
             text: "foo bar"
   
   - do:
+      headers:
+        Content-Type: application/json
       index:
           index:  "test-no-dv"
           type:   "test"
           id:     2
           body:
-            binary: "abcd1234"
+            binary: "YWJjZGUxMjM0"
             boolean: false
             date: "2017-01-01"
             geo_point: [0.0, 20.0]
@@ -248,13 +263,15 @@ setup:
             text: "foo bar"
   
   - do:
+      headers:
+        Content-Type: application/json
       index:
           index:  "test-no-dv"
           type:   "test"
           id:     3
           routing: "route_me"
           body:
-            binary: "abcd1234"
+            binary: "YWJjZGUxMjM0"
             boolean: true
             date: "2017-01-01"
             geo_point: [0.0, 20.0]
@@ -358,7 +375,7 @@ setup:
               exists:
                 field: binary
 
-  - match: {hits.total: 0}
+  - match: {hits.total: 3}
 
 ---
 "Test exists query on mapped boolean field":
@@ -1065,7 +1082,7 @@ setup:
               exists:
                 field: binary
 
-  - match: {hits.total: 0}
+  - match: {hits.total: 3}
 
 ---
 "Test exists query on mapped boolean field with no doc values":

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query.yml
@@ -583,6 +583,9 @@ setup:
 
 ---
 "Test exists query on _uid field":
+  - skip:
+      version: " - 6.1.0"
+      reason: exists on _uid not supported prior to 6.1.0
   - do:
       search:
           index: test
@@ -595,6 +598,9 @@ setup:
 
 ---
 "Test exists query on _index field":
+  - skip:
+      version: " - 6.1.0"
+      reason: exists on _index not supported prior to 6.1.0
   - do:
       search:
           index: test
@@ -607,6 +613,9 @@ setup:
 
 ---
 "Test exists query on _type field":
+  - skip:
+      version: " - 6.1.0"
+      reason: exists on _type not supported prior to 6.1.0
   - do:
       search:
           index: test
@@ -643,6 +652,9 @@ setup:
 
 ---
 "Test exists query on _source field":
+  - skip:
+      version: " - 6.1.0"
+      reason: exists on _source not supported prior to 6.1.0
   - do:
       catch: /query_shard_exception/
       search:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/160_exists_query.yml
@@ -1,0 +1,1260 @@
+setup:
+  - do:
+      indices.create:
+          index:  test
+          body:
+            mappings:
+              test:
+                dynamic: false
+                properties:
+                  binary:
+                    type: binary
+                  boolean:
+                    type: boolean
+                  date:
+                    type: date
+                  geo_point:
+                    type: geo_point
+                  geo_shape:
+                    type: geo_shape
+                  ip:
+                    type: ip
+                  keyword:
+                    type: keyword
+                  byte:
+                    type: byte
+                  double:
+                    type: double
+                  float:
+                    type: float
+                  half_float:
+                    type: half_float
+                  integer:
+                    type: integer
+                  long:
+                    type: long
+                  short:
+                    type: short
+                  object:
+                    type: object
+                    properties:
+                      inner1:
+                        type: keyword
+                      inner2:
+                        type: keyword
+                  text:
+                    type: text
+  
+  - do:
+      index:
+          index:  "test"
+          type:   "test"
+          id:     1
+          body:
+            binary: "abcd1234"
+            boolean: true
+            date: "2017-01-01"
+            geo_point: [0.0, 20.0]
+            geo_shape: 
+              type: "point"
+              coordinates: [0.0, 20.0]
+            ip: "192.168.0.1"
+            keyword: "foo"
+            byte: 1
+            double: 1.0
+            float: 1.0
+            half_float: 1.0
+            integer: 1
+            long: 1
+            short: 1
+            object: 
+              inner1: "foo"
+              inner2: "bar"
+            text: "foo bar"
+  
+  - do:
+      index:
+          index:  "test"
+          type:   "test"
+          id:     2
+          body:
+            binary: "abcd1234"
+            boolean: false
+            date: "2017-01-01"
+            geo_point: [0.0, 20.0]
+            geo_shape: 
+              type: "point"
+              coordinates: [0.0, 20.0]
+            ip: "192.168.0.1"
+            keyword: "foo"
+            byte: 1
+            double: 1.0
+            float: 1.0
+            half_float: 1.0
+            integer: 1
+            long: 1
+            short: 1
+            object: 
+              inner1: "foo"
+            text: "foo bar"
+  
+  - do:
+      index:
+          index:  "test"
+          type:   "test"
+          id:     3
+          routing: "route_me"
+          body:
+            binary: "abcd1234"
+            boolean: true
+            date: "2017-01-01"
+            geo_point: [0.0, 20.0]
+            geo_shape: 
+              type: "point"
+              coordinates: [0.0, 20.0]
+            ip: "192.168.0.1"
+            keyword: "foo"
+            byte: 1
+            double: 1.0
+            float: 1.0
+            half_float: 1.0
+            integer: 1
+            long: 1
+            short: 1
+            object: 
+              inner2: "bar"
+            text: "foo bar"
+  
+  - do:
+      index:
+          index:  "test"
+          type:   "test"
+          id:     4
+          body: {}
+
+  - do:
+      indices.create:
+          index:  test-no-dv
+          body:
+            mappings:
+              test:
+                dynamic: false
+                properties:
+                  binary:
+                    type: binary
+                    doc_values: false
+                  boolean:
+                    type: boolean
+                    doc_values: false
+                  date:
+                    type: date
+                    doc_values: false
+                  geo_point:
+                    type: geo_point
+                    doc_values: false
+                  geo_shape:
+                    type: geo_shape
+                  ip:
+                    type: ip
+                    doc_values: false
+                  keyword:
+                    type: keyword
+                    doc_values: false
+                  byte:
+                    type: byte
+                    doc_values: false
+                  double:
+                    type: double
+                    doc_values: false
+                  float:
+                    type: float
+                    doc_values: false
+                  half_float:
+                    type: half_float
+                    doc_values: false
+                  integer:
+                    type: integer
+                    doc_values: false
+                  long:
+                    type: long
+                    doc_values: false
+                  short:
+                    type: short
+                    doc_values: false
+                  object:
+                    type: object
+                    properties:
+                      inner1:
+                        type: keyword
+                        doc_values: false
+                      inner2:
+                        type: keyword
+                        doc_values: false
+                  text:
+                    type: text
+                    doc_values: false
+  
+  - do:
+      index:
+          index:  "test-no-dv"
+          type:   "test"
+          id:     1
+          body:
+            binary: "abcd1234"
+            boolean: true
+            date: "2017-01-01"
+            geo_point: [0.0, 20.0]
+            geo_shape: 
+              type: "point"
+              coordinates: [0.0, 20.0]
+            ip: "192.168.0.1"
+            keyword: "foo"
+            byte: 1
+            double: 1.0
+            float: 1.0
+            half_float: 1.0
+            integer: 1
+            long: 1
+            short: 1
+            object: 
+              inner1: "foo"
+              inner2: "bar"
+            text: "foo bar"
+  
+  - do:
+      index:
+          index:  "test-no-dv"
+          type:   "test"
+          id:     2
+          body:
+            binary: "abcd1234"
+            boolean: false
+            date: "2017-01-01"
+            geo_point: [0.0, 20.0]
+            geo_shape: 
+              type: "point"
+              coordinates: [0.0, 20.0]
+            ip: "192.168.0.1"
+            keyword: "foo"
+            byte: 1
+            double: 1.0
+            float: 1.0
+            half_float: 1.0
+            integer: 1
+            long: 1
+            short: 1
+            object: 
+              inner1: "foo"
+            text: "foo bar"
+  
+  - do:
+      index:
+          index:  "test-no-dv"
+          type:   "test"
+          id:     3
+          routing: "route_me"
+          body:
+            binary: "abcd1234"
+            boolean: true
+            date: "2017-01-01"
+            geo_point: [0.0, 20.0]
+            geo_shape: 
+              type: "point"
+              coordinates: [0.0, 20.0]
+            ip: "192.168.0.1"
+            keyword: "foo"
+            byte: 1
+            double: 1.0
+            float: 1.0
+            half_float: 1.0
+            integer: 1
+            long: 1
+            short: 1
+            object: 
+              inner2: "bar"
+            text: "foo bar"
+  
+  - do:
+      index:
+          index:  "test-no-dv"
+          type:   "test"
+          id:     4
+          body: {}
+
+  - do:
+      indices.create:
+          index:  test-unmapped
+          body:
+            mappings:
+              test:
+                dynamic: false
+                properties:
+                  unrelated:
+                    type: keyword
+  
+  - do:
+      index:
+          index:  "test-unmapped"
+          type:   "test"
+          id:     1
+          body: 
+            unrelated: "foo"
+
+  - do:
+      indices.create:
+          index:  test-empty
+          body:
+            mappings:
+              test:
+                dynamic: false
+                properties:
+                  binary:
+                    type: binary
+                  date:
+                    type: date
+                  geo_point:
+                    type: geo_point
+                  geo_shape:
+                    type: geo_shape
+                  ip:
+                    type: ip
+                  keyword:
+                    type: keyword
+                  byte:
+                    type: byte
+                  double:
+                    type: double
+                  float:
+                    type: float
+                  half_float:
+                    type: half_float
+                  integer:
+                    type: integer
+                  long:
+                    type: long
+                  short:
+                    type: short
+                  object:
+                    type: object
+                    properties:
+                      inner1:
+                        type: keyword
+                      inner2:
+                        type: keyword
+                  text:
+                    type: text
+
+  - do:
+      indices.refresh:
+          index: [test, test-unmapped, test-empty, test-no-dv]
+
+---
+"Test exists query on mapped binary field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: binary
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on mapped boolean field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: boolean
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped date field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: date
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped geo_point field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: geo_point
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped geo_shape field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: geo_shape
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped ip field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: ip
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped keyword field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: keyword
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped byte field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: byte
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped double field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: double
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped float field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: float
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped half_float field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: half_float
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped integer field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: integer
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped long field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: long
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped short field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: short
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped object field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: object
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped object inner field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: object.inner1
+
+  - match: {hits.total: 2}
+
+---
+"Test exists query on mapped text field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: text
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on _id field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: _id
+
+  - match: {hits.total: 4}
+
+---
+"Test exists query on _uid field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: _uid
+
+  - match: {hits.total: 4}
+
+---
+"Test exists query on _index field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: _index
+
+  - match: {hits.total: 4}
+
+---
+"Test exists query on _type field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: _type
+
+  - match: {hits.total: 4}
+
+---
+"Test exists query on _routing field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: _routing
+
+  - match: {hits.total: 1}
+
+---
+"Test exists query on _seq_no field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: _seq_no
+
+  - match: {hits.total: 4}
+
+---
+"Test exists query on _source field":
+  - do:
+      catch: /query_shard_exception/
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: _source
+
+---
+"Test exists query on _version field":
+  - do:
+      search:
+          index: test
+          body:
+            query:
+              exists:
+                field: _version
+
+  - match: {hits.total: 4}
+
+---
+"Test exists query on unmapped binary field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: binary
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped boolean field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: boolean
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped date field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: date
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped geo_point field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: geo_point
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped geo_shape field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: geo_shape
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped ip field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: ip
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped keyword field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: keyword
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped byte field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: byte
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped double field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: double
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped float field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: float
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped half_float field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: half_float
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped integer field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: integer
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped long field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: long
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped short field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: short
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped object field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: object
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped object inner field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: object.inner1
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on unmapped text field":
+  - do:
+      search:
+          index: test-unmapped
+          body:
+            query:
+              exists:
+                field: text
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on binary field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: binary
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on boolean field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: boolean
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on date field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: date
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on geo_point field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: geo_point
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on geo_shape field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: geo_shape
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on ip field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: ip
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on keyword field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: keyword
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on byte field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: byte
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on double field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: double
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on float field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: float
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on half_float field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: half_float
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on integer field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: integer
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on long field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: long
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on short field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: short
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on object field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: object
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on object inner field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: object.inner1
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on text field in empty index":
+  - do:
+      search:
+          index: test-empty
+          body:
+            query:
+              exists:
+                field: text
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on mapped binary field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: binary
+
+  - match: {hits.total: 0}
+
+---
+"Test exists query on mapped boolean field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: boolean
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped date field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: date
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped geo_point field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: geo_point
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped geo_shape field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: geo_shape
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped ip field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: ip
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped keyword field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: keyword
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped byte field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: byte
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped double field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: double
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped float field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: float
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped half_float field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: half_float
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped integer field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: integer
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped long field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: long
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped short field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: short
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped object field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: object
+
+  - match: {hits.total: 3}
+
+---
+"Test exists query on mapped object inner field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: object.inner1
+
+  - match: {hits.total: 2}
+
+---
+"Test exists query on mapped text field with no doc values":
+  - do:
+      search:
+          index: test-no-dv
+          body:
+            query:
+              exists:
+                field: text
+
+  - match: {hits.total: 3}

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -19,11 +19,13 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.similarity.BM25SimilarityProvider;
 import org.elasticsearch.test.ESTestCase;
 
@@ -285,6 +287,8 @@ public abstract class FieldTypeTestCase extends ESTestCase {
             public MappedFieldType clone() {return null;}
             @Override
             public String typeName() { return fieldType.typeName();}
+            @Override
+            public Query existsQuery(QueryShardContext context) { return null; }
         };
         try {
             fieldType.checkCompatibility(bogus, conflicts, random().nextBoolean());
@@ -299,6 +303,8 @@ public abstract class FieldTypeTestCase extends ESTestCase {
             public MappedFieldType clone() {return null;}
             @Override
             public String typeName() { return "othertype";}
+            @Override
+            public Query existsQuery(QueryShardContext context) { return null; }
         };
         try {
             fieldType.checkCompatibility(other, conflicts, random().nextBoolean());

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryShardContext;
 
@@ -76,14 +77,7 @@ public class MockFieldMapper extends FieldMapper {
             if (hasDocValues()) {
                 return new DocValuesFieldExistsQuery(name());
             } else {
-                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
-                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
-                if (fieldNamesFieldType == null) {
-                    // can only happen when no types exist, so no docs exist
-                    // either
-                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
-                }
-                return fieldNamesFieldType.termQuery(name(), context);
+                return new TermQuery(new Term(FieldNamesFieldMapper.NAME, name()));
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -19,12 +19,16 @@
 
 package org.elasticsearch.index.mapper;
 
-import java.io.IOException;
-import java.util.List;
-
+import org.apache.lucene.search.DocValuesFieldExistsQuery;
+import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import java.io.IOException;
+import java.util.List;
 
 // this sucks how much must be overridden just do get a dummy field mapper...
 public class MockFieldMapper extends FieldMapper {
@@ -65,6 +69,22 @@ public class MockFieldMapper extends FieldMapper {
         @Override
         public String typeName() {
             return "faketype";
+        }
+
+        @Override
+        public Query existsQuery(QueryShardContext context) {
+            if (hasDocValues()) {
+                return new DocValuesFieldExistsQuery(name());
+            } else {
+                final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
+                        .getMapperService().fullName(FieldNamesFieldMapper.NAME);
+                if (fieldNamesFieldType == null) {
+                    // can only happen when no types exist, so no docs exist
+                    // either
+                    return Queries.newMatchNoDocsQuery("Missing types in \"" + name() + "\" field.");
+                }
+                return fieldNamesFieldType.termQuery(name(), context);
+            }
         }
     }
 


### PR DESCRIPTION
Before this change we wrote the name all the fields in a document to a `_field_names` field and then implemented exists queries as a term query on this field. The problem with this approach is that it bloats the index and also affects indexing performance.

This change adds a new method `existsQuery()` to `MappedFieldType` which is implemented by each sub-class. For most field types if doc values are available a `DocValuesFieldExistsQuery` is used, falling back to using `_field_names` if doc values are disabled. Note that only fields where no doc values are available are written to `_field_names`.

Closes #26770