### PR TITLE
Fix resync request serialization

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
@@ -47,10 +47,10 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
         if (in.getVersion().equals(Version.V_6_0_0)) {
             throw new IllegalStateException("resync replication request serialization is broken in 6.0.0");
         }
+        super.readFrom(in);
         operations = in.readArray(Translog.Operation::readOperation, Translog.Operation[]::new);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
@@ -48,6 +48,12 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
     @Override
     public void readFrom(StreamInput in) throws IOException {
         if (in.getVersion().equals(Version.V_6_0_0)) {
+            /*
+             * Resync replication request serialization was broken in 6.0.0 due to the elements of the stream not being prefixed with a
+             * byte indicating the type of the operation.
+             */
+            // TODO: remove this check in 8.0.0 which provides no BWC guarantees with 6.x.
+            assert Version.CURRENT.major <= 7;
             throw new IllegalStateException("resync replication request serialization is broken in 6.0.0");
         }
         super.readFrom(in);

--- a/core/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
@@ -52,7 +52,7 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
         final int size = in.readVInt();
         operations = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            operations.add(Translog.Operation.readType(in));
+            operations.add(Translog.Operation.readOperation(in));
         }
     }
 
@@ -61,7 +61,7 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
         super.writeTo(out);
         out.writeVInt(operations.size());
         for (int i = 0; i < operations.size(); i++) {
-            Translog.Operation.writeType(operations.get(i), out);
+            Translog.Operation.writeOperation(operations.get(i), out);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
@@ -28,6 +28,9 @@ import org.elasticsearch.index.translog.Translog;
 import java.io.IOException;
 import java.util.Arrays;
 
+/**
+ * Represents a batch of operations sent from the primary to its replicas during the primary-replica resync.
+ */
 public final class ResyncReplicationRequest extends ReplicatedWriteRequest<ResyncReplicationRequest> {
 
     private Translog.Operation[] operations;
@@ -36,7 +39,7 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
         super();
     }
 
-    public ResyncReplicationRequest(ShardId shardId, Translog.Operation[] operations) {
+    public ResyncReplicationRequest(final ShardId shardId, final Translog.Operation[] operations) {
         super(shardId);
         this.operations = operations;
     }
@@ -46,7 +49,7 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
+    public void readFrom(final StreamInput in) throws IOException {
         if (in.getVersion().equals(Version.V_6_0_0)) {
             /*
              * Resync replication request serialization was broken in 6.0.0 due to the elements of the stream not being prefixed with a
@@ -61,16 +64,16 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
+    public void writeTo(final StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeArray(Translog.Operation::writeOperation, operations);
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        ResyncReplicationRequest that = (ResyncReplicationRequest) o;
+        final ResyncReplicationRequest that = (ResyncReplicationRequest) o;
         return Arrays.equals(operations, that.operations);
     }
 

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -688,9 +688,21 @@ public abstract class StreamInput extends InputStream {
         return bytes;
     }
 
-    public <T> T[] readArray(Writeable.Reader<T> reader, IntFunction<T[]> arraySupplier) throws IOException {
-        int length = readArraySize();
-        T[] values = arraySupplier.apply(length);
+    /**
+     * Reads an array from the stream using the specified {@link org.elasticsearch.common.io.stream.Writeable.Reader} to read array elements
+     * from the stream. This method can be seen as the reader version of {@link StreamOutput#writeArray(Writeable.Writer, Object[])}. It is
+     * assumed that the stream first contains a variable-length integer representing the size of the array, and then contains that many
+     * elements that can be read from the stream.
+     *
+     * @param reader the reader used to read individual elements
+     * @param arraySupplier a supplier used to construct a new array
+     * @param <T> the type of the elements of the array
+     * @return an array read from the stream
+     * @throws IOException if an I/O exception occurs while reading the array
+     */
+    public <T> T[] readArray(final Writeable.Reader<T> reader, final IntFunction<T[]> arraySupplier) throws IOException {
+        final int length = readArraySize();
+        final T[] values = arraySupplier.apply(length);
         for (int i = 0; i < length; i++) {
             values[i] = reader.read(this);
         }

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -58,6 +58,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.IntFunction;
 
 /**
  * A stream from another node to this node. Technically, it can also be streamed from a byte array but that is mostly for testing.
@@ -706,7 +707,17 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
-    public <T> void writeArray(Writer<T> writer, T[] array) throws IOException {
+    /**
+     * Writes the specified array to the stream using the specified {@link Writer} for each element in the array. This method can be seen as
+     * writer version of {@link StreamInput#readArray(Writeable.Reader, IntFunction)}. The length of array encoded as a variable-length
+     * integer is first written to the stream, and then the elements of the array are written to the stream.
+     *
+     * @param writer the writer used to write individual elements
+     * @param array the array
+     * @param <T> the type of the elements of the array
+     * @throws IOException if an I/O exception occurs while writing the array
+     */
+    public <T> void writeArray(final Writer<T> writer, final T[] array) throws IOException {
         writeVInt(array.length);
         for (T value : array) {
             writer.write(this, value);

--- a/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/core/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -706,6 +706,13 @@ public abstract class StreamOutput extends OutputStream {
         }
     }
 
+    public <T> void writeArray(Writer<T> writer, T[] array) throws IOException {
+        writeVInt(array.length);
+        for (T value : array) {
+            writer.write(this, value);
+        }
+    }
+
     public <T extends Writeable> void writeArray(T[] array) throws IOException {
         writeVInt(array.length);
         for (T value: array) {

--- a/core/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
@@ -218,6 +218,8 @@ public class PrimaryReplicaSyncer extends AbstractComponent {
             }
         }
 
+        private static Translog.Operation[] EMPTY_ARRAY = new Translog.Operation[0];
+
         @Override
         protected void doRun() throws Exception {
             long size = 0;
@@ -247,7 +249,7 @@ public class PrimaryReplicaSyncer extends AbstractComponent {
 
             if (!operations.isEmpty()) {
                 task.setPhase("sending_ops");
-                ResyncReplicationRequest request = new ResyncReplicationRequest(shardId, operations);
+                ResyncReplicationRequest request = new ResyncReplicationRequest(shardId, operations.toArray(EMPTY_ARRAY));
                 logger.trace("{} sending batch of [{}][{}] (total sent: [{}], skipped: [{}])", shardId, operations.size(),
                     new ByteSizeValue(size), totalSentOps.get(), totalSkippedOps.get());
                 syncAction.sync(request, task, primaryAllocationId, primaryTerm, this);

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.translog;
 
-import com.vividsolutions.jts.util.Assert;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.apache.lucene.index.Term;
@@ -893,7 +892,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         /**
          * Reads the type and the operation from the given stream. The operation must be written with
-         * {@link Operation#writeOperation(Operation, StreamOutput)}
+         * {@link Operation#writeOperation(StreamOutput, Operation)}
          */
         static Operation readOperation(final StreamInput input) throws IOException {
             final Translog.Operation.Type type = Translog.Operation.Type.fromId(input.readByte());
@@ -914,7 +913,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         /**
          * Writes the type and translog operation to the given stream
          */
-        static void writeOperation(final Translog.Operation operation, final StreamOutput output) throws IOException {
+        static void writeOperation(final StreamOutput output, final Operation operation) throws IOException {
             output.writeByte(operation.opType().id());
             switch(operation.opType()) {
                 case CREATE:
@@ -1493,7 +1492,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         // because closing it closes the underlying stream, which we don't
         // want to do here.
         out.resetDigest();
-        Translog.Operation.writeOperation(op, out);
+        Translog.Operation.writeOperation(out, op);
         long checksum = out.getChecksum();
         out.writeInt((int) checksum);
     }

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -895,8 +895,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
          * Reads the type and the operation from the given stream. The operation must be written with
          * {@link Operation#writeOperation(Operation, StreamOutput)}
          */
-        static Operation readOperation(StreamInput input) throws IOException {
-            Translog.Operation.Type type = Translog.Operation.Type.fromId(input.readByte());
+        static Operation readOperation(final StreamInput input) throws IOException {
+            final Translog.Operation.Type type = Translog.Operation.Type.fromId(input.readByte());
             switch (type) {
                 case CREATE:
                     // the de-serialization logic in Index was identical to that of Create when create was deprecated
@@ -914,7 +914,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         /**
          * Writes the type and translog operation to the given stream
          */
-        static void writeOperation(Translog.Operation operation, StreamOutput output) throws IOException {
+        static void writeOperation(final Translog.Operation operation, final StreamOutput output) throws IOException {
             output.writeByte(operation.opType().id());
             switch(operation.opType()) {
                 case CREATE:
@@ -967,7 +967,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         private final String routing;
         private final String parent;
 
-        private Index(StreamInput in) throws IOException {
+        private Index(final StreamInput in) throws IOException {
             final int format = in.readVInt(); // SERIALIZATION_FORMAT
             assert format >= FORMAT_2_X : "format was: " + format;
             id = in.readString();
@@ -1080,7 +1080,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             return new Source(source, routing, parent);
         }
 
-        private void write(StreamOutput out) throws IOException {
+        private void write(final StreamOutput out) throws IOException {
             out.writeVInt(SERIALIZATION_FORMAT);
             out.writeString(id);
             out.writeString(type);
@@ -1168,7 +1168,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         private final long version;
         private final VersionType versionType;
 
-        private Delete(StreamInput in) throws IOException {
+        private Delete(final StreamInput in) throws IOException {
             final int format = in.readVInt();// SERIALIZATION_FORMAT
             assert format >= FORMAT_5_0 : "format was: " + format;
             if (format >= FORMAT_SINGLE_TYPE) {
@@ -1263,7 +1263,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             throw new IllegalStateException("trying to read doc source from delete operation");
         }
 
-        private void write(StreamOutput out) throws IOException {
+        private void write(final StreamOutput out) throws IOException {
             out.writeVInt(SERIALIZATION_FORMAT);
             out.writeString(type);
             out.writeString(id);
@@ -1348,7 +1348,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             this.reason = reason;
         }
 
-        private void write(StreamOutput out) throws IOException {
+        private void write(final StreamOutput out) throws IOException {
             out.writeLong(seqNo);
             out.writeLong(primaryTerm);
             out.writeString(reason);

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -899,12 +899,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             Translog.Operation.Type type = Translog.Operation.Type.fromId(input.readByte());
             switch (type) {
                 case CREATE:
-                    // the deserialization logic in Index was identical to that of Create when create was deprecated
+                    // the de-serialization logic in Index was identical to that of Create when create was deprecated
+                case INDEX:
                     return new Index(input);
                 case DELETE:
                     return new Delete(input);
-                case INDEX:
-                    return new Index(input);
                 case NO_OP:
                     return new NoOp(input);
                 default:
@@ -919,6 +918,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             output.writeByte(operation.opType().id());
             switch(operation.opType()) {
                 case CREATE:
+                    // the serialization logic in Index was identical to that of Create when create was deprecated
                 case INDEX:
                     ((Index) operation).write(output);
                     break;

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -927,8 +927,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 case NO_OP:
                     ((NoOp) operation).write(output);
                     break;
-                    default:
-                throw new IOException("no type for [" + operation.opType() + "]");
+                default:
+                    throw new IOException("no type for [" + operation.opType() + "]");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -875,7 +875,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                     case 4:
                         return NO_OP;
                     default:
-                        throw new IllegalArgumentException("No type mapped for [" + id + "]");
+                        throw new IllegalArgumentException("no type mapped for [" + id + "]");
                 }
             }
         }
@@ -907,7 +907,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 case NO_OP:
                     return new NoOp(input);
                 default:
-                    throw new IOException("No type for [" + type + "]");
+                    throw new IOException("no type for [" + type + "]");
             }
         }
 
@@ -928,7 +928,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                     ((NoOp) operation).write(output);
                     break;
                     default:
-                throw new IOException("No type for [" + operation.opType() + "]");
+                throw new IOException("no type for [" + operation.opType() + "]");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.translog;
 
+import com.vividsolutions.jts.util.Assert;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.apache.lucene.index.Term;
@@ -907,7 +908,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 case NO_OP:
                     return new NoOp(input);
                 default:
-                    throw new IOException("no type for [" + type + "]");
+                    throw new AssertionError("no case for [" + type + "]");
             }
         }
 
@@ -928,7 +929,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                     ((NoOp) operation).write(output);
                     break;
                 default:
-                    throw new IOException("no type for [" + operation.opType() + "]");
+                    throw new AssertionError("no case for [" + operation.opType() + "]");
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -892,9 +892,9 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         /**
          * Reads the type and the operation from the given stream. The operation must be written with
-         * {@link Operation#writeType(Operation, StreamOutput)}
+         * {@link Operation#writeOperation(Operation, StreamOutput)}
          */
-        static Operation readType(StreamInput input) throws IOException {
+        static Operation readOperation(StreamInput input) throws IOException {
             Translog.Operation.Type type = Translog.Operation.Type.fromId(input.readByte());
             switch (type) {
                 case CREATE:
@@ -914,7 +914,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         /**
          * Writes the type and translog operation to the given stream
          */
-        static void writeType(Translog.Operation operation, StreamOutput output) throws IOException {
+        static void writeOperation(Translog.Operation operation, StreamOutput output) throws IOException {
             output.writeByte(operation.opType().id());
             switch(operation.opType()) {
                 case CREATE:
@@ -1449,7 +1449,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 verifyChecksum(in);
                 in.reset();
             }
-            operation = Translog.Operation.readType(in);
+            operation = Translog.Operation.readOperation(in);
             verifyChecksum(in);
         } catch (TranslogCorruptedException e) {
             throw e;
@@ -1492,7 +1492,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         // because closing it closes the underlying stream, which we don't
         // want to do here.
         out.resetDigest();
-        Translog.Operation.writeType(op, out);
+        Translog.Operation.writeOperation(op, out);
         long checksum = out.getChecksum();
         out.writeInt((int) checksum);
     }

--- a/core/src/test/java/org/elasticsearch/action/resync/ResyncReplicationRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/resync/ResyncReplicationRequestTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -40,7 +39,7 @@ public class ResyncReplicationRequestTests extends ESTestCase {
         final byte[] bytes = "{}".getBytes(Charset.forName("UTF-8"));
         final Translog.Index index = new Translog.Index("type", "id", 0, Versions.MATCH_ANY, VersionType.INTERNAL, bytes, null, null, -1);
         final ShardId shardId = new ShardId(new Index("index", "uuid"), 0);
-        final ResyncReplicationRequest before = new ResyncReplicationRequest(shardId, Collections.singletonList(index));
+        final ResyncReplicationRequest before = new ResyncReplicationRequest(shardId, new Translog.Operation[]{index});
 
         final BytesStreamOutput out = new BytesStreamOutput();
         before.writeTo(out);

--- a/core/src/test/java/org/elasticsearch/action/resync/ResyncReplicationRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/resync/ResyncReplicationRequestTests.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.resync;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ResyncReplicationRequestTests extends ESTestCase {
+
+    public void testSerialization() throws IOException {
+        final byte[] bytes = "{}".getBytes(Charset.forName("UTF-8"));
+        final Translog.Index index = new Translog.Index("type", "id", 0, Versions.MATCH_ANY, VersionType.INTERNAL, bytes, null, null, -1);
+        final ShardId shardId = new ShardId(new Index("index", "uuid"), 0);
+        final ResyncReplicationRequest before = new ResyncReplicationRequest(shardId, Collections.singletonList(index));
+
+        final BytesStreamOutput out = new BytesStreamOutput();
+        before.writeTo(out);
+
+        final StreamInput in = out.bytes().streamInput();
+        final ResyncReplicationRequest after = new ResyncReplicationRequest();
+        after.readFrom(in);
+
+        assertThat(after, equalTo(before));
+    }
+
+}

--- a/core/src/test/java/org/elasticsearch/index/shard/PrimaryReplicaSyncerTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/PrimaryReplicaSyncerTests.java
@@ -48,7 +48,7 @@ public class PrimaryReplicaSyncerTests extends IndexShardTestCase {
         AtomicBoolean syncActionCalled = new AtomicBoolean();
         PrimaryReplicaSyncer.SyncAction syncAction =
             (request, parentTask, allocationId, primaryTerm, listener) -> {
-                logger.info("Sending off {} operations", request.getOperations().size());
+                logger.info("Sending off {} operations", request.getOperations().length);
                 syncActionCalled.set(true);
                 assertThat(parentTask, instanceOf(PrimaryReplicaSyncer.ResyncTask.class));
                 listener.onResponse(new ResyncReplicationResponse());
@@ -98,7 +98,7 @@ public class PrimaryReplicaSyncerTests extends IndexShardTestCase {
         CountDownLatch syncCalledLatch = new CountDownLatch(1);
         PrimaryReplicaSyncer.SyncAction syncAction =
             (request, parentTask, allocationId, primaryTerm, listener) -> {
-                logger.info("Sending off {} operations", request.getOperations().size());
+                logger.info("Sending off {} operations", request.getOperations().length);
                 syncActionCalled.set(true);
                 syncCalledLatch.countDown();
                 threadPool.generic().execute(() -> listener.onResponse(new ResyncReplicationResponse()));

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -2343,7 +2343,7 @@ public class TranslogTests extends ESTestCase {
         Translog.Index index = new Translog.Index(eIndex, eIndexResult);
 
         BytesStreamOutput out = new BytesStreamOutput();
-        Translog.Operation.writeOperation(index, out);
+        Translog.Operation.writeOperation(out, index);
         StreamInput in = out.bytes().streamInput();
         Translog.Index serializedIndex = (Translog.Index) Translog.Operation.readOperation(in);
         assertEquals(index, serializedIndex);
@@ -2354,7 +2354,7 @@ public class TranslogTests extends ESTestCase {
         Translog.Delete delete = new Translog.Delete(eDelete, eDeleteResult);
 
         out = new BytesStreamOutput();
-        Translog.Operation.writeOperation(delete, out);
+        Translog.Operation.writeOperation(out, delete);
         in = out.bytes().streamInput();
         Translog.Delete serializedDelete = (Translog.Delete) Translog.Operation.readOperation(in);
         assertEquals(delete, serializedDelete);

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -2343,9 +2343,9 @@ public class TranslogTests extends ESTestCase {
         Translog.Index index = new Translog.Index(eIndex, eIndexResult);
 
         BytesStreamOutput out = new BytesStreamOutput();
-        index.writeTo(out);
+        Translog.Operation.writeType(index, out);
         StreamInput in = out.bytes().streamInput();
-        Translog.Index serializedIndex = new Translog.Index(in);
+        Translog.Index serializedIndex = (Translog.Index) Translog.Operation.readType(in);
         assertEquals(index, serializedIndex);
 
         Engine.Delete eDelete = new Engine.Delete(doc.type(), doc.id(), newUid(doc), randomSeqNum, randomPrimaryTerm,
@@ -2354,13 +2354,14 @@ public class TranslogTests extends ESTestCase {
         Translog.Delete delete = new Translog.Delete(eDelete, eDeleteResult);
 
         out = new BytesStreamOutput();
-        delete.writeTo(out);
+        Translog.Operation.writeType(delete, out);
         in = out.bytes().streamInput();
-        Translog.Delete serializedDelete = new Translog.Delete(in);
+        Translog.Delete serializedDelete = (Translog.Delete) Translog.Operation.readType(in);
         assertEquals(delete, serializedDelete);
 
         // simulate legacy delete serialization
         out = new BytesStreamOutput();
+        out.writeByte(Translog.Operation.Type.DELETE.id());
         out.writeVInt(Translog.Delete.FORMAT_5_0);
         out.writeString(UidFieldMapper.NAME);
         out.writeString("my_type#my_id");
@@ -2369,7 +2370,7 @@ public class TranslogTests extends ESTestCase {
         out.writeLong(2); // seq no
         out.writeLong(0); // primary term
         in = out.bytes().streamInput();
-        serializedDelete = new Translog.Delete(in);
+        serializedDelete = (Translog.Delete) Translog.Operation.readType(in);
         assertEquals("my_type", serializedDelete.type());
         assertEquals("my_id", serializedDelete.id());
     }

--- a/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/core/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -2343,9 +2343,9 @@ public class TranslogTests extends ESTestCase {
         Translog.Index index = new Translog.Index(eIndex, eIndexResult);
 
         BytesStreamOutput out = new BytesStreamOutput();
-        Translog.Operation.writeType(index, out);
+        Translog.Operation.writeOperation(index, out);
         StreamInput in = out.bytes().streamInput();
-        Translog.Index serializedIndex = (Translog.Index) Translog.Operation.readType(in);
+        Translog.Index serializedIndex = (Translog.Index) Translog.Operation.readOperation(in);
         assertEquals(index, serializedIndex);
 
         Engine.Delete eDelete = new Engine.Delete(doc.type(), doc.id(), newUid(doc), randomSeqNum, randomPrimaryTerm,
@@ -2354,9 +2354,9 @@ public class TranslogTests extends ESTestCase {
         Translog.Delete delete = new Translog.Delete(eDelete, eDeleteResult);
 
         out = new BytesStreamOutput();
-        Translog.Operation.writeType(delete, out);
+        Translog.Operation.writeOperation(delete, out);
         in = out.bytes().streamInput();
-        Translog.Delete serializedDelete = (Translog.Delete) Translog.Operation.readType(in);
+        Translog.Delete serializedDelete = (Translog.Delete) Translog.Operation.readOperation(in);
         assertEquals(delete, serializedDelete);
 
         // simulate legacy delete serialization
@@ -2370,7 +2370,7 @@ public class TranslogTests extends ESTestCase {
         out.writeLong(2); // seq no
         out.writeLong(0); // primary term
         in = out.bytes().streamInput();
-        serializedDelete = (Translog.Delete) Translog.Operation.readType(in);
+        serializedDelete = (Translog.Delete) Translog.Operation.readOperation(in);
         assertEquals("my_type", serializedDelete.type());
         assertEquals("my_id", serializedDelete.id());
     }


### PR DESCRIPTION
This commit addresses a subtle bug in the serialization routine for resync requests. The problem here is that Translog.Operation#readType is not compatible with the implementations of Translog.Operation#writeTo. Unfortunately, this issue prevents primary-replica from succeeding, issues which we will address in follow-ups.

Relates #24841

