### PR TITLE
Remove unused search plugin extension

### DIFF
--- a/core/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
+++ b/core/src/main/java/org/elasticsearch/plugins/SearchPlugin.java
@@ -57,7 +57,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.BiConsumer;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -132,15 +131,6 @@ public interface SearchPlugin {
      * The next {@link Rescorer}s added by this plugin.
      */
     default List<RescorerSpec<?>> getRescorers() {
-        return emptyList();
-    }
-    /**
-     * The new search response listeners in the form of {@link BiConsumer}s added by this plugin.
-     * The listeners are invoked on the coordinating node, at the very end of the search request.
-     * This provides a convenient location if you wish to inspect/modify the final response (took time, etc).
-     * The BiConsumers are passed the original {@link SearchRequest} and the final {@link SearchResponse}
-     */
-    default List<BiConsumer<SearchRequest, SearchResponse>> getSearchResponseListeners() {
         return emptyList();
     }
 


### PR DESCRIPTION
Search response listeners should not be exposed in search plugin.
The support for it was added but reverted right after (not present in any release).
Though the SearchPlugin still contains a default definition for search response listeners
due to a broken revert. This change removes this extension point that is basically no-op.