### PR TITLE
Make ShardSearchTarget optional when parsing ShardSearchFailure

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -131,7 +131,8 @@ public class ShardSearchFailure implements ShardOperationFailedException {
 
     @Override
     public String toString() {
-        return "shard [" + (shardTarget == null ? "_na" : shardTarget) + "], reason [" + reason + "], cause [" + (cause == null ? "_na" : ExceptionsHelper.stackTrace(cause)) + "]";
+        return "shard [" + (shardTarget == null ? "_na" : shardTarget) + "], reason [" + reason + "], cause [" +
+                (cause == null ? "_na" : ExceptionsHelper.stackTrace(cause)) + "]";
     }
 
     public static ShardSearchFailure readShardSearchFailure(StreamInput in) throws IOException {
@@ -210,9 +211,12 @@ public class ShardSearchFailure implements ShardOperationFailedException {
                 parser.skipChildren();
             }
         }
-        return new ShardSearchFailure(exception,
-                new SearchShardTarget(nodeId,
-                        new ShardId(new Index(indexName, IndexMetaData.INDEX_UUID_NA_VALUE), shardId), null, OriginalIndices.NONE));
+        SearchShardTarget searchShardTarget = null;
+        if (nodeId != null) {
+            searchShardTarget = new SearchShardTarget(nodeId,
+                    new ShardId(new Index(indexName, IndexMetaData.INDEX_UUID_NA_VALUE), shardId), null, OriginalIndices.NONE);
+        }
+        return new ShardSearchFailure(exception, searchShardTarget);
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
@@ -175,7 +175,7 @@ public class SearchResponseTests extends ESTestCase {
                 ShardSearchFailure parsedFailure = parsed.getShardFailures()[i];
                 ShardSearchFailure originalFailure = failures[i];
                 assertEquals(originalFailure.index(), parsedFailure.index());
-                assertEquals(originalFailure.shard().getNodeId(), parsedFailure.shard().getNodeId());
+                assertEquals(originalFailure.shard(), parsedFailure.shard());
                 assertEquals(originalFailure.shardId(), parsedFailure.shardId());
                 String originalMsg = originalFailure.getCause().getMessage();
                 assertEquals(parsedFailure.getCause().getMessage(), "Elasticsearch exception [type=parsing_exception, reason=" +

--- a/core/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/ShardSearchFailureTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -40,12 +41,14 @@ public class ShardSearchFailureTests extends ESTestCase {
     public static ShardSearchFailure createTestItem() {
         String randomMessage = randomAlphaOfLengthBetween(3, 20);
         Exception ex = new ParsingException(0, 0, randomMessage , new IllegalArgumentException("some bad argument"));
-        String nodeId = randomAlphaOfLengthBetween(5, 10);
-        String indexName = randomAlphaOfLengthBetween(5, 10);
-        String indexUuid = randomAlphaOfLengthBetween(5, 10);
-        int shardId = randomInt();
-        return new ShardSearchFailure(ex,
-                new SearchShardTarget(nodeId, new ShardId(new Index(indexName, indexUuid), shardId), null, null));
+        SearchShardTarget searchShardTarget = null;
+        if (randomBoolean()) {
+            String nodeId = randomAlphaOfLengthBetween(5, 10);
+            String indexName = randomAlphaOfLengthBetween(5, 10);
+            searchShardTarget = new SearchShardTarget(nodeId,
+                    new ShardId(new Index(indexName, IndexMetaData.INDEX_UUID_NA_VALUE), randomInt()), null, null);
+        }
+        return new ShardSearchFailure(ex, searchShardTarget);
     }
 
     public void testFromXContent() throws IOException {
@@ -80,10 +83,10 @@ public class ShardSearchFailureTests extends ESTestCase {
             assertNull(parser.nextToken());
         }
         assertEquals(response.index(), parsed.index());
-        assertEquals(response.shard().getNodeId(), parsed.shard().getNodeId());
+        assertEquals(response.shard(), parsed.shard());
         assertEquals(response.shardId(), parsed.shardId());
 
-        /**
+        /*
          * we cannot compare the cause, because it will be wrapped in an outer
          * ElasticSearchException best effort: try to check that the original
          * message appears somewhere in the rendered xContent


### PR DESCRIPTION
Turns out that `ShardSearchTarget` is nullable, hence its fields may not be printed out as part of `ShardSearchFailure#toXContent`, in which case `fromXContent` cannot parse it back. We would previously try to create the object with all of its fields set to null, but `Index` complains about it in the constructor. Also made sure that this code path is covered by our unit tests in `ShardSearchFailureTests`.

Closes #27055