### PR TITLE
Fix a typo.

### DIFF
--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -89,8 +89,8 @@ setting the routing parameter.
 
 Note that deleting a parent document does not automatically delete its
 children. One way of deleting all child documents given a parent's id is
-to use the <<docs-delete-by-query,Delete By Query API>> to perform an
- index with the automatically generated (and indexed)
+to use the <<docs-delete-by-query,Delete By Query API>> to perform a
+ delete with the automatically generated (and indexed)
 field _parent, which is in the format parent_type#parent_id.
 
 When deleting a child document its parent id must be specified, otherwise

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -89,7 +89,7 @@ setting the routing parameter.
 
 Note that deleting a parent document does not automatically delete its
 children. One way of deleting all child documents given a parent's id is
-to use the <<docs-delete-by-query,Delete By Query API>> to perform a
+to use the <<docs-delete-by-query,Delete By Query API>> to perform an
  index with the automatically generated (and indexed)
 field _parent, which is in the format parent_type#parent_id.
 


### PR DESCRIPTION
'a index' should be 'an index'.