### PR TITLE
`rest-api-spec` : setting path parts as required to reflect the code base

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -12,6 +12,7 @@
         },
         "name": {
           "type" : "list",
+          "required" : true,
           "description" : "A comma-separated list of alias names to return"
         }
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_rethrottle.json
@@ -8,6 +8,7 @@
       "parts": {
         "task_id": {
           "type": "string",
+          "required" : true,
           "description": "The task id to rethrottle"
         }
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -8,6 +8,7 @@
       "parts": {
         "task_id": {
           "type": "string",
+          "required" : true,
           "description": "Return the task with specified id (node_id:task_number)"
         }
       },


### PR DESCRIPTION
Setting path parts as `required` when needed in the `rest-spec-api`s.
