### PR TITLE
Add note on plugin distributions in plugins folder

### DIFF
--- a/docs/plugins/plugin-script.asciidoc
+++ b/docs/plugins/plugin-script.asciidoc
@@ -82,6 +82,10 @@ bin\elasticsearch-plugin install file:///C:/path/to/plugin.zip
 -----------------------------------
 +
 NOTE: Any path that contains spaces must be wrapped in quotes!
++
+NOTE: If you are installing a plugin from the filesystem the plugin distribution
+must not be contained in the `plugins` directory for the node that you are
+installing the plugin to or installation will fail.
 
 HTTP::
 To install a plugin from a HTTP URL:


### PR DESCRIPTION
This commit adds a note regarding not storing a plugin distribution in the plugins directory during installation or instllation will fail.

