### PR TITLE
Prevent duplicate fields when mixing parent and root nested includes

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -75,6 +75,41 @@ public class RootObjectMapper extends ObjectMapper {
         }
 
         @Override
+        public RootObjectMapper build(BuilderContext context) {
+            fixRedundantIncludes(this, true);
+            return super.build(context);
+        }
+
+        /**
+         * Removes redundant root includes in {@link ObjectMapper.Nested} trees to avoid duplicate
+         * fields on the root mapper when {@code isIncludeInRoot} is {@code true} for a node that is
+         * itself included into a parent node, for which either {@code isIncludeInRoot} is
+         * {@code true} or which is transitively included in root by a chain of nodes with
+         * {@code isIncludeInParent} returning {@code true}.
+         * @param omb Builder whose children to check.
+         * @param parentIncluded True iff node is a child of root or a node that is included in
+         * root
+         */
+        private static void fixRedundantIncludes(ObjectMapper.Builder omb, boolean parentIncluded) {
+            for (Object mapper : omb.mappersBuilders) {
+                if (mapper instanceof ObjectMapper.Builder) {
+                    ObjectMapper.Builder child = (ObjectMapper.Builder) mapper;
+                    Nested nested = child.nested;
+                    boolean included;
+                    if (parentIncluded) {
+                        included = nested.isNested() && nested.isIncludeInParent();
+                        if (included) {
+                            child.nested = Nested.newNested(true, false);
+                        }
+                    } else {
+                        included = nested.isNested() && nested.isIncludeInRoot();
+                    }
+                    fixRedundantIncludes(child, included);
+                }
+            }
+        }
+
+        @Override
         protected ObjectMapper createMapper(String name, String fullPath, boolean enabled, Nested nested, Dynamic dynamic,
                 Map<String, Mapper> mappers, @Nullable Settings settings) {
             assert !nested.isNested();

--- a/core/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -95,16 +95,13 @@ public class RootObjectMapper extends ObjectMapper {
                 if (mapper instanceof ObjectMapper.Builder) {
                     ObjectMapper.Builder child = (ObjectMapper.Builder) mapper;
                     Nested nested = child.nested;
-                    boolean included;
-                    if (parentIncluded) {
-                        included = nested.isNested() && nested.isIncludeInParent();
-                        if (included) {
-                            child.nested = Nested.newNested(true, false);
-                        }
-                    } else {
-                        included = nested.isNested() && nested.isIncludeInRoot();
+                    boolean isNested = nested.isNested();
+                    boolean includedInParent = parentIncluded && isNested && nested.isIncludeInParent();
+                    boolean includedInRoot = isNested && nested.isIncludeInRoot();
+                    if (includedInParent && includedInRoot) {
+                        child.nested = Nested.newNested(true, false);
                     }
-                    fixRedundantIncludes(child, included);
+                    fixRedundantIncludes(child, includedInParent || includedInRoot);
                 }
             }
         }

--- a/core/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -96,12 +96,12 @@ public class RootObjectMapper extends ObjectMapper {
                     ObjectMapper.Builder child = (ObjectMapper.Builder) mapper;
                     Nested nested = child.nested;
                     boolean isNested = nested.isNested();
-                    boolean includedInParent = parentIncluded && isNested && nested.isIncludeInParent();
+                    boolean includeInRootViaParent = parentIncluded && isNested && nested.isIncludeInParent();
                     boolean includedInRoot = isNested && nested.isIncludeInRoot();
-                    if (includedInParent && includedInRoot) {
+                    if (includeInRootViaParent && includedInRoot) {
                         child.nested = Nested.newNested(true, false);
                     }
-                    fixRedundantIncludes(child, includedInParent || includedInRoot);
+                    fixRedundantIncludes(child, includeInRootViaParent || includedInRoot);
                 }
             }
         }

--- a/core/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.index.mapper;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -331,6 +334,33 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
         assertThat(doc.docs().get(6).get("field"), equalTo("value"));
         assertThat(doc.docs().get(6).get("nested1.field1"), nullValue());
         assertThat(doc.docs().get(6).getFields("nested1.nested2.field2").length, equalTo(4));
