### PR TITLE
Switch to G1GC as the default garbage collector for Elasticsearch

### DIFF
--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -33,9 +33,14 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
--XX:CMSInitiatingOccupancyFraction=75
--XX:+UseCMSInitiatingOccupancyOnly
+-XX:+UseG1GC
+-XX:InitiatingHeapOccupancyPercent=75
+
+# To use the older CMS garbage collector configuration, comment out the GC
+# configuration above and uncomment these:
+#-XX:+UseConcMarkSweepGC
+#-XX:CMSInitiatingOccupancyFraction=75
+#-XX:+UseCMSInitiatingOccupancyOnly
 
 ## optimizations
 

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -183,7 +183,7 @@ you must not start Elasticsearch with the serial collector (whether it's
 from the defaults for the JVM that you're using, or you've explicitly
 specified it with `-XX:+UseSerialGC`). Note that the default JVM
 configuration that ships with Elasticsearch configures Elasticsearch to
-use the CMS collector.
+use the G1GC collector.
 
 === System call filter check
 Elasticsearch installs system call filters of various flavors depending


### PR DESCRIPTION
With Java 9, CMS is deprecated and will be removed in a future version of the
JDK.

In we past we have shied away from using G1 related to safety of the collector, lately, however, we have had the opinion that G1 has enough safety, but the performance characteristics were not what we desired. With the 6.0 release, this led me to benchmark exactly how switching from CMS to G1GC would impact the performance of Elasticsearch.

The full benchmarks and numbers are at https://writequit.org/org/es/design/testing-at-scale.html with the conclusions copied here:

Indexing median throughput:

| Test       | CMS     | G1GC    | Improvement % |
|---------- |------- |------- |------------- |
| Nested     | 32798.9 | 33789.5 | 3.0202232     |
| Percolator | 131616  | 164038  | 24.633783     |
| NOAA       | 58808.1 | 64123.2 | 9.0380407     |
| Geopoint   | 218265  | 272666  | 24.924289     |
| PMC        | 1283.09 | 1430.46 | 11.485554     |
| Geonames   | 59152.2 | 69893.7 | 18.159088     |
| Logging    | 139993  | 166042  | 18.607359     |
| NYC Taxis  | 59227.1 | 64273.2 | 8.5199174     |

G1GC gives an improvement in the indexing throughput for **all** of our benchmarks.

I can't generalize for queries for all the benchmarks, because they have different queries and test different things. Looking at the benchmarks linked above though, generally (not all cases, but most), G1GC has better latency for queries than CMS does. I've summarized below in case you didn't read all the benchmarks:

| Test       | Query Improvement                                                                          |
|---------- |------------------------------------------------------------------------------------------ |
| Nested     | Generally not as good as CMS for nested queries                                            |
| Percolator | Overall improved latency for percolated queries, large improvements in some cases          |
| NOAA       | Not a huge improvement, pretty similar to CMS speeds, faster in some and slower in others  |
| Geopoint   | Big improvements in latency for polygon, bbox, and distance queries, distance range slower |
| PMC        | G1 generally faster for all queries                                                        |
| Geonames   | G1 generally faster, **much** faster for painless queries (both static and dynamic)        |
| Logging    | Slightly slower for range, faster for aggs and term                                        |
| NYC Taxis  | Faster for distance amount aggregation                                                     |

Obviously this is subjective, so check out the raw numbers from the linked page.

From the 60gb benchmarks, it seems like G1GC could be a good way to go. It helps in all cases for indexing throughput, and frequently outperforms CMS for queries. Even with the 1 billion docs use case, g1 was about 7,200 docs a second faster. These tests were with 31gb heaps, but even with an 8gb heap, there were improvements in the numbers with G1. With a 2gb heap and two nodes, G1 was slightly slower than CMS, however, this is farther away from production usages of Elasticsearch.

One of the downsides of this testing was that it wasn't "long-term" scale. These were just the Rally benchmarks, rather than production clusters being run for months at a time. We've heard some users have success with G1, while others haven't had as much luck.

