### PR TITLE
Fix inconsistencies in the rest api specs for cat.snapshots

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -10,7 +10,6 @@
       "parts": {
         "repository": {
           "type" : "list",
-          "required": true,
           "description": "Name of repository from which to fetch the snapshot information"
         }
       },


### PR DESCRIPTION
Removing inconsistencies in the resp api specs for the *_script by setting some path parts to optional.

Related to : #26923, #25737

CC @javanna @jdconrad @Mpdreamz