### PR TITLE
Remove potential nio selector leak

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/ESSelector.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/ESSelector.java
@@ -177,8 +177,11 @@ public abstract class ESSelector implements Closeable {
                 try {
                     exitedLoop.await();
                 } catch (InterruptedException e) {
-                    eventHandler.uncaughtException(e);
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("CountDownLatch got interrupted", e);
                 }
+            } else if (selector.isOpen()) {
+                selector.close();
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/ESSelector.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/ESSelector.java
@@ -178,7 +178,7 @@ public abstract class ESSelector implements Closeable {
                     exitedLoop.await();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    throw new IllegalStateException("CountDownLatch got interrupted", e);
+                    throw new IllegalStateException("Thread was interrupted while waiting for selector to close", e);
                 }
             } else if (selector.isOpen()) {
                 selector.close();

--- a/test/framework/src/test/java/org/elasticsearch/transport/nio/ESSelectorTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/nio/ESSelectorTests.java
@@ -81,6 +81,12 @@ public class ESSelectorTests extends ESTestCase {
         verify(handler).selectException(ioException);
     }
 
+    public void testSelectorClosedIfOpenAndEventLoopNotRunning() throws IOException {
+        when(rawSelector.isOpen()).thenReturn(true);
+        selector.close();
+        verify(rawSelector).close();
+    }
+
     private static class TestSelector extends ESSelector {
 
         TestSelector(EventHandler eventHandler, Selector selector) throws IOException {


### PR DESCRIPTION
When an `ESSelector` is created an underlying nio selector is opened. 
This selector is closed by the event loop after `close` has been 
signaled by another thread.

However, there is a possibility that an `ESSelector` is created and 
some exception in the startup process prevents it from ever being 
started (however, `close`` will still be called). The allows the 
selector to leak.

This commit addresses this issue by having the signaling thread close
the selector if the event loop is not running when close is signaled.