### PR TITLE
Prevent constructing an index template without index patterns

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -93,6 +93,9 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
                                  ImmutableOpenMap<String, CompressedXContent> mappings,
                                  ImmutableOpenMap<String, AliasMetaData> aliases,
                                  ImmutableOpenMap<String, IndexMetaData.Custom> customs) {
+        if (patterns == null || patterns.isEmpty()) {
+            throw new IllegalArgumentException("Index patterns must not be null or empty; got " + patterns);
+        }
         this.name = name;
         this.order = order;
         this.version = version;
@@ -244,7 +247,7 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
         if (out.getVersion().onOrAfter(Version.V_6_0_0_alpha1)) {
             out.writeStringList(patterns);
         } else {
-            out.writeString(patterns.size() > 0 ? patterns.get(0) : "");
+            out.writeString(patterns.get(0));
         }
         Settings.writeSettingsToStream(settings, out);
         out.writeVInt(mappings.size());

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -170,8 +171,8 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
     public void testObjectReuseWhenApplyingClusterStateDiff() throws Exception {
         IndexMetaData indexMetaData
             = IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(10).numberOfReplicas(1).build();
-        IndexTemplateMetaData indexTemplateMetaData
-            = IndexTemplateMetaData.builder("test-template").patterns(new ArrayList<>()).build();
+        IndexTemplateMetaData indexTemplateMetaData = IndexTemplateMetaData.builder("test-template")
+            .patterns(Arrays.asList()).build();
         MetaData metaData = MetaData.builder().put(indexMetaData, true).put(indexTemplateMetaData).build();
 
         RoutingTable routingTable = RoutingTable.builder().addAsNew(metaData.index("test")).build();

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -172,7 +172,7 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
         IndexMetaData indexMetaData
             = IndexMetaData.builder("test").settings(settings(Version.CURRENT)).numberOfShards(10).numberOfReplicas(1).build();
         IndexTemplateMetaData indexTemplateMetaData = IndexTemplateMetaData.builder("test-template")
-            .patterns(Arrays.asList()).build();
+            .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false))).build();
         MetaData metaData = MetaData.builder().put(indexMetaData, true).put(indexTemplateMetaData).build();
 
         RoutingTable routingTable = RoutingTable.builder().addAsNew(metaData.index("test")).build();

--- a/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterStateToStringTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/serialization/ClusterStateToStringTests.java
@@ -32,6 +32,8 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.Arrays;
+
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.containsString;
@@ -40,7 +42,8 @@ public class ClusterStateToStringTests extends ESAllocationTestCase {
     public void testClusterStateSerialization() throws Exception {
         MetaData metaData = MetaData.builder()
                 .put(IndexMetaData.builder("test_idx").settings(settings(Version.CURRENT)).numberOfShards(10).numberOfReplicas(1))
-                .put(IndexTemplateMetaData.builder("test_template").build())
+                .put(IndexTemplateMetaData.builder("test_template")
+                    .patterns(Arrays.asList(generateRandomStringArray(10, 100, false,false))).build())
                 .build();
 
         RoutingTable routingTable = RoutingTable.builder()

--- a/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/core/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -308,7 +308,8 @@ public class GatewayMetaStateTests extends ESAllocationTestCase {
             Collections.emptyList(),
             Collections.singletonList(
                 templates -> {
-                    templates.put("added_test_template", IndexTemplateMetaData.builder("added_test_template").build());
+                    templates.put("added_test_template", IndexTemplateMetaData.builder("added_test_template")
+                        .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false))).build());
                     return templates;
                 }
             ));
@@ -438,14 +439,17 @@ public class GatewayMetaStateTests extends ESAllocationTestCase {
             Collections.emptyList(),
             Arrays.asList(
                 indexTemplateMetaDatas -> {
-                    indexTemplateMetaDatas.put("template1", IndexTemplateMetaData.builder("template1").settings(
-                        Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 20).build()).build());
+                    indexTemplateMetaDatas.put("template1", IndexTemplateMetaData.builder("template1")
+                        .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false)))
+                        .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 20).build())
+                        .build());
                     return indexTemplateMetaDatas;
 
                 },
                 indexTemplateMetaDatas -> {
-                    indexTemplateMetaDatas.put("template2", IndexTemplateMetaData.builder("template2").settings(
-                        Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 10).build()).build());
+                    indexTemplateMetaDatas.put("template2", IndexTemplateMetaData.builder("template2")
+                        .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false)))
+                        .settings(Settings.builder().put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 10).build()).build());
                     return indexTemplateMetaDatas;
 
                 }
@@ -535,6 +539,7 @@ public class GatewayMetaStateTests extends ESAllocationTestCase {
                 .settings(settings(Version.CURRENT)
                     .put(IndexMetaData.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), randomIntBetween(0, 3))
                     .put(IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), randomIntBetween(1, 5)))
+                .patterns(Arrays.asList(generateRandomStringArray(10, 100, false, false)))
                 .build();
             builder.put(templateMetaData);
         }


### PR DESCRIPTION
Today, we prevent the system from storing a broken index template in the transport layer, however we don't prevent this in XContent. A broken index template can break the whole cluster state.

This commit attempts to prevent the system from constructing an index template without a proper index patterns.