### PR TITLE
Remove `delimited_payload_filter`

### DIFF
--- a/docs/reference/migration/migrate_7_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_7_0/analysis.asciidoc
@@ -1,19 +1,11 @@
 [[breaking_70_analysis_changes]]
 === Analysis changes
 
-==== The `delimited_payload_filter` is renamed
-
-The `delimited_payload_filter` is renamed to `delimited_payload`, the old name is 
-deprecated and will be removed at some point, so it should be replaced by 
-`delimited_payload`.
-
-
 ==== Limiting the number of tokens produced by _analyze
 
 To safeguard against out of memory errors, the number of tokens that can be produced
 using the `_analyze` endpoint has been limited to 10000. This default limit can be changed
 for a particular index with the index setting `index.analyze.max_token_count`.
-
 
 ==== Limiting the length of an analyzed text during highlighting
 
@@ -23,3 +15,10 @@ For large texts this analysis may take substantial amount of time and memory.
 To protect against this, the maximum number of characters that will be analyzed has been
 limited to 1000000. This default limit can be changed
 for a particular index with the index setting `index.highlight.max_analyzed_offset`.
+
+==== `delimited_payload_filter` renaming
+
+The `delimited_payload_filter` was deprecated and renamed to `delimited_payload` in 6.2.
+Using it in indices created before 7.0 will issue deprecation warnings. Using the old
+name in new indices created in 7.0 will throw an error. Use the new name `delimited_payload`
+instead.

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LegacyDelimitedPayloadTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LegacyDelimitedPayloadTokenFilterFactory.java
@@ -32,6 +32,10 @@ public class LegacyDelimitedPayloadTokenFilterFactory extends DelimitedPayloadTo
 
     LegacyDelimitedPayloadTokenFilterFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
         super(indexSettings, env, name, settings);
+        if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_7_0_0_alpha1)) {
+            throw new IllegalArgumentException(
+                    "[delimited_payload_filter] is not supported for new indices, use [delimited_payload] instead");
+        }
         if (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_6_2_0)) {
             DEPRECATION_LOGGER.deprecated("Deprecated [delimited_payload_filter] used, replaced by [delimited_payload]");
         }

--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/40_token_filters.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/40_token_filters.yml
@@ -1026,15 +1026,13 @@
     - match:  { tokens.10.token: ちた }
 
 ---
-"delimited_payload_filter":
+"delimited_payload_filter_error":
     - skip:
-        version: " - 6.1.99"
-        reason:  delimited_payload_filter deprecated in 6.2, replaced by delimited_payload
-        features: "warnings"
+        version: " - 6.99.99"
+        reason:  using delimited_payload_filter throws error from 7.0 on
 
     - do:
-        warnings:
-          - "Deprecated [delimited_payload_filter] used, replaced by [delimited_payload]"
+        catch: /\[delimited_payload_filter\] is not supported for new indices, use \[delimited_payload\] instead/
         indices.create:
           index: test
           body:
@@ -1045,29 +1043,15 @@
                     type: delimited_payload_filter
                     delimiter: ^
                     encoding: identity
-    - do:
-        warnings:
-          - "Deprecated [delimited_payload_filter] used, replaced by [delimited_payload]"
-        indices.analyze:
-          index: test
-          body:
-            text:      foo^bar
-            tokenizer: keyword
-            filter:    [my_delimited_payload_filter]
-    - length: { tokens: 1 }
-    - match:  { tokens.0.token: foo }
 
     # Test pre-configured token filter too:
     - do:
-        warnings:
-          - "Deprecated [delimited_payload_filter] used, replaced by [delimited_payload]"
+        catch: /\[delimited_payload_filter\] is not supported for new indices, use \[delimited_payload\] instead/
         indices.analyze:
           body:
             text:      foo|5
             tokenizer: keyword
             filter:    [delimited_payload_filter]
-    - length: { tokens: 1 }
-    - match:  { tokens.0.token: foo }
 
 ---
 "delimited_payload":


### PR DESCRIPTION
From 7.0 on, using `delimited_payload_filter` should throw an error (the use was deprecated in 6.2 in favour of `delimited_payload` in #26625.

Relates to #27704 