### PR TITLE
Clarify using supported LTS versions of the Java

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -4,6 +4,7 @@
 :lucene_version_path:   7_2_0
 :branch:                master
 :jdk:                   1.8.0_131
+:jdk_major:             8
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -16,7 +16,7 @@ running, including:
 == Supported platforms
 
 The matrix of officially supported operating systems and JVMs is available here:
-link:/support/matrix[Support Matrix].  Elasticsearch is tested on the listed
+link:/support/matrix[Support Matrix]. Elasticsearch is tested on the listed
 platforms, but it is possible that it will work on other platforms too.
 
 [float]
@@ -24,12 +24,15 @@ platforms, but it is possible that it will work on other platforms too.
 == Java (JVM) Version
 
 Elasticsearch is built using Java, and requires at least
-http://www.oracle.com/technetwork/java/javase/downloads/index.html[Java 8] in
-order to run. Only Oracle's Java and the OpenJDK are supported. The same JVM
+http://www.oracle.com/technetwork/java/javase/downloads/index.html[Java {jdk_major}]
+in order to run. Only Oracle's Java and the OpenJDK are supported. The same JVM
 version should be used on all Elasticsearch nodes and clients.
 
-We recommend installing Java version *{jdk} or later*. Elasticsearch will
-refuse to start if a known-bad version of Java is used.
+We recommend installing Java version *{jdk} or a later version in the Java
+{jdk_major} release series*. We recommend using a
+link:/support/matrix[supported]
+http://www.oracle.com/technetwork/java/eol-135779.html[LTS version of Java].
+Elasticsearch will refuse to start if a known-bad version of Java is used.
 
 The version of Java that Elasticsearch will use can be configured by setting
 the `JAVA_HOME` environment variable.


### PR DESCRIPTION
This commit clarifies that we recommended using supported LTS versions of Java as opposed to supporting a minimum version and any version above that.

