### PR TITLE
Ignore the `-snapshot` suffix when comparing the Lucene version in the build and the docs.

### DIFF
--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -76,10 +76,8 @@ task verifyDocsLuceneVersion {
       throw new GradleException('Could not find lucene version in docs version file')
     }
     String expectedLuceneVersion = VersionProperties.lucene
-    if (expectedLuceneVersion.contains('-snapshot-')) {
-      expectedLuceneVersion = expectedLuceneVersion.substring(0, expectedLuceneVersion.lastIndexOf('-'))
-      expectedLuceneVersion = expectedLuceneVersion.toUpperCase(Locale.ROOT)
-    }
+    // remove potential -snapshot-{gitrev} suffix
+    expectedLuceneVersion -= ~/-snapshot-[0-9a-f]+$/
     if (docsLuceneVersion != expectedLuceneVersion) {
       throw new GradleException("Lucene version in docs [${docsLuceneVersion}] does not match version.properties [${expectedLuceneVersion}]")
     }


### PR DESCRIPTION
Currently if the Lucene version is `X.Y.Z-snapshot-{gitrev}`, then we will
expect the docs to have `X.Y.Z-snapshot` as a Lucene version. I would like
to change it to `X.Y.Z` so that this doesn't need changing when we move from a
snapshot to a final release.