### PR TITLE
Fix skip section version parsing

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SkipSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/SkipSection.java
@@ -160,8 +160,8 @@ public class SkipSection {
         if (versionRange.trim().equals("all")) {
             return new Version[]{VersionUtils.getFirstVersion(), Version.CURRENT};
         }
-        String[] skipVersions = versionRange.split("-");
-        if (skipVersions.length > 2) {
+        String[] skipVersions = versionRange.split("-(?=\\d+|\\s+|$)", -1);
+        if (skipVersions.length != 2) {
             throw new IllegalArgumentException("version range malformed: " + versionRange);
         }
 


### PR DESCRIPTION
Skip section version parsing does not support any versions which contains '-' such as "6.0.0-rc1". The expected versions size should been two so raise a exception before access it via index.
