### PR TITLE
Improve error message for parse failures of completion fields

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -30,7 +30,6 @@ import org.apache.lucene.search.suggest.document.FuzzyCompletionQuery;
 import org.apache.lucene.search.suggest.document.PrefixCompletionQuery;
 import org.apache.lucene.search.suggest.document.RegexCompletionQuery;
 import org.apache.lucene.search.suggest.document.SuggestField;
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;

--- a/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -560,7 +560,7 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
                 }
             }
         } else {
-            throw new ElasticsearchParseException("failed to parse expected text or object got" + token.name());
+            throw new ElasticsearchParseException("failed to parse [" + parser.currentName() + "][" + parser.getTokenLocation() + "]: expected text or object, but got " + token.name());
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.suggest.document.SuggestField;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.util.set.Sets;
@@ -560,7 +561,7 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
                 }
             }
         } else {
-            throw new ElasticsearchParseException("failed to parse [" + parser.currentName() + "][" + parser.getTokenLocation() + "]: expected text or object, but got " + token.name());
+            throw new ParsingException(parser.getTokenLocation(), "failed to parse [" + parser.currentName() + "]: expected text or object, but got " + token.name());
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -172,17 +172,14 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
 
-        try {
+        MapperParsingException e = expectThrows(MapperParsingException.class, () ->
             defaultMapper.parse(SourceToParse.source("test", "type1", "1", XContentFactory.jsonBuilder()
                     .startObject()
                     .field("completion", 1.0)
                     .endObject()
                     .bytes(),
-                XContentType.JSON));
-            fail("Expected parse() to throw an exception, but it did not.");
-        } catch (MapperParsingException e) {
-            assertEquals("failed to parse [completion][1:15]: expected text or object, but got VALUE_NUMBER", e.getCause().getMessage());
-        }
+                XContentType.JSON)));
+        assertEquals("failed to parse [completion][1:15]: expected text or object, but got VALUE_NUMBER", e.getCause().getMessage());
     }
 
     public void testParsingMultiValued() throws Exception {

--- a/core/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -163,6 +163,28 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
         assertSuggestFields(fields, 1);
     }
 
+    public void testParsingFailure() throws Exception {
+        String mapping = jsonBuilder().startObject().startObject("type1")
+            .startObject("properties").startObject("completion")
+            .field("type", "completion")
+            .endObject().endObject()
+            .endObject().endObject().string();
+
+        DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
+
+        try {
+            defaultMapper.parse(SourceToParse.source("test", "type1", "1", XContentFactory.jsonBuilder()
+                    .startObject()
+                    .field("completion", 1.0)
+                    .endObject()
+                    .bytes(),
+                XContentType.JSON));
+            fail("Expected parse() to throw an exception, but it did not.");
+        } catch (MapperParsingException e) {
+            assertEquals("failed to parse [completion][1:15]: expected text or object, but got VALUE_NUMBER", e.getCause().getMessage());
+        }
+    }
+
     public void testParsingMultiValued() throws Exception {
         String mapping = jsonBuilder().startObject().startObject("type1")
                 .startObject("properties").startObject("completion")

--- a/core/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -179,7 +179,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                     .endObject()
                     .bytes(),
                 XContentType.JSON)));
-        assertEquals("failed to parse [completion][1:15]: expected text or object, but got VALUE_NUMBER", e.getCause().getMessage());
+        assertEquals("failed to parse [completion]: expected text or object, but got VALUE_NUMBER", e.getCause().getMessage());
     }
 
     public void testParsingMultiValued() throws Exception {


### PR DESCRIPTION
Fix spacing/grammar/punctuation, and include the field name and location in the source document.