### PR TITLE
Fix place-holder in allocation decider messages

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -118,7 +118,7 @@ public abstract class AllocationDecider extends AbstractComponent {
             // On a NO decision, by default, we allow force allocating the primary.
             return allocation.decision(Decision.YES,
                                        decision.label(),
-                                       "primary shard [{}] allowed to force allocate on node [{}]",
+                                       "primary shard [%s] allowed to force allocate on node [%s]",
                                        shardRouting.shardId(), node.nodeId());
         } else {
             // On a THROTTLE/YES decision, we use the same decision instead of forcing allocation

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -116,20 +116,20 @@ public class EnableAllocationDecider extends AllocationDecider {
             case ALL:
                 return allocation.decision(Decision.YES, NAME, "all allocations are allowed");
             case NONE:
-                return allocation.decision(Decision.NO, NAME, "no allocations are allowed due to {}", setting(enable, usedIndexSetting));
+                return allocation.decision(Decision.NO, NAME, "no allocations are allowed due to %s", setting(enable, usedIndexSetting));
             case NEW_PRIMARIES:
                 if (shardRouting.primary() && shardRouting.active() == false &&
                     shardRouting.recoverySource().getType() != RecoverySource.Type.EXISTING_STORE) {
                     return allocation.decision(Decision.YES, NAME, "new primary allocations are allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "non-new primary allocations are forbidden due to {}",
+                    return allocation.decision(Decision.NO, NAME, "non-new primary allocations are forbidden due to %s",
                                                 setting(enable, usedIndexSetting));
                 }
             case PRIMARIES:
                 if (shardRouting.primary()) {
                     return allocation.decision(Decision.YES, NAME, "primary allocations are allowed");
                 } else {
-                    return allocation.decision(Decision.NO, NAME, "replica allocations are forbidden due to {}",
+                    return allocation.decision(Decision.NO, NAME, "replica allocations are forbidden due to %s",
                                                 setting(enable, usedIndexSetting));
                 }
             default:


### PR DESCRIPTION
Saw this here: https://discuss.elastic.co/t/help-after-upgrading-to-elasticsearch-6-cluster-shard-replicas-will-not-allocate/108077

```
"no allocations are allowed due to {}"
```

I did a quick grep for similar occurrences in the code and found other places.