### PR TITLE
Fix illegal cast of the "low cardinality" optimization of the `terms` aggregation.

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalMapping.java
+++ b/core/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalMapping.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * A {@link SortedSetDocValues} implementation that returns ordinals that are global.
  */
-public class GlobalOrdinalMapping extends SortedSetDocValues {
+final class GlobalOrdinalMapping extends SortedSetDocValues {
 
     private final SortedSetDocValues values;
     private final OrdinalMap ordinalMap;
@@ -49,7 +49,7 @@ public class GlobalOrdinalMapping extends SortedSetDocValues {
         return ordinalMap.getValueCount();
     }
 
-    public final long getGlobalOrd(long segmentOrd) {
+    public long getGlobalOrd(long segmentOrd) {
         return mapping.get(segmentOrd);
     }
 

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.fielddata.AbstractSortedSetDocValues;
-import org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalMapping;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -50,6 +49,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.LongUnaryOperator;
 
 import static org.apache.lucene.index.SortedSetDocValues.NO_MORE_ORDS;
 
@@ -295,9 +295,8 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
      */
     static class LowCardinality extends GlobalOrdinalsStringTermsAggregator {
 
+        private LongUnaryOperator mapping;
         private IntArray segmentDocCounts;
-        private SortedSetDocValues globalOrds;
-        private SortedSetDocValues segmentOrds;
 
         LowCardinality(String name,
                        AggregatorFactories factories,
@@ -321,14 +320,14 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         @Override
         public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
                                                     final LeafBucketCollector sub) throws IOException {
-            if (segmentOrds != null) {
-                mapSegmentCountsToGlobalCounts();
+            if (mapping != null) {
+                mapSegmentCountsToGlobalCounts(mapping);
             }
-            globalOrds = valuesSource.globalOrdinalsValues(ctx);
-            segmentOrds = valuesSource.ordinalsValues(ctx);
+            final SortedSetDocValues segmentOrds = valuesSource.ordinalsValues(ctx);
             segmentDocCounts = context.bigArrays().grow(segmentDocCounts, 1 + segmentOrds.getValueCount());
             assert sub == LeafBucketCollector.NO_OP_COLLECTOR;
             final SortedDocValues singleValues = DocValues.unwrapSingleton(segmentOrds);
+            mapping = valuesSource.globalOrdinalsMapping(ctx);
             if (singleValues != null) {
                 return new LeafBucketCollectorBase(sub, segmentOrds) {
                     @Override
@@ -356,9 +355,10 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
         }
 
         @Override
-        protected void doPostCollection() {
-            if (segmentOrds != null) {
-                mapSegmentCountsToGlobalCounts();
+        protected void doPostCollection() throws IOException {
+            if (mapping != null) {
+                mapSegmentCountsToGlobalCounts(mapping);
+                mapping = null;
             }
         }
 
@@ -367,16 +367,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
             Releasables.close(segmentDocCounts);
         }
 
-        private void mapSegmentCountsToGlobalCounts() {
-            // There is no public method in Ordinals.Docs that allows for this mapping...
-            // This is the cleanest way I can think of so far
-
-            GlobalOrdinalMapping mapping;
-            if (globalOrds.getValueCount() == segmentOrds.getValueCount()) {
-                mapping = null;
-            } else {
-                mapping = (GlobalOrdinalMapping) globalOrds;
-            }
+        private void mapSegmentCountsToGlobalCounts(LongUnaryOperator mapping) throws IOException {
             for (long i = 1; i < segmentDocCounts.size(); i++) {
                 // We use set(...) here, because we need to reset the slow to 0.
                 // segmentDocCounts get reused over the segments and otherwise counts would be too high.
@@ -385,7 +376,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                     continue;
                 }
                 final long ord = i - 1; // remember we do +1 when counting
-                final long globalOrd = mapping == null ? ord : mapping.getGlobalOrd(ord);
+                final long globalOrd = mapping.applyAsLong(ord);
                 long bucketOrd = getBucketOrd(globalOrd);
                 incrementBucketDocCount(bucketOrd, inc);
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -316,15 +316,14 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
             assert factories == null || factories.countAggregators() == 0;
             this.segmentDocCounts = context.bigArrays().newIntArray(1, true);
         }
-        SortedSetDocValues segmentOrds, globalOrds;
+
         @Override
         public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
                                                     final LeafBucketCollector sub) throws IOException {
             if (mapping != null) {
                 mapSegmentCountsToGlobalCounts(mapping);
             }
-            /*final SortedSetDocValues*/ segmentOrds = valuesSource.ordinalsValues(ctx);
-            globalOrds = valuesSource.globalOrdinalsValues(ctx);
+            final SortedSetDocValues segmentOrds = valuesSource.ordinalsValues(ctx);
             segmentDocCounts = context.bigArrays().grow(segmentDocCounts, 1 + segmentOrds.getValueCount());
             assert sub == LeafBucketCollector.NO_OP_COLLECTOR;
             final SortedDocValues singleValues = DocValues.unwrapSingleton(segmentOrds);
@@ -378,9 +377,6 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                 }
                 final long ord = i - 1; // remember we do +1 when counting
                 final long globalOrd = mapping.applyAsLong(ord);
-                BytesRef a = segmentOrds.lookupOrd(ord);
-                BytesRef b = globalOrds.lookupOrd(globalOrd);
-                //assert a.equals(b);
                 long bucketOrd = getBucketOrd(globalOrd);
                 incrementBucketDocCount(bucketOrd, inc);
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -316,14 +316,15 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
             assert factories == null || factories.countAggregators() == 0;
             this.segmentDocCounts = context.bigArrays().newIntArray(1, true);
         }
-
+        SortedSetDocValues segmentOrds, globalOrds;
         @Override
         public LeafBucketCollector getLeafCollector(LeafReaderContext ctx,
                                                     final LeafBucketCollector sub) throws IOException {
             if (mapping != null) {
                 mapSegmentCountsToGlobalCounts(mapping);
             }
-            final SortedSetDocValues segmentOrds = valuesSource.ordinalsValues(ctx);
+            /*final SortedSetDocValues*/ segmentOrds = valuesSource.ordinalsValues(ctx);
+            globalOrds = valuesSource.globalOrdinalsValues(ctx);
             segmentDocCounts = context.bigArrays().grow(segmentDocCounts, 1 + segmentOrds.getValueCount());
             assert sub == LeafBucketCollector.NO_OP_COLLECTOR;
             final SortedDocValues singleValues = DocValues.unwrapSingleton(segmentOrds);
@@ -377,6 +378,9 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                 }
                 final long ord = i - 1; // remember we do +1 when counting
                 final long globalOrd = mapping.applyAsLong(ord);
+                BytesRef a = segmentOrds.lookupOrd(ord);
+                BytesRef b = globalOrds.lookupOrd(globalOrd);
+                //assert a.equals(b);
                 long bucketOrd = getBucketOrd(globalOrd);
                 incrementBucketDocCount(bucketOrd, inc);
             }

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -156,7 +156,8 @@ public abstract class ValuesSource {
 
                 @Override
                 public LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context) throws IOException {
-                    final OrdinalMap map = indexFieldData.getOrdinalMap();
+                    final IndexOrdinalsFieldData global = indexFieldData.loadGlobal((DirectoryReader)context.parent.reader());
+                    final OrdinalMap map = global.getOrdinalMap();
                     if (map == null) {
                         // segments and global ordinals are the same
                         return LongUnaryOperator.identity();

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.IndexSearcher;
@@ -47,6 +48,7 @@ import org.elasticsearch.search.aggregations.support.values.ScriptDoubleValues;
 import org.elasticsearch.search.aggregations.support.values.ScriptLongValues;
 
 import java.io.IOException;
+import java.util.function.LongUnaryOperator;
 
 public abstract class ValuesSource {
 
@@ -90,6 +92,11 @@ public abstract class ValuesSource {
                     return org.elasticsearch.index.fielddata.FieldData.emptySortedBinary();
                 }
 
+                @Override
+                public LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context) throws IOException {
+                    return LongUnaryOperator.identity();
+                }
+
             };
 
             @Override
@@ -103,6 +110,10 @@ public abstract class ValuesSource {
                     throws IOException;
 
             public abstract SortedSetDocValues globalOrdinalsValues(LeafReaderContext context)
+                    throws IOException;
+
+            /** Returns a mapping from segment ordinals to global ordinals. */
+            public abstract LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context)
                     throws IOException;
 
             public long globalMaxOrd(IndexSearcher indexSearcher) throws IOException {
@@ -141,6 +152,17 @@ public abstract class ValuesSource {
                     final IndexOrdinalsFieldData global = indexFieldData.loadGlobal((DirectoryReader)context.parent.reader());
                     final AtomicOrdinalsFieldData atomicFieldData = global.load(context);
                     return atomicFieldData.getOrdinalsValues();
+                }
+
+                @Override
+                public LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context) throws IOException {
+                    final OrdinalMap map = indexFieldData.getOrdinalMap();
+                    if (map == null) {
+                        // segments and global ordinals are the same
+                        return LongUnaryOperator.identity();
+                    }
+                    final org.apache.lucene.util.LongValues segmentToGlobalOrd = map.getGlobalOrds(context.ord);
+                    return segmentToGlobalOrd::get;
                 }
             }
         }

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.elasticsearch.search.aggregations.bucket;
+package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -34,9 +34,11 @@ import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.AggregationTestScriptsPlugin;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.bucket.AbstractTermsTestCase;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
 import org.elasticsearch.search.aggregations.metrics.avg.Avg;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
@@ -44,6 +46,8 @@ import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStat
 import org.elasticsearch.search.aggregations.metrics.sum.Sum;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -82,6 +86,18 @@ public class StringTermsIT extends AbstractTermsTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.singleton(CustomScriptPlugin.class);
+    }
+
+    @Before
+    public void randomizeOptimizations() {
+        TermsAggregatorFactory.COLLECT_SEGMENT_ORDS = randomBoolean();
+        TermsAggregatorFactory.REMAP_GLOBAL_ORDS = randomBoolean();
+    }
+
+    @After
+    public void resetOptimizations() {
+        TermsAggregatorFactory.COLLECT_SEGMENT_ORDS = null;
+        TermsAggregatorFactory.REMAP_GLOBAL_ORDS = null;
     }
 
     public static class CustomScriptPlugin extends AggregationTestScriptsPlugin {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -90,7 +90,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
 
     @Before
     public void randomizeOptimizations() {
-        TermsAggregatorFactory.COLLECT_SEGMENT_ORDS = randomBoolean();
+        TermsAggregatorFactory.COLLECT_SEGMENT_ORDS = false;randomBoolean();
         TermsAggregatorFactory.REMAP_GLOBAL_ORDS = randomBoolean();
     }
 


### PR DESCRIPTION
The GlobalOrdinalsStringTermsAggregator.LowCardinality aggregator casts global
values to `GlobalOrdinalMapping`, even though the implementation of global
values is different when a `missing` value is configured.

This commit adds a new API that gives access to the ordinal remapping in order
to fix this problem.
