### PR TITLE
Platform independent mktemp

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -75,9 +75,5 @@ if [ -z "$ES_PATH_CONF" ]; then
 fi
 
 if [ -z "$ES_TMPDIR" ]; then
-  if [ "`uname`" == "Darwin" ]; then
-    ES_TMPDIR=`mktemp -d -t elasticsearch`
-  else
-    ES_TMPDIR=`mktemp -d -t elasticsearch.XXXXXXXX`
-  fi
+  ES_TMPDIR=`mktemp -d "${TMPDIR:-/tmp}/elasticsearch.XXXXXXXX"`
 fi


### PR DESCRIPTION
Generate platform independent temp directory using an explicit template instead of branching on the platform. (branching can fail if you use `coreutils` on `Darwin`)
on macOS:
```
   -t prefix
       Generate a template (using the supplied prefix and TMPDIR if set) to create a filename tem-plate. 
```
on linux (coreutils):
```
  -t                  interpret TEMPLATE as a single file name component,
                        relative to a directory: $TMPDIR, if set; else the
                        directory specified via -p; else /tmp [deprecated]
```


All hail [StackOverflow](https://stackoverflow.com/questions/31396985/why-is-mktemp-on-os-x-broken-with-a-command-that-worked-on-linux)
