### PR TITLE
Obey translog durability in global checkpoint sync

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
+++ b/core/src/main/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -116,13 +117,17 @@ public class GlobalCheckpointSyncAction extends TransportReplicationAction<
     @Override
     protected PrimaryResult<Request, ReplicationResponse> shardOperationOnPrimary(
             final Request request, final IndexShard indexShard) throws Exception {
-        indexShard.getTranslog().sync();
+        if (indexShard.getTranslogDurability() == Translog.Durability.REQUEST) {
+            indexShard.getTranslog().sync();
+        }
         return new PrimaryResult<>(request, new ReplicationResponse());
     }
 
     @Override
     protected ReplicaResult shardOperationOnReplica(final Request request, final IndexShard indexShard) throws Exception {
-        indexShard.getTranslog().sync();
+        if (indexShard.getTranslogDurability() == Translog.Durability.REQUEST) {
+            indexShard.getTranslog().sync();
+        }
         return new ReplicaResult();
     }
 


### PR DESCRIPTION
After write operations in some situations we fire a post-operation global checkpoint sync. The global checkpoint sync unconditionally fsyncs the translog and this can then look like an fsync per-request. This violates the translog durability settings on the index if this durability is set to async. This commit changes the global checkpoint sync to observe the translog durability.
