### PR TITLE
Fix classes that can exit

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -119,7 +119,11 @@ final class Security {
         Policy.setPolicy(new ESPolicy(createPermissions(environment), getPluginPermissions(environment), filterBadDefaults));
 
         // enable security manager
-        final String[] classesThatCanExit = new String[]{ElasticsearchUncaughtExceptionHandler.class.getName(), Command.class.getName()};
+        final String[] classesThatCanExit =
+                new String[]{
+                        // SecureSM matches class names as regular expressions so we escape the $ that arises from the static class name
+                        ElasticsearchUncaughtExceptionHandler.PrivilegedHaltAction.class.getName().replace("$", "\\$"),
+                        Command.class.getName()};
         System.setSecurityManager(new SecureSM(classesThatCanExit));
 
         // do some basic tests

--- a/core/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -121,7 +121,7 @@ final class Security {
         // enable security manager
         final String[] classesThatCanExit =
                 new String[]{
-                        // SecureSM matches class names as regular expressions so we escape the $ that arises from the static class name
+                        // SecureSM matches class names as regular expressions so we escape the $ that arises from the nested class name
                         ElasticsearchUncaughtExceptionHandler.PrivilegedHaltAction.class.getName().replace("$", "\\$"),
                         Command.class.getName()};
         System.setSecurityManager(new SecureSM(classesThatCanExit));


### PR DESCRIPTION
In a previous change, we locked down the classes that can exit by specifying explicit classes rather than packages than can exit. Alas, there was a bug in the sense that the class that we exit from in the case of an uncaught exception is not ElasticsearchUncaughtExceptionHandler but rather an anonymous nested class of ElasticsearchUncaughtExceptionHandler. To address this, we replace this anonymous class with a bonafide nested class ElasticsearchUncaughtExceptionHandler$PrivilegedHaltAction. Note that if we try to get this class name we have a $ in the middle of the string which is a special regular expression character; as such, we have to escape it.
