### PR TITLE
 Remove optimisations to reuse objects when applying a new `ClusterState`

### DIFF
--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -775,7 +775,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
             logger.debug("got first state from fresh master [{}]", newClusterState.nodes().getMasterNodeId());
             adaptedNewClusterState = newClusterState;
         } else if (newClusterState.nodes().isLocalNodeElectedMaster() == false) {
-            adaptedNewClusterState = ClusterState.builder(newClusterState).build();
+            adaptedNewClusterState = newClusterState;
         } else {
             adaptedNewClusterState = newClusterState;
         }

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -775,8 +775,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
             logger.debug("got first state from fresh master [{}]", newClusterState.nodes().getMasterNodeId());
             adaptedNewClusterState = newClusterState;
         } else if (newClusterState.nodes().isLocalNodeElectedMaster() == false) {
-            ClusterState.Builder builder = ClusterState.builder(newClusterState);
-            adaptedNewClusterState = builder.build();
+            adaptedNewClusterState = ClusterState.builder(newClusterState).build();
         } else {
             adaptedNewClusterState = newClusterState;
         }

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -773,12 +773,10 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         if (currentState.blocks().hasGlobalBlock(discoverySettings.getNoMasterBlock())) {
             // its a fresh update from the master as we transition from a start of not having a master to having one
             logger.debug("got first state from fresh master [{}]", newClusterState.nodes().getMasterNodeId());
-            adaptedNewClusterState = newClusterState;
         } else if (newClusterState.nodes().isLocalNodeElectedMaster() == false) {
-            adaptedNewClusterState = newClusterState;
         } else {
-            adaptedNewClusterState = newClusterState;
         }
+        adaptedNewClusterState = newClusterState;
 
         if (currentState == adaptedNewClusterState) {
             return false;

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -773,7 +773,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         if (currentState.blocks().hasGlobalBlock(discoverySettings.getNoMasterBlock())) {
             // its a fresh update from the master as we transition from a start of not having a master to having one
             logger.debug("got first state from fresh master [{}]", newClusterState.nodes().getMasterNodeId());
-        } else if (newClusterState.nodes().isLocalNodeElectedMaster() == false) {
         } else {
         }
         adaptedNewClusterState = newClusterState;

--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -773,7 +773,6 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
         if (currentState.blocks().hasGlobalBlock(discoverySettings.getNoMasterBlock())) {
             // its a fresh update from the master as we transition from a start of not having a master to having one
             logger.debug("got first state from fresh master [{}]", newClusterState.nodes().getMasterNodeId());
-        } else {
         }
         adaptedNewClusterState = newClusterState;
 

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -194,9 +194,6 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
 
         ClusterState clusterState3 = ClusterState.builder(clusterState1).incrementVersion()
             .metaData(MetaData.builder().put(IndexMetaData.builder(indexMetaData).numberOfReplicas(2).build(), true)).build();
-        assertNotEquals("Should have created a new, different, IndexMetaData object in clusterState3",
-            clusterState2.metaData().index("test"), clusterState3.metaData().index("test"));
-
         ClusterState serializedClusterState3 = updateUsingSerialisedDiff(serializedClusterState2, clusterState3.diff(clusterState2));
         assertNotEquals("Should have a new IndexMetaData object",
             serializedClusterState2.metaData().index("test"), serializedClusterState3.metaData().index("test"));

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -181,6 +181,7 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
             new NamedWriteableRegistry(ClusterModule.getNamedWriteables()));
         ClusterState serializedClusterState1 = ClusterState.readFrom(inStream, newNode("node4"));
 
+        // Create a new, albeit equal, IndexMetadata object
         ClusterState clusterState2 = ClusterState.builder(clusterState1).incrementVersion()
             .metaData(MetaData.builder().put(IndexMetaData.builder(indexMetaData).numberOfReplicas(1).build(), true)).build();
         assertNotSame("Should have created a new, equivalent, IndexMetaData object in clusterState2",
@@ -192,6 +193,7 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
         assertSame("Unchanged routing table should not create new IndexRoutingTable objects",
             serializedClusterState1.routingTable().index("test"), serializedClusterState2.routingTable().index("test"));
 
+        // Create a new and different IndexMetadata object
         ClusterState clusterState3 = ClusterState.builder(clusterState1).incrementVersion()
             .metaData(MetaData.builder().put(IndexMetaData.builder(indexMetaData).numberOfReplicas(2).build(), true)).build();
         ClusterState serializedClusterState3 = updateUsingSerialisedDiff(serializedClusterState2, clusterState3.diff(clusterState2));

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.RestoreInProgress;
 import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -44,6 +45,7 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -168,7 +170,9 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
     public void testObjectReuseWhenApplyingClusterStateDiff() throws Exception {
         IndexMetaData indexMetaData
             = IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(10).numberOfReplicas(1).build();
-        MetaData metaData = MetaData.builder().put(indexMetaData, true).build();
+        IndexTemplateMetaData indexTemplateMetaData
+            = IndexTemplateMetaData.builder("test-template").patterns(new ArrayList<>()).build();
+        MetaData metaData = MetaData.builder().put(indexMetaData, true).put(indexTemplateMetaData).build();
 
         RoutingTable routingTable = RoutingTable.builder().addAsNew(metaData.index("test")).build();
 
@@ -201,5 +205,10 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
             serializedClusterState2.metaData().index("test"), serializedClusterState3.metaData().index("test"));
         assertSame("Unchanged routing table should not create new IndexRoutingTable objects",
             serializedClusterState2.routingTable().index("test"), serializedClusterState3.routingTable().index("test"));
+
+        assertSame("nodes", serializedClusterState2.nodes(), serializedClusterState3.nodes());
+        assertSame("blocks", serializedClusterState2.blocks(), serializedClusterState3.blocks());
+        assertSame("template", serializedClusterState2.metaData().templates().get("test-template"),
+            serializedClusterState3.metaData().templates().get("test-template"));
     }
 }


### PR DESCRIPTION
In order to avoid churn when applying a new `ClusterState`, there are some checks that compare parts of the old and new states and, if equal, the new object is discarded and the old one reused. Since `ClusterState` updates are now largely diff-based, this code is unnecessary: applying a diff also reuses any old objects if unchanged. Moreover, the code compares the parts of the `ClusterState` using their `version()` values which is not guaranteed to be correct, because of a lack of consensus.

This change removes this optimisation, and tests that objects are still reused as expected via the diff mechanism.