### PR TITLE
Flush old indices on primary promotion and relocation

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/core/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -351,9 +351,11 @@ public class InternalEngine extends Engine {
         } else if (translog.isCurrent(translogGeneration) == false) {
             commitIndexWriter(indexWriter, translog, lastCommittedSegmentInfos.getUserData().get(Engine.SYNC_COMMIT_ID));
             refreshLastCommittedSegmentInfos();
-        } else if (lastCommittedSegmentInfos.getUserData().containsKey(HISTORY_UUID_KEY) == false)  {
-            assert historyUUID != null;
-            // put the history uuid into the index
+        } else if (lastCommittedSegmentInfos.getUserData().containsKey(SequenceNumbers.LOCAL_CHECKPOINT_KEY) == false)  {
+            assert engineConfig.getIndexSettings().getIndexVersionCreated().before(Version.V_6_0_0_alpha1) :
+                "index was created on version " + engineConfig.getIndexSettings().getIndexVersionCreated() + "but has "
+                    + "no sequence numbers info in commit";
+
             commitIndexWriter(indexWriter, translog, lastCommittedSegmentInfos.getUserData().get(Engine.SYNC_COMMIT_ID));
             refreshLastCommittedSegmentInfos();
         }

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbers.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbers.java
@@ -72,8 +72,9 @@ public class SequenceNumbers {
     /**
      * Compute the minimum of the given current minimum sequence number and the specified sequence number, accounting for the fact that the
      * current minimum sequence number could be {@link SequenceNumbers#NO_OPS_PERFORMED} or
-     * {@link SequenceNumbers#UNASSIGNED_SEQ_NO}. The method guarantees that once we see an operation we make sure all future operations
-     * either have an assigned sequence number (if the first operation had one) or do not (if the first operation didn't).
+     * {@link SequenceNumbers#UNASSIGNED_SEQ_NO}. When the current minimum sequence number is not
+     * {@link SequenceNumbers#NO_OPS_PERFORMED} nor {@link SequenceNumbers#UNASSIGNED_SEQ_NO}, the specified sequence number
+     * must not be {@link SequenceNumbers#UNASSIGNED_SEQ_NO}.
      *
      * @param minSeqNo the current minimum sequence number
      * @param seqNo the specified sequence number
@@ -83,10 +84,7 @@ public class SequenceNumbers {
         if (minSeqNo == NO_OPS_PERFORMED) {
             return seqNo;
         } else if (minSeqNo == UNASSIGNED_SEQ_NO) {
-            if (seqNo != UNASSIGNED_SEQ_NO) {
-                throw new IllegalArgumentException("sequence number may not be assigned. got " + seqNo);
-            }
-            return UNASSIGNED_SEQ_NO;
+            return seqNo;
         } else {
             if (seqNo == UNASSIGNED_SEQ_NO) {
                 throw new IllegalArgumentException("sequence number must be assigned");
@@ -98,8 +96,9 @@ public class SequenceNumbers {
     /**
      * Compute the maximum of the given current maximum sequence number and the specified sequence number, accounting for the fact that the
      * current maximum sequence number could be {@link SequenceNumbers#NO_OPS_PERFORMED} or
-     * {@link SequenceNumbers#UNASSIGNED_SEQ_NO}. The method guarantees that once we see an operation we make sure all future operations
-     * either have an assigned sequence number (if the first operation had one) or do not (if the first operation didn't).
+     * {@link SequenceNumbers#UNASSIGNED_SEQ_NO}. When the current maximum sequence number is not
+     * {@link SequenceNumbers#NO_OPS_PERFORMED} nor {@link SequenceNumbers#UNASSIGNED_SEQ_NO}, the specified sequence number
+     * must not be {@link SequenceNumbers#UNASSIGNED_SEQ_NO}.
      *
      * @param maxSeqNo the current maximum sequence number
      * @param seqNo the specified sequence number
@@ -109,10 +108,7 @@ public class SequenceNumbers {
         if (maxSeqNo == NO_OPS_PERFORMED) {
             return seqNo;
         } else if (maxSeqNo == UNASSIGNED_SEQ_NO) {
-            if (seqNo != UNASSIGNED_SEQ_NO) {
-                throw new IllegalArgumentException("sequence number may not be assigned. got " + seqNo);
-            }
-            return UNASSIGNED_SEQ_NO;
+            return seqNo;
         } else {
             if (seqNo == UNASSIGNED_SEQ_NO) {
                 throw new IllegalArgumentException("sequence number must be assigned");

--- a/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbers.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/SequenceNumbers.java
@@ -72,9 +72,8 @@ public class SequenceNumbers {
     /**
      * Compute the minimum of the given current minimum sequence number and the specified sequence number, accounting for the fact that the
      * current minimum sequence number could be {@link SequenceNumbers#NO_OPS_PERFORMED} or
-     * {@link SequenceNumbers#UNASSIGNED_SEQ_NO}. When the current minimum sequence number is not
-     * {@link SequenceNumbers#NO_OPS_PERFORMED} nor {@link SequenceNumbers#UNASSIGNED_SEQ_NO}, the specified sequence number
-     * must not be {@link SequenceNumbers#UNASSIGNED_SEQ_NO}.
+     * {@link SequenceNumbers#UNASSIGNED_SEQ_NO}. The method guarantees that once we see an operation we make sure all future operations
+     * either have an assigned sequence number (if the first operation had one) or do not (if the first operation didn't).
      *
      * @param minSeqNo the current minimum sequence number
      * @param seqNo the specified sequence number
@@ -84,7 +83,10 @@ public class SequenceNumbers {
         if (minSeqNo == NO_OPS_PERFORMED) {
             return seqNo;
         } else if (minSeqNo == UNASSIGNED_SEQ_NO) {
-            return seqNo;
+            if (seqNo != UNASSIGNED_SEQ_NO) {
+                throw new IllegalArgumentException("sequence number may not be assigned. got " + seqNo);
+            }
+            return UNASSIGNED_SEQ_NO;
         } else {
             if (seqNo == UNASSIGNED_SEQ_NO) {
                 throw new IllegalArgumentException("sequence number must be assigned");
@@ -96,9 +98,8 @@ public class SequenceNumbers {
     /**
      * Compute the maximum of the given current maximum sequence number and the specified sequence number, accounting for the fact that the
      * current maximum sequence number could be {@link SequenceNumbers#NO_OPS_PERFORMED} or
-     * {@link SequenceNumbers#UNASSIGNED_SEQ_NO}. When the current maximum sequence number is not
-     * {@link SequenceNumbers#NO_OPS_PERFORMED} nor {@link SequenceNumbers#UNASSIGNED_SEQ_NO}, the specified sequence number
-     * must not be {@link SequenceNumbers#UNASSIGNED_SEQ_NO}.
+     * {@link SequenceNumbers#UNASSIGNED_SEQ_NO}. The method guarantees that once we see an operation we make sure all future operations
+     * either have an assigned sequence number (if the first operation had one) or do not (if the first operation didn't).
      *
      * @param maxSeqNo the current maximum sequence number
      * @param seqNo the specified sequence number
@@ -108,7 +109,10 @@ public class SequenceNumbers {
         if (maxSeqNo == NO_OPS_PERFORMED) {
             return seqNo;
         } else if (maxSeqNo == UNASSIGNED_SEQ_NO) {
-            return seqNo;
+            if (seqNo != UNASSIGNED_SEQ_NO) {
+                throw new IllegalArgumentException("sequence number may not be assigned. got " + seqNo);
+            }
+            return UNASSIGNED_SEQ_NO;
         } else {
             if (seqNo == UNASSIGNED_SEQ_NO) {
                 throw new IllegalArgumentException("sequence number must be assigned");

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1333,6 +1333,17 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             active.set(true);
             newEngine.recoverFromTranslog();
         }
+        assertSequenceNumbersInCommit();
+    }
+
+    private boolean assertSequenceNumbersInCommit() throws IOException {
+        final Map<String, String> userData = SegmentInfos.readLatestCommit(store.directory()).getUserData();
+        assert userData.containsKey(SequenceNumbers.LOCAL_CHECKPOINT_KEY) : "commit point doesn't contains a local checkpoint";
+        assert userData.containsKey(SequenceNumbers.MAX_SEQ_NO) : "commit point doesn't contains a maximum sequence number";
+        assert userData.containsKey(Engine.HISTORY_UUID_KEY) : "commit point doesn't contains a history uuid";
+        assert userData.get(Engine.HISTORY_UUID_KEY).equals(getHistoryUUID()) : "commit point history uuid ["
+            + userData.get(Engine.HISTORY_UUID_KEY) + "] is different than engine [" + getHistoryUUID() + "]";
+        return true;
     }
 
     private boolean assertMaxUnsafeAutoIdInCommit() throws IOException {

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -498,7 +498,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                                 final Engine engine = getEngine();
                                 engine.restoreLocalCheckpointFromTranslog();
                                 if (indexSettings.getIndexVersionCreated().onOrBefore(Version.V_6_0_0_alpha1)) {
-                                    // an index that was created before sequence numbers were introduce may contain operations in its
+                                    // an index that was created before sequence numbers were introduced may contain operations in its
                                     // translog that do not have a sequence numbers. We want to make sure those operations will never
                                     // be replayed as part of peer recovery to avoid an arbitrary mixture of operations with seq# (due
                                     // to active indexing) and operations without a seq# coming from the translog. We therefore flush

--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -493,6 +493,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                                  * simplifies reasoning about the relationship between primary terms and translog generations.
                                  */
                                 final Engine engine = getEngine();
+                                engine.restoreLocalCheckpointFromTranslog();
                                 if (indexSettings.getIndexVersionCreated().onOrBefore(Version.V_6_0_0_alpha1) &&
                                     engine.getTranslog().uncommittedOperations() > 0) {
                                     // an index that was created before sequence numbers were introduce may contain operations in its
@@ -504,7 +505,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                                 } else {
                                     engine.rollTranslogGeneration();
                                 }
-                                engine.restoreLocalCheckpointFromTranslog();
                                 engine.fillSeqNoGaps(newPrimaryTerm);
                                 engine.seqNoService().updateLocalCheckpointForShard(currentRouting.allocationId().getId(),
                                     getEngine().seqNoService().getLocalCheckpoint());

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -562,7 +562,7 @@ public class RecoverySourceHandler {
             cancellableThreads.checkForCancel();
 
             final long seqNo = operation.seqNo();
-            if (seqNo < startingSeqNo && seqNo > endingSeqNo) {
+            if (seqNo < startingSeqNo || seqNo > endingSeqNo) {
                 skippedOps++;
                 continue;
             }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -450,7 +450,8 @@ public class RecoverySourceHandler {
      * @param snapshot      a snapshot of the translog
      * @return the local checkpoint on the target
      */
-    long phase2(final long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo, final Translog.Snapshot snapshot) throws IOException {
+    long phase2(final long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo, final Translog.Snapshot snapshot)
+        throws IOException {
         if (shard.state() == IndexShardState.CLOSED) {
             throw new IndexShardClosedException(request.shardId());
         }
@@ -530,7 +531,8 @@ public class RecoverySourceHandler {
      *                      number of operations sent
      * @throws IOException if an I/O exception occurred reading the translog snapshot
      */
-    protected SendSnapshotResult sendSnapshot(final long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo, final Translog.Snapshot snapshot) throws IOException {
+    protected SendSnapshotResult sendSnapshot(final long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo,
+                                              final Translog.Snapshot snapshot) throws IOException {
         assert requiredSeqNoRangeStart <= endingSeqNo :
             "requiredSeqNoRangeStart " + requiredSeqNoRangeStart + " is larger than endingSeqNo " + endingSeqNo;
         assert startingSeqNo <= endingSeqNo :

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -440,11 +440,11 @@ public class RecoverySourceHandler {
      * point-in-time view of the translog). It then sends each translog operation to the target node so it can be replayed into the new
      * shard.
      *
-     * @param startingSeqNo the sequence number to start recovery from, or {@link SequenceNumbers#UNASSIGNED_SEQ_NO} if all
-     *                      ops should be sent
+     * @param startingSeqNo           the sequence number to start recovery from, or {@link SequenceNumbers#UNASSIGNED_SEQ_NO} if all
+     *                                ops should be sent
      * @param requiredSeqNoRangeStart the lower sequence number of the required range (ending with endingSeqNo)
-     * @param endingSeqNo   the highest sequence number that should be sent
-     * @param snapshot      a snapshot of the translog
+     * @param endingSeqNo             the highest sequence number that should be sent
+     * @param snapshot                a snapshot of the translog
      * @return the local checkpoint on the target
      */
     long phase2(final long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo, final Translog.Snapshot snapshot)
@@ -521,11 +521,11 @@ public class RecoverySourceHandler {
      * <p>
      * Operations are bulked into a single request depending on an operation count limit or size-in-bytes limit.
      *
-     * @param startingSeqNo the sequence number for which only operations with a sequence number greater than this will be sent
+     * @param startingSeqNo           the sequence number for which only operations with a sequence number greater than this will be sent
      * @param requiredSeqNoRangeStart the lower sequence number of the required range
-     * @param endingSeqNo   the upper bound of the sequence number range to be sent (inclusive)
-     * @param snapshot      the translog snapshot to replay operations from  @return the local checkpoint on the target and the total
-     *                      number of operations sent
+     * @param endingSeqNo             the upper bound of the sequence number range to be sent (inclusive)
+     * @param snapshot                the translog snapshot to replay operations from  @return the local checkpoint on the target and the
+     *                                total number of operations sent
      * @throws IOException if an I/O exception occurred reading the translog snapshot
      */
     protected SendSnapshotResult sendSnapshot(final long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo,

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -543,7 +543,8 @@ public class RecoverySourceHandler {
              * any ops before the starting sequence number.
              */
             final long seqNo = operation.seqNo();
-            if (startingSeqNo >= 0 && (seqNo == SequenceNumbers.UNASSIGNED_SEQ_NO || seqNo < startingSeqNo)) {
+            assert seqNo >= 0 : "translog operations must have a sequence number. got: " + operation;
+            if (seqNo < startingSeqNo) {
                 skippedOps++;
                 continue;
             }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -168,8 +168,6 @@ public class RecoverySourceHandler {
                 // but we must have everything above the local checkpoint in the commit
                 requiredSeqNoRangeStart =
                     Long.parseLong(phase1Snapshot.getIndexCommit().getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY)) + 1;
-                assert requiredSeqNoRangeStart >= 0 :
-                    "base commit contains an illegal local checkpoint " + (requiredSeqNoRangeStart - 1);
                 try {
                     phase1(phase1Snapshot.getIndexCommit(), translog::totalOperations);
                 } catch (final Exception e) {
@@ -182,6 +180,9 @@ public class RecoverySourceHandler {
                     }
                 }
             }
+            assert startingSeqNo >= 0 : "startingSeqNo must be non negative. got: " + startingSeqNo;
+            assert requiredSeqNoRangeStart >= startingSeqNo : "requiredSeqNoRangeStart [" + requiredSeqNoRangeStart + "] is lower than ["
+                + startingSeqNo + "]";
 
             runUnderPrimaryPermit(() -> shard.initiateTracking(request.targetAllocationId()));
 
@@ -190,7 +191,15 @@ public class RecoverySourceHandler {
             } catch (final Exception e) {
                 throw new RecoveryEngineException(shard.shardId(), 1, "prepare target for translog failed", e);
             }
-            final long endingSeqNo = determineEndingSeqNo();
+
+            final long endingSeqNo = shard.seqNoStats().getMaxSeqNo();
+            /*
+             * We need to wait for all operations up to the current max to complete, otherwise we can not guarantee that all
+             * operations in the required range will be available for replaying from the translog of the source.
+             */
+            cancellableThreads.execute(() -> shard.waitForOpsToComplete(endingSeqNo));
+
+            logger.trace("all operations up to [{}] completed, which will be used as an ending sequence number", endingSeqNo);
 
             logger.trace("snapshot translog for recovery; current size is [{}]", translog.estimateTotalOperationsFromMinSeq(startingSeqNo));
             final long targetLocalCheckpoint;
@@ -225,18 +234,6 @@ public class RecoverySourceHandler {
                 runnable.run();
             }
         });
-    }
-
-    private long determineEndingSeqNo() {
-        final long endingSeqNo = shard.seqNoStats().getMaxSeqNo();
-        /*
-         * We need to wait for all operations up to the current max to complete, otherwise we can not guarantee that all
-         * operations in the required range will be available for replaying from the translog of the source.
-         */
-        cancellableThreads.execute(() -> shard.waitForOpsToComplete(endingSeqNo));
-
-        logger.trace("all operations up to [{}] completed, which will be used as an ending sequence number", endingSeqNo);
-        return endingSeqNo + 1;
     }
 
     /**
@@ -525,16 +522,16 @@ public class RecoverySourceHandler {
      * Operations are bulked into a single request depending on an operation count limit or size-in-bytes limit.
      *
      * @param startingSeqNo the sequence number for which only operations with a sequence number greater than this will be sent
-     * @param requiredSeqNoRangeStart the lower sequence number of the required range (ending with endingSeqNo - 1)
-     * @param endingSeqNo   the upper bound of the sequence number range to be sent (exclusive)
+     * @param requiredSeqNoRangeStart the lower sequence number of the required range
+     * @param endingSeqNo   the upper bound of the sequence number range to be sent (inclusive)
      * @param snapshot      the translog snapshot to replay operations from  @return the local checkpoint on the target and the total
      *                      number of operations sent
      * @throws IOException if an I/O exception occurred reading the translog snapshot
      */
     protected SendSnapshotResult sendSnapshot(final long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo,
                                               final Translog.Snapshot snapshot) throws IOException {
-        assert requiredSeqNoRangeStart <= endingSeqNo :
-            "requiredSeqNoRangeStart " + requiredSeqNoRangeStart + " is larger than endingSeqNo" + endingSeqNo;
+        assert requiredSeqNoRangeStart <= endingSeqNo + 1:
+            "requiredSeqNoRangeStart " + requiredSeqNoRangeStart + " is larger than endingSeqNo " + endingSeqNo;
         assert startingSeqNo <= requiredSeqNoRangeStart :
             "startingSeqNo " + startingSeqNo + " is larger than requiredSeqNoRangeStart " + requiredSeqNoRangeStart;
         int ops = 0;
@@ -562,7 +559,7 @@ public class RecoverySourceHandler {
             cancellableThreads.checkForCancel();
 
             final long seqNo = operation.seqNo();
-            if (seqNo < startingSeqNo || seqNo >= endingSeqNo) {
+            if (seqNo < startingSeqNo || seqNo > endingSeqNo) {
                 skippedOps++;
                 continue;
             }
@@ -587,7 +584,7 @@ public class RecoverySourceHandler {
             cancellableThreads.executeIO(sendBatch);
         }
 
-        if (requiredOpsTracker.getCheckpoint() < endingSeqNo - 1) {
+        if (requiredOpsTracker.getCheckpoint() < endingSeqNo) {
             throw new IllegalStateException("translog replay failed to covered required sequence numbers" +
                 " (required range [" + requiredSeqNoRangeStart + ":" + endingSeqNo + "). first missing op is ["
                 + (requiredOpsTracker.getCheckpoint() + 1) + "]");

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -161,9 +161,9 @@ public class RecoverySourceHandler {
                 } catch (final Exception e) {
                     throw new RecoveryEngineException(shard.shardId(), 1, "snapshot failed", e);
                 }
-                // we set this to unassigned to create a translog roughly according to the retention policy
-                // on the target
-                startingSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
+                // we set this to 0 to create a translog roughly according to the retention policy
+                // on the target. Note that it will still filter out legacy operations with no sequence numbers
+                startingSeqNo = 0;
 
                 try {
                     phase1(phase1Snapshot.getIndexCommit(), translog::totalOperations);
@@ -543,7 +543,6 @@ public class RecoverySourceHandler {
              * any ops before the starting sequence number.
              */
             final long seqNo = operation.seqNo();
-            assert seqNo >= 0 : "translog operations must have a sequence number. got: " + operation;
             if (seqNo < startingSeqNo) {
                 skippedOps++;
                 continue;

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -585,7 +585,7 @@ public class RecoverySourceHandler {
         }
 
         if (requiredOpsTracker.getCheckpoint() < endingSeqNo) {
-            throw new IllegalStateException("translog replay failed to covered required sequence numbers" +
+            throw new IllegalStateException("translog replay failed to cover required sequence numbers" +
                 " (required range [" + requiredSeqNoRangeStart + ":" + endingSeqNo + "). first missing op is ["
                 + (requiredOpsTracker.getCheckpoint() + 1) + "]");
         }

--- a/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/core/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -458,7 +458,8 @@ public class RecoverySourceHandler {
 
         final StopWatch stopWatch = new StopWatch().start();
 
-        logger.trace("recovery [phase2]: sending transaction log operations");
+        logger.trace("recovery [phase2]: sending transaction log operations (seq# from [" +  startingSeqNo  + "], " +
+            "required [" + requiredSeqNoRangeStart + ":" + endingSeqNo + "]");
 
         // send all the snapshot's translog operations to the target
         final SendSnapshotResult result = sendSnapshot(startingSeqNo, requiredSeqNoRangeStart, endingSeqNo, snapshot);

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -183,7 +183,8 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         operations.add(null);
         final long startingSeqNo = randomIntBetween(0, 16);
         // todo add proper tests
-        RecoverySourceHandler.SendSnapshotResult result = handler.sendSnapshot(startingSeqNo, startingSeqNo, 16, new Translog.Snapshot() {
+        RecoverySourceHandler.SendSnapshotResult result = handler.sendSnapshot(startingSeqNo, startingSeqNo,
+            numberOfDocsWithValidSequenceNumbers, new Translog.Snapshot() {
             @Override
             public void close() {
 

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -188,7 +188,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         operations.add(null);
         final long startingSeqNo = randomIntBetween(0, numberOfDocsWithValidSequenceNumbers - 1);
         final long requiredStartingSeqNo = randomIntBetween((int) startingSeqNo, numberOfDocsWithValidSequenceNumbers - 1);
-        final long endingSeqNo = randomIntBetween((int) requiredStartingSeqNo, numberOfDocsWithValidSequenceNumbers);
+        final long endingSeqNo = randomIntBetween((int) requiredStartingSeqNo, numberOfDocsWithValidSequenceNumbers - 1);
         // todo add proper tests
         RecoverySourceHandler.SendSnapshotResult result = handler.sendSnapshot(startingSeqNo, requiredStartingSeqNo,
             endingSeqNo, new Translog.Snapshot() {
@@ -209,7 +209,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                     return operations.get(counter++);
                 }
             });
-        final int expectedOps = (int) (endingSeqNo - startingSeqNo);
+        final int expectedOps = (int) (endingSeqNo - startingSeqNo + 1);
         assertThat(result.totalOperations, equalTo(expectedOps));
         final ArgumentCaptor<List> shippedOpsCaptor = ArgumentCaptor.forClass(List.class);
         if (expectedOps > 0) {
@@ -227,7 +227,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         if (endingSeqNo >= requiredStartingSeqNo + 1) {
             // check that missing ops blows up
             List<Translog.Operation> requiredOps = operations.subList(0, operations.size() - 1).stream() // remove last null marker
-                .filter(o -> o.seqNo() >= requiredStartingSeqNo && o.seqNo() < endingSeqNo).collect(Collectors.toList());
+                .filter(o -> o.seqNo() >= requiredStartingSeqNo && o.seqNo() <= endingSeqNo).collect(Collectors.toList());
             List<Translog.Operation> opsToSkip = randomSubsetOf(randomIntBetween(1, requiredOps.size()), requiredOps);
             expectThrows(IllegalStateException.class, () ->
                 handler.sendSnapshot(startingSeqNo, requiredStartingSeqNo,

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -188,8 +188,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         operations.add(null);
         final long startingSeqNo = randomIntBetween(0, numberOfDocsWithValidSequenceNumbers - 1);
         final long requiredStartingSeqNo = randomIntBetween((int) startingSeqNo, numberOfDocsWithValidSequenceNumbers - 1);
-        final long endingSeqNo = randomIntBetween((int) requiredStartingSeqNo, numberOfDocsWithValidSequenceNumbers - 1);
-        // todo add proper tests
+        final long endingSeqNo = randomIntBetween((int) requiredStartingSeqNo - 1, numberOfDocsWithValidSequenceNumbers - 1);
         RecoverySourceHandler.SendSnapshotResult result = handler.sendSnapshot(startingSeqNo, requiredStartingSeqNo,
             endingSeqNo, new Translog.Snapshot() {
                 @Override
@@ -222,7 +221,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                 assertThat(shippedOps.get(i), equalTo(operations.get(i + (int) startingSeqNo + initialNumberOfDocs)));
             }
         } else {
-            verify(recoveryTarget, never()).indexTranslogOperations(null, 0);
+            verify(recoveryTarget, never()).indexTranslogOperations(any(), any());
         }
         if (endingSeqNo >= requiredStartingSeqNo + 1) {
             // check that missing ops blows up
@@ -249,8 +248,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                             Translog.Operation op;
                             do {
                                 op = operations.get(counter++);
-                            }
-                            while (op != null && opsToSkip.contains(op));
+                            } while (op != null && opsToSkip.contains(op));
                             return op;
                         }
                     }));

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -182,7 +182,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         }
         operations.add(null);
         final long startingSeqNo = randomBoolean() ? SequenceNumbers.UNASSIGNED_SEQ_NO : randomIntBetween(0, 16);
-        RecoverySourceHandler.SendSnapshotResult result = handler.sendSnapshot(startingSeqNo, new Translog.Snapshot() {
+        RecoverySourceHandler.SendSnapshotResult result = handler.sendSnapshot(startingSeqNo, requiredSeqNoRangeStart, endingSeqNo, new Translog.Snapshot() {
             @Override
             public void close() {
 
@@ -383,7 +383,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             }
 
             @Override
-            long phase2(long startingSeqNo, Translog.Snapshot snapshot) throws IOException {
+            long phase2(long startingSeqNo, long requiredSeqNoRangeStart, long endingSeqNo, Translog.Snapshot snapshot) throws IOException {
                 phase2Called.set(true);
                 return SequenceNumbers.UNASSIGNED_SEQ_NO;
             }

--- a/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -181,8 +181,9 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             operations.add(new Translog.Index(index, new Engine.IndexResult(1, i - initialNumberOfDocs, true)));
         }
         operations.add(null);
-        final long startingSeqNo = randomBoolean() ? SequenceNumbers.UNASSIGNED_SEQ_NO : randomIntBetween(0, 16);
-        RecoverySourceHandler.SendSnapshotResult result = handler.sendSnapshot(startingSeqNo, requiredSeqNoRangeStart, endingSeqNo, new Translog.Snapshot() {
+        final long startingSeqNo = randomIntBetween(0, 16);
+        // todo add proper tests
+        RecoverySourceHandler.SendSnapshotResult result = handler.sendSnapshot(startingSeqNo, startingSeqNo, 16, new Translog.Snapshot() {
             @Override
             public void close() {
 
@@ -200,11 +201,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
                 return operations.get(counter++);
             }
         });
-        if (startingSeqNo == SequenceNumbers.UNASSIGNED_SEQ_NO) {
-            assertThat(result.totalOperations, equalTo(initialNumberOfDocs + numberOfDocsWithValidSequenceNumbers));
-        } else {
-            assertThat(result.totalOperations, equalTo(Math.toIntExact(numberOfDocsWithValidSequenceNumbers - startingSeqNo)));
-        }
+        assertThat(result.totalOperations, equalTo(Math.toIntExact(numberOfDocsWithValidSequenceNumbers - startingSeqNo)));
     }
 
     private Engine.Index getIndex(final String id) {

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -591,7 +591,7 @@ public class FullClusterRestartIT extends ESRestTestCase {
      * Tests that a single empty shard index is correctly recovered. Empty shards are often an edge case.
      */
     public void testEmptyShard() throws IOException {
-        final String index = "test_empty_hard";
+        final String index = "test_empty_shard";
 
         if (runningAgainstOldCluster) {
             Settings.Builder settings = Settings.builder()

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -25,8 +25,10 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -49,6 +51,8 @@ import java.util.regex.Pattern;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.elasticsearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -582,6 +586,28 @@ public class FullClusterRestartIT extends ESRestTestCase {
 
         assertThat(toStr(client().performRequest("GET", docLocation)), containsString(doc));
     }
+
+    /**
+     * Tests that a single empty shard index is correctly recovered. Empty shards are often an edge case.
+     */
+    public void testEmptyShard() throws IOException {
+        final String index = "test_empty_hard";
+
+        if (runningAgainstOldCluster) {
+            Settings.Builder settings = Settings.builder()
+                .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
+                // if the node with the replica is the first to be restarted, while a replica is still recovering
+                // then delayed allocation will kick in. When the node comes back, the master will search for a copy
+                // but the recovering copy will be seen as invalid and the cluster health won't return to GREEN
+                // before timing out
+                .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms")
+                .put(SETTING_ALLOCATION_MAX_RETRY.getKey(), "0"); // fail faster
+            createIndex(index, settings.build());
+        }
+        ensureGreen(index);
+    }
+
 
     /**
      * Tests recovery of an index with or without a translog and the

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
@@ -103,7 +103,7 @@ public class IndexingIT extends ESRestTestCase {
             final int finalVersionForDoc1 = indexDocWithConcurrentUpdates(index, 1, nUpdates);
             logger.info("allowing shards on all nodes");
             updateIndexSetting(index, Settings.builder().putNull("index.routing.allocation.include._name"));
-            ensureGreen();
+            ensureGreen(index);
             assertOK(client().performRequest("POST", index + "/_refresh"));
             List<Shard> shards = buildShards(index, nodes, newNodeClient);
             Shard primary = buildShards(index, nodes, newNodeClient).stream().filter(Shard::isPrimary).findFirst().get();
@@ -128,7 +128,7 @@ public class IndexingIT extends ESRestTestCase {
             primary = shards.stream().filter(Shard::isPrimary).findFirst().get();
             logger.info("moving primary to new node by excluding {}", primary.getNode().getNodeName());
             updateIndexSetting(index, Settings.builder().put("index.routing.allocation.exclude._name", primary.getNode().getNodeName()));
-            ensureGreen();
+            ensureGreen(index);
             nUpdates = randomIntBetween(minUpdates, maxUpdates);
             logger.info("indexing docs with [{}] concurrent updates after moving primary", nUpdates);
             final int finalVersionForDoc3 = indexDocWithConcurrentUpdates(index, 3, nUpdates);
@@ -141,7 +141,7 @@ public class IndexingIT extends ESRestTestCase {
 
             logger.info("setting number of replicas to 0");
             updateIndexSetting(index, Settings.builder().put("index.number_of_replicas", 0));
-            ensureGreen();
+            ensureGreen(index);
             nUpdates = randomIntBetween(minUpdates, maxUpdates);
             logger.info("indexing doc with [{}] concurrent updates after setting number of replicas to 0", nUpdates);
             final int finalVersionForDoc4 = indexDocWithConcurrentUpdates(index, 4, nUpdates);
@@ -154,7 +154,7 @@ public class IndexingIT extends ESRestTestCase {
 
             logger.info("setting number of replicas to 1");
             updateIndexSetting(index, Settings.builder().put("index.number_of_replicas", 1));
-            ensureGreen();
+            ensureGreen(index);
             nUpdates = randomIntBetween(minUpdates, maxUpdates);
             logger.info("indexing doc with [{}] concurrent updates after setting number of replicas to 1", nUpdates);
             final int finalVersionForDoc5 = indexDocWithConcurrentUpdates(index, 5, nUpdates);
@@ -192,7 +192,7 @@ public class IndexingIT extends ESRestTestCase {
             assertSeqNoOnShards(index, nodes, nodes.getBWCVersion().major >= 6 ? numDocs : 0, newNodeClient);
             logger.info("allowing shards on all nodes");
             updateIndexSetting(index, Settings.builder().putNull("index.routing.allocation.include._name"));
-            ensureGreen();
+            ensureGreen(index);
             assertOK(client().performRequest("POST", index + "/_refresh"));
             for (final String bwcName : bwcNamesList) {
                 assertCount(index, "_only_nodes:" + bwcName, numDocs);
@@ -204,7 +204,7 @@ public class IndexingIT extends ESRestTestCase {
             Shard primary = buildShards(index, nodes, newNodeClient).stream().filter(Shard::isPrimary).findFirst().get();
             logger.info("moving primary to new node by excluding {}", primary.getNode().getNodeName());
             updateIndexSetting(index, Settings.builder().put("index.routing.allocation.exclude._name", primary.getNode().getNodeName()));
-            ensureGreen();
+            ensureGreen(index);
             int numDocsOnNewPrimary = 0;
             final int numberOfDocsAfterMovingPrimary = 1 + randomInt(5);
             logger.info("indexing [{}] docs after moving primary", numberOfDocsAfterMovingPrimary);
@@ -223,7 +223,7 @@ public class IndexingIT extends ESRestTestCase {
             numDocs += numberOfDocsAfterDroppingReplicas;
             logger.info("setting number of replicas to 1");
             updateIndexSetting(index, Settings.builder().put("index.number_of_replicas", 1));
-            ensureGreen();
+            ensureGreen(index);
             assertOK(client().performRequest("POST", index + "/_refresh"));
             // the number of documents on the primary and on the recovered replica should match the number of indexed documents
             assertCount(index, "_primary", numDocs);

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/IndexingIT.java
@@ -25,7 +25,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -44,18 +43,9 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
 public class IndexingIT extends ESRestTestCase {
-
-    private void updateIndexSetting(String name, Settings.Builder settings) throws IOException {
-        updateIndexSetting(name, settings.build());
-    }
-    private void updateIndexSetting(String name, Settings settings) throws IOException {
-        assertOK(client().performRequest("PUT", name + "/_settings", Collections.emptyMap(),
-            new StringEntity(Strings.toString(settings), ContentType.APPLICATION_JSON)));
-    }
 
     private int indexDocs(String index, final int idStart, final int numDocs) throws IOException {
         for (int i = 0; i < numDocs; i++) {

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
+import java.util.function.Predicate;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
 import static java.util.Collections.emptyMap;
@@ -198,17 +199,17 @@ public class RecoveryIT extends ESRestTestCase {
     }
 
 
-    private String getNewNodeName() throws IOException {
+    private String getNodeId(Predicate<Version> versionPredicate) throws IOException {
         Response response = client().performRequest("GET", "_nodes");
         ObjectPath objectPath = ObjectPath.createFromResponse(response);
         Map<String, Object> nodesAsMap = objectPath.evaluate("nodes");
         for (String id : nodesAsMap.keySet()) {
             Version version = Version.fromString(objectPath.evaluate("nodes." + id + ".version"));
-            if (version.equals(Version.CURRENT)) {
-                return objectPath.evaluate("nodes." + id + ".name");
+            if (versionPredicate.test(version)) {
+                return id;
             }
         }
-        throw new IllegalStateException("couldn't find an old node");
+        return null;
     }
 
 
@@ -228,24 +229,30 @@ public class RecoveryIT extends ESRestTestCase {
                 createIndex(index, settings.build());
                 indexDocs(index, 0, 10);
                 ensureGreen(index);
-                // make sure that the replicas are not started (so we have the primary on an old node)
-                updateIndexSetting(index, Settings.builder().put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "primaries"));
+                // make sure that no shards are allocated, so we can make sure the primary stays on the old node (when one
+                // node stops, we lose the master too, so a replica will not be promoted)
+                updateIndexSetting(index, Settings.builder().put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none"));
                 break;
             case MIXED:
-                final String newNodeName = getNewNodeName();
+                final String newNode = getNodeId(v -> v.equals(Version.CURRENT));
+                final String oldNode = getNodeId(v -> v.before(Version.CURRENT));
                 // remove the replica now that we know that the primary is an old node
                 updateIndexSetting(index, Settings.builder()
                     .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
                     .put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), (String)null)
+                    .put("index.routing.allocation.include._id", oldNode)
                 );
-                updateIndexSetting(index, Settings.builder().put("index.routing.allocation.include._name", newNodeName));
+                updateIndexSetting(index, Settings.builder().put("index.routing.allocation.include._id", newNode));
                 asyncIndexDocs(index, 10, 50).get();
                 ensureGreen(index);
                 assertOK(client().performRequest("POST", index + "/_refresh"));
                 assertCount(index, "_primary", 60);
                 break;
             case UPGRADED:
-                updateIndexSetting(index, Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1));
+                updateIndexSetting(index, Settings.builder()
+                    .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
+                    .put("index.routing.allocation.include._id", (String)null)
+                );
                 asyncIndexDocs(index, 60, 50).get();
                 ensureGreen(index);
                 assertOK(client().performRequest("POST", index + "/_refresh"));

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -101,7 +101,7 @@ public class RecoveryIT extends ESRestTestCase {
                 .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms");
             createIndex(index, settings.build());
         } else if (clusterType == CLUSTER_TYPE.UPGRADED) {
-            ensureGreen();
+            ensureGreen(index);
             Response response = client().performRequest("GET", index + "/_stats", Collections.singletonMap("level", "shards"));
             assertOK(response);
             ObjectPath objectPath = ObjectPath.createFromResponse(response);
@@ -163,14 +163,14 @@ public class RecoveryIT extends ESRestTestCase {
                     .put(SETTING_ALLOCATION_MAX_RETRY.getKey(), "0"); // fail faster
                 createIndex(index, settings.build());
                 indexDocs(index, 0, 10);
-                ensureGreen();
+                ensureGreen(index);
                 // make sure that we can index while the replicas are recovering
                 updateIndexSetting(index, Settings.builder().put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "primaries"));
                 break;
             case MIXED:
                 updateIndexSetting(index, Settings.builder().put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), (String)null));
                 asyncIndexDocs(index, 10, 50).get();
-                ensureGreen();
+                ensureGreen(index);
                 assertOK(client().performRequest("POST", index + "/_refresh"));
                 assertCount(index, "_primary", 60);
                 assertCount(index, "_replica", 60);
@@ -180,7 +180,7 @@ public class RecoveryIT extends ESRestTestCase {
             case UPGRADED:
                 updateIndexSetting(index, Settings.builder().put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), (String)null));
                 asyncIndexDocs(index, 10, 50).get();
-                ensureGreen();
+                ensureGreen(index);
                 assertOK(client().performRequest("POST", index + "/_refresh"));
                 assertCount(index, "_primary", 110);
                 assertCount(index, "_replica", 110);
@@ -227,7 +227,7 @@ public class RecoveryIT extends ESRestTestCase {
                     .put(SETTING_ALLOCATION_MAX_RETRY.getKey(), "0"); // fail faster
                 createIndex(index, settings.build());
                 indexDocs(index, 0, 10);
-                ensureGreen();
+                ensureGreen(index);
                 // make sure that the replicas are not started (so we have the primary on an old node)
                 updateIndexSetting(index, Settings.builder().put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "primaries"));
                 break;
@@ -240,14 +240,14 @@ public class RecoveryIT extends ESRestTestCase {
                 );
                 updateIndexSetting(index, Settings.builder().put("index.routing.allocation.include._name", newNodeName));
                 asyncIndexDocs(index, 10, 50).get();
-                ensureGreen();
+                ensureGreen(index);
                 assertOK(client().performRequest("POST", index + "/_refresh"));
                 assertCount(index, "_primary", 60);
                 break;
             case UPGRADED:
                 updateIndexSetting(index, Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1));
                 asyncIndexDocs(index, 10, 50).get();
-                ensureGreen();
+                ensureGreen(index);
                 assertOK(client().performRequest("POST", index + "/_refresh"));
                 assertCount(index, "_primary", 110);
                 assertCount(index, "_replica", 110);

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -179,7 +179,7 @@ public class RecoveryIT extends ESRestTestCase {
                 break;
             case UPGRADED:
                 updateIndexSetting(index, Settings.builder().put(INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), (String)null));
-                asyncIndexDocs(index, 10, 50).get();
+                asyncIndexDocs(index, 60, 50).get();
                 ensureGreen(index);
                 assertOK(client().performRequest("POST", index + "/_refresh"));
                 assertCount(index, "_primary", 110);
@@ -246,7 +246,7 @@ public class RecoveryIT extends ESRestTestCase {
                 break;
             case UPGRADED:
                 updateIndexSetting(index, Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1));
-                asyncIndexDocs(index, 10, 50).get();
+                asyncIndexDocs(index, 60, 50).get();
                 ensureGreen(index);
                 assertOK(client().performRequest("POST", index + "/_refresh"));
                 assertCount(index, "_primary", 110);

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
@@ -16,6 +16,16 @@
           # allocation will kick in, and the cluster health won't return to GREEN
           # before timing out
           index.unassigned.node_left.delayed_timeout: "100ms"
+
+  - do:
+      indices.create:
+        index: empty_index # index to ensure we can recover empty indices
+        body:
+          # if the node with the replica is the first to be restarted, then delayed
+          # allocation will kick in, and the cluster health won't return to GREEN
+          # before timing out
+          index.unassigned.node_left.delayed_timeout: "100ms"
+
   - do:
       bulk:
         refresh: true

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -7,6 +7,7 @@
         # wait for long enough that we give delayed unassigned shards to stop being delayed
         timeout: 70s
         level: shards
+        index: test_index, index_with_replicas, multi_type_index
 
  - do:
      search:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -7,7 +7,7 @@
         # wait for long enough that we give delayed unassigned shards to stop being delayed
         timeout: 70s
         level: shards
-        index: test_index, index_with_replicas, multi_type_index
+        index: test_index, index_with_replicas
 
  - do:
      search:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -7,7 +7,7 @@
         # wait for long enough that we give delayed unassigned shards to stop being delayed
         timeout: 70s
         level: shards
-        index: test_index,index_with_replicas
+        index: test_index,index_with_replicas,empty_index
 
  - do:
      search:

--- a/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -7,7 +7,7 @@
         # wait for long enough that we give delayed unassigned shards to stop being delayed
         timeout: 70s
         level: shards
-        index: test_index, index_with_replicas
+        index: test_index,index_with_replicas
 
  - do:
      search:

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -411,4 +411,12 @@ public abstract class ESRestTestCase extends ESTestCase {
                 + ", \"mappings\" : {" + mapping + "} }", ContentType.APPLICATION_JSON)));
     }
 
+    protected void updateIndexSetting(String index, Settings.Builder settings) throws IOException {
+        updateIndexSetting(index, settings.build());
+    }
+
+    private void updateIndexSetting(String index, Settings settings) throws IOException {
+        assertOK(client().performRequest("PUT", index + "/_settings", Collections.emptyMap(),
+            new StringEntity(Strings.toString(settings), ContentType.APPLICATION_JSON)));
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -392,13 +392,18 @@ public abstract class ESRestTestCase extends ESTestCase {
         assertThat(response.getStatusLine().getStatusCode(), anyOf(equalTo(200), equalTo(201)));
     }
 
-    protected void ensureGreen() throws IOException {
+    /**
+     * checks that the specific index is green. we force a selection of an index as the tests share a cluster and often leave indices
+     * in an non green state
+     * @param index index to test for
+     **/
+    protected void ensureGreen(String index) throws IOException {
         Map<String, String> params = new HashMap<>();
         params.put("wait_for_status", "green");
         params.put("wait_for_no_relocating_shards", "true");
         params.put("timeout", "70s");
         params.put("level", "shards");
-        assertOK(client().performRequest("GET", "_cluster/health", params));
+        assertOK(client().performRequest("GET", "_cluster/health/" + index, params));
     }
 
     protected void createIndex(String name, Settings settings) throws IOException {


### PR DESCRIPTION
During a recovery the target shard may process both new indexing operations and old ones concurrently. When the primary is on a 6.0 node, the new indexing operations are guaranteed to have sequence numbers but we don't have that guarantee for the old operations as they may come from a period when the primary was on a pre 6.0 node. Have this mixture of old and new is something we do not support and it triggers exceptions.

This PR adds a flush on primary promotion and primary relocations to make sure that any recoveries from a primary on a 6.0 will be guaranteed to only need operations with sequence numbers. A recovery from store already flushes when we start the engine if there were any ops in the translog.

With this extra flushes in place we can now actively filter out operations that have no sequence numbers during recovery. Since filtering out operations is risky, I have opted to harden the logic in the recovery source handler to verify that all operations in the required sequence number range (from the local checkpoint in the commit onwards) are not missed. This comes at an extra complexity for this PR but I think it's worth it.

Finally I added two tests that reproduce the problems.

Closes #27536 

PS. I still need to add unit tests but since there's some time pressure on this one I think we can start reviewing.
