### PR TITLE
Bump version to 6.0.1 on the 6.x branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ List<Version> versions = []
 // keep track of the previous major version's last minor, so we know where wire compat begins
 int prevMinorIndex = -1 // index in the versions list of the last minor from the prev major
 int lastPrevMinor = -1 // the minor version number from the prev major we most recently seen
+int prevBugfixIndex = -1 // index in the versions list of the last bugfix release from the prev major
 for (String line : versionLines) {
   /* Note that this skips alphas and betas which is fine because they aren't
    * compatible with anything. */
@@ -97,11 +98,18 @@ for (String line : versionLines) {
       prevMinorIndex = versions.size() - 1
       lastPrevMinor = minor
     }
+    if (major == prevMajor) {
+      prevBugfixIndex = versions.size() - 1
+    }
   }
 }
 if (versions.toSorted { it.id } != versions) {
   println "Versions: ${versions}"
   throw new GradleException("Versions.java contains out of order version constants")
+}
+if (prevBugfixIndex != -1) {
+  versions[prevBugfixIndex] = new Version(
+      versions[prevBugfixIndex].major, versions[prevBugfixIndex].minor, versions[prevBugfixIndex].bugfix, true)
 }
 if (currentVersion.bugfix == 0) {
   // If on a release branch, after the initial release of that branch, the bugfix version will
@@ -248,6 +256,11 @@ subprojects {
       ext.projectSubstitutions["org.elasticsearch.distribution.rpm:elasticsearch:${indexCompatVersions[-1]}"] = ':distribution:bwc-release-snapshot'
       ext.projectSubstitutions["org.elasticsearch.distribution.zip:elasticsearch:${indexCompatVersions[-1]}"] = ':distribution:bwc-release-snapshot'
     }
+  } else if (indexCompatVersions[-2].snapshot) {
+    /* This is a terrible hack for the bump to 6.0.1 which will be fixed by #27397 */
+    ext.projectSubstitutions["org.elasticsearch.distribution.deb:elasticsearch:${indexCompatVersions[-2]}"] = ':distribution:bwc-release-snapshot'
+    ext.projectSubstitutions["org.elasticsearch.distribution.rpm:elasticsearch:${indexCompatVersions[-2]}"] = ':distribution:bwc-release-snapshot'
+    ext.projectSubstitutions["org.elasticsearch.distribution.zip:elasticsearch:${indexCompatVersions[-2]}"] = ':distribution:bwc-release-snapshot'
   }
   project.afterEvaluate {
     configurations.all {

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -360,12 +360,8 @@ public class Version implements Comparable<Version> {
      * is a beta or RC release then the version itself is returned.
      */
     public Version minimumCompatibilityVersion() {
-        final int bwcMajor;
-        final int bwcMinor;
-        if (major == 6) { // we only specialize for current major here
-            bwcMajor = Version.V_5_6_0.major;
-            bwcMinor = Version.V_5_6_0.minor;
-        } else if (major > 6) { // all the future major versions are compatible with last minor series of the previous major
+        if (major >= 6) {
+            // all major versions from 6 onwards are compatible with last minor series of the previous major
             List<Version> declaredVersions = getDeclaredVersions(getClass());
             Version bwcVersion = null;
             for (int i = declaredVersions.size() - 1; i >= 0; i--) {
@@ -378,11 +374,9 @@ public class Version implements Comparable<Version> {
                 }
             }
             return bwcVersion == null ? this : bwcVersion;
-        } else {
-            bwcMajor = major;
-            bwcMinor = 0;
         }
-        return Version.min(this, fromId(bwcMajor * 1000000 + bwcMinor * 10000 + 99));
+
+        return Version.min(this, fromId((int) major * 1000000 + 0 * 10000 + 99));
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -487,7 +487,7 @@ public class Version implements Comparable<Version> {
 
     /**
      * Extracts a sorted list of declared version constants from a class.
-     * version. The argument would normally be Version.class but is exposed for
+     * The argument would normally be Version.class but is exposed for
      * testing with other classes-containing-version-constants.
      */
     public static List<Version> getDeclaredVersions(Class<?> versionClass) {

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -119,6 +119,8 @@ public class Version implements Comparable<Version> {
     public static final int V_6_0_0_ID = 6000099;
     public static final Version V_6_0_0 =
         new Version(V_6_0_0_ID, org.apache.lucene.util.Version.LUCENE_7_0_1);
+    public static final int V_6_0_1_ID = 6000199;
+    public static final Version V_6_0_1 = new Version(V_6_0_1_ID, org.apache.lucene.util.Version.LUCENE_7_0_1);
     public static final int V_6_1_0_ID = 6010099;
     public static final Version V_6_1_0 = new Version(V_6_1_0_ID, org.apache.lucene.util.Version.LUCENE_7_1_0);
     public static final Version CURRENT = V_6_1_0;
@@ -136,6 +138,8 @@ public class Version implements Comparable<Version> {
         switch (id) {
             case V_6_1_0_ID:
                 return V_6_1_0;
+            case V_6_0_1_ID:
+                return V_6_0_1;
             case V_6_0_0_ID:
                 return V_6_0_0;
             case V_6_0_0_rc2_ID:

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -365,9 +365,19 @@ public class Version implements Comparable<Version> {
         if (major == 6) { // we only specialize for current major here
             bwcMajor = Version.V_5_6_0.major;
             bwcMinor = Version.V_5_6_0.minor;
-        } else if (major > 6) { // all the future versions are compatible with first minor...
-            bwcMajor = major -1;
-            bwcMinor = 0;
+        } else if (major > 6) { // all the future major versions are compatible with last minor series of the previous major
+            List<Version> declaredVersions = getDeclaredVersions(getClass());
+            Version bwcVersion = null;
+            for (int i = declaredVersions.size() - 1; i >= 0; i--) {
+                Version candidateVersion = declaredVersions.get(i);
+                if (candidateVersion.major == major - 1 && candidateVersion.isRelease() && after(candidateVersion)) {
+                    if (bwcVersion != null && candidateVersion.minor < bwcVersion.minor) {
+                        break;
+                    }
+                    bwcVersion = candidateVersion;
+                }
+            }
+            return bwcVersion == null ? this : bwcVersion;
         } else {
             bwcMajor = major;
             bwcMinor = 0;

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -362,10 +362,10 @@ public class Version implements Comparable<Version> {
     public Version minimumCompatibilityVersion() {
         if (major >= 6) {
             // all major versions from 6 onwards are compatible with last minor series of the previous major
-            List<Version> declaredVersions = getDeclaredVersions(getClass());
+            final List<Version> declaredVersions = getDeclaredVersions(getClass());
             Version bwcVersion = null;
             for (int i = declaredVersions.size() - 1; i >= 0; i--) {
-                Version candidateVersion = declaredVersions.get(i);
+                final Version candidateVersion = declaredVersions.get(i);
                 if (candidateVersion.major == major - 1 && candidateVersion.isRelease() && after(candidateVersion)) {
                     if (bwcVersion != null && candidateVersion.minor < bwcVersion.minor) {
                         break;
@@ -490,9 +490,9 @@ public class Version implements Comparable<Version> {
      * The argument would normally be Version.class but is exposed for
      * testing with other classes-containing-version-constants.
      */
-    public static List<Version> getDeclaredVersions(Class<?> versionClass) {
-        Field[] fields = versionClass.getFields();
-        List<Version> versions = new ArrayList<>(fields.length);
+    public static List<Version> getDeclaredVersions(final Class<?> versionClass) {
+        final Field[] fields = versionClass.getFields();
+        final List<Version> versions = new ArrayList<>(fields.length);
         for (final Field field : fields) {
             final int mod = field.getModifiers();
             if (false == Modifier.isStatic(mod) && Modifier.isFinal(mod) && Modifier.isPublic(mod)) {

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -485,6 +485,11 @@ public class Version implements Comparable<Version> {
         return build == 99;
     }
 
+    /**
+     * Extracts a sorted list of declared version constants from a class.
+     * version. The argument would normally be Version.class but is exposed for
+     * testing with other classes-containing-version-constants.
+     */
     public static List<Version> getDeclaredVersions(Class<?> versionClass) {
         Field[] fields = versionClass.getFields();
         List<Version> versions = new ArrayList<>(fields.length);

--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -124,8 +124,6 @@ public class Version implements Comparable<Version> {
     public static final int V_6_0_0_ID = 6000099;
     public static final Version V_6_0_0 =
         new Version(V_6_0_0_ID, org.apache.lucene.util.Version.LUCENE_7_0_1);
-    public static final int V_6_0_1_ID = 6000199;
-    public static final Version V_6_0_1 = new Version(V_6_0_1_ID, org.apache.lucene.util.Version.LUCENE_7_0_1);
     public static final int V_6_1_0_ID = 6010099;
     public static final Version V_6_1_0 = new Version(V_6_1_0_ID, org.apache.lucene.util.Version.LUCENE_7_1_0);
     public static final Version CURRENT = V_6_1_0;
@@ -143,8 +141,6 @@ public class Version implements Comparable<Version> {
         switch (id) {
             case V_6_1_0_ID:
                 return V_6_1_0;
-            case V_6_0_1_ID:
-                return V_6_0_1;
             case V_6_0_0_ID:
                 return V_6_0_0;
             case V_6_0_0_rc2_ID:

--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -337,7 +337,6 @@ public class VersionTests extends ESTestCase {
         assertTrue(isCompatible(Version.V_5_6_0, Version.V_6_0_0_alpha2));
         assertFalse(isCompatible(Version.fromId(2000099), Version.V_6_0_0_alpha2));
         assertFalse(isCompatible(Version.fromId(2000099), Version.V_5_0_0));
-        assertTrue(isCompatible(Version.fromString("6.0.0"), Version.fromString("7.0.0")));
         if (Version.CURRENT.isRelease()) {
             assertTrue(isCompatible(Version.CURRENT, Version.fromString("7.0.0")));
         } else {

--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -343,6 +343,8 @@ public class VersionTests extends ESTestCase {
         } else {
             assertFalse(isCompatible(Version.CURRENT, Version.fromString("7.0.0")));
         }
+        assertFalse("only compatible with the latest minor",
+            isCompatible(VersionUtils.getPreviousMinorVersion(), Version.fromString("7.0.0")));
         assertFalse(isCompatible(Version.V_5_0_0, Version.fromString("6.0.0")));
         assertFalse(isCompatible(Version.V_5_0_0, Version.fromString("7.0.0")));
 

--- a/core/src/test/java/org/elasticsearch/VersionTests.java
+++ b/core/src/test/java/org/elasticsearch/VersionTests.java
@@ -343,8 +343,6 @@ public class VersionTests extends ESTestCase {
         } else {
             assertFalse(isCompatible(Version.CURRENT, Version.fromString("7.0.0")));
         }
-        assertFalse("only compatible with the latest minor",
-            isCompatible(VersionUtils.getPreviousMinorVersion(), Version.fromString("7.0.0")));
         assertFalse(isCompatible(Version.V_5_0_0, Version.fromString("6.0.0")));
         assertFalse(isCompatible(Version.V_5_0_0, Version.fromString("7.0.0")));
 

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -85,8 +85,9 @@ public class VersionUtils {
          * minor branch_ is unreleased, whereas in 5.x it's more complicated: There were
          * (sometimes, and sometimes multiple) minor branches containing no releases, each
          * of which contains a single version constant of the form 5.n.0, and these
-         * branches always followed a branch that _did_ contain a released version of the
-         * form 5.n.m (m>0).
+         * branches always followed a branch that _did_ contain a version of the
+         * form 5.m.p (p>0). All versions strictly before the last 5.m version are released,
+         * and all other 5.* versions are unreleased.
          */
 
         if (current.major == 5 && current.revision != 0) {

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -38,17 +38,8 @@ import static java.util.Collections.unmodifiableList;
 
 /** Utilities for selecting versions in tests */
 public class VersionUtils {
-    /**
-     * Sort versions that have backwards compatibility guarantees from
-     * those that don't. Doesn't actually check whether or not the versions
-     * are released, instead it relies on gradle to have already checked
-     * this which it does in {@code :core:verifyVersions}. So long as the
-     * rules here match up with the rules in gradle then this should
-     * produce sensible results.
-     * @return a tuple containing versions with backwards compatibility
-     * guarantees in v1 and versions without the guranteees in v2
-     */
-    static Tuple<List<Version>, List<Version>> resolveReleasedVersions(Version current, Class<?> versionClass) {
+
+    static List<Version> getDeclaredVersions(Class<?> versionClass) {
         Field[] fields = versionClass.getFields();
         List<Version> versions = new ArrayList<>(fields.length);
         for (final Field field : fields) {
@@ -69,6 +60,21 @@ public class VersionUtils {
                 throw new RuntimeException(e);
             }
         }
+        return versions;
+    }
+
+    /**
+     * Sort versions that have backwards compatibility guarantees from
+     * those that don't. Doesn't actually check whether or not the versions
+     * are released, instead it relies on gradle to have already checked
+     * this which it does in {@code :core:verifyVersions}. So long as the
+     * rules here match up with the rules in gradle then this should
+     * produce sensible results.
+     * @return a tuple containing versions with backwards compatibility
+     * guarantees in v1 and versions without the guranteees in v2
+     */
+    static Tuple<List<Version>, List<Version>> resolveReleasedVersions(Version current, Class<?> versionClass) {
+        List<Version> versions = getDeclaredVersions(versionClass);
         Collections.sort(versions);
         Version last = versions.remove(versions.size() - 1);
         assert last.equals(current) : "The highest version must be the current one "

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -35,7 +35,6 @@ import static java.util.Collections.unmodifiableList;
 
 /** Utilities for selecting versions in tests */
 public class VersionUtils {
-
     /**
      * Sort versions that have backwards compatibility guarantees from
      * those that don't. Doesn't actually check whether or not the versions

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -75,9 +75,15 @@ public class VersionUtils {
             + "but was [" + versions.get(versions.size() - 1) + "] and current was [" + current + "]";
 
         if (current.revision != 0) {
-            /* If we are in a stable branch there should be no unreleased version constants
-             * because we don't expect to release any new versions in older branches. If there
-             * are extra constants then gradle will yell about it. */
+            /* If we are in a stable branch then the only unreleased versions should be the current one and
+             * the latest one in the previous major version. If there are extra constants then gradle will yell about it. */
+            for (int i = versions.size() - 1; i >= 0; i--) {
+                if (versions.get(i).major < current.major) {
+                    Version lastOfPreviousMajor = versions.remove(i);
+                    return new Tuple<>(unmodifiableList(versions), Arrays.asList(lastOfPreviousMajor, current));
+                }
+            }
+
             return new Tuple<>(unmodifiableList(versions), singletonList(current));
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -72,7 +72,7 @@ public class VersionUtils {
         Collections.sort(versions);
         Version last = versions.remove(versions.size() - 1);
         assert last.equals(current) : "The highest version must be the current one "
-            + "but was [" + versions.get(versions.size() - 1) + "] and current was [" + current + "]";
+            + "but was [" + last + "] and current was [" + current + "]";
 
         if (current.revision != 0) {
             /* If we are in a stable branch then the only unreleased versions should be the current one and

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -102,17 +102,21 @@ public class VersionUtils {
         for (int i = versions.size() - 1; i >= 0; i--) {
             Version currConsideredVersion = versions.get(i);
             if (currConsideredVersion.major == 5) {
-            /* Currently considering the latest version in the 5.x series,
-             * which is (a) unreleased and (b) the only such. So we're done. */
                 unreleased.add(currConsideredVersion);
                 versions.remove(i);
                 if (currConsideredVersion.revision != 0) {
+                    /* Currently considering the latest version in the 5.x series,
+                     * which is (a) unreleased and (b) the only such. So we're done. */
                     break;
                 }
+                /* ... else we're on a version of the form 5.n.0, and have not yet
+                 * considered a version of the form 5.n.m (m>0), so this entire branch
+                 * is unreleased, so carry on looking for a branch containing releases.
+                 */
             } else if (currConsideredVersion.major != prevConsideredVersion.major
                 || currConsideredVersion.minor != prevConsideredVersion.minor) {
-            /* Have moved to the end of a new minor branch, so this is
-             * an unreleased version. */
+                /* Have moved to the end of a new minor branch, so this is
+                 * an unreleased version. */
                 unreleased.add(currConsideredVersion);
                 versions.remove(i);
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -23,10 +23,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -39,30 +36,6 @@ import static java.util.Collections.unmodifiableList;
 /** Utilities for selecting versions in tests */
 public class VersionUtils {
 
-    static List<Version> getDeclaredVersions(Class<?> versionClass) {
-        Field[] fields = versionClass.getFields();
-        List<Version> versions = new ArrayList<>(fields.length);
-        for (final Field field : fields) {
-            final int mod = field.getModifiers();
-            if (false == Modifier.isStatic(mod) && Modifier.isFinal(mod) && Modifier.isPublic(mod)) {
-                continue;
-            }
-            if (field.getType() != Version.class) {
-                continue;
-            }
-            if ("CURRENT".equals(field.getName())) {
-                continue;
-            }
-            assert field.getName().matches("V(_\\d+)+(_(alpha|beta|rc)\\d+)?") : field.getName();
-            try {
-                versions.add(((Version) field.get(null)));
-            } catch (final IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return versions;
-    }
-
     /**
      * Sort versions that have backwards compatibility guarantees from
      * those that don't. Doesn't actually check whether or not the versions
@@ -74,8 +47,7 @@ public class VersionUtils {
      * guarantees in v1 and versions without the guranteees in v2
      */
     static Tuple<List<Version>, List<Version>> resolveReleasedVersions(Version current, Class<?> versionClass) {
-        List<Version> versions = getDeclaredVersions(versionClass);
-        Collections.sort(versions);
+        List<Version> versions = Version.getDeclaredVersions(versionClass);
         Version last = versions.remove(versions.size() - 1);
         assert last.equals(current) : "The highest version must be the current one "
             + "but was [" + last + "] and current was [" + current + "]";

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -95,7 +95,7 @@ public class VersionUtilsTests extends ESTestCase {
         assertEquals(unreleased, VersionUtils.randomVersionBetween(random(), unreleased, unreleased));
     }
 
-    static class TestReleaseBranch {
+    public static class TestReleaseBranch {
         public static final Version V_5_3_0 = Version.fromString("5.3.0");
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
@@ -112,7 +112,7 @@ public class VersionUtilsTests extends ESTestCase {
         assertEquals(singletonList(TestReleaseBranch.V_5_4_1), unreleased);
     }
 
-    static class TestStableBranch {
+    public static class TestStableBranch {
         public static final Version V_5_3_0 = Version.fromString("5.3.0");
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
@@ -128,7 +128,7 @@ public class VersionUtilsTests extends ESTestCase {
         assertEquals(Arrays.asList(TestStableBranch.V_5_3_2, TestStableBranch.V_5_4_0), unreleased);
     }
 
-    static class TestStableBranchBehindStableBranch {
+    public static class TestStableBranchBehindStableBranch {
         public static final Version V_5_3_0 = Version.fromString("5.3.0");
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
@@ -146,7 +146,7 @@ public class VersionUtilsTests extends ESTestCase {
                 TestStableBranchBehindStableBranch.V_5_5_0), unreleased);
     }
 
-    static class TestUnstableBranch {
+    public static class TestUnstableBranch {
         public static final Version V_5_3_0 = Version.fromString("5.3.0");
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
@@ -167,7 +167,7 @@ public class VersionUtilsTests extends ESTestCase {
         assertEquals(Arrays.asList(TestUnstableBranch.V_5_3_2, TestUnstableBranch.V_5_4_0, TestUnstableBranch.V_6_0_0_beta1), unreleased);
     }
 
-    static class TestNewMajorRelease {
+    public static class TestNewMajorRelease {
         public static final Version V_5_6_0 = Version.fromString("5.6.0");
         public static final Version V_5_6_1 = Version.fromString("5.6.1");
         public static final Version V_5_6_2 = Version.fromString("5.6.2");
@@ -192,7 +192,7 @@ public class VersionUtilsTests extends ESTestCase {
         assertEquals(Arrays.asList(TestNewMajorRelease.V_5_6_2, TestNewMajorRelease.V_6_0_1), unreleased);
     }
 
-    static class TestVersionBumpIn6x {
+    public static class TestVersionBumpIn6x {
         public static final Version V_5_6_0 = Version.fromString("5.6.0");
         public static final Version V_5_6_1 = Version.fromString("5.6.1");
         public static final Version V_5_6_2 = Version.fromString("5.6.2");
@@ -218,7 +218,7 @@ public class VersionUtilsTests extends ESTestCase {
         assertEquals(Arrays.asList(TestVersionBumpIn6x.V_5_6_2, TestVersionBumpIn6x.V_6_0_1, TestVersionBumpIn6x.V_6_1_0), unreleased);
     }
 
-    static class TestNewMinorBranchIn6x {
+    public static class TestNewMinorBranchIn6x {
         public static final Version V_5_6_0 = Version.fromString("5.6.0");
         public static final Version V_5_6_1 = Version.fromString("5.6.1");
         public static final Version V_5_6_2 = Version.fromString("5.6.2");

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -136,7 +136,7 @@ public class VersionUtilsTests extends ESTestCase {
         public static final Version V_5_5_0 = Version.fromString("5.5.0");
         public static final Version CURRENT = V_5_5_0;
     }
-    public void testResolveReleasedVersionsForStableBtranchBehindStableBranch() {
+    public void testResolveReleasedVersionsForStableBranchBehindStableBranch() {
         Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestStableBranchBehindStableBranch.CURRENT,
                 TestStableBranchBehindStableBranch.class);
         List<Version> released = t.v1();
@@ -190,6 +190,62 @@ public class VersionUtilsTests extends ESTestCase {
             TestNewMajorRelease.V_6_0_0_beta1, TestNewMajorRelease.V_6_0_0_beta2,
             TestNewMajorRelease.V_6_0_0), released);
         assertEquals(Arrays.asList(TestNewMajorRelease.V_5_6_2, TestNewMajorRelease.V_6_0_1), unreleased);
+    }
+
+    static class TestVersionBumpIn6x {
+        public static final Version V_5_6_0 = Version.fromString("5.6.0");
+        public static final Version V_5_6_1 = Version.fromString("5.6.1");
+        public static final Version V_5_6_2 = Version.fromString("5.6.2");
+        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
+        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
+        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
+        public static final Version V_6_0_0_beta2 = Version.fromString("6.0.0-beta2");
+        public static final Version V_6_0_0 = Version.fromString("6.0.0");
+        public static final Version V_6_0_1 = Version.fromString("6.0.1");
+        public static final Version V_6_1_0 = Version.fromString("6.1.0");
+        public static final Version CURRENT = V_6_1_0;
+    }
+
+    public void testResolveReleasedVersionsAtVersionBumpIn6x() {
+        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestVersionBumpIn6x.CURRENT,
+            TestVersionBumpIn6x.class);
+        List<Version> released = t.v1();
+        List<Version> unreleased = t.v2();
+        assertEquals(Arrays.asList(TestVersionBumpIn6x.V_5_6_0, TestVersionBumpIn6x.V_5_6_1,
+            TestVersionBumpIn6x.V_6_0_0_alpha1, TestVersionBumpIn6x.V_6_0_0_alpha2,
+            TestVersionBumpIn6x.V_6_0_0_beta1, TestVersionBumpIn6x.V_6_0_0_beta2,
+            TestVersionBumpIn6x.V_6_0_0), released);
+        assertEquals(Arrays.asList(TestVersionBumpIn6x.V_5_6_2, TestVersionBumpIn6x.V_6_0_1, TestVersionBumpIn6x.V_6_1_0), unreleased);
+    }
+
+    static class TestNewMinorBranchIn6x {
+        public static final Version V_5_6_0 = Version.fromString("5.6.0");
+        public static final Version V_5_6_1 = Version.fromString("5.6.1");
+        public static final Version V_5_6_2 = Version.fromString("5.6.2");
+        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
+        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
+        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
+        public static final Version V_6_0_0_beta2 = Version.fromString("6.0.0-beta2");
+        public static final Version V_6_0_0 = Version.fromString("6.0.0");
+        public static final Version V_6_0_1 = Version.fromString("6.0.1");
+        public static final Version V_6_1_0 = Version.fromString("6.1.0");
+        public static final Version V_6_1_1 = Version.fromString("6.1.1");
+        public static final Version V_6_1_2 = Version.fromString("6.1.2");
+        public static final Version V_6_2_0 = Version.fromString("6.2.0");
+        public static final Version CURRENT = V_6_2_0;
+    }
+
+    public void testResolveReleasedVersionsAtNewMinorBranchIn6x() {
+        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestNewMinorBranchIn6x.CURRENT,
+            TestNewMinorBranchIn6x.class);
+        List<Version> released = t.v1();
+        List<Version> unreleased = t.v2();
+        assertEquals(Arrays.asList(TestNewMinorBranchIn6x.V_5_6_0, TestNewMinorBranchIn6x.V_5_6_1,
+            TestNewMinorBranchIn6x.V_6_0_0_alpha1, TestNewMinorBranchIn6x.V_6_0_0_alpha2,
+            TestNewMinorBranchIn6x.V_6_0_0_beta1, TestNewMinorBranchIn6x.V_6_0_0_beta2,
+            TestNewMinorBranchIn6x.V_6_0_0, TestNewMinorBranchIn6x.V_6_1_0, TestNewMinorBranchIn6x.V_6_1_1), released);
+        assertEquals(Arrays.asList(TestNewMinorBranchIn6x.V_5_6_2, TestNewMinorBranchIn6x.V_6_0_1,
+            TestNewMinorBranchIn6x.V_6_1_2, TestNewMinorBranchIn6x.V_6_2_0), unreleased);
     }
 
     /**

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -221,15 +221,7 @@ public class VersionUtilsTests extends ESTestCase {
 
         // Now the wire compatible versions
         VersionsFromProperty wireCompatible = new VersionsFromProperty("tests.gradle_wire_compat_versions");
-
-        // Big horrible hack:
-        // This *should* be:
-        //         Version minimumCompatibleVersion = Version.CURRENT.minimumCompatibilityVersion();
-        // But instead it is:
-        Version minimumCompatibleVersion = Version.V_5_6_0;
-        // Because things blow up all over the place if the minimum compatible version isn't released.
-        // We'll fix this very, very soon. But for now, this hack.
-        // end big horrible hack
+        Version minimumCompatibleVersion = Version.CURRENT.minimumCompatibilityVersion();
         List<String> releasedWireCompatible = released.stream()
                 .filter(v -> v.onOrAfter(minimumCompatibleVersion))
                 .map(Object::toString)

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -167,6 +167,31 @@ public class VersionUtilsTests extends ESTestCase {
         assertEquals(Arrays.asList(TestUnstableBranch.V_5_3_2, TestUnstableBranch.V_5_4_0, TestUnstableBranch.V_6_0_0_beta1), unreleased);
     }
 
+    static class TestNewMajorRelease {
+        public static final Version V_5_6_0 = Version.fromString("5.6.0");
+        public static final Version V_5_6_1 = Version.fromString("5.6.1");
+        public static final Version V_5_6_2 = Version.fromString("5.6.2");
+        public static final Version V_6_0_0_alpha1 = Version.fromString("6.0.0-alpha1");
+        public static final Version V_6_0_0_alpha2 = Version.fromString("6.0.0-alpha2");
+        public static final Version V_6_0_0_beta1 = Version.fromString("6.0.0-beta1");
+        public static final Version V_6_0_0_beta2 = Version.fromString("6.0.0-beta2");
+        public static final Version V_6_0_0 = Version.fromString("6.0.0");
+        public static final Version V_6_0_1 = Version.fromString("6.0.1");
+        public static final Version CURRENT = V_6_0_1;
+    }
+
+    public void testResolveReleasedVersionsAtNewMajorRelease() {
+        Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestNewMajorRelease.CURRENT,
+            TestNewMajorRelease.class);
+        List<Version> released = t.v1();
+        List<Version> unreleased = t.v2();
+        assertEquals(Arrays.asList(TestNewMajorRelease.V_5_6_0, TestNewMajorRelease.V_5_6_1,
+            TestNewMajorRelease.V_6_0_0_alpha1, TestNewMajorRelease.V_6_0_0_alpha2,
+            TestNewMajorRelease.V_6_0_0_beta1, TestNewMajorRelease.V_6_0_0_beta2,
+            TestNewMajorRelease.V_6_0_0), released);
+        assertEquals(Arrays.asList(TestNewMajorRelease.V_5_6_2, TestNewMajorRelease.V_6_0_1), unreleased);
+    }
+
     /**
      * Tests that {@link Version#minimumCompatibilityVersion()} and {@link VersionUtils#allReleasedVersions()}
      * agree with the list of wire and index compatible versions we build in gradle.


### PR DESCRIPTION
Mainly opening this PR to get a full CI run before merging, as it's mostly a port of #27386 to the 6.x branch. The changes to `VersionUtils#resolveReleasedVersions()` and associated tests deserve attention, and ultimately backporting to 6.0 too.

I'd wait for CI to pass before looking at this too hard.