### PR TITLE
Remove quotation marks around a number

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -1034,7 +1034,7 @@ GET /bank/_search
   "query": {
     "bool": {
       "must": [
-        { "match": { "age": "40" } }
+        { "match": { "age": 40 } }
       ],
       "must_not": [
         { "match": { "state": "ID" } }


### PR DESCRIPTION
Numbers should not be quoted. One of the sample queries in the "Getting Started" docs contains `{ "match": { "age": "40" } }`, which incorrectly quotes a number. Although the query works, this is inconsistent with the rest of the docs, e.g., with `{ "match": { "account_number": 20 } }`. Note that in the sample schema, `age` is a number.