### PR TITLE
Return an empty _source for nested inner hit when filtering on a field that doesn't exist

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceSubPhase.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceSubPhase.java
@@ -20,20 +20,15 @@
 package org.elasticsearch.search.fetch.subphase;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Map;
-
-import static org.elasticsearch.common.xcontent.XContentFactory.contentBuilder;
 
 public final class FetchSourceSubPhase implements FetchSubPhase {
 
@@ -65,7 +60,17 @@ public final class FetchSourceSubPhase implements FetchSubPhase {
             final int initialCapacity = nestedHit ? 1024 : Math.min(1024, source.internalSourceRef().length());
             BytesStreamOutput streamOutput = new BytesStreamOutput(initialCapacity);
             XContentBuilder builder = new XContentBuilder(source.sourceContentType().xContent(), streamOutput);
-            builder.value(value);
+            if (value != null) {
+                builder.value(value);
+            } else {
+                // This happens if the source filtering could not find the specified in the _source.
+                // Just doing `builder.value(null)` is valid, but the xcontent validation can't detect what format
+                // it is. In certain cases, for example response serialization we fail if no xcontent type can't be
+                // detected. So instead we just return an empty top level object. Also this is in inline with what was
+                // being return in this situation in 5.x and earlier.
+                builder.startObject();
+                builder.endObject();
+            }
             hitContext.hit().sourceRef(builder.bytes());
         } catch (IOException e) {
             throw new ElasticsearchException("Error filtering source", e);


### PR DESCRIPTION
Before this change the search request would fail with an error indicating that it couldn't detect xcontent type based on the string: `null`.