### PR TITLE
Adjust CombinedDeletionPolicy for multiple commits

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
@@ -60,20 +60,23 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
             EngineConfig.OpenMode.OPEN_INDEX_AND_TRANSLOG);
         List<IndexCommit> commitList = new ArrayList<>();
         long count = randomIntBetween(10, 20);
-        long lastGen = 0;
+        long minGen = Long.MAX_VALUE;
         for (int i = 0; i < count; i++) {
-            lastGen += randomIntBetween(10, 20000);
+            long lastGen = randomIntBetween(10, 20000);
+            minGen = Math.min(minGen, lastGen);
             commitList.add(mockIndexCommitWithTranslogGen(lastGen));
         }
         combinedDeletionPolicy.onInit(commitList);
-        verify(translogDeletionPolicy, times(1)).setMinTranslogGenerationForRecovery(lastGen);
+        verify(translogDeletionPolicy, times(1)).setMinTranslogGenerationForRecovery(minGen);
         commitList.clear();
+        minGen = Long.MAX_VALUE;
         for (int i = 0; i < count; i++) {
-            lastGen += randomIntBetween(10, 20000);
+            long lastGen = randomIntBetween(10, 20000);
+            minGen = Math.min(minGen, lastGen);
             commitList.add(mockIndexCommitWithTranslogGen(lastGen));
         }
         combinedDeletionPolicy.onCommit(commitList);
-        verify(translogDeletionPolicy, times(1)).setMinTranslogGenerationForRecovery(lastGen);
+        verify(translogDeletionPolicy, times(1)).setMinTranslogGenerationForRecovery(minGen);
     }
 
     IndexCommit mockIndexCommitWithTranslogGen(long gen) throws IOException {


### PR DESCRIPTION
Today, we keep only the last index commit and use only it to calculate the minimum required translog generation. This may no longer be correct as we introduced a new deletion policy which keeps multiple index commits. This change adjusts the `CombinedDeletionPolicy` so that it can work correctly with a new index deletion policy.

Relates to #10708, #27367