### PR TITLE
Make AbstractQueryBuilder.declareStandardFields to be protected (#27865)

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -352,7 +352,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
      * {@link MatchAllQueryBuilder} and {@link MatchNoneQueryBuilder} support these fields so they
      * should use this method.
      */
-    static void declareStandardFields(AbstractObjectParser<? extends QueryBuilder, ?> parser) {
+    protected static void declareStandardFields(AbstractObjectParser<? extends QueryBuilder, ?> parser) {
         parser.declareFloat(QueryBuilder::boost, AbstractQueryBuilder.BOOST_FIELD);
         parser.declareString(QueryBuilder::queryName, AbstractQueryBuilder.NAME_FIELD);
     }


### PR DESCRIPTION
Closes #27865 

/cc @cbuescher 