### PR TITLE
use ConcurrentHashMap to avoid synchronized block

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -79,7 +79,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
         this.mapperService = mapperService;
     }
 
-    public void clear() {
+    public synchronized void clear() {
         List<Exception> exceptions = new ArrayList<>(0);
         final Collection<IndexFieldDataCache> fieldDataCacheValues = fieldDataCaches.values();
         for (IndexFieldDataCache cache : fieldDataCacheValues) {

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -93,7 +93,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
         ExceptionsHelper.maybeThrowRuntimeAndSuppress(exceptions);
     }
 
-    public void clearField(final String fieldName) {
+    public synchronized void clearField(final String fieldName) {
         List<Exception> exceptions = new ArrayList<>(0);
         final IndexFieldDataCache cache = fieldDataCaches.remove(fieldName);
         if (cache != null) {


### PR DESCRIPTION
During our perf test against elasticsearch, we noticed two synchronized block in the call stack of fetching doc values, which i think is necessary and cause a serious gc issue for us, especially when "size" param is large and fetch docvalue fields.

`getForField` method in IndexFieldDataService.java
There is a synchronized block for getting from fieldDataCaches map, which is unnecessary when cache != null, we suggest changing fieldDataCaches from HashMap to ConcurrentHashMap thus we don't need any explicit synchronized logic at all.
We see threads waiting on getForField method in our JFR recording.
![screen shot 2017-11-10 at 4 23 39 pm](https://user-images.githubusercontent.com/22285417/32684412-10b184cc-c638-11e7-879f-f428b49368c2.png)

`gradle test` all passed in my local.

For reference, below is a sample query we used for testing:
```
{
  "stored_fields": "_none_",
  "docvalue_fields": ["user_number"],
  "size": 33000,
  "query": {
    "bool": {
    	 "must": [
    	   {
    	   	"match_all":{}
    	   }
    	 ]
    }
  }
}