### PR TITLE
Validate `op_type` for `_create`

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
@@ -69,7 +69,7 @@ public class RestIndexAction extends BaseRestHandler {
             return RestIndexAction.this.prepareRequest(request, client);
         }
 
-        public void validateOpType(String opType) {
+        void validateOpType(String opType) {
             if (null != opType && false == "create".equals(opType.toLowerCase(Locale.ROOT))) {
                 throw new IllegalArgumentException("opType must be 'create', found: [" + opType + "]");
             }

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -63,8 +64,15 @@ public class RestIndexAction extends BaseRestHandler {
 
         @Override
         public RestChannelConsumer prepareRequest(RestRequest request, final NodeClient client) throws IOException {
+            validateOpType(request.params().get("op_type"));
             request.params().put("op_type", "create");
             return RestIndexAction.this.prepareRequest(request, client);
+        }
+
+        public void validateOpType(String opType) {
+            if (null != opType && !"create".equals(opType.toLowerCase(Locale.US))) {
+                throw new IllegalArgumentException("opType must be 'create', found: [" + opType + "]");
+            }
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
@@ -70,7 +70,7 @@ public class RestIndexAction extends BaseRestHandler {
         }
 
         public void validateOpType(String opType) {
-            if (null != opType && !"create".equals(opType.toLowerCase(Locale.US))) {
+            if (null != opType && false == "create".equals(opType.toLowerCase(Locale.ROOT))) {
                 throw new IllegalArgumentException("opType must be 'create', found: [" + opType + "]");
             }
         }

--- a/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -55,23 +55,18 @@ public class IndexRequestTests extends ESTestCase {
 
         IndexRequest indexRequest = new IndexRequest("");
         indexRequest.opType(create);
-        assertThat(indexRequest.opType() , equalTo(DocWriteRequest.OpType.CREATE));
+        assertThat(indexRequest.opType(), equalTo(DocWriteRequest.OpType.CREATE));
         indexRequest.opType(createUpper);
-        assertThat(indexRequest.opType() , equalTo(DocWriteRequest.OpType.CREATE));
+        assertThat(indexRequest.opType(), equalTo(DocWriteRequest.OpType.CREATE));
         indexRequest.opType(index);
-        assertThat(indexRequest.opType() , equalTo(DocWriteRequest.OpType.INDEX));
+        assertThat(indexRequest.opType(), equalTo(DocWriteRequest.OpType.INDEX));
         indexRequest.opType(indexUpper);
-        assertThat(indexRequest.opType() , equalTo(DocWriteRequest.OpType.INDEX));
+        assertThat(indexRequest.opType(), equalTo(DocWriteRequest.OpType.INDEX));
     }
 
-    public void testReadBogusString() {
-        try {
-            IndexRequest indexRequest = new IndexRequest("");
-            indexRequest.opType("foobar");
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), equalTo("opType must be 'create' or 'index', found: [foobar]"));
-        }
+    public void testReadIncorrectOpType() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new IndexRequest("").opType("foobar"));
+        assertThat(e.getMessage(), equalTo("opType must be 'create' or 'index', found: [foobar]"));
     }
 
     public void testCreateOperationRejectsVersions() {

--- a/core/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
+++ b/core/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.document;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+
+public class RestIndexActionTests extends ESTestCase {
+
+    public void testCreateOpTypeValidation() throws Exception {
+        Settings settings = settings(Version.CURRENT).build();
+        RestIndexAction.CreateHandler create = new RestIndexAction(settings, mock(RestController.class)).new CreateHandler(settings);
+
+        String opType = randomFrom("CREATE", null);
+        create.validateOpType(opType);
+
+        String illegalOpType = randomFrom("index", "unknown", "");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> create.validateOpType(illegalOpType));
+        assertThat(e.getMessage(), equalTo("opType must be 'create', found: [" + illegalOpType + "]"));
+    }
+}


### PR DESCRIPTION
Currently any `op_type` passed to `_create` is simply set to `create` without any validation.

This PR will validate the passed `op_type` to `_create` as discussed in [comment](https://github.com/elastic/elasticsearch/pull/27346#discussion_r150602483)

CC @javanna 