### PR TITLE
Fix issue where the incorrect buffers are written

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/WriteOperation.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/WriteOperation.java
@@ -81,9 +81,9 @@ public class WriteOperation {
 
         ByteBuffer[] postIndexBuffers = new ByteBuffer[buffers.length - offsetIndex];
 
-        ByteBuffer firstBuffer = buffers[0].duplicate();
+        ByteBuffer firstBuffer = buffers[offsetIndex].duplicate();
         firstBuffer.position(internalIndex - offsets[offsetIndex]);
-        postIndexBuffers[offsetIndex] = firstBuffer;
+        postIndexBuffers[0] = firstBuffer;
         int j = 1;
         for (int i = (offsetIndex + 1); i < buffers.length; ++i) {
             postIndexBuffers[j++] = buffers[i].duplicate();


### PR DESCRIPTION
This is a followup to #27551. That commit introduced a bug where the
incorrect byte buffers would be returned when we attempted a write. This
commit fixes the logic.