### PR TITLE
Add method to drop bytes from head of a `BigArray`

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
+++ b/core/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
@@ -51,12 +51,7 @@ public enum Recyclers {
      * Return a recycler based on a deque.
      */
     public static <T> Recycler.Factory<T> dequeFactory(final Recycler.C<T> c, final int limit) {
-        return new Recycler.Factory<T>() {
-            @Override
-            public Recycler<T> build() {
-                return deque(c, limit);
-            }
-        };
+        return () -> deque(c, limit);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -456,7 +456,7 @@ public class BigArrays implements Releasable {
         assert oldMemSize == array.ramBytesEstimated(oldSize) :
             "ram bytes used should equal that which was previously estimated: ramBytesUsed=" +
                 oldMemSize + ", ramBytesEstimated=" + array.ramBytesEstimated(oldSize);
-        array.shrink(numberToDrop);
+        array.dropFromHead(numberToDrop);
         long delta = array.ramBytesUsed() - oldMemSize;
         assert delta <= 0 : "shrink should never lead to an increase in array size: ramBytesUsed delta=" + delta;
         adjustBreaker(delta, true);

--- a/core/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.common.util;
 
-import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.RamUsageEstimator;
-
 import java.util.Arrays;
 
 import static org.elasticsearch.common.util.BigArrays.LONG_PAGE_SIZE;
@@ -30,34 +27,28 @@ import static org.elasticsearch.common.util.BigArrays.LONG_PAGE_SIZE;
  * Double array abstraction able to support more than 2B values. This implementation slices data into fixed-sized blocks of
  * configurable length.
  */
-final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
+final class BigDoubleArray extends AbstractBigArray<long[]> implements DoubleArray {
 
     private static final BigDoubleArray ESTIMATOR = new BigDoubleArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
-    private long[][] pages;
-
     /** Constructor. */
+    @SuppressWarnings("unchecked")
     BigDoubleArray(long size, BigArrays bigArrays, boolean clearOnResize) {
-        super(LONG_PAGE_SIZE, bigArrays, clearOnResize);
-        this.size = size;
-        pages = new long[numPages(size)][];
-        for (int i = 0; i < pages.length; ++i) {
-            pages[i] = newLongPage(i);
-        }
+        super(size, LONG_PAGE_SIZE, createLongSupplier(bigArrays, clearOnResize), bigArrays, clearOnResize);
     }
 
     @Override
     public double get(long index) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        return Double.longBitsToDouble(pages[pageIndex][indexInPage]);
+        return Double.longBitsToDouble(getPage(pageIndex)[indexInPage]);
     }
 
     @Override
     public double set(long index, double value) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        final long[] page = pages[pageIndex];
+        final long[] page = getPage(pageIndex);
         final double ret = Double.longBitsToDouble(page[indexInPage]);
         page[indexInPage] = Double.doubleToRawLongBits(value);
         return ret;
@@ -67,30 +58,13 @@ final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
     public double increment(long index, double inc) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        final long[] page = pages[pageIndex];
+        final long[] page = getPage(pageIndex);
         return page[indexInPage] = Double.doubleToRawLongBits(Double.longBitsToDouble(page[indexInPage]) + inc);
     }
 
     @Override
     protected int numBytesPerElement() {
         return Integer.BYTES;
-    }
-
-    /** Change the size of this array. Content between indexes <code>0</code> and <code>min(size(), newSize)</code> will be preserved. */
-    @Override
-    public void resize(long newSize) {
-        final int numPages = numPages(newSize);
-        if (numPages > pages.length) {
-            pages = Arrays.copyOf(pages, ArrayUtil.oversize(numPages, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
-        }
-        for (int i = numPages - 1; i >= 0 && pages[i] == null; --i) {
-            pages[i] = newLongPage(i);
-        }
-        for (int i = numPages; i < pages.length && pages[i] != null; ++i) {
-            pages[i] = null;
-            releasePage(i);
-        }
-        this.size = newSize;
     }
 
     @Override
@@ -102,13 +76,13 @@ final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
         final int fromPage = pageIndex(fromIndex);
         final int toPage = pageIndex(toIndex - 1);
         if (fromPage == toPage) {
-            Arrays.fill(pages[fromPage], indexInPage(fromIndex), indexInPage(toIndex - 1) + 1, longBits);
+            Arrays.fill(getPage(fromPage), indexInPage(fromIndex), indexInPage(toIndex - 1) + 1, longBits);
         } else {
-            Arrays.fill(pages[fromPage], indexInPage(fromIndex), pages[fromPage].length, longBits);
+            Arrays.fill(getPage(fromPage), indexInPage(fromIndex), getPage(fromPage).length, longBits);
             for (int i = fromPage + 1; i < toPage; ++i) {
-                Arrays.fill(pages[i], longBits);
+                Arrays.fill(getPage(i), longBits);
             }
-            Arrays.fill(pages[toPage], 0, indexInPage(toIndex - 1) + 1, longBits);
+            Arrays.fill(getPage(toPage), 0, indexInPage(toIndex - 1) + 1, longBits);
         }
     }
 
@@ -116,5 +90,4 @@ final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
     public static long estimateRamBytes(final long size) {
         return ESTIMATOR.ramBytesEstimated(size);
     }
-
 }

--- a/core/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.recycler.Recycler;
 
 import java.util.Arrays;
 
@@ -30,27 +31,21 @@ import static org.elasticsearch.common.util.BigArrays.INT_PAGE_SIZE;
  * Float array abstraction able to support more than 2B values. This implementation slices data into fixed-sized blocks of
  * configurable length.
  */
-final class BigFloatArray extends AbstractBigArray implements FloatArray {
+final class BigFloatArray extends AbstractBigArray<int[]> implements FloatArray {
 
     private static final BigFloatArray ESTIMATOR = new BigFloatArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
-    private int[][] pages;
-
     /** Constructor. */
+    @SuppressWarnings("unchecked")
     BigFloatArray(long size, BigArrays bigArrays, boolean clearOnResize) {
-        super(INT_PAGE_SIZE, bigArrays, clearOnResize);
-        this.size = size;
-        pages = new int[numPages(size)][];
-        for (int i = 0; i < pages.length; ++i) {
-            pages[i] = newIntPage(i);
-        }
+        super(size, INT_PAGE_SIZE, createIntSupplier(bigArrays, clearOnResize), bigArrays, clearOnResize);
     }
 
     @Override
     public float set(long index, float value) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        final int[] page = pages[pageIndex];
+        final int[] page = getPage(pageIndex);
         final float ret = Float.intBitsToFloat(page[indexInPage]);
         page[indexInPage] = Float.floatToRawIntBits(value);
         return ret;
@@ -60,7 +55,7 @@ final class BigFloatArray extends AbstractBigArray implements FloatArray {
     public float increment(long index, float inc) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        final int[] page = pages[pageIndex];
+        final int[] page = getPage(pageIndex);
         return page[indexInPage] = Float.floatToRawIntBits(Float.intBitsToFloat(page[indexInPage]) + inc);
     }
 
@@ -68,29 +63,12 @@ final class BigFloatArray extends AbstractBigArray implements FloatArray {
     public float get(long index) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        return Float.intBitsToFloat(pages[pageIndex][indexInPage]);
+        return Float.intBitsToFloat(getPage(pageIndex)[indexInPage]);
     }
 
     @Override
     protected int numBytesPerElement() {
         return Float.BYTES;
-    }
-
-    /** Change the size of this array. Content between indexes <code>0</code> and <code>min(size(), newSize)</code> will be preserved. */
-    @Override
-    public void resize(long newSize) {
-        final int numPages = numPages(newSize);
-        if (numPages > pages.length) {
-            pages = Arrays.copyOf(pages, ArrayUtil.oversize(numPages, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
-        }
-        for (int i = numPages - 1; i >= 0 && pages[i] == null; --i) {
-            pages[i] = newIntPage(i);
-        }
-        for (int i = numPages; i < pages.length && pages[i] != null; ++i) {
-            pages[i] = null;
-            releasePage(i);
-        }
-        this.size = newSize;
     }
 
     @Override
@@ -102,13 +80,13 @@ final class BigFloatArray extends AbstractBigArray implements FloatArray {
         final int fromPage = pageIndex(fromIndex);
         final int toPage = pageIndex(toIndex - 1);
         if (fromPage == toPage) {
-            Arrays.fill(pages[fromPage], indexInPage(fromIndex), indexInPage(toIndex - 1) + 1, intBits);
+            Arrays.fill(getPage(fromPage), indexInPage(fromIndex), indexInPage(toIndex - 1) + 1, intBits);
         } else {
-            Arrays.fill(pages[fromPage], indexInPage(fromIndex), pages[fromPage].length, intBits);
+            Arrays.fill(getPage(fromPage), indexInPage(fromIndex), getPage(fromPage).length, intBits);
             for (int i = fromPage + 1; i < toPage; ++i) {
-                Arrays.fill(pages[i], intBits);
+                Arrays.fill(getPage(i), intBits);
             }
-            Arrays.fill(pages[toPage], 0, indexInPage(toIndex - 1) + 1, intBits);
+            Arrays.fill(getPage(toPage), 0, indexInPage(toIndex - 1) + 1, intBits);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/common/util/BigIntArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigIntArray.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.recycler.Recycler;
 
 import java.util.Arrays;
 
@@ -30,34 +31,28 @@ import static org.elasticsearch.common.util.BigArrays.INT_PAGE_SIZE;
  * Int array abstraction able to support more than 2B values. This implementation slices data into fixed-sized blocks of
  * configurable length.
  */
-final class BigIntArray extends AbstractBigArray implements IntArray {
+final class BigIntArray extends AbstractBigArray<int[]> implements IntArray {
 
     private static final BigIntArray ESTIMATOR = new BigIntArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
-    private int[][] pages;
-
     /** Constructor. */
+    @SuppressWarnings("unchecked")
     BigIntArray(long size, BigArrays bigArrays, boolean clearOnResize) {
-        super(INT_PAGE_SIZE, bigArrays, clearOnResize);
-        this.size = size;
-        pages = new int[numPages(size)][];
-        for (int i = 0; i < pages.length; ++i) {
-            pages[i] = newIntPage(i);
-        }
+        super(size, INT_PAGE_SIZE, createIntSupplier(bigArrays, clearOnResize), bigArrays, clearOnResize);
     }
 
     @Override
     public int get(long index) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        return pages[pageIndex][indexInPage];
+        return getPage(pageIndex)[indexInPage];
     }
 
     @Override
     public int set(long index, int value) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        final int[] page = pages[pageIndex];
+        final int[] page = getPage(pageIndex);
         final int ret = page[indexInPage];
         page[indexInPage] = value;
         return ret;
@@ -67,7 +62,7 @@ final class BigIntArray extends AbstractBigArray implements IntArray {
     public int increment(long index, int inc) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        return pages[pageIndex][indexInPage] += inc;
+        return getPage(pageIndex)[indexInPage] += inc;
     }
 
     @Override
@@ -78,36 +73,19 @@ final class BigIntArray extends AbstractBigArray implements IntArray {
         final int fromPage = pageIndex(fromIndex);
         final int toPage = pageIndex(toIndex - 1);
         if (fromPage == toPage) {
-            Arrays.fill(pages[fromPage], indexInPage(fromIndex), indexInPage(toIndex - 1) + 1, value);
+            Arrays.fill(getPage(fromPage), indexInPage(fromIndex), indexInPage(toIndex - 1) + 1, value);
         } else {
-            Arrays.fill(pages[fromPage], indexInPage(fromIndex), pages[fromPage].length, value);
+            Arrays.fill(getPage(fromPage), indexInPage(fromIndex), getPage(fromPage).length, value);
             for (int i = fromPage + 1; i < toPage; ++i) {
-                Arrays.fill(pages[i], value);
+                Arrays.fill(getPage(i), value);
             }
-            Arrays.fill(pages[toPage], 0, indexInPage(toIndex - 1) + 1, value);
+            Arrays.fill(getPage(toPage), 0, indexInPage(toIndex - 1) + 1, value);
         }
     }
 
     @Override
     protected int numBytesPerElement() {
         return Integer.BYTES;
-    }
-
-    /** Change the size of this array. Content between indexes <code>0</code> and <code>min(size(), newSize)</code> will be preserved. */
-    @Override
-    public void resize(long newSize) {
-        final int numPages = numPages(newSize);
-        if (numPages > pages.length) {
-            pages = Arrays.copyOf(pages, ArrayUtil.oversize(numPages, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
-        }
-        for (int i = numPages - 1; i >= 0 && pages[i] == null; --i) {
-            pages[i] = newIntPage(i);
-        }
-        for (int i = numPages; i < pages.length && pages[i] != null; ++i) {
-            pages[i] = null;
-            releasePage(i);
-        }
-        this.size = newSize;
     }
 
     /** Estimates the number of bytes that would be consumed by an array of the given size. */

--- a/core/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
+++ b/core/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
@@ -19,31 +19,20 @@
 
 package org.elasticsearch.common.util;
 
-import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.RamUsageEstimator;
-
-import java.util.Arrays;
-
 import static org.elasticsearch.common.util.BigArrays.OBJECT_PAGE_SIZE;
 
 /**
  * Int array abstraction able to support more than 2B values. This implementation slices data into fixed-sized blocks of
  * configurable length.
  */
-final class BigObjectArray<T> extends AbstractBigArray implements ObjectArray<T> {
+final class BigObjectArray<T> extends AbstractBigArray<Object[]> implements ObjectArray<T> {
 
     private static final BigObjectArray ESTIMATOR = new BigObjectArray(0, BigArrays.NON_RECYCLING_INSTANCE);
 
-    private Object[][] pages;
-
     /** Constructor. */
+    @SuppressWarnings("unchecked")
     BigObjectArray(long size, BigArrays bigArrays) {
-        super(OBJECT_PAGE_SIZE, bigArrays, true);
-        this.size = size;
-        pages = new Object[numPages(size)][];
-        for (int i = 0; i < pages.length; ++i) {
-            pages[i] = newObjectPage(i);
-        }
+        super(size, OBJECT_PAGE_SIZE, createObjectSupplier(bigArrays), bigArrays, true);
     }
 
     @SuppressWarnings("unchecked")
@@ -51,14 +40,14 @@ final class BigObjectArray<T> extends AbstractBigArray implements ObjectArray<T>
     public T get(long index) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        return (T) pages[pageIndex][indexInPage];
+        return (T) getPage(pageIndex)[indexInPage];
     }
 
     @Override
     public T set(long index, T value) {
         final int pageIndex = pageIndex(index);
         final int indexInPage = indexInPage(index);
-        final Object[] page = pages[pageIndex];
+        final Object[] page = getPage(pageIndex);
         @SuppressWarnings("unchecked")
         final T ret = (T) page[indexInPage];
         page[indexInPage] = value;
@@ -68,23 +57,6 @@ final class BigObjectArray<T> extends AbstractBigArray implements ObjectArray<T>
     @Override
     protected int numBytesPerElement() {
         return Integer.BYTES;
-    }
-
-    /** Change the size of this array. Content between indexes <code>0</code> and <code>min(size(), newSize)</code> will be preserved. */
-    @Override
-    public void resize(long newSize) {
-        final int numPages = numPages(newSize);
-        if (numPages > pages.length) {
-            pages = Arrays.copyOf(pages, ArrayUtil.oversize(numPages, RamUsageEstimator.NUM_BYTES_OBJECT_REF));
-        }
-        for (int i = numPages - 1; i >= 0 && pages[i] == null; --i) {
-            pages[i] = newObjectPage(i);
-        }
-        for (int i = numPages; i < pages.length && pages[i] != null; ++i) {
-            pages[i] = null;
-            releasePage(i);
-        }
-        this.size = newSize;
     }
 
     /** Estimates the number of bytes that would be consumed by an array of the given size. */

--- a/core/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -75,11 +75,16 @@ public class BigArraysTests extends ESTestCase {
             array.set(i, (byte) (i % 127));
         }
         int bytesDropped = 0;
+        byte lastValue = (byte) ((totalLen - 1) % 127);
         while (array.size() > (BigArrays.BYTE_PAGE_SIZE * 2)) {
             int i = randomIntBetween(1, (int) (BigArrays.BYTE_PAGE_SIZE * 1.5));
             bytesDropped += i;
             array = bigArrays.dropFromHead(array, i);
-            assertEquals((byte) (bytesDropped % 127), array.get(0));
+            int expectedInt = (bytesDropped % 127);
+            assertEquals((byte) expectedInt, array.get(0));
+            assertEquals((byte) (expectedInt + 1), array.get(1));
+            assertEquals(lastValue, array.get(array.size() - 1));
+            assertEquals(totalLen - bytesDropped, array.size());
         }
         array.close();
     }

--- a/core/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/core/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -68,6 +68,22 @@ public class BigArraysTests extends ESTestCase {
         array.close();
     }
 
+    public void testByteArrayDropFromHead() {
+        final int totalLen = randomIntBetween(BigArrays.BYTE_PAGE_SIZE, BigArrays.BYTE_PAGE_SIZE * 10);
+        ByteArray array = bigArrays.newByteArray(totalLen, false);
+        for (int i = 0; i < totalLen; ++i) {
+            array.set(i, (byte) (i % 127));
+        }
+        int bytesDropped = 0;
+        while (array.size() > (BigArrays.BYTE_PAGE_SIZE * 2)) {
+            int i = randomIntBetween(1, (int) (BigArrays.BYTE_PAGE_SIZE * 1.5));
+            bytesDropped += i;
+            array = bigArrays.dropFromHead(array, i);
+            assertEquals((byte) (bytesDropped % 127), array.get(0));
+        }
+        array.close();
+    }
+
     public void testIntArrayGrowth() {
         final int totalLen = randomIntBetween(1, 1000000);
         final int startLen = randomIntBetween(1, randomBoolean() ? 1000 : totalLen);

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -120,6 +120,19 @@ public class MockBigArrays extends BigArrays {
     }
 
     @Override
+    public ByteArray dropFromHead(ByteArray array, long numberToDrop) {
+        ByteArrayWrapper arr = (ByteArrayWrapper) array;
+        array = super.dropFromHead(arr.in, numberToDrop);
+        ACQUIRED_ARRAYS.remove(arr);
+        if (array instanceof ByteArrayWrapper) {
+            arr = (ByteArrayWrapper) array;
+        } else {
+            arr = new ByteArrayWrapper(array, arr.clearOnResize);
+        }
+        return arr;
+    }
+
+    @Override
     public IntArray newIntArray(long size, boolean clearOnResize) {
         final IntArrayWrapper array = new IntArrayWrapper(super.newIntArray(size, clearOnResize), clearOnResize);
         if (!clearOnResize) {


### PR DESCRIPTION
This is related to #27051. Essentially, we want to use big arrays for
byte reusage when reading and writing to channels. Unfortunately, big
arrays are currently designed to expand forever. This does not fit with
reading from a channel where from time to time you will want to drop
bytes when a message is fully read.

This commit refactors big arrays to only have one array for both
pages and recyclers. This is a change from the current situation where
these are stored in two different arrays. This change simplifies the
array manipulation that is necessary when dropping bytes from the head.

Second, it adds a method `dropFromHead` that will remove and release
pages up until the provided index. This change also requires the
introduction of potential "offsets" for big arrays.