### PR TITLE
Fixes error message in test when no types are present

### DIFF
--- a/core/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -265,7 +265,11 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
         ShapeBuilder shape = RandomShapeGenerator.createShapeWithin(random(), null, shapeType);
         final GeoShapeQueryBuilder queryBuilder = new GeoShapeQueryBuilder(STRING_FIELD_NAME, shape);
         QueryShardException e = expectThrows(QueryShardException.class, () -> queryBuilder.toQuery(createShardContext()));
-        assertThat(e.getMessage(), containsString("Field [mapped_string] is not of type [geo_shape] but of type [text]"));
+        if (getCurrentTypes().length == 0) {
+            assertThat(e.getMessage(), containsString("failed to find geo_shape field [" + STRING_FIELD_NAME + "]"));
+        } else {
+            assertThat(e.getMessage(), containsString("Field [mapped_string] is not of type [geo_shape] but of type [text]"));
+        }
     }
 
     public void testSerializationFailsUnlessFetched() throws IOException {


### PR DESCRIPTION
Before this change `GeoShapeQueryBuilderTest#testWrongFieldType()` failed with random seeds that meant no types were created in the mapping (e.g. [1]). This change modifies the expected error message in the case where no types are present so the field in the test doesn't exist)


[1] `gradle :core:test -Dtests.seed=CF0EC1DAD76AA1DC -Dtests.class=org.elasticsearch.index.query.GeoShapeQueryBuilderTests -Dtests.method="testWrongFieldType" -Dtests.security.manager=true -Dtests.locale=da-DK -Dtests.timezone=Africa/Abidjan`