### PR TITLE
Fix a type check that is always false

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -625,9 +625,7 @@ final class DocumentParser {
 
     private static Mapper.Builder<?,?> createBuilderFromFieldType(final ParseContext context, MappedFieldType fieldType, String currentFieldName) {
         Mapper.Builder builder = null;
-        if (fieldType instanceof StringFieldType) {
-            builder = context.root().findTemplateBuilder(context, currentFieldName, "string", XContentFieldType.STRING);
-        } else if (fieldType instanceof TextFieldType) {
+        if (fieldType instanceof TextFieldType) {
             builder = context.root().findTemplateBuilder(context, currentFieldName, "text", XContentFieldType.STRING);
             if (builder == null) {
                 builder = new TextFieldMapper.Builder(currentFieldName)


### PR DESCRIPTION
DocumentParser: The checks for Text and Keyword were masked by the
earlier check for String, which they are child classes of. I changed
the order to have the more specific checks first so that they are all
now possible.

Separated for more review from https://github.com/elastic/elasticsearch/pull/27706