### PR TITLE
Update documentation for systemd configuration

### DIFF
--- a/docs/reference/setup/sysconfig/configuring.asciidoc
+++ b/docs/reference/setup/sysconfig/configuring.asciidoc
@@ -92,14 +92,23 @@ specified via systemd.
 The systemd service file (`/usr/lib/systemd/system/elasticsearch.service`)
 contains the limits that are applied by default.
 
-To override these, add a file called
-`/etc/systemd/system/elasticsearch.service.d/elasticsearch.conf` and specify
-any changes in that file, such as:
+To override them, add a file called
+`/etc/systemd/system/elasticsearch.service.d/override.conf` (alternatively,
+you may run `sudo systemctl edit elasticsearch` which opens the file 
+automatically inside your default editor). Set any changes in this file,
+such as:
 
 [source,sh]
 ---------------------------------
 [Service]
 LimitMEMLOCK=infinity
+---------------------------------
+
+Once finished, run the following command to reload units:
+
+[source,sh]
+---------------------------------
+sudo systemctl daemon-reload
 ---------------------------------
 
 [[jvm-options]]


### PR DESCRIPTION
The documentation to override limits for the RPM/ Debian packages on systems that use systemd is not accurate. [Link](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/setting-system-settings.html#systemd)

I spend quite a long time figuring out how to override them, since by defining a file called elasticsearch.conf I was not having the limits overriden.

As a matter of fact, when running `sudo systemctl edit elasticsearch`, the override file is actually created as override.conf.