### PR TITLE
Remove newline from log message

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
@@ -165,7 +165,7 @@ public class ClientYamlTestClient {
         Header[] requestHeaders = new Header[headers.size()];
         int index = 0;
         for (Map.Entry<String, String> header : headers.entrySet()) {
-            logger.info("Adding header {}\n with value {}", header.getKey(), header.getValue());
+            logger.info("Adding header {} with value {}", header.getKey(), header.getValue());
             requestHeaders[index++] = new BasicHeader(header.getKey(), header.getValue());
         }
 


### PR DESCRIPTION
It leads to harder-to-parse logs that look like this:

```
  1> [2017-11-16T20:46:21,804][INFO ][o.e.t.r.y.ClientYamlTestClient] Adding header Content-Type
  1>  with value application/json
  1> [2017-11-16T20:46:21,812][INFO ][o.e.t.r.y.ClientYamlTestClient] Adding header Content-Type
  1>  with value application/json
  1> [2017-11-16T20:46:21,820][INFO ][o.e.t.r.y.ClientYamlTestClient] Adding header Content-Type
  1>  with value application/json
  1> [2017-11-16T20:46:21,966][INFO ][o.e.t.r.y.ClientYamlTestClient] Adding header Content-Type
  1>  with value application/json
```
