### PR TITLE
Fix some type checks that were always false

### DIFF
--- a/core/src/main/java/org/apache/lucene/search/vectorhighlight/CustomFieldQuery.java
+++ b/core/src/main/java/org/apache/lucene/search/vectorhighlight/CustomFieldQuery.java
@@ -75,9 +75,6 @@ public class CustomFieldQuery extends FieldQuery {
         } else if (sourceQuery instanceof BlendedTermQuery) {
             final BlendedTermQuery blendedTermQuery = (BlendedTermQuery) sourceQuery;
             flatten(blendedTermQuery.rewrite(reader), reader, flatQueries, boost);
-        } else if (sourceQuery instanceof ESToParentBlockJoinQuery) {
-            ESToParentBlockJoinQuery blockJoinQuery = (ESToParentBlockJoinQuery) sourceQuery;
-            flatten(blockJoinQuery.getChildQuery(), reader, flatQueries, boost);
         } else if (sourceQuery instanceof BoostingQuery) {
             BoostingQuery boostingQuery = (BoostingQuery) sourceQuery;
             //flatten positive query with query boost

--- a/core/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
+++ b/core/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedEsThreadPoolExecutor.java
@@ -137,7 +137,7 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
     @Override
     protected Runnable wrapRunnable(Runnable command) {
         if (command instanceof PrioritizedRunnable) {
-            if ((command instanceof TieBreakingPrioritizedRunnable)) {
+            if (command instanceof TieBreakingPrioritizedRunnable) {
                 return command;
             }
             Priority priority = ((PrioritizedRunnable) command).priority();
@@ -145,9 +145,6 @@ public class PrioritizedEsThreadPoolExecutor extends EsThreadPoolExecutor {
         } else if (command instanceof PrioritizedFutureTask) {
             return command;
         } else { // it might be a callable wrapper...
-            if (command instanceof TieBreakingPrioritizedRunnable) {
-                return command;
-            }
             return new TieBreakingPrioritizedRunnable(super.wrapRunnable(command), Priority.NORMAL, insertionOrder.incrementAndGet());
         }
     }


### PR DESCRIPTION
* CustomFieldQuery: this was added in:
  https://lgtm.com/projects/g/elastic/elasticsearch/rev/4756c9a884f3e5341db0cf7799e7e8656c7338d0
  but there was already a type check higher up in the same if/else
  chain. I opted to keep the new one, as it contains a null check that
  the earlier one does not.
* PrioritizedEsThreadPoolExecutor: This check was simply a duplicate
  of one earlier and would never have been true. The behaviour would
  have been the same if it was reached.
* DocumentParser: The checks for Text and Keyword were masked by the
  earlier check for String, which they are child classes of. I changed
  the order to have the more specific checks first so that they are
  all now possible.