### PR TITLE
Remove `operationThreaded` from Java API

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardOperationRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardOperationRequestBuilder.java
@@ -39,13 +39,4 @@ public abstract class SingleShardOperationRequestBuilder<Request extends SingleS
         request.index(index);
         return (RequestBuilder) this;
     }
-
-    /**
-     * Controls if the operation will be executed on a separate thread when executed locally.
-     */
-    @SuppressWarnings("unchecked")
-    public final RequestBuilder setOperationThreaded(boolean threadedOperation) {
-        request.operationThreaded(threadedOperation);
-        return (RequestBuilder) this;
-    }
 }

--- a/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
@@ -94,22 +94,6 @@ public abstract class SingleShardRequest<Request extends SingleShardRequest<Requ
         return INDICES_OPTIONS;
     }
 
-    /**
-     * Controls if the operation will be executed on a separate thread when executed locally.
-     */
-    public boolean operationThreaded() {
-        return threadedOperation;
-    }
-
-    /**
-     * Controls if the operation will be executed on a separate thread when executed locally.
-     */
-    @SuppressWarnings("unchecked")
-    public final Request operationThreaded(boolean threadedOperation) {
-        this.threadedOperation = threadedOperation;
-        return (Request) this;
-    }
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);

--- a/core/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/core/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -277,7 +277,6 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
         @Override
         public void messageReceived(Request request, final TransportChannel channel) throws Exception {
             // if we have a local operation, execute it on a thread since we don't spawn
-            request.operationThreaded(true);
             execute(request, new ActionListener<Response>() {
                 @Override
                 public void onResponse(Response result) {

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -383,7 +383,6 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
             throw new IllegalStateException("JTS not available");
         }
         getRequest.preference("_local");
-        getRequest.operationThreaded(false);
         client.get(getRequest, new ActionListener<GetResponse>(){
 
             @Override

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
@@ -56,7 +56,6 @@ public class RestGetAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         final GetRequest getRequest = new GetRequest(request.param("index"), request.param("type"), request.param("id"));
-        getRequest.operationThreaded(true);
         getRequest.refresh(request.paramAsBoolean("refresh", getRequest.refresh()));
         getRequest.routing(request.param("routing"));
         getRequest.parent(request.param("parent"));

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestGetSourceAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestGetSourceAction.java
@@ -59,7 +59,6 @@ public class RestGetSourceAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         final GetRequest getRequest = new GetRequest(request.param("index"), request.param("type"), request.param("id"));
-        getRequest.operationThreaded(true);
         getRequest.refresh(request.paramAsBoolean("refresh", getRequest.refresh()));
         getRequest.routing(request.param("routing"));
         getRequest.parent(request.param("parent"));

--- a/core/src/test/java/org/elasticsearch/document/DocumentActionsIT.java
+++ b/core/src/test/java/org/elasticsearch/document/DocumentActionsIT.java
@@ -95,11 +95,11 @@ public class DocumentActionsIT extends ESIntegTestCase {
 
         logger.info("Get [type1/1]");
         for (int i = 0; i < 5; i++) {
-            getResult = client().prepareGet("test", "type1", "1").setOperationThreaded(false).execute().actionGet();
+            getResult = client().prepareGet("test", "type1", "1").execute().actionGet();
             assertThat(getResult.getIndex(), equalTo(getConcreteIndexName()));
             assertThat("cycle #" + i, getResult.getSourceAsString(), equalTo(source("1", "test").string()));
             assertThat("cycle(map) #" + i, (String) getResult.getSourceAsMap().get("name"), equalTo("test"));
-            getResult = client().get(getRequest("test").type("type1").id("1").operationThreaded(true)).actionGet();
+            getResult = client().get(getRequest("test").type("type1").id("1")).actionGet();
             assertThat("cycle #" + i, getResult.getSourceAsString(), equalTo(source("1", "test").string()));
             assertThat(getResult.getIndex(), equalTo(getConcreteIndexName()));
         }

--- a/core/src/test/java/org/elasticsearch/recovery/SimpleRecoveryIT.java
+++ b/core/src/test/java/org/elasticsearch/recovery/SimpleRecoveryIT.java
@@ -72,13 +72,13 @@ public class SimpleRecoveryIT extends ESIntegTestCase {
         GetResponse getResult;
 
         for (int i = 0; i < 5; i++) {
-            getResult = client().get(getRequest("test").type("type1").id("1").operationThreaded(false)).actionGet();
+            getResult = client().get(getRequest("test").type("type1").id("1")).actionGet();
             assertThat(getResult.getSourceAsString(), equalTo(source("1", "test")));
-            getResult = client().get(getRequest("test").type("type1").id("1").operationThreaded(false)).actionGet();
+            getResult = client().get(getRequest("test").type("type1").id("1")).actionGet();
             assertThat(getResult.getSourceAsString(), equalTo(source("1", "test")));
-            getResult = client().get(getRequest("test").type("type1").id("2").operationThreaded(true)).actionGet();
+            getResult = client().get(getRequest("test").type("type1").id("2")).actionGet();
             assertThat(getResult.getSourceAsString(), equalTo(source("2", "test")));
-            getResult = client().get(getRequest("test").type("type1").id("2").operationThreaded(true)).actionGet();
+            getResult = client().get(getRequest("test").type("type1").id("2")).actionGet();
             assertThat(getResult.getSourceAsString(), equalTo(source("2", "test")));
         }
 
@@ -95,11 +95,11 @@ public class SimpleRecoveryIT extends ESIntegTestCase {
             assertThat(getResult.getSourceAsString(), equalTo(source("1", "test")));
             getResult = client().get(getRequest("test").type("type1").id("1")).actionGet();
             assertThat(getResult.getSourceAsString(), equalTo(source("1", "test")));
-            getResult = client().get(getRequest("test").type("type1").id("2").operationThreaded(true)).actionGet();
+            getResult = client().get(getRequest("test").type("type1").id("2")).actionGet();
             assertThat(getResult.getSourceAsString(), equalTo(source("2", "test")));
-            getResult = client().get(getRequest("test").type("type1").id("2").operationThreaded(true)).actionGet();
+            getResult = client().get(getRequest("test").type("type1").id("2")).actionGet();
             assertThat(getResult.getSourceAsString(), equalTo(source("2", "test")));
-            getResult = client().get(getRequest("test").type("type1").id("2").operationThreaded(true)).actionGet();
+            getResult = client().get(getRequest("test").type("type1").id("2")).actionGet();
             assertThat(getResult.getSourceAsString(), equalTo(source("2", "test")));
         }
     }

--- a/docs/java-api/docs/delete.asciidoc
+++ b/docs/java-api/docs/delete.asciidoc
@@ -14,28 +14,6 @@ DeleteResponse response = client.prepareDelete("twitter", "tweet", "1").get();
 For more information on the delete operation, check out the
 {ref}/docs-delete.html[delete API] docs.
 
-
-[[java-docs-delete-thread]]
-==== Operation Threading
-
-The delete API allows to set the threading model the operation will be
-performed when the actual execution of the API is performed on the same
-node (the API is executed on a shard that is allocated on the same
-server).
-
-The options are to execute the operation on a different thread, or to
-execute it on the calling thread (note that the API is still async). By
-default, `operationThreaded` is set to `true` which means the operation
-is executed on a different thread. Here is an example that sets it to
-`false`:
-
-[source,java]
---------------------------------------------------
-DeleteResponse response = client.prepareDelete("twitter", "tweet", "1")
-        .setOperationThreaded(false)
-        .get();
---------------------------------------------------
-
 [[java-docs-delete-by-query]]
 === Delete By Query API
 

--- a/docs/java-api/docs/get.asciidoc
+++ b/docs/java-api/docs/get.asciidoc
@@ -12,25 +12,3 @@ GetResponse response = client.prepareGet("twitter", "tweet", "1").get();
 
 For more information on the get operation, check out the REST
 {ref}/docs-get.html[get] docs.
-
-
-[[java-docs-get-thread]]
-==== Operation Threading
-
-The get API allows to set the threading model the operation will be
-performed when the actual execution of the API is performed on the same
-node (the API is executed on a shard that is allocated on the same
-server).
-
-The options are to execute the operation on a different thread, or to
-execute it on the calling thread (note that the API is still async). By
-default, `operationThreaded` is set to `true` which means the operation
-is executed on a different thread. Here is an example that sets it to
-`false`:
-
-[source,java]
---------------------------------------------------
-GetResponse response = client.prepareGet("twitter", "tweet", "1")
-        .setOperationThreaded(false)
-        .get();
---------------------------------------------------

--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -163,16 +163,3 @@ RestStatus status = response.status();
 For more information on the index operation, check out the REST
 {ref}/docs-index_.html[index] docs.
 
-
-[[java-docs-index-thread]]
-==== Operation Threading
-
-The index API allows one to set the threading model the operation will be
-performed when the actual execution of the API is performed on the same
-node (the API is executed on a shard that is allocated on the same
-server).
-
-The options are to execute the operation on a different thread, or to
-execute it on the calling thread (note that the API is still asynchronous). By
-default, `operationThreaded` is set to `true` which means the operation
-is executed on a different thread.


### PR DESCRIPTION
This option is completely unused. Some places set it but we never read
the value neither respect it.
