### PR TITLE
Deprecate use of `htmlStrip` as name for HtmlStripCharFilter

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -176,8 +176,8 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin {
     public List<PreConfiguredCharFilter> getPreConfiguredCharFilters() {
         List<PreConfiguredCharFilter> filters = new ArrayList<>();
         filters.add(PreConfiguredCharFilter.singleton("html_strip", false, HTMLStripCharFilter::new));
-        filters.add(PreConfiguredCharFilter.singleton("htmlStrip", false, (reader, version) -> {
-            if (version.onOrAfter(org.elasticsearch.Version.V_7_0_0_alpha1)) {
+        filters.add(PreConfiguredCharFilter.singletonWithVersion("htmlStrip", false, (reader, version) -> {
+            if (version.onOrAfter(org.elasticsearch.Version.V_6_3_0)) {
                 DEPRECATION_LOGGER.deprecatedAndMaybeLog("htmlStrip_deprecation",
                         "The [htmpStrip] char filter name is deprecated and will be removed in a future version. "
                                 + "Please change the filter name to [html_strip] instead.");

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -67,6 +67,8 @@ import org.apache.lucene.analysis.snowball.SnowballFilter;
 import org.apache.lucene.analysis.standard.ClassicFilter;
 import org.apache.lucene.analysis.tr.ApostropheFilter;
 import org.apache.lucene.analysis.util.ElisionFilter;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.PreConfiguredCharFilter;
 import org.elasticsearch.index.analysis.PreConfiguredTokenFilter;
@@ -88,6 +90,9 @@ import java.util.TreeMap;
 import static org.elasticsearch.plugins.AnalysisPlugin.requriesAnalysisSettings;
 
 public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(CommonAnalysisPlugin.class));
+
     @Override
     public Map<String, AnalysisProvider<TokenFilterFactory>> getTokenFilters() {
         Map<String, AnalysisProvider<TokenFilterFactory>> filters = new TreeMap<>();
@@ -171,8 +176,14 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin {
     public List<PreConfiguredCharFilter> getPreConfiguredCharFilters() {
         List<PreConfiguredCharFilter> filters = new ArrayList<>();
         filters.add(PreConfiguredCharFilter.singleton("html_strip", false, HTMLStripCharFilter::new));
-        // TODO deprecate htmlStrip
-        filters.add(PreConfiguredCharFilter.singleton("htmlStrip", false, HTMLStripCharFilter::new));
+        filters.add(PreConfiguredCharFilter.singleton("htmlStrip", false, (reader, version) -> {
+            if (version.onOrAfter(org.elasticsearch.Version.V_7_0_0_alpha1)) {
+                DEPRECATION_LOGGER.deprecatedAndMaybeLog("htmlStrip_deprecation",
+                        "The [htmpStrip] char filter name is deprecated and will be removed in a future version. "
+                                + "Please change the filter name to [html_strip] instead.");
+            }
+            return new HTMLStripCharFilter(reader);
+        }));
         return filters;
     }
 

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/HtmlStripCharFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/HtmlStripCharFilterFactoryTests.java
@@ -37,11 +37,11 @@ import java.util.Map;
 public class HtmlStripCharFilterFactoryTests extends ESTestCase {
 
     /**
-     * Check that the deprecated name "htmlStrip" issues a deprecation warning for indices created since 6.0.0
+     * Check that the deprecated name "htmlStrip" issues a deprecation warning for indices created since 6.3.0
      */
     public void testDeprecationWarning() throws IOException {
         Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
-                .put(IndexMetaData.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, Version.CURRENT))
+                .put(IndexMetaData.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_6_3_0, Version.CURRENT))
                 .build();
 
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
@@ -49,18 +49,18 @@ public class HtmlStripCharFilterFactoryTests extends ESTestCase {
             Map<String, CharFilterFactory> charFilters = createTestAnalysis(idxSettings, settings, commonAnalysisPlugin).charFilter;
             CharFilterFactory charFilterFactory = charFilters.get("htmlStrip");
             assertNotNull(charFilterFactory.create(new StringReader("input")));
-            assertWarnings(
-                    "The [htmpStrip] char filter name is deprecated and will be removed in a future version. "
+            assertWarnings("The [htmpStrip] char filter name is deprecated and will be removed in a future version. "
                     + "Please change the filter name to [html_strip] instead.");
         }
     }
 
     /**
-     * Check that the deprecated name "htmlStrip" does NOT issues a deprecation warning for indices created before 6.0.0
+     * Check that the deprecated name "htmlStrip" does NOT issues a deprecation warning for indices created before 6.3.0
      */
-    public void testNoDeprecationWarningPre6() throws IOException {
+    public void testNoDeprecationWarningPre6_3() throws IOException {
         Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
-                .put(IndexMetaData.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_5_0_0, Version.V_5_6_4))
+                .put(IndexMetaData.SETTING_VERSION_CREATED,
+                        VersionUtils.randomVersionBetween(random(), Version.V_5_0_0, Version.V_6_2_4))
                 .build();
 
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/HtmlStripCharFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/HtmlStripCharFilterFactoryTests.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.analysis.common;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.analysis.CharFilterFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.IndexSettingsModule;
+import org.elasticsearch.test.VersionUtils;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+
+
+public class HtmlStripCharFilterFactoryTests extends ESTestCase {
+
+    /**
+     * Check that the deprecated name "htmlStrip" issues a deprecation warning for indices created since 6.0.0
+     */
+    public void testDeprecationWarning() throws IOException {
+        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_6_0_0, Version.CURRENT))
+                .build();
+
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
+        try (CommonAnalysisPlugin commonAnalysisPlugin = new CommonAnalysisPlugin()) {
+            Map<String, CharFilterFactory> charFilters = createTestAnalysis(idxSettings, settings, commonAnalysisPlugin).charFilter;
+            CharFilterFactory charFilterFactory = charFilters.get("htmlStrip");
+            assertNotNull(charFilterFactory.create(new StringReader("input")));
+            assertWarnings(
+                    "The [htmpStrip] char filter name is deprecated and will be removed in a future version. "
+                    + "Please change the filter name to [html_strip] instead.");
+        }
+    }
+
+    /**
+     * Check that the deprecated name "htmlStrip" does NOT issues a deprecation warning for indices created before 6.0.0
+     */
+    public void testNoDeprecationWarningPre6() throws IOException {
+        Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+                .put(IndexMetaData.SETTING_VERSION_CREATED, VersionUtils.randomVersionBetween(random(), Version.V_5_0_0, Version.V_5_6_4))
+                .build();
+
+        IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);
+        try (CommonAnalysisPlugin commonAnalysisPlugin = new CommonAnalysisPlugin()) {
+            Map<String, CharFilterFactory> charFilters = createTestAnalysis(idxSettings, settings, commonAnalysisPlugin).charFilter;
+            CharFilterFactory charFilterFactory = charFilters.get("htmlStrip");
+            assertNotNull(charFilterFactory.create(new StringReader("")));
+        }
+    }
+}

--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
@@ -17,3 +17,57 @@
     - match: { error.type: illegal_argument_exception }
     - match: { error.reason: "Custom normalizer may not use filter [word_delimiter]" }
 
+---
+"htmlStrip_deprecated":
+    - skip:
+        version: " - 6.0.99"
+        reason: deprecated in 6.1
+        features: "warnings"
+
+    - do:
+        indices.create:
+          index: test_deprecated_htmlstrip
+          body:
+            settings:
+              index:
+                analysis:
+                  analyzer:
+                    my_htmlStripWithCharfilter:
+                      tokenizer: keyword
+                      char_filter: ["htmlStrip"]
+            mappings:
+              type:
+                properties:
+                  name:
+                    type: text
+                    analyzer: my_htmlStripWithCharfilter
+
+    - do:
+        warnings:
+          - 'The [htmpStrip] char filter name is deprecated and will be removed in a future version. Please change the filter name to [html_strip] instead.'
+        index:
+          index:   test_deprecated_htmlstrip
+          type:    type
+          id:      1
+          body:    { "name": "foo bar" }
+
+    - do:
+        warnings:
+          - 'The [htmpStrip] char filter name is deprecated and will be removed in a future version. Please change the filter name to [html_strip] instead.'
+        index:
+          index:   test_deprecated_htmlstrip
+          type:    type
+          id:      1
+          body:    { "name": "foo baz" }
+
+    - do:
+        warnings:
+          - 'The [htmpStrip] char filter name is deprecated and will be removed in a future version. Please change the filter name to [html_strip] instead.'
+        indices.analyze:
+          index: test_deprecated_htmlstrip
+          body:
+            analyzer: "my_htmlStripWithCharfilter"
+            text: "<html>foo</html>"
+    - length: { tokens: 1 }
+    - match:  { tokens.0.token: "\nfoo\n" }
+

--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
@@ -20,8 +20,8 @@
 ---
 "htmlStrip_deprecated":
     - skip:
-        version: " - 6.0.99"
-        reason: deprecated in 6.1
+        version: " - 6.2.99"
+        reason: deprecated in 6.3
         features: "warnings"
 
     - do:
@@ -57,7 +57,7 @@
         index:
           index:   test_deprecated_htmlstrip
           type:    type
-          id:      1
+          id:      2
           body:    { "name": "foo baz" }
 
     - do:
@@ -70,4 +70,3 @@
             text: "<html>foo</html>"
     - length: { tokens: 1 }
     - match:  { tokens.0.token: "\nfoo\n" }
-

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredCharFilter.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredCharFilter.java
@@ -41,6 +41,15 @@ public class PreConfiguredCharFilter extends PreConfiguredAnalysisComponent<Char
     }
 
     /**
+     * Create a pre-configured char filter that may not vary at all, provide access to the elasticsearch verison
+     */
+    public static PreConfiguredCharFilter singleton(String name, boolean useFilterForMultitermQueries,
+            BiFunction<Reader, org.elasticsearch.Version, Reader> create) {
+        return new PreConfiguredCharFilter(name, CachingStrategy.ONE, useFilterForMultitermQueries,
+                (reader, version) -> create.apply(reader, version));
+    }
+
+    /**
      * Create a pre-configured token filter that may vary based on the Lucene version.
      */
     public static PreConfiguredCharFilter luceneVersion(String name, boolean useFilterForMultitermQueries,
@@ -56,6 +65,8 @@ public class PreConfiguredCharFilter extends PreConfiguredAnalysisComponent<Char
             BiFunction<Reader, org.elasticsearch.Version, Reader> create) {
         return new PreConfiguredCharFilter(name, CachingStrategy.ELASTICSEARCH, useFilterForMultitermQueries, create);
     }
+
+
 
     private final boolean useFilterForMultitermQueries;
     private final BiFunction<Reader, Version, Reader> create;

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredCharFilter.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredCharFilter.java
@@ -43,7 +43,7 @@ public class PreConfiguredCharFilter extends PreConfiguredAnalysisComponent<Char
     /**
      * Create a pre-configured char filter that may not vary at all, provide access to the elasticsearch verison
      */
-    public static PreConfiguredCharFilter singleton(String name, boolean useFilterForMultitermQueries,
+    public static PreConfiguredCharFilter singletonWithVersion(String name, boolean useFilterForMultitermQueries,
             BiFunction<Reader, org.elasticsearch.Version, Reader> create) {
         return new PreConfiguredCharFilter(name, CachingStrategy.ONE, useFilterForMultitermQueries,
                 (reader, version) -> create.apply(reader, version));
@@ -65,8 +65,6 @@ public class PreConfiguredCharFilter extends PreConfiguredAnalysisComponent<Char
             BiFunction<Reader, org.elasticsearch.Version, Reader> create) {
         return new PreConfiguredCharFilter(name, CachingStrategy.ELASTICSEARCH, useFilterForMultitermQueries, create);
     }
-
-
 
     private final boolean useFilterForMultitermQueries;
     private final BiFunction<Reader, Version, Reader> create;


### PR DESCRIPTION
The camel case name `htmlStip` should be removed in favour of `html_strip`, but
we need to deprecate it first. This change adds deprecation warnings for indices 
which are create after 6.3.0 and logs deprecation warnings for these.