### PR TITLE
Correct two equality checks on incomparable types

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -369,7 +369,7 @@ public class GeoShapeFieldMapper extends FieldMapper {
         public void setStrategyName(String strategyName) {
             checkIfFrozen();
             this.strategyName = strategyName;
-            if (this.strategyName.equals(SpatialStrategy.TERM)) {
+            if (this.strategyName.equals(SpatialStrategy.TERM.getStrategyName())) {
                 this.pointsOnly = true;
             }
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -768,7 +768,7 @@ public final class Definition {
             painlessConstructor = new Method("<init>", ownerStruct, null, getTypeInternal("void"), painlessParametersTypes,
                 asmConstructor, javaConstructor.getModifiers(), javaHandle);
             ownerStruct.constructors.put(painlessMethodKey, painlessConstructor);
-        } else if (painlessConstructor.equals(painlessParametersTypes) == false){
+        } else if (painlessConstructor.arguments.equals(painlessParametersTypes) == false){
             throw new IllegalArgumentException(
                     "illegal duplicate constructors [" + painlessMethodKey + "] found within the struct [" + ownerStruct.name + "] " +
                     "with parameters " + painlessParametersTypes + " and " + painlessConstructor.arguments);


### PR DESCRIPTION
Hi! I was browsing the project on [lgtm.com](https://lgtm.com/projects/g/elastic/elasticsearch) and came across a couple of alerts where different types are being compared using `.equals()`. In these cases the fix seemed pretty obvious so I've gone ahead and done it here.

I've already gone ahead and signed the CLA. I hope these fixes are useful!

Full disclosure -- I am one of the developers working on lgtm.com
