### PR TITLE
Fix default value of ignore_unavailable for snapshot REST API (#25359)

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -380,8 +380,9 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
      * @param source snapshot definition
      * @return this request
      */
+    @SuppressWarnings("unchecked")
     public CreateSnapshotRequest source(Map<String, Object> source) {
-        for (Map.Entry<String, Object> entry : ((Map<String, Object>) source).entrySet()) {
+        for (Map.Entry<String, Object> entry : source.entrySet()) {
             String name = entry.getKey();
             if (name.equals("indices")) {
                 if (entry.getValue() instanceof String) {
@@ -402,7 +403,7 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
                 includeGlobalState = nodeBooleanValue(entry.getValue(), "include_global_state");
             }
         }
-        indicesOptions(IndicesOptions.fromMap((Map<String, Object>) source, IndicesOptions.lenientExpandOpen()));
+        indicesOptions(IndicesOptions.fromMap(source, IndicesOptions.strictExpandOpen()));
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -403,7 +403,7 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
                 includeGlobalState = nodeBooleanValue(entry.getValue(), "include_global_state");
             }
         }
-        indicesOptions(IndicesOptions.fromMap(source, IndicesOptions.strictExpandOpen()));
+        indicesOptions(IndicesOptions.fromMap(source, indicesOptions));
         return this;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -505,6 +505,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
      * @param source restore definition
      * @return this request
      */
+    @SuppressWarnings("unchecked")
     public RestoreSnapshotRequest source(Map<String, Object> source) {
         for (Map.Entry<String, Object> entry : source.entrySet()) {
             String name = entry.getKey();
@@ -558,7 +559,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
                 }
             }
         }
-        indicesOptions(IndicesOptions.fromMap((Map<String, Object>) source, IndicesOptions.lenientExpandOpen()));
+        indicesOptions(IndicesOptions.fromMap(source, indicesOptions));
         return this;
     }
 

--- a/core/src/test/java/org/elasticsearch/snapshots/SnapshotRequestsTests.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SnapshotRequestsTests.java
@@ -37,7 +37,7 @@ public class SnapshotRequestsTests extends ESTestCase {
 
         XContentBuilder builder = jsonBuilder().startObject();
 
-        if(randomBoolean()) {
+        if (randomBoolean()) {
             builder.field("indices", "foo,bar,baz");
         } else {
             builder.startArray("indices");
@@ -76,6 +76,10 @@ public class SnapshotRequestsTests extends ESTestCase {
             builder.value("set3");
             builder.endArray();
         }
+        boolean includeIgnoreUnavailable = randomBoolean();
+        if (includeIgnoreUnavailable) {
+            builder.field("ignore_unavailable", indicesOptions.ignoreUnavailable());
+        }
 
         BytesReference bytes = builder.endObject().bytes();
 
@@ -89,7 +93,10 @@ public class SnapshotRequestsTests extends ESTestCase {
         assertEquals(partial, request.partial());
         assertEquals("val1", request.settings().get("set1"));
         assertArrayEquals(request.ignoreIndexSettings(), new String[]{"set2", "set3"});
-
+        boolean expectedIgnoreAvailable = includeIgnoreUnavailable
+            ? indicesOptions.ignoreUnavailable()
+            : IndicesOptions.strictExpandOpen().ignoreUnavailable();
+        assertEquals(expectedIgnoreAvailable, request.indicesOptions().ignoreUnavailable());
     }
 
     public void testCreateSnapshotRequestParsing() throws IOException {
@@ -97,7 +104,7 @@ public class SnapshotRequestsTests extends ESTestCase {
 
         XContentBuilder builder = jsonBuilder().startObject();
 
-        if(randomBoolean()) {
+        if (randomBoolean()) {
             builder.field("indices", "foo,bar,baz");
         } else {
             builder.startArray("indices");
@@ -134,6 +141,10 @@ public class SnapshotRequestsTests extends ESTestCase {
             builder.value("set3");
             builder.endArray();
         }
+        boolean includeIgnoreUnavailable = randomBoolean();
+        if (includeIgnoreUnavailable) {
+            builder.field("ignore_unavailable", indicesOptions.ignoreUnavailable());
+        }
 
         BytesReference bytes = builder.endObject().bytes();
 
@@ -144,6 +155,10 @@ public class SnapshotRequestsTests extends ESTestCase {
         assertArrayEquals(request.indices(), new String[]{"foo", "bar", "baz"});
         assertEquals(partial, request.partial());
         assertEquals("val1", request.settings().get("set1"));
+        boolean expectedIgnoreAvailable = includeIgnoreUnavailable
+            ? indicesOptions.ignoreUnavailable()
+            : IndicesOptions.strictExpandOpen().ignoreUnavailable();
+        assertEquals(expectedIgnoreAvailable, request.indicesOptions().ignoreUnavailable());
     }
 
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.create/10_basic.yml
@@ -37,3 +37,38 @@ setup:
         snapshot: test_snapshot
 
   - match: { acknowledged: true }
+
+---
+"Create a snapshot for missing index":
+  - skip:
+      version: " - 6.99.99"
+      reason: ignore_unavailable default is false in 7.0.0
+
+  - do:
+      catch: missing
+      snapshot.create:
+        repository: test_repo_create_1
+        snapshot: test_snapshot_1
+        wait_for_completion: true
+        body: |
+          { "indices": "missing_1" }
+
+  - do:
+      snapshot.create:
+        repository: test_repo_create_1
+        snapshot: test_snapshot_2
+        wait_for_completion: true
+        body: |
+          { "indices": "missing_2", "ignore_unavailable": true }
+
+  - match: { snapshot.snapshot: test_snapshot_2 }
+  - match: { snapshot.state : SUCCESS }
+  - match: { snapshot.shards.successful: 0 }
+  - match: { snapshot.shards.failed : 0 }
+
+  - do:
+      snapshot.delete:
+        repository: test_repo_create_1
+        snapshot: test_snapshot_2
+
+  - match: { acknowledged: true }


### PR DESCRIPTION
The default value for `ignore_unavailable` did not match what was documented when using the REST APIs for snapshot creation and restore.  This PR sets the default value of `ignore_unavailable` to `false`, [the way it is documented](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html) and ensures it's the same when using either REST API or transport client.

Closes #25359 