### PR TITLE
Make yaml test runner stricter by enforcing `required` for paths and parameters

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.test.rest.yaml;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
+
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -42,6 +43,8 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * Used by {@link ESClientYamlSuiteTestCase} to execute REST requests according to the tests written in yaml suite files. Wraps a
@@ -80,18 +83,32 @@ public class ClientYamlTestClient {
         //divide params between ones that go within query string and ones that go within path
         Map<String, String> pathParts = new HashMap<>();
         Map<String, String> queryStringParams = new HashMap<>();
+
+        List<String> apiPathParts = restApi.getPathParts().entrySet().stream().filter(e -> e.getValue() == true).map(Entry::getKey)
+                .collect(Collectors.toList());
+        List<String> apiParameters = restApi.getParams().entrySet().stream().filter(e -> e.getValue() == true).map(Entry::getKey)
+                .collect(Collectors.toList());
+
         for (Map.Entry<String, String> entry : params.entrySet()) {
-            if (restApi.getPathParts().contains(entry.getKey())) {
+            if (restApi.getPathParts().containsKey(entry.getKey())) {
                 pathParts.put(entry.getKey(), entry.getValue());
+                apiPathParts.remove(entry.getKey());
+            } else if (restApi.getParams().containsKey(entry.getKey())
+                    || restSpec.isGlobalParameter(entry.getKey())
+                    || restSpec.isClientParameter(entry.getKey())) {
+                queryStringParams.put(entry.getKey(), entry.getValue());
+                apiParameters.remove(entry.getKey());
             } else {
-                if (restApi.getParams().contains(entry.getKey()) || restSpec.isGlobalParameter(entry.getKey())
-                        || restSpec.isClientParameter(entry.getKey())) {
-                    queryStringParams.put(entry.getKey(), entry.getValue());
-                } else {
-                    throw new IllegalArgumentException("param [" + entry.getKey() + "] not supported in ["
-                            + restApi.getName() + "] " + "api");
-                }
+                throw new IllegalArgumentException(
+                        "path/param [" + entry.getKey() + "] not supported by [" + restApi.getName() + "] " + "api");
             }
+        }
+        
+        if (!apiPathParts.isEmpty()) {
+            throw new IllegalArgumentException("missing required path part: " + apiPathParts + " by [" + restApi.getName() + "] api");
+        }
+        if (!apiParameters.isEmpty()) {
+            throw new IllegalArgumentException("missing required parameter: " + apiParameters + " by [" + restApi.getName() + "] api");
         }
 
         List<String> supportedMethods = restApi.getSupportedMethods(pathParts.keySet());

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
@@ -105,11 +105,11 @@ public class ClientYamlTestClient {
             }
         }
 
-        if (!apiRequiredPathParts.isEmpty()) {
+        if (false == apiRequiredPathParts.isEmpty()) {
             throw new IllegalArgumentException(
                     "missing required path part: " + apiRequiredPathParts + " by [" + restApi.getName() + "] api");
         }
-        if (!apiRequiredParameters.isEmpty()) {
+        if (false == apiRequiredParameters.isEmpty()) {
             throw new IllegalArgumentException(
                     "missing required parameter: " + apiRequiredParameters + " by [" + restApi.getName() + "] api");
         }
@@ -117,7 +117,7 @@ public class ClientYamlTestClient {
         List<String> supportedMethods = restApi.getSupportedMethods(pathParts.keySet());
         String requestMethod;
         if (entity != null) {
-            if (!restApi.isBodySupported()) {
+            if (false == restApi.isBodySupported()) {
                 throw new IllegalArgumentException("body is not supported by [" + restApi.getName() + "] api");
             }
             String contentType = entity.getContentType().getValue();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApi.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApi.java
@@ -99,19 +99,27 @@ public class ClientYamlSuiteRestApi {
         this.paths.add(path);
     }
 
+    /**
+     * Gets all path parts supported by the api. For every path part defines if it
+     * is required or optional.
+     */
     public Map<String, Boolean> getPathParts() {
         return pathParts;
     }
 
-    void addPathPart(String pathPart, Boolean required) {
+    void addPathPart(String pathPart, boolean required) {
         this.pathParts.put(pathPart, required);
     }
 
+    /**
+     * Gets all parameters supported by the api. For every parameter defines if it
+     * is required or optional.
+     */
     public Map<String, Boolean> getParams() {
         return params;
     }
 
-    void addParam(String param, Boolean required) {
+    void addParam(String param, boolean required) {
         this.params.put(param, required);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApi.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApi.java
@@ -22,6 +22,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,8 +36,8 @@ public class ClientYamlSuiteRestApi {
     private final String name;
     private List<String> methods = new ArrayList<>();
     private List<String> paths = new ArrayList<>();
-    private List<String> pathParts = new ArrayList<>();
-    private List<String> params = new ArrayList<>();
+    private Map<String, Boolean> pathParts = new HashMap<>();
+    private Map<String, Boolean> params = new HashMap<>();
     private Body body = Body.NOT_SUPPORTED;
 
     public enum Body {
@@ -98,20 +99,20 @@ public class ClientYamlSuiteRestApi {
         this.paths.add(path);
     }
 
-    public List<String> getPathParts() {
+    public Map<String, Boolean> getPathParts() {
         return pathParts;
     }
 
-    void addPathPart(String pathPart) {
-        this.pathParts.add(pathPart);
+    void addPathPart(String pathPart, Boolean required) {
+        this.pathParts.put(pathPart, required);
     }
 
-    public List<String> getParams() {
+    public Map<String, Boolean> getParams() {
         return params;
     }
 
-    void addParam(String param) {
-        this.params.add(param);
+    void addParam(String param, Boolean required) {
+        this.params.put(param, required);
     }
 
     void setBodyOptional() {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
@@ -18,6 +18,8 @@
  */
 package org.elasticsearch.test.rest.yaml.restspec;
 
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -146,16 +148,19 @@ public class ClientYamlSuiteRestApiParser {
         return restApi;
     }
     
-    private boolean getRequired(XContentParser parser) throws IOException {
-        boolean required = false;
-        while(parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            if (parser.currentToken() == XContentParser.Token.FIELD_NAME) {
-                if ("required".equals(parser.currentName())) {
-                    parser.nextToken();
-                    required = parser.booleanValue();
-                }
-            }
+    class YamlElement {
+        private boolean required;
+        public boolean isRequired() {
+            return required;
         }
-        return required;
+        public void setRequired(boolean required) {
+            this.required = required;
+        }
+    }
+
+    private boolean getRequired(XContentParser parser) throws IOException {
+        ObjectParser<YamlElement, Void> objParser = new ObjectParser<>("", true, YamlElement::new);
+        objParser.declareBoolean(YamlElement::setRequired, new ParseField("required"));
+        return objParser.parse(parser, null).isRequired();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
@@ -57,7 +57,6 @@ public class ClientYamlSuiteRestApiParser {
                         if (parser.currentToken() == XContentParser.Token.FIELD_NAME) {
                             currentFieldName = parser.currentName();
                         }
-
                         if (parser.currentToken() == XContentParser.Token.START_ARRAY && "paths".equals(currentFieldName)) {
                             while (parser.nextToken() == XContentParser.Token.VALUE_STRING) {
                                 String path = parser.text();
@@ -71,30 +70,30 @@ public class ClientYamlSuiteRestApiParser {
                         if (parser.currentToken() == XContentParser.Token.START_OBJECT && "parts".equals(currentFieldName)) {
                             while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
                                 String part = parser.currentName();
-                                if (restApi.getPathParts().contains(part)) {
+                                if (restApi.getPathParts().containsKey(part)) {
                                     throw new IllegalArgumentException("Found duplicate part [" + part + "]");
                                 }
-                                restApi.addPathPart(part);
                                 parser.nextToken();
                                 if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
                                     throw new IllegalArgumentException("Expected parts field in rest api definition to contain an object");
                                 }
-                                parser.skipChildren();
+                                restApi.addPathPart(part, getRequired(parser));
                             }
                         }
 
                         if (parser.currentToken() == XContentParser.Token.START_OBJECT && "params".equals(currentFieldName)) {
                             while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
+                                
                                 String param = parser.currentName();
-                                if (restApi.getParams().contains(param)) {
+                                if (restApi.getParams().containsKey(param)) {
                                     throw new IllegalArgumentException("Found duplicate param [" + param + "]");
                                 }
-                                restApi.addParam(parser.currentName());
+                                
                                 parser.nextToken();
                                 if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
                                     throw new IllegalArgumentException("Expected params field in rest api definition to contain an object");
                                 }
-                                parser.skipChildren();
+                                restApi.addParam(param, getRequired(parser));
                             }
                         }
 
@@ -145,5 +144,18 @@ public class ClientYamlSuiteRestApiParser {
         parser.nextToken();
 
         return restApi;
+    }
+    
+    private boolean getRequired(XContentParser parser) throws IOException {
+        boolean required = false;
+        while(parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            if (parser.currentToken() == XContentParser.Token.FIELD_NAME) {
+                if ("required".equals(parser.currentName())) {
+                    parser.nextToken();
+                    required = parser.booleanValue();
+                }
+            }
+        }
+        return required;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
@@ -147,8 +147,8 @@ public class ClientYamlSuiteRestApiParser {
 
         return restApi;
     }
-    
-    class YamlElement {
+
+    private static class Parameter {
         private boolean required;
         public boolean isRequired() {
             return required;
@@ -158,9 +158,9 @@ public class ClientYamlSuiteRestApiParser {
         }
     }
 
-    private boolean getRequired(XContentParser parser) throws IOException {
-        ObjectParser<YamlElement, Void> objParser = new ObjectParser<>("", true, YamlElement::new);
-        objParser.declareBoolean(YamlElement::setRequired, new ParseField("required"));
+    private static boolean getRequired(XContentParser parser) throws IOException {
+        ObjectParser<Parameter, Void> objParser = new ObjectParser<>("", true, Parameter::new);
+        objParser.declareBoolean(Parameter::setRequired, new ParseField("required"));
         return objParser.parse(parser, null).isRequired();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParser.java
@@ -29,6 +29,11 @@ import java.io.IOException;
  */
 public class ClientYamlSuiteRestApiParser {
 
+    private static final ObjectParser<Parameter, Void> PARAMETER_PARSER = new ObjectParser<>("parameter", true, Parameter::new);
+    static {
+        PARAMETER_PARSER.declareBoolean(Parameter::setRequired, new ParseField("required"));
+    }
+
     public ClientYamlSuiteRestApi parse(String location, XContentParser parser) throws IOException {
 
         while ( parser.nextToken() != XContentParser.Token.FIELD_NAME ) {
@@ -79,7 +84,7 @@ public class ClientYamlSuiteRestApiParser {
                                 if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
                                     throw new IllegalArgumentException("Expected parts field in rest api definition to contain an object");
                                 }
-                                restApi.addPathPart(part, getRequired(parser));
+                                restApi.addPathPart(part, PARAMETER_PARSER.parse(parser, null).isRequired());
                             }
                         }
 
@@ -95,7 +100,7 @@ public class ClientYamlSuiteRestApiParser {
                                 if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
                                     throw new IllegalArgumentException("Expected params field in rest api definition to contain an object");
                                 }
-                                restApi.addParam(param, getRequired(parser));
+                                restApi.addParam(param, PARAMETER_PARSER.parse(parser, null).isRequired());
                             }
                         }
 
@@ -125,7 +130,7 @@ public class ClientYamlSuiteRestApiParser {
                                 }
                             }
                         }
-                        if (!requiredFound) {
+                        if (false == requiredFound) {
                             restApi.setBodyOptional();
                         }
                     }
@@ -156,11 +161,5 @@ public class ClientYamlSuiteRestApiParser {
         public void setRequired(boolean required) {
             this.required = required;
         }
-    }
-
-    private static boolean getRequired(XContentParser parser) throws IOException {
-        ObjectParser<Parameter, Void> objParser = new ObjectParser<>("", true, Parameter::new);
-        objParser.declareBoolean(Parameter::setRequired, new ParseField("required"));
-        return objParser.parse(parser, null).isRequired();
     }
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserTests.java
@@ -21,13 +21,11 @@ package org.elasticsearch.test.rest.yaml.restspec;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 import org.elasticsearch.test.rest.yaml.section.AbstractClientYamlTestFragmentParserTestCase;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFragmentParserTestCase {
     public void testParseRestSpecIndexApi() throws Exception {
@@ -43,10 +41,10 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         assertThat(restApi.getPaths().get(0), equalTo("/{index}/{type}"));
         assertThat(restApi.getPaths().get(1), equalTo("/{index}/{type}/{id}"));
         assertThat(restApi.getPathParts().size(), equalTo(3));
-        assertThat(restApi.getPathParts().keySet(), containsInAnyOrder("id","index", "type"));
-        assertThat(restApi.getPathParts().get("index"), equalTo(true));
-        assertThat(restApi.getPathParts().get("type"), equalTo(true));
-        assertThat(restApi.getPathParts().get("id"), equalTo(false));
+        assertThat(restApi.getPathParts().keySet(), containsInAnyOrder("id", "index", "type"));
+        assertThat(restApi.getPathParts(), hasEntry("index", true));
+        assertThat(restApi.getPathParts(), hasEntry("type", true));
+        assertThat(restApi.getPathParts(), hasEntry("id", false));
         assertThat(restApi.getParams().size(), equalTo(4));
         assertThat(restApi.getParams().keySet(), containsInAnyOrder("wait_for_active_shards", "op_type", "parent", "refresh"));
         restApi.getParams().entrySet().stream().forEach(e -> assertThat(e.getValue(), equalTo(false)));
@@ -65,8 +63,7 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         assertThat(restApi.getPaths().get(0), equalTo("/_template"));
         assertThat(restApi.getPaths().get(1), equalTo("/_template/{name}"));
         assertThat(restApi.getPathParts().size(), equalTo(1));
-        assertThat(restApi.getPathParts().containsKey("name"), equalTo(true));
-        assertThat(restApi.getPathParts().get("name"), equalTo(false));
+        assertThat(restApi.getPathParts(), hasEntry("name", false));
         assertThat(restApi.getParams().size(), equalTo(0));
         assertThat(restApi.isBodySupported(), equalTo(false));
         assertThat(restApi.isBodyRequired(), equalTo(false));
@@ -89,7 +86,7 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         restApi.getPathParts().entrySet().stream().forEach(e -> assertThat(e.getValue(), equalTo(false)));
         assertThat(restApi.getParams().size(), equalTo(1));
         assertThat(restApi.getParams().keySet(), contains("ignore_unavailable"));
-        assertThat(restApi.getParams().get("ignore_unavailable"), equalTo(false));
+        assertThat(restApi.getParams(), hasEntry("ignore_unavailable", false));
         assertThat(restApi.isBodySupported(), equalTo(true));
         assertThat(restApi.isBodyRequired(), equalTo(false));
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestApiParserTests.java
@@ -21,9 +21,13 @@ package org.elasticsearch.test.rest.yaml.restspec;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
 import org.elasticsearch.test.rest.yaml.section.AbstractClientYamlTestFragmentParserTestCase;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFragmentParserTestCase {
     public void testParseRestSpecIndexApi() throws Exception {
@@ -39,11 +43,13 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         assertThat(restApi.getPaths().get(0), equalTo("/{index}/{type}"));
         assertThat(restApi.getPaths().get(1), equalTo("/{index}/{type}/{id}"));
         assertThat(restApi.getPathParts().size(), equalTo(3));
-        assertThat(restApi.getPathParts().get(0), equalTo("id"));
-        assertThat(restApi.getPathParts().get(1), equalTo("index"));
-        assertThat(restApi.getPathParts().get(2), equalTo("type"));
+        assertThat(restApi.getPathParts().keySet(), containsInAnyOrder("id","index", "type"));
+        assertThat(restApi.getPathParts().get("index"), equalTo(true));
+        assertThat(restApi.getPathParts().get("type"), equalTo(true));
+        assertThat(restApi.getPathParts().get("id"), equalTo(false));
         assertThat(restApi.getParams().size(), equalTo(4));
-        assertThat(restApi.getParams(), contains("wait_for_active_shards", "op_type", "parent", "refresh"));
+        assertThat(restApi.getParams().keySet(), containsInAnyOrder("wait_for_active_shards", "op_type", "parent", "refresh"));
+        restApi.getParams().entrySet().stream().forEach(e -> assertThat(e.getValue(), equalTo(false)));
         assertThat(restApi.isBodySupported(), equalTo(true));
         assertThat(restApi.isBodyRequired(), equalTo(true));
     }
@@ -59,7 +65,8 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         assertThat(restApi.getPaths().get(0), equalTo("/_template"));
         assertThat(restApi.getPaths().get(1), equalTo("/_template/{name}"));
         assertThat(restApi.getPathParts().size(), equalTo(1));
-        assertThat(restApi.getPathParts().get(0), equalTo("name"));
+        assertThat(restApi.getPathParts().containsKey("name"), equalTo(true));
+        assertThat(restApi.getPathParts().get("name"), equalTo(false));
         assertThat(restApi.getParams().size(), equalTo(0));
         assertThat(restApi.isBodySupported(), equalTo(false));
         assertThat(restApi.isBodyRequired(), equalTo(false));
@@ -78,10 +85,11 @@ public class ClientYamlSuiteRestApiParserTests extends AbstractClientYamlTestFra
         assertThat(restApi.getPaths().get(1), equalTo("/{index}/_count"));
         assertThat(restApi.getPaths().get(2), equalTo("/{index}/{type}/_count"));
         assertThat(restApi.getPathParts().size(), equalTo(2));
-        assertThat(restApi.getPathParts().get(0), equalTo("index"));
-        assertThat(restApi.getPathParts().get(1), equalTo("type"));
+        assertThat(restApi.getPathParts().keySet(), containsInAnyOrder("index", "type"));
+        restApi.getPathParts().entrySet().stream().forEach(e -> assertThat(e.getValue(), equalTo(false)));
         assertThat(restApi.getParams().size(), equalTo(1));
-        assertThat(restApi.getParams().get(0), equalTo("ignore_unavailable"));
+        assertThat(restApi.getParams().keySet(), contains("ignore_unavailable"));
+        assertThat(restApi.getParams().get("ignore_unavailable"), equalTo(false));
         assertThat(restApi.isBodySupported(), equalTo(true));
         assertThat(restApi.isBodyRequired(), equalTo(false));
     }


### PR DESCRIPTION
Till now the yaml test runner was verifying that the provided path parts and parameters are supported.
With this PR, yaml test runner also checks that all required path parts and parameters are provided.

Related to #25737