### PR TITLE
Breaking change for /_nodes/settings?flat_settings

### DIFF
--- a/docs/reference/release-notes/6.1.0.asciidoc
+++ b/docs/reference/release-notes/6.1.0.asciidoc
@@ -12,6 +12,7 @@ Network::
 
 REST::
 * Standardize underscore requirements in parameters {pull}27414[#27414] (issues: {issue}26886[#26886], {issue}27040[#27040])
+* `/_nodes/settings?flat_settings` returns `"settings"` key/value values as `string` and `array` values {pull}26878[#26878] (issue: {issue}27805[#27805])
 
 Scroll::
 * Fail queries with scroll that explicitely set request_cache {pull}27342[#27342]


### PR DESCRIPTION
Relates #27805

Prior to Elasticsearch 6.1.0, `GET /_nodes/http,settings?flat_settings` returned settings as an object where all property values were strings. In Elasticsearch 6.1.0, settings is returned as an object where proprty values can be string and arrays. This commit adds this as a breaking change to the release notes in order to notify users.