### PR TITLE
Release tests failing on master

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/VersionCollection.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/VersionCollection.groovy
@@ -95,6 +95,12 @@ class VersionCollection {
             prevConsideredVersion = currConsideredVersion
         }
 
+        // If we're making a release build then the current should not be a snapshot after all.
+        final boolean currentIsSnapshot = "true" == System.getProperty("build.snapshot", "true")
+        if (false == currentIsSnapshot) {
+            versions[-1] = new Version(versions[-1].major, versions[-1].minor, versions[-1].revision, versions[-1].suffix, false, null)
+        }
+
         this.versions = Collections.unmodifiableList(versions)
     }
 


### PR DESCRIPTION
```
> The last version in Versions.java [7.0.0-alpha1-SNAPSHOT] does not match VersionProperties.elasticsearch [7.0.0-alpha1]
```

Looks related to #27397 .