### PR TITLE
Do not set data paths on no local storage required

### DIFF
--- a/core/src/test/java/org/elasticsearch/env/EnvironmentTests.java
+++ b/core/src/test/java/org/elasticsearch/env/EnvironmentTests.java
@@ -28,7 +28,10 @@ import java.nio.file.Path;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasToString;
 
 /**
  * Simple unit-tests for Environment.java
@@ -113,6 +116,34 @@ public class EnvironmentTests extends ESTestCase {
         final Settings settings = Settings.builder().put("path.home", pathHome).build();
         final Environment environment = new Environment(settings, null);
         assertThat(environment.configFile(), equalTo(pathHome.resolve("config")));
+    }
+
+    public void testNodeDoesNotRequireLocalStorage() {
+        final Path pathHome = createTempDir().toAbsolutePath();
+        final Settings settings =
+                Settings.builder()
+                        .put("path.home", pathHome)
+                        .put("node.local_storage", false)
+                        .put("node.master", false)
+                        .put("node.data", false)
+                        .build();
+        final Environment environment = new Environment(settings, null);
+        assertThat(environment.dataFiles(), arrayWithSize(0));
+    }
+
+    public void testNodeDoesNotRequireLocalStorageButHasPathData() {
+        final Path pathHome = createTempDir().toAbsolutePath();
+        final Path pathData = pathHome.resolve("data");
+        final Settings settings =
+                Settings.builder()
+                        .put("path.home", pathHome)
+                        .put("path.data", pathData)
+                        .put("node.local_storage", false)
+                        .put("node.master", false)
+                        .put("node.data", false)
+                        .build();
+        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> new Environment(settings, null));
+        assertThat(e, hasToString(containsString("node does not require local storage yet path.data is set to [" + pathData + "]")));
     }
 
 }

--- a/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/core/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -397,14 +397,14 @@ public class NodeEnvironmentTests extends ESTestCase {
     }
 
     public void testPersistentNodeId() throws IOException {
-        String[] paths = tmpPaths();
-        NodeEnvironment env = newNodeEnvironment(paths, Settings.builder()
+        NodeEnvironment env = newNodeEnvironment(new String[0], Settings.builder()
             .put("node.local_storage", false)
             .put("node.master", false)
             .put("node.data", false)
             .build());
         String nodeID = env.nodeId();
         env.close();
+        final String[] paths = tmpPaths();
         env = newNodeEnvironment(paths, Settings.EMPTY);
         assertThat("previous node didn't have local storage enabled, id should change", env.nodeId(), not(equalTo(nodeID)));
         nodeID = env.nodeId();


### PR DESCRIPTION
Today when configuring the data paths for the environment, we set data paths to either the specified path.data or default to data relative to the Elasticsearch home. Yet if node.local_storage is false, data paths do not even make sense. In this case, we should reject if path.data is set, and instead of defaulting data paths to data relative to home, we should set this to empty paths. This commit does this.

Closes #27572
