### PR TITLE
Deprecate the transport client in favour of the high-level REST client

### DIFF
--- a/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
+++ b/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
@@ -45,8 +45,11 @@ import java.util.concurrent.TimeUnit;
  * {@link MustachePlugin},
  * {@link ParentJoinPlugin}
  * plugins for the client. These plugins are all the required modules for Elasticsearch.
+ *
+ * @deprecated the transport client is deprecated in favour of the high-level REST client
  */
 @SuppressWarnings({"unchecked","varargs"})
+@Deprecated
 public class PreBuiltTransportClient extends TransportClient {
 
     static {

--- a/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
+++ b/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
@@ -46,7 +46,8 @@ import java.util.concurrent.TimeUnit;
  * {@link ParentJoinPlugin}
  * plugins for the client. These plugins are all the required modules for Elasticsearch.
  *
- * @deprecated the transport client is deprecated in favour of the high-level REST client
+ * @deprecated {@link TransportClient} is deprecated in favour of the High Level REST client and will
+ * be removed in Elasticsearch 8.0.
  */
 @SuppressWarnings({"unchecked","varargs"})
 @Deprecated

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -79,7 +79,10 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  * <p>
  * The transport client important modules used is the {@link org.elasticsearch.common.network.NetworkModule} which is
  * started in client mode (only connects, no bind).
+ *
+ * @deprecated the transport client is deprecated in favour of the high-level REST client
  */
+@Deprecated
 public abstract class TransportClient extends AbstractClient {
 
     public static final Setting<TimeValue> CLIENT_TRANSPORT_NODES_SAMPLER_INTERVAL =

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -80,7 +80,8 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  * The transport client important modules used is the {@link org.elasticsearch.common.network.NetworkModule} which is
  * started in client mode (only connects, no bind).
  *
- * @deprecated the transport client is deprecated in favour of the high-level REST client
+ * @deprecated {@link TransportClient} is deprecated in favour of the High Level REST client and will
+ * be removed in Elasticsearch 8.0.
  */
 @Deprecated
 public abstract class TransportClient extends AbstractClient {

--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -23,13 +23,10 @@ cluster.
 
 ==============================
 
-WARNING: The `TransportClient` is aimed to be replaced by the Java High Level REST
-Client, which executes HTTP requests instead of serialized Java requests. The
-`TransportClient` will be deprecated in upcoming versions of Elasticsearch and it
-is advised to use the Java High Level REST Client instead.
-
 [[transport-client]]
 === Transport Client
+
+deprecated[6.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed once the latter is feature complete]
 
 The `TransportClient` connects remotely to an Elasticsearch cluster
 using the transport module. It does not join the cluster, but simply

--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -26,7 +26,7 @@ cluster.
 [[transport-client]]
 === Transport Client
 
-deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0]
+deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The {java-rest}/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
 
 The `TransportClient` connects remotely to an Elasticsearch cluster
 using the transport module. It does not join the cluster, but simply

--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -26,7 +26,7 @@ cluster.
 [[transport-client]]
 === Transport Client
 
-deprecated[6.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed once the latter is feature complete]
+deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0]
 
 The `TransportClient` connects remotely to an Elasticsearch cluster
 using the transport module. It does not join the cluster, but simply

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -6,7 +6,7 @@ include::../Versions.asciidoc[]
 [preface]
 == Preface
 
-deprecated[6.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed once the latter is feature complete]
+deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0]
 
 This section describes the Java API that Elasticsearch provides. All
 Elasticsearch operations are executed using a

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -6,7 +6,7 @@ include::../Versions.asciidoc[]
 [preface]
 == Preface
 
-deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0]
+deprecated[7.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed in Elasticsearch 8.0. The {java-rest}/java-rest-high-level-migration.html[migration guide] describes all the steps needed to migrate.]
 
 This section describes the Java API that Elasticsearch provides. All
 Elasticsearch operations are executed using a

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -5,6 +5,9 @@ include::../Versions.asciidoc[]
 
 [preface]
 == Preface
+
+deprecated[6.0.0, The `TransportClient` is deprecated in favour of the {java-rest}/java-rest-high.html[Java High Level REST Client] and will be removed once the latter is feature complete]
+
 This section describes the Java API that Elasticsearch provides. All
 Elasticsearch operations are executed using a
 <<client,Client>> object. All
@@ -16,11 +19,6 @@ Additionally, operations on a client may be accumulated and executed in
 
 Note, all the APIs are exposed through the
 Java API (actually, the Java API is used internally to execute them).
-
-WARNING: Starting from version 5.6.0, a new Java client has been
-released: the {java-rest}/java-rest-high.html[Java High Level REST Client].
-This new client is designed to replace the `TransportClient` in Java
-applications which will be deprecated in future versions of Elasticsearch.
 
 == Javadoc
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/MockTransportClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/MockTransportClient.java
@@ -30,10 +30,10 @@ import java.util.Arrays;
 import java.util.Collection;
 
 @SuppressWarnings({"unchecked","varargs"})
+@Deprecated
 public class MockTransportClient extends TransportClient {
     private static final Settings DEFAULT_SETTINGS = Settings.builder().put("transport.type.default",
         MockTcpTransportPlugin.MOCK_TCP_TRANSPORT_NAME).build();
-
 
     public MockTransportClient(Settings settings, Class<? extends Plugin>... plugins) {
         this(settings, Arrays.asList(plugins));


### PR DESCRIPTION
This PR deprecates the transport client in our docs and in the java code.