### PR TITLE
Remove unneeded Throwable handling in nio

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/NioTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/NioTransport.java
@@ -188,9 +188,7 @@ public class NioTransport extends TcpTransport<NioChannel> {
         return new SocketEventHandler(logger, this::exceptionCaught, openChannels);
     }
 
-    final void exceptionCaught(NioSocketChannel channel, Throwable cause) {
-        final Throwable unwrapped = ExceptionsHelper.unwrap(cause, ElasticsearchException.class);
-        final Throwable t = unwrapped != null ? unwrapped : cause;
-        onException(channel, t instanceof Exception ? (Exception) t : new ElasticsearchException(t));
+    final void exceptionCaught(NioSocketChannel channel, Exception exception) {
+        onException(channel, exception);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketEventHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketEventHandler.java
@@ -34,10 +34,10 @@ import java.util.function.BiConsumer;
  */
 public class SocketEventHandler extends EventHandler {
 
-    private final BiConsumer<NioSocketChannel, Throwable> exceptionHandler;
+    private final BiConsumer<NioSocketChannel, Exception> exceptionHandler;
     private final Logger logger;
 
-    public SocketEventHandler(Logger logger, BiConsumer<NioSocketChannel, Throwable> exceptionHandler, OpenChannels openChannels) {
+    public SocketEventHandler(Logger logger, BiConsumer<NioSocketChannel, Exception> exceptionHandler, OpenChannels openChannels) {
         super(logger, openChannels);
         this.exceptionHandler = exceptionHandler;
         this.logger = logger;

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/TcpReadHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/TcpReadHandler.java
@@ -32,10 +32,9 @@ public class TcpReadHandler {
         this.transport = transport;
     }
 
-    public void handleMessage(BytesReference reference, NioSocketChannel channel, String profileName,
-                              int messageBytesLength) {
+    public void handleMessage(BytesReference reference, NioSocketChannel channel, int messageBytesLength) {
         try {
-            transport.messageReceived(reference, channel, profileName, channel.getRemoteAddress(), messageBytesLength);
+            transport.messageReceived(reference, channel, channel.getProfile(), channel.getRemoteAddress(), messageBytesLength);
         } catch (IOException e) {
             handleException(channel, e);
         }

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/TcpReadContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/TcpReadContext.java
@@ -80,7 +80,7 @@ public class TcpReadContext implements ReadContext {
 
                 // A message length of 6 bytes it is just a ping. Ignore for now.
                 if (messageLengthWithHeader != 6) {
-                    handler.handleMessage(messageWithoutHeader, channel, channel.getProfile(), messageWithoutHeader.length());
+                    handler.handleMessage(messageWithoutHeader, channel, messageWithoutHeader.length());
                 }
             } catch (Exception e) {
                 handler.handleException(channel, e);

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/SocketEventHandlerTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/SocketEventHandlerTests.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 
 public class SocketEventHandlerTests extends ESTestCase {
 
-    private BiConsumer<NioSocketChannel, Throwable> exceptionHandler;
+    private BiConsumer<NioSocketChannel, Exception> exceptionHandler;
 
     private SocketEventHandler handler;
     private NioSocketChannel channel;

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/TestingSocketEventHandler.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/TestingSocketEventHandler.java
@@ -30,11 +30,8 @@ import java.util.function.BiConsumer;
 
 public class TestingSocketEventHandler extends SocketEventHandler {
 
-    private final Logger logger;
-
-    public TestingSocketEventHandler(Logger logger, BiConsumer<NioSocketChannel, Throwable> exceptionHandler, OpenChannels openChannels) {
+    public TestingSocketEventHandler(Logger logger, BiConsumer<NioSocketChannel, Exception> exceptionHandler, OpenChannels openChannels) {
         super(logger, exceptionHandler, openChannels);
-        this.logger = logger;
     }
 
     private Set<NioSocketChannel> hasConnectedMap = Collections.newSetFromMap(new WeakHashMap<>());

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/channel/TcpReadContextTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/channel/TcpReadContextTests.java
@@ -72,7 +72,7 @@ public class TcpReadContextTests extends ESTestCase {
 
         readContext.read();
 
-        verify(handler).handleMessage(new BytesArray(bytes), channel, PROFILE, messageLength);
+        verify(handler).handleMessage(new BytesArray(bytes), channel, messageLength);
         assertEquals(1024 * 16, bufferCapacity.get());
 
         BytesArray bytesArray = new BytesArray(new byte[10]);
@@ -110,7 +110,7 @@ public class TcpReadContextTests extends ESTestCase {
         assertEquals(1024 * 16 - fullPart1.length, bufferCapacity.get());
 
         CompositeBytesReference reference = new CompositeBytesReference(new BytesArray(part1), new BytesArray(part2));
-        verify(handler).handleMessage(reference, channel, PROFILE, messageLength + messageLength);
+        verify(handler).handleMessage(reference, channel, messageLength + messageLength);
     }
 
     public void testReadThrowsIOException() throws IOException {


### PR DESCRIPTION
This is related to #27260. In the nio transport work we do not catch or
handle `Throwable`. There are a few places where we have exception
handlers that accept `Throwable`. This commit removes those cases.