### PR TITLE
docs: Clarify html encoder

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -136,8 +136,9 @@ You can specify the locale to use with `boundary_scanner_locale`.
 boundary_scanner_locale:: Controls which locale is used to search for sentence
 and word boundaries.
 
-encoder:: Indicates if the highlighted text should be HTML encoded:
-`default` (no encoding) or `html` (encodes the content as HTML, but not the highlighting tags).
+encoder:: Indicates if the snippet should be HTML encoded:
+`default` (no encoding) or `html` (HTML-escape the snippet text and then
+insert the highlighting tags)
 
 fields:: Specifies the fields to retrieve highlights for. You can use wildcards
 to specify fields. For example, you could specify `comment_*` to

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -137,7 +137,7 @@ boundary_scanner_locale:: Controls which locale is used to search for sentence
 and word boundaries.
 
 encoder:: Indicates if the highlighted text should be HTML encoded:
-`default` (no encoding) or `html` (escapes HTML highlighting tags).
+`default` (no encoding) or `html` (encodes the content as HTML, but not the highlighting tags).
 
 fields:: Specifies the fields to retrieve highlights for. You can use wildcards
 to specify fields. For example, you could specify `comment_*` to


### PR DESCRIPTION
The previous description was a bit confusing because the pre/post tags used for highlighting are not escaped, the rest of the content is.