### PR TITLE
Remove implementations of `TransportChannel`

### DIFF
--- a/core/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
+++ b/core/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
@@ -24,18 +24,19 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class TcpTransportChannel<Channel> implements TransportChannel {
+
     private final TcpTransport<Channel> transport;
-    protected final Version version;
-    protected final String action;
-    protected final long requestId;
+    private final Version version;
+    private final String action;
+    private final long requestId;
     private final String profileName;
     private final long reservedBytes;
     private final AtomicBoolean released = new AtomicBoolean();
     private final String channelType;
     private final Channel channel;
 
-    public TcpTransportChannel(TcpTransport<Channel> transport, Channel channel, String channelType, String action,
-                               long requestId, Version version, String profileName, long reservedBytes) {
+    TcpTransportChannel(TcpTransport<Channel> transport, Channel channel, String channelType, String action,
+                        long requestId, Version version, String profileName, long reservedBytes) {
         this.version = version;
         this.channel = channel;
         this.transport = transport;
@@ -49,11 +50,6 @@ public final class TcpTransportChannel<Channel> implements TransportChannel {
     @Override
     public String getProfileName() {
         return profileName;
-    }
-
-    @Override
-    public String action() {
-        return this.action;
     }
 
     @Override
@@ -78,6 +74,7 @@ public final class TcpTransportChannel<Channel> implements TransportChannel {
             release(true);
         }
     }
+
     private Exception releaseBy;
 
     private void release(boolean isExceptionResponse) {
@@ -92,22 +89,17 @@ public final class TcpTransportChannel<Channel> implements TransportChannel {
     }
 
     @Override
-    public long getRequestId() {
-        return requestId;
-    }
-
-    @Override
     public String getChannelType() {
         return channelType;
-    }
-
-    public Channel getChannel() {
-        return channel;
     }
 
     @Override
     public Version getVersion() {
         return version;
+    }
+
+    public Channel getChannel() {
+        return channel;
     }
 }
 

--- a/core/src/main/java/org/elasticsearch/transport/TransportChannel.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportChannel.java
@@ -28,11 +28,7 @@ import java.io.IOException;
  */
 public interface TransportChannel {
 
-    String action();
-
     String getProfileName();
-
-    long getRequestId();
 
     String getChannelType();
 

--- a/core/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/core/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1117,19 +1117,14 @@ public class TransportService extends AbstractLifecycleComponent {
         final TransportService service;
         final ThreadPool threadPool;
 
-        DirectResponseChannel(Logger logger, DiscoveryNode localNode, String action, long requestId,
-                                     TransportService service, ThreadPool threadPool) {
+        DirectResponseChannel(Logger logger, DiscoveryNode localNode, String action, long requestId, TransportService service,
+                              ThreadPool threadPool) {
             this.logger = logger;
             this.localNode = localNode;
             this.action = action;
             this.requestId = requestId;
             this.service = service;
             this.threadPool = threadPool;
-        }
-
-        @Override
-        public String action() {
-            return action;
         }
 
         @Override
@@ -1177,13 +1172,7 @@ public class TransportService extends AbstractLifecycleComponent {
                 if (ThreadPool.Names.SAME.equals(executor)) {
                     processException(handler, rtx);
                 } else {
-                    threadPool.executor(handler.executor()).execute(new Runnable() {
-                        @SuppressWarnings({"unchecked"})
-                        @Override
-                        public void run() {
-                            processException(handler, rtx);
-                        }
-                    });
+                    threadPool.executor(handler.executor()).execute(() -> processException(handler, rtx));
                 }
             }
         }
@@ -1203,11 +1192,6 @@ public class TransportService extends AbstractLifecycleComponent {
                     (Supplier<?>) () -> new ParameterizedMessage(
                         "failed to handle exception for action [{}], handler [{}]", action, handler), e);
             }
-        }
-
-        @Override
-        public long getRequestId() {
-            return requestId;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -472,11 +472,6 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
         }
 
         @Override
-        public String action() {
-            return null;
-        }
-
-        @Override
         public String getProfileName() {
             return "";
         }
@@ -492,11 +487,6 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
 
         @Override
         public void sendResponse(Exception exception) throws IOException {
-        }
-
-        @Override
-        public long getRequestId() {
-            return 0;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -1238,11 +1238,6 @@ public class TransportReplicationActionTests extends ESTestCase {
         return new TransportChannel() {
 
             @Override
-            public String action() {
-                return null;
-            }
-
-            @Override
             public String getProfileName() {
                 return "";
             }
@@ -1260,11 +1255,6 @@ public class TransportReplicationActionTests extends ESTestCase {
             @Override
             public void sendResponse(Exception exception) throws IOException {
                 listener.onFailure(exception);
-            }
-
-            @Override
-            public long getRequestId() {
-                return 0;
             }
 
             @Override

--- a/core/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
@@ -915,11 +915,6 @@ public class PublishClusterStateActionTests extends ESTestCase {
         }
 
         @Override
-        public String action() {
-            return "_noop_";
-        }
-
-        @Override
         public String getProfileName() {
             return "_noop_";
         }
@@ -940,11 +935,6 @@ public class PublishClusterStateActionTests extends ESTestCase {
         public void sendResponse(Exception exception) throws IOException {
             this.error.set(exception);
             assertThat(response.get(), nullValue());
-        }
-
-        @Override
-        public long getRequestId() {
-            return 0;
         }
 
         @Override

--- a/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/discovery/zen/ZenDiscoveryUnitTests.java
@@ -47,7 +47,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.discovery.zen.PublishClusterStateActionTests.AssertingAckListener;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
@@ -378,19 +377,10 @@ public class ZenDiscoveryUnitTests extends ESTestCase {
             } else {
                 AtomicBoolean sendResponse = new AtomicBoolean(false);
                 request.messageReceived(new MembershipAction.ValidateJoinRequest(stateBuilder.build()), new TransportChannel() {
-                    @Override
-                    public String action() {
-                        return null;
-                    }
 
                     @Override
                     public String getProfileName() {
                         return null;
-                    }
-
-                    @Override
-                    public long getRequestId() {
-                        return 0;
                     }
 
                     @Override


### PR DESCRIPTION
Right now we have unnecessary implementations of `TransportChannel`.
Additionally, there are methods on the interface that are not used. This
commit removes unnecessary implementations and methods.