+    }
+
+    /**
+     * Checks that multiple levels of nested includes where a node is both directly and transitively
+     * included in root by {@code include_in_root} and a chain of {@code include_in_parent} does not
+     * lead to duplicate fields on the root document.
+     */
+    public void testMultipleLevelsIncludeRoot() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject().startObject("type").startObject("properties")
+            .startObject("nested1").field("type", "nested").field("include_in_root", true).field("include_in_parent", true).startObject("properties")
+            .startObject("nested2").field("type", "nested").field("include_in_root", true).field("include_in_parent", true)
+            .endObject().endObject().endObject()
+            .endObject().endObject().endObject().string();
+
+        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
+
+        ParsedDocument doc = docMapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject().startArray("nested1")
+                .startObject().startArray("nested2").startObject().field("foo", "bar")
+                .endObject().endArray().endObject().endArray()
+                .endObject()
+                .bytes(),
+            XContentType.JSON));
+
+        final Collection<IndexableField> fields = doc.rootDoc().getFields();
+        assertThat(fields.size(), equalTo(new HashSet<>(fields).size()));
     }
 
     public void testNestedArrayStrict() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -341,7 +341,7 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
      * included in root by {@code include_in_root} and a chain of {@code include_in_parent} does not
      * lead to duplicate fields on the root document.
      */
-    public void testMultipleLevelsIncludeRoot() throws Exception {
+    public void testMultipleLevelsIncludeRoot1() throws Exception {
         String mapping = XContentFactory.jsonBuilder()
             .startObject().startObject("type").startObject("properties")
             .startObject("nested1").field("type", "nested").field("include_in_root", true).field("include_in_parent", true).startObject("properties")
@@ -355,6 +355,40 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
                 .startObject().startArray("nested1")
                 .startObject().startArray("nested2").startObject().field("foo", "bar")
                 .endObject().endArray().endObject().endArray()
+                .endObject()
+                .bytes(),
+            XContentType.JSON));
+
+        final Collection<IndexableField> fields = doc.rootDoc().getFields();
+        assertThat(fields.size(), equalTo(new HashSet<>(fields).size()));
+    }
+
+    /**
+     * Same as {@link NestedObjectMapperTests#testMultipleLevelsIncludeRoot1()} but tests for the
+     * case where the transitive {@code include_in_parent} and redundant {@code include_in_root}
+     * happen on a chain of nodes that starts from a parent node that is not directly connected to
+     * root by a chain of {@code include_in_parent}, i.e. that has {@code include_in_parent} set to
+     * {@code false} and {@code include_in_root} set to {@code true}.
+     */
+    public void testMultipleLevelsIncludeRoot2() throws Exception {
+        String mapping = XContentFactory.jsonBuilder()
+            .startObject().startObject("type").startObject("properties")
+            .startObject("nested1").field("type", "nested")
+            .field("include_in_root", true).field("include_in_parent", true).startObject("properties")
+            .startObject("nested2").field("type", "nested")
+            .field("include_in_root", true).field("include_in_parent", false).startObject("properties")
+            .startObject("nested3").field("type", "nested")
+            .field("include_in_root", true).field("include_in_parent", true)
+            .endObject().endObject().endObject().endObject().endObject()
+            .endObject().endObject().endObject().string();
+
+        DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
+
+        ParsedDocument doc = docMapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                .startObject().startArray("nested1")
+                .startObject().startArray("nested2")
+                .startObject().startArray("nested3").startObject().field("foo", "bar")
+                .endObject().endArray().endObject().endArray().endObject().endArray()
                 .endObject()
                 .bytes(),
             XContentType.JSON));


### PR DESCRIPTION
Fixes #26990 (I think :))

Fixed this by traversing the tree of `Nested` instances in the `Builder` for `RootObjectMapper` since it seemed to be the one place before instantiating the mappers where I can mutate builders and have the full tree of `Nested` available to me.
So my logic was:

* The duplicate fields arise from a child nested by more than one level, that is directly included in the root and also transitively included via a chain of parent(s).
 => Set all `include_in_root` to `false`, that are already covered by transitive chains of `include_in_parent == true`