### PR TITLE
Fix cat API help with url parameters

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/AbstractCatAction.java
@@ -54,6 +54,8 @@ public abstract class AbstractCatAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         boolean helpWanted = request.paramAsBoolean("help", false);
         if (helpWanted) {
+            // consume all request parameters for 'help' to prevent an IllegalArgumentException
+            request.params().keySet().forEach(request::param);
             return channel -> {
                 Table table = getTableWithHeader(request);
                 int[] width = buildHelpWidths(table, request);

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cat.shards/10_basic.yml
@@ -257,3 +257,21 @@
             /^ foo \s+ 0\n
                bar \s+ 1\n
             $/
+
+---
+"Test cat shards help with params":
+  - skip:
+      version: " - 6.2.99"
+      reason: until 6.3.0 '/_cat/shards/index?help' was throwing IllegalArgumentException
+  - do:
+      indices.create:
+        index: index
+        body:
+          settings:
+            number_of_shards: 2
+            number_of_replicas: 0
+
+  - do:
+      cat.shards:
+        index: index
+        help: true


### PR DESCRIPTION
The `_cat` API was throwing IllegalArgumentException if url parameters were provided
```
# worked
GET _cat/shards?help
GET _cat/shards/test_index
# returned an exception
GET _cat/shards/test_index?help
```
Fixes #27424