### PR TITLE
Add support for wildcard on `_index`

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -27,6 +27,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -150,12 +151,8 @@ public class IndexFieldMapper extends MetadataFieldMapper {
         }
 
         private boolean isSameIndex(Object value, String indexName) {
-            if (value instanceof BytesRef) {
-                BytesRef indexNameRef = new BytesRef(indexName);
-                return (indexNameRef.bytesEquals((BytesRef) value));
-            } else {
-                return indexName.equals(value.toString());
-            }
+            String pattern = value instanceof BytesRef ? pattern = ((BytesRef) value).utf8ToString() : value.toString();
+            return Regex.simpleMatch(pattern, indexName);
         }
 
         @Override

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
@@ -31,6 +33,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.IndexFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.support.QueryParsers;
 
@@ -187,6 +190,9 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
             term = new Term(fieldName, BytesRefs.toBytesRef(value));
         } else {
             Query termQuery = fieldType.termQuery(value, context);
+            if (termQuery instanceof MatchNoDocsQuery || termQuery instanceof MatchAllDocsQuery) {
+                return termQuery;
+            }
             term = MappedFieldType.extractTerm(termQuery);
         }
 

--- a/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/WildcardQueryBuilderTests.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
 import org.elasticsearch.common.ParsingException;
@@ -135,5 +137,21 @@ public class WildcardQueryBuilderTests extends AbstractQueryTestCase<WildcardQue
             Query expected = new WildcardQuery(new Term(field, "toto"));
             assertEquals(expected, query);
         }
+    }
+    
+    public void testIndexWildcard() throws IOException {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+
+        QueryShardContext context = createShardContext();
+        String index = context.getFullyQualifiedIndexName();
+        
+        Query query = new WildcardQueryBuilder("_index", index).doToQuery(context);
+        assertThat(query instanceof MatchAllDocsQuery, equalTo(true));
+        
+        query = new WildcardQueryBuilder("_index", index + "*").doToQuery(context);
+        assertThat(query instanceof MatchAllDocsQuery, equalTo(true));
+        
+        query = new WildcardQueryBuilder("_index", "index_" + index + "*").doToQuery(context);
+        assertThat(query instanceof MatchNoDocsQuery, equalTo(true));
     }
 }


### PR DESCRIPTION
The wildcard is evaluated against the index name.

Fixes #25722