### PR TITLE
Add exception handling for write listeners

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketEventHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketEventHandler.java
@@ -21,6 +21,7 @@ package org.elasticsearch.transport.nio;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.transport.nio.channel.NioChannel;
 import org.elasticsearch.transport.nio.channel.NioSocketChannel;
 import org.elasticsearch.transport.nio.channel.SelectionKeyUtils;
@@ -144,6 +145,16 @@ public class SocketEventHandler extends EventHandler {
     void genericChannelException(NioChannel channel, Exception exception) {
         super.genericChannelException(channel, exception);
         exceptionCaught((NioSocketChannel) channel, exception);
+    }
+
+    /**
+     * This method is called when a listener attached to a channel operation throws an exception.
+     *
+     * @param listener that was called
+     * @param exception that occurred
+     */
+    <V> void listenerException(ActionListener<V> listener, Exception exception) {
+        logger.warn(new ParameterizedMessage("exception while executing listener: {}", listener), exception);
     }
 
     private void exceptionCaught(NioSocketChannel channel, Exception e) {

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/TcpWriteContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/channel/TcpWriteContext.java
@@ -82,7 +82,7 @@ public class TcpWriteContext implements WriteContext {
     public void clearQueuedWriteOps(Exception e) {
         assert channel.getSelector().isOnCurrentThread() : "Must be on selector thread to clear queued writes";
         for (WriteOperation op : queued) {
-            op.getListener().onFailure(e);
+            channel.getSelector().executeFailedListener(op.getListener(), e);
         }
         queued.clear();
     }
@@ -91,12 +91,12 @@ public class TcpWriteContext implements WriteContext {
         try {
             headOp.flush();
         } catch (IOException e) {
-            headOp.getListener().onFailure(e);
+            channel.getSelector().executeFailedListener(headOp.getListener(), e);
             throw e;
         }
 
         if (headOp.isFullyFlushed()) {
-            headOp.getListener().onResponse(null);
+            channel.getSelector().executeListener(headOp.getListener(), null);
         } else {
             queued.push(headOp);
         }

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/SocketSelectorTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/SocketSelectorTests.java
@@ -308,4 +308,23 @@ public class SocketSelectorTests extends ESTestCase {
         verify(eventHandler).handleClose(channel);
         verify(eventHandler).handleClose(unRegisteredChannel);
     }
+
+    public void testExecuteListenerWillHandleException() throws Exception {
+        RuntimeException exception = new RuntimeException();
+        doThrow(exception).when(listener).onResponse(null);
+
+        socketSelector.executeListener(listener, null);
+
+        verify(eventHandler).listenerException(listener, exception);
+    }
+
+    public void testExecuteFailedListenerWillHandleException() throws Exception {
+        IOException ioException = new IOException();
+        RuntimeException exception = new RuntimeException();
+        doThrow(exception).when(listener).onFailure(ioException);
+
+        socketSelector.executeFailedListener(listener, ioException);
+
+        verify(eventHandler).listenerException(listener, exception);
+    }
 }

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/channel/TcpWriteContextTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/channel/TcpWriteContextTests.java
@@ -118,7 +118,7 @@ public class TcpWriteContextTests extends ESTestCase {
         ClosedChannelException e = new ClosedChannelException();
         writeContext.clearQueuedWriteOps(e);
 
-        verify(listener).onFailure(e);
+        verify(selector).executeFailedListener(listener, e);
 
         assertFalse(writeContext.hasQueuedWriteOps());
     }
@@ -136,7 +136,7 @@ public class TcpWriteContextTests extends ESTestCase {
         writeContext.flushChannel();
 
         verify(writeOperation).flush();
-        verify(listener).onResponse(null);
+        verify(selector).executeListener(listener, null);
         assertFalse(writeContext.hasQueuedWriteOps());
     }
 
@@ -173,7 +173,7 @@ public class TcpWriteContextTests extends ESTestCase {
         when(writeOperation2.isFullyFlushed()).thenReturn(false);
         writeContext.flushChannel();
 
-        verify(listener).onResponse(null);
+        verify(selector).executeListener(listener, null);
         verify(listener2, times(0)).onResponse(channel);
         assertTrue(writeContext.hasQueuedWriteOps());
 
@@ -181,7 +181,7 @@ public class TcpWriteContextTests extends ESTestCase {
 
         writeContext.flushChannel();
 
-        verify(listener2).onResponse(null);
+        verify(selector).executeListener(listener2, null);
         assertFalse(writeContext.hasQueuedWriteOps());
     }
 
@@ -198,7 +198,7 @@ public class TcpWriteContextTests extends ESTestCase {
         when(writeOperation.getListener()).thenReturn(listener);
         expectThrows(IOException.class, () -> writeContext.flushChannel());
 
-        verify(listener).onFailure(exception);
+        verify(selector).executeFailedListener(listener, exception);
         assertFalse(writeContext.hasQueuedWriteOps());
     }
 


### PR DESCRIPTION
This potential issue was exposed when I saw this PR #27542. Essentially
we currently execute the write listeners all over the place without
consistently catching and handling exceptions. Some of these exceptions
will be logged in different ways (including as low as `debug`).

This commit adds a single location where these listeners are executed.
If the listener throws an execption, the exception is caught and logged
at the `warn` level.