### PR TITLE
No longer unidle shard during recovery

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1745,11 +1745,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     public void initiateTracking(final String allocationId) {
         verifyPrimary();
         getEngine().seqNoService().initiateTracking(allocationId);
-        /*
-         * We could have blocked so long waiting for the replica to catch up that we fell idle and there will not be a background sync to
-         * the replica; mark our self as active to force a future background sync.
-         */
-        active.compareAndSet(false, true);
     }
 
     /**


### PR DESCRIPTION
Previously we would unidle a primary shard during recovery in case the recovery target would miss a background global checkpoint sync. However, the background global checkpoint syncs are no longer tied to the primary shard falling idle and so this unidling is no longer needed.

Relates #26591

