### PR TITLE
`rest-api-spec` : setting the body to required to reflect the code base

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
@@ -22,7 +22,8 @@
       }
     },
     "body": {
-      "description": "The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart)."
+      "description": "The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart).",
+      "required" : true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -7,8 +7,8 @@
       "paths": ["/_search/template", "/{index}/_search/template", "/{index}/{type}/_search/template"],
       "parts": {
         "index": {
-         "type" : "list",
-         "description" : "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"
+          "type" : "list",
+          "description" : "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"
         },
         "type": {
           "type" : "list",
@@ -17,18 +17,18 @@
       },
       "params" : {
         "ignore_unavailable": {
-            "type" : "boolean",
-            "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+          "type" : "boolean",
+          "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
         },
         "allow_no_indices": {
-            "type" : "boolean",
-            "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+          "type" : "boolean",
+          "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
         },
         "expand_wildcards": {
-            "type" : "enum",
-            "options" : ["open","closed","none","all"],
-            "default" : "open",
-            "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+          "type" : "enum",
+          "options" : ["open","closed","none","all"],
+          "default" : "open",
+          "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
         },
         "preference": {
           "type" : "string",
@@ -62,7 +62,8 @@
       }
     },
     "body": {
-      "description": "The search definition template and its params"
+      "description": "The search definition template and its params",
+      "required" : true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -88,7 +88,8 @@
       }
     },
     "body": {
-      "description": "The request definition using either `script` or partial `doc`"
+      "description": "The request definition requires either `script` or partial `doc`",
+      "required": true
     }
   }
 }


### PR DESCRIPTION
Setting the `body` as `required` when needed in the `rest-spec-api`s.
Using consistent indentation.

Relates to #27158