### PR TITLE
Rename TCPTransportTests to TcpTransportTests

### DIFF
--- a/core/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
+++ b/core/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
@@ -46,7 +46,7 @@ import java.util.function.Consumer;
 import static org.hamcrest.Matchers.equalTo;
 
 /** Unit tests for TCPTransport */
-public class TCPTransportTests extends ESTestCase {
+public class TcpTransportTests extends ESTestCase {
 
     /** Test ipv4 host with a default port works */
     public void testParseV4DefaultPort() throws Exception {
@@ -175,7 +175,7 @@ public class TCPTransportTests extends ESTestCase {
         final boolean compressed = randomBoolean();
         final AtomicBoolean called = new AtomicBoolean(false);
         Req request = new Req(randomRealisticUnicodeOfLengthBetween(10, 100));
-        ThreadPool threadPool = new TestThreadPool(TCPTransportTests.class.getName());
+        ThreadPool threadPool = new TestThreadPool(TcpTransportTests.class.getName());
         AtomicReference<IOException> exceptionReference = new AtomicReference<>();
         try {
             TcpTransport transport = new TcpTransport("test", Settings.builder().put("transport.tcp.compress", compressed).build(),


### PR DESCRIPTION
Our convention is to use lower case when naming things "Tcp". For
example, `TcpTransport`. This commit renames the outlier
(`TcpTransportTests`) to use lower case.