### PR TITLE
Use full profile on JDK 10 builds

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -408,7 +408,11 @@ class BuildPlugin implements Plugin<Project> {
 
     /** Adds compiler settings to the project */
     static void configureCompile(Project project) {
-        project.ext.compactProfile = 'compact3'
+        if (project.javaVersion < JavaVersion.VERSION_1_10) {
+            project.ext.compactProfile = 'compact3'
+        } else {
+            project.ext.compactProfile = 'full'
+        }
         project.afterEvaluate {
             project.tasks.withType(JavaCompile) {
                 File gradleJavaHome = Jvm.current().javaHome


### PR DESCRIPTION
JDK 10 has gone fully-modular. This means that:
 - when targeting JDK 8 with a JDK 10 compiler, we have to use the full profile
 - when targeting JDK 10 with a JDK 10 compiler, we have to use -add-modules java.base

Today we only target JDK 8 (our minimum compatibility version) so we need to change the compiler flags conditional on using a JDK 10 compiler. This commit does that.

Closes #27908