### PR TITLE
[DOCS] Clarify plan on transport client deprecation and removal

### DIFF
--- a/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
+++ b/client/transport/src/main/java/org/elasticsearch/transport/client/PreBuiltTransportClient.java
@@ -45,6 +45,9 @@ import java.util.concurrent.TimeUnit;
  * {@link MustachePlugin},
  * {@link ParentJoinPlugin}
  * plugins for the client. These plugins are all the required modules for Elasticsearch.
+ *
+ * Note that {@link TransportClient} will be deprecated in Elasticsearch 7.0 and removed in Elasticsearch 8.0.
+ * Use the High Level REST Client instead.
  */
 @SuppressWarnings({"unchecked","varargs"})
 public class PreBuiltTransportClient extends TransportClient {

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -79,6 +79,9 @@ import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
  * <p>
  * The transport client important modules used is the {@link org.elasticsearch.common.network.NetworkModule} which is
  * started in client mode (only connects, no bind).
+ *
+ * Note that {@link TransportClient} will be deprecated in Elasticsearch 7.0 and removed in Elasticsearch 8.0.
+ * Use the High Level REST Client instead.
  */
 public abstract class TransportClient extends AbstractClient {
 

--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -23,10 +23,12 @@ cluster.
 
 ==============================
 
-WARNING: The `TransportClient` is aimed to be replaced by the Java High Level REST
-Client, which executes HTTP requests instead of serialized Java requests. The
-`TransportClient` will be deprecated in upcoming versions of Elasticsearch and it
-is advised to use the Java High Level REST Client instead.
+WARNING: The `TransportClient` will be replaced by the
+{java-rest}/java-rest-high.html[Java High Level REST Client], which executes
+HTTP requests instead of serialized Java requests. The `TransportClient` will
+be deprecated in Elasticsearch 7.0 and removed in  Elasticsearch 8.0.
+It is advised to use the Java High Level REST Client instead.
+
 
 [[transport-client]]
 === Transport Client

--- a/docs/java-api/client.asciidoc
+++ b/docs/java-api/client.asciidoc
@@ -23,12 +23,28 @@ cluster.
 
 ==============================
 
-WARNING: The `TransportClient` will be replaced by the
-{java-rest}/java-rest-high.html[Java High Level REST Client], which executes
-HTTP requests instead of serialized Java requests. The `TransportClient` will
-be deprecated in Elasticsearch 7.0 and removed in  Elasticsearch 8.0.
-It is advised to use the Java High Level REST Client instead.
+[WARNING]
+===================================
 
+We plan on deprecating the `TransportClient` in Elasticsearch 7.0 and removing
+it completely in 8.0. Instead, you should be using the
+{java-rest}/java-rest-high.html[Java High Level REST Client], which executes
+HTTP requests rather than serialized Java requests. The
+{java-rest}/java-rest-high-level-migration.html[migration guide] describes
+all the steps needed to migrate.
+
+The Java High Level REST Client currently has support for the more commonly
+used APIs, but there are a lot more that still need to be added.  You can help
+us prioritise by telling us which missing APIs you need for your application
+by adding a comment to this issue:
+https://github.com/elastic/elasticsearch/issues/27205[Java high-level REST
+client completeness].
+
+Any missing APIs can always be implemented today by using the
+link:/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[low
+level Java REST Client] with JSON request and response bodies.
+
+===================================
 
 [[transport-client]]
 === Transport Client

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -17,10 +17,11 @@ Additionally, operations on a client may be accumulated and executed in
 Note, all the APIs are exposed through the
 Java API (actually, the Java API is used internally to execute them).
 
-WARNING: Starting from version 5.6.0, a new Java client has been
-released: the {java-rest}/java-rest-high.html[Java High Level REST Client].
-This new client is designed to replace the `TransportClient` in Java
-applications which will be deprecated in future versions of Elasticsearch.
+WARNING: The `TransportClient` will be replaced by the
+{java-rest}/java-rest-high.html[Java High Level REST Client], which executes
+HTTP requests instead of serialized Java requests. The `TransportClient` will
+be deprecated in Elasticsearch 7.0 and removed in  Elasticsearch 8.0.
+It is advised to use the Java High Level REST Client instead.
 
 == Javadoc
 

--- a/docs/java-api/index.asciidoc
+++ b/docs/java-api/index.asciidoc
@@ -17,11 +17,28 @@ Additionally, operations on a client may be accumulated and executed in
 Note, all the APIs are exposed through the
 Java API (actually, the Java API is used internally to execute them).
 
-WARNING: The `TransportClient` will be replaced by the
+[WARNING]
+===================================
+
+We plan on deprecating the `TransportClient` in Elasticsearch 7.0 and removing
+it completely in 8.0. Instead, you should be using the
 {java-rest}/java-rest-high.html[Java High Level REST Client], which executes
-HTTP requests instead of serialized Java requests. The `TransportClient` will
-be deprecated in Elasticsearch 7.0 and removed in  Elasticsearch 8.0.
-It is advised to use the Java High Level REST Client instead.
+HTTP requests rather than serialized Java requests. The
+{java-rest}/java-rest-high-level-migration.html[migration guide] describes
+all the steps needed to migrate.
+
+The Java High Level REST Client currently has support for the more commonly
+used APIs, but there are a lot more that still need to be added.  You can help
+us prioritise by telling us which missing APIs you need for your application
+by adding a comment to this issue:
+https://github.com/elastic/elasticsearch/issues/27205[Java high-level REST
+client completeness].
+
+Any missing APIs can always be implemented today by using the
+link:/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html[low
+level Java REST Client] with JSON request and response bodies.
+
+===================================
 
 == Javadoc
 


### PR DESCRIPTION
The transport client will be deprecated in Elasticsearch 7.0 and removed in Elasticsearch 8.0. Updated docs and javadoc according to this plan.