### PR TITLE
Limit the number of tokens produced by _analyze

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -111,6 +111,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexSettings.INDEX_REFRESH_INTERVAL_SETTING,
         IndexSettings.MAX_RESULT_WINDOW_SETTING,
         IndexSettings.MAX_INNER_RESULT_WINDOW_SETTING,
+        IndexSettings.MAX_TOKEN_COUNT_SETTING,
         IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING,
         IndexSettings.MAX_SCRIPT_FIELDS_SETTING,
         IndexSettings.MAX_NGRAM_DIFF_SETTING,

--- a/core/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/core/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -111,6 +111,14 @@ public final class IndexSettings {
         Setting.intSetting("index.max_script_fields", 32, 0, Property.Dynamic, Property.IndexScope);
 
     /**
+     * A setting describing the maximum number of tokens that can be
+     * produced using _analyze API. The default maximum of 10000 is defensive
+     * to prevent generating too many token objects.
+     */
+    public static final Setting<Integer> MAX_TOKEN_COUNT_SETTING =
+        Setting.intSetting("index.analyze.max_token_count", 10000, 1, Property.Dynamic, Property.IndexScope);
+
+    /**
      * Index setting describing for NGramTokenizer and NGramTokenFilter
      * the maximum difference between
      * max_gram (maximum length of characters in a gram) and
@@ -262,6 +270,7 @@ public final class IndexSettings {
     private volatile int maxRescoreWindow;
     private volatile int maxDocvalueFields;
     private volatile int maxScriptFields;
+    private volatile int maxTokenCount;
     private volatile int maxNgramDiff;
     private volatile int maxShingleDiff;
     private volatile boolean TTLPurgeDisabled;
@@ -369,6 +378,7 @@ public final class IndexSettings {
         maxRescoreWindow = scopedSettings.get(MAX_RESCORE_WINDOW_SETTING);
         maxDocvalueFields = scopedSettings.get(MAX_DOCVALUE_FIELDS_SEARCH_SETTING);
         maxScriptFields = scopedSettings.get(MAX_SCRIPT_FIELDS_SETTING);
+        maxTokenCount = scopedSettings.get(MAX_TOKEN_COUNT_SETTING);
         maxNgramDiff = scopedSettings.get(MAX_NGRAM_DIFF_SETTING);
         maxShingleDiff = scopedSettings.get(MAX_SHINGLE_DIFF_SETTING);
         TTLPurgeDisabled = scopedSettings.get(INDEX_TTL_DISABLE_PURGE_SETTING);
@@ -403,6 +413,7 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(MAX_RESCORE_WINDOW_SETTING, this::setMaxRescoreWindow);
         scopedSettings.addSettingsUpdateConsumer(MAX_DOCVALUE_FIELDS_SEARCH_SETTING, this::setMaxDocvalueFields);
         scopedSettings.addSettingsUpdateConsumer(MAX_SCRIPT_FIELDS_SETTING, this::setMaxScriptFields);
+        scopedSettings.addSettingsUpdateConsumer(MAX_TOKEN_COUNT_SETTING, this::setMaxTokenCount);
         scopedSettings.addSettingsUpdateConsumer(MAX_NGRAM_DIFF_SETTING, this::setMaxNgramDiff);
         scopedSettings.addSettingsUpdateConsumer(MAX_SHINGLE_DIFF_SETTING, this::setMaxShingleDiff);
         scopedSettings.addSettingsUpdateConsumer(INDEX_WARMER_ENABLED_SETTING, this::setEnableWarmer);
@@ -675,6 +686,18 @@ public final class IndexSettings {
     private void setMaxDocvalueFields(int maxDocvalueFields) {
         this.maxDocvalueFields = maxDocvalueFields;
     }
+
+    /**
+     * Returns the maximum number of tokens that can be produced
+     */
+    public int getMaxTokenCount() {
+        return maxTokenCount;
+    }
+
+    private void setMaxTokenCount(int maxTokenCount) {
+        this.maxTokenCount = maxTokenCount;
+    }
+
 
     /**
      * Returns the maximum allowed difference between max and min length of ngram

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/TransportAnalyzeActionTests.java
@@ -61,6 +61,8 @@ public class TransportAnalyzeActionTests extends ESTestCase {
     private IndexAnalyzers indexAnalyzers;
     private AnalysisRegistry registry;
     private Environment environment;
+    private int maxTokenCount;
+    private int idxMaxTokenCount;
 
     @Override
     public void setUp() throws Exception {
@@ -73,6 +75,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                 .put("index.analysis.analyzer.custom_analyzer.tokenizer", "standard")
                 .put("index.analysis.analyzer.custom_analyzer.filter", "mock")
                 .put("index.analysis.normalizer.my_normalizer.type", "custom")
+                .put("index.analyze.max_token_count", 100)
                 .putList("index.analysis.normalizer.my_normalizer.filter", "lowercase").build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", indexSettings);
         environment = TestEnvironment.newEnvironment(settings);
@@ -116,6 +119,8 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         };
         registry = new AnalysisModule(environment, singletonList(plugin)).getAnalysisRegistry();
         indexAnalyzers = registry.build(idxSettings);
+        maxTokenCount = IndexSettings.MAX_TOKEN_COUNT_SETTING.getDefault(settings);
+        idxMaxTokenCount = idxSettings.getMaxTokenCount();
     }
 
     /**
@@ -126,7 +131,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         AnalyzeRequest request = new AnalyzeRequest();
         request.text("the quick brown fox");
         request.analyzer("standard");
-        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, null, registry, environment);
+        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, null, registry, environment, maxTokenCount);
         List<AnalyzeResponse.AnalyzeToken> tokens = analyze.getTokens();
         assertEquals(4, tokens.size());
 
@@ -135,7 +140,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         request.text("the qu1ck brown fox");
         request.tokenizer("standard");
         request.addTokenFilter("mock");
-        analyze = TransportAnalyzeAction.analyze(request, "text", null, randomBoolean() ? indexAnalyzers : null, registry, environment);
+        analyze = TransportAnalyzeAction.analyze(request, "text", null, randomBoolean() ? indexAnalyzers : null, registry, environment, maxTokenCount);
         tokens = analyze.getTokens();
         assertEquals(3, tokens.size());
         assertEquals("qu1ck", tokens.get(0).getTerm());
@@ -147,7 +152,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         request.text("the qu1ck brown fox");
         request.tokenizer("standard");
         request.addCharFilter("append_foo");
-        analyze = TransportAnalyzeAction.analyze(request, "text", null, randomBoolean() ? indexAnalyzers : null, registry, environment);
+        analyze = TransportAnalyzeAction.analyze(request, "text", null, randomBoolean() ? indexAnalyzers : null, registry, environment, maxTokenCount);
         tokens = analyze.getTokens();
         assertEquals(4, tokens.size());
         assertEquals("the", tokens.get(0).getTerm());
@@ -161,7 +166,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         request.tokenizer("standard");
         request.addCharFilter("append");
         request.text("the qu1ck brown fox");
-        analyze = TransportAnalyzeAction.analyze(request, "text", null, randomBoolean() ? indexAnalyzers : null, registry, environment);
+        analyze = TransportAnalyzeAction.analyze(request, "text", null, randomBoolean() ? indexAnalyzers : null, registry, environment, maxTokenCount);
         tokens = analyze.getTokens();
         assertEquals(4, tokens.size());
         assertEquals("the", tokens.get(0).getTerm());
@@ -174,7 +179,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         AnalyzeRequest request = new AnalyzeRequest();
         request.analyzer("standard");
         request.text("the 1 brown fox");
-        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, null, registry, environment);
+        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, null, registry, environment, maxTokenCount);
         List<AnalyzeResponse.AnalyzeToken> tokens = analyze.getTokens();
         assertEquals(4, tokens.size());
         assertEquals("the", tokens.get(0).getTerm());
@@ -206,7 +211,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         AnalyzeRequest request = new AnalyzeRequest();
         request.text("the quick brown fox");
         request.analyzer("custom_analyzer");
-        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment);
+        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment, maxTokenCount);
         List<AnalyzeResponse.AnalyzeToken> tokens = analyze.getTokens();
         assertEquals(3, tokens.size());
         assertEquals("quick", tokens.get(0).getTerm());
@@ -214,7 +219,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         assertEquals("fox", tokens.get(2).getTerm());
 
         request.analyzer("standard");
-        analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment);
+        analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment, maxTokenCount);
         tokens = analyze.getTokens();
         assertEquals(4, tokens.size());
         assertEquals("the", tokens.get(0).getTerm());
@@ -225,7 +230,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         // Switch the analyzer out for just a tokenizer
         request.analyzer(null);
         request.tokenizer("standard");
-        analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment);
+        analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment, maxTokenCount);
         tokens = analyze.getTokens();
         assertEquals(4, tokens.size());
         assertEquals("the", tokens.get(0).getTerm());
@@ -235,7 +240,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
 
         // Now try applying our token filter
         request.addTokenFilter("mock");
-        analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment);
+        analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment, maxTokenCount);
         tokens = analyze.getTokens();
         assertEquals(3, tokens.size());
         assertEquals("quick", tokens.get(0).getTerm());
@@ -249,7 +254,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                 new AnalyzeRequest()
                     .analyzer("custom_analyzer")
                     .text("the qu1ck brown fox-dog"),
-                "text", null, null, registry, environment));
+                "text", null, null, registry, environment, maxTokenCount));
         assertEquals(e.getMessage(), "failed to find global analyzer [custom_analyzer]");
     }
 
@@ -260,7 +265,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                 new AnalyzeRequest()
                     .analyzer("foobar")
                     .text("the qu1ck brown fox"),
-                "text", null, notGlobal ? indexAnalyzers : null, registry, environment));
+                "text", null, notGlobal ? indexAnalyzers : null, registry, environment, maxTokenCount));
         if (notGlobal) {
             assertEquals(e.getMessage(), "failed to find analyzer [foobar]");
         } else {
@@ -272,7 +277,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                 new AnalyzeRequest()
                     .tokenizer("foobar")
                     .text("the qu1ck brown fox"),
-                "text", null, notGlobal ? indexAnalyzers : null, registry, environment));
+                "text", null, notGlobal ? indexAnalyzers : null, registry, environment, maxTokenCount));
         if (notGlobal) {
             assertEquals(e.getMessage(), "failed to find tokenizer under [foobar]");
         } else {
@@ -285,7 +290,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                     .tokenizer("whitespace")
                     .addTokenFilter("foobar")
                     .text("the qu1ck brown fox"),
-                "text", null, notGlobal ? indexAnalyzers : null, registry, environment));
+                "text", null, notGlobal ? indexAnalyzers : null, registry, environment, maxTokenCount));
         if (notGlobal) {
             assertEquals(e.getMessage(), "failed to find token filter under [foobar]");
         } else {
@@ -299,7 +304,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                     .addTokenFilter("lowercase")
                     .addCharFilter("foobar")
                     .text("the qu1ck brown fox"),
-                "text", null, notGlobal ? indexAnalyzers : null, registry, environment));
+                "text", null, notGlobal ? indexAnalyzers : null, registry, environment, maxTokenCount));
         if (notGlobal) {
             assertEquals(e.getMessage(), "failed to find char filter under [foobar]");
         } else {
@@ -311,7 +316,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
                 new AnalyzeRequest()
                     .normalizer("foobar")
                     .text("the qu1ck brown fox"),
-                "text", null, indexAnalyzers, registry, environment));
+                "text", null, indexAnalyzers, registry, environment, maxTokenCount));
         assertEquals(e.getMessage(), "failed to find normalizer under [foobar]");
     }
 
@@ -320,7 +325,7 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         request.tokenizer("whitespace");
         request.addTokenFilter("stop"); // stop token filter is not prebuilt in AnalysisModule#setupPreConfiguredTokenFilters()
         request.text("the quick brown fox");
-        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment);
+        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment, maxTokenCount);
         List<AnalyzeResponse.AnalyzeToken> tokens = analyze.getTokens();
         assertEquals(3, tokens.size());
         assertEquals("quick", tokens.get(0).getTerm());
@@ -332,10 +337,68 @@ public class TransportAnalyzeActionTests extends ESTestCase {
         AnalyzeRequest request = new AnalyzeRequest("index");
         request.normalizer("my_normalizer");
         request.text("ABc");
-        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment);
+        AnalyzeResponse analyze = TransportAnalyzeAction.analyze(request, "text", null, indexAnalyzers, registry, environment, maxTokenCount);
         List<AnalyzeResponse.AnalyzeToken> tokens = analyze.getTokens();
 
         assertEquals(1, tokens.size());
         assertEquals("abc", tokens.get(0).getTerm());
+    }
+
+    /**
+     * This test is equivalent of calling _analyze without a specific index.
+     * The default value for the maximum token count is used.
+     */
+    public void testExceedDefaultMaxTokenLimit() throws IOException{
+        // create a string with No. words more than maxTokenCount
+        StringBuilder sbText = new StringBuilder();
+        for (int i = 0; i <= maxTokenCount; i++){
+            sbText.append('a');
+            sbText.append(' ');
+        }
+        String text = sbText.toString();
+
+        // request with explain=false to test simpleAnalyze path in TransportAnalyzeAction
+        AnalyzeRequest request = new AnalyzeRequest();
+        request.text(text);
+        request.analyzer("standard");
+        IllegalStateException e = expectThrows(IllegalStateException.class,
+            () -> TransportAnalyzeAction.analyze(
+                request, "text", null, null, registry, environment, maxTokenCount));
+        assertEquals(e.getMessage(), "The number of tokens produced by calling _analyze has exceeded the allowed maximum of ["
+            + maxTokenCount + "]." + " This limit can be set by changing the [index.analyze.max_token_count] index level setting.");
+
+        // request with explain=true to test detailAnalyze path in TransportAnalyzeAction
+        AnalyzeRequest request2 = new AnalyzeRequest();
+        request2.text(text);
+        request2.analyzer("standard");
+        request2.explain(true);
+        IllegalStateException e2 = expectThrows(IllegalStateException.class,
+            () -> TransportAnalyzeAction.analyze(
+                request2, "text", null, null, registry, environment, maxTokenCount));
+        assertEquals(e2.getMessage(), "The number of tokens produced by calling _analyze has exceeded the allowed maximum of ["
+            + maxTokenCount + "]." + " This limit can be set by changing the [index.analyze.max_token_count] index level setting.");
+    }
+
+    /**
+     * This test is equivalent of calling _analyze against a specific index.
+     * The index specific value for the maximum token count is used.
+     */
+    public void testExceedSetMaxTokenLimit() throws IOException{
+        // create a string with No. words more than idxMaxTokenCount
+        StringBuilder sbText = new StringBuilder();
+        for (int i = 0; i <= idxMaxTokenCount; i++){
+            sbText.append('a');
+            sbText.append(' ');
+        }
+        String text = sbText.toString();
+
+        AnalyzeRequest request = new AnalyzeRequest();
+        request.text(text);
+        request.analyzer("standard");
+        IllegalStateException e = expectThrows(IllegalStateException.class,
+            () -> TransportAnalyzeAction.analyze(
+                request, "text", null, indexAnalyzers, registry, environment, idxMaxTokenCount));
+        assertEquals(e.getMessage(), "The number of tokens produced by calling _analyze has exceeded the allowed maximum of ["
+            + idxMaxTokenCount + "]." + " This limit can be set by changing the [index.analyze.max_token_count] index level setting.");
     }
 }

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -193,6 +193,11 @@ specific index module:
     Maximum number of refresh listeners available on each shard of the index.
     These listeners are used to implement <<docs-refresh,`refresh=wait_for`>>.
 
