### PR TITLE
Do not start snapshots that are deleted during initialization

### DIFF
--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotException.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotException.java
@@ -66,7 +66,7 @@ public class SnapshotException extends ElasticsearchException {
     }
 
     public SnapshotException(final String repositoryName, final String snapshotName, final String msg, final Throwable cause) {
-        super("[" + repositoryName + ":" + snapshotName + "]" + msg, cause);
+        super("[" + repositoryName + ":" + snapshotName + "] " + msg, cause);
         this.repositoryName = repositoryName;
         this.snapshotName = snapshotName;
     }

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotMissingException.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotMissingException.java
@@ -30,15 +30,15 @@ import java.io.IOException;
 public class SnapshotMissingException extends SnapshotException {
 
     public SnapshotMissingException(final String repositoryName, final SnapshotId snapshotId, final Throwable cause) {
-        super(repositoryName, snapshotId, " is missing", cause);
+        super(repositoryName, snapshotId, "is missing", cause);
     }
 
     public SnapshotMissingException(final String repositoryName, final SnapshotId snapshotId) {
-        super(repositoryName, snapshotId, " is missing");
+        super(repositoryName, snapshotId, "is missing");
     }
 
     public SnapshotMissingException(final String repositoryName, final String snapshotName) {
-        super(repositoryName, snapshotName, " is missing");
+        super(repositoryName, snapshotName, "is missing");
     }
 
     public SnapshotMissingException(StreamInput in) throws IOException {

--- a/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -25,6 +25,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotIndexShardStage;
@@ -46,6 +47,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.RestoreInProgress;
 import org.elasticsearch.cluster.SnapshotsInProgress;
@@ -102,6 +104,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -3141,6 +3144,74 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(shardStats.getSeqNoStats().getLocalCheckpoint(), equalTo(15L)); // 15 indexed docs and one "missing" op.
         assertThat(shardStats.getSeqNoStats().getGlobalCheckpoint(), equalTo(15L));
         assertThat(shardStats.getSeqNoStats().getMaxSeqNo(), equalTo(15L));
+    }
+
+    public void testAbortedSnapshotDuringInitDoesNotStart() throws Exception {
+        final Client client = client();
+
+        // Blocks on initialization
+        assertAcked(client.admin().cluster().preparePutRepository("repository")
+            .setType("mock").setSettings(Settings.builder()
+                .put("location", randomRepoPath())
+                .put("block_on_init", true)
+            ));
+
+        createIndex("test-idx");
+        final int nbDocs = scaledRandomIntBetween(1, 100);
+        for (int i = 0; i < nbDocs; i++) {
+            index("test-idx", "_doc", Integer.toString(i), "foo", "bar" + i);
+        }
+        refresh();
+        assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits(), equalTo((long) nbDocs));
+
+        // Create a snapshot
+        client.admin().cluster().prepareCreateSnapshot("repository", "snap").execute();
+        waitForBlock(internalCluster().getMasterName(), "repository", TimeValue.timeValueMinutes(1));
+        boolean blocked = true;
+
+        // Snapshot is initializing (and is blocked at this stage)
+        SnapshotsStatusResponse snapshotsStatus = client.admin().cluster().prepareSnapshotStatus("repository").setSnapshots("snap").get();
+        assertThat(snapshotsStatus.getSnapshots().iterator().next().getState(), equalTo(State.INIT));
+
+        final List<State> states = new CopyOnWriteArrayList<>();
+        final ClusterStateListener listener = event -> {
+            SnapshotsInProgress snapshotsInProgress = event.state().custom(SnapshotsInProgress.TYPE);
+            for (SnapshotsInProgress.Entry entry : snapshotsInProgress.entries()) {
+                if ("snap".equals(entry.snapshot().getSnapshotId().getName())) {
+                    states.add(entry.state());
+                }
+            }
+        };
+
+        try {
+            // Record the upcoming states of the snapshot on all nodes
+            internalCluster().getInstances(ClusterService.class).forEach(clusterService -> clusterService.addListener(listener));
+
+            // Delete the snapshot while it is being initialized
+            ActionFuture<DeleteSnapshotResponse> delete = client.admin().cluster().prepareDeleteSnapshot("repository", "snap").execute();
+
+            // The deletion must set the snapshot in the ABORTED state
+            assertBusy(() -> {
+                SnapshotsStatusResponse status = client.admin().cluster().prepareSnapshotStatus("repository").setSnapshots("snap").get();
+                assertThat(status.getSnapshots().iterator().next().getState(), equalTo(State.ABORTED));
+            });
+
+            // Now unblock the repository
+            unblockNode("repository", internalCluster().getMasterName());
+            blocked = false;
+
+            assertAcked(delete.get());
+            expectThrows(SnapshotMissingException.class, () ->
+                client.admin().cluster().prepareGetSnapshots("repository").setSnapshots("snap").get());
+
+            assertFalse("Expecting snapshot state to be updated", states.isEmpty());
+            assertFalse("Expecting snapshot to be aborted and not started at all", states.contains(State.STARTED));
+        } finally {
+            internalCluster().getInstances(ClusterService.class).forEach(clusterService -> clusterService.removeListener(listener));
+            if (blocked) {
+                unblockNode("repository", internalCluster().getMasterName());
+            }
+        }
     }
 
     private void verifySnapshotInfo(final GetSnapshotsResponse response, final Map<String, List<String>> indicesPerSnapshot) {


### PR DESCRIPTION
When a new snapshot is created it is added to the cluster state as a snapshot-in-progress in `INIT` state, and the initialization is kicked off in a new runnable task by `SnapshotService.beginSnapshot()`. The
initialization writes multiple files before updating the cluster state to change the snapshot-in-progress to `STARTED` state. 

This leaves a short window in which the snapshot could be deleted (let's say, because the snapshot is stuck in `INIT` or because it takes too much time to upload all the initialization files for all snapshotted indices). If the `INIT` snapshot is deleted, a race begins between the deletion which sets the snapshot-in-progress to ABORTED in cluster state and tries to finalize the snapshot and the initialization in `SnapshotService.beginSnapshot()` which changes the state back to `STARTED`.

This pull request changes `SnapshotService.beginSnapshot()` so that an `ABORTED` snapshot is not started if it has been deleted during initialization. It also adds a test that would have failed
with the previous behaviour, and changes few method names here and there.