### PR TITLE
[Tests] Relax allowed delta in extended_stats aggregation

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
@@ -82,7 +82,7 @@ public class InternalExtendedStatsTests extends InternalAggregationTestCase<Inte
         assertEquals(expectedCount, reduced.getCount());
         // The order in which you add double values in java can give different results. The difference can
         // be larger for large sum values, so we make the delta in the assertion depend on the values magnitude
-        assertEquals(expectedSum, reduced.getSum(), Math.abs(expectedSum) * 1e-12);
+        assertEquals(expectedSum, reduced.getSum(), Math.abs(expectedSum) * 1e-11);
         assertEquals(expectedMin, reduced.getMin(), 0d);
         assertEquals(expectedMax, reduced.getMax(), 0d);
         // summing squared values, see reason for delta above


### PR DESCRIPTION
The order in which double values are added in java can give different results
for the sum, so we need to allow a certain delta in the test assertions. The
current value was still a bit too low, which manifested itself in occasional
test failures.

e.g. the CI failure that triggered this PR:
https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+periodic/4835/testReport/junit/org.elasticsearch.search.aggregations.metrics/InternalExtendedStatsTests/testReduceRandom/