### PR TITLE
Remove colons from task and configuration names

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -239,7 +239,7 @@ class BuildPlugin implements Plugin<Project> {
 
     /** Return the configuration name used for finding transitive deps of the given dependency. */
     private static String transitiveDepConfigName(String groupId, String artifactId, String version) {
-        return "_transitive_${groupId}:${artifactId}:${version}"
+        return "_transitive_${groupId}_${artifactId}_${version}"
     }
 
     /**

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -102,11 +102,11 @@ task krb5AddPrincipals {
   dependsOn krb5kdcFixture
 }
 
-List<String> principals = [ "elasticsearch", "hdfs_hdfs.build.elastic.co" ]
+List<String> principals = [ "elasticsearch", "hdfs/hdfs.build.elastic.co" ]
 String realm = "BUILD.ELASTIC.CO"
 
 for (String principal : principals) {
-  Task create = project.tasks.create("addPrincipal#${principal}", org.elasticsearch.gradle.vagrant.VagrantCommandTask) {
+  Task create = project.tasks.create("addPrincipal#${principal}".replace('/', '_'), org.elasticsearch.gradle.vagrant.VagrantCommandTask) {
     command 'ssh'
     args '--command', "sudo bash /vagrant/src/main/resources/provision/addprinc.sh $principal"
     boxName box
@@ -132,7 +132,7 @@ task secureHdfsFixture(type: org.elasticsearch.gradle.test.AntFixture) {
 
   miniHDFSArgs.add('hdfs.MiniHDFS')
   miniHDFSArgs.add(baseDir)
-  miniHDFSArgs.add("hdfs_hdfs.build.elastic.co@${realm}")
+  miniHDFSArgs.add("hdfs/hdfs.build.elastic.co@${realm}")
   miniHDFSArgs.add("${keytabPath}")
 
   args miniHDFSArgs.toArray()

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -102,7 +102,7 @@ task krb5AddPrincipals {
   dependsOn krb5kdcFixture
 }
 
-List<String> principals = [ "elasticsearch", "hdfs/hdfs.build.elastic.co" ]
+List<String> principals = [ "elasticsearch", "hdfs_hdfs.build.elastic.co" ]
 String realm = "BUILD.ELASTIC.CO"
 
 for (String principal : principals) {
@@ -132,7 +132,7 @@ task secureHdfsFixture(type: org.elasticsearch.gradle.test.AntFixture) {
 
   miniHDFSArgs.add('hdfs.MiniHDFS')
   miniHDFSArgs.add(baseDir)
-  miniHDFSArgs.add("hdfs/hdfs.build.elastic.co@${realm}")
+  miniHDFSArgs.add("hdfs_hdfs.build.elastic.co@${realm}")
   miniHDFSArgs.add("${keytabPath}")
 
   args miniHDFSArgs.toArray()


### PR DESCRIPTION
Gradle 5.0 will remove support for colons in configuration and task
names. This commit fixes this for our build by removing all current uses
of colons in configuration and task names.

Relates #27250

