### PR TITLE
Refer to CONTRIBUTING.md when encountering IntelliJ jar hell

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/JarHell.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JarHell.java
@@ -141,9 +141,9 @@ public class JarHell {
                 if (urlElements.add(url) == false) {
                     String jarHellDescription;
                     if (element.endsWith("idea_rt.jar")) {
-                        jarHellDescription = "Jar hell, caused by IntelliJ IDEA's run launcher; see CONTRIBUTING.md for the necessary fix.";
+                        jarHellDescription = "jar hell, caused by IntelliJ IDEA's run launcher; see CONTRIBUTING.md for the necessary fix.";
                     } else {
-                        jarHellDescription = "Jar hell!";
+                        jarHellDescription = "jar hell!";
                     }
                     throw new IllegalStateException(jarHellDescription + System.lineSeparator() +
                         "duplicate jar [" + element + "] on classpath: " + classPath);

--- a/core/src/main/java/org/elasticsearch/bootstrap/JarHell.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JarHell.java
@@ -139,7 +139,13 @@ public class JarHell {
             try {
                 URL url = PathUtils.get(element).toUri().toURL();
                 if (urlElements.add(url) == false) {
-                    throw new IllegalStateException("jar hell!" + System.lineSeparator() +
+                    String jarHellDescription;
+                    if (element.endsWith("idea_rt.jar")) {
+                        jarHellDescription = "Jar hell, caused by IntelliJ IDEA's run launcher; see CONTRIBUTING.md for the necessary fix.";
+                    } else {
+                        jarHellDescription = "Jar hell!";
+                    }
+                    throw new IllegalStateException(jarHellDescription + System.lineSeparator() +
                         "duplicate jar [" + element + "] on classpath: " + classPath);
                 }
             } catch (MalformedURLException e) {


### PR DESCRIPTION
As of PR https://github.com/elastic/elasticsearch/pull/13465, newbies to Elasticsearch using IntelliJ are almost certain to get the scary "Jar hell!" exception the first time they run a test; and they might not immediately think to look in `CONTRIBUTING.md` for a fix. So this should send them in the right direction 🙂 