### PR TITLE
Fix handling of paths containing parentheses in 5.6

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -167,9 +167,7 @@ if exist "%JAVA_HOME%\bin\client\jvm.dll" (
 )
 
 :foundJVM
-if "%ES_JVM_OPTIONS%" == "" (
-set ES_JVM_OPTIONS=%ES_HOME%\config\jvm.options
-)
+if "%ES_JVM_OPTIONS%" == "" set ES_JVM_OPTIONS=%ES_HOME%\config\jvm.options
 
 if not "%ES_JAVA_OPTS%" == "" set ES_JAVA_OPTS=%ES_JAVA_OPTS: =;%
 


### PR DESCRIPTION
If the `ES_HOME` contains parentheses, the service cannot be installed.

This fix extends  #26916 and is applicable only to `5.x`

Relates to : #26454

CC @jasontedor 
