### PR TITLE
Add breaking changes note on all permission check

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -20,3 +20,5 @@ As a general rule:
 See <<setup-upgrade>> for more info.
 --
 include::migrate_6_0.asciidoc[]
+
+include::migrate_6_2.asciidoc[]

--- a/docs/reference/migration/migrate_6_2.asciidoc
+++ b/docs/reference/migration/migrate_6_2.asciidoc
@@ -1,0 +1,14 @@
+[[breaking-changes-6.2]]
+== Breaking changes in 6.2
+
+[[breaking_62_packaging]]
+[float]
+=== All permission bootstrap check
+
+Elasticsearch installs a security manager during bootstrap to mitigate the scope
+of exploits in the JDK, in third-party dependencies, and in Elasticsearch itself
+as well as to sandbox untrusted plugins. A custom security policy can be applied
+and one permission that can be added to this policy is
+`java.security.AllPermission`. However, this effectively disables the security
+manager. As such, granting this permission in production mode is now forbidden
+via the <<all-permission-check, all permission bootstrap check>>.

--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -228,6 +228,7 @@ enabled.  The versions impacted are those earlier than the version of
 HotSpot that shipped with JDK 8u40. The G1GC check detects these early
 versions of the HotSpot JVM.
 
+[[all-permission-check]]
 === All permission check
 
 The all permission check ensures that the security policy used during bootstrap


### PR DESCRIPTION
The all permission can no longer be granted in production as it effectively disables the security manager. This commit adds a note to the breaking changes regarding this.

Relates #27548
