### PR TITLE
Fix BWC release tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/VersionCollection.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/VersionCollection.groovy
@@ -64,7 +64,10 @@ class VersionCollection {
             throw new GradleException("Unexpectedly found no version constants in Versions.java");
         }
 
-        // The tip of each minor series (>= 5.6) is unreleased, so set their 'snapshot' flags
+        /*
+         * The tip of each minor series (>= 5.6) is unreleased, so they must be built from source (we set branch to non-null), and we set
+         * the snapshot flag if and only if build.snapshot is true.
+         */
         Version prevConsideredVersion = null
         boolean found6xSnapshot = false
         for (final int versionIndex = versions.size() - 1; versionIndex >= 0; versionIndex--) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/VersionCollection.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/VersionCollection.groovy
@@ -29,6 +29,7 @@ import java.util.regex.Matcher
 class VersionCollection {
 
     private final List<Version> versions
+    private final boolean buildSnapshot = System.getProperty("build.snapshot", "true") == "true"
 
     /**
      * Construct a VersionCollection from the lines of the Version.java file.
@@ -85,7 +86,7 @@ class VersionCollection {
 
                 versions[versionIndex] = new Version(
                         currConsideredVersion.major, currConsideredVersion.minor,
-                        currConsideredVersion.revision, currConsideredVersion.suffix, true, branch)
+                        currConsideredVersion.revision, currConsideredVersion.suffix, buildSnapshot, branch)
             }
 
             if (currConsideredVersion.onOrBefore("5.6.0")) {
@@ -93,12 +94,6 @@ class VersionCollection {
             }
 
             prevConsideredVersion = currConsideredVersion
-        }
-
-        // If we're making a release build then the current should not be a snapshot after all.
-        final boolean currentIsSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        if (false == currentIsSnapshot) {
-            versions[-1] = new Version(versions[-1].major, versions[-1].minor, versions[-1].revision, versions[-1].suffix, false, null)
         }
 
         this.versions = Collections.unmodifiableList(versions)
@@ -137,7 +132,7 @@ class VersionCollection {
     private Version getLastSnapshotWithMajor(int targetMajor) {
         final String currentVersion = currentVersion.toString()
         final int snapshotIndex = versions.findLastIndexOf {
-            it.major == targetMajor && it.before(currentVersion) && it.snapshot
+            it.major == targetMajor && it.before(currentVersion) && it.snapshot == buildSnapshot
         }
         return snapshotIndex == -1 ? null : versions[snapshotIndex]
     }

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -119,7 +119,7 @@ if (project.hasProperty('bwcVersion')) {
     dependsOn checkoutBwcBranch, writeBuildMetadata
     dir = checkoutDir
     tasks = [':distribution:deb:assemble', ':distribution:rpm:assemble', ':distribution:zip:assemble']
-    startParameter.systemPropertiesArgs = ['build.snapshot': 'true']
+    startParameter.systemPropertiesArgs = ['build.snapshot': System.getProperty("build.snapshot") ?: "true"]
     doLast {
       List missing = [bwcDeb, bwcRpm, bwcZip].grep { file ->
         false == file.exists() }


### PR DESCRIPTION
When running the release tests, we set build.snapshot to false and this causes all version numbers to not have "-SNAPSHOT". This is true even for the tips of the branches (e.g., currently 5.6.6 on the 5.6 branch). Yet, if we do not set snapshot to false, then we would still be trying to find artifacts with "-SNAPSHOT" appended which would not have been build since build.snapshot is false. To fix this, we have to push build.snapshot into the version logic.

