### PR TITLE
Tie-break shard path decision based on total number of shards on path

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -222,8 +222,13 @@ public final class ShardPath {
                         .sorted((p1, p2) -> {
                                 int cmp = Long.compare(pathToShardCount.getOrDefault(p1, 0L), pathToShardCount.getOrDefault(p2, 0L));
                                 if (cmp == 0) {
-                                    // if the number of shards is equal, tie-break with the usable bytes
-                                    cmp = pathsToSpace.get(p2).compareTo(pathsToSpace.get(p1));
+                                    // if the number of shards is equal, tie-break with the number of total shards
+                                    cmp = Integer.compare(dataPathToShardCount.getOrDefault(p1.path, 0),
+                                            dataPathToShardCount.getOrDefault(p2.path, 0));
+                                    if (cmp == 0) {
+                                        // if the number of shards is equal, tie-break with the usable bytes
+                                        cmp = pathsToSpace.get(p2).compareTo(pathsToSpace.get(p1));
+                                    }
                                 }
                                 return cmp;
                             })


### PR DESCRIPTION
Right now if the number of shards for a particular index is equal across the
data paths, we tie-break on space. This changes to tie-break first on the total
number of shards for each path, and then, if that is the same, on the usable
bytes.

Relates to #26654 (it's a follow-up)