### PR TITLE
Java api clean-up : consistency for `shards_acknowledged` getters 

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/IndicesClientDocumentationIT.java
@@ -190,10 +190,10 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
             // tag::create-index-response
             boolean acknowledged = createIndexResponse.isAcknowledged(); // <1>
-            boolean shardsAcked = createIndexResponse.isShardsAcked(); // <2>
+            boolean shardsAcknowledged = createIndexResponse.isShardsAcknowledged(); // <2>
             // end::create-index-response
             assertTrue(acknowledged);
-            assertTrue(shardsAcked);
+            assertTrue(shardsAcknowledged);
         }
     }
 
@@ -202,7 +202,6 @@ public class IndicesClientDocumentationIT extends ESRestHighLevelClientTestCase 
 
         {
             CreateIndexRequest request = new CreateIndexRequest("twitter");
-
             // tag::create-index-execute-async
             client.indices().createIndexAsync(request, new ActionListener<CreateIndexResponse>() {
                 @Override

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -453,7 +453,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      * non-negative integer, up to the number of copies per shard (number of replicas + 1),
      * to wait for the desired amount of shard copies to become active before returning.
      * Index creation will only wait up until the timeout value for the number of shard copies
-     * to be active before returning.  Check {@link CreateIndexResponse#isShardsAcked()} to
+     * to be active before returning.  Check {@link CreateIndexResponse#isShardsAcknowledged()} to
      * determine if the requisite shard copies were all started before returning or timing out.
      *
      * @param waitForActiveShards number of active shard copies to wait on

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -254,7 +254,7 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<Create
      * non-negative integer, up to the number of copies per shard (number of replicas + 1),
      * to wait for the desired amount of shard copies to become active before returning.
      * Index creation will only wait up until the timeout value for the number of shard copies
-     * to be active before returning.  Check {@link CreateIndexResponse#isShardsAcked()} to
+     * to be active before returning.  Check {@link CreateIndexResponse#isShardsAcknowledged()} to
      * determine if the requisite shard copies were all started before returning or timing out.
      *
      * @param waitForActiveShards number of active shard copies to wait on

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
@@ -52,16 +52,16 @@ public class CreateIndexResponse extends AcknowledgedResponse implements ToXCont
         PARSER.declareField(constructorArg(), (parser, context) -> parser.text(), INDEX, ObjectParser.ValueType.STRING);
     }
 
-    private boolean shardsAcked;
+    private boolean shardsAcknowledged;
     private String index;
 
     protected CreateIndexResponse() {
     }
 
-    protected CreateIndexResponse(boolean acknowledged, boolean shardsAcked, String index) {
+    protected CreateIndexResponse(boolean acknowledged, boolean shardsAcknowledged, String index) {
         super(acknowledged);
-        assert acknowledged || shardsAcked == false; // if its not acknowledged, then shards acked should be false too
-        this.shardsAcked = shardsAcked;
+        assert acknowledged || shardsAcknowledged == false; // if its not acknowledged, then shardsAcknowledged should be false too
+        this.shardsAcknowledged = shardsAcknowledged;
         this.index = index;
     }
 
@@ -69,7 +69,7 @@ public class CreateIndexResponse extends AcknowledgedResponse implements ToXCont
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         readAcknowledged(in);
-        shardsAcked = in.readBoolean();
+        shardsAcknowledged = in.readBoolean();
         if (in.getVersion().onOrAfter(Version.V_5_6_0)) {
             index = in.readString();
         }
@@ -79,7 +79,7 @@ public class CreateIndexResponse extends AcknowledgedResponse implements ToXCont
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         writeAcknowledged(out);
-        out.writeBoolean(shardsAcked);
+        out.writeBoolean(shardsAcknowledged);
         if (out.getVersion().onOrAfter(Version.V_5_6_0)) {
             out.writeString(index);
         }
@@ -87,11 +87,23 @@ public class CreateIndexResponse extends AcknowledgedResponse implements ToXCont
 
     /**
      * Returns true if the requisite number of shards were started before
-     * returning from the index creation operation.  If {@link #isAcknowledged()}
+     * returning from the index creation operation. If {@link #isAcknowledged()}
+     * is false, then this also returns false.
+     * 
+     * @deprecated use {@link #isShardsAcknowledged()}
+     */
+    @Deprecated
+    public boolean isShardsAcked() {
+        return shardsAcknowledged;
+    }
+
+    /**
+     * Returns true if the requisite number of shards were started before
+     * returning from the index creation operation. If {@link #isAcknowledged()}
      * is false, then this also returns false.
      */
-    public boolean isShardsAcked() {
-        return shardsAcked;
+    public boolean isShardsAcknowledged() {
+        return shardsAcknowledged;
     }
 
     public String index() {
@@ -99,7 +111,7 @@ public class CreateIndexResponse extends AcknowledgedResponse implements ToXCont
     }
 
     public void addCustomFields(XContentBuilder builder) throws IOException {
-        builder.field(SHARDS_ACKNOWLEDGED.getPreferredName(), isShardsAcked());
+        builder.field(SHARDS_ACKNOWLEDGED.getPreferredName(), isShardsAcknowledged());
         builder.field(INDEX.getPreferredName(), index());
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -79,7 +79,7 @@ public class TransportCreateIndexAction extends TransportMasterNodeAction<Create
                 .waitForActiveShards(request.waitForActiveShards());
 
         createIndexService.createIndex(updateRequest, ActionListener.wrap(response ->
-            listener.onResponse(new CreateIndexResponse(response.isAcknowledged(), response.isShardsAcked(), indexName)),
+            listener.onResponse(new CreateIndexResponse(response.isAcknowledged(), response.isShardsAcknowledged(), indexName)),
             listener::onFailure));
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
@@ -202,7 +202,7 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
      * non-negative integer, up to the number of copies per shard (number of replicas + 1),
      * to wait for the desired amount of shard copies to become active before returning.
      * Index creation will only wait up until the timeout value for the number of shard copies
-     * to be active before returning.  Check {@link RolloverResponse#isShardsAcked()} to
+     * to be active before returning.  Check {@link RolloverResponse#isShardsAcknowledged()} to
      * determine if the requisite shard copies were all started before returning or timing out.
      *
      * @param waitForActiveShards number of active shard copies to wait on

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestBuilder.java
@@ -87,7 +87,7 @@ public class RolloverRequestBuilder extends MasterNodeOperationRequestBuilder<Ro
      * non-negative integer, up to the number of copies per shard (number of replicas + 1),
      * to wait for the desired amount of shard copies to become active before returning.
      * Index creation will only wait up until the timeout value for the number of shard copies
-     * to be active before returning.  Check {@link RolloverResponse#isShardsAcked()} to
+     * to be active before returning.  Check {@link RolloverResponse#isShardsAcknowledged()} to
      * determine if the requisite shard copies were all started before returning or timing out.
      *
      * @param waitForActiveShards number of active shard copies to wait on

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponse.java
@@ -48,19 +48,19 @@ public final class RolloverResponse extends ActionResponse implements ToXContent
     private boolean dryRun;
     private boolean rolledOver;
     private boolean acknowledged;
-    private boolean shardsAcked;
+    private boolean shardsAcknowledged;
 
     RolloverResponse() {
     }
 
     RolloverResponse(String oldIndex, String newIndex, Set<Condition.Result> conditionResults,
-                     boolean dryRun, boolean rolledOver, boolean acknowledged, boolean shardsAcked) {
+                     boolean dryRun, boolean rolledOver, boolean acknowledged, boolean shardsAcknowledged) {
         this.oldIndex = oldIndex;
         this.newIndex = newIndex;
         this.dryRun = dryRun;
         this.rolledOver = rolledOver;
         this.acknowledged = acknowledged;
-        this.shardsAcked = shardsAcked;
+        this.shardsAcknowledged = shardsAcknowledged;
         this.conditionStatus = conditionResults.stream()
             .map(result -> new AbstractMap.SimpleEntry<>(result.condition.toString(), result.matched))
             .collect(Collectors.toSet());
@@ -105,7 +105,7 @@ public final class RolloverResponse extends ActionResponse implements ToXContent
      * Returns true if the creation of the new rollover index and switching of the
      * alias to the newly created index was successful, and returns false otherwise.
      * If {@link #isDryRun()} is true, then this will also return false. If this
-     * returns false, then {@link #isShardsAcked()} will also return false.
+     * returns false, then {@link #isShardsAcknowledged()} will also return false.
      */
     public boolean isAcknowledged() {
         return acknowledged;
@@ -113,11 +113,23 @@ public final class RolloverResponse extends ActionResponse implements ToXContent
 
     /**
      * Returns true if the requisite number of shards were started in the newly
-     * created rollover index before returning.  If {@link #isAcknowledged()} is
+     * created rollover index before returning. If {@link #isAcknowledged()} is
+     * false, then this will also return false.
+     * 
+     * @deprecated use {@link #isShardsAcknowledged()}
+     */
+    @Deprecated
+    public boolean isShardsAcked() {
+        return shardsAcknowledged;
+    }
+
+    /**
+     * Returns true if the requisite number of shards were started in the newly
+     * created rollover index before returning. If {@link #isAcknowledged()} is
      * false, then this will also return false.
      */
-    public boolean isShardsAcked() {
-        return shardsAcked;
+    public boolean isShardsAcknowledged() {
+        return shardsAcknowledged;
     }
 
     @Override
@@ -136,7 +148,7 @@ public final class RolloverResponse extends ActionResponse implements ToXContent
         dryRun = in.readBoolean();
         rolledOver = in.readBoolean();
         acknowledged = in.readBoolean();
-        shardsAcked = in.readBoolean();
+        shardsAcknowledged = in.readBoolean();
     }
 
     @Override
@@ -152,7 +164,7 @@ public final class RolloverResponse extends ActionResponse implements ToXContent
         out.writeBoolean(dryRun);
         out.writeBoolean(rolledOver);
         out.writeBoolean(acknowledged);
-        out.writeBoolean(shardsAcked);
+        out.writeBoolean(shardsAcknowledged);
     }
 
     @Override
@@ -163,7 +175,7 @@ public final class RolloverResponse extends ActionResponse implements ToXContent
         builder.field(ROLLED_OVER, rolledOver);
         builder.field(DRY_RUN, dryRun);
         builder.field(ACKNOWLEDGED, acknowledged);
-        builder.field(SHARDS_ACKED, shardsAcked);
+        builder.field(SHARDS_ACKED, shardsAcknowledged);
         builder.startObject(CONDITIONS);
         for (Map.Entry<String, Boolean> entry : conditionStatus) {
             builder.field(entry.getKey(), entry.getValue());

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -140,8 +140,9 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                                         activeShardsObserver.waitForActiveShards(new String[]{rolloverIndexName},
                                             rolloverRequest.getCreateIndexRequest().waitForActiveShards(),
                                             rolloverRequest.masterNodeTimeout(),
-                                            isShardsAcked -> listener.onResponse(new RolloverResponse(sourceIndexName, rolloverIndexName,
-                                                                                    conditionResults, false, true, true, isShardsAcked)),
+                                            isShardsAcknowledged -> listener.onResponse(new RolloverResponse(
+                                                                sourceIndexName, rolloverIndexName, conditionResults, false, true, true,
+                                                                isShardsAcknowledged)),
                                             listener::onFailure);
                                     } else {
                                         listener.onResponse(new RolloverResponse(sourceIndexName, rolloverIndexName, conditionResults,

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
@@ -142,7 +142,7 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
      * non-negative integer, up to the number of copies per shard (number of replicas + 1),
      * to wait for the desired amount of shard copies to become active before returning.
      * Index creation will only wait up until the timeout value for the number of shard copies
-     * to be active before returning.  Check {@link ResizeResponse#isShardsAcked()} to
+     * to be active before returning.  Check {@link ResizeResponse#isShardsAcknowledged()} to
      * determine if the requisite shard copies were all started before returning or timing out.
      *
      * @param waitForActiveShards number of active shard copies to wait on

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestBuilder.java
@@ -56,7 +56,7 @@ public class ResizeRequestBuilder extends AcknowledgedRequestBuilder<ResizeReque
      * non-negative integer, up to the number of copies per shard (number of replicas + 1),
      * to wait for the desired amount of shard copies to become active before returning.
      * Index creation will only wait up until the timeout value for the number of shard copies
-     * to be active before returning.  Check {@link ResizeResponse#isShardsAcked()} to
+     * to be active before returning.  Check {@link ResizeResponse#isShardsAcknowledged()} to
      * determine if the requisite shard copies were all started before returning or timing out.
      *
      * @param waitForActiveShards number of active shard copies to wait on

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeResponse.java
@@ -25,7 +25,7 @@ public final class ResizeResponse extends CreateIndexResponse {
     ResizeResponse() {
     }
 
-    ResizeResponse(boolean acknowledged, boolean shardsAcked, String index) {
-        super(acknowledged, shardsAcked, index);
+    ResizeResponse(boolean acknowledged, boolean shardsAcknowledged, String index) {
+        super(acknowledged, shardsAcknowledged, index);
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -109,8 +109,8 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
                 createIndexService.createIndex(
                     updateRequest,
                     ActionListener.wrap(response ->
-                            listener.onResponse(new ResizeResponse(response.isAcknowledged(), response.isShardsAcked(),
-                                updateRequest.index())), listener::onFailure
+                            listener.onResponse(new ResizeResponse(response.isAcknowledged(), response.isShardsAcknowledged(),
+                                    updateRequest.index())), listener::onFailure
                     )
                 );
             }

--- a/core/src/main/java/org/elasticsearch/cluster/ack/CreateIndexClusterStateUpdateResponse.java
+++ b/core/src/main/java/org/elasticsearch/cluster/ack/CreateIndexClusterStateUpdateResponse.java
@@ -24,17 +24,24 @@ package org.elasticsearch.cluster.ack;
  */
 public class CreateIndexClusterStateUpdateResponse extends ClusterStateUpdateResponse {
 
-    private final boolean shardsAcked;
+    private final boolean shardsAcknowledged;
 
-    public CreateIndexClusterStateUpdateResponse(boolean acknowledged, boolean shardsAcked) {
+    public CreateIndexClusterStateUpdateResponse(boolean acknowledged, boolean shardsAcknowledged) {
         super(acknowledged);
-        this.shardsAcked = shardsAcked;
+        this.shardsAcknowledged = shardsAcknowledged;
     }
 
     /**
      * Returns whether the requisite number of shard copies started before the completion of the operation.
+     * 
+     * @deprecated use {@link #isShardsAcknowledged()}
      */
+    @Deprecated
     public boolean isShardsAcked() {
-        return shardsAcked;
+        return shardsAcknowledged;
+    }
+    
+    public boolean isShardsAcknowledged() {
+        return shardsAcknowledged;
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -191,9 +191,9 @@ public class MetaDataCreateIndexService extends AbstractComponent {
      * before sending the response on the listener. If the index creation was successfully applied on
      * the cluster state, then {@link CreateIndexClusterStateUpdateResponse#isAcknowledged()} will return
      * true, otherwise it will return false and no waiting will occur for started shards
-     * ({@link CreateIndexClusterStateUpdateResponse#isShardsAcked()} will also be false).  If the index
+     * ({@link CreateIndexClusterStateUpdateResponse#isShardsAcknowledged()} will also be false).  If the index
      * creation in the cluster state was successful and the requisite shard copies were started before
-     * the timeout, then {@link CreateIndexClusterStateUpdateResponse#isShardsAcked()} will
+     * the timeout, then {@link CreateIndexClusterStateUpdateResponse#isShardsAcknowledged()} will
      * return true, otherwise if the operation timed out, then it will return false.
      *
      * @param request the index creation cluster state update request
@@ -204,12 +204,12 @@ public class MetaDataCreateIndexService extends AbstractComponent {
         onlyCreateIndex(request, ActionListener.wrap(response -> {
             if (response.isAcknowledged()) {
                 activeShardsObserver.waitForActiveShards(new String[]{request.index()}, request.waitForActiveShards(), request.ackTimeout(),
-                    shardsAcked -> {
-                        if (shardsAcked == false) {
+                    shardsAcknowledged -> {
+                        if (shardsAcknowledged == false) {
                             logger.debug("[{}] index created, but the operation timed out while waiting for " +
                                              "enough shards to be started.", request.index());
                         }
-                        listener.onResponse(new CreateIndexClusterStateUpdateResponse(response.isAcknowledged(), shardsAcked));
+                        listener.onResponse(new CreateIndexClusterStateUpdateResponse(response.isAcknowledged(), shardsAcknowledged));
                     }, listener::onFailure);
             } else {
                 listener.onResponse(new CreateIndexClusterStateUpdateResponse(false, false));

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -308,14 +308,16 @@ public class CreateIndexIT extends ESIntegTestCase {
                        .put(settings)
                        .put(SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), "all")
                        .build();
-        assertFalse(client().admin().indices().prepareCreate("test-idx-2").setSettings(settings).setTimeout("100ms").get().isShardsAcked());
+        assertFalse(client().admin().indices().prepareCreate("test-idx-2").setSettings(settings).setTimeout("100ms").get()
+                .isShardsAcknowledged());
 
         // the numeric equivalent of all should also fail
         settings = Settings.builder()
                        .put(settings)
                        .put(SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), Integer.toString(numReplicas + 1))
                        .build();
-        assertFalse(client().admin().indices().prepareCreate("test-idx-3").setSettings(settings).setTimeout("100ms").get().isShardsAcked());
+        assertFalse(client().admin().indices().prepareCreate("test-idx-3").setSettings(settings).setTimeout("100ms").get()
+                .isShardsAcknowledged());
     }
 
     public void testInvalidPartitionSize() {

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponseTests.java
@@ -44,7 +44,7 @@ public class CreateIndexResponseTests extends ESTestCase {
             try (StreamInput in = output.bytes().streamInput()) {
                 CreateIndexResponse serialized = new CreateIndexResponse();
                 serialized.readFrom(in);
-                assertEquals(response.isShardsAcked(), serialized.isShardsAcked());
+                assertEquals(response.isShardsAcknowledged(), serialized.isShardsAcknowledged());
                 assertEquals(response.isAcknowledged(), serialized.isAcknowledged());
                 assertEquals(response.index(), serialized.index());
             }
@@ -63,7 +63,7 @@ public class CreateIndexResponseTests extends ESTestCase {
                 in.setVersion(oldVersion);
                 CreateIndexResponse serialized = new CreateIndexResponse();
                 serialized.readFrom(in);
-                assertEquals(response.isShardsAcked(), serialized.isShardsAcked());
+                assertEquals(response.isShardsAcknowledged(), serialized.isShardsAcknowledged());
                 assertEquals(response.isAcknowledged(), serialized.isAcknowledged());
                 assertNull(serialized.index());
             }
@@ -110,7 +110,7 @@ public class CreateIndexResponseTests extends ESTestCase {
         }
 
         assertEquals(createIndexResponse.index(), parsedCreateIndexResponse.index());
-        assertEquals(createIndexResponse.isShardsAcked(), parsedCreateIndexResponse.isShardsAcked());
+        assertEquals(createIndexResponse.isShardsAcknowledged(), parsedCreateIndexResponse.isShardsAcknowledged());
         assertEquals(createIndexResponse.isAcknowledged(), parsedCreateIndexResponse.isAcknowledged());
     }
 
@@ -119,9 +119,9 @@ public class CreateIndexResponseTests extends ESTestCase {
      */
     private static CreateIndexResponse createTestItem() throws IOException {
         boolean acknowledged = randomBoolean();
-        boolean shardsAcked = acknowledged && randomBoolean();
+        boolean shardsAcknowledged = acknowledged && randomBoolean();
         String index = randomAlphaOfLength(5);
 
-        return new CreateIndexResponse(acknowledged, shardsAcked, index);
+        return new CreateIndexResponse(acknowledged, shardsAcknowledged, index);
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/admin/indices/open/OpenIndexResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/admin/indices/open/OpenIndexResponseTests.java
@@ -57,7 +57,7 @@ public class OpenIndexResponseTests extends ESTestCase {
     
     private static OpenIndexResponse createTestItem() {
         boolean acknowledged = randomBoolean();
-        boolean shardsAcked = acknowledged && randomBoolean();
-        return new OpenIndexResponse(acknowledged, shardsAcked);
+        boolean shardsAcknowledged = acknowledged && randomBoolean();
+        return new OpenIndexResponse(acknowledged, shardsAcknowledged);
     }
 }

--- a/core/src/test/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
+++ b/core/src/test/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
@@ -51,7 +51,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
                        .setWaitForActiveShards(randomBoolean() ? ActiveShardCount.from(1) : ActiveShardCount.ALL)
                        .setTimeout("100ms")
                        .get()
-                       .isShardsAcked());
+                       .isShardsAcknowledged());
         waitForIndexCreationToComplete(indexName);
     }
 
@@ -86,7 +86,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
                        .setWaitForActiveShards(randomIntBetween(numDataNodes + 1, numReplicas + 1))
                        .setTimeout("100ms")
                        .get()
-                       .isShardsAcked());
+                       .isShardsAcknowledged());
         waitForIndexCreationToComplete(indexName);
     }
 
@@ -116,7 +116,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
                        .setWaitForActiveShards(ActiveShardCount.ALL)
                        .setTimeout("100ms")
                        .get()
-                       .isShardsAcked());
+                       .isShardsAcknowledged());
         waitForIndexCreationToComplete(indexName);
         if (client().admin().indices().prepareExists(indexName).get().isExists()) {
             client().admin().indices().prepareDelete(indexName).get();

--- a/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/core/src/test/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -128,7 +128,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
                 .setSettings(settings)
                 .addMapping("type", mapping, XContentType.JSON).execute().actionGet();
         final int numDocs;
-        if (response.isShardsAcked() == false) {
+        if (response.isShardsAcknowledged() == false) {
             /* some seeds just won't let you create the index at all and we enter a ping-pong mode
              * trying one node after another etc. that is ok but we need to make sure we don't wait
              * forever when indexing documents so we set numDocs = 1 and expect all shards to fail

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -143,7 +143,7 @@ public class ElasticsearchAssertions {
         assertThat(response.getClass().getSimpleName() + " failed - not acked", response.isAcknowledged(), equalTo(true));
         assertVersionSerializable(response);
         assertTrue(response.getClass().getSimpleName() + " failed - index creation acked but not all shards were started",
-            response.isShardsAcked());
+            response.isShardsAcknowledged());
     }
 
     /**


### PR DESCRIPTION
Several responses include the `shards_acknowledged` flag ( indicating whether the requisite number of shard copies started before the completion of the operation ) and there are two different getters used : `isShardsAcknowledged()` and `isShardsAcked()`

This PR deprecates the `isShardsAcked` in favour of `isShardsAcknowledged`.

Closes #27784