### PR TITLE
Reduce synchronization on field data cache

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -118,7 +118,8 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
         cache = fieldDataCaches.get(fieldName);
         if (cache == null) {
             synchronized (this) {
-                if (fieldDataCaches.get(fieldName) == null) {
+                cache = fieldDataCaches.get(fieldName);
+                if (cache == null) {
                     String cacheType = indexSettings.getValue(INDEX_FIELDDATA_CACHE_KEY);
                     if (FIELDDATA_CACHE_VALUE_NODE.equals(cacheType)) {
                         cache = indicesFieldDataCache.buildIndexFieldDataCache(listener, index(), fieldName);

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -114,8 +114,7 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
         final String fieldName = fieldType.name();
         IndexFieldData.Builder builder = fieldType.fielddataBuilder(fullyQualifiedIndexName);
 
-        IndexFieldDataCache cache;
-        cache = fieldDataCaches.get(fieldName);
+        IndexFieldDataCache cache = fieldDataCaches.get(fieldName);
         if (cache == null) {
             synchronized (this) {
                 cache = fieldDataCaches.get(fieldName);

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -115,18 +115,20 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
         IndexFieldData.Builder builder = fieldType.fielddataBuilder(fullyQualifiedIndexName);
 
         IndexFieldDataCache cache;
-        synchronized (this) {
-            cache = fieldDataCaches.get(fieldName);
-            if (cache == null) {
-                String cacheType = indexSettings.getValue(INDEX_FIELDDATA_CACHE_KEY);
-                if (FIELDDATA_CACHE_VALUE_NODE.equals(cacheType)) {
-                    cache = indicesFieldDataCache.buildIndexFieldDataCache(listener, index(), fieldName);
-                } else if ("none".equals(cacheType)){
-                    cache = new IndexFieldDataCache.None();
-                } else {
-                    throw new IllegalArgumentException("cache type not supported [" + cacheType + "] for field [" + fieldName + "]");
+        cache = fieldDataCaches.get(fieldName);
+        if (cache == null) {
+            synchronized (this) {
+                if (fieldDataCaches.get(fieldName) == null) {
+                    String cacheType = indexSettings.getValue(INDEX_FIELDDATA_CACHE_KEY);
+                    if (FIELDDATA_CACHE_VALUE_NODE.equals(cacheType)) {
+                        cache = indicesFieldDataCache.buildIndexFieldDataCache(listener, index(), fieldName);
+                    } else if ("none".equals(cacheType)){
+                        cache = new IndexFieldDataCache.None();
+                    } else {
+                        throw new IllegalArgumentException("cache type not supported [" + cacheType + "] for field [" + fieldName + "]");
+                    }
+                    fieldDataCaches.put(fieldName, cache);
                 }
-                fieldDataCaches.put(fieldName, cache);
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -116,8 +116,11 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
 
         IndexFieldDataCache cache = fieldDataCaches.get(fieldName);
         if (cache == null) {
+            //for perf reason, only synchronize when cache is null
             synchronized (this) {
                 cache = fieldDataCaches.get(fieldName);
+                //double checked locking to make sure it is thread safe
+                //especially when other threads calling clear() or clearField()
                 if (cache == null) {
                     String cacheType = indexSettings.getValue(INDEX_FIELDDATA_CACHE_KEY);
                     if (FIELDDATA_CACHE_VALUE_NODE.equals(cacheType)) {


### PR DESCRIPTION
During our perf test against elasticsearch, we noticed two synchronized block in the call stack of fetching doc values, which i think is necessary and cause a serious gc issue for us, especially when "size" param is large and fetch docvalue fields.

There is a synchronized block for getting from fieldDataCaches map, which is unnecessary when cache != null. And `getForField` method is called for every hit thus blocking at here impact performance a lot. We suggest changing to double checked locking and only do synchronize when `cache==null`.
We see threads waiting on getForField method in our JFR recording.
![screen shot 2017-11-10 at 4 23 39 pm](https://user-images.githubusercontent.com/22285417/32744824-a1bbd830-c865-11e7-9aa5-9bedca05eb69.png)


`gradle test` all passed in my local.

For reference, below is a sample query we used for testing:
```
{
  "stored_fields": "_none_",
  "docvalue_fields": ["user_number"],
  "size": 33000,
  "query": {
    "bool": {
    	 "must": [
    	   {
    	   	"match_all":{}
    	   }
    	 ]
    }
  }
}
```
This PR links to https://github.com/elastic/elasticsearch/pull/27350
@jasontedor @s1monw 