### PR TITLE
Added build() to low level client creation passed to RestHighLevelClient

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MainDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MainDocumentationIT.java
@@ -73,7 +73,7 @@ public class MainDocumentationIT extends ESRestHighLevelClientTestCase {
         RestHighLevelClient client = new RestHighLevelClient(
                 RestClient.builder(
                         new HttpHost("localhost", 9200, "http"),
-                        new HttpHost("localhost", 9201, "http")));
+                        new HttpHost("localhost", 9201, "http")).build());
         //end::rest-high-level-client-init
 
         //tag::rest-high-level-client-close


### PR DESCRIPTION
Changed the documentation from:

```
        RestHighLevelClient client = new RestHighLevelClient(
                RestClient.builder(
                        new HttpHost("localhost", 9200, "http"),
                        new HttpHost("localhost", 9201, "http")));
```

To:

```
        RestHighLevelClient client = new RestHighLevelClient(
                RestClient.builder(
                        new HttpHost("localhost", 9200, "http"),
                        new HttpHost("localhost", 9201, "http")).build());
```
