### PR TITLE
Reduce BWC testing against unreleased versions

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -76,6 +76,7 @@ public class VersionUtils {
         final List<Version> unreleased = new ArrayList<>();
         unreleased.add(current);
         Version prevConsideredVersion = current;
+        boolean foundUnreleasedVersionInCurrentConsideredMajor = false;
 
         for (int i = versions.size() - 1; i >= 0; i--) {
             Version currConsideredVersion = versions.get(i);
@@ -91,12 +92,23 @@ public class VersionUtils {
                  * considered a version of the form 5.n.m (m>0), so this entire branch
                  * is unreleased, so carry on looking for a branch containing releases.
                  */
-            } else if (currConsideredVersion.major != prevConsideredVersion.major
-                || currConsideredVersion.minor != prevConsideredVersion.minor) {
-                /* Have moved to the end of a new minor branch, so this is
-                 * an unreleased version. */
-                unreleased.add(currConsideredVersion);
-                versions.remove(i);
+            } else {
+                if (currConsideredVersion.major != prevConsideredVersion.major) {
+                    foundUnreleasedVersionInCurrentConsideredMajor = false;
+                }
+
+                if (currConsideredVersion.major != prevConsideredVersion.major
+                    || currConsideredVersion.minor != prevConsideredVersion.minor) {
+                    /* Have moved to the end of a new minor branch, so this is
+                     * an unreleased version. */
+
+                    if (foundUnreleasedVersionInCurrentConsideredMajor == false) {
+                        unreleased.add(currConsideredVersion);
+                        foundUnreleasedVersionInCurrentConsideredMajor = true;
+                    }
+
+                    versions.remove(i);
+                }
             }
             prevConsideredVersion = currConsideredVersion;
 

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -250,7 +250,7 @@ public class VersionUtilsTests extends ESTestCase {
             TestNewMinorBranchIn6x.V_6_0_0_alpha1, TestNewMinorBranchIn6x.V_6_0_0_alpha2,
             TestNewMinorBranchIn6x.V_6_0_0_beta1, TestNewMinorBranchIn6x.V_6_0_0_beta2,
             TestNewMinorBranchIn6x.V_6_0_0, TestNewMinorBranchIn6x.V_6_1_0, TestNewMinorBranchIn6x.V_6_1_1), released);
-        assertEquals(Arrays.asList(TestNewMinorBranchIn6x.V_5_6_2, TestNewMinorBranchIn6x.V_6_0_1,
+        assertEquals(Arrays.asList(TestNewMinorBranchIn6x.V_5_6_2,
             TestNewMinorBranchIn6x.V_6_1_2, TestNewMinorBranchIn6x.V_6_2_0), unreleased);
     }
 


### PR DESCRIPTION
This reduces the number of unreleased versions against which to perform BWC testing down to at most 2: the latest in the previous major series, and the latest in the previous minor series (if this exists). This was discussed in the core/infra team sync on 2017-11-29.

This is a step towards removing the list of branch names in `settings.gradle` here: https://github.com/elastic/elasticsearch/blob/9cd69e7ec196b6fa3ad713414b8fe538c8bdd57c/settings.gradle#L101-L104