### PR TITLE
Fix rare failure in docs tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/NotEqualMessageBuilder.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/NotEqualMessageBuilder.java
@@ -153,8 +153,12 @@ public class NotEqualMessageBuilder {
         String expectedString = Objects.toString(expected);
         String actualString = Objects.toString(actual);
         if (expectedString.equals(actualString)) {
-            expectedString += " (" + (expected == null ? "null" : expected.getClass().getName()) + ")";
-            actualString += " (" + (actual == null ? "null" : actual.getClass().getName()) + ")";
+            if (expected != null) {
+                expectedString += " (" + expected.getClass().getName() + ")";
+            }
+            if (actual != null) {
+                actualString += " (" + actual.getClass().getName() + ")";
+            }
         }
         field(field, "expected [" + expectedString + "] but was [" + actualString + "]");
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/NotEqualMessageBuilder.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/NotEqualMessageBuilder.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.TreeMap;
 
 /**
- * Builds a message describing how two sets of values are unequal. 
+ * Builds a message describing how two sets of values are unequal.
  */
 public class NotEqualMessageBuilder {
     private final StringBuilder message;
@@ -150,7 +150,13 @@ public class NotEqualMessageBuilder {
             field(field, "same [" + expected + "]");
             return;
         }
-        field(field, "expected [" + expected + "] but was [" + actual + "]");
+        String expectedString = expected.toString();
+        String actualString = actual.toString();
+        if (expectedString.equals(actualString)) {
+            expectedString += " (" + expected.getClass().getName() + ")";
+            actualString += " (" + actual.getClass().getName() + ")";
+        }
+        field(field, "expected [" + expectedString + "] but was [" + actualString + "]");
     }
 
     private void indent() {

--- a/test/framework/src/main/java/org/elasticsearch/test/NotEqualMessageBuilder.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/NotEqualMessageBuilder.java
@@ -150,11 +150,11 @@ public class NotEqualMessageBuilder {
             field(field, "same [" + expected + "]");
             return;
         }
-        String expectedString = expected.toString();
-        String actualString = actual.toString();
+        String expectedString = Objects.toString(expected);
+        String actualString = Objects.toString(actual);
         if (expectedString.equals(actualString)) {
-            expectedString += " (" + expected.getClass().getName() + ")";
-            actualString += " (" + actual.getClass().getName() + ")";
+            expectedString += " (" + (expected == null ? "null" : expected.getClass().getName()) + ")";
+            actualString += " (" + (actual == null ? "null" : actual.getClass().getName()) + ")";
         }
         field(field, "expected [" + expectedString + "] but was [" + actualString + "]");
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/MatchAssertion.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/MatchAssertion.java
@@ -91,7 +91,7 @@ public class MatchAssertion extends Assertion {
     }
 
     /**
-     * Like {@link Map#equals(Object)} except it treats {@link Float}s as {@link Double}s.
+     * Like {@link Object#equals(Object)} except it treats {@link Float}s as {@link Double}s.
      */
     private boolean checkEquals(Object actualValue, Object expectedValue) {
         if (expectedValue instanceof Map) {
@@ -104,9 +104,18 @@ public class MatchAssertion extends Assertion {
                 return false;
             }
             for (Map.Entry<?, ?> e : expectedMap.entrySet()) {
-                Object a = actualMap.get(e.getKey());
-                if (a == null || false == checkEquals(a, e.getValue())) {
+                if (false == actualMap.containsKey(e.getKey())) {
                     return false;
+                }
+                Object a = actualMap.get(e.getKey());
+                if (e.getValue() == null) {
+                    if (a != null) {
+                        return false;
+                    }
+                } else {
+                    if (false == checkEquals(a, e.getValue())) {
+                        return false;
+                    }
                 }
             }
             return true;


### PR DESCRIPTION
Rarely, we'll hit a situation where our randomization uses cbor to serialize a request made in our docs tests *and* that docs test sends a `float` instead of a `double`. cbor, unlike json or yaml, preserves the `float` as a `float`, instead of converting it to a `double` when serializing it and deserializing it. In this case our docs tests were failing because we compared the `float` to the `double`, and, because they are a different type, declared them not equal. But the failure message was maddeningly useless: `expected [1.0] but was [1.0]`. This fixes both the comparison and the error message.

For the comparison if we get a `float` back from the other end downcast our expected value to a `float` and compare. If we get a `double` we just compare.

For the error message we now output the more useful `expected [1.0 (java.lang.Double)] but was [1.0 (java.lang.Float)]`, but only when the string representation of the values differ. Otherwise we stick with the normal `expected [1.0] but was [2.0]`.