### PR TITLE
When building Settings do not set SecureSettings if empty

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -1071,7 +1071,8 @@ public final class Settings implements ToXContentFragment {
             Map<String, Object> settingsMap = new HashMap<>(settings.settings);
             processLegacyLists(settingsMap);
             map.putAll(settingsMap);
-            if (copySecureSettings && settings.getSecureSettings() != null) {
+            if (copySecureSettings && settings.getSecureSettings() != null
+                    && settings.getSecureSettings().getSettingNames().isEmpty() == false) {
                 setSecureSettings(settings.getSecureSettings());
             }
             return this;


### PR DESCRIPTION
`IndexSettings#316` constructor will throw if `IndexMetaData#getSettings()` returns a `Setting` with an empty, but non-null, `SecureSettings`.

I think this could be solved in many ways. For me, this raises more questions, such as:
Do we neet `IndexSettings#settings`, shouldn't `nodeSettings` and `scopedSettings` be enough?
Should `PutIndexTemplateRequest` (or other `ActionRequest`s) contain `SecureSettings`?
