### PR TITLE
Misleading incorrect for in loop in painless documentation.

### DIFF
--- a/docs/painless/painless-syntax.asciidoc
+++ b/docs/painless/painless-syntax.asciidoc
@@ -14,7 +14,7 @@ Painless also supports the `for in` syntax from Groovy:
 
 [source,painless]
 ---------------------------------------------------------
-for (item : list) {
+for (def item : list) {
   ...
 }
 ---------------------------------------------------------


### PR DESCRIPTION
Just small error in documentation. Without it you get weird and confusing `invalid sequence of tokens near [':'].` error. On [this](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/modules-scripting-painless-syntax.html#painless-control-flow) page it is correct.