### PR TITLE
While defining IAM console custom policy for s3 buckets we have to me…

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -216,6 +216,7 @@ IAM in conjunction with pre-existing S3 buckets. Here is an example policy which
         "s3:ListBucketVersions"
       ],
       "Effect": "Allow",
+      "Principal":"CanonicalUser:3674589dc9857ed3b33287d5c40c1c9b9679ec422f92946b30c0428bfc03d3e7",
       "Resource": [
         "arn:aws:s3:::snaps.example.com"
       ]
@@ -229,6 +230,7 @@ IAM in conjunction with pre-existing S3 buckets. Here is an example policy which
         "s3:ListMultipartUploadParts"
       ],
       "Effect": "Allow",
+      "Principal":"CanonicalUser:3674589dc9857ed3b33287d5c40c1c9b9679ec422f92946b30c0428bfc03d3e7",
       "Resource": [
         "arn:aws:s3:::snaps.example.com/*"
       ]


### PR DESCRIPTION
…ntion a Principal field.

Whatever example policy is mentioned there, in that a required principal field is missing.so while defining same s3 custom policy in AWS it is prompting error like Principal field is missing and for that purpose we do have to change the required example.
