### PR TITLE
Break apart the multi type aspect of rolling upgrade tests in 6.x and 6.0 branches

### DIFF
--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/10_basic.yml
@@ -7,6 +7,7 @@
 
  - do:
      search:
+        type: doc
         index: test_index
 
  - match: { hits.total: 5 } # no new indexed data, so expect the original 5 documents from the old cluster
@@ -16,6 +17,84 @@
        index: index_with_replicas
 
  - match: { hits.total: 5 } # just check we recovered fine
+
+ - do:
+     bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v1_mixed", "f2": 5}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v2_mixed", "f2": 6}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v3_mixed", "f2": 7}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v4_mixed", "f2": 8}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v5_mixed", "f2": 9}'
+
+ - do:
+     index:
+       index: test_index
+       type: doc
+       id: d10
+       body: {"f1": "v6_mixed", "f2": 10}
+
+ - do:
+     indices.flush:
+        index: test_index
+
+ - do:
+     search:
+        type: doc
+        index: test_index
+
+ - match: { hits.total: 11 } # 5 docs from old cluster, 6 docs from mixed cluster
+
+ - do:
+     delete:
+       index: test_index
+       type: doc
+       id: d10
+
+ - do:
+     indices.flush:
+        index: test_index
+
+ - do:
+     search:
+        type: doc
+        index: test_index
+
+ - match: { hits.total: 10 }
+
+---
+"Verify that we can still find things with the template":
+  - do:
+      search_template:
+        body:
+          id: test_search_template
+          params:
+            f1: v5_old
+  - match: { hits.total: 1 }
+
+---
+"Verify custom cluster metadata still exists during upgrade":
+  - do:
+      snapshot.get_repository:
+        repository: my_repo
+  - is_true: my_repo
+
+  - do:
+      ingest.get_pipeline:
+        id: "my_pipeline"
+  - match: { my_pipeline.description: "_description" }
+
+---
+"Test old multi type stuff":
+ - skip:
+    version: "6.0.0 - "
+    reason:  multiple types are not supported from 6.0 and beyond
 
  - do:
      bulk:
@@ -46,43 +125,20 @@
  - do:
      search:
         index: test_index
+        type: test_type
 
- - match: { hits.total: 11 } # 5 docs from old cluster, 6 docs from mixed cluster
+ - match: { hits.total: 6 }
 
  - do:
      delete:
+       refresh: true
        index: test_index
        type: test_type
        id: d10
 
  - do:
-     indices.flush:
-        index: test_index
-
- - do:
      search:
         index: test_index
+        type: test_type
 
- - match: { hits.total: 10 }
-
----
-"Verify that we can still find things with the template":
-  - do:
-      search_template:
-        body:
-          id: test_search_template
-          params:
-            f1: v5_old
-  - match: { hits.total: 1 }
-
----
-"Verify custom cluster metadata still exists during upgrade":
-  - do:
-      snapshot.get_repository:
-        repository: my_repo
-  - is_true: my_repo
-
-  - do:
-      ingest.get_pipeline:
-        id: "my_pipeline"
-  - match: { my_pipeline.description: "_description" }
+ - match: { hits.total: 5 }

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
@@ -1,5 +1,5 @@
 ---
-"Index data, search, and create things in the cluster state that we'll validate are there after the ugprade":
+"Index data, search, and create things in the cluster state that we'll validate are there after the upgrade":
   - do:
       indices.create:
         index: test_index
@@ -7,28 +7,6 @@
           settings:
             index:
               number_of_replicas: 0
-  - do:
-      indices.create:
-        index: multi_type_index
-        body:
-          settings:
-            index.number_of_replicas: 0
-            index.mapping.single_type: false
-
-  - do:
-      bulk:
-        refresh: true
-        body:
-          - '{"index": {"_index": "multi_type_index", "_type": "type1"}}'
-          - '{"f1": "v1_old", "f2": 0}'
-          - '{"index": {"_index": "multi_type_index", "_type": "type2"}}'
-          - '{"f1": "v1_old", "f2": 0}'
-
-  - do:
-      search:
-        index: multi_type_index
-
-  - match: { hits.total: 2 }
 
   - do:
       indices.create:
@@ -123,3 +101,32 @@
           params:
             f1: v5_old
   - match: { hits.total: 1 }
+
+---
+"Test old multi type stuff":
+  - skip:
+      version: "6.0.0 - "
+      reason:  multiple types are not supported from 6.0 and beyond
+
+  - do:
+      indices.create:
+        index: multi_type_index
+        body:
+          settings:
+            index.number_of_replicas: 0
+            index.mapping.single_type: false
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "multi_type_index", "_type": "type1"}}'
+          - '{"f1": "v1_old", "f2": 0}'
+          - '{"index": {"_index": "multi_type_index", "_type": "type2"}}'
+          - '{"f1": "v1_old", "f2": 0}'
+
+  - do:
+      search:
+        index: multi_type_index
+
+  - match: { hits.total: 2 }

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -11,6 +11,7 @@
  - do:
      search:
        index: test_index
+       type: doc
 
  - match: { hits.total: 10 } # no new indexed data, so expect the original 10 documents from the old and mixed clusters
 
@@ -20,6 +21,59 @@
 
  - match: { hits.total: 5 } # just check we recovered fine
 
+ - do:
+     bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v1_upgraded", "f2": 10}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v2_upgraded", "f2": 11}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v3_upgraded", "f2": 12}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v4_upgraded", "f2": 13}'
+          - '{"index": {"_index": "test_index", "_type": "doc"}}'
+          - '{"f1": "v5_upgraded", "f2": 14}'
+
+ - do:
+     indices.flush:
+        index: test_index
+
+ - do:
+     search:
+        type: doc
+        index: test_index
+
+ - match: { hits.total: 15 } # 10 docs from previous clusters plus 5 new docs
+
+---
+"Verify that we can still find things with the template":
+  - do:
+      search_template:
+        body:
+          id: test_search_template
+          params:
+            f1: v5_old
+  - match: { hits.total: 1 }
+
+---
+"Verify custom cluster metadata still exists after rolling upgrade":
+  - do:
+      snapshot.get_repository:
+        repository: my_repo
+  - is_true: my_repo
+
+  - do:
+      ingest.get_pipeline:
+        id: "my_pipeline"
+  - match: { my_pipeline.description: "_description" }
+
+---
+"Test old multi type stuff":
+ - skip:
+    version: "6.0.0 - "
+    reason:  multiple types are not supported from 6.0 and beyond
 
  - do:
     search:
@@ -54,28 +108,8 @@
 
  - do:
      search:
+        type: test_type
         index: test_index
 
- - match: { hits.total: 15 } # 10 docs from previous clusters plus 5 new docs
+ - match: { hits.total: 10 } # 5 docs from previous clusters plus 5 new docs
 
----
-"Verify that we can still find things with the template":
-  - do:
-      search_template:
-        body:
-          id: test_search_template
-          params:
-            f1: v5_old
-  - match: { hits.total: 1 }
-
----
-"Verify custom cluster metadata still exists after rolling upgrade":
-  - do:
-      snapshot.get_repository:
-        repository: my_repo
-  - is_true: my_repo
-
-  - do:
-      ingest.get_pipeline:
-        id: "my_pipeline"
-  - match: { my_pipeline.description: "_description" }


### PR DESCRIPTION
So that old multi type support can be tested if upgrading from ES versions prior 6.0 and otherwise these multi type support tests are ignored.

PR for #27259
