### PR TITLE
String distance algorithms cleanup

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
@@ -464,7 +464,7 @@ public final class DirectCandidateGeneratorBuilder implements CandidateGenerator
     }
 
     static StringDistance resolveDistance(String distanceVal) {
-        distanceVal = distanceVal.toLowerCase(Locale.US);
+        distanceVal = distanceVal.toLowerCase(Locale.ROOT);
         if ("internal".equals(distanceVal)) {
             return DirectSpellChecker.INTERNAL_LEVENSHTEIN;
         } else if ("damerau_levenshtein".equals(distanceVal)) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
@@ -469,9 +469,6 @@ public final class DirectCandidateGeneratorBuilder implements CandidateGenerator
             return DirectSpellChecker.INTERNAL_LEVENSHTEIN;
         } else if ("damerau_levenshtein".equals(distanceVal)) {
             return new LuceneLevenshteinDistance();
-        } else if ("levenstein".equals(distanceVal)) {
-            DEPRECATION_LOGGER.deprecated("Deprecated distance [levenstein] used, replaced by [levenshtein]");
-            return new LevensteinDistance();
         } else if ("levenshtein".equals(distanceVal)) {
             return new LevensteinDistance();
         } else if ("jarowinkler".equals(distanceVal)) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
@@ -471,9 +471,6 @@ public final class DirectCandidateGeneratorBuilder implements CandidateGenerator
             return new LuceneLevenshteinDistance();
         } else if ("levenshtein".equals(distanceVal)) {
             return new LevensteinDistance();
-        } else if ("jarowinkler".equals(distanceVal)) {
-            DEPRECATION_LOGGER.deprecated("Deprecated distance [jarowinkler] used, replaced by [jaro_winkler]");
-            return new JaroWinklerDistance();
         } else if ("jaro_winkler".equals(distanceVal)) {
             return new JaroWinklerDistance();
         } else if ("ngram".equals(distanceVal)) {

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorBuilder.java
@@ -467,7 +467,7 @@ public final class DirectCandidateGeneratorBuilder implements CandidateGenerator
         distanceVal = distanceVal.toLowerCase(Locale.US);
         if ("internal".equals(distanceVal)) {
             return DirectSpellChecker.INTERNAL_LEVENSHTEIN;
-        } else if ("damerau_levenshtein".equals(distanceVal) || "damerauLevenshtein".equals(distanceVal)) {
+        } else if ("damerau_levenshtein".equals(distanceVal)) {
             return new LuceneLevenshteinDistance();
         } else if ("levenstein".equals(distanceVal)) {
             DEPRECATION_LOGGER.deprecated("Deprecated distance [levenstein] used, replaced by [levenshtein]");

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
@@ -586,7 +586,6 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
                 case "internal":
                     return INTERNAL;
                 case "damerau_levenshtein":
-                case "damerauLevenshtein":
                     return DAMERAU_LEVENSHTEIN;
                 case "levenstein":
                     DEPRECATION_LOGGER.deprecated("Deprecated distance [levenstein] used, replaced by [levenshtein]");

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
@@ -587,9 +587,6 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
                     return INTERNAL;
                 case "damerau_levenshtein":
                     return DAMERAU_LEVENSHTEIN;
-                case "levenstein":
-                    DEPRECATION_LOGGER.deprecated("Deprecated distance [levenstein] used, replaced by [levenshtein]");
-                    return LEVENSHTEIN;
                 case "levenshtein":
                     return LEVENSHTEIN;
                 case "ngram":

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
@@ -591,9 +591,6 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
                     return LEVENSHTEIN;
                 case "ngram":
                     return NGRAM;
-                case "jarowinkler":
-                    DEPRECATION_LOGGER.deprecated("Deprecated distance [jarowinkler] used, replaced by [jaro_winkler]");
-                    return JARO_WINKLER;
                 case "jaro_winkler":
                     return JARO_WINKLER;
                 default: throw new IllegalArgumentException("Illegal distance option " + str);

--- a/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/term/TermSuggestionBuilder.java
@@ -581,7 +581,7 @@ public class TermSuggestionBuilder extends SuggestionBuilder<TermSuggestionBuild
 
         public static StringDistanceImpl resolve(final String str) {
             Objects.requireNonNull(str, "Input string is null");
-            final String distanceVal = str.toLowerCase(Locale.US);
+            final String distanceVal = str.toLowerCase(Locale.ROOT);
             switch (distanceVal) {
                 case "internal":
                     return INTERNAL;

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
@@ -83,11 +83,6 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
         expectThrows(NullPointerException.class, () -> DirectCandidateGeneratorBuilder.resolveDistance(null));
     }
 
-    public void testLevensteinDeprecation() {
-        assertThat(DirectCandidateGeneratorBuilder.resolveDistance("levenstein"), instanceOf(LevensteinDistance.class));
-        assertWarnings("Deprecated distance [levenstein] used, replaced by [levenshtein]");
-    }
-
     public void testJaroWinklerDeprecation() {
         assertThat(DirectCandidateGeneratorBuilder.resolveDistance("jaroWinkler"), instanceOf(JaroWinklerDistance.class));
         assertWarnings("Deprecated distance [jarowinkler] used, replaced by [jaro_winkler]");

--- a/core/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
@@ -83,11 +83,6 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
         expectThrows(NullPointerException.class, () -> DirectCandidateGeneratorBuilder.resolveDistance(null));
     }
 
-    public void testJaroWinklerDeprecation() {
-        assertThat(DirectCandidateGeneratorBuilder.resolveDistance("jaroWinkler"), instanceOf(JaroWinklerDistance.class));
-        assertWarnings("Deprecated distance [jarowinkler] used, replaced by [jaro_winkler]");
-    }
-
     private static DirectCandidateGeneratorBuilder mutate(DirectCandidateGeneratorBuilder original) throws IOException {
         DirectCandidateGeneratorBuilder mutation = copy(original);
         List<Supplier<DirectCandidateGeneratorBuilder>> mutators = new ArrayList<>();

--- a/core/src/test/java/org/elasticsearch/search/suggest/term/StringDistanceImplTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/term/StringDistanceImplTests.java
@@ -58,11 +58,6 @@ public class StringDistanceImplTests extends AbstractWriteableEnumTestCase {
         assertThat(e.getMessage(), equalTo("Input string is null"));
     }
 
-    public void testJaroWinklerDeprecation() {
-        assertThat(StringDistanceImpl.resolve("jaroWinkler"), equalTo(StringDistanceImpl.JARO_WINKLER));
-        assertWarnings("Deprecated distance [jarowinkler] used, replaced by [jaro_winkler]");
-    }
-
     @Override
     public void testWriteTo() throws IOException {
         assertWriteToStream(StringDistanceImpl.INTERNAL, 0);
@@ -80,5 +75,4 @@ public class StringDistanceImplTests extends AbstractWriteableEnumTestCase {
         assertReadFromStream(3, StringDistanceImpl.JARO_WINKLER);
         assertReadFromStream(4, StringDistanceImpl.NGRAM);
     }
-
 }

--- a/core/src/test/java/org/elasticsearch/search/suggest/term/StringDistanceImplTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/term/StringDistanceImplTests.java
@@ -58,11 +58,6 @@ public class StringDistanceImplTests extends AbstractWriteableEnumTestCase {
         assertThat(e.getMessage(), equalTo("Input string is null"));
     }
 
-    public void testLevensteinDeprecation() {
-        assertThat(StringDistanceImpl.resolve("levenstein"), equalTo(StringDistanceImpl.LEVENSHTEIN));
-        assertWarnings("Deprecated distance [levenstein] used, replaced by [levenshtein]");
-    }
-
     public void testJaroWinklerDeprecation() {
         assertThat(StringDistanceImpl.resolve("jaroWinkler"), equalTo(StringDistanceImpl.JARO_WINKLER));
         assertWarnings("Deprecated distance [jarowinkler] used, replaced by [jaro_winkler]");

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -35,9 +35,9 @@ The Search API returns `400 - Bad request` while it would previously return
 *   number of filters in the adjacency matrix aggregation is too large
 
 
-==== Scroll queries cannot use the request_cache anymore
+==== Scroll queries cannot use the `request_cache` anymore
 
-Setting `request_cache:true` on a query that creates a scroll ('scroll=1m`)
+Setting `request_cache:true` on a query that creates a scroll (`scroll=1m`)
 has been deprecated in 6 and will now return a `400 - Bad request`.
 Scroll queries are not meant to be cached.
 

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -43,8 +43,9 @@ Scroll queries are not meant to be cached.
 
 ==== Term Suggesters supported distance algorithms
 
-For better readability and consistency the following string distance algorithms
-have been renamed:
+The following string distance algorithms were given additional names in 6.2 and
+their existing names were deprecated. The deprecated names have now been
+removed.
 
 * 	`levenstein` - replaced by `levenshtein`
 * 	`jarowinkler` - replaced by `jaro_winkler`

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -43,7 +43,8 @@ Scroll queries are not meant to be cached.
 
 ==== Term Suggesters supported distance algorithms
 
-The following suggestion distance algorithms have been removed:
+For better readability and consistency the following string distance algorithms
+have been renamed:
 
 * 	`levenstein` - replaced by `levenshtein`
 * 	`jarowinkler` - replaced by `jaro_winkler`

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -46,3 +46,4 @@ Scroll queries are not meant to be cached.
 The following suggestion distance algorithms have been removed:
 
 * 	`levenstein` - replaced by `levenshtein`
+* 	`jarowinkler` - replaced by `jaro_winkler`

--- a/docs/reference/migration/migrate_7_0/search.asciidoc
+++ b/docs/reference/migration/migrate_7_0/search.asciidoc
@@ -40,3 +40,9 @@ The Search API returns `400 - Bad request` while it would previously return
 Setting `request_cache:true` on a query that creates a scroll ('scroll=1m`)
 has been deprecated in 6 and will now return a `400 - Bad request`.
 Scroll queries are not meant to be cached.
+
+==== Term Suggesters supported distance algorithms
+
+The following suggestion distance algorithms have been removed:
+
+* 	`levenstein` - replaced by `levenshtein`


### PR DESCRIPTION
Remove deprecated `levenstein` and `jarowinkler` string distance algs

Remove `damerauLevenshtein` : `distanceVal` is explicitly converted to lowercase, thus it can never match `damerauLevenshtein`

Use the ROOT locale for to lowercase