### PR TITLE
Fix publication of elasticsearch-cli to Maven

### DIFF
--- a/core/cli/build.gradle
+++ b/core/cli/build.gradle
@@ -20,6 +20,17 @@
 import org.elasticsearch.gradle.precommit.PrecommitTasks
 
 apply plugin: 'elasticsearch.build'
+apply plugin: 'nebula.optional-base'
+apply plugin: 'nebula.maven-base-publish'
+apply plugin: 'nebula.maven-scm'
+
+publishing {
+    publications {
+        nebula {
+            artifactId 'elasticsearch-cli'
+        }
+    }
+}
 
 archivesBaseName = 'elasticsearch-cli'
 


### PR DESCRIPTION
This commit addresses the publication of the elasticsearch-cli to Maven. For now for simplicity we publish this to Maven so that it is available as a transitive dependency for any artifacts that depend on the core elasticsearch artifact. It is possible that in the future we can simply exclude this dependency but for now this is the safest and simplest approach that can happen in a patch release.

Relates #27114, relates #27806

