### PR TITLE
Fixes DocStats to properly deal with shards that report -1 index size

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/shard/DocsStats.java
+++ b/core/src/main/java/org/elasticsearch/index/shard/DocsStats.java
@@ -49,7 +49,11 @@ public class DocsStats implements Streamable, ToXContentFragment {
         if (other == null) {
             return;
         }
-        this.totalSizeInBytes += other.totalSizeInBytes;
+        if (this.totalSizeInBytes == -1) {
+            this.totalSizeInBytes = other.totalSizeInBytes;
+        } else if (other.totalSizeInBytes != -1) {
+            this.totalSizeInBytes += other.totalSizeInBytes;
+        }
         this.count += other.count;
         this.deleted += other.deleted;
     }

--- a/core/src/test/java/org/elasticsearch/index/shard/DocsStatsTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/DocsStatsTests.java
@@ -41,6 +41,24 @@ public class DocsStatsTests extends ESTestCase {
         assertThat(stats.getTotalSizeInBytes(), equalTo(600L));
         assertThat(stats.getAverageSizeInBytes(), equalTo(12L));
     }
+    
+    public void testUninitialisedShards() {
+        DocsStats stats = new DocsStats(0, 0, -1);
+        assertThat(stats.getTotalSizeInBytes(), equalTo(-1L));
+        assertThat(stats.getAverageSizeInBytes(), equalTo(0L));
+        stats.add(new DocsStats(0, 0, -1));
+        assertThat(stats.getTotalSizeInBytes(), equalTo(-1L));
+        assertThat(stats.getAverageSizeInBytes(), equalTo(0L));
+        stats.add(new DocsStats(1, 0, 10));
+        assertThat(stats.getTotalSizeInBytes(), equalTo(10L));
+        assertThat(stats.getAverageSizeInBytes(), equalTo(10L));
+        stats.add(new DocsStats(0, 0, -1));
+        assertThat(stats.getTotalSizeInBytes(), equalTo(10L));
+        assertThat(stats.getAverageSizeInBytes(), equalTo(10L));
+        stats.add(new DocsStats(1, 0, 20));
+        assertThat(stats.getTotalSizeInBytes(), equalTo(30L));
+        assertThat(stats.getAverageSizeInBytes(), equalTo(15L));
+    }
 
     public void testSerialize() throws Exception {
         DocsStats originalStats = new DocsStats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yml
@@ -1,8 +1,6 @@
 ---
 "Rollover index via API":
-  - skip:
-         version: "all"
-         reason:  "AwaitsFix https://github.com/elastic/elasticsearch/pull/27863"
+
 
   # create index with alias
   - do:
@@ -80,8 +78,8 @@
 ---
 "Rollover no condition matched":
   - skip:
-        version: "all"
-        reason:  "AwaitsFix https://github.com/elastic/elasticsearch/pull/27863"
+        version: " - 5.0.0"
+        reason:  bug fixed in 5.0.1
 
   # create index with alias
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/20_max_doc_condition.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/20_max_doc_condition.yml
@@ -1,8 +1,8 @@
 ---
 "Max docs rollover conditions matches only primary shards":
   - skip:
-        version: "all"
-        reason:  "AwaitsFix https://github.com/elastic/elasticsearch/pull/27863"
+        version: "- 5.4.1"
+        reason:  "matching docs changed from all shards to primary shards"
 
   # create index with alias and replica
   - do:


### PR DESCRIPTION
Previously to this change when DocStats are added together (for example when adding the index size of all primary shards for an index)  we naively added the `totalSizeInBytes` together. This worked most of the time but not when the index size on one or multiple shards was reported to be `-1` (no value).

This change improves the logic by considering if the current value or the value to be added is `-1`:
* If the current and new value are both `-1` the value remains at `-1`
* If the current value is `-1` and the new value is not `-1`, current value is changed to be equal to the new value
* If the current value is not `-1` and the new value is `-1` the new value is ignored and the current value is not changed
* If both the current and new values are not `-1` the current value is changed to be equal to the sum of the current and new values.

The change also re-enables the failing rollover YAML test that was failing due to this bug.