### PR TITLE
Test: Change randomValueOtherThan(null, supplier)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -684,11 +684,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * helper to get a random value in a certain range that's different from the input
      */
     public static <T> T randomValueOtherThan(T input, Supplier<T> randomSupplier) {
-        if (input != null) {
-            return randomValueOtherThanMany(input::equals, randomSupplier);
-        }
-
-        return(randomSupplier.get());
+        return randomValueOtherThanMany(v -> Objects.equals(input, v), randomSupplier);
     }
 
     /**

--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -179,6 +179,6 @@ public class ESTestCaseTests extends ESTestCase {
          * like any other value.
          */
         Supplier<Object> usuallyNull = () -> usually() ? null : randomInt();
-        assertNotNull(null, randomValueOtherThan(null, usuallyNull));
+        assertNotNull(randomValueOtherThan(null, usuallyNull));
     }
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/ESTestCaseTests.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -165,5 +166,19 @@ public class ESTestCaseTests extends ESTestCase {
 
     public void testRandomUniqueNormalUsageAlwayMoreThanOne() {
         assertThat(randomUnique(() -> randomAlphaOfLengthBetween(1, 20), 10), hasSize(greaterThan(0)));
+    }
+
+    public void testRandomValueOtherThan() {
+        // "normal" way of calling where the value is not null
+        int bad = randomInt();
+        assertNotEquals(bad, (int) randomValueOtherThan(bad, ESTestCase::randomInt));
+
+        /*
+         * "funny" way of calling where the value is null. This once
+         * had a unique behavior but at this point `null` acts just
+         * like any other value.
+         */
+        Supplier<Object> usuallyNull = () -> usually() ? null : randomInt();
+        assertNotNull(null, randomValueOtherThan(null, usuallyNull));
     }
 }


### PR DESCRIPTION
When the first parameter of `ESTestCase#randomValueOtherThan` is `null`
then run the supplier until it returns non-`null`. Previously,
`randomValueOtherThan` just ran the supplier one time which was
confusing.

Unexpectedly, it looks like not tests rely on the original `null`
handling.

Closes #27821