### PR TITLE
Fix composite aggregation when after term is missing in the shard

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -196,7 +196,7 @@ setup:
 ---
 "Invalid Composite aggregation":
   - skip:
-      version: " - 6.1.99"
+      version: " - 6.0.99"
       reason:  this uses a new API that has been added in 6.1
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -164,9 +164,39 @@ setup:
   - match: { aggregations.test.buckets.1.doc_count: 1 }
 
 ---
+"Aggregate After Missing":
+  - skip:
+      version: " - 6.99.99"
+      reason:  bug fixed in 7.0.0
+
+
+  - do:
+      search:
+        index: test
+        body:
+          aggregations:
+            test:
+              composite:
+                sources: [
+                  {
+                    "kw": {
+                      "terms": {
+                        "field": "keyword"
+                      }
+                    }
+                  }
+                ]
+                after: { "kw": "delta" }
+
+  - match: {hits.total: 4}
+  - length: { aggregations.test.buckets: 1 }
+  - match: { aggregations.test.buckets.0.key.kw: "foo" }
+  - match: { aggregations.test.buckets.0.doc_count: 2 }
+
+---
 "Invalid Composite aggregation":
   - skip:
-      version: " - 6.0.99"
+      version: " - 6.1.99"
       reason:  this uses a new API that has been added in 6.1
 
   - do:


### PR DESCRIPTION
This change fixes a bug when a keyword term in the `after` key is not present in the shard.
In this case the global ord of the document values are compared with the insertion point of the
`after` keyword and values that are equal to the insertion point should be considered "after" the top value.