### PR TITLE
Stats to record how often the ClusterState diff mechanism is used successfully

### DIFF
--- a/core/src/main/java/org/elasticsearch/discovery/DiscoveryStats.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoveryStats.java
@@ -44,7 +44,7 @@ public class DiscoveryStats implements Writeable, ToXContentFragment {
     public DiscoveryStats(StreamInput in) throws IOException {
         queueStats = in.readOptionalWriteable(PendingClusterStateStats::new);
 
-        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+        if (in.getVersion().onOrAfter(Version.V_6_1_0)) {
             publishStats = in.readOptionalWriteable(PublishClusterStateStats::new);
         } else {
             publishStats = null;
@@ -55,7 +55,7 @@ public class DiscoveryStats implements Writeable, ToXContentFragment {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(queueStats);
 
-        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+        if (out.getVersion().onOrAfter(Version.V_6_1_0)) {
             out.writeOptionalWriteable(publishStats);
         }
     }

--- a/core/src/main/java/org/elasticsearch/discovery/DiscoveryStats.java
+++ b/core/src/main/java/org/elasticsearch/discovery/DiscoveryStats.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.discovery;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -26,32 +27,47 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.discovery.zen.PendingClusterStateStats;
+import org.elasticsearch.discovery.zen.PublishClusterStateStats;
 
 import java.io.IOException;
 
 public class DiscoveryStats implements Writeable, ToXContentFragment {
 
-    @Nullable
     private final PendingClusterStateStats queueStats;
+    private final PublishClusterStateStats publishStats;
 
-    public DiscoveryStats(PendingClusterStateStats queueStats) {
+    public DiscoveryStats(PendingClusterStateStats queueStats, PublishClusterStateStats publishStats) {
         this.queueStats = queueStats;
+        this.publishStats = publishStats;
     }
 
     public DiscoveryStats(StreamInput in) throws IOException {
         queueStats = in.readOptionalWriteable(PendingClusterStateStats::new);
+
+        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+            publishStats = in.readOptionalWriteable(PublishClusterStateStats::new);
+        } else {
+            publishStats = null;
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(queueStats);
+
+        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+            out.writeOptionalWriteable(publishStats);
+        }
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.DISCOVERY);
-        if (queueStats != null ){
+        if (queueStats != null) {
             queueStats.toXContent(builder, params);
+        }
+        if (publishStats != null) {
+            publishStats.toXContent(builder, params);
         }
         builder.endObject();
         return builder;
@@ -63,5 +79,9 @@ public class DiscoveryStats implements Writeable, ToXContentFragment {
 
     public PendingClusterStateStats getQueueStats() {
         return queueStats;
+    }
+
+    public PublishClusterStateStats getPublishStats() {
+        return publishStats;
     }
 }

--- a/core/src/main/java/org/elasticsearch/discovery/single/SingleNodeDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/single/SingleNodeDiscovery.java
@@ -21,7 +21,6 @@ package org.elasticsearch.discovery.single;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.block.ClusterBlocks;
@@ -34,6 +33,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.DiscoveryStats;
 import org.elasticsearch.discovery.zen.PendingClusterStateStats;
+import org.elasticsearch.discovery.zen.PublishClusterStateStats;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -94,7 +94,7 @@ public class SingleNodeDiscovery extends AbstractLifecycleComponent implements D
 
     @Override
     public DiscoveryStats stats() {
-        return new DiscoveryStats((PendingClusterStateStats) null);
+        return new DiscoveryStats(null, null);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateStats.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/PublishClusterStateStats.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.discovery.zen;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Class encapsulating stats about the PublishClusterStateAction
+ */
+public class PublishClusterStateStats implements Writeable, ToXContentObject {
+
+    private final long fullClusterStateReceivedCount;
+    private final long incompatibleClusterStateDiffReceivedCount;
+    private final long compatibleClusterStateDiffReceivedCount;
+
+    /**
+     * @param fullClusterStateReceivedCount the number of times this node has received a full copy of the cluster state from the master.
+     * @param incompatibleClusterStateDiffReceivedCount the number of times this node has received a cluster-state diff from the master.
+     * @param compatibleClusterStateDiffReceivedCount the number of times that received cluster-state diffs were compatible with
+     */
+    public PublishClusterStateStats(long fullClusterStateReceivedCount,
+                                    long incompatibleClusterStateDiffReceivedCount,
+                                    long compatibleClusterStateDiffReceivedCount) {
+        this.fullClusterStateReceivedCount = fullClusterStateReceivedCount;
+        this.incompatibleClusterStateDiffReceivedCount = incompatibleClusterStateDiffReceivedCount;
+        this.compatibleClusterStateDiffReceivedCount = compatibleClusterStateDiffReceivedCount;
+    }
+
+    public PublishClusterStateStats(StreamInput in) throws IOException {
+        fullClusterStateReceivedCount = in.readVLong();
+        incompatibleClusterStateDiffReceivedCount = in.readVLong();
+        compatibleClusterStateDiffReceivedCount = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(fullClusterStateReceivedCount);
+        out.writeVLong(incompatibleClusterStateDiffReceivedCount);
+        out.writeVLong(compatibleClusterStateDiffReceivedCount);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("published_cluster_states");
+        {
+            builder.field("full_states", fullClusterStateReceivedCount);
+            builder.field("incompatible_diffs", incompatibleClusterStateDiffReceivedCount);
+            builder.field("compatible_diffs", compatibleClusterStateDiffReceivedCount);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    long getFullClusterStateReceivedCount() { return fullClusterStateReceivedCount; }
+
+    long getIncompatibleClusterStateDiffReceivedCount() { return incompatibleClusterStateDiffReceivedCount; }
+
+    long getCompatibleClusterStateDiffReceivedCount() { return compatibleClusterStateDiffReceivedCount; }
+
+    @Override
+    public String toString() {
+        return "PublishClusterStateStats(full=" + fullClusterStateReceivedCount
+            + ", incompatible=" + incompatibleClusterStateDiffReceivedCount
+            + ", compatible=" + compatibleClusterStateDiffReceivedCount
+            + ")";
+    }
+}

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -412,8 +412,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
 
     @Override
     public DiscoveryStats stats() {
-        PendingClusterStateStats queueStats = pendingStatesQueue.stats();
-        return new DiscoveryStats(queueStats);
+        return new DiscoveryStats(pendingStatesQueue.stats(), publishClusterState.stats());
     }
 
     public DiscoverySettings getDiscoverySettings() {

--- a/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.discovery.DiscoveryStats;
 import org.elasticsearch.discovery.zen.PendingClusterStateStats;
+import org.elasticsearch.discovery.zen.PublishClusterStateStats;
 import org.elasticsearch.http.HttpStats;
 import org.elasticsearch.indices.breaker.AllCircuitBreakerStats;
 import org.elasticsearch.indices.breaker.CircuitBreakerStats;
@@ -410,8 +411,18 @@ public class NodeStatsTests extends ESTestCase {
             allCircuitBreakerStats = new AllCircuitBreakerStats(circuitBreakerStatsArray);
         }
         ScriptStats scriptStats = frequently() ? new ScriptStats(randomNonNegativeLong(), randomNonNegativeLong()) : null;
-        DiscoveryStats discoveryStats = frequently() ? new DiscoveryStats(randomBoolean() ? new PendingClusterStateStats(randomInt(),
-                randomInt(), randomInt()) : null) : null;
+        DiscoveryStats discoveryStats = frequently()
+            ? new DiscoveryStats(
+                randomBoolean()
+                ? new PendingClusterStateStats(randomInt(), randomInt(), randomInt())
+                : null,
+                randomBoolean()
+                ? new PublishClusterStateStats(
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong(),
+                    randomNonNegativeLong())
+                : null)
+            : null;
         IngestStats ingestStats = null;
         if (frequently()) {
             IngestStats.Stats totalStats = new IngestStats.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(),

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryIT.java
@@ -47,7 +47,6 @@ import org.elasticsearch.transport.EmptyTransportResponseHandler;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
-import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -255,6 +254,11 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
                 "      \"total\" : 0,\n" +
                 "      \"pending\" : 0,\n" +
                 "      \"committed\" : 0\n" +
+                "    },\n" +
+                "    \"published_cluster_states\" : {\n" +
+                "      \"full_states\" : 0,\n" +
+                "      \"incompatible_diffs\" : 0,\n" +
+                "      \"compatible_diffs\" : 0\n" +
                 "    }\n" +
                 "  }\n" +
                 "}";
@@ -274,6 +278,11 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
         assertThat(stats.getQueueStats().getTotal(), equalTo(0));
         assertThat(stats.getQueueStats().getCommitted(), equalTo(0));
         assertThat(stats.getQueueStats().getPending(), equalTo(0));
+
+        assertThat(stats.getPublishStats(), notNullValue());
+        assertThat(stats.getPublishStats().getFullClusterStateReceivedCount(), equalTo(0L));
+        assertThat(stats.getPublishStats().getIncompatibleClusterStateDiffReceivedCount(), equalTo(0L));
+        assertThat(stats.getPublishStats().getCompatibleClusterStateDiffReceivedCount(), equalTo(0L));
 
         XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
         builder.startObject();

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
@@ -1,5 +1,8 @@
 ---
 "Discovery stats":
+  - skip:
+      version:     " - 6.99.99"
+      reason:      "published_cluster_states_received is not (yet) in 6.x"
   - do:
       cluster.state: {}
 
@@ -15,6 +18,11 @@
   - is_true: nodes.$master.name
   - is_false: nodes.$master.jvm
   - is_true:  nodes.$master.discovery
+  - is_true:  nodes.$master.discovery.cluster_state_queue
+  - is_true:  nodes.$master.discovery.published_cluster_states
+  - gte: { nodes.$master.discovery.published_cluster_states.full_states: 0 }
+  - gte: { nodes.$master.discovery.published_cluster_states.incompatible_diffs: 0 }
+  - gte: { nodes.$master.discovery.published_cluster_states.compatible_diffs: 0 }
   - is_true:  nodes.$master.roles
 
   - do:
@@ -26,4 +34,9 @@
   - is_false: nodes.$master.name
   - is_false: nodes.$master.jvm
   - is_true:  nodes.$master.discovery
+  - is_true:  nodes.$master.discovery.cluster_state_queue
+  - is_true:  nodes.$master.discovery.published_cluster_states
+  - gte: { nodes.$master.discovery.published_cluster_states.full_states: 0 }
+  - gte: { nodes.$master.discovery.published_cluster_states.incompatible_diffs: 0 }
+  - gte: { nodes.$master.discovery.published_cluster_states.compatible_diffs: 0 }
   - is_false:  nodes.$master.roles

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
@@ -1,5 +1,8 @@
 ---
 "Discovery stats":
+  - skip:
+      version:     " - 6.0.99"
+      reason:      "published_cluster_states_received is not in 6.0.x"
   - do:
       cluster.state: {}
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/nodes.stats/30_discovery.yml
@@ -1,8 +1,5 @@
 ---
 "Discovery stats":
-  - skip:
-      version:     " - 6.99.99"
-      reason:      "published_cluster_states_received is not (yet) in 6.x"
   - do:
       cluster.state: {}
 


### PR DESCRIPTION
It's believed that using diffs obsoletes the other mechanism for reusing the bits of the ClusterState that didn't change between updates, but in fact we don't know for sure how often the diff mechanism works successfully. The stats collected here will tell us.

Backport of #26973 to 6.x