### PR TITLE
Improve error msg when a field name contains only white spaces

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -180,10 +180,10 @@ final class DocumentParser {
             String[] parts = fullFieldPath.split("\\.");
             for (String part : parts) {
                 if (Strings.hasText(part) == false) {
-                    // check if the field name contains only white spaces
+                    // check if the field name contains only whitespace
                     if (Strings.isEmpty(part) == false) {
                         throw new IllegalArgumentException(
-                                "object field cannot contain only white spaces: ['" + fullFieldPath + "']");
+                                "object field cannot contain only whitespace: ['" + fullFieldPath + "']");
                     }
                     throw new IllegalArgumentException(
                             "object field starting or ending with a [.] makes object resolution ambiguous: [" + fullFieldPath + "]");

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -180,6 +180,11 @@ final class DocumentParser {
             String[] parts = fullFieldPath.split("\\.");
             for (String part : parts) {
                 if (Strings.hasText(part) == false) {
+                    // check if the field name contains only white spaces
+                    if (Strings.isEmpty(part) == false) {
+                        throw new IllegalArgumentException(
+                                "object field cannot contain only white spaces: ['" + fullFieldPath + "']");
+                    }
                     throw new IllegalArgumentException(
                             "object field starting or ending with a [.] makes object resolution ambiguous: [" + fullFieldPath + "]");
                 }

--- a/core/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1377,6 +1377,23 @@ public class DocumentParserTests extends ESSingleNodeTestCase {
         }
     }
 
+    public void testDynamicFieldsEmptyName() throws Exception {
+        BytesReference bytes = XContentFactory.jsonBuilder()
+                .startObject().startArray("top.")
+                .startObject()
+                .startObject("aoeu")
+                .field("a", 1).field(" ", 2)
+                .endObject()
+                .endObject().endArray()
+                .endObject().bytes();
+
+        IllegalArgumentException emptyFieldNameException = expectThrows(IllegalArgumentException.class,
+                () -> client().prepareIndex("idx", "type").setSource(bytes, XContentType.JSON).get());
+
+        assertThat(emptyFieldNameException.getMessage(), containsString(
+                "object field cannot contain only white spaces: ['top.aoeu. ']"));
+    }
+
     public void testBlankFieldNames() throws Exception {
         final BytesReference bytes = XContentFactory.jsonBuilder()
                 .startObject()

--- a/core/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1391,7 +1391,7 @@ public class DocumentParserTests extends ESSingleNodeTestCase {
                 () -> client().prepareIndex("idx", "type").setSource(bytes, XContentType.JSON).get());
 
         assertThat(emptyFieldNameException.getMessage(), containsString(
-                "object field cannot contain only white spaces: ['top.aoeu. ']"));
+                "object field cannot contain only whitespace: ['top.aoeu. ']"));
     }
 
     public void testBlankFieldNames() throws Exception {


### PR DESCRIPTION
Till now if a field name is empty or contains only white spaces, the error msg is `object field starting or ending with a [.] makes object resolution ambiguous`.

This PR explicitly check if the field name contains only white spaces and result in the error `object field cannot contain only white spaces`.

Fixes #27701

CC @danielmitterdorfer @dakrone 