### PR TITLE
Remove workaround in translog rest test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.stats/20_translog.yml
@@ -3,12 +3,9 @@ setup:
   - do:
       indices.create:
           index: test
-          body:
-           settings:
-             index:
-               # initializing replicas maintain the translog causing the test to fail.
-               # remove once https://github.com/elastic/elasticsearch/issues/25623 is fixed.
-               number_of_replicas: 0
+  - do:
+      cluster.health:
+        wait_for_no_initializing_shards: true
 
 ---
 "Translog retention":


### PR DESCRIPTION
Remove a workaround in a translog rest test using `wait_for_initializing_shards`.

Relates #25623 and https://github.com/elastic/elasticsearch/commit/a6db0ea9087619d8b9bca2dfdd11a921012990de