### PR TITLE
Reinstate recommendation for ≥ 3 master-eligible nodes.

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -158,7 +158,7 @@ discovery.zen.minimum_master_nodes: 2 <1>
 
 Clusters should have at least three master-eligible nodes, with
 `minimum_master_nodes` set accordingly, in order to be able to remain available
-when one of the master-eligible nodes fail. A <<rolling-upgrades,rolling
+when one of the master-eligible nodes fails. A <<rolling-upgrades,rolling
 upgrade>>, performed without any downtime, also requires at least three
 master-eligible nodes to avoid the possibility of data loss if a network split
 occurs while the upgrade is in progress.

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -156,11 +156,12 @@ discovery.zen.minimum_master_nodes: 2 <1>
 ----------------------------
 <1> Defaults to `1`.
 
-Critical clusters must have at least three master-eligible nodes, with
+Clusters should have at least three master-eligible nodes, with
 `minimum_master_nodes` set accordingly, in order to remain available even when
-a node fails. A <<rolling-upgrades,rolling upgrade>> also requires at least
-three master-eligible nodes to avoid the possibility of data loss if a network
-split occurs while the upgrade is in progress.
+a node fails. A <<rolling-upgrades,rolling upgrade>>, performed without any
+downtime, also requires at least three master-eligible nodes to avoid the
+possibility of data loss if a network split occurs while the upgrade is in
+progress.
 
 This setting can also be changed dynamically on a live cluster with the
 <<cluster-update-settings,cluster update settings API>>:

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -157,11 +157,11 @@ discovery.zen.minimum_master_nodes: 2 <1>
 <1> Defaults to `1`.
 
 Clusters should have at least three master-eligible nodes, with
-`minimum_master_nodes` set accordingly, in order to remain available even when
-a node fails. A <<rolling-upgrades,rolling upgrade>>, performed without any
-downtime, also requires at least three master-eligible nodes to avoid the
-possibility of data loss if a network split occurs while the upgrade is in
-progress.
+`minimum_master_nodes` set accordingly, in order to be able to remain available
+when one of the master-eligible nodes fail. A <<rolling-upgrades,rolling
+upgrade>>, performed without any downtime, also requires at least three
+master-eligible nodes to avoid the possibility of data loss if a network split
+occurs while the upgrade is in progress.
 
 This setting can also be changed dynamically on a live cluster with the
 <<cluster-update-settings,cluster update settings API>>:

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -156,12 +156,12 @@ discovery.zen.minimum_master_nodes: 2 <1>
 ----------------------------
 <1> Defaults to `1`.
 
-Clusters should have at least three master-eligible nodes, with
-`minimum_master_nodes` set accordingly, in order to be able to remain available
-when one of the master-eligible nodes fails. A <<rolling-upgrades,rolling
-upgrade>>, performed without any downtime, also requires at least three
-master-eligible nodes to avoid the possibility of data loss if a network split
-occurs while the upgrade is in progress.
+To be able to remain available when one of the master-eligible nodes fails,
+clusters should have at least three master-eligible nodes, with
+`minimum_master_nodes` set accordingly. A <<rolling-upgrades,rolling upgrade>>,
+performed without any downtime, also requires at least three master-eligible
+nodes to avoid the possibility of data loss if a network split occurs while the
+upgrade is in progress.
 
 This setting can also be changed dynamically on a live cluster with the
 <<cluster-update-settings,cluster update settings API>>:

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -156,6 +156,12 @@ discovery.zen.minimum_master_nodes: 2 <1>
 ----------------------------
 <1> Defaults to `1`.
 
+Critical clusters must have at least three master-eligible nodes, with
+`minimum_master_nodes` set accordingly, in order to remain available even when
+a node fails. A <<rolling-upgrades,rolling upgrade>> also requires at least
+three master-eligible nodes to avoid the possibility of data loss if a network
+split occurs while the upgrade is in progress.
+
 This setting can also be changed dynamically on a live cluster with the
 <<cluster-update-settings,cluster update settings API>>:
 


### PR DESCRIPTION
In the docs for 1.7 ([doc][doc-1.7], [src][src-1.7]) there was a recommendation for at least 3 master-eligible nodes "in critical clusters" but this was lost when that page was updated in 2.0 ([doc][doc-2.0], [src][src-2.0]). I'd like to reinstate this.

[doc-1.7]: https://www.elastic.co/guide/en/elasticsearch/reference/1.7/modules-node.html
[src-1.7]: https://github.com/elastic/elasticsearch/blob/2cbaccb2f2a495923bc64447fe3396e0fc58b3d3/docs/reference/modules/node.asciidoc
[doc-2.0]: https://www.elastic.co/guide/en/elasticsearch/reference/2.0/modules-node.html#split-brain
[src-2.0]: https://github.com/elastic/elasticsearch/blob/4799009ad7ea8f885b6aedc6f62ad61d69e7a40d/docs/reference/modules/node.asciidoc
