### PR TITLE
Enable grok processor to support long, double and boolean

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1240,7 +1240,7 @@ The `SEMANTIC` is the identifier you give to the piece of text being matched. Fo
 duration of an event, so you could call it simply `duration`. Further, a string `55.3.244.1` might identify
 the `client` making a request.
 
-The `TYPE` is the type you wish to cast your named field. `int` and `float` are currently the only types supported for coercion.
+The `TYPE` is the type you wish to cast your named field. `int`, `long`, `double`, `float` and `boolean` are supported types for coercion.
 
 For example, you might want to match the following text:
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokMatchGroup.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokMatchGroup.java
@@ -53,8 +53,14 @@ final class GrokMatchGroup {
         switch(type) {
             case "int":
                 return Integer.parseInt(groupValue);
+            case "long":
+                return Long.parseLong(groupValue);
+            case "double":
+                return Double.parseDouble(groupValue);
             case "float":
                 return Float.parseFloat(groupValue);
+            case "boolean":
+                return Boolean.parseBoolean(groupValue);
             default:
                 return groupValue;
         }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokTests.java
@@ -205,6 +205,39 @@ public class GrokTests extends ESTestCase {
         assertEquals(expected, actual);
     }
 
+    public void testBooleanCaptures() {
+        Map<String, String> bank = new HashMap<>();
+
+        String pattern = "%{WORD:name}=%{WORD:status:boolean}";
+        Grok g = new Grok(basePatterns, pattern);
+
+        String text = "active=true";
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("name", "active");
+        expected.put("status", true);
+        Map<String, Object> actual = g.captures(text);
+
+        assertEquals(expected, actual);
+    }
+
+    public void testNumericCaptures() {
+        Map<String, String> bank = new HashMap<>();
+        bank.put("BASE10NUM", "(?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\\.[0-9]+)?)|(?:\\.[0-9]+)))");
+        bank.put("NUMBER", "(?:%{BASE10NUM})");
+
+        String pattern = "%{NUMBER:bytes:float} %{NUMBER:id:long} %{NUMBER:rating:double}";
+        Grok g = new Grok(bank, pattern);
+
+        String text = "12009.34 20000000000 4820.092";
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("bytes", 12009.34f);
+        expected.put("id", 20000000000L);
+        expected.put("rating", 4820.092);
+        Map<String, Object> actual = g.captures(text);
+
+        assertEquals(expected, actual);
+    }
+
     public void testNumericCapturesCoercion() {
         Map<String, String> bank = new HashMap<>();
         bank.put("BASE10NUM", "(?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\\.[0-9]+)?)|(?:\\.[0-9]+)))");


### PR DESCRIPTION
It would be useful to allow grok processor to support long, double, and boolean type.