### PR TITLE
Stop invoking non-existent syscall

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -199,7 +199,6 @@ final class SystemCallFilter {
     static final int SECCOMP_RET_ALLOW = 0x7FFF0000;
 
     // some errno constants for error checking/handling
-    static final int EPERM  = 0x01;
     static final int EACCES = 0x0D;
     static final int EFAULT = 0x0E;
     static final int EINVAL = 0x16;

--- a/core/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -272,27 +272,6 @@ final class SystemCallFilter {
                 "with CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER compiled in");
         }
 
-        // pure paranoia:
-
-        // check that unimplemented syscalls actually return ENOSYS
-        // you never know (e.g. https://code.google.com/p/chromium/issues/detail?id=439795)
-        if (linux_syscall(999) >= 0) {
-            throw new UnsupportedOperationException("seccomp unavailable: your kernel is buggy and you should upgrade");
-        }
-
-        switch (Native.getLastError()) {
-            case ENOSYS:
-                break; // ok
-            case EPERM:
-                // NOT ok, but likely a docker container
-                if (logger.isDebugEnabled()) {
-                    logger.debug("syscall(BOGUS) bogusly gets EPERM instead of ENOSYS");
-                }
-                break;
-            default:
-                throw new UnsupportedOperationException("seccomp unavailable: your kernel is buggy and you should upgrade");
-        }
-
         // try to check system calls really are who they claim
         // you never know (e.g. https://chromium.googlesource.com/chromium/src.git/+/master/sandbox/linux/seccomp-bpf/sandbox_bpf.cc#57)
         final int bogusArg = 0xf7a46a5c;


### PR DESCRIPTION
Today when getting ready to enter seccomp, we do some probes to ensure that we are really talking to seccomp, etc. One of these probes is pure paranoia. The paranoia was driven by a kernel bug (https://lkml.org/lkml/2014/7/20/222) that only impacted 32-bit x86 kernels wherein invoking a non-existant syscall was not returning ENOSYS (as it should). This probe causes problems though, for example in containers with syscall filters, invoking a non-existant syscall will lead to the process being sent SIGSYS and terminated. We do not need this paranoid, we do not support 32-bit, and our other probes give us enough of a defense to ensure that we are talking to seccomp (and we hardcode the seccomp syscall number for platforms that we support). Given that this probe offers us little value, but does cause problems in valid use-cases, this commit removes this paranoia.

Closes #20179

