### PR TITLE
Detect mktemp from coreutils

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -75,9 +75,13 @@ if [ -z "$ES_PATH_CONF" ]; then
 fi
 
 if [ -z "$ES_TMPDIR" ]; then
-  if [ "`uname`" == "Darwin" ]; then
-    ES_TMPDIR=`mktemp -d -t elasticsearch`
+  set +e
+  mktemp --version 2>&1 | grep coreutils > /dev/null
+  mktemp_coreutils=$?
+  set -e
+  if [ $mktemp_coreutils -eq 0 ]; then
+    ES_TMPDIR=`mktemp -d --tmpdir "elasticearch.XXXXXXXX"`
   else
-    ES_TMPDIR=`mktemp -d -t elasticsearch.XXXXXXXX`
+    ES_TMPDIR=`mktemp -d -t elasticsearch`
   fi
 fi


### PR DESCRIPTION
GNU mktemp and BSD mktemp have different command line flags. On some macOS systems users have mktemp from coreutils in their PATH overriding the system mktemp from BSD. This commit adds detection for the coreutils mktemp versus the BSD mktemp and uses the appropriate syntax based on the detection.

Relates #27609, relates #27643
