### PR TITLE
[TEST] Make randomNonNegativeLong() draw from a uniform distribution

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -509,12 +509,12 @@ public abstract class ESTestCase extends LuceneTestCase {
         return random().nextInt();
     }
 
+    /**
+     * @return a <code>long</code> between <code>0</code> and <code>Long.MAX_VALUE</code> (inclusive) chosen uniformly at random.
+     */
     public static long randomNonNegativeLong() {
-        long randomLong;
-        do {
-            randomLong = randomLong();
-        } while (randomLong == Long.MIN_VALUE);
-        return Math.abs(randomLong);
+        long randomLong = randomLong();
+        return randomLong == Long.MIN_VALUE ? 0 : Math.abs(randomLong);
     }
 
     public static float randomFloat() {


### PR DESCRIPTION
Currently `randomNonNegativeLong()` returns `0` half as often as any positive `long`, but random number generators are typically expected to return uniformly-distributed values unless otherwise specified. This fixes this issue by mapping `Long.MIN_VALUE` directly onto `0` rather than resampling.

Admittedly, any specific value is _extraordinarily_ unlikely, so the bias that this PR fixes is undetectable in all practical senses. I doubt we've ever been round this loop more than once.