### PR TITLE
[TEST] Remove leftover ES temp directories before Vagrant tests

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -307,4 +307,9 @@ Defaults   env_keep += "BATS_ARCHIVES"
 SUDOERS_VARS
     chmod 0440 /etc/sudoers.d/elasticsearch_vars
   SHELL
+  # This prevents leftovers from previous tests using the
+  # same VM from messing up the current test
+  config.vm.provision "clean_tmp", run: "always", type: "shell", inline: <<-SHELL
+    rm -rf /tmp/elastic*earch*
+  SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -310,6 +310,6 @@ SUDOERS_VARS
   # This prevents leftovers from previous tests using the
   # same VM from messing up the current test
   config.vm.provision "clean_tmp", run: "always", type: "shell", inline: <<-SHELL
-    rm -rf /tmp/elastic*earch*
+    rm -rf /tmp/elasticsearch*
   SHELL
 end


### PR DESCRIPTION
Some of the Vagrant tests were failing due to ES temp directories
left over from previous uses of the same VM confusing subsequent
tests into thinking there were multiple ES installs present.

This change wipes all ES temp directories when the test VMs are
brought up.