### PR TITLE
Retain originalIndex info when rewriting FieldCapabilities requests

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.fieldcaps;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -66,14 +67,20 @@ public class FieldCapabilitiesIndexRequest
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         fields = in.readStringArray();
-        originalIndices = OriginalIndices.readOriginalIndices(in);
+        if (in.getVersion().onOrAfter(Version.V_6_2_0)) {
+            originalIndices = OriginalIndices.readOriginalIndices(in);
+        } else {
+            originalIndices = OriginalIndices.NONE;
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(fields);
-        OriginalIndices.writeOriginalIndices(originalIndices, out);
+        if (out.getVersion().onOrAfter(Version.V_6_2_0)) {
+            OriginalIndices.writeOriginalIndices(originalIndices, out);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexRequest.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,16 +32,20 @@ public class FieldCapabilitiesIndexRequest
     extends SingleShardRequest<FieldCapabilitiesIndexRequest> {
 
     private String[] fields;
+    private OriginalIndices originalIndices;
 
     // For serialization
     FieldCapabilitiesIndexRequest() {}
 
-    FieldCapabilitiesIndexRequest(String[] fields, String index) {
+    FieldCapabilitiesIndexRequest(String[] fields, String index, OriginalIndices originalIndices) {
         super(index);
         if (fields == null || fields.length == 0) {
             throw new IllegalArgumentException("specified fields can't be null or empty");
         }
         this.fields = fields;
+        assert index != null;
+        this.index(index);
+        this.originalIndices = originalIndices;
     }
 
     public String[] fields() {
@@ -47,15 +53,27 @@ public class FieldCapabilitiesIndexRequest
     }
 
     @Override
+    public String[] indices() {
+        return originalIndices.indices();
+    }
+
+    @Override
+    public IndicesOptions indicesOptions() {
+        return originalIndices.indicesOptions();
+    }
+
+    @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         fields = in.readStringArray();
+        originalIndices = OriginalIndices.readOriginalIndices(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(fields);
+        OriginalIndices.writeOriginalIndices(originalIndices, out);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/core/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -110,7 +110,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                 }
             };
             for (String index : concreteIndices) {
-                shardAction.execute(new FieldCapabilitiesIndexRequest(request.fields(), index), innerListener);
+                shardAction.execute(new FieldCapabilitiesIndexRequest(request.fields(), index, localIndices), innerListener);
             }
 
             // this is the cross cluster part of this API - we force the other cluster to not merge the results but instead

--- a/core/src/test/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/core/src/test/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -59,6 +59,8 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.explain.ExplainAction;
 import org.elasticsearch.action.explain.ExplainRequest;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.MultiGetAction;
@@ -186,6 +188,19 @@ public class IndicesRequestIT extends ESIntegTestCase {
 
         clearInterceptedActions();
         assertSameIndices(getFieldMappingsRequest, getFieldMappingsShardAction);
+    }
+
+    public void testFieldCapabilities() {
+        String fieldCapabilitiesShardAction = FieldCapabilitiesAction.NAME + "[index][s]";
+        interceptTransportActions(fieldCapabilitiesShardAction);
+
+        FieldCapabilitiesRequest fieldCapabilitiesRequest = new FieldCapabilitiesRequest();
+        fieldCapabilitiesRequest.indices(randomIndicesOrAliases());
+        fieldCapabilitiesRequest.fields(randomAlphaOfLength(8));
+        internalCluster().coordOnlyNodeClient().fieldCaps(fieldCapabilitiesRequest).actionGet();
+
+        clearInterceptedActions();
+        assertSameIndices(fieldCapabilitiesRequest, fieldCapabilitiesShardAction);
     }
 
     public void testAnalyze() {


### PR DESCRIPTION
A [FieldCapabilities](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html) request can cover multiple indices (or aliases pointing to multiple indices).
The original request is rewritten for each concrete index but these new requests miss the original requested indices.

This PR mimics GetFieldMapping behavior, see [GetFieldMappingsIndexRequest](https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsIndexRequest.java).