### PR TITLE
Added clarification on interaction with create index api

### DIFF
--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -8,7 +8,9 @@ and a simple pattern template that controls whether the template should be
 applied to the new index.
 
 NOTE: Templates are only applied at index creation time.  Changing a template
-will have no impact on existing indices.
+will have no impact on existing indices.  When using the create index api, the settings/mappings
+defined as part of the create index call will take precedence over any matching settings/mappings 
+defined in the template.
 
 For example:
 

--- a/docs/reference/indices/templates.asciidoc
+++ b/docs/reference/indices/templates.asciidoc
@@ -8,7 +8,7 @@ and a simple pattern template that controls whether the template should be
 applied to the new index.
 
 NOTE: Templates are only applied at index creation time.  Changing a template
-will have no impact on existing indices.  When using the create index api, the settings/mappings
+will have no impact on existing indices.  When using the create index API, the settings/mappings
 defined as part of the create index call will take precedence over any matching settings/mappings 
 defined in the template.
 


### PR DESCRIPTION
Some users are not expecting create index api settings/mappings to take precedence over index template.  This is added to clarify the behavior.