### PR TITLE
Fix inconsistencies in the rest api specs for `tasks`

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -12,7 +12,7 @@
         }
       },
       "params": {
-        "node_id": {
+        "nodes": {
           "type": "list",
           "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"
         },
@@ -24,7 +24,7 @@
           "type": "string",
           "description": "Cancel tasks with specified parent node."
         },
-        "parent_task": {
+        "parent_task_id": {
           "type" : "string",
           "description" : "Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all."
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -7,7 +7,7 @@
       "paths": ["/_tasks"],
       "parts": {},
       "params": {
-        "node_id": {
+        "nodes": {
           "type": "list",
           "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"
         },
@@ -23,7 +23,7 @@
           "type": "string",
           "description": "Return tasks with specified parent node."
         },
-        "parent_task": {
+        "parent_task_id": {
           "type" : "string",
           "description" : "Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all."
         },


### PR DESCRIPTION
Modify parameters names to bring the `tasks` `rest-api-spec`up to date with the code base.

Fixes #27124