### PR TITLE
Allocation: add delay between retries for failed allocations

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationRetryBackoffPolicy.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationRetryBackoffPolicy.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.Random;
+import java.util.function.Function;
+
+/**
+ *
+ * A policy controls when to retry allocating if shard allocation has failed.
+ */
+public abstract class AllocationRetryBackoffPolicy {
+    public enum PolicyType {
+        NO_BACKOFF(5) {
+            @Override
+            AllocationRetryBackoffPolicy policyForSettings(Settings settings) {
+                return noBackOffPolicy();
+            }
+        },
+        EXPONENTIAL_BACKOFF(1000) {
+            @Override
+            AllocationRetryBackoffPolicy policyForSettings(Settings settings) {
+                return exponentialBackoffPolicy(settings);
+            }
+        };
+        private final int defaultMaxRetries;
+
+        abstract AllocationRetryBackoffPolicy policyForSettings(Settings settings);
+
+        PolicyType(int defaultMaxRetries) {
+            this.defaultMaxRetries = defaultMaxRetries;
+        }
+
+        public int getDefaultMaxRetries() {
+            return defaultMaxRetries;
+        }
+
+        public static PolicyType fromString(String policyName) {
+            if ("exponential_backoff".equals(policyName)) {
+                return EXPONENTIAL_BACKOFF;
+            } else if ("no_backoff".equals(policyName)) {
+                return NO_BACKOFF;
+            }
+            throw new IllegalStateException("No backoff policy name match for [" + policyName + "]");
+        }
+    }
+
+    public static final Setting<PolicyType> SETTING_ALLOCATION_RETRY_POLICY =
+        new Setting<>("cluster.allocation.retry.policy", "exponential_backoff", PolicyType::fromString, Setting.Property.NodeScope);
+
+    public static final Function<Settings, Integer> SETTING_ALLOCATION_DEFAULT_MAX_RETRIES =
+        settings -> SETTING_ALLOCATION_RETRY_POLICY.get(settings).defaultMaxRetries;
+
+    public static final Setting<TimeValue> SETTING_ALLOCATION_RETRY_EXPONENTIAL_BACKOFF_BASE_DELAY =
+        Setting.positiveTimeSetting("cluster.allocation.retry.exponential_backoff.base_delay",
+            TimeValue.timeValueMillis(50), Setting.Property.NodeScope);
+
+    public static final Setting<TimeValue> SETTING_ALLOCATION_RETRY_EXPONENTIAL_BACKOFF_MAX_DELAY =
+        Setting.positiveTimeSetting("cluster.allocation.retry.exponential_backoff.max_delay",
+            TimeValue.timeValueMinutes(30), Setting.Property.NodeScope);
+
+    /**
+     * Determines a delay interval after a shard allocation has failed numOfFailures times.
+     * This method may produce different value for each call.
+     */
+    public abstract TimeValue delayInterval(int numOfFailures);
+
+    /**
+     * Constructs the allocation retry policy for the given settings.
+     */
+    public static AllocationRetryBackoffPolicy policyForSettings(Settings settings) {
+        return SETTING_ALLOCATION_RETRY_POLICY.get(settings).policyForSettings(settings);
+    }
+
+    public static AllocationRetryBackoffPolicy exponentialBackoffPolicy(Settings settings) {
+        return new ExponentialBackOffPolicy(settings);
+    }
+
+    public static AllocationRetryBackoffPolicy noBackOffPolicy() {
+        return new NoBackoffPolicy();
+    }
+
+    static class ExponentialBackOffPolicy extends AllocationRetryBackoffPolicy {
+        private final Random random;
+        private final long delayUnitMS;
+        private final long maxDelayMS;
+
+        ExponentialBackOffPolicy(Settings settings) {
+            this.random = new Random(Randomness.get().nextInt());
+            this.delayUnitMS = SETTING_ALLOCATION_RETRY_EXPONENTIAL_BACKOFF_BASE_DELAY.get(settings).millis();
+            this.maxDelayMS = SETTING_ALLOCATION_RETRY_EXPONENTIAL_BACKOFF_MAX_DELAY.get(settings).millis();
+        }
+
+        @Override
+        public TimeValue delayInterval(int numOfFailures) {
+            assert numOfFailures >= 0;
+            int bound = numOfFailures > 30 ? Integer.MAX_VALUE : 1 << numOfFailures;
+            return TimeValue.timeValueMillis(Math.min(maxDelayMS, delayUnitMS * random.nextInt(bound)));
+        }
+    }
+
+    static class NoBackoffPolicy extends AllocationRetryBackoffPolicy {
+        @Override
+        public TimeValue delayInterval(int numOfFailures) {
+            return TimeValue.ZERO;
+        }
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.AllocationRetryBackoffPolicy;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -37,8 +38,8 @@ import org.elasticsearch.common.settings.Settings;
  */
 public class MaxRetryAllocationDecider extends AllocationDecider {
 
-    public static final Setting<Integer> SETTING_ALLOCATION_MAX_RETRY = Setting.intSetting("index.allocation.max_retries", 5, 0,
-        Setting.Property.Dynamic, Setting.Property.IndexScope);
+    public static final Setting<Integer> SETTING_ALLOCATION_MAX_RETRY = Setting.intSetting("index.allocation.max_retries",
+        AllocationRetryBackoffPolicy.SETTING_ALLOCATION_DEFAULT_MAX_RETRIES, 0, Setting.Property.Dynamic, Setting.Property.IndexScope);
 
     public static final String NAME = "max_retry";
 

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -903,6 +903,10 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, (s) -> Integer.toString(defaultValue), (s) -> parseInt(s, minValue, key), properties);
     }
 
+    public static Setting<Integer> intSetting(String key, Function<Settings, Integer> defaultValue, int minValue, Property... properties) {
+        return new Setting<>(key, defaultValue.andThen(n -> Integer.toString(n)), (s) -> parseInt(s, minValue, key), properties);
+    }
+
     public static Setting<Integer> intSetting(String key, Setting<Integer> fallbackSetting, int minValue, Property... properties) {
         return new Setting<>(key, fallbackSetting, (s) -> parseInt(s, minValue, key), properties);
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingServiceTests.java
@@ -19,45 +19,98 @@
 
 package org.elasticsearch.cluster.routing;
 
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
 import org.junit.Before;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RoutingServiceTests extends ESAllocationTestCase {
 
     private TestRoutingService routingService;
+    private ThreadPool threadPool;
+
+    @After
+    public void stopThreadPool() throws Exception {
+        super.tearDown();
+        if (threadPool != null) {
+            threadPool.shutdownNow();
+            threadPool = null;
+        }
+    }
 
     @Before
     public void createRoutingService() {
-        routingService = new TestRoutingService();
+        if (threadPool == null) {
+            threadPool = new TestThreadPool(getTestClass().getName());
+        }
+        this.routingService = new TestRoutingService(threadPool);
     }
 
     public void testReroute() {
-        assertThat(routingService.hasReroutedAndClear(), equalTo(false));
+        assertThat(routingService.getSchedulesAndClear(), empty());
         routingService.reroute("test");
-        assertThat(routingService.hasReroutedAndClear(), equalTo(true));
+        assertThat(routingService.getSchedulesAndClear(), contains("test"));
+    }
+
+    public void testScheduleReroute() throws Exception {
+        assertThat(routingService.getSchedulesAndClear(), empty());
+        routingService.scheduleReroute("Schedule rerouting", TimeValue.timeValueMillis(20));
+        assertBusy(() -> assertThat(routingService.getSchedulesAndClear(), contains("Schedule rerouting")),
+            1, TimeUnit.SECONDS);
+    }
+
+    public void testScheduleMultipleTimesCollapseToSingle() throws Exception {
+        assertThat(routingService.getSchedulesAndClear(), empty());
+        IntStream.rangeClosed(0, randomIntBetween(5, 10)).forEach(n ->
+            routingService.scheduleReroute("Schedule-" + n, TimeValue.timeValueMillis(randomIntBetween(200, 300))));
+
+        routingService.scheduleReroute("master", TimeValue.timeValueMillis(randomInt(10)));
+        boolean rerouteMoreThanOnce = awaitBusy(() -> routingService.schedules.size() > 1, 2, TimeUnit.SECONDS);
+        assertThat(rerouteMoreThanOnce, equalTo(false));
+    }
+
+    public void testScheduleOverridePreviousSchedule() throws Exception {
+        assertThat(routingService.getSchedulesAndClear(), empty());
+        routingService.scheduleReroute("1000ms", TimeValue.timeValueMillis(1000));
+        routingService.scheduleReroute("108ms", TimeValue.timeValueMillis(108));
+        routingService.scheduleReroute("500ms", TimeValue.timeValueMillis(500));
+        routingService.scheduleReroute("100ms", TimeValue.timeValueMillis(100));
+        assertBusy(() -> assertTrue(routingService.schedules.contains("100ms")));
+        assertBusy(() -> assertFalse(routingService.schedules.contains("108ms")));
     }
 
     private class TestRoutingService extends RoutingService {
 
-        private AtomicBoolean rerouted = new AtomicBoolean();
+        final BlockingQueue<String> schedules = new LinkedBlockingQueue<>();
 
-        TestRoutingService() {
-            super(Settings.EMPTY, null, null);
+        TestRoutingService(ThreadPool threadPool) {
+            super(Settings.EMPTY, null, null, threadPool);
         }
 
-        public boolean hasReroutedAndClear() {
-            return rerouted.getAndSet(false);
+        List<String> getSchedulesAndClear() {
+            List<String> result = new ArrayList<>();
+            schedules.drainTo(result);
+            return result;
         }
 
         @Override
         protected void performReroute(String reason) {
             logger.info("--> performing fake reroute [{}]", reason);
-            rerouted.set(true);
+            schedules.add(reason);
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationRetryBackoffPolicyTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationRetryBackoffPolicyTests.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class AllocationRetryBackoffPolicyTests extends ESTestCase {
+
+    public void testNoBackOff() throws Exception {
+        Settings noBackOffSettings = Settings.builder().put("cluster.allocation.retry.policy", "no_backoff").build();
+        AllocationRetryBackoffPolicy backoffPolicy = AllocationRetryBackoffPolicy.policyForSettings(noBackOffSettings);
+        assertThat(backoffPolicy.delayInterval(randomIntBetween(0, 1000)), equalTo(TimeValue.ZERO));
+    }
+
+    public void testExponentialBackoff() throws Exception {
+        Settings defaultSettings = Settings.EMPTY;
+        TimeValue baseInterval = AllocationRetryBackoffPolicy.SETTING_ALLOCATION_RETRY_EXPONENTIAL_BACKOFF_BASE_DELAY.get(defaultSettings);
+        TimeValue maxInterval = AllocationRetryBackoffPolicy.SETTING_ALLOCATION_RETRY_EXPONENTIAL_BACKOFF_MAX_DELAY.get(defaultSettings);
+        assertThat(baseInterval, greaterThan(TimeValue.ZERO));
+        assertThat(maxInterval, greaterThanOrEqualTo(baseInterval));
+        AllocationRetryBackoffPolicy backoffPolicy = AllocationRetryBackoffPolicy.exponentialBackoffPolicy(defaultSettings);
+        int numOfFailures = randomIntBetween(10, 30);
+        TimeValue longestDelay = TimeValue.ZERO;
+        for (int n = 0; n < numOfFailures; n++) {
+            TimeValue delayInterval = backoffPolicy.delayInterval(n);
+            assertThat(delayInterval, lessThanOrEqualTo(maxInterval));
+            if (longestDelay.compareTo(delayInterval) < 0) {
+                longestDelay = delayInterval;
+            }
+            long times = delayInterval.millis() / baseInterval.millis();
+            assertThat((double) times, lessThanOrEqualTo(Math.pow(2, n)));
+        }
+        assertThat(longestDelay, greaterThan(baseInterval));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/InSyncAllocationIdTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/InSyncAllocationIdTests.java
@@ -58,7 +58,8 @@ public class InSyncAllocationIdTests extends ESAllocationTestCase {
     @Before
     public void setupAllocationService() {
         allocation = createAllocationService();
-        failedClusterStateTaskExecutor = new ShardStateAction.ShardFailedClusterStateTaskExecutor(allocation, null, logger);
+        failedClusterStateTaskExecutor = new ShardStateAction.ShardFailedClusterStateTaskExecutor(allocation, null,
+            AllocationRetryBackoffPolicy.noBackOffPolicy(), logger);
     }
 
     public void testInSyncAllocationIdsUpdated() {
@@ -164,7 +165,8 @@ public class InSyncAllocationIdTests extends ESAllocationTestCase {
         logger.info("fail replica (for which there is no shard routing in the CS anymore)");
         assertNull(clusterState.getRoutingNodes().getByAllocationId(replicaShard.shardId(), replicaShard.allocationId().getId()));
         ShardStateAction.ShardFailedClusterStateTaskExecutor failedClusterStateTaskExecutor =
-            new ShardStateAction.ShardFailedClusterStateTaskExecutor(allocation, null, logger);
+            new ShardStateAction.ShardFailedClusterStateTaskExecutor(allocation, null,
+                AllocationRetryBackoffPolicy.noBackOffPolicy(), logger);
         long primaryTerm = clusterState.metaData().index("test").primaryTerm(0);
         clusterState = failedClusterStateTaskExecutor.execute(clusterState, Arrays.asList(
                 new ShardEntry(shardRoutingTable.shardId(), replicaShard.allocationId().getId(), primaryTerm, "dummy", null))

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -644,6 +644,15 @@ public class SettingTests extends ESTestCase {
         assertEquals(1, integerSetting.get(Settings.EMPTY).intValue());
     }
 
+    public void testDefaultFunctionInt() throws Exception {
+        Setting<Integer> bar = Setting.intSetting("bar", 100);
+        Setting<Integer> foo = Setting.intSetting("foo", bar::get, 0);
+        assertThat(foo.get(Settings.EMPTY), equalTo(100));
+        assertThat(foo.get(Settings.builder().put("foo", 1).build()), equalTo(1));
+        assertThat(foo.get(Settings.builder().put("bar", 2).build()), equalTo(2));
+        assertThat(foo.get(Settings.builder().put("foo",10).put("bar", 20).build()), equalTo(10));
+    }
+
     /**
      * Only one single scope can be added to any setting
      */

--- a/core/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/core/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -57,6 +57,7 @@ import org.elasticsearch.cluster.metadata.MetaDataIndexUpgradeService;
 import org.elasticsearch.cluster.metadata.MetaDataUpdateSettingsService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.AllocationRetryBackoffPolicy;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.RandomAllocationDeciderTests;
@@ -125,7 +126,8 @@ public class ClusterStateChanges extends AbstractComponent {
                 new RandomAllocationDeciderTests.RandomAllocationDecider(getRandom())))),
             new TestGatewayAllocator(), new BalancedShardsAllocator(settings),
             EmptyClusterInfoService.INSTANCE);
-        shardFailedClusterStateTaskExecutor = new ShardStateAction.ShardFailedClusterStateTaskExecutor(allocationService, null, logger);
+        shardFailedClusterStateTaskExecutor = new ShardStateAction.ShardFailedClusterStateTaskExecutor(allocationService, null,
+            AllocationRetryBackoffPolicy.noBackOffPolicy(), logger);
         shardStartedClusterStateTaskExecutor = new ShardStateAction.ShardStartedClusterStateTaskExecutor(allocationService, logger);
         ActionFilters actionFilters = new ActionFilters(Collections.emptySet());
         IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(settings);

--- a/docs/reference/cluster/reroute.asciidoc
+++ b/docs/reference/cluster/reroute.asciidoc
@@ -112,7 +112,7 @@ are available:
 === Retry failed shards
 
 The cluster will attempt to allocate a shard a maximum of
-`index.allocation.max_retries` times in a row (defaults to `5`), before giving
+`index.allocation.max_retries` (defaults to `1000`) times with some exponential backoff delays between retries, before giving
 up and leaving the shard unallocated. This scenario can be caused by
 structural problems such as having an analyzer which refers to a stopwords
 file which doesn't exist on all nodes.


### PR DESCRIPTION
Previously, a failed allocation was retried in a tight loop that filled
up log files and caused the cluster be unstable. We solved this problem
by limiting the number of retries. However, this solution requires
manual intervention when the environment is adjusted. This PR aims to
reduce user intervention by increasing the number of retries and adding
some exponential backoff delays between retries.

Closes #24530