### PR TITLE
Add validation of keystore setting names

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
@@ -46,6 +46,7 @@ public abstract class SecureSetting<T> extends Setting<T> {
     private SecureSetting(String key, Property... properties) {
         super(key, (String)null, null, ArrayUtils.concat(properties, FIXED_PROPERTIES, Property.class));
         assert assertAllowedProperties(properties);
+        KeyStoreWrapper.validateSettingName(key);
     }
 
     private boolean assertAllowedProperties(Setting.Property... properties) {

--- a/core/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/KeyStoreWrapperTests.java
@@ -97,4 +97,14 @@ public class KeyStoreWrapperTests extends ESTestCase {
         keystore.decrypt(new char[0]);
         assertEquals(seed.toString(), keystore.getString(KeyStoreWrapper.SEED_SETTING.getKey()).toString());
     }
+
+    public void testIllegalSettingName() throws Exception {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> KeyStoreWrapper.validateSettingName("UpperCase"));
+        assertTrue(e.getMessage().contains("does not match the allowed setting name pattern"));
+        KeyStoreWrapper keystore = KeyStoreWrapper.create(new char[0]);
+        e = expectThrows(IllegalArgumentException.class, () -> keystore.setString("UpperCase", new char[0]));
+        assertTrue(e.getMessage().contains("does not match the allowed setting name pattern"));
+        e = expectThrows(IllegalArgumentException.class, () -> keystore.setFile("UpperCase", new byte[0]));
+        assertTrue(e.getMessage().contains("does not match the allowed setting name pattern"));
+    }
 }

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -486,6 +486,15 @@ public class SettingsTests extends ESTestCase {
         assertTrue(e.getMessage().contains("must be stored inside the Elasticsearch keystore"));
     }
 
+    public void testSecureSettingIllegalName() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
+            SecureSetting.secureString("UpperCaseSetting", null));
+        assertTrue(e.getMessage().contains("does not match the allowed setting name pattern"));
+        e = expectThrows(IllegalArgumentException.class, () ->
+            SecureSetting.secureFile("UpperCaseSetting", null));
+        assertTrue(e.getMessage().contains("does not match the allowed setting name pattern"));
+    }
+
     public void testGetAsArrayFailsOnDuplicates() {
         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> Settings.builder()
             .put("foobar.0", "bar")


### PR DESCRIPTION
This commit restricts settings added to the keystore to have a lowercase
ascii name. The java Keystore javadocs state that case sensitivity of
key alias names are implementation dependent. This ensures regardless of
case sensitivity in a jvm implementation, the keys will be stored as we
expect.