+ `index.analyze.max_token_count`::
+
+    The maximum number of tokens that can be produced using _analyze API.
+    Defaults to `10000`.
+
 
 [float]
 === Settings in other index modules

--- a/docs/reference/indices/analyze.asciidoc
+++ b/docs/reference/indices/analyze.asciidoc
@@ -207,3 +207,39 @@ The request returns the following result:
 --------------------------------------------------
 // TESTRESPONSE
 <1> Output only "keyword" attribute, since specify "attributes" in the request.
+
+[[tokens-limit-settings]]
+[float]
+== Settings to prevent tokens explosion
+Generating excessive amount of tokens may cause a node to run out of memory.
+The following setting allows to limit the number of tokens that can be produced:
+
+`index.analyze.max_token_count`::
+    The maximum number of tokens that can be produced using `_analyze` API.
+    The default value is `10000`. If more than this limit of tokens gets
+    generated, an error will be thrown. The `_analyze` endpoint without a specified
+    index will always use `10000` value as a limit. This setting allows you to control
+    the limit for a specific index:
+
+
+[source,js]
+--------------------------------------------------
+PUT analyze_sample
+{
+  "settings" : {
+    "index.analyze.max_token_count" : 20000
+  }
+}
+--------------------------------------------------
+// CONSOLE
+
+
+[source,js]
+--------------------------------------------------
+GET analyze_sample/_analyze
+{
+  "text" : "this is a test"
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:analyze_sample]

--- a/docs/reference/migration/migrate_7_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_7_0/analysis.asciidoc
@@ -6,3 +6,10 @@
 The `delimited_payload_filter` is renamed to `delimited_payload`, the old name is 
 deprecated and will be removed at some point, so it should be replaced by 
 `delimited_payload`.
+
+
+==== Limiting the number of tokens produced by _analyze
+
+To safeguard against out of memory errors, the number of tokens that can be produced
+using the `_analyze` endpoint has been limited to 10000. This default limit can be changed
+for a particular index with the index setting `index.analyze.max_token_count`.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/20_analyze_limit.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.analyze/20_analyze_limit.yml
@@ -1,0 +1,52 @@
+---
+setup:
+  - do:
+      indices.create:
+          index: test_1
+          body:
+              settings:
+                  index.analyze.max_token_count: 3
+
+---
+"_analyze with No. generated tokens less than or equal to index.analyze.max_token_count should succeed":
+  - skip:
+      version: " - 6.99.99"
+      reason:  index.analyze.max_token_count setting has been added in 7.0.0
+  - do:
+      indices.analyze:
+          index:  test_1
+          body:
+              text: This should succeed
+              analyzer: standard
+  - length: { tokens: 3 }
+  - match:  { tokens.0.token: this }
+  - match:  { tokens.1.token: should }
+  - match:  { tokens.2.token: succeed }
+
+---
+"_analyze with No. generated tokens more than index.analyze.max_token_count should fail":
+  - skip:
+      version: " - 6.99.99"
+      reason:  index.analyze.max_token_count setting has been added in 7.0.0
+  - do:
+      catch: /The number of tokens produced by calling _analyze has exceeded the allowed maximum of \[3\]. This limit can be set by changing the \[index.analyze.max_token_count\] index level setting\./
+      indices.analyze:
+          index:  test_1
+          body:
+              text: This should fail as it exceeds limit
+              analyzer: standard
+
+
+---
+"_analyze with explain with No. generated tokens more than index.analyze.max_token_count should fail":
+  - skip:
+      version: " - 6.99.99"
+      reason:  index.analyze.max_token_count setting has been added in 7.0.0
+  - do:
+      catch: /The number of tokens produced by calling _analyze has exceeded the allowed maximum of \[3\]. This limit can be set by changing the \[index.analyze.max_token_count\] index level setting\./
+      indices.analyze:
+          index:  test_1
+          body:
+              text: This should fail as it exceeds limit
+              analyzer: standard
+              explain: true


### PR DESCRIPTION
Add an index level setting `index.analyze.max_token_count` to control
the number of generated tokens in the  _analyze endpoint.
Defaults to 10000.

Throw an error if the number of generated tokens exceeds this limit.

Closes #27038