### PR TITLE
timestamp and ttl in index requests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -44,14 +44,6 @@
           "type" : "time",
           "description" : "Explicit operation timeout"
         },
-        "timestamp": {
-          "type" : "time",
-          "description" : "Explicit timestamp for the document"
-        },
-        "ttl": {
-          "type" : "time",
-          "description" : "Expiration time for the document"
-        },
         "version" : {
           "type" : "number",
           "description" : "Explicit version number for concurrency control"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -49,14 +49,6 @@
           "type" : "time",
           "description" : "Explicit operation timeout"
         },
-        "timestamp": {
-          "type" : "time",
-          "description" : "Explicit timestamp for the document"
-        },
-        "ttl": {
-          "type" : "time",
-          "description" : "Expiration time for the document"
-        },
         "version" : {
           "type" : "number",
           "description" : "Explicit version number for concurrency control"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -68,14 +68,6 @@
           "type": "time",
           "description": "Explicit operation timeout"
         },
-        "timestamp": {
-          "type": "time",
-          "description": "Explicit timestamp for the document"
-        },
-        "ttl": {
-          "type": "time",
-          "description": "Expiration time for the document"
-        },
         "version": {
           "type": "number",
           "description": "Explicit version number for concurrency control"


### PR DESCRIPTION
timestamp and ttl are not accepted anymore as parameters of index/update requests.

https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_60_rest_changes.html