### PR TITLE
Consistent update of stage and failure message in IndexShardSnapshotStatus

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -50,7 +50,7 @@ public class IndexShardSnapshotStatus {
         FAILURE
     }
 
-    private Stage stage = Stage.INIT;
+    private volatile Stage stage = Stage.INIT;
 
     private long startTime;
 
@@ -68,7 +68,7 @@ public class IndexShardSnapshotStatus {
 
     private volatile boolean aborted;
 
-    private String failure;
+    private volatile String failure;
 
     /**
      * Returns current snapshot stage
@@ -84,8 +84,27 @@ public class IndexShardSnapshotStatus {
      *
      * @param stage new snapshot stage
      */
-    public void updateStage(Stage stage) {
+    public void updateStage(final Stage stage) {
+        updateStage(stage, null);
+    }
+
+    /**
+     * Sets new snapshot stage and the reason for the failure if the snapshot
+     * is in the {@link IndexShardSnapshotStatus.Stage#FAILURE} state
+     *
+     * @param stage   new snapshot stage
+     * @param failure the reason for the failure
+     */
+    public synchronized void updateStage(final Stage stage, final String failure) {
         this.stage = stage;
+        this.failure = failure;
+    }
+
+    /**
+     * Returns the reason for the failure if the snapshot is in the {@link IndexShardSnapshotStatus.Stage#FAILURE} state
+     */
+    public String failure() {
+        return failure;
     }
 
     /**
@@ -223,19 +242,5 @@ public class IndexShardSnapshotStatus {
      */
     public long indexVersion() {
         return indexVersion;
-    }
-
-    /**
-     * Sets the reason for the failure if the snapshot is in the {@link IndexShardSnapshotStatus.Stage#FAILURE} state
-     */
-    public void failure(String failure) {
-        this.failure = failure;
-    }
-
-    /**
-     * Returns the reason for the failure if the snapshot is in the {@link IndexShardSnapshotStatus.Stage#FAILURE} state
-     */
-    public String failure() {
-        return failure;
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -75,7 +75,7 @@ public class IndexShardSnapshotStatus {
      *
      * @return current snapshot stage
      */
-    public Stage stage() {
+    public synchronized Stage stage() {
         return this.stage;
     }
 
@@ -103,7 +103,7 @@ public class IndexShardSnapshotStatus {
     /**
      * Returns the reason for the failure if the snapshot is in the {@link IndexShardSnapshotStatus.Stage#FAILURE} state
      */
-    public String failure() {
+    public synchronized String failure() {
         return failure;
     }
 

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -825,8 +825,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             snapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.DONE);
         } catch (Exception e) {
             snapshotStatus.time(System.currentTimeMillis() - snapshotStatus.startTime());
-            snapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.FAILURE);
-            snapshotStatus.failure(ExceptionsHelper.detailedMessage(e));
+            snapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.FAILURE,ExceptionsHelper.detailedMessage(e));
             if (e instanceof IndexShardSnapshotFailedException) {
                 throw (IndexShardSnapshotFailedException) e;
             } else {

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -228,7 +228,8 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 // running shards is missed, then the snapshot is removed is a subsequent cluster
                 // state update, which is being processed here
                 for (IndexShardSnapshotStatus snapshotStatus : entry.getValue().shards.values()) {
-                    if (snapshotStatus.stage() == Stage.INIT || snapshotStatus.stage() == Stage.STARTED) {
+                    Stage stage = snapshotStatus.stage();
+                    if (stage == Stage.INIT || stage == Stage.STARTED) {
                         snapshotStatus.abort();
                     }
                 }

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -596,8 +596,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     SnapshotShardFailure shardFailure = findShardFailure(snapshotInfo.shardFailures(), shardId);
                     if (shardFailure != null) {
                         IndexShardSnapshotStatus shardSnapshotStatus = new IndexShardSnapshotStatus();
-                        shardSnapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.FAILURE);
-                        shardSnapshotStatus.failure(shardFailure.reason());
+                        shardSnapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.FAILURE, shardFailure.reason());
                         shardStatus.put(shardId, shardSnapshotStatus);
                     } else {
                         final IndexShardSnapshotStatus shardSnapshotStatus;
@@ -610,8 +609,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                             // a status for the shard to indicate that the shard snapshot
                             // could not be taken due to partial being set to false.
                             shardSnapshotStatus = new IndexShardSnapshotStatus();
-                            shardSnapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.FAILURE);
-                            shardSnapshotStatus.failure("skipped");
+                            shardSnapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.FAILURE, "skipped");
                         } else {
                             shardSnapshotStatus = repository.getShardSnapshotStatus(
                                 snapshotInfo.snapshotId(),


### PR DESCRIPTION
As @ywelsch commented in https://github.com/elastic/elasticsearch/issues/26480#issuecomment-331383391, `IndexShardSnapshotStatus` is not consistently updated. 

This pull request adds a synchronized `updateStage(stage, failure)` to ensure that both fields are updated at the same time and also makes the fields volatile so that threads always read the latest values.

Closes #26480