### PR TITLE
Blacklist Gradle 4.2 and above

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -123,10 +123,17 @@ class BuildPlugin implements Plugin<Project> {
             }
             println "  Random Testing Seed   : ${project.testSeed}"
 
-            // enforce gradle version
-            GradleVersion minGradle = GradleVersion.version('3.3')
-            if (GradleVersion.current() < minGradle) {
+            // enforce Gradle version
+            final GradleVersion currentGradleVersion = GradleVersion.current();
+
+            final GradleVersion minGradle = GradleVersion.version('3.3')
+            if (currentGradleVersion < minGradle) {
                 throw new GradleException("${minGradle} or above is required to build elasticsearch")
+            }
+
+            final GradleVersion maxGradle = GradleVersion.version('4.2')
+            if (currentGradleVersion >= maxGradle) {
+                throw new GradleException("${maxGradle} or above is not compatible with the elasticsearch build")
             }
 
             // enforce Java version


### PR DESCRIPTION
An upstream Gradle change has broken us starting on version 4.2. This commit blacklists these versions until we can either find a workaround, or the upstream issue is addressed.
