### PR TITLE
[Docs] Add WPSOLR, an active Elasticsearch WordPress plugin

### DIFF
--- a/docs/plugins/integrations.asciidoc
+++ b/docs/plugins/integrations.asciidoc
@@ -17,6 +17,9 @@ Integrations are not plugins, but are external tools or modules that make it eas
 * https://drupal.org/project/elasticsearch_connector[Drupal]:
   Drupal Elasticsearch integration.
 
+* https://wordpress.org/plugins/wpsolr-search-engine/[WPSOLR]:
+  Elasticsearch (and Apache Solr) WordPress Plugin
+ 
 * http://searchbox-io.github.com/wp-elasticsearch/[Wp-Elasticsearch]:
   Elasticsearch WordPress Plugin
 


### PR DESCRIPTION
I noticed that the 2 WordPress plugins currently mentioned are not active anymore.
I added a link to WPSOLR, the plugin that I maintain. It is active, and supported.
