### PR TITLE
Add limits for ngram and shingle settings 

### DIFF
--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -19,3 +19,21 @@ had the undocumented side-effect of refreshing the index which made new document
 visible to searches and non-realtime GET operations. From now on these operations
 don't have this side-effect anymore. To make documents visible an explicit `_refresh`
 call is needed unless the index is refreshed by the internal scheduler.
+
+
+==== Limit to the difference between max_size and min_size in NGramTokenFilter and NGramTokenizer
+
+To safeguard against creating too many index terms, the difference between `max_ngram` and
+`min_ngram` in `NGramTokenFilter` and `NGramTokenizer` has been limited to 1. This default
+limit can be changed with the index setting `index.max_ngram_diff`. Note that if the limit is
+exceeded a error is thrown only for new indices. For existing pre-7.0 indices, a deprecation
+warning is logged.
+
+
+==== Limit to the difference between max_size and min_size in ShingleTokenFilter
+
+To safeguard against creating too many tokens, the difference between `max_shingle_size` and
+`min_shingle_size` in `ShingleTokenFilter` has been limited to 3. This default
+limit can be changed with the index setting `index.max_shingle_diff`. Note that if the limit is
+exceeded a error is thrown only for new indices. For existing pre-7.0 indices, a deprecation
+warning is logged.


### PR DESCRIPTION
Add breaking change documentation for the  #27211 

This adds to PR #27211 to explain what is changing in the index level settings for ngram and shingles.

Relates to #27211
Also closes issue #25887