### PR TITLE
Fail restore when the shard allocations max retries count is reached

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -54,6 +54,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.ResizeAllocationDeci
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.SnapshotInProgressAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.RestoreInProgressAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.ParseField;
@@ -191,6 +192,7 @@ public class ClusterModule extends AbstractModule {
         addAllocationDecider(deciders, new EnableAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new NodeVersionAllocationDecider(settings));
         addAllocationDecider(deciders, new SnapshotInProgressAllocationDecider(settings));
+        addAllocationDecider(deciders, new RestoreInProgressAllocationDecider(settings));
         addAllocationDecider(deciders, new FilterAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new SameShardAllocationDecider(settings, clusterSettings));
         addAllocationDecider(deciders, new DiskThresholdDecider(settings, clusterSettings));

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -48,6 +48,8 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.elasticsearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
 
 
@@ -135,13 +137,14 @@ public class AllocationService extends AbstractComponent {
         return newState;
     }
 
+    // Used for testing
     public ClusterState applyFailedShard(ClusterState clusterState, ShardRouting failedShard) {
-        return applyFailedShards(clusterState, Collections.singletonList(new FailedShard(failedShard, null, null)),
-            Collections.emptyList());
+        return applyFailedShards(clusterState, singletonList(new FailedShard(failedShard, null, null)), emptyList());
     }
 
+    // Used for testing
     public ClusterState applyFailedShards(ClusterState clusterState, List<FailedShard> failedShards) {
-        return applyFailedShards(clusterState, failedShards, Collections.emptyList());
+        return applyFailedShards(clusterState, failedShards, emptyList());
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -240,7 +240,7 @@ public class RoutingAllocation {
      * Returns updated {@link RestoreInProgress} based on the changes that were made to the routing nodes
      */
     public RestoreInProgress updateRestoreInfoWithRoutingChanges(RestoreInProgress restoreInProgress) {
-        return restoreInProgressUpdater.applyChanges(metaData, routingTable, restoreInProgress);
+        return restoreInProgressUpdater.applyChanges(restoreInProgress);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -240,7 +240,7 @@ public class RoutingAllocation {
      * Returns updated {@link RestoreInProgress} based on the changes that were made to the routing nodes
      */
     public RestoreInProgress updateRestoreInfoWithRoutingChanges(RestoreInProgress restoreInProgress) {
-        return restoreInProgressUpdater.applyChanges(restoreInProgress);
+        return restoreInProgressUpdater.applyChanges(metaData, routingTable, restoreInProgress);
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
@@ -65,7 +65,8 @@ public class RestoreInProgressAllocationDecider extends AllocationDecider {
                 if (restoreInProgress.snapshot().equals(snapshot)) {
                     RestoreInProgress.ShardRestoreStatus shardRestoreStatus = restoreInProgress.shards().get(shardRouting.shardId());
                     if (shardRestoreStatus != null && shardRestoreStatus.state().completed() == false) {
-                        assert shardRestoreStatus.state() != RestoreInProgress.State.SUCCESS : "expected initializing shard";
+                        assert shardRestoreStatus.state() != RestoreInProgress.State.SUCCESS : "expected shard [" + shardRouting
+                            + "] to be in initializing state but got [" + shardRestoreStatus.state() + "]";
                         return allocation.decision(Decision.YES, NAME, "shard is currently being restored");
                     }
                     break;

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
@@ -63,7 +63,6 @@ public class RestoreInProgressAllocationDecider extends AllocationDecider {
         if (restoresInProgress != null) {
             for (RestoreInProgress.Entry restoreInProgress : restoresInProgress.entries()) {
                 if (restoreInProgress.snapshot().equals(snapshot)) {
-                    assert restoreInProgress.state().completed() == false : "completed restore should have been removed from cluster state";
                     RestoreInProgress.ShardRestoreStatus shardRestoreStatus = restoreInProgress.shards().get(shardRouting.shardId());
                     if (shardRestoreStatus != null && shardRestoreStatus.state().completed() == false) {
                         assert shardRestoreStatus.state() != RestoreInProgress.State.SUCCESS : "expected initializing shard";

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.decider;
+
+import org.elasticsearch.cluster.RestoreInProgress;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.snapshots.Snapshot;
+
+/**
+ * This {@link AllocationDecider} prevents shards that have failed to be
+ * restored from a snapshot to be allocated.
+ */
+public class RestoreInProgressAllocationDecider extends AllocationDecider {
+
+    public static final String NAME = "restore_in_progress";
+
+    /**
+     * Creates a new {@link RestoreInProgressAllocationDecider} instance from
+     * given settings
+     *
+     * @param settings {@link Settings} to use
+     */
+    public RestoreInProgressAllocationDecider(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    public Decision canAllocate(final ShardRouting shardRouting, final RoutingNode node, final RoutingAllocation allocation) {
+        return canAllocate(shardRouting, allocation);
+    }
+
+    @Override
+    public Decision canAllocate(final ShardRouting shardRouting, final RoutingAllocation allocation) {
+        if (shardRouting.primary() == false) {
+            return allocation.decision(Decision.YES, NAME, "shard is not a primary shard");
+        }
+
+        final RecoverySource recoverySource = shardRouting.recoverySource();
+        if (recoverySource == null || recoverySource.getType() != RecoverySource.Type.SNAPSHOT) {
+            return allocation.decision(Decision.YES, NAME, "shard is not being restored");
+        }
+
+        final Snapshot snapshot = ((RecoverySource.SnapshotRecoverySource) recoverySource).snapshot();
+        final RestoreInProgress restoresInProgress = allocation.custom(RestoreInProgress.TYPE);
+
+        if (restoresInProgress != null) {
+            for (RestoreInProgress.Entry restoreInProgress : restoresInProgress.entries()) {
+                if (restoreInProgress.snapshot().equals(snapshot)) {
+                    assert restoreInProgress.state().completed() == false : "completed restore should have been removed from cluster state";
+                    RestoreInProgress.ShardRestoreStatus shardRestoreStatus = restoreInProgress.shards().get(shardRouting.shardId());
+                    if (shardRestoreStatus.state() != RestoreInProgress.State.FAILURE) {
+                        return allocation.decision(Decision.YES, NAME, "shard is currently being restored");
+                    }
+                    break;
+                }
+            }
+        }
+        return allocation.decision(Decision.NO, NAME, "shard has failed to be restored from the snapshot [%s] because of [%s] - " +
+            "manually delete the index [%s] in order to retry to restore the snapshot again or use the Reroute API to force the " +
+            "allocation of an empty primary shard", snapshot, shardRouting.unassignedInfo().getDetails(), shardRouting.getIndexName());
+    }
+}

--- a/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -64,7 +64,6 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
@@ -534,7 +533,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                 RecoverySource recoverySource = initializingShard.recoverySource();
                 if (recoverySource.getType() == RecoverySource.Type.SNAPSHOT) {
                     Snapshot snapshot = ((SnapshotRecoverySource) recoverySource).snapshot();
-                    changes(snapshot).startedShards.put(initializingShard.shardId(),
+                    changes(snapshot).shards.put(initializingShard.shardId(),
                         new ShardRestoreStatus(initializingShard.currentNodeId(), RestoreInProgress.State.SUCCESS));
                 }
             }
@@ -550,7 +549,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                     // to restore this shard on another node if the snapshot files are corrupt. In case where a node just left or crashed,
                     // however, we only want to acknowledge the restore operation once it has been successfully restored on another node.
                     if (unassignedInfo.getFailure() != null && Lucene.isCorruptionException(unassignedInfo.getFailure().getCause())) {
-                        changes(snapshot).failedShards.put(failedShard.shardId(), new ShardRestoreStatus(failedShard.currentNodeId(),
+                        changes(snapshot).shards.put(failedShard.shardId(), new ShardRestoreStatus(failedShard.currentNodeId(),
                             RestoreInProgress.State.FAILURE, unassignedInfo.getFailure().getCause().getMessage()));
                     }
                 }
@@ -563,7 +562,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
             if (unassignedShard.recoverySource().getType() == RecoverySource.Type.SNAPSHOT &&
                 initializedShard.recoverySource().getType() != RecoverySource.Type.SNAPSHOT) {
                 Snapshot snapshot = ((SnapshotRecoverySource) unassignedShard.recoverySource()).snapshot();
-                changes(snapshot).failedShards.put(unassignedShard.shardId(), new ShardRestoreStatus(null,
+                changes(snapshot).shards.put(unassignedShard.shardId(), new ShardRestoreStatus(null,
                     RestoreInProgress.State.FAILURE, "recovery source type changed from snapshot to " + initializedShard.recoverySource()));
             }
         }
@@ -575,8 +574,8 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                 if (recoverySource.getType() == RecoverySource.Type.SNAPSHOT) {
                     if (newUnassignedInfo.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {
                         Snapshot snapshot = ((SnapshotRecoverySource) recoverySource).snapshot();
-                        String reason = "shard was denied allocation by all allocation deciders";
-                        changes(snapshot).unassignedShards.put(unassignedShard.shardId(),
+                        String reason = "shard could not be allocated on any of the nodes";
+                        changes(snapshot).shards.put(unassignedShard.shardId(),
                             new ShardRestoreStatus(unassignedShard.currentNodeId(), RestoreInProgress.State.FAILURE, reason));
                     }
                 }
@@ -591,13 +590,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
         }
 
         private static class Updates {
-            private Map<ShardId, ShardRestoreStatus> failedShards = new HashMap<>();
-            private Map<ShardId, ShardRestoreStatus> startedShards = new HashMap<>();
-            private Map<ShardId, ShardRestoreStatus> unassignedShards = new HashMap<>();
-
-            boolean isEmpty() {
-                return startedShards.isEmpty() && failedShards.isEmpty() && unassignedShards.isEmpty();
-            }
+            private Map<ShardId, ShardRestoreStatus> shards = new HashMap<>();
         }
 
         public RestoreInProgress applyChanges(final RestoreInProgress oldRestore) {
@@ -606,18 +599,12 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                 for (RestoreInProgress.Entry entry : oldRestore.entries()) {
                     Snapshot snapshot = entry.snapshot();
                     Updates updates = shardChanges.get(snapshot);
-                    assert Sets.haveEmptyIntersection(updates.startedShards.keySet(), updates.failedShards.keySet());
-                    if (updates.isEmpty() == false) {
+                    if (updates.shards.isEmpty() == false) {
                         ImmutableOpenMap.Builder<ShardId, ShardRestoreStatus> shardsBuilder = ImmutableOpenMap.builder(entry.shards());
-                        for (Map.Entry<ShardId, ShardRestoreStatus> startedShard : updates.startedShards.entrySet()) {
-                            shardsBuilder.put(startedShard.getKey(), startedShard.getValue());
+                        for (Map.Entry<ShardId, ShardRestoreStatus> shard : updates.shards.entrySet()) {
+                            shardsBuilder.put(shard.getKey(), shard.getValue());
                         }
-                        for (Map.Entry<ShardId, ShardRestoreStatus> failedShard : updates.failedShards.entrySet()) {
-                            shardsBuilder.put(failedShard.getKey(), failedShard.getValue());
-                        }
-                        for (Map.Entry<ShardId, ShardRestoreStatus> unassignedShard : updates.unassignedShards.entrySet()) {
-                            shardsBuilder.put(unassignedShard.getKey(), unassignedShard.getValue());
-                        }
+
                         ImmutableOpenMap<ShardId, ShardRestoreStatus> shards = shardsBuilder.build();
                         RestoreInProgress.State newState = overallState(RestoreInProgress.State.STARTED, shards);
                         entries.add(new RestoreInProgress.Entry(entry.snapshot(), newState, entry.indices(), shards));

--- a/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -569,15 +569,13 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
 
         @Override
         public void unassignedInfoUpdated(ShardRouting unassignedShard, UnassignedInfo newUnassignedInfo) {
-            if (unassignedShard.primary()) {
-                RecoverySource recoverySource = unassignedShard.recoverySource();
-                if (recoverySource.getType() == RecoverySource.Type.SNAPSHOT) {
-                    if (newUnassignedInfo.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {
-                        Snapshot snapshot = ((SnapshotRecoverySource) recoverySource).snapshot();
-                        String reason = "shard could not be allocated on any of the nodes";
-                        changes(snapshot).shards.put(unassignedShard.shardId(),
-                            new ShardRestoreStatus(unassignedShard.currentNodeId(), RestoreInProgress.State.FAILURE, reason));
-                    }
+            RecoverySource recoverySource = unassignedShard.recoverySource();
+            if (recoverySource.getType() == RecoverySource.Type.SNAPSHOT) {
+                if (newUnassignedInfo.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {
+                    Snapshot snapshot = ((SnapshotRecoverySource) recoverySource).snapshot();
+                    String reason = "shard could not be allocated to any of the nodes";
+                    changes(snapshot).shards.put(unassignedShard.shardId(),
+                        new ShardRestoreStatus(unassignedShard.currentNodeId(), RestoreInProgress.State.FAILURE, reason));
                 }
             }
         }

--- a/core/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.NodeVersionAllocatio
 import org.elasticsearch.cluster.routing.allocation.decider.RebalanceOnlyWhenActiveAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ResizeAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.RestoreInProgressAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.SnapshotInProgressAllocationDecider;
@@ -183,6 +184,7 @@ public class ClusterModuleTests extends ModuleTestCase {
             EnableAllocationDecider.class,
             NodeVersionAllocationDecider.class,
             SnapshotInProgressAllocationDecider.class,
+            RestoreInProgressAllocationDecider.class,
             FilterAllocationDecider.class,
             SameShardAllocationDecider.class,
             DiskThresholdDecider.class,

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/ThrottlingAllocationTests.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.RestoreInProgress;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -38,6 +39,7 @@ import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
@@ -46,7 +48,10 @@ import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -309,6 +314,8 @@ public class ThrottlingAllocationTests extends ESAllocationTestCase {
         DiscoveryNode node1 = newNode("node1");
         MetaData.Builder metaDataBuilder = new MetaData.Builder(metaData);
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
+        Snapshot snapshot = new Snapshot("repo", new SnapshotId("snap", "randomId"));
+        Set<String> snapshotIndices = new HashSet<>();
         for (ObjectCursor<IndexMetaData> cursor: metaData.indices().values()) {
             Index index = cursor.value.getIndex();
             IndexMetaData.Builder indexMetaDataBuilder = IndexMetaData.builder(cursor.value);
@@ -329,14 +336,14 @@ public class ThrottlingAllocationTests extends ESAllocationTestCase {
                     routingTableBuilder.addAsFromDangling(indexMetaData);
                     break;
                 case 3:
+                    snapshotIndices.add(index.getName());
                     routingTableBuilder.addAsNewRestore(indexMetaData,
-                        new SnapshotRecoverySource(new Snapshot("repo", new SnapshotId("snap", "randomId")), Version.CURRENT,
-                            indexMetaData.getIndex().getName()), new IntHashSet());
+                        new SnapshotRecoverySource(snapshot, Version.CURRENT, indexMetaData.getIndex().getName()), new IntHashSet());
                     break;
                 case 4:
+                    snapshotIndices.add(index.getName());
                     routingTableBuilder.addAsRestore(indexMetaData,
-                        new SnapshotRecoverySource(new Snapshot("repo", new SnapshotId("snap", "randomId")), Version.CURRENT,
-                            indexMetaData.getIndex().getName()));
+                        new SnapshotRecoverySource(snapshot, Version.CURRENT, indexMetaData.getIndex().getName()));
                     break;
                 case 5:
                     routingTableBuilder.addAsNew(indexMetaData);
@@ -345,10 +352,31 @@ public class ThrottlingAllocationTests extends ESAllocationTestCase {
                     throw new IndexOutOfBoundsException();
             }
         }
+
+        final RoutingTable routingTable = routingTableBuilder.build();
+
+        final ImmutableOpenMap.Builder<String, ClusterState.Custom> restores = ImmutableOpenMap.builder();
+        if (snapshotIndices.isEmpty() == false) {
+            // Some indices are restored from snapshot, the RestoreInProgress must be set accordingly
+            ImmutableOpenMap.Builder<ShardId, RestoreInProgress.ShardRestoreStatus> restoreShards = ImmutableOpenMap.builder();
+            for (ShardRouting shard : routingTable.allShards()) {
+                if (shard.primary() && shard.recoverySource().getType() == RecoverySource.Type.SNAPSHOT) {
+                    ShardId shardId = shard.shardId();
+                    restoreShards.put(shardId, new RestoreInProgress.ShardRestoreStatus(node1.getId(), RestoreInProgress.State.INIT));
+                }
+            }
+
+            RestoreInProgress.Entry restore = new RestoreInProgress.Entry(snapshot, RestoreInProgress.State.INIT,
+                new ArrayList<>(snapshotIndices), restoreShards.build());
+            restores.put(RestoreInProgress.TYPE, new RestoreInProgress(restore));
+        }
+
         return ClusterState.builder(CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
             .nodes(DiscoveryNodes.builder().add(node1))
             .metaData(metaDataBuilder.build())
-            .routingTable(routingTableBuilder.build()).build();
+            .routingTable(routingTable)
+            .customs(restores.build())
+            .build();
     }
 
     private void addInSyncAllocationIds(Index index, IndexMetaData.Builder indexMetaData,

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.elasticsearch.cluster.routing.allocation.decider;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -1,0 +1,193 @@
+package org.elasticsearch.cluster.routing.allocation.decider;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.RestoreInProgress;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotId;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Test {@link RestoreInProgressAllocationDecider}
+ */
+public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCase {
+
+    public void testCanAllocateReplica() {
+        ClusterState clusterState = createInitialClusterState();
+        ShardRouting replica = clusterState.getRoutingTable().shardRoutingTable("test", 0).replicaShards().get(0);
+
+        final Decision decision = executeAllocation(clusterState, replica);
+        assertEquals(Decision.Type.YES, decision.type());
+        assertEquals("shard is not a primary shard", decision.getExplanation());
+    }
+
+    public void testCanAllocatePrimary() {
+        ClusterState clusterState = createInitialClusterState();
+        ShardRouting primary = clusterState.getRoutingTable().shardRoutingTable("test", 0).primaryShard();
+        assertEquals(RecoverySource.Type.EMPTY_STORE, primary.recoverySource().getType());
+
+        final Decision decision = executeAllocation(clusterState, primary);
+        assertEquals(Decision.Type.YES, decision.type());
+        assertEquals("shard is not being restored", decision.getExplanation());
+    }
+
+    public void testCannotAllocatePrimaryMissingInRestoreInProgress() {
+        ClusterState clusterState = createInitialClusterState();
+        RoutingTable routingTable = RoutingTable.builder(clusterState.getRoutingTable())
+            .addAsRestore(clusterState.getMetaData().index("test"), createSnapshotRecoverySource("_missing"))
+            .build();
+
+        clusterState = ClusterState.builder(clusterState)
+            .routingTable(routingTable)
+            .build();
+
+        ShardRouting primary = clusterState.getRoutingTable().shardRoutingTable("test", 0).primaryShard();
+        assertEquals(ShardRoutingState.UNASSIGNED, primary.state());
+        assertEquals(RecoverySource.Type.SNAPSHOT, primary.recoverySource().getType());
+
+        final Decision decision = executeAllocation(clusterState, primary);
+        assertEquals(Decision.Type.NO, decision.type());
+        assertEquals("shard has failed to be restored from the snapshot [_repository:_missing/_uuid] because of " +
+            "[restore_source[_repository/_missing]] - manually delete the index [test] in order to retry to restore " +
+            "the snapshot again or use the Reroute API to force the allocation of an empty primary shard", decision.getExplanation());
+    }
+
+    public void testCanAllocatePrimaryExistingInRestoreInProgress() {
+        RecoverySource.SnapshotRecoverySource recoverySource = createSnapshotRecoverySource("_existing");
+
+        ClusterState clusterState = createInitialClusterState();
+        RoutingTable routingTable = RoutingTable.builder(clusterState.getRoutingTable())
+            .addAsRestore(clusterState.getMetaData().index("test"), recoverySource)
+            .build();
+
+        clusterState = ClusterState.builder(clusterState)
+            .routingTable(routingTable)
+            .build();
+
+        ShardRouting primary = clusterState.getRoutingTable().shardRoutingTable("test", 0).primaryShard();
+        assertEquals(ShardRoutingState.UNASSIGNED, primary.state());
+        assertEquals(RecoverySource.Type.SNAPSHOT, primary.recoverySource().getType());
+
+        routingTable = clusterState.routingTable();
+
+        final RestoreInProgress.State shardState;
+        if (randomBoolean()) {
+            shardState = randomFrom(RestoreInProgress.State.STARTED, RestoreInProgress.State.INIT, RestoreInProgress.State.SUCCESS);
+        } else {
+            shardState = RestoreInProgress.State.FAILURE;
+
+            UnassignedInfo currentInfo = primary.unassignedInfo();
+            UnassignedInfo newInfo = new UnassignedInfo(currentInfo.getReason(), currentInfo.getMessage(), new IOException("i/o failure"),
+                currentInfo.getNumFailedAllocations(), currentInfo.getUnassignedTimeInNanos(),
+                currentInfo.getUnassignedTimeInMillis(), currentInfo.isDelayed(), currentInfo.getLastAllocationStatus());
+            primary = primary.updateUnassigned(newInfo, primary.recoverySource());
+
+            IndexRoutingTable indexRoutingTable = routingTable.index("test");
+            IndexRoutingTable.Builder newIndexRoutingTable = IndexRoutingTable.builder(indexRoutingTable.getIndex());
+            for (final ObjectCursor<IndexShardRoutingTable> shardEntry : indexRoutingTable.getShards().values()) {
+                final IndexShardRoutingTable shardRoutingTable = shardEntry.value;
+                for (ShardRouting shardRouting : shardRoutingTable.getShards()) {
+                    if (shardRouting.primary()) {
+                        newIndexRoutingTable.addShard(primary);
+                    } else {
+                        newIndexRoutingTable.addShard(shardRouting);
+                    }
+                }
+            }
+            routingTable = RoutingTable.builder(routingTable).add(newIndexRoutingTable).build();
+        }
+
+        ImmutableOpenMap.Builder<ShardId, RestoreInProgress.ShardRestoreStatus> shards = ImmutableOpenMap.builder();
+        shards.put(primary.shardId(), new RestoreInProgress.ShardRestoreStatus(clusterState.getNodes().getLocalNodeId(), shardState));
+
+        Snapshot snapshot = recoverySource.snapshot();
+        RestoreInProgress.State restoreState = RestoreInProgress.State.STARTED;
+        RestoreInProgress.Entry restore = new RestoreInProgress.Entry(snapshot, restoreState, singletonList("test"), shards.build());
+
+        clusterState = ClusterState.builder(clusterState)
+            .putCustom(RestoreInProgress.TYPE, new RestoreInProgress(restore))
+            .routingTable(routingTable)
+            .build();
+
+        Decision decision = executeAllocation(clusterState, primary);
+        if (shardState == RestoreInProgress.State.FAILURE) {
+            assertEquals(Decision.Type.NO, decision.type());
+            assertEquals("shard has failed to be restored from the snapshot [_repository:_existing/_uuid] because of " +
+                "[restore_source[_repository/_existing], failure IOException[i/o failure]] - manually delete the index " +
+                "[test] in order to retry to restore the snapshot again or use the Reroute API to force the allocation of " +
+                "an empty primary shard", decision.getExplanation());
+        } else {
+            assertEquals(Decision.Type.YES, decision.type());
+            assertEquals("shard is currently being restored", decision.getExplanation());
+        }
+    }
+
+    private ClusterState createInitialClusterState() {
+        MetaData metaData = MetaData.builder()
+            .put(IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .build();
+
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsNew(metaData.index("test"))
+            .build();
+
+        DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
+            .add(newNode("master", Collections.singleton(DiscoveryNode.Role.MASTER)))
+            .localNodeId("master")
+            .masterNodeId("master")
+            .build();
+
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .metaData(metaData)
+            .routingTable(routingTable)
+            .nodes(discoveryNodes)
+            .build();
+
+        assertEquals(2, clusterState.getRoutingTable().shardsWithState(ShardRoutingState.UNASSIGNED).size());
+        return clusterState;
+    }
+
+    private Decision executeAllocation(final ClusterState clusterState, final ShardRouting shardRouting) {
+        final AllocationDecider decider = new RestoreInProgressAllocationDecider(Settings.EMPTY);
+        final RoutingAllocation allocation = new RoutingAllocation(new AllocationDeciders(Settings.EMPTY, Collections.singleton(decider)),
+            clusterState.getRoutingNodes(), clusterState, null, 0L);
+        allocation.debugDecision(true);
+
+        final Decision decision;
+        if (randomBoolean()) {
+            decision = decider.canAllocate(shardRouting, allocation);
+        } else {
+            DiscoveryNode node = clusterState.getNodes().getMasterNode();
+            decision = decider.canAllocate(shardRouting, new RoutingNode(node.getId(), node), allocation);
+        }
+        return decision;
+    }
+
+    private RecoverySource.SnapshotRecoverySource createSnapshotRecoverySource(final String snapshotName) {
+        Snapshot snapshot = new Snapshot("_repository", new SnapshotId(snapshotName, "_uuid"));
+        return new RecoverySource.SnapshotRecoverySource(snapshot, Version.CURRENT, "test");
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -53,23 +53,20 @@ import static java.util.Collections.singletonList;
  */
 public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCase {
 
-    public void testCanAllocateReplica() {
-        ClusterState clusterState = createInitialClusterState();
-        ShardRouting replica = clusterState.getRoutingTable().shardRoutingTable("test", 0).replicaShards().get(0);
-
-        final Decision decision = executeAllocation(clusterState, replica);
-        assertEquals(Decision.Type.YES, decision.type());
-        assertEquals("shard is not a primary shard", decision.getExplanation());
-    }
-
     public void testCanAllocatePrimary() {
         ClusterState clusterState = createInitialClusterState();
-        ShardRouting primary = clusterState.getRoutingTable().shardRoutingTable("test", 0).primaryShard();
-        assertEquals(RecoverySource.Type.EMPTY_STORE, primary.recoverySource().getType());
+        ShardRouting shard;
+        if (randomBoolean()) {
+            shard = clusterState.getRoutingTable().shardRoutingTable("test", 0).primaryShard();
+            assertEquals(RecoverySource.Type.EMPTY_STORE, shard.recoverySource().getType());
+        }  else {
+            shard = clusterState.getRoutingTable().shardRoutingTable("test", 0).replicaShards().get(0);
+            assertEquals(RecoverySource.Type.PEER, shard.recoverySource().getType());
+        }
 
-        final Decision decision = executeAllocation(clusterState, primary);
+        final Decision decision = executeAllocation(clusterState, shard);
         assertEquals(Decision.Type.YES, decision.type());
-        assertEquals("shard is not being restored", decision.getExplanation());
+        assertEquals("ignored as shard is not being recovered from a snapshot", decision.getExplanation());
     }
 
     public void testCannotAllocatePrimaryMissingInRestoreInProgress() {
@@ -89,8 +86,8 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
         final Decision decision = executeAllocation(clusterState, primary);
         assertEquals(Decision.Type.NO, decision.type());
         assertEquals("shard has failed to be restored from the snapshot [_repository:_missing/_uuid] because of " +
-            "[restore_source[_repository/_missing]] - manually delete the index [test] in order to retry to restore " +
-            "the snapshot again or use the Reroute API to force the allocation of an empty primary shard", decision.getExplanation());
+            "[restore_source[_repository/_missing]] - manually close or delete the index [test] in order to retry to restore " +
+            "the snapshot again or use the reroute API to force the allocation of an empty primary shard", decision.getExplanation());
     }
 
     public void testCanAllocatePrimaryExistingInRestoreInProgress() {
@@ -113,7 +110,7 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
 
         final RestoreInProgress.State shardState;
         if (randomBoolean()) {
-            shardState = randomFrom(RestoreInProgress.State.STARTED, RestoreInProgress.State.INIT, RestoreInProgress.State.SUCCESS);
+            shardState = randomFrom(RestoreInProgress.State.STARTED, RestoreInProgress.State.INIT);
         } else {
             shardState = RestoreInProgress.State.FAILURE;
 
@@ -154,8 +151,8 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
         if (shardState == RestoreInProgress.State.FAILURE) {
             assertEquals(Decision.Type.NO, decision.type());
             assertEquals("shard has failed to be restored from the snapshot [_repository:_existing/_uuid] because of " +
-                "[restore_source[_repository/_existing], failure IOException[i/o failure]] - manually delete the index " +
-                "[test] in order to retry to restore the snapshot again or use the Reroute API to force the allocation of " +
+                "[restore_source[_repository/_existing], failure IOException[i/o failure]] - manually close or delete the index " +
+                "[test] in order to retry to restore the snapshot again or use the reroute API to force the allocation of " +
                 "an empty primary shard", decision.getExplanation());
         } else {
             assertEquals(Decision.Type.YES, decision.type());


### PR DESCRIPTION
When the allocation of a shard has been retried too many times, the
`MaxRetryDecider` is engaged to prevent any future allocation of the
failed shard. If it happens while restoring a snapshot, the restore
hangs and never completes because it stays around waiting for the
shards to be assigned. It also blocks future attempts to restore the
snapshot again.

This commit changes the current behaviour in order to fail the restore if
a shard reached the maximum allocations attempts without being successfully
assigned.

This is the second part of the #26865 issue.