### PR TITLE
Remove manual tracking of registered channels

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/AcceptingSelector.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/AcceptingSelector.java
@@ -22,13 +22,9 @@ package org.elasticsearch.transport.nio;
 import org.elasticsearch.transport.nio.channel.NioServerSocketChannel;
 
 import java.io.IOException;
-import java.nio.channels.CancelledKeyException;
 import java.nio.channels.ClosedChannelException;
-import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
-import java.util.Iterator;
-import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
@@ -93,7 +89,6 @@ public class AcceptingSelector extends ESSelector {
                     newChannel.register();
                     SelectionKey selectionKey = newChannel.getSelectionKey();
                     selectionKey.attach(newChannel);
-                    addRegisteredChannel(newChannel);
                     eventHandler.serverChannelRegistered(newChannel);
                 } else {
                     eventHandler.registrationException(newChannel, new ClosedChannelException());

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketSelector.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketSelector.java
@@ -171,7 +171,6 @@ public class SocketSelector extends ESSelector {
         try {
             if (newChannel.isOpen()) {
                 newChannel.register();
-                addRegisteredChannel(newChannel);
                 SelectionKey key = newChannel.getSelectionKey();
                 key.attach(newChannel);
                 eventHandler.handleRegistration(newChannel);

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/AbstractNioChannel.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/AbstractNioChannel.java
@@ -115,9 +115,6 @@ public abstract class AbstractNioChannel<S extends SelectableChannel & NetworkCh
             } catch (IOException e) {
                 closeContext.completeExceptionally(e);
                 throw e;
-            } finally {
-                // There is no problem with calling this multiple times
-                selector.removeRegisteredChannel(this);
             }
         }
     }

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/ESSelectorTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/ESSelectorTests.java
@@ -51,19 +51,12 @@ public class ESSelectorTests extends ESTestCase {
     public void testQueueChannelForClosed() throws IOException {
         NioChannel channel = mock(NioChannel.class);
         when(channel.getSelector()).thenReturn(selector);
-        selector.addRegisteredChannel(channel);
 
         selector.queueChannelClose(channel);
-
-        assertEquals(1, selector.getRegisteredChannels().size());
 
         selector.singleLoop();
 
         verify(handler).handleClose(channel);
-        // Will be called in the channel close method
-        selector.removeRegisteredChannel(channel);
-
-        assertEquals(0, selector.getRegisteredChannels().size());
     }
 
     public void testSelectorClosedExceptionIsNotCaughtWhileRunning() throws IOException {

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/SocketSelectorTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/SocketSelectorTests.java
@@ -34,7 +34,8 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
-import java.util.Set;
+import java.util.Collections;
+import java.util.HashSet;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -54,6 +55,7 @@ public class SocketSelectorTests extends ESTestCase {
     private WriteContext writeContext;
     private ActionListener<NioChannel> listener;
     private NetworkBytesReference bufferReference = NetworkBytesReference.wrap(new BytesArray(new byte[1]));
+    private Selector rawSelector;
 
     @Before
     @SuppressWarnings("unchecked")
@@ -65,7 +67,7 @@ public class SocketSelectorTests extends ESTestCase {
         listener = mock(ActionListener.class);
         selectionKey = new TestSelectionKey(0);
         selectionKey.attach(channel);
-        Selector rawSelector = mock(Selector.class);
+        rawSelector = mock(Selector.class);
 
         this.socketSelector = new SocketSelector(eventHandler, rawSelector);
         this.socketSelector.setThread();
@@ -83,10 +85,6 @@ public class SocketSelectorTests extends ESTestCase {
         socketSelector.preSelect();
 
         verify(eventHandler).handleRegistration(channel);
-
-        Set<NioChannel> registeredChannels = socketSelector.getRegisteredChannels();
-        assertEquals(1, registeredChannels.size());
-        assertTrue(registeredChannels.contains(channel));
     }
 
     public void testClosedChannelWillNotBeRegistered() throws Exception {
@@ -97,10 +95,6 @@ public class SocketSelectorTests extends ESTestCase {
 
         verify(eventHandler).registrationException(same(channel), any(ClosedChannelException.class));
         verify(channel, times(0)).finishConnect();
-
-        Set<NioChannel> registeredChannels = socketSelector.getRegisteredChannels();
-        assertEquals(0, registeredChannels.size());
-        assertFalse(registeredChannels.contains(channel));
     }
 
     public void testRegisterChannelFailsDueToException() throws Exception {
@@ -113,10 +107,6 @@ public class SocketSelectorTests extends ESTestCase {
 
         verify(eventHandler).registrationException(channel, closedChannelException);
         verify(channel, times(0)).finishConnect();
-
-        Set<NioChannel> registeredChannels = socketSelector.getRegisteredChannels();
-        assertEquals(0, registeredChannels.size());
-        assertFalse(registeredChannels.contains(channel));
     }
 
     public void testSuccessfullyRegisterChannelWillConnect() throws Exception {
@@ -308,6 +298,10 @@ public class SocketSelectorTests extends ESTestCase {
         NetworkBytesReference networkBuffer = NetworkBytesReference.wrap(new BytesArray(new byte[1]));
         socketSelector.queueWrite(new WriteOperation(mock(NioSocketChannel.class), networkBuffer, listener));
         socketSelector.scheduleForRegistration(unRegisteredChannel);
+
+        TestSelectionKey testSelectionKey = new TestSelectionKey(0);
+        testSelectionKey.attach(channel);
+        when(rawSelector.keys()).thenReturn(new HashSet<>(Collections.singletonList(testSelectionKey)));
 
         socketSelector.cleanupAndCloseChannels();
 


### PR DESCRIPTION
This is related to #27260. Currently, every ESSelector keeps track of
all channels that are registered with it. ESSelector is just an
abstraction over a raw java nio selector. The java nio selector already
tracks its own selection keys. This commit removes our tracking and
relies on the java nio selector tracking.