### PR TITLE
Fix typo in thrown exception in IndicesAliasesRequest

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -176,7 +176,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                             if (action == null) {
                                 action = (AliasActions) o;
                             } else {
-                                throw new IllegalArgumentException("Too many operations declared in on opeation entry");
+                                throw new IllegalArgumentException("Too many operations declared on operation entry");
                             }
                         }
                     }


### PR DESCRIPTION
There is a typo in the exception thrown in `IndicesAliasesRequest`. This PR corrects the spelling and removes extraneous word.

Closes #27027 