### PR TITLE
Add k parameter to PrecisionAtK metric

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvaluationMetric.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/EvaluationMetric.java
@@ -89,4 +89,13 @@ public interface EvaluationMetric extends ToXContent, NamedWriteable {
     default double combine(Collection<EvalQueryQuality> partialResults) {
         return partialResults.stream().mapToDouble(EvalQueryQuality::getQualityLevel).sum() / partialResults.size();
     }
+
+    /**
+     * Metrics can define a size of the search hits windows they want to retrieve by overwriting
+     * this method. The default implementation returns an empty optional.
+     * @return the number of search hits this metrics requests
+     */
+    default Optional<Integer> forcedSearchSize() {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
The window size in the precision metric calculation for ranking evaluation is currently controlled by the search size specified in the `requests` array. This might be error prone, since users might forget to add the size parameter to each search request, or might mistakenly add different sizes. It would probably be better to overwrite the search request size with one provided in the metric definition to avoid this.

This adds an optional "k" parameter (which defaults to 10) to the PrecisionAtK metric. It might make sense to add similar parameters to reciprocal rank and DCG as follow ups as well.