### PR TITLE
Make fields optional in multi_match query and rely on index.query.default_field by default

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -260,7 +260,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
             out.writeOptionalBoolean(lenient);
         } else {
-            out.writeBoolean(lenient);
+            out.writeBoolean(lenient == null ? MatchQuery.DEFAULT_LENIENCY : lenient);
         }
         out.writeOptionalFloat(cutoffFrequency);
         zeroTermsQuery.writeTo(out);

--- a/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -32,8 +32,10 @@ import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder.Type;
 import org.elasticsearch.index.search.MatchQuery;
@@ -41,6 +43,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,18 +69,28 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
             assumeTrue("test with date fields runs only when at least a type is registered", getCurrentTypes().length > 0);
         }
 
-        // creates the query with random value and field name
-        Object value;
+        final Object value;
         if (fieldName.equals(STRING_FIELD_NAME)) {
             value = getRandomQueryText();
         } else {
             value = getRandomValueForFieldName(fieldName);
         }
-        MultiMatchQueryBuilder query = new MultiMatchQueryBuilder(value, fieldName);
-        // field with random boost
-        if (randomBoolean()) {
-            query.field(fieldName, randomFloat() * 10);
+
+        final MultiMatchQueryBuilder query;
+        if (rarely()) {
+            query = new MultiMatchQueryBuilder(value, fieldName);
+            if (randomBoolean()) {
+                query.lenient(randomBoolean());
+            }
+            // field with random boost
+            if (randomBoolean()) {
+                query.field(fieldName, randomFloat() * 10);
+            }
+        } else {
+            query = new MultiMatchQueryBuilder(value);
+            query.lenient(true);
         }
+
         // sets other parameters of the multi match query
         if (randomBoolean()) {
             query.type(randomFrom(MultiMatchQueryBuilder.Type.values()));
@@ -111,9 +124,6 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         }
         if (randomBoolean()) {
             query.tieBreaker(randomFloat());
-        }
-        if (randomBoolean()) {
-            query.lenient(randomBoolean());
         }
         if (randomBoolean()) {
             query.cutoffFrequency((float) 10 / randomIntBetween(1, 100));
@@ -337,5 +347,48 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         FuzzyQuery expected = new FuzzyQuery(new Term(STRING_FIELD_NAME, "text"), 2, 2, 5, false);
 
         assertEquals(expected, query);
+    }
+
+    public void testDefaultField() throws Exception {
+        assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        QueryShardContext context = createShardContext();
+        context.getIndexSettings().updateIndexMetaData(
+            newIndexMeta("index", context.getIndexSettings().getSettings(), Settings.builder().putList("index.query.default_field",
+                STRING_FIELD_NAME, STRING_FIELD_NAME_2 + "^5").build())
+        );
+        MultiMatchQueryBuilder qb = new MultiMatchQueryBuilder("hello");
+        Query q = qb.toQuery(context);
+        DisjunctionMaxQuery expected = new DisjunctionMaxQuery(
+            Arrays.asList(
+                new TermQuery(new Term(STRING_FIELD_NAME, "hello")),
+                new BoostQuery(new TermQuery(new Term(STRING_FIELD_NAME_2, "hello")), 5.0f)
+            ), 0.0f
+        );
+        assertEquals(expected, q);
+
+        context.getIndexSettings().updateIndexMetaData(
+            newIndexMeta("index", context.getIndexSettings().getSettings(), Settings.builder().putList("index.query.default_field",
+                STRING_FIELD_NAME, STRING_FIELD_NAME_2 + "^5", INT_FIELD_NAME).build())
+        );
+        IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> qb.toQuery(context));
+        assertThat(exc, instanceOf(NumberFormatException.class));
+        assertThat(exc.getMessage(), equalTo("For input string: \"hello\""));
+        qb.lenient(true);
+        q = qb.toQuery(context);
+        expected = new DisjunctionMaxQuery(
+            Arrays.asList(
+                new TermQuery(new Term(STRING_FIELD_NAME, "hello")),
+                new BoostQuery(new TermQuery(new Term(STRING_FIELD_NAME_2, "hello")), 5.0f),
+                new MatchNoDocsQuery("failed [mapped_int] query, caused by number_format_exception:[For input string: \"hello\"]")
+            ), 0.0f
+        );
+        assertEquals(expected, q);
+    }
+
+    private static IndexMetaData newIndexMeta(String name, Settings oldIndexSettings, Settings indexSettings) {
+        Settings build = Settings.builder().put(oldIndexSettings)
+            .put(indexSettings)
+            .build();
+        return IndexMetaData.builder(name).settings(build).build();
     }
 }

--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -58,6 +58,11 @@ GET /_search
 
 <1> The `subject` field is three times as important as the `message` field.
 
+If no `fields` are provided, the `multi_match` query defaults to the `index.query.default_field`
+index settings, which in turn defaults to `*`. `*` extracts all fields in the mapping that
+are eligible to term queries and filters the metadata fields. All extracted fields are then
+combined to build a query.
+
 WARNING: There is a limit of no more than 1024 fields being queried at once.
 
 [[multi-match-types]]


### PR DESCRIPTION
This commit adds the ability to send `multi_match` query without providing any `fields`.
When no fields are provided the `multi_match` query will use the fields defined in the index setting `index.query.default_field`
(which in turns defaults to `*`).
The same behavior is already implemented in `query_string` and `simple_query_string` so this change just applies
the heuristic to `multi_match` queries.
Relying on `index.query.default_field` rather than `*` is safer for big mappings that break the 1024 field expansion limit added in 7.0 for all
text queries. For these kind of mappings the admin can change the `index.query.default_field` in order to make sure that exploratory queries using
`multi_match`, `query_string` or `simple_query_string` do not throw an exception.