### PR TITLE
Analyze numbers, dates and ips with a whitespace analyzer in text queries

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/core/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -144,7 +144,7 @@ public class MatchQuery {
      */
     public static final ZeroTermsQuery DEFAULT_ZERO_TERMS_QUERY = ZeroTermsQuery.NONE;
 
-    private static Analyzer WHITESPACE_ANALYZER = new WhitespaceAnalyzer();
+    private static final Analyzer WHITESPACE_ANALYZER = new WhitespaceAnalyzer();
 
     protected final QueryShardContext context;
 

--- a/core/src/test/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilderTests.java
@@ -19,10 +19,7 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
-import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.ParsingException;
@@ -42,23 +39,13 @@ import static org.hamcrest.Matchers.notNullValue;
 public class MatchPhrasePrefixQueryBuilderTests extends AbstractQueryTestCase<MatchPhrasePrefixQueryBuilder> {
     @Override
     protected MatchPhrasePrefixQueryBuilder doCreateTestQueryBuilder() {
-        String fieldName = randomFrom(STRING_FIELD_NAME, BOOLEAN_FIELD_NAME, INT_FIELD_NAME,
-                DOUBLE_FIELD_NAME, DATE_FIELD_NAME);
-        if (fieldName.equals(DATE_FIELD_NAME)) {
-            assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        String fieldName = STRING_FIELD_NAME;
+        int terms = randomIntBetween(0, 3);
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < terms; i++) {
+            builder.append(randomAlphaOfLengthBetween(1, 10)).append(" ");
         }
-        Object value;
-        if (fieldName.equals(STRING_FIELD_NAME)) {
-            int terms = randomIntBetween(0, 3);
-            StringBuilder builder = new StringBuilder();
-            for (int i = 0; i < terms; i++) {
-                builder.append(randomAlphaOfLengthBetween(1, 10)).append(" ");
-            }
-            value = builder.toString().trim();
-        } else {
-            value = getRandomValueForFieldName(fieldName);
-        }
-
+        Object value = builder.toString().trim();
         MatchPhrasePrefixQueryBuilder matchQuery = new MatchPhrasePrefixQueryBuilder(fieldName, value);
 
         if (randomBoolean()) {
@@ -94,9 +81,7 @@ public class MatchPhrasePrefixQueryBuilderTests extends AbstractQueryTestCase<Ma
             throws IOException {
         assertThat(query, notNullValue());
         assertThat(query,
-                either(instanceOf(BooleanQuery.class)).or(instanceOf(MultiPhrasePrefixQuery.class))
-                .or(instanceOf(TermQuery.class)).or(instanceOf(PointRangeQuery.class))
-                .or(instanceOf(IndexOrDocValuesQuery.class)).or(instanceOf(MatchNoDocsQuery.class)));
+                either(instanceOf(MultiPhrasePrefixQuery.class)).or(instanceOf(TermQuery.class)).or(instanceOf(MatchNoDocsQuery.class)));
     }
 
     public void testIllegalValues() {

--- a/core/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
@@ -42,23 +42,13 @@ import static org.hamcrest.Matchers.notNullValue;
 public class MatchPhraseQueryBuilderTests extends AbstractQueryTestCase<MatchPhraseQueryBuilder> {
     @Override
     protected MatchPhraseQueryBuilder doCreateTestQueryBuilder() {
-        String fieldName = randomFrom(STRING_FIELD_NAME, BOOLEAN_FIELD_NAME, INT_FIELD_NAME,
-                DOUBLE_FIELD_NAME, DATE_FIELD_NAME);
-        if (fieldName.equals(DATE_FIELD_NAME)) {
-            assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
+        String fieldName = STRING_FIELD_NAME;
+        int terms = randomIntBetween(0, 3);
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < terms; i++) {
+            builder.append(randomAlphaOfLengthBetween(1, 10)).append(" ");
         }
-        Object value;
-        if (fieldName.equals(STRING_FIELD_NAME)) {
-            int terms = randomIntBetween(0, 3);
-            StringBuilder builder = new StringBuilder();
-            for (int i = 0; i < terms; i++) {
-                builder.append(randomAlphaOfLengthBetween(1, 10)).append(" ");
-            }
-            value = builder.toString().trim();
-        } else {
-            value = getRandomValueForFieldName(fieldName);
-        }
-
+        String value = builder.toString().trim();
         MatchPhraseQueryBuilder matchQuery = new MatchPhraseQueryBuilder(fieldName, value);
 
         if (randomBoolean()) {

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -797,7 +797,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                     .field(INT_FIELD_NAME);
             IllegalArgumentException exc =
                 expectThrows(IllegalArgumentException.class, () -> queryBuilder.toQuery(createShardContext()));
-            assertThat(exc.getMessage(), equalTo("For input string: \">10 foo\""));
+            assertThat(exc.getMessage(), equalTo("For input string: \">10\""));
         }
     }
 

--- a/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
@@ -630,21 +630,18 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
                 .setQuery(randomizeType(multiMatchQuery("alpha 15", "first_name", "skill")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .lenient(true))).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("ultimate1"));
-        /*
-         * Doesn't find theone because "alpha 15" isn't a number and we don't
-         * break on spaces.
-         */
-        assertHitCount(searchResponse, 1);
+        assertSecondHit(searchResponse, hasId("theone"));
 
         // Lenient wasn't always properly lenient with two numeric fields
         searchResponse = client().prepareSearch("test")
                 .setQuery(randomizeType(multiMatchQuery("alpha 15", "int-field", "first_name", "skill")
                         .type(MultiMatchQueryBuilder.Type.CROSS_FIELDS)
                         .lenient(true))).get();
-        assertHitCount(searchResponse, 1L);
+        assertHitCount(searchResponse, 2L);
         assertFirstHit(searchResponse, hasId("ultimate1"));
+        assertSecondHit(searchResponse, hasId("theone"));
 
 
         // Check that cross fields works with date fields

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -733,8 +733,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertFirstHit(searchResponse, hasId("2"));
         searchResponse = client().prepareSearch().setQuery(matchQuery("double", "2 3 4")).get();
         assertHitCount(searchResponse, 2L);
-        assertFirstHit(searchResponse, hasId("2"));
-        assertSecondHit(searchResponse, hasId("3"));
+        assertSearchHits(searchResponse, "2", "3");
     }
 
     public void testMultiMatchQuery() throws Exception {

--- a/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/core/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -731,7 +731,10 @@ public class SearchQueryIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch().setQuery(matchQuery("double", "2")).get();
         assertHitCount(searchResponse, 1L);
         assertFirstHit(searchResponse, hasId("2"));
-        expectThrows(SearchPhaseExecutionException.class, () -> client().prepareSearch().setQuery(matchQuery("double", "2 3 4")).get());
+        searchResponse = client().prepareSearch().setQuery(matchQuery("double", "2 3 4")).get();
+        assertHitCount(searchResponse, 2L);
+        assertFirstHit(searchResponse, hasId("2"));
+        assertSecondHit(searchResponse, hasId("3"));
     }
 
     public void testMultiMatchQuery() throws Exception {


### PR DESCRIPTION
This change allows the parsing of multiple ip/date/number in a single query using
`match`, `multi_match`, `query_string` and `simple_query_string`.

For instance the following query:
```
"match": {
  "number": "200 404"
}
```

... forces the analysis on `number` to pre-process the input with a whitespace analyzer if the field "number" is mapped as a number.
This allows to build two clauses for this query, one for `200` and the other one for `404`, instead of throwing a number format exception
on the whole string.
Combined with `lenient` it can also be used to extract valid numbers from a mixed query like:

```
"match": {
  "number": {
    "query": "foo 404",
    "lenient": true
  }
}
```

`foo` is translated in a `match_no_docs` query because it cannot be parsed as a number but `404` is valid so with the default operator (`OR`) this query would return all documents that contain `404` in the number field.