### PR TITLE
add json-processor support for non-map json types

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1580,6 +1580,8 @@ Converts a JSON string into a structured JSON object.
 | `add_to_root`  | no        | false    | Flag that forces the serialized json to be injected into the top level of the document. `target_field` must not be set when this option is chosen.
 |======
 
+All JSON-supported types will be parsed (null, boolean, number, array, object, string).
+
 Suppose you provide this configuration of the `json` processor:
 
 [source,js]

--- a/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/140_json.yml
+++ b/modules/ingest-common/src/test/resources/rest-api-spec/test/ingest/140_json.yml
@@ -15,7 +15,32 @@ teardown:
             "processors": [
               {
                 "json" : {
-                  "field" : "foo"
+                  "field" : "foo_object"
+                }
+              },
+              {
+                "json" : {
+                  "field" : "foo_array"
+                }
+              },
+              {
+                "json" : {
+                  "field" : "foo_null"
+                }
+              },
+              {
+                "json" : {
+                  "field" : "foo_string"
+                }
+              },
+              {
+                "json" : {
+                  "field" : "foo_number"
+                }
+              },
+              {
+                "json" : {
+                  "field" : "foo_boolean"
                 }
               }
             ]
@@ -29,7 +54,12 @@ teardown:
         id: 1
         pipeline: "1"
         body: {
-          foo: "{\"hello\": \"world\"}"
+          foo_object: "{\"hello\": \"world\"}",
+          foo_array: "[1, 2, 3]",
+          foo_null: null,
+          foo_string: "\"bla bla\"",
+          foo_number: 3,
+          foo_boolean: "true"
         }
 
   - do:
@@ -37,4 +67,9 @@ teardown:
         index: test
         type: test
         id: 1
-  - match: { _source.foo.hello: "world" }
+  - match: { _source.foo_object.hello: "world" }
+  - match: { _source.foo_array.0: 1 }
+  - match: { _source.foo_string: "bla bla" }
+  - match: { _source.foo_number: 3 }
+  - is_true:  _source.foo_boolean
+  - is_false: _source.foo_null


### PR DESCRIPTION
The Json Processor originally only supported parsing field values into Maps even
though the JSON spec specifies that strings, null-values, numbers, booleans, and arrays
are also valid JSON types. This commit enables parsing these values now.

response to #25972.