### PR TITLE
Introduce templating support to timezone/locale in DateProcessor

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -852,7 +852,7 @@ Here is an example that adds the parsed date to the `timestamp` field based on t
 --------------------------------------------------
 // NOTCONSOLE
 
-The `timezone` and `locale` fields are templated. This means that their values can be
+The `timezone` and `locale` processor parameters are templated. This means that their values can be
 extracted from fields within documents. The example below shows how to extract the locale/timezone
 details from existing fields, `my_timezone` and `my_locale`, in the ingested document that contain
 the timezone and locale values.

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -852,6 +852,30 @@ Here is an example that adds the parsed date to the `timestamp` field based on t
 --------------------------------------------------
 // NOTCONSOLE
 
+The `timezone` and `locale` fields are templated. This means that their values can be
+extracted from fields within documents. The example below shows how to extract the locale/timezone
+details from existing fields, `my_timezone` and `my_locale`, in the ingested document that contain
+the timezone and locale values.
+
+[source,js]
+--------------------------------------------------
+{
+  "description" : "...",
+  "processors" : [
+    {
+      "date" : {
+        "field" : "initial_date",
+        "target_field" : "timestamp",
+        "formats" : ["ISO8601"],
+        "timezone" : "{{ my_timezone }}",
+        "locale" : "{{ my_locale }}"
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// NOTCONSOLE
+
 [[date-index-name-processor]]
 === Date Index Name Processor
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -20,11 +20,14 @@
 package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.TemplateScript;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
@@ -40,14 +43,15 @@ public final class DateProcessor extends AbstractProcessor {
     public static final String TYPE = "date";
     static final String DEFAULT_TARGET_FIELD = "@timestamp";
 
-    private final DateTimeZone timezone;
-    private final Locale locale;
+    private final TemplateScript.Factory timezone;
+    private final TemplateScript.Factory locale;
     private final String field;
     private final String targetField;
     private final List<String> formats;
-    private final List<Function<String, DateTime>> dateParsers;
+    private final List<Function<Map<String, Object>, Function<String, DateTime>>> dateParsers;
 
-    DateProcessor(String tag, DateTimeZone timezone, Locale locale, String field, List<String> formats, String targetField) {
+    DateProcessor(String tag, @Nullable TemplateScript.Factory timezone, @Nullable TemplateScript.Factory locale,
+                  String field, List<String> formats, String targetField) {
         super(tag);
         this.timezone = timezone;
         this.locale = locale;
@@ -57,8 +61,16 @@ public final class DateProcessor extends AbstractProcessor {
         this.dateParsers = new ArrayList<>(this.formats.size());
         for (String format : formats) {
             DateFormat dateFormat = DateFormat.fromString(format);
-            dateParsers.add(dateFormat.getFunction(format, timezone, locale));
+            dateParsers.add((params) -> dateFormat.getFunction(format, newDateTimeZone(params), newLocale(params)));
         }
+    }
+
+    private DateTimeZone newDateTimeZone(Map<String, Object> params) {
+        return timezone == null ? DateTimeZone.UTC : DateTimeZone.forID(timezone.newInstance(params).execute());
+    }
+
+    private Locale newLocale(Map<String, Object> params) {
+        return (locale == null) ? Locale.ROOT : LocaleUtils.parse(locale.newInstance(params).execute());
     }
 
     @Override
@@ -72,9 +84,9 @@ public final class DateProcessor extends AbstractProcessor {
 
         DateTime dateTime = null;
         Exception lastException = null;
-        for (Function<String, DateTime> dateParser : dateParsers) {
+        for (Function<Map<String, Object>, Function<String, DateTime>> dateParser : dateParsers) {
             try {
-                dateTime = dateParser.apply(value);
+                dateTime = dateParser.apply(ingestDocument.getSourceAndMetadata()).apply(value);
             } catch (Exception e) {
                 //try the next parser and keep track of the exceptions
                 lastException = ExceptionsHelper.useOrSuppress(lastException, e);
@@ -93,11 +105,11 @@ public final class DateProcessor extends AbstractProcessor {
         return TYPE;
     }
 
-    DateTimeZone getTimezone() {
+    TemplateScript.Factory getTimezone() {
         return timezone;
     }
 
-    Locale getLocale() {
+    TemplateScript.Factory getLocale() {
         return locale;
     }
 
@@ -115,19 +127,30 @@ public final class DateProcessor extends AbstractProcessor {
 
     public static final class Factory implements Processor.Factory {
 
+        private final ScriptService scriptService;
+
+        public Factory(ScriptService scriptService) {
+            this.scriptService = scriptService;
+        }
+
         public DateProcessor create(Map<String, Processor.Factory> registry, String processorTag,
                                     Map<String, Object> config) throws Exception {
             String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             String targetField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "target_field", DEFAULT_TARGET_FIELD);
             String timezoneString = ConfigurationUtils.readOptionalStringProperty(TYPE, processorTag, config, "timezone");
-            DateTimeZone timezone = timezoneString == null ? DateTimeZone.UTC : DateTimeZone.forID(timezoneString);
+            TemplateScript.Factory compiledTimezoneTemplate = null;
+            if (timezoneString != null) {
+                compiledTimezoneTemplate = ConfigurationUtils.compileTemplate(TYPE, processorTag,
+                    "timezone", timezoneString, scriptService);
+            }
             String localeString = ConfigurationUtils.readOptionalStringProperty(TYPE, processorTag, config, "locale");
-            Locale locale = Locale.ROOT;
+            TemplateScript.Factory compiledLocaleTemplate = null;
             if (localeString != null) {
-                locale = LocaleUtils.parse(localeString);
+                compiledLocaleTemplate = ConfigurationUtils.compileTemplate(TYPE, processorTag,
+                    "locale", localeString, scriptService);
             }
             List<String> formats = ConfigurationUtils.readList(TYPE, processorTag, config, "formats");
-            return new DateProcessor(processorTag, timezone, locale, field, formats, targetField);
+            return new DateProcessor(processorTag, compiledTimezoneTemplate, compiledLocaleTemplate, field, formats, targetField);
         }
     }
 }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/IngestCommonPlugin.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/IngestCommonPlugin.java
@@ -70,7 +70,7 @@ public class IngestCommonPlugin extends Plugin implements ActionPlugin, IngestPl
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
         Map<String, Processor.Factory> processors = new HashMap<>();
-        processors.put(DateProcessor.TYPE, new DateProcessor.Factory());
+        processors.put(DateProcessor.TYPE, new DateProcessor.Factory(parameters.scriptService));
         processors.put(SetProcessor.TYPE, new SetProcessor.Factory(parameters.scriptService));
         processors.put(AppendProcessor.TYPE, new AppendProcessor.Factory(parameters.scriptService));
         processors.put(RenameProcessor.TYPE, new RenameProcessor.Factory());


### PR DESCRIPTION
Sometimes systems like Beats would want to extract the date's timezone and/or locale
from a value in a field of the document. This PR adds support for mustache templating
to extract these values.

Closes #24024.