### PR TITLE
`rest-api-spec` : update index parameters to reflect the code base

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -27,6 +27,12 @@
           "type" : "string",
           "description" : "Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
         },
+        "op_type": {
+          "type" : "enum",
+          "options" : ["index", "create"],
+          "default" : "index",
+          "description" : "Explicit operation type"
+        },
         "parent": {
           "type" : "string",
           "description" : "ID of the parent document"
@@ -43,14 +49,6 @@
         "timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout"
-        },
-        "timestamp": {
-          "type" : "time",
-          "description" : "Explicit timestamp for the document"
-        },
-        "ttl": {
-          "type" : "time",
-          "description" : "Expiration time for the document"
         },
         "version" : {
           "type" : "number",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -27,12 +27,6 @@
           "type" : "string",
           "description" : "Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
         },
-        "op_type": {
-          "type" : "enum",
-          "options" : ["index", "create"],
-          "default" : "index",
-          "description" : "Explicit operation type"
-        },
         "parent": {
           "type" : "string",
           "description" : "ID of the parent document"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -49,14 +49,6 @@
           "type" : "time",
           "description" : "Explicit operation timeout"
         },
-        "timestamp": {
-          "type" : "time",
-          "description" : "Explicit timestamp for the document"
-        },
-        "ttl": {
-          "type" : "time",
-          "description" : "Expiration time for the document"
-        },
         "version" : {
           "type" : "number",
           "description" : "Explicit version number for concurrency control"


### PR DESCRIPTION
Removing outdated parameters to `index` and `_create`; adding missing `op_type` to `_create`.

Relates to #27158