### PR TITLE
Decouple `ChannelFactory` from Tcp classes

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ChannelFactory.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ChannelFactory.java
@@ -41,6 +41,15 @@ public class ChannelFactory {
     private final Consumer<NioSocketChannel> contextSetter;
     private final RawChannelFactory rawChannelFactory;
 
+    /**
+     * This will create a {@link ChannelFactory} using the profile settings and context setter passed to this
+     * constructor. The context setter must be a {@link Consumer<NioSocketChannel>} that calls
+     * {@link NioSocketChannel#setContexts(ReadContext, WriteContext)} with the appropriate read and write
+     * contexts. The read and write contexts handle the protocol specific encoding and decoding of messages.
+     *
+     * @param profileSettings the profile settings channels opened by this factory
+     * @param contextSetter a consumer that takes a channel and sets the read and write contexts
+     */
     public ChannelFactory(TcpTransport.ProfileSettings profileSettings, Consumer<NioSocketChannel> contextSetter) {
         this(new RawChannelFactory(profileSettings.tcpNoDelay,
                 profileSettings.tcpKeepAlive,

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ChannelFactory.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ChannelFactory.java
@@ -58,7 +58,7 @@ public class ChannelFactory {
                                            Consumer<NioChannel> closeListener) throws IOException {
         SocketChannel rawChannel = rawChannelFactory.openNioChannel(remoteAddress);
         NioSocketChannel channel = new NioSocketChannel(NioChannel.CLIENT, rawChannel, selector);
-        contextSetter.accept(channel);
+        setContexts(channel);
         channel.getCloseFuture().addListener(ActionListener.wrap(closeListener::accept, (e) -> closeListener.accept(channel)));
         scheduleChannel(channel, selector);
         return channel;
@@ -68,7 +68,7 @@ public class ChannelFactory {
                                              Consumer<NioChannel> closeListener) throws IOException {
         SocketChannel rawChannel = rawChannelFactory.acceptNioChannel(serverChannel);
         NioSocketChannel channel = new NioSocketChannel(serverChannel.getProfile(), rawChannel, selector);
-        contextSetter.accept(channel);
+        setContexts(channel);
         channel.getCloseFuture().addListener(ActionListener.wrap(closeListener::accept, (e) -> closeListener.accept(channel)));
         scheduleChannel(channel, selector);
         return channel;
@@ -98,6 +98,12 @@ public class ChannelFactory {
             IOUtils.closeWhileHandlingException(channel.getRawChannel());
             throw e;
         }
+    }
+
+    private void setContexts(NioSocketChannel channel) {
+        contextSetter.accept(channel);
+        assert channel.getReadContext() != null : "read context should have been set on channel";
+        assert channel.getWriteContext() != null : "write context should have been set on channel";
     }
 
     static class RawChannelFactory {

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ChannelFactory.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/ChannelFactory.java
@@ -43,7 +43,7 @@ public class ChannelFactory {
 
     /**
      * This will create a {@link ChannelFactory} using the profile settings and context setter passed to this
-     * constructor. The context setter must be a {@link Consumer<NioSocketChannel>} that calls
+     * constructor. The context setter must be a {@link Consumer} that calls
      * {@link NioSocketChannel#setContexts(ReadContext, WriteContext)} with the appropriate read and write
      * contexts. The read and write contexts handle the protocol specific encoding and decoding of messages.
      *

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/channel/ChannelFactoryTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/channel/ChannelFactoryTests.java
@@ -55,7 +55,7 @@ public class ChannelFactoryTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     public void setupFactory() throws IOException {
         rawChannelFactory = mock(ChannelFactory.RawChannelFactory.class);
-        channelFactory = new ChannelFactory(rawChannelFactory, mock(TcpReadHandler.class));
+        channelFactory = new ChannelFactory(rawChannelFactory, mock(Consumer.class));
         listener = mock(Consumer.class);
         socketSelector = mock(SocketSelector.class);
         acceptingSelector = mock(AcceptingSelector.class);

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/channel/ChannelFactoryTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/channel/ChannelFactoryTests.java
@@ -26,6 +26,8 @@ import org.elasticsearch.transport.nio.SocketSelector;
 import org.elasticsearch.transport.nio.TcpReadHandler;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -36,6 +38,7 @@ import java.util.function.Consumer;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -55,12 +58,19 @@ public class ChannelFactoryTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     public void setupFactory() throws IOException {
         rawChannelFactory = mock(ChannelFactory.RawChannelFactory.class);
-        channelFactory = new ChannelFactory(rawChannelFactory, mock(Consumer.class));
+        Consumer contextSetter = mock(Consumer.class);
+        channelFactory = new ChannelFactory(rawChannelFactory, contextSetter);
         listener = mock(Consumer.class);
         socketSelector = mock(SocketSelector.class);
         acceptingSelector = mock(AcceptingSelector.class);
         rawChannel = SocketChannel.open();
         rawServerChannel = ServerSocketChannel.open();
+
+        doAnswer(invocationOnMock -> {
+            NioSocketChannel channel = (NioSocketChannel) invocationOnMock.getArguments()[0];
+            channel.setContexts(mock(ReadContext.class), mock(WriteContext.class));
+            return null;
+        }).when(contextSetter).accept(any());
     }
 
     @After


### PR DESCRIPTION
This is related to #27260. Currently `ChannelFactory` is tightly coupled
to classes related to the elasticsearch Tcp binary protocol. This commit
modifies the factory to be able to construct http or other protocol
channels.