### PR TITLE
Fix sporadic failures in testCorruptedShards

### DIFF
--- a/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -188,7 +188,7 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
             }
         }
 
-        assertBusy(() -> {
+        assertBusy(() -> { // IndicesClusterStateService#failAndRemoveShard() called asynchronously but we need it to have completed here.
             IndicesShardStoresResponse rsp = client().admin().indices().prepareShardStores(index).setShardStatuses("all").get();
             ImmutableOpenIntMap<List<IndicesShardStoresResponse.StoreStatus>> shardStatuses = rsp.getStoreStatuses().get(index);
             assertNotNull(shardStatuses);

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -152,7 +152,6 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         assertThat(shardStatuses.get(index1).size(), equalTo(2));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/12416")
     public void testCorruptedShards() throws Exception {
         String index = "test";
         internalCluster().ensureAtLeastNumDataNodes(2);


### PR DESCRIPTION
`failAndRemoveShard` is called asynchronously...

https://github.com/elastic/elasticsearch/blob/95bcee56c42dc457c4157e51b7277d99d43a666a/core/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java#L707-L715

... but `testCorruptedShards` assumes otherwise. This wraps the test in an `assertBusy()` to allow for retries.

Resolves #12416.