### PR TITLE
Remove Stored Script Check for Empty Code Strings

### DIFF
--- a/core/src/main/java/org/elasticsearch/script/StoredScriptSource.java
+++ b/core/src/main/java/org/elasticsearch/script/StoredScriptSource.java
@@ -138,8 +138,6 @@ public class StoredScriptSource extends AbstractDiffable<StoredScriptSource> imp
 
             if (code == null) {
                 throw new IllegalArgumentException("must specify code for stored script");
-            } else if (code.isEmpty()) {
-                throw new IllegalArgumentException("code cannot be empty");
             }
 
             if (options.size() > 1 || options.size() == 1 && options.get(Script.CONTENT_TYPE_OPTION) == null) {

--- a/core/src/test/java/org/elasticsearch/script/StoredScriptTests.java
+++ b/core/src/test/java/org/elasticsearch/script/StoredScriptTests.java
@@ -324,4 +324,25 @@ public class StoredScriptTests extends ESTestCase {
             assertThat(iae.getMessage(), equalTo("illegal compiler options [{option=option}] specified"));
         }
     }
+
+    public void testEmptyScript() throws Exception {
+        try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)) {
+            builder.startObject().field("script").startObject().field("lang", "lang").field("code", "").
+                startObject("options").endObject().endObject().endObject().string();
+
+            StoredScriptSource parsed = StoredScriptSource.parse(null, builder.bytes(), XContentType.JSON);
+            StoredScriptSource source = new StoredScriptSource("lang", "", Collections.emptyMap());
+
+            assertThat(parsed, equalTo(source));
+        }
+
+        try (XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)) {
+            builder.startObject().field("template", "").endObject();
+
+            StoredScriptSource parsed = StoredScriptSource.parse("lang", builder.bytes(), XContentType.JSON);
+            StoredScriptSource source = new StoredScriptSource("lang", "", Collections.emptyMap());
+
+            assertThat(parsed, equalTo(source));
+        }
+    }
 }


### PR DESCRIPTION
Removes a backwards incompatible check for empty code strings being loaded from stored scripts.  Search templates did not have an appropriate check for not allowing stored scripts to have an empty code string, so when an empty search template is added, future restarts of the node will fail.

Edit: @rjernst says I need to change the version to 5.6.x.  I will be doing that soon.