### PR TITLE
Use forkOptions.javaHome instead of executable

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -414,7 +414,7 @@ class BuildPlugin implements Plugin<Project> {
                 File gradleJavaHome = Jvm.current().javaHome
                 // we fork because compiling lots of different classes in a shared jvm can eventually trigger GC overhead limitations
                 options.fork = true
-                options.forkOptions.executable = new File(project.javaHome, 'bin/javac')
+                options.forkOptions.javaHome = new File(project.javaHome)
                 options.forkOptions.memoryMaximumSize = "1g"
                 if (project.targetCompatibility >= JavaVersion.VERSION_1_8) {
                     // compile with compact 3 profile by default


### PR DESCRIPTION
Since Gradle 3.5 it is possible to specify the Java home in fork options
instead of the actual executable for JavaCompile. This makes it possible
to use the build cache to speed up Java compilation.