### PR TITLE
Apply missing request options to the expand phase

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/core/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -124,16 +124,12 @@ final class ExpandSearchPhase extends SearchPhase {
             .types(orig.types())
             .source(sourceBuilder)
             .indicesOptions(orig.indicesOptions())
-            .requestCache(orig.requestCache());
-        groupRequest.setMaxConcurrentShardRequests(orig.getMaxConcurrentShardRequests());
-        if (orig.preference() != null) {
-            groupRequest.preference(orig.preference());
-        }
-        if (orig.routing() != null) {
-            groupRequest.routing(orig.routing());
-        }
-        if (orig.searchType() != null) {
-            groupRequest.searchType(orig.searchType());
+            .requestCache(orig.requestCache())
+            .preference(orig.preference())
+            .routing(orig.routing())
+            .searchType(orig.searchType());
+        if (orig.isMaxConcurrentShardRequestsSet()) {
+            groupRequest.setMaxConcurrentShardRequests(orig.getMaxConcurrentShardRequests());
         }
         return groupRequest;
     }

--- a/core/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
@@ -225,6 +226,45 @@ public class ExpandSearchPhaseTests extends ESTestCase {
         };
         mockSearchPhaseContext.getRequest().source(new SearchSourceBuilder()
             .collapse(new CollapseBuilder("someField").setInnerHits(new InnerHitBuilder().setName("foobarbaz"))));
+
+        SearchHits hits = new SearchHits(new SearchHit[0], 1, 1.0f);
+        InternalSearchResponse internalSearchResponse = new InternalSearchResponse(hits, null, null, null, false, null, 1);
+        AtomicReference<SearchResponse> reference = new AtomicReference<>();
+        ExpandSearchPhase phase = new ExpandSearchPhase(mockSearchPhaseContext, internalSearchResponse, r ->
+            new SearchPhase("test") {
+                @Override
+                public void run() throws IOException {
+                    reference.set(mockSearchPhaseContext.buildSearchResponse(r, null));
+                }
+            }
+        );
+        phase.run();
+        mockSearchPhaseContext.assertNoFailure();
+        assertNotNull(reference.get());
+        assertEquals(1, mockSearchPhaseContext.phasesExecuted.get());
+    }
+
+    public void testExpandRequestOptions() throws IOException {
+        MockSearchPhaseContext mockSearchPhaseContext = new MockSearchPhaseContext(1);
+        mockSearchPhaseContext.searchTransport = new SearchTransportService(
+            Settings.builder().put("search.remote.connect", false).build(), null, null) {
+
+            @Override
+            void sendExecuteMultiSearch(MultiSearchRequest request, SearchTask task, ActionListener<MultiSearchResponse> listener) {
+                final QueryBuilder postFilter = QueryBuilders.existsQuery("foo");
+                assertTrue(request.requests().stream().allMatch((r) -> "foo".equals(r.preference())));
+                assertTrue(request.requests().stream().allMatch((r) -> "baz".equals(r.routing())));
+                assertTrue(request.requests().stream().allMatch((r) -> postFilter.equals(r.source().postFilter())));
+            }
+        };
+        mockSearchPhaseContext.getRequest().source(new SearchSourceBuilder()
+            .collapse(
+                new CollapseBuilder("someField")
+                    .setInnerHits(new InnerHitBuilder().setName("foobarbaz"))
+            )
+            .postFilter(QueryBuilders.existsQuery("foo")))
+            .preference("foobar")
+            .routing("baz");
 
         SearchHits hits = new SearchHits(new SearchHit[0], 1, 1.0f);
         InternalSearchResponse internalSearchResponse = new InternalSearchResponse(hits, null, null, null, false, null, 1);


### PR DESCRIPTION
This change adds some missing options to the expand query that builds the inner hits for field collapsing.
The following options are now applied to the inner_hits query:
 * post_filters
 * preferences
 * routing

Closes #27079
Closes #26649