### PR TITLE
Remove `operation_threading` from the rest specs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -38,9 +38,6 @@
           "type" : "boolean",
           "description" : "Specify whether the operation should only expunge deleted documents"
         },
-        "operation_threading": {
-          "description" : "TODO: ?"
-        },
         "wait_for_merge": {
           "type" : "boolean",
           "description" : "Specify whether the request should block until the merge process is finished (default: true)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -26,9 +26,6 @@
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
         },
-        "operation_threading": {
-          "description" : "TODO: ?"
-        },
         "verbose": {
           "type": "boolean",
           "description": "Includes detailed memory usage by Lucene.",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
@@ -30,9 +30,6 @@
             "options" : ["open","closed","none","all"],
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
-        },
-        "operation_threading": {
-          "description" : "TODO: ?"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
@@ -34,9 +34,6 @@
             "default" : "open",
             "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
         },
-        "operation_threading": {
-          "description" : "TODO: ?"
-        },
         "q": {
           "type" : "string",
           "description" : "Query in the Lucene query string syntax"


### PR DESCRIPTION
Remove `operation_threading` from the rest specs as this parameter is no longer supported.

Relates to #27158