### PR TITLE
Reduce the default number of cached queries.

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
@@ -53,7 +53,7 @@ public class IndicesQueryCache extends AbstractComponent implements QueryCache, 
     public static final Setting<ByteSizeValue> INDICES_CACHE_QUERY_SIZE_SETTING = 
             Setting.memorySizeSetting("indices.queries.cache.size", "10%", Property.NodeScope);
     public static final Setting<Integer> INDICES_CACHE_QUERY_COUNT_SETTING = 
-            Setting.intSetting("indices.queries.cache.count", 10000, 1, Property.NodeScope);
+            Setting.intSetting("indices.queries.cache.count", 1000, 1, Property.NodeScope);
     // enables caching on all segments instead of only the larger ones, for testing only
     public static final Setting<Boolean> INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING = 
             Setting.boolSetting("indices.queries.cache.all_segments", false, Property.NodeScope);


### PR DESCRIPTION
Memory usage of queries can't be properly accounted, which can be an issue when
large queries are cached since the actual memory usage will be much higher than
what the cache thinks. This problem is very hard if not impossible to fix so as
a workaround I would like to decrease the maximum number of cached queries so
that this problem is

For the record, this problem is more likely to occur in envirenments that have
small shards or don't give much memory to the JVM.

Closes #26938
