### PR TITLE
Update docs about `script` parameter

### DIFF
--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -98,8 +98,9 @@ parameter in the same way as the search api.
 So far we've only been updating documents without changing their source. That
 is genuinely useful for things like
 <<picking-up-a-new-property,picking up new properties>> but it's only half the
-fun. `_update_by_query` supports a `script` object to update the document. This
-will increment the `likes` field on all of kimchy's tweets:
+fun. `_update_by_query` supports a `script` object to update the document.
+The usage of scripts is described in <<modules-scripting-using, How to use scripts>>.
+This will increment the `likes` field on all of kimchy's tweets:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -98,9 +98,8 @@ parameter in the same way as the search api.
 So far we've only been updating documents without changing their source. That
 is genuinely useful for things like
 <<picking-up-a-new-property,picking up new properties>> but it's only half the
-fun. `_update_by_query` supports a `script` object to update the document.
-The usage of scripts is described in <<modules-scripting-using, How to use scripts>>.
-This will increment the `likes` field on all of kimchy's tweets:
+fun. `_update_by_query` <<modules-scripting-using,supports scripts>> to update
+the document. This will increment the `likes` field on all of kimchy's tweets:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/modules/scripting/using.asciidoc
+++ b/docs/reference/modules/scripting/using.asciidoc
@@ -109,6 +109,30 @@ minute will be compiled. You can change this setting dynamically by setting
 ========================================
 
 [float]
+[[modules-scripting-short-script-form]]
+=== Short Script Form
+A short script form can be used for brevity. In the short form, `script` is represented
+by a string instead of an object. This string contains the source of the script.
+
+Short form:
+
+[source,js]
+----------------------
+  "script": "ctx._source.likes++"
+----------------------
+// NOTCONSOLE
+
+The same script in the normal form:
+
+[source,js]
+----------------------
+  "script": {
+    "source": "ctx._source.likes++"
+    }
+----------------------
+// NOTCONSOLE
+
+[float]
 [[modules-scripting-stored-scripts]]
 === Stored Scripts
 

--- a/docs/reference/modules/scripting/using.asciidoc
+++ b/docs/reference/modules/scripting/using.asciidoc
@@ -125,7 +125,7 @@ The same script in the normal form:
 ----------------------
   "script": {
     "source": "ctx._source.likes++"
-    }
+  }
 ----------------------
 // NOTCONSOLE
 

--- a/docs/reference/modules/scripting/using.asciidoc
+++ b/docs/reference/modules/scripting/using.asciidoc
@@ -49,10 +49,7 @@ GET my_index/_search
 
 `lang`::
 
-    Specifies the language the script is written in.  Defaults to `painless` but
-    may be set to any of languages listed in <<modules-scripting>>. The
-    default language may be changed in the `elasticsearch.yml` config file by
-    setting `script.default_lang` to the appropriate language.
+    Specifies the language the script is written in.  Defaults to `painless`.
 
 
 `source`, `id`::


### PR DESCRIPTION
The next changes were made:

1. The description of short `script` form was added.
2. The mention of obsolete config parameter `script.default_lang` config parameter was removed.
3. The link to "How to use scripts" was added to "Update by queue" docs.

@nik9000, Please have a look on these changes.
I've tested them with gradle and build them too. Everything seems ok...