### PR TITLE
Fixed rounding of bounds in scaled float comparison

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -256,19 +256,19 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             failIfNotIndexed();
             Long lo = null;
             if (lowerTerm != null) {
-                double dValue = parse(lowerTerm);
+                double dValue = parse(lowerTerm) * scalingFactor;
                 if (includeLower == false) {
                     dValue = Math.nextUp(dValue);
                 }
-                lo = Math.round(Math.ceil(dValue * scalingFactor));
+                lo = Math.round(Math.ceil(dValue));
             }
             Long hi = null;
             if (upperTerm != null) {
-                double dValue = parse(upperTerm);
+                double dValue = parse(upperTerm) * scalingFactor;
                 if (includeUpper == false) {
                     dValue = Math.nextDown(dValue);
                 }
-                hi = Math.round(Math.floor(dValue * scalingFactor));
+                hi = Math.round(Math.floor(dValue));
             }
             Query query = NumberFieldMapper.NumberType.LONG.rangeQuery(name(), lo, hi, true, true, hasDocValues());
             if (boost() != 1f) {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -130,6 +130,16 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
         ft.setScalingFactor(100.0);
         Query scaledFloatQ = ft.rangeQuery(null, 0.1, true, false, null);
         assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(null, 0.1, true, true, null);
+        assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(null, 0.095, true, false, null);
+        assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(null, 0.095, true, true, null);
+        assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(null, 0.105, true, false, null);
+        assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(null, 0.105, true, true, null);
+        assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
     }
 
     public void testRoundsLowerBoundCorrectly() {
@@ -138,6 +148,16 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
         ft.setScalingFactor(100.0);
         Query scaledFloatQ = ft.rangeQuery(-0.1, null, false, true, null);
         assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(-0.1, null, true, true, null);
+        assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(-0.095, null, false, true, null);
+        assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(-0.095, null, true, true, null);
+        assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(-0.105, null, false, true, null);
+        assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
+        scaledFloatQ = ft.rangeQuery(-0.105, null, true, true, null);
+        assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
     }
 
     public void testValueForSearch() {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/ScaledFloatFieldTypeTests.java
@@ -124,6 +124,22 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
         IOUtils.close(reader, dir);
     }
 
+    public void testRoundsUpperBoundCorrectly() {
+        ScaledFloatFieldMapper.ScaledFloatFieldType ft = new ScaledFloatFieldMapper.ScaledFloatFieldType();
+        ft.setName("scaled_float");
+        ft.setScalingFactor(100.0);
+        Query scaledFloatQ = ft.rangeQuery(null, 0.1, true, false, null);
+        assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
+    }
+
+    public void testRoundsLowerBoundCorrectly() {
+        ScaledFloatFieldMapper.ScaledFloatFieldType ft = new ScaledFloatFieldMapper.ScaledFloatFieldType();
+        ft.setName("scaled_float");
+        ft.setScalingFactor(100.0);
+        Query scaledFloatQ = ft.rangeQuery(-0.1, null, false, true, null);
+        assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
+    }
+
     public void testValueForSearch() {
         ScaledFloatFieldMapper.ScaledFloatFieldType ft = new ScaledFloatFieldMapper.ScaledFloatFieldType();
         ft.setName("scaled_float");


### PR DESCRIPTION
This fixes #27189 I think:

* Fixed by switching the order of operations between `nextDown`, `nextUp` and multiplication by the scaling factor to reduce rounding errors. Now the error incurred by `nextUp` and `nextDown` doesn't propagate into the multiplication by the scaling factor, whereas without this change the error incurred when multiplying two `double` can cancel out the `Math.nextDown` step as seen in the example below  
  * Added unit tests for the example in #27189 in which we were hit by 

```java
Math.floor(Math.nextDown(0.1) * 100.0) = 10.0
```

while

```java
Math.floor(Math.nextDown(0.1 * 100.0)) = 9.0
```

