### PR TITLE
Use the correct bwc version in mixed cluster qa module

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -37,14 +37,14 @@ for (Version version : wireCompatVersions) {
     includePackaged = true
   }
 
-  /* This project runs the core REST tests against a 2 node cluster where one of
+  /* This project runs the core REST tests against a 4 node cluster where two of
      the nodes has a different minor.  */
   Object extension = extensions.findByName("${baseName}#mixedClusterTestCluster")
-  configure(extensions.findByName("${baseName}#mixedClusterTestCluster")) {
+  configure(extension) {
     distribution = 'zip'
     numNodes = 4
     numBwcNodes = 2
-    bwcVersion = project.wireCompatVersions[-1]
+    bwcVersion = version
   }
 
   Task versionBwcTest = tasks.create(name: "${baseName}#bwcTest") {


### PR DESCRIPTION
I was looking into #27229 and I realized by looking at the elasticsearch directories in `../build/cluster/*/` that only latest minor version was used for all bwc test tasks.

Prior to this change if the `bwcTest` task is run then it would create
task for each version, but each task in reality would use wireCompatVersions - 1
ES version and not version prior to that. So we were not actually testing against 5.6.x versions in the
6.x and 6.0 branches.
