### PR TITLE
Fix find remote when building BWC

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -74,6 +74,8 @@ if (enabled) {
     dependsOn createClone
     workingDir = checkoutDir
     commandLine = ['git', 'remote', '-v']
+    ByteArrayOutputStream output = new ByteArrayOutputStream()
+    standardOutput = output
     doLast {
       project.ext.remoteExists = false
       output.toString('UTF-8').eachLine {


### PR DESCRIPTION
We look for the remote by scanning the output of "git remote -v" but we were not actually looking at the output since standard output was not redirected anywhere. This commit fixes this issue.
