### PR TITLE
Allow ip_range to accept CIDR notation

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldMapperTests.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.index.mapper;
+
+import java.util.Collection;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.junit.Before;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class IpRangeFieldMapperTests extends ESSingleNodeTestCase {
+
+    private IndexService indexService;
+    private DocumentMapperParser parser;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(MapperExtrasPlugin.class);
+    }
+
+    @Before
+    public void setup() {
+        indexService = createIndex("test");
+        parser = indexService.mapperService().documentMapperParser();
+    }
+
+    public void testStoreCidr() throws Exception {
+        XContentBuilder mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
+            .startObject("properties").startObject("field").field("type", "ip_range")
+            .field("store", true);
+        mapping = mapping.endObject().endObject().endObject().endObject();
+        DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping.string()));
+        assertEquals(mapping.string(), mapper.mappingSource().toString());
+        ParsedDocument doc =
+            mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
+                    .startObject()
+                    .field("field", "192.168.0.0/16")
+                    .endObject().bytes(),
+                XContentType.JSON
+            ));
+        IndexableField[] fields = doc.rootDoc().getFields("field");
+        assertEquals(3, fields.length);
+        IndexableField dvField = fields[0];
+        assertEquals(DocValuesType.BINARY, dvField.fieldType().docValuesType());
+        IndexableField pointField = fields[1];
+        assertEquals(2, pointField.fieldType().pointDimensionCount());
+        IndexableField storedField = fields[2];
+        assertTrue(storedField.fieldType().stored());
+        String strVal = InetAddresses.toAddrString(InetAddresses.forString("192.168.0.0")) + " : " +
+            InetAddresses.toAddrString(InetAddresses.forString("192.168.255.255"));
+        assertThat(storedField.stringValue(), containsString(strVal));
+    }
+}


### PR DESCRIPTION
My attempt at #26260 : 

* Used the same approach as in `org.elasticsearch.search.aggregations.bucket.range.IpRangeAggregationBuilder.Range#Range(java.lang.String, java.lang.String)` for the parsing (with some minor simplifications that could be made here by fixing the include/exclude behaviour of the boundaries)
* added a new test class `IpRangeFieldMapperTests` since there were only (at least as far as I could find) generic test classes that covered all `Range` types in a loop that applied here