### PR TITLE
fix unnecessary synchronized block

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/DocValuesIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/DocValuesIndexFieldData.java
@@ -46,13 +46,11 @@ public abstract class DocValuesIndexFieldData {
 
     protected final Index index;
     protected final String fieldName;
-    protected final Logger logger;
 
     public DocValuesIndexFieldData(Index index, String fieldName) {
         super();
         this.index = index;
         this.fieldName = fieldName;
-        this.logger = Loggers.getLogger(getClass());
     }
 
     public final String getFieldName() {

--- a/core/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.fielddata.plain;
 
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.OrdinalMap;
@@ -28,6 +29,7 @@ import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
@@ -48,6 +50,7 @@ public class SortedSetDVOrdinalsIndexFieldData extends DocValuesIndexFieldData i
     private final IndexFieldDataCache cache;
     private final CircuitBreakerService breakerService;
     private final Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction;
+    private static final Logger logger = Loggers.getLogger(SortedSetDVOrdinalsIndexFieldData.class);
 
     public SortedSetDVOrdinalsIndexFieldData(IndexSettings indexSettings, IndexFieldDataCache cache, String fieldName,
             CircuitBreakerService breakerService, Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction) {


### PR DESCRIPTION
During our perf test against elasticsearch, we noticed two synchronized block in the call stack of fetching doc values, which i think is necessary and cause a serious gc issue for us, especially when "size" param is large and fetch docvalue fields.

1) Logger object in DocValuesIndexFieldData.java class
Each doc value fetch will essentially create an instance of DocValuesIndexFieldData class, which will create a logger object in its constructor. However in PrefixLogger class, there is a [synchronized block around marker](https://github.com/elastic/elasticsearch/blob/8904fc821015d951944555259d1247fd7fdbe757/core/src/main/java/org/elasticsearch/common/logging/PrefixLogger.java#L82) which will block the initialization of DocValuesIndexFieldData class. We noticed a lot of thread block in PrefixLogger from JFR recording, which we believe is the root cause for super long ParNew GC:
![screen shot 2017-11-10 at 4 07 06 pm](https://user-images.githubusercontent.com/22285417/32683590-3a3494bc-c631-11e7-802f-f61d769130ec.png)
We noticed that among all the classes which extend DocValuesIndexFieldData, only SortedSetDVOrdinalsIndexFieldData class actually uses the logger, thus we are proposing moving the logger creation to this class.
We also noticed that there are quite a few other places where loggers get initialized in constructor, e.g. BulkRequestHandler.java and AbstractComponent.java. We think it could also potentially be an issue if lots of instances of such classes are created in a short period of time and suggest revisit such use cases.

2) `getForField` method in IndexFieldDataService.java
There is a synchronized block for getting from fieldDataCaches map, which is unnecessary when `cache != null`, we suggest changing fieldDataCaches from HashMap to ConcurrentHashMap thus we don't need any explicit synchronized logic at all.
We see similar behavior(threads waiting on `getForField` method) in our JFR too.
![screen shot 2017-11-10 at 4 23 39 pm](https://user-images.githubusercontent.com/22285417/32683873-923ac616-c633-11e7-9325-c4d5667c3ba6.png)


`gradle test` all passed in my local.

For reference, below is a sample query we used for testing:
```
{
  "stored_fields": "_none_",
  "docvalue_fields": ["user_number"],
  "size": 33000,
  "query": {
    "bool": {
    	 "must": [
    	   {
    	   	"match_all":{}
    	   }
    	 ]
    }
  }
}
