### PR TITLE
Log primary-replica resync failures

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -18,11 +18,13 @@
  */
 package org.elasticsearch.action.resync;
 
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
@@ -158,6 +160,14 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
 
                 @Override
                 public void handleResponse(ResyncReplicationResponse response) {
+                    final ReplicationResponse.ShardInfo.Failure[] failures = response.getShardInfo().getFailures();
+                    for (int i = 0; i < failures.length; i++) {
+                        final ReplicationResponse.ShardInfo.Failure f = failures[i];
+                        logger.warn(
+                                new ParameterizedMessage(
+                                        "{} primary-replica resync to replica on node [{}] failed", f.fullShardId(), f.nodeId()),
+                                f.getCause());
+                    }
                     listener.onResponse(response);
                 }
 

--- a/core/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -163,7 +163,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
                     final ReplicationResponse.ShardInfo.Failure[] failures = response.getShardInfo().getFailures();
                     for (int i = 0; i < failures.length; i++) {
                         final ReplicationResponse.ShardInfo.Failure f = failures[i];
-                        logger.warn(
+                        logger.info(
                                 new ParameterizedMessage(
                                         "{} primary-replica resync to replica on node [{}] failed", f.fullShardId(), f.nodeId()),
                                 f.getCause());

--- a/core/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/core/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -161,6 +161,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
                 @Override
                 public void handleResponse(ResyncReplicationResponse response) {
                     final ReplicationResponse.ShardInfo.Failure[] failures = response.getShardInfo().getFailures();
+                    // noinspection ForLoopReplaceableByForEach
                     for (int i = 0; i < failures.length; i++) {
                         final ReplicationResponse.ShardInfo.Failure f = failures[i];
                         logger.info(


### PR DESCRIPTION
Today we do not fail a replica shard if the primary-replica resync to that replica fails. Yet, we should at least log the failure messages. This commit causes this to be the case.

Relates #24841, relates #27418