### PR TITLE
wrong link target for datatype murmur3

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -34,7 +34,7 @@ string::        <<text,`text`>> and <<keyword,`keyword`>>
 <<search-suggesters-completion,Completion datatype>>::
                     `completion` to provide auto-complete suggestions
 <<token-count>>::   `token_count` to count the number of tokens in a string
-{plugins}/mapper-size.html[`mapper-murmur3`]:: `murmur3` to compute hashes of values at index-time and store them in the index
+{plugins}/mapper-murmur3.html[`mapper-murmur3`]:: `murmur3` to compute hashes of values at index-time and store them in the index
 
 <<percolator>>::    Accepts queries from the query-dsl
 


### PR DESCRIPTION
docu for specialised datatype "murmur3" should link to "mapper-murmur3.html" and not to "mapper-size.html"
