### PR TITLE
Using DocValueFormat::parseBytesRef for parsing missing value parameter

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/core/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -56,7 +56,7 @@ public interface DocValueFormat extends NamedWriteable {
      *  such as the {@code long}, {@code double} or {@code date} fields. */
     String format(double value);
 
-    /** Format a double value. This is used by terms aggregations to format
+    /** Format a binary value. This is used by terms aggregations to format
      *  keys for fields that use binary doc value representations such as the
      *  {@code keyword} and {@code ip} fields. */
     String format(BytesRef value);

--- a/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -252,7 +252,7 @@ public class ValuesSourceConfig<VS extends ValuesSource> {
         }
 
         if (vs instanceof ValuesSource.Bytes) {
-            final BytesRef missing = new BytesRef(missing().toString());
+            final BytesRef missing = format.parseBytesRef(missing().toString());
             if (vs instanceof ValuesSource.Bytes.WithOrdinals) {
                 return (VS) MissingValues.replaceMissing((ValuesSource.Bytes.WithOrdinals) vs, missing);
             } else {

--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/IpTermsIT.java
@@ -113,4 +113,29 @@ public class IpTermsIT extends AbstractTermsTestCase {
         assertEquals("2001:db8::2:1", bucket2.getKey());
         assertEquals("2001:db8::2:1", bucket2.getKeyAsString());
     }
+
+    public void testMissingValue() throws Exception {
+        assertAcked(prepareCreate("index").addMapping("type", "ip", "type=ip"));
+        indexRandom(true,
+            client().prepareIndex("index", "type", "1").setSource("ip", "192.168.1.7"),
+            client().prepareIndex("index", "type", "2").setSource("ip", "192.168.1.7"),
+            client().prepareIndex("index", "type", "3").setSource("ip", "127.0.0.1"),
+            client().prepareIndex("index", "type", "4").setSource("not_ip", "something"));
+        SearchResponse response = client().prepareSearch("index").addAggregation(AggregationBuilders
+            .terms("my_terms").field("ip").missing("127.0.0.1").executionHint(randomExecutionHint())).get();
+
+        assertSearchResponse(response);
+        Terms terms = response.getAggregations().get("my_terms");
+        assertEquals(2, terms.getBuckets().size());
+
+        Terms.Bucket bucket1 = terms.getBuckets().get(0);
+        assertEquals(2, bucket1.getDocCount());
+        assertEquals("127.0.0.1", bucket1.getKey());
+        assertEquals("127.0.0.1", bucket1.getKeyAsString());
+
+        Terms.Bucket bucket2 = terms.getBuckets().get(1);
+        assertEquals(2, bucket2.getDocCount());
+        assertEquals("192.168.1.7", bucket2.getKey());
+        assertEquals("192.168.1.7", bucket2.getKeyAsString());
+    }
 }


### PR DESCRIPTION
of fields that use binary representation

Closes #27788