### PR TITLE
Fix RestGetAction name typo

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
@@ -50,7 +50,7 @@ public class RestGetAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "docuemnt_get_action";
+        return "document_get_action";
     }
 
     @Override


### PR DESCRIPTION
This changes the name from 'docuemnt_get_action' to 'document_get_action'.