### PR TITLE
Disable Javadocs on JDK 10

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -458,6 +458,10 @@ class BuildPlugin implements Plugin<Project> {
             executable = new File(project.javaHome, 'bin/javadoc')
         }
         configureJavadocJar(project)
+        if (project.javaVersion == JavaVersion.VERSION_1_10) {
+            project.tasks.withType(Javadoc) { it.enabled = false }
+            project.tasks.getByName('javadocJar').each { it.enabled = false }
+        }
     }
 
     /** Adds a javadocJar task to generate a jar containing javadocs. */


### PR DESCRIPTION
There appears to be a bug in JDK 10 for generating Javadocs with some nested anonymous classes. This commit disables these on JDK 10 until the upstream issue is resolved.

