### PR TITLE
Add explicit coreutils dependency

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -392,6 +392,7 @@ configure(distributions.findAll { ['deb', 'rpm'].contains(it.name) }) {
     } else if (project.name == 'deb') {
       requires('bash')
     }
+    requires('coreutils')
 
     into '/usr/share/elasticsearch'
     fileMode 0644


### PR DESCRIPTION
The RPM and Debian packages depend on coreutils (for mktemp among others). This commit adds an explicit package dependency on coreutils.

Relates #27609
