### PR TITLE
Splits nio project into two for eclipse build only

### DIFF
--- a/libs/elasticsearch-nio/build.gradle
+++ b/libs/elasticsearch-nio/build.gradle
@@ -18,6 +18,8 @@
  */
 
 import org.elasticsearch.gradle.precommit.PrecommitTasks
+import com.carrotsearch.gradle.junit4.RandomizedTestingTask
+import org.elasticsearch.gradle.BuildPlugin
 
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
@@ -39,8 +41,24 @@ dependencies {
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
   testCompile "junit:junit:${versions.junit}"
   testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
-  testCompile("org.elasticsearch.test:framework:${version}") {
-    exclude group: 'org.elasticsearch', module: 'elasticsearch-nio'
+  
+  if (isEclipse == false || project.path == ":libs:elasticsearch-nio-tests") {
+      testCompile("org.elasticsearch.test:framework:${version}") {
+        exclude group: 'org.elasticsearch', module: 'elasticsearch-nio'
+      }
+  }
+}
+
+if (isEclipse) {
+  // in eclipse the project is under a fake root, we need to change around the source sets
+  sourceSets {
+    if (project.path == ":libs:elasticsearch-nio") {
+      main.java.srcDirs = ['java']
+      main.resources.srcDirs = ['resources']
+    } else {
+      test.java.srcDirs = ['java']
+      test.resources.srcDirs = ['resources']
+    }
   }
 }
 
@@ -64,3 +82,17 @@ thirdPartyAudit.excludes = [
         'org/osgi/framework/wiring/BundleWire',
         'org/osgi/framework/wiring/BundleWiring'
 ]
+
+if (isEclipse == false || project.path == ":libs:elasticsearch-nio-tests") {
+  task integTest(type: RandomizedTestingTask,
+                 group: JavaBasePlugin.VERIFICATION_GROUP,
+                 description: 'Multi-node tests',
+                 dependsOn: test.dependsOn) {
+    configure(BuildPlugin.commonTestConfig(project))
+    classpath = project.test.classpath
+    testClassesDir = project.test.testClassesDir
+    include '**/*IT.class'
+  }
+  check.dependsOn integTest
+  integTest.mustRunAfter test
+}

--- a/libs/elasticsearch-nio/build.gradle
+++ b/libs/elasticsearch-nio/build.gradle
@@ -18,8 +18,6 @@
  */
 
 import org.elasticsearch.gradle.precommit.PrecommitTasks
-import com.carrotsearch.gradle.junit4.RandomizedTestingTask
-import org.elasticsearch.gradle.BuildPlugin
 
 apply plugin: 'elasticsearch.build'
 apply plugin: 'nebula.maven-base-publish'
@@ -82,17 +80,3 @@ thirdPartyAudit.excludes = [
         'org/osgi/framework/wiring/BundleWire',
         'org/osgi/framework/wiring/BundleWiring'
 ]
-
-if (isEclipse == false || project.path == ":libs:elasticsearch-nio-tests") {
-  task integTest(type: RandomizedTestingTask,
-                 group: JavaBasePlugin.VERIFICATION_GROUP,
-                 description: 'Multi-node tests',
-                 dependsOn: test.dependsOn) {
-    configure(BuildPlugin.commonTestConfig(project))
-    classpath = project.test.classpath
-    testClassesDir = project.test.testClassesDir
-    include '**/*IT.class'
-  }
-  check.dependsOn integTest
-  integTest.mustRunAfter test
-}

--- a/libs/elasticsearch-nio/src/main/eclipse-build.gradle
+++ b/libs/elasticsearch-nio/src/main/eclipse-build.gradle
@@ -1,0 +1,3 @@
+
+// this is just shell gradle file for eclipse to have separate projects for elasticsearch-nio src and tests
+apply from: '../../build.gradle'

--- a/libs/elasticsearch-nio/src/test/eclipse-build.gradle
+++ b/libs/elasticsearch-nio/src/test/eclipse-build.gradle
@@ -1,0 +1,7 @@
+
+// this is just shell gradle file for eclipse to have separate projects for elasticsearch-nio src and tests
+apply from: '../../build.gradle'
+
+dependencies {
+  testCompile project(':libs:elasticsearch-nio')
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -109,6 +109,7 @@ if (isEclipse) {
   // eclipse cannot handle an intermediate dependency between main and test, so we must create separate projects
   // for core-src and core-tests
   projects << 'core-tests'
+  projects << 'libs:elasticsearch-nio-tests'
 }
 
 include projects.toArray(new String[0])
@@ -131,6 +132,10 @@ if (isEclipse) {
   project(":core").buildFileName = 'eclipse-build.gradle'
   project(":core-tests").projectDir = new File(rootProject.projectDir, 'core/src/test')
   project(":core-tests").buildFileName = 'eclipse-build.gradle'
+  project(":libs:elasticsearch-nio").projectDir = new File(rootProject.projectDir, 'libs/elasticsearch-nio/src/main')
+  project(":libs:elasticsearch-nio").buildFileName = 'eclipse-build.gradle'
+  project(":libs:elasticsearch-nio-tests").projectDir = new File(rootProject.projectDir, 'libs/elasticsearch-nio/src/test')
+  project(":libs:elasticsearch-nio-tests").buildFileName = 'eclipse-build.gradle'
 }
 
 /**


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/27801 introduced a new gradle project `:libs:elasticsearch-nio` which creates cyclical project dependencies when importing the projects into Eclipse.

This change applies the same trick as we have for the core project where, and building for Eclipse, splits the `:libs:elasticsearch-nio` project into `:libs:elasticsearch-nio` which points to `src/main` and `:libs:elasticsearch-nio-tests` which points to `src/test`. This prevents cyclical project dependencies in Eclipse arising from the fact that eclipse does not separate compile/runtime dependencies from test dependencies.