### PR TITLE
Fix links to the new SHA512 checksums and check the integrity directly

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -119,11 +119,12 @@ The Debian package for Elasticsearch v{version} can be downloaded from the websi
 ["source","sh",subs="attributes"]
 --------------------------------------------
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.deb
-sha1sum elasticsearch-{version}.deb <1>
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.deb.sha512
+shasum -a 512 -c elasticsearch-{version}.deb.sha512 <1>
 sudo dpkg -i elasticsearch-{version}.deb
 --------------------------------------------
-<1> Compare the SHA produced by `sha1sum` or `shasum` with the
-    https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.deb.sha1[published SHA].
+<1> Compares the SHA of the downloaded Debian package and the published checksum, which should output
+    `elasticsearch-{version}.deb: OK`.
 
 endif::[]
 

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -104,11 +104,12 @@ The RPM for Elasticsearch v{version} can be downloaded from the website and inst
 ["source","sh",subs="attributes"]
 --------------------------------------------
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.rpm
-sha1sum elasticsearch-{version}.rpm <1>
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.rpm.sha512
+shasum -a 512 -c elasticsearch-{version}.rpm.sha512 <1>
 sudo rpm --install elasticsearch-{version}.rpm
 --------------------------------------------
-<1> Compare the SHA produced by `sha1sum` or `shasum` with the
-    https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.rpm.sha1[published SHA].
+<1> Compares the SHA of the downloaded RPM and the published checksum, which should output
+    `elasticsearch-{version}.rpm: OK`.
 
 endif::[]
 

--- a/docs/reference/setup/install/zip-targz.asciidoc
+++ b/docs/reference/setup/install/zip-targz.asciidoc
@@ -31,12 +31,13 @@ The `.zip` archive for Elasticsearch v{version} can be downloaded and installed 
 ["source","sh",subs="attributes"]
 --------------------------------------------
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.zip
-sha1sum elasticsearch-{version}.zip <1>
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.zip.sha512
+shasum -a 512 -c elasticsearch-{version}.zip.sha512 <1>
 unzip elasticsearch-{version}.zip
 cd elasticsearch-{version}/ <2>
 --------------------------------------------
-<1> Compare the SHA produced by `sha1sum` or `shasum` with the
-    https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.zip.sha1[published SHA].
+<1> Compares the SHA of the downloaded `.zip` archive and the published checksum, which should output
+    `elasticsearch-{version}.zip: OK`.
 <2> This directory is known as `$ES_HOME`.
 
 endif::[]
@@ -58,12 +59,13 @@ The `.tar.gz` archive for Elasticsearch v{version} can be downloaded and install
 ["source","sh",subs="attributes"]
 --------------------------------------------
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.tar.gz
-sha1sum elasticsearch-{version}.tar.gz <1>
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.tar.gz.sha512
+shasum -a 512 -c elasticsearch-{version}.tar.gz.sha512 <1>
 tar -xzf elasticsearch-{version}.tar.gz
 cd elasticsearch-{version}/ <2>
 --------------------------------------------
-<1> Compare the SHA produced by `sha1sum` or `shasum` with the
-    https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.tar.gz.sha1[published SHA].
+<1> Compares the SHA of the downloaded `.tar.gz` archive and the published checksum, which should output
+    `elasticsearch-{version}.tar.gz: OK`.
 <2> This directory is known as `$ES_HOME`.
 
 endif::[]


### PR DESCRIPTION
We don't provide SHA1 any more for 6.0+ artefacts, so the link is currently broken. Also switched to checking the integrity directly instead of comparing hashes.

Related blog post: https://www.elastic.co/blog/sha512-checksums-for-elastic-stack-artifacts ( @mgreau )

Will cherrypick to 6.0 and 6.1 branches if approved.