### PR TITLE
Use private directory for temporary files

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch
+++ b/distribution/src/main/resources/bin/elasticsearch
@@ -24,7 +24,8 @@ parse_jvm_options() {
 
 ES_JVM_OPTIONS="$ES_PATH_CONF"/jvm.options
 
-ES_JAVA_OPTS="`parse_jvm_options "$ES_JVM_OPTIONS"` $ES_JAVA_OPTS"
+JVM_OPTIONS=`parse_jvm_options "$ES_JVM_OPTIONS"`
+ES_JAVA_OPTS="${JVM_OPTIONS//\$\{ES_TMPDIR\}/$ES_TMPDIR} $ES_JAVA_OPTS"
 
 # manual parsing to find out, if process should be detached
 if ! echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )' > /dev/null; then

--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -73,3 +73,7 @@ if [ -z "$ES_PATH_CONF" ]; then
   echo "ES_PATH_CONF must be set to the configuration path"
   exit 1
 fi
+
+if [ -z "$ES_TMPDIR" ]; then
+  ES_TMPDIR=`mktemp -d`
+fi

--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -75,5 +75,9 @@ if [ -z "$ES_PATH_CONF" ]; then
 fi
 
 if [ -z "$ES_TMPDIR" ]; then
-  ES_TMPDIR=`mktemp -d`
+  if [ "`uname`" == "Darwin" ]; then
+    ES_TMPDIR=`mktemp -d -t elasticsearch`
+  else
+    ES_TMPDIR=`mktemp -d -t elasticsearch.XXXXXXXX`
+  fi
 fi

--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -49,3 +49,7 @@ set HOSTNAME=%COMPUTERNAME%
 if not defined ES_PATH_CONF (
   set ES_PATH_CONF=!ES_HOME!\config
 )
+
+if not defined ES_TMPDIR (
+  set ES_TMPDIR=!TMP!
+)

--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -51,5 +51,5 @@ if not defined ES_PATH_CONF (
 )
 
 if not defined ES_TMPDIR (
-  set ES_TMPDIR=!TMP!
+  set ES_TMPDIR=!TMP!\elasticsearch
 )

--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -104,7 +104,7 @@ if not "%ES_JAVA_OPTS%" == "" set ES_JAVA_OPTS=%ES_JAVA_OPTS: =;%
 
 @setlocal
 for /F "usebackq delims=" %%a in (`findstr /b \- "%ES_JVM_OPTIONS%" ^| findstr /b /v "\-server \-client"`) do set JVM_OPTIONS=!JVM_OPTIONS!%%a;
-@endlocal & set ES_JAVA_OPTS=%JVM_OPTIONS%%ES_JAVA_OPTS%
+@endlocal & set ES_JAVA_OPTS=%JVM_OPTIONS:${ES_TMPDIR}=!ES_TMPDIR!% %ES_JAVA_OPTS%
 
 if "%ES_JAVA_OPTS:~-1%"==";" set ES_JAVA_OPTS=%ES_JAVA_OPTS:~0,-1%
 

--- a/distribution/src/main/resources/bin/elasticsearch-service.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-service.bat
@@ -104,7 +104,7 @@ if not "%ES_JAVA_OPTS%" == "" set ES_JAVA_OPTS=%ES_JAVA_OPTS: =;%
 
 @setlocal
 for /F "usebackq delims=" %%a in (`findstr /b \- "%ES_JVM_OPTIONS%" ^| findstr /b /v "\-server \-client"`) do set JVM_OPTIONS=!JVM_OPTIONS!%%a;
-@endlocal & set ES_JAVA_OPTS=%JVM_OPTIONS:${ES_TMPDIR}=!ES_TMPDIR!% %ES_JAVA_OPTS%
+@endlocal & set ES_JAVA_OPTS=%JVM_OPTIONS:${ES_TMPDIR}=!ES_TMPDIR!%%ES_JAVA_OPTS%
 
 if "%ES_JAVA_OPTS:~-1%"==";" set ES_JAVA_OPTS=%ES_JAVA_OPTS:~0,-1%
 

--- a/distribution/src/main/resources/bin/elasticsearch.bat
+++ b/distribution/src/main/resources/bin/elasticsearch.bat
@@ -47,7 +47,7 @@ set "ES_JVM_OPTIONS=%ES_PATH_CONF%\jvm.options"
 rem extract the options from the JVM options file %ES_JVM_OPTIONS%
 rem such options are the lines beginning with '-', thus "findstr /b"
 for /F "usebackq delims=" %%a in (`findstr /b \- "%ES_JVM_OPTIONS%"`) do set JVM_OPTIONS=!JVM_OPTIONS! %%a
-@endlocal & set ES_JAVA_OPTS=%JVM_OPTIONS% %ES_JAVA_OPTS%
+@endlocal & set ES_JAVA_OPTS=%JVM_OPTIONS:${ES_TMPDIR}=!ES_TMPDIR!% %ES_JAVA_OPTS%
 
 %JAVA% %ES_JAVA_OPTS% -Delasticsearch -Des.path.home="%ES_HOME%" -Des.path.conf="%ES_PATH_CONF%" -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch" !newparams!
 

--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -72,6 +72,8 @@
 -Dlog4j.shutdownHookEnabled=false
 -Dlog4j2.disable.jmx=true
 
+-Djava.io.tmpdir=${ES_TMPDIR}
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails


### PR DESCRIPTION
This change ensures that the temporary directory used for java.io.tmpdir is a private temporary directory. To achieve this we use mktemp on macOS and Linux to give us a private temporary directory and the value of the environment variable TMP on Windows. For this to work with our packaging, we add java.io.tmpdir=${ES_TMPDIR} to our packaged jvm.options, we set ES_TMPDIR respectively in our startup scripts, and resolve the value of the template ${ES_TMPDIR} at startup.

Relates #14372, supersedes #27144