### PR TITLE
[DOCS] Removed links to pre-release RNs.

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,13 +6,6 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-6.0.0>>
-* <<release-notes-6.0.0-rc2>>
-* <<release-notes-6.0.0-rc1>>
-* <<release-notes-6.0.0-beta2>>
-* <<release-notes-6.0.0-beta1>>
-* <<release-notes-6.0.0-alpha2>>
-* <<release-notes-6.0.0-alpha1>>
-* <<release-notes-6.0.0-alpha1-5x>>
 
 --
 include::release-notes/6.0.0.asciidoc[]


### PR DESCRIPTION
I think the links to the pre-release RNs gives the impression that we *haven't* rolled up the release notes for 6.0. The RNs for each release are still there, I've just removed the links to them on https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html