### PR TITLE
Make Segment statistics aware of segments hold by internal readers

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -28,7 +28,6 @@ import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentCommitInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SegmentReader;
@@ -76,12 +75,13 @@ import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -90,6 +90,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 public abstract class Engine implements Closeable {
 
@@ -592,25 +593,40 @@ public abstract class Engine implements Closeable {
      */
     public final SegmentsStats segmentsStats(boolean includeSegmentFileSizes) {
         ensureOpen();
-        try (Searcher searcher = acquireSearcher("segments_stats")) {
-            SegmentsStats stats = new SegmentsStats();
-            for (LeafReaderContext reader : searcher.reader().leaves()) {
-                final SegmentReader segmentReader = Lucene.segmentReader(reader.reader());
-                stats.add(1, segmentReader.ramBytesUsed());
-                stats.addTermsMemoryInBytes(guardedRamBytesUsed(segmentReader.getPostingsReader()));
-                stats.addStoredFieldsMemoryInBytes(guardedRamBytesUsed(segmentReader.getFieldsReader()));
-                stats.addTermVectorsMemoryInBytes(guardedRamBytesUsed(segmentReader.getTermVectorsReader()));
-                stats.addNormsMemoryInBytes(guardedRamBytesUsed(segmentReader.getNormsReader()));
-                stats.addPointsMemoryInBytes(guardedRamBytesUsed(segmentReader.getPointsReader()));
-                stats.addDocValuesMemoryInBytes(guardedRamBytesUsed(segmentReader.getDocValuesReader()));
+        Set<String> segmentName = new HashSet<>();
+        SegmentsStats stats = new SegmentsStats();
+        try (Searcher searcher = acquireSearcher("segments_stats", SearcherScope.INTERNAL)) {
+            List<SegmentReader> internalSegmentReaders = searcher.reader().getContext()
+                .leaves().stream().map(l -> Lucene.segmentReader(l.reader())).collect(Collectors.toList());
+            internalSegmentReaders.forEach(r -> segmentName.add(r.getSegmentName()));
+            fillSegmentStats(includeSegmentFileSizes, internalSegmentReaders, stats);
+        }
 
-                if (includeSegmentFileSizes) {
-                    // TODO: consider moving this to StoreStats
-                    stats.addFileSizes(getSegmentFileSizes(segmentReader));
-                }
+        try (Searcher searcher = acquireSearcher("segments_stats", SearcherScope.EXTERNAL)) {
+            Set<SegmentReader> externalSegmentReaders = searcher.reader().getContext()
+                .leaves().stream().map(l -> Lucene.segmentReader(l.reader()))
+                .filter(r -> segmentName.contains(r.getSegmentName()) == false)
+                .collect(Collectors.toSet());
+            fillSegmentStats(includeSegmentFileSizes, externalSegmentReaders, stats);
+        }
+        writerSegmentStats(stats);
+        return stats;
+    }
+
+    private void fillSegmentStats(boolean includeSegmentFileSizes, Iterable<SegmentReader> readers, SegmentsStats stats) {
+        for (SegmentReader segmentReader : readers) {
+            stats.add(1, segmentReader.ramBytesUsed());
+            stats.addTermsMemoryInBytes(guardedRamBytesUsed(segmentReader.getPostingsReader()));
+            stats.addStoredFieldsMemoryInBytes(guardedRamBytesUsed(segmentReader.getFieldsReader()));
+            stats.addTermVectorsMemoryInBytes(guardedRamBytesUsed(segmentReader.getTermVectorsReader()));
+            stats.addNormsMemoryInBytes(guardedRamBytesUsed(segmentReader.getNormsReader()));
+            stats.addPointsMemoryInBytes(guardedRamBytesUsed(segmentReader.getPointsReader()));
+            stats.addDocValuesMemoryInBytes(guardedRamBytesUsed(segmentReader.getDocValuesReader()));
+
+            if (includeSegmentFileSizes) {
+                // TODO: consider moving this to StoreStats
+                stats.addFileSizes(getSegmentFileSizes(segmentReader));
             }
-            writerSegmentStats(stats);
-            return stats;
         }
     }
 
@@ -700,31 +716,18 @@ public abstract class Engine implements Closeable {
         ensureOpen();
         Map<String, Segment> segments = new HashMap<>();
         // first, go over and compute the search ones...
-        try (Searcher searcher = acquireSearcher("segments")){
-            for (LeafReaderContext reader : searcher.reader().leaves()) {
-                final SegmentReader segmentReader = Lucene.segmentReader(reader.reader());
-                SegmentCommitInfo info = segmentReader.getSegmentInfo();
-                assert !segments.containsKey(info.info.name);
-                Segment segment = new Segment(info.info.name);
-                segment.search = true;
-                segment.docCount = reader.reader().numDocs();
-                segment.delDocCount = reader.reader().numDeletedDocs();
-                segment.version = info.info.getVersion();
-                segment.compound = info.info.getUseCompoundFile();
-                try {
-                    segment.sizeInBytes = info.sizeInBytes();
-                } catch (IOException e) {
-                    logger.trace((Supplier<?>) () -> new ParameterizedMessage("failed to get size for [{}]", info.info.name), e);
-                }
-                segment.memoryInBytes = segmentReader.ramBytesUsed();
-                segment.segmentSort = info.info.getIndexSort();
-                if (verbose) {
-                    segment.ramTree = Accountables.namedAccountable("root", segmentReader);
-                }
-                segment.attributes = info.info.getAttributes();
-                // TODO: add more fine grained mem stats values to per segment info here
-                segments.put(info.info.name, segment);
-            }
+        try (Searcher searcher = acquireSearcher("segments", SearcherScope.EXTERNAL)){
+            List<SegmentReader> externalSegmentReaders = searcher.reader().getContext()
+                .leaves().stream().map(l -> Lucene.segmentReader(l.reader())).collect(Collectors.toList());
+            fillSegmentInfo(verbose, true, segments, externalSegmentReaders);
+        }
+
+        try (Searcher searcher = acquireSearcher("segments", SearcherScope.INTERNAL)){
+            List<SegmentReader> internalSegmentReaders = searcher.reader().getContext()
+                .leaves().stream().map(l -> Lucene.segmentReader(l.reader()))
+                .filter(r -> segments.containsKey(r.getSegmentName())  == false)
+                .collect(Collectors.toList());
+            fillSegmentInfo(verbose, false, segments, internalSegmentReaders);
         }
 
         // now, correlate or add the committed ones...
@@ -753,14 +756,34 @@ public abstract class Engine implements Closeable {
         }
 
         Segment[] segmentsArr = segments.values().toArray(new Segment[segments.values().size()]);
-        Arrays.sort(segmentsArr, new Comparator<Segment>() {
-            @Override
-            public int compare(Segment o1, Segment o2) {
-                return (int) (o1.getGeneration() - o2.getGeneration());
-            }
-        });
-
+        Arrays.sort(segmentsArr, (o1, o2) -> (int) (o1.getGeneration() - o2.getGeneration()));
         return segmentsArr;
+    }
+
+    private void fillSegmentInfo(boolean verbose, boolean search, Map<String, Segment> segments, Iterable<SegmentReader> segmentReaders) {
+        for (SegmentReader segmentReader  : segmentReaders) {
+            SegmentCommitInfo info = segmentReader.getSegmentInfo();
+            assert segments.containsKey(info.info.name) == false;
+            Segment segment = new Segment(info.info.name);
+            segment.search = search;
+            segment.docCount = segmentReader.numDocs();
+            segment.delDocCount = segmentReader.numDeletedDocs();
+            segment.version = info.info.getVersion();
+            segment.compound = info.info.getUseCompoundFile();
+            try {
+                segment.sizeInBytes = info.sizeInBytes();
+            } catch (IOException e) {
+                logger.trace((Supplier<?>) () -> new ParameterizedMessage("failed to get size for [{}]", info.info.name), e);
+            }
+            segment.memoryInBytes = segmentReader.ramBytesUsed();
+            segment.segmentSort = info.info.getIndexSort();
+            if (verbose) {
+                segment.ramTree = Accountables.namedAccountable("root", segmentReader);
+            }
+            segment.attributes = info.info.getAttributes();
+            // TODO: add more fine grained mem stats values to per segment info here
+            segments.put(info.info.name, segment);
+        }
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/core/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -174,7 +174,7 @@ public class InternalEngineTests extends EngineTestCase {
 
     public void testSegments() throws Exception {
         try (Store store = createStore();
-             Engine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE)) {
+             InternalEngine engine = createEngine(defaultSettings, store, createTempDir(), NoMergePolicy.INSTANCE)) {
             List<Segment> segments = engine.segments(false);
             assertThat(segments.isEmpty(), equalTo(true));
             assertThat(engine.segmentsStats(false).getCount(), equalTo(0L));
@@ -290,6 +290,69 @@ public class InternalEngineTests extends EngineTestCase {
             assertThat(segments.get(2).getNumDocs(), equalTo(1));
             assertThat(segments.get(2).getDeletedDocs(), equalTo(0));
             assertThat(segments.get(2).isCompound(), equalTo(true));
+
+            // internal refresh - lets make sure we see those segments in the stats
+            ParsedDocument doc5 = testParsedDocument("5", null, testDocumentWithTextField(), B_3, null);
+            engine.index(indexForDoc(doc5));
+            engine.refresh("test", Engine.SearcherScope.INTERNAL);
+
+            segments = engine.segments(false);
+            assertThat(segments.size(), equalTo(4));
+            assertThat(engine.segmentsStats(false).getCount(), equalTo(4L));
+            assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
+            assertThat(segments.get(0).isCommitted(), equalTo(true));
+            assertThat(segments.get(0).isSearch(), equalTo(true));
+            assertThat(segments.get(0).getNumDocs(), equalTo(1));
+            assertThat(segments.get(0).getDeletedDocs(), equalTo(1));
+            assertThat(segments.get(0).isCompound(), equalTo(true));
+
+            assertThat(segments.get(1).isCommitted(), equalTo(false));
+            assertThat(segments.get(1).isSearch(), equalTo(true));
+            assertThat(segments.get(1).getNumDocs(), equalTo(1));
+            assertThat(segments.get(1).getDeletedDocs(), equalTo(0));
+            assertThat(segments.get(1).isCompound(), equalTo(true));
+
+            assertThat(segments.get(2).isCommitted(), equalTo(false));
+            assertThat(segments.get(2).isSearch(), equalTo(true));
+            assertThat(segments.get(2).getNumDocs(), equalTo(1));
+            assertThat(segments.get(2).getDeletedDocs(), equalTo(0));
+            assertThat(segments.get(2).isCompound(), equalTo(true));
+
+            assertThat(segments.get(3).isCommitted(), equalTo(false));
+            assertThat(segments.get(3).isSearch(), equalTo(false));
+            assertThat(segments.get(3).getNumDocs(), equalTo(1));
+            assertThat(segments.get(3).getDeletedDocs(), equalTo(0));
+            assertThat(segments.get(3).isCompound(), equalTo(true));
+
+            // now refresh the external searcher and make sure it has the new segment
+            engine.refresh("test");
+            segments = engine.segments(false);
+            assertThat(segments.size(), equalTo(4));
+            assertThat(engine.segmentsStats(false).getCount(), equalTo(4L));
+            assertThat(segments.get(0).getGeneration() < segments.get(1).getGeneration(), equalTo(true));
+            assertThat(segments.get(0).isCommitted(), equalTo(true));
+            assertThat(segments.get(0).isSearch(), equalTo(true));
+            assertThat(segments.get(0).getNumDocs(), equalTo(1));
+            assertThat(segments.get(0).getDeletedDocs(), equalTo(1));
+            assertThat(segments.get(0).isCompound(), equalTo(true));
+
+            assertThat(segments.get(1).isCommitted(), equalTo(false));
+            assertThat(segments.get(1).isSearch(), equalTo(true));
+            assertThat(segments.get(1).getNumDocs(), equalTo(1));
+            assertThat(segments.get(1).getDeletedDocs(), equalTo(0));
+            assertThat(segments.get(1).isCompound(), equalTo(true));
+
+            assertThat(segments.get(2).isCommitted(), equalTo(false));
+            assertThat(segments.get(2).isSearch(), equalTo(true));
+            assertThat(segments.get(2).getNumDocs(), equalTo(1));
+            assertThat(segments.get(2).getDeletedDocs(), equalTo(0));
+            assertThat(segments.get(2).isCompound(), equalTo(true));
+
+            assertThat(segments.get(3).isCommitted(), equalTo(false));
+            assertThat(segments.get(3).isSearch(), equalTo(true));
+            assertThat(segments.get(3).getNumDocs(), equalTo(1));
+            assertThat(segments.get(3).getDeletedDocs(), equalTo(0));
+            assertThat(segments.get(3).isCompound(), equalTo(true));
         }
     }
 


### PR DESCRIPTION
Today we only expose the external readers segments. Yet, from a statistics
perspective both internal and external segments are relevant. This commit
exposes the additional segments of the internal and external reader respectively.