### PR TITLE
Restart Elasticsearch service on failure

### DIFF
--- a/distribution/src/main/packaging/systemd/elasticsearch.service
+++ b/distribution/src/main/packaging/systemd/elasticsearch.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+Restart=on-failure
 RuntimeDirectory=elasticsearch
 Environment=ES_HOME=/usr/share/elasticsearch
 Environment=ES_PATH_CONF=${path.conf}


### PR DESCRIPTION
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)? yes

Hi,

When using the systemd service for ES, if the ES service crashes for any reason (For example, OOM), it will not auto start itself.

This PR adds the systemd built-in feature for restarting failed resources.