### PR TITLE
Avoid uid creation in ParsedDocument

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.Field;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.mapper.ParseContext.Document;
@@ -35,7 +34,6 @@ public class ParsedDocument {
     private final Field version;
 
     private final String id, type;
-    private final BytesRef uid;
     private final SeqNoFieldMapper.SequenceIDFields seqID;
 
     private final String routing;
@@ -62,7 +60,6 @@ public class ParsedDocument {
         this.seqID = seqID;
         this.id = id;
         this.type = type;
-        this.uid = Uid.createUidAsBytes(type, id);
         this.routing = routing;
         this.documents = documents;
         this.source = source;
@@ -140,9 +137,7 @@ public class ParsedDocument {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Document ").append("uid[").append(uid).append("] doc [").append(documents).append("]");
-        return sb.toString();
+        return "Document uid[" + Uid.createUidAsBytes(type, id) + "] doc [" + documents + ']';
     }
 
 }


### PR DESCRIPTION
The `uid` was only used in the `toString` implementation, which I
suspect is only used for logging or debugging purposes. So the `uid`
creation can be avoided in most cases.

This might be a left-over of the work of moving to a single `id` without
embedded `type`, because the `uid` is created later on in
`IndexShard.prepareIndex` if it is still required.