### PR TITLE
docs: Docker SSL/TLS getting started

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -275,6 +275,11 @@ overriding the default command for the image. For example:
 docker run <various parameters> bin/elasticsearch -Ecluster.name=mynewclustername
 --------------------------------------------
 
+[[next-getting-started-tls-docker]]
+==== Configuring SSL/TLS with the Elasticsearch Docker image
+
+Please refer to the <<getting-started-tls-docker, Getting started with SSL/TLS and Elasticsearch>>.
+
 ==== Notes for production use and defaults
 
 We have collected a number of best practices for production use.
@@ -334,3 +339,4 @@ instead.
 
 
 include::next-steps.asciidoc[]
+include::getting-started-tls-docker.asciidoc[]

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -278,7 +278,7 @@ docker run <various parameters> bin/elasticsearch -Ecluster.name=mynewclusternam
 [[next-getting-started-tls-docker]]
 ==== Configuring SSL/TLS with the Elasticsearch Docker image
 
-Please refer to the <<getting-started-tls-docker, Getting started with SSL/TLS and Elasticsearch>>.
+Please refer to the <<getting-started-tls-docker, Getting started with SSL/TLS and Elasticsearch>> guide.
 
 ==== Notes for production use and defaults
 

--- a/docs/reference/setup/install/getting-started-tls-docker.asciidoc
+++ b/docs/reference/setup/install/getting-started-tls-docker.asciidoc
@@ -38,14 +38,23 @@ ELASTIC_PASSWORD=PleaseChangeMe <2>
 <1> The path, inside the docker image, where certificates are expected to be found.
 <2> Initial password for the `elastic` user.
 
+[[getting-starter-tls-create-certs-composefile]]
 `create-certs.yml`:
-[source,yaml]
+ifeval::["{release-state}"=="unreleased"]
 
+WARNING: Version {version} of Elasticsearch has not yet been released, so a
+`create-certs.yml` is not available for this version.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+["source","yaml",subs="attributes"]
+----
 version: '2.2'
 services:
   create_certs:
     container_name: create_certs
-    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.0-rc2
+    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:{version}
     command: >
       bash -c '
       if [[ ! -d config/x-pack/certificates/certs ]]; then
@@ -60,16 +69,28 @@ services:
     user: ${UID:-1000}
     working_dir: /usr/share/elasticsearch
     volumes: ['.:/usr/share/elasticsearch/config/x-pack/certificates']
+----
 
 <1> The new node certificates and CA certificate+key are placed under the local directory `certs`.
+endif::[]
 
+[[getting-starter-tls-create-docker-compose]]
 `docker-compose.yml`:
-[source,yaml]
+ifeval::["{release-state}"=="unreleased"]
+
+WARNING: Version {version} of Elasticsearch has not yet been released, so a
+`docker-compose.yml` is not available for this version.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+["source","yaml",subs="attributes"]
+----
 version: '2.2'
 services:
   es01:
     container_name: es01
-    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.0-rc2
+    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:{version}
     environment:
       - node.name=es01
       - ELASTIC_PASSWORD=$ELASTIC_PASSWORD <1>
@@ -90,7 +111,7 @@ services:
       retries: 5
   es02:
     container_name: es02
-    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.0-rc2
+    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:{version}
     environment:
       - node.name=es02
       - ELASTIC_PASSWORD=$ELASTIC_PASSWORD
@@ -104,13 +125,15 @@ services:
       - xpack.ssl.key=$CERTS_DIR/es02/es02.key
     volumes: ['esdata_02:/usr/share/elasticsearch/data', './certs:$CERTS_DIR']
   wait_until_ready:
-    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.0-rc2
+    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:{version}
     command: /usr/bin/true
     depends_on: {"es01": {"condition": "service_healthy"}}
 volumes: {"esdata_01": {"driver": "local"}, "esdata_02": {"driver": "local"}}
+----
 
 <1> Bootstrap `elastic` with the password defined in `.env`. See {xpack-ref}/setting-up-authentication.html#bootstrap-elastic-passwords[the Elastic Boostrap Password].
 <2> Disable verification of authenticity for inter-node communication. Allows creating self-signed certificates without having to pin specific internal IP addresses.
+endif::[]
 
 ==== Run the example
 . Generate the certificates (only needed once):

--- a/docs/reference/setup/install/getting-started-tls-docker.asciidoc
+++ b/docs/reference/setup/install/getting-started-tls-docker.asciidoc
@@ -12,7 +12,7 @@ For further details, please refer to {xpack-ref}/encrypting-communications.html[
 Inside a new, empty, directory create the following **four files**:
 
 `instances.yml`:
-[source,yaml]
+["source","yaml"]
 instances:
   - name: es01
     dns:
@@ -138,30 +138,34 @@ endif::[]
 ==== Run the example
 . Generate the certificates (only needed once):
 +
-[source,sh]
+--
+["source","sh"]
 ----
 docker-compose -f create-certs.yml up
 ----
-+
+--
 . Start two elasticsearch nodes configured for SSL/TLS:
 +
-[source,sh]
+--
+["source","sh"]
 ----
 docker-compose up -d
 ----
-+
+--
 . Access the elasticsearch API over SSL/TLS using the bootstrapped password:
 +
-[source,sh]
+--
+["source","sh"]
 ----
 curl --cacert certs/ca/ca.crt -u elastic:PleaseChangeMe https://localhost:9200
 ----
-+
 // NOTCONSOLE
-+
+--
 . The `setup-passwords` tool can also be used to generate random passwords for all users:
 +
-[source,sh]
+--
+["source","sh"]
 ----
 docker exec es01 /bin/bash -c "bin/x-pack/setup-passwords auto --batch -Expack.ssl.certificate=x-pack/certificates/es01/es01.crt -Expack.ssl.certificate_authorities=x-pack/certificates/ca/ca.crt -Expack.ssl.key=x-pack/certificates/es01/es01.key --url https://localhost:9200"
 ----
+--

--- a/docs/reference/setup/install/getting-started-tls-docker.asciidoc
+++ b/docs/reference/setup/install/getting-started-tls-docker.asciidoc
@@ -58,16 +58,16 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch-platinum:{version}
     command: >
       bash -c '
-      if [[ ! -d config/x-pack/certificates/certs ]]; then
-      mkdir config/x-pack/certificates/certs;
-      fi;
-      if [[ ! -f /local/certs/bundle.zip ]]; then
-      bin/x-pack/certgen --silent --in config/x-pack/certificates/instances.yml --out config/x-pack/certificates/certs/bundle.zip;
-      unzip config/x-pack/certificates/certs/bundle.zip -d config/x-pack/certificates/certs; <1>
-      fi;
-      chgrp -R 0 config/x-pack/certificates/certs
+        if [[ ! -d config/x-pack/certificates/certs ]]; then
+          mkdir config/x-pack/certificates/certs;
+        fi;
+        if [[ ! -f /local/certs/bundle.zip ]]; then
+          bin/x-pack/certgen --silent --in config/x-pack/certificates/instances.yml --out config/x-pack/certificates/certs/bundle.zip;
+          unzip config/x-pack/certificates/certs/bundle.zip -d config/x-pack/certificates/certs; <1>
+        fi;
+        chgrp -R 0 config/x-pack/certificates/certs
       '
-    user: ${UID:-1000}
+    user: $\{UID:-1000\}
     working_dir: /usr/share/elasticsearch
     volumes: ['.:/usr/share/elasticsearch/config/x-pack/certificates']
 ----

--- a/docs/reference/setup/install/getting-started-tls-docker.asciidoc
+++ b/docs/reference/setup/install/getting-started-tls-docker.asciidoc
@@ -13,6 +13,7 @@ Inside a new, empty, directory create the following **four files**:
 
 `instances.yml`:
 ["source","yaml"]
+----
 instances:
   - name: es01
     dns:
@@ -26,15 +27,15 @@ instances:
       - localhost
     ip:
       - 127.0.0.1
-
+----
 <1> Allow use of embedded Docker DNS server names.
 
 `.env`:
 [source,yaml]
-
+----
 CERTS_DIR=/usr/share/elasticsearch/config/x-pack/certificates <1>
 ELASTIC_PASSWORD=PleaseChangeMe <2>
-
+----
 <1> The path, inside the docker image, where certificates are expected to be found.
 <2> Initial password for the `elastic` user.
 

--- a/docs/reference/setup/install/getting-started-tls-docker.asciidoc
+++ b/docs/reference/setup/install/getting-started-tls-docker.asciidoc
@@ -115,19 +115,30 @@ volumes: {"esdata_01": {"driver": "local"}, "esdata_02": {"driver": "local"}}
 ==== Run the example
 . Generate the certificates (only needed once):
 +
-`docker-compose -f create-certs.yml up`
+[source,sh]
+----
+docker-compose -f create-certs.yml up
+----
 +
 . Start two elasticsearch nodes configured for SSL/TLS:
 +
-`docker-compose up -d`
+[source,sh]
+----
+docker-compose up -d
+----
 +
 . Access the elasticsearch API over SSL/TLS using the bootstrapped password:
 +
-`curl --cacert certs/ca/ca.crt -u elastic:PleaseChangeMe https://localhost:9200`
+[source,sh]
+----
+curl --cacert certs/ca/ca.crt -u elastic:PleaseChangeMe https://localhost:9200
+----
++
 // NOTCONSOLE
 +
 . The `setup-passwords` tool can also be used to generate random passwords for all users:
 +
 [source,sh]
-
+----
 docker exec es01 /bin/bash -c "bin/x-pack/setup-passwords auto --batch -Expack.ssl.certificate=x-pack/certificates/es01/es01.crt -Expack.ssl.certificate_authorities=x-pack/certificates/ca/ca.crt -Expack.ssl.key=x-pack/certificates/es01/es01.key --url https://localhost:9200"
+----

--- a/docs/reference/setup/install/getting-started-tls-docker.asciidoc
+++ b/docs/reference/setup/install/getting-started-tls-docker.asciidoc
@@ -1,0 +1,132 @@
+[[getting-started-tls-docker]]
+=== Getting started with TLS and Elasticsearch
+
+Starting with version 6.0.0, x-pack licensed for security (gold, platinum or enterprise subscriptions) https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking-6.0.0-xes.html[requires SSL/TLS] encryption for the transport networking layer.
+
+This section demonstrates an easy path to get started with SSL/TLS for both http and transport using the elasticsearch-platinum docker image.
+
+For further details, please refer to {xpack-ref}/encrypting-communications.html[Encrypting Communications] and https://www.elastic.co/subscriptions[available subscriptions].
+
+==== Prepare the environment
+
+Inside a new, empty, directory create the following **four files**:
+
+`instances.yml`:
+[source,yaml]
+instances:
+  - name: es01
+    dns:
+      - es01 <1>
+      - localhost
+    ip:
+      - 127.0.0.1
+  - name: es02
+    dns:
+      - es02
+      - localhost
+    ip:
+      - 127.0.0.1
+
+<1> Allow use of embedded Docker DNS server names.
+
+`.env`:
+[source,yaml]
+
+CERTS_DIR=/usr/share/elasticsearch/config/x-pack/certificates <1>
+ELASTIC_PASSWORD=PleaseChangeMe <2>
+
+<1> The path, inside the docker image, where certificates are expected to be found.
+<2> Initial password for the `elastic` user.
+
+`create-certs.yml`:
+[source,yaml]
+
+version: '2.2'
+services:
+  create_certs:
+    container_name: create_certs
+    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.0-rc2
+    command: >
+      bash -c '
+      if [[ ! -d config/x-pack/certificates/certs ]]; then
+      mkdir config/x-pack/certificates/certs;
+      fi;
+      if [[ ! -f /local/certs/bundle.zip ]]; then
+      bin/x-pack/certgen --silent --in config/x-pack/certificates/instances.yml --out config/x-pack/certificates/certs/bundle.zip;
+      unzip config/x-pack/certificates/certs/bundle.zip -d config/x-pack/certificates/certs; <1>
+      fi;
+      chgrp -R 0 config/x-pack/certificates/certs
+      '
+    user: ${UID:-1000}
+    working_dir: /usr/share/elasticsearch
+    volumes: ['.:/usr/share/elasticsearch/config/x-pack/certificates']
+
+<1> The new node certificates and CA certificate+key are placed under the local directory `certs`.
+
+`docker-compose.yml`:
+[source,yaml]
+version: '2.2'
+services:
+  es01:
+    container_name: es01
+    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.0-rc2
+    environment:
+      - node.name=es01
+      - ELASTIC_PASSWORD=$ELASTIC_PASSWORD <1>
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.verification_mode=certificate <2>
+      - xpack.ssl.certificate_authorities=$CERTS_DIR/ca/ca.crt
+      - xpack.ssl.certificate=$CERTS_DIR/es01/es01.crt
+      - xpack.ssl.key=$CERTS_DIR/es01/es01.key
+    volumes: ['esdata_01:/usr/share/elasticsearch/data', './certs:$CERTS_DIR']
+    ports:
+      - 9200:9200
+    healthcheck:
+      test: curl --cacert $CERTS_DIR/ca/ca.crt -s https://localhost:9200 >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  es02:
+    container_name: es02
+    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.0-rc2
+    environment:
+      - node.name=es02
+      - ELASTIC_PASSWORD=$ELASTIC_PASSWORD
+      - discovery.zen.ping.unicast.hosts=es01
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.ssl.certificate_authorities=$CERTS_DIR/ca/ca.crt
+      - xpack.ssl.certificate=$CERTS_DIR/es02/es02.crt
+      - xpack.ssl.key=$CERTS_DIR/es02/es02.key
+    volumes: ['esdata_02:/usr/share/elasticsearch/data', './certs:$CERTS_DIR']
+  wait_until_ready:
+    image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.0-rc2
+    command: /usr/bin/true
+    depends_on: {"es01": {"condition": "service_healthy"}}
+volumes: {"esdata_01": {"driver": "local"}, "esdata_02": {"driver": "local"}}
+
+<1> Bootstrap `elastic` with the password defined in `.env`. See {xpack-ref}/setting-up-authentication.html#bootstrap-elastic-passwords[the Elastic Boostrap Password].
+<2> Disable verification of authenticity for inter-node communication. Allows creating self-signed certificates without having to pin specific internal IP addresses.
+
+==== Run the example
+. Generate the certificates (only needed once):
++
+`docker-compose -f create-certs.yml up`
++
+. Start two elasticsearch nodes configured for SSL/TLS:
++
+`docker-compose up -d`
++
+. Access the elasticsearch API over SSL/TLS using the bootstrapped password:
++
+`curl --cacert certs/ca/ca.crt -u elastic:PleaseChangeMe https://localhost:9200`
++
+. The `setup-passwords` tool can also be used to generate random passwords for all users:
++
+[source,sh]
+
+docker exec es01 /bin/bash -c "bin/x-pack/setup-passwords auto --batch -Expack.ssl.certificate=x-pack/certificates/es01/es01.crt -Expack.ssl.certificate_authorities=x-pack/certificates/ca/ca.crt -Expack.ssl.key=x-pack/certificates/es01/es01.key --url https://localhost:9200"

--- a/docs/reference/setup/install/getting-started-tls-docker.asciidoc
+++ b/docs/reference/setup/install/getting-started-tls-docker.asciidoc
@@ -124,6 +124,7 @@ volumes: {"esdata_01": {"driver": "local"}, "esdata_02": {"driver": "local"}}
 . Access the elasticsearch API over SSL/TLS using the bootstrapped password:
 +
 `curl --cacert certs/ca/ca.crt -u elastic:PleaseChangeMe https://localhost:9200`
+// NOTCONSOLE
 +
 . The `setup-passwords` tool can also be used to generate random passwords for all users:
 +

--- a/docs/reference/setup/install/getting-started-tls-docker.asciidoc
+++ b/docs/reference/setup/install/getting-started-tls-docker.asciidoc
@@ -93,6 +93,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch-platinum:{version}
     environment:
       - node.name=es01
+      - discovery.zen.minimum_master_nodes=2
       - ELASTIC_PASSWORD=$ELASTIC_PASSWORD <1>
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - xpack.security.http.ssl.enabled=true
@@ -114,6 +115,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch-platinum:{version}
     environment:
       - node.name=es02
+      - discovery.zen.minimum_master_nodes=2
       - ELASTIC_PASSWORD=$ELASTIC_PASSWORD
       - discovery.zen.ping.unicast.hosts=es01
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"

--- a/docs/reference/setup/install/getting-started-tls-docker.asciidoc
+++ b/docs/reference/setup/install/getting-started-tls-docker.asciidoc
@@ -1,9 +1,9 @@
 [[getting-started-tls-docker]]
 === Getting started with TLS and Elasticsearch
 
-Starting with version 6.0.0, x-pack licensed for security (gold, platinum or enterprise subscriptions) https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking-6.0.0-xes.html[requires SSL/TLS] encryption for the transport networking layer.
+Starting with version 6.0.0, X-Pack Security (Gold, Platinum or Enterprise subscriptions) https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking-6.0.0-xes.html[requires SSL/TLS] encryption for the transport networking layer.
 
-This section demonstrates an easy path to get started with SSL/TLS for both http and transport using the elasticsearch-platinum docker image.
+This section demonstrates an easy path to get started with SSL/TLS for both HTTPS and transport using the `elasticsearch-platinum` docker image.
 
 For further details, please refer to {xpack-ref}/encrypting-communications.html[Encrypting Communications] and https://www.elastic.co/subscriptions[available subscriptions].
 
@@ -36,7 +36,7 @@ instances:
 CERTS_DIR=/usr/share/elasticsearch/config/x-pack/certificates <1>
 ELASTIC_PASSWORD=PleaseChangeMe <2>
 ----
-<1> The path, inside the docker image, where certificates are expected to be found.
+<1> The path, inside the Docker image, where certificates are expected to be found.
 <2> Initial password for the `elastic` user.
 
 [[getting-starter-tls-create-certs-composefile]]
@@ -134,7 +134,7 @@ services:
 volumes: {"esdata_01": {"driver": "local"}, "esdata_02": {"driver": "local"}}
 ----
 
-<1> Bootstrap `elastic` with the password defined in `.env`. See {xpack-ref}/setting-up-authentication.html#bootstrap-elastic-passwords[the Elastic Boostrap Password].
+<1> Bootstrap `elastic` with the password defined in `.env`. See {xpack-ref}/setting-up-authentication.html#bootstrap-elastic-passwords[the Elastic Bootstrap Password].
 <2> Disable verification of authenticity for inter-node communication. Allows creating self-signed certificates without having to pin specific internal IP addresses.
 endif::[]
 
@@ -147,7 +147,7 @@ endif::[]
 docker-compose -f create-certs.yml up
 ----
 --
-. Start two elasticsearch nodes configured for SSL/TLS:
+. Start two Elasticsearch nodes configured for SSL/TLS:
 +
 --
 ["source","sh"]
@@ -155,7 +155,7 @@ docker-compose -f create-certs.yml up
 docker-compose up -d
 ----
 --
-. Access the elasticsearch API over SSL/TLS using the bootstrapped password:
+. Access the Elasticsearch API over SSL/TLS using the bootstrapped password:
 +
 --
 ["source","sh"]


### PR DESCRIPTION
Commit docs for a getting started example for https and TLS/SSL enabled transport with the Docker Elasticsearch image.