### PR TITLE
Enclose CombinedDeletionPolicy in SnapshotDeletionPolicy

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
@@ -95,7 +95,7 @@ class CombinedDeletionPolicy extends IndexDeletionPolicy {
         private final IndexCommit commit;
         private boolean markedAsDeleted;
 
-        public TrackedIndexCommit(IndexCommit commit) {
+        TrackedIndexCommit(IndexCommit commit) {
             this.commit = commit;
         }
 

--- a/core/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
@@ -22,24 +22,26 @@ package org.elasticsearch.index.engine;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexDeletionPolicy;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
+import org.apache.lucene.store.Directory;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogDeletionPolicy;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * An {@link IndexDeletionPolicy} that coordinates between Lucene's commits and the retention of translog generation files,
  * making sure that all translog files that are needed to recover from the Lucene commit are not deleted.
  */
 class CombinedDeletionPolicy extends IndexDeletionPolicy {
-
+    private final IndexDeletionPolicy indexDeletionPolicy;
     private final TranslogDeletionPolicy translogDeletionPolicy;
     private final EngineConfig.OpenMode openMode;
 
-    private final SnapshotDeletionPolicy indexDeletionPolicy;
-
-    CombinedDeletionPolicy(SnapshotDeletionPolicy indexDeletionPolicy, TranslogDeletionPolicy translogDeletionPolicy,
+    CombinedDeletionPolicy(IndexDeletionPolicy indexDeletionPolicy, TranslogDeletionPolicy translogDeletionPolicy,
                            EngineConfig.OpenMode openMode) {
         this.indexDeletionPolicy = indexDeletionPolicy;
         this.translogDeletionPolicy = translogDeletionPolicy;
@@ -47,7 +49,8 @@ class CombinedDeletionPolicy extends IndexDeletionPolicy {
     }
 
     @Override
-    public void onInit(List<? extends IndexCommit> commits) throws IOException {
+    public void onInit(List<? extends IndexCommit> originalCommits) throws IOException {
+        final List<TrackedIndexCommit> commits = wrapCommits(originalCommits);
         indexDeletionPolicy.onInit(commits);
         switch (openMode) {
             case CREATE_INDEX_AND_TRANSLOG:
@@ -65,25 +68,85 @@ class CombinedDeletionPolicy extends IndexDeletionPolicy {
     }
 
     @Override
-    public void onCommit(List<? extends IndexCommit> commits) throws IOException {
+    public void onCommit(List<? extends IndexCommit> originalCommits) throws IOException {
+        final List<TrackedIndexCommit> commits = wrapCommits(originalCommits);
         indexDeletionPolicy.onCommit(commits);
         setLastCommittedTranslogGeneration(commits);
     }
 
-    private void setLastCommittedTranslogGeneration(List<? extends IndexCommit> commits) throws IOException {
+    private void setLastCommittedTranslogGeneration(List<TrackedIndexCommit> commits) throws IOException {
         // when opening an existing lucene index, we currently always open the last commit.
         // we therefore use the translog gen as the one that will be required for recovery
-        final IndexCommit indexCommit = commits.get(commits.size() - 1);
-        assert indexCommit.isDeleted() == false : "last commit is deleted";
+        final TrackedIndexCommit indexCommit = commits.get(commits.size() - 1);
+        assert indexCommit.isMarkedAsDeleted() == false : "last commit is deleted";
         long minGen = Long.parseLong(indexCommit.getUserData().get(Translog.TRANSLOG_GENERATION_KEY));
         translogDeletionPolicy.setMinTranslogGenerationForRecovery(minGen);
     }
 
-    public SnapshotDeletionPolicy getIndexDeletionPolicy() {
-        return indexDeletionPolicy;
+    private List<TrackedIndexCommit> wrapCommits(List<? extends IndexCommit> commits) {
+        return commits.stream().map(TrackedIndexCommit::new).collect(Collectors.toList());
     }
 
-    public TranslogDeletionPolicy getTranslogDeletionPolicy() {
-        return translogDeletionPolicy;
+    /**
+     * Wraps a provided {@link IndexCommit} and tracks if it has been deleted by the policy.
+     * This tracks if {@link #delete()} has been called or not even the actual action can be ignored by {@link SnapshotDeletionPolicy}.
+     */
+    private static class TrackedIndexCommit extends IndexCommit {
+        private final IndexCommit commit;
+        private boolean markedAsDeleted;
+
+        public TrackedIndexCommit(IndexCommit commit) {
+            this.commit = commit;
+        }
+
+        @Override
+        public String getSegmentsFileName() {
+            return commit.getSegmentsFileName();
+        }
+
+        @Override
+        public Collection<String> getFileNames() throws IOException {
+            return commit.getFileNames();
+        }
+
+        @Override
+        public Directory getDirectory() {
+            return commit.getDirectory();
+        }
+
+        @Override
+        public void delete() {
+            markedAsDeleted = true;
+            // The actual delete action can be ignore by SnapshotDeletionPolicy.
+            commit.delete();
+        }
+
+        /**
+         * Returns true if this index commit is marked as deleted by the deletion policy.
+         * We should only keep translog of index commits which are not marked as deleted by the deletion policy.
+         */
+        boolean isMarkedAsDeleted() {
+            return markedAsDeleted;
+        }
+
+        @Override
+        public boolean isDeleted() {
+            return commit.isDeleted();
+        }
+
+        @Override
+        public int getSegmentCount() {
+            return commit.getSegmentCount();
+        }
+
+        @Override
+        public long getGeneration() {
+            return commit.getGeneration();
+        }
+
+        @Override
+        public Map<String, String> getUserData() throws IOException {
+            return commit.getUserData();
+        }
     }
 }


### PR DESCRIPTION
Today we can not distinguish between index commits that are kept by the
primary policy and those are kept for snapshotting with a
SnapshotDeletionPolicy. Since we enclose a SnapshotDeletionPolicy in a
CombinedDeletionPolicy, we also we can not distinguish between those
with a CombinedDeletionPolicy. This can be a problem if we update the
TranslogDeletionPolicy to keep the minimum translog generation of
undeleted index commits as we may keep the translog of a snapshotting
commit even though it is "deleted" by the primary policy.

To solve this, we enclose a CombinedDeletionPolicy in a
SnapshotDeletionPolicy and track if an index commit is deleted by the
primary policy, then use that value to maintain translog rather than the
actual deletion of an index commit.

Relates #27456 #27367
