### PR TITLE
Move DNS cache settings to important configuration

### DIFF
--- a/docs/reference/modules/discovery/zen.asciidoc
+++ b/docs/reference/modules/discovery/zen.asciidoc
@@ -22,16 +22,12 @@ other nodes.
 [[unicast]]
 ===== Unicast
 
-Unicast discovery requires a list of hosts to use that will act as gossip routers. These hosts can be specified as
-hostnames or IP addresses; hosts specified as hostnames are resolved to IP addresses during each round of pinging. Note
-that with the Java security manager in place, the JVM defaults to caching positive hostname resolutions indefinitely.
-This can be modified by adding
-http://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html[`networkaddress.cache.ttl=<timeout>`] to your
-http://docs.oracle.com/javase/8/docs/technotes/guides/security/PolicyFiles.html[Java security policy]. Any hosts that
-fail to resolve will be logged. Note also that with the Java security manager in place, the JVM defaults to caching
-negative hostname resolutions for ten seconds. This can be modified by adding
-http://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html[`networkaddress.cache.negative.ttl=<timeout>`]
-to your http://docs.oracle.com/javase/8/docs/technotes/guides/security/PolicyFiles.html[Java security policy].
+Unicast discovery requires a list of hosts to use that will act as gossip
+routers. These hosts can be specified as hostnames or IP addresses; hosts
+specified as hostnames are resolved to IP addresses during each round of
+pinging. Note that if you are in an environment where DNS resolutions vary with
+time, you might need to adjust your <<networkaddress-cache-ttl,JVM security
+settings>>.
 
 It is recommended that the unicast hosts list be maintained as the list of
 master-eligible nodes in the cluster.

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -201,3 +201,22 @@ the Elasticsearch process. If you wish to configure a heap dump path, you should
 modify the entry `#-XX:HeapDumpPath=/heap/dump/path` in
 <<jvm-options,`jvm.options`>> to remove the comment marker `#` and to specify an
 actual path.
+
+[float]
+[[networkaddress-cache-ttl]]
+
+Elasticsearch runs with a security manager in place. With a security manager in
+place, the JVM defaults to caching positive hostname resolutions
+indefinitely. If your Elasticsearch nodes rely on DNS in an environment where
+DNS resolutions vary with time (e.g., for node-to-node discovery) then you might
+want to modify the default JVM behavior.  This can be modified by adding
+http://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html[`networkaddress.cache.ttl=<timeout>`]
+to your
+http://docs.oracle.com/javase/8/docs/technotes/guides/security/PolicyFiles.html[Java
+security policy]. Any hosts that fail to resolve will be logged. Note also that
+with the Java security manager in place, the JVM defaults to caching negative
+hostname resolutions for ten seconds. This can be modified by adding
+http://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html[`networkaddress.cache.negative.ttl=<timeout>`]
+to your
+http://docs.oracle.com/javase/8/docs/technotes/guides/security/PolicyFiles.html[Java
+security policy].


### PR DESCRIPTION
This commit moves the DNS cache settings for the JVM to the important settings section of the docs.

