### PR TITLE
Add terminate_after to count parameters

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -71,6 +71,10 @@
         "lowercase_expanded_terms": {
           "type" : "boolean",
           "description" : "Specify whether query terms should be lowercased"
+        },
+        "terminate_after" : {
+          "type" : "number",
+          "description" : "The maximum count for each shard, upon reaching which the query execution will terminate early"
         }
       }
     },


### PR DESCRIPTION
The documentation indicates that a count request accepts a terminate_after query string parameter:

https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-count.html#_request_parameters

This PR adds the parameter to the REST API spec.
