### PR TITLE
Fix Laplace scorer to multiply by alpha (and not add)

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/CandidateScorer.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/CandidateScorer.java
@@ -93,7 +93,7 @@ final class CandidateScorer {
     private void updateTop(CandidateSet[] candidates, Candidate[] path, PriorityQueue<Correction> corrections, double cutoffScore, double score)
             throws IOException {
         score = Math.exp(score);
-        assert Math.abs(score - score(path, candidates)) < 0.00001;
+        assert Math.abs(score - score(path, candidates)) < 0.00001 : "cur_score=" + score + ", path_score=" + score(path,candidates);
         if (score > cutoffScore) {
             if (corrections.size() < maxNumCorrections) {
                 Candidate[] c = new Candidate[candidates.length];

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/LaplaceScorer.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/LaplaceScorer.java
@@ -39,6 +39,11 @@ final class LaplaceScorer extends WordScorer {
     }
 
     @Override
+    protected double scoreUnigram(Candidate word) throws IOException {
+        return (alpha + frequency(word.term)) / (vocabluarySize + alpha * numTerms);
+    }
+
+    @Override
     protected double scoreBigram(Candidate word, Candidate w_1) throws IOException {
         join(separator, spare, w_1.term, word.term);
         return (alpha + frequency(spare.get())) / (w_1.frequency + alpha * numTerms);

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/LaplaceScorer.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/LaplaceScorer.java
@@ -41,7 +41,7 @@ final class LaplaceScorer extends WordScorer {
     @Override
     protected double scoreBigram(Candidate word, Candidate w_1) throws IOException {
         join(separator, spare, w_1.term, word.term);
-        return (alpha + frequency(spare.get())) / (alpha +  w_1.frequency + vocabluarySize);
+        return (alpha + frequency(spare.get())) / (w_1.frequency + alpha * numTerms);
     }
 
     @Override
@@ -49,7 +49,7 @@ final class LaplaceScorer extends WordScorer {
         join(separator, spare, w_2.term, w_1.term, word.term);
         long trigramCount = frequency(spare.get());
         join(separator, spare, w_1.term, word.term);
-        return (alpha + trigramCount) / (alpha  +  frequency(spare.get()) + vocabluarySize);
+        return (alpha + trigramCount) / (frequency(spare.get()) + alpha * numTerms);
     }
 
 

--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -126,7 +126,7 @@ The response contains suggestions scored by the most likely spell correction fir
         "options" : [ {
           "text" : "nobel prize",
           "highlighted": "<em>nobel</em> prize",
-          "score" : 0.5962314
+          "score" : 0.48614594
         }]
       }
     ]


### PR DESCRIPTION
Laplace scorer seems to incorrectly apply `alpha`. According to Wikipedia https://en.wikipedia.org/wiki/Additive_smoothing, the formula should be `(C_i + alpha) / (N + alpha * V)`, where in our case `C_i` denotes the frequency of the term, and `N` and `V` denote the `sum_ttf` and `num_terms` respectively.

I've also fixed the implementation to add `numTerms` and not `vocabSize` per the additive smoothing formula (`numTerms == num_terms` and `vocabSize == sum_ttf`). This is also supported by other research papers I find on the web -- you should add one per unique term, and not one (or alpha) per term occurrence.

In that regard, shouldn't `LaplaceScorer` also override `scoreUnigram`? Currently it inherits the implementation from `WordScorer` which implements add-one smoothing, but in Laplace, seems that we should implement add-k.