### PR TITLE
Fix preserving FiltersAggregationBuilder#keyed field on rewrite

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregationBuilder.java
@@ -65,15 +65,19 @@ public class FiltersAggregationBuilder extends AbstractAggregationBuilder<Filter
      *            the KeyedFilters to use with this aggregation.
      */
     public FiltersAggregationBuilder(String name, KeyedFilter... filters) {
-        this(name, Arrays.asList(filters));
+        this(name, Arrays.asList(filters), true);
     }
 
-    private FiltersAggregationBuilder(String name, List<KeyedFilter> filters) {
+    private FiltersAggregationBuilder(String name, List<KeyedFilter> filters, boolean keyed) {
         super(name);
-        // internally we want to have a fixed order of filters, regardless of the order of the filters in the request
         this.filters = new ArrayList<>(filters);
-        Collections.sort(this.filters, (KeyedFilter kf1, KeyedFilter kf2) -> kf1.key().compareTo(kf2.key()));
-        this.keyed = true;
+        if (keyed) {
+            // internally we want to have a fixed order of filters, regardless of the order of the filters in the request
+            Collections.sort(this.filters, (KeyedFilter kf1, KeyedFilter kf2) -> kf1.key().compareTo(kf2.key()));
+            this.keyed = true;
+        } else {
+            this.keyed = false;
+        }
     }
 
     /**
@@ -153,6 +157,13 @@ public class FiltersAggregationBuilder extends AbstractAggregationBuilder<Filter
     }
 
     /**
+     * @return true if this builders filters have a key
+     */
+    public boolean isKeyed() {
+        return this.keyed;
+    }
+
+    /**
      * Set the key to use for the bucket for documents not matching any
      * filter.
      */
@@ -184,7 +195,7 @@ public class FiltersAggregationBuilder extends AbstractAggregationBuilder<Filter
             }
         }
         if (changed) {
-            return new FiltersAggregationBuilder(getName(), rewrittenFilters);
+            return new FiltersAggregationBuilder(getName(), rewrittenFilters, this.keyed);
         } else {
             return this;
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/220_filters_bucket.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/220_filters_bucket.yml
@@ -247,6 +247,22 @@ setup:
   - match: { aggregations.the_filter.meta.foo: "bar" }
 
 ---
+"Single anonymous bool query":
+
+  - do:
+      search:
+        body:
+          aggs:
+            the_filter:
+              filters:
+                filters:
+                  - bool: {}
+
+  - match: { hits.total: 4 }
+  - length: { hits.hits: 4 }
+  - match: { aggregations.the_filter.buckets.0.doc_count: 4 }
+
+---
 "Bad params":
 
   - do:


### PR DESCRIPTION
Currently FiltersAggregationBuilder#doRewrite creates a new FiltersAggregationBuilder which doesn't correctly copy the original "keyed" field if a non-keyed filter gets rewritten.
This can cause rendering bugs of the output aggregations like the one reported in #27841.

Closes #27841 