### PR TITLE
Fix inconsistencies in the rest api specs for *_script

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPutStoredScriptAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestPutStoredScriptAction.java
@@ -41,6 +41,7 @@ public class RestPutStoredScriptAction extends BaseRestHandler {
 
         controller.registerHandler(POST, "/_scripts/{id}", this);
         controller.registerHandler(PUT, "/_scripts/{id}", this);
+        controller.registerHandler(POST, "/_scripts/{id}/{context}", this);
         controller.registerHandler(PUT, "/_scripts/{id}/{context}", this);
     }
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
@@ -10,11 +10,6 @@
           "type" : "string",
           "description" : "Script ID",
           "required" : true
-        },
-        "lang" : {
-          "type" : "string",
-          "description" : "Script language",
-          "required" : true
         }
       },
       "params" : {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
@@ -10,11 +10,6 @@
           "type" : "string",
           "description" : "Script ID",
           "required" : true
-        },
-        "lang" : {
-          "type" : "string",
-          "description" : "Script language",
-          "required" : true
         }
       },
       "params" : {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
@@ -13,7 +13,7 @@
         },
         "context" : {
           "type" : "string",
-          "description" : "Script language"
+          "description" : "Script context"
         }
       },
       "params" : {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
@@ -11,10 +11,9 @@
           "description" : "Script ID",
           "required" : true
         },
-        "lang" : {
+        "context" : {
           "type" : "string",
-          "description" : "Script language",
-          "required" : true
+          "description" : "Script language"
         }
       },
       "params" : {


### PR DESCRIPTION
Removing inconsistencies in the resp api specs for the *_script by setting some path parts to optional.

Fixes #26923

CC @javanna @jdconrad @Mpdreamz 