### PR TITLE
TEST: Rewrite GeoPointParsingTests#testEqualsHashCodeContract

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.test.geo.RandomGeoGenerator;
 import java.io.IOException;
 
 import static org.elasticsearch.common.geo.GeoHashUtils.stringEncode;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class GeoPointParsingTests  extends ESTestCase {
@@ -77,12 +78,10 @@ public class GeoPointParsingTests  extends ESTestCase {
 
         /** hashCode test */
         // symmetry
-        assertTrue(x.hashCode() == y.hashCode());
+        assertThat(x.hashCode(), equalTo(y.hashCode()));
         // transitivity
-        assertTrue(y.hashCode() == z.hashCode());
-        assertTrue(x.hashCode() == z.hashCode());
-        // inequality
-        assertFalse(x.hashCode() == a.hashCode());
+        assertThat(y.hashCode(), equalTo(z.hashCode()));
+        assertThat(x.hashCode(), equalTo(z.hashCode()));
     }
 
     public void testGeoPointParsing() throws IOException {

--- a/core/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
+++ b/core/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
@@ -61,16 +61,12 @@ public class GeoPointParsingTests  extends ESTestCase {
     public void testEqualsHashCodeContract() {
         // GeoPoint doesn't care about coordinate system bounds, this simply validates equality and hashCode.
         final DoubleSupplier randomDelta = () -> randomValueOtherThan(0.0, () -> randomDoubleBetween(-1000000, 1000000, true));
-        checkEqualsAndHashCode(RandomGeoGenerator.randomPoint(random()), GeoPoint::new, pt -> {
-            switch (randomInt(2)) {
-                case 1:
-                    return new GeoPoint(pt.lat(), pt.lon() + randomDelta.getAsDouble());
-                case 2:
-                    return new GeoPoint(pt.lat() + randomDelta.getAsDouble(), pt.lon());
-                default:
-                    return new GeoPoint(pt.lat() + randomDelta.getAsDouble(), pt.lon() + randomDelta.getAsDouble());
-            }
-        });
+        checkEqualsAndHashCode(RandomGeoGenerator.randomPoint(random()), GeoPoint::new,
+            pt -> new GeoPoint(pt.lat() + randomDelta.getAsDouble(), pt.lon()));
+        checkEqualsAndHashCode(RandomGeoGenerator.randomPoint(random()), GeoPoint::new,
+            pt -> new GeoPoint(pt.lat(), pt.lon() + randomDelta.getAsDouble()));
+        checkEqualsAndHashCode(RandomGeoGenerator.randomPoint(random()), GeoPoint::new,
+            pt -> new GeoPoint(pt.lat() + randomDelta.getAsDouble(), pt.lon() + randomDelta.getAsDouble()));
     }
 
     public void testGeoPointParsing() throws IOException {


### PR DESCRIPTION
The hashCode contract states that equal objects must have equal hash codes, however the unequal objects are not required to have unequal hashCodes. This commit rewrites `GeoPointParsingTests#testEqualsHashCodeContract` using `#checkEqualsAndHashCode` helper.

Closes #27633