### PR TITLE
 Start to uncouple deprecation handling from log4j

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
@@ -45,6 +45,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -270,7 +271,9 @@ public final class Request {
                 BytesReference indexSource = indexRequest.source();
                 XContentType indexXContentType = indexRequest.getContentType();
 
-                try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, indexSource, indexXContentType)) {
+                // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because copyCurrentStructure does not interact with deprecation
+                try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+                        ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, indexSource, indexXContentType)) {
                     try (XContentBuilder builder = XContentBuilder.builder(bulkContentType.xContent())) {
                         builder.copyCurrentStructure(parser);
                         source = builder.bytes().toBytesRef();

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -595,7 +595,13 @@ public class RestHighLevelClient implements Closeable {
         if (xContentType == null) {
             throw new IllegalStateException("Unsupported Content-Type: " + entity.getContentType().getValue());
         }
-        try (XContentParser parser = xContentType.xContent().createParser(registry, entity.getContent())) {
+        /*
+         * We use IGNORING_DEPRECATION_HANDLER because users of the high
+         * level rest client can't do anything about deprecated fields in
+         * the responses.
+         */
+        try (XContentParser parser = xContentType.xContent()
+                .createParser(registry, ParseField.IGNORING_DEPRECATION_HANDLER, entity.getContent())) {
             return entityParser.apply(parser);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -248,7 +249,9 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
             listener.onFailure(new ElasticsearchException("Stored task status for [{}] didn't contain any source!", response.getId()));
             return;
         }
-        try (XContentParser parser = XContentHelper.createParser(xContentRegistry, response.getSourceAsBytesRef())) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because there are no deprecated field declared in TaskResult.PARSER
+        try (XContentParser parser = XContentHelper.createParser(xContentRegistry,
+                ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, response.getSourceAsBytesRef())) {
             TaskResult result = TaskResult.PARSER.apply(parser, null);
             listener.onResponse(new GetTaskResponse(result));
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
@@ -205,16 +205,16 @@ public class Alias implements Streamable, ToXContentObject {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (FILTER.match(currentFieldName)) {
+                if (FILTER.match(currentFieldName, parser.deprecationHandler())) {
                     Map<String, Object> filter = parser.mapOrdered();
                     alias.filter(filter);
                 }
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (ROUTING.match(currentFieldName)) {
+                if (ROUTING.match(currentFieldName, parser.deprecationHandler())) {
                     alias.routing(parser.text());
-                } else if (INDEX_ROUTING.match(currentFieldName)) {
+                } else if (INDEX_ROUTING.match(currentFieldName, parser.deprecationHandler())) {
                     alias.indexRouting(parser.text());
-                } else if (SEARCH_ROUTING.match(currentFieldName)) {
+                } else if (SEARCH_ROUTING.match(currentFieldName, parser.deprecationHandler())) {
                     alias.searchRouting(parser.text());
                 }
             }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -320,7 +320,10 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      */
     public CreateIndexRequest aliases(BytesReference source) {
         // EMPTY is safe here because we never call namedObject
-        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, source)) {
+        // TODO LoggingDeprecationHandler probably should be visible to a request
+        // because the requests might be in a separate jar from core
+        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE, source)) {
             //move to the first alias
             parser.nextToken();
             while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -373,9 +376,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      */
     public CreateIndexRequest source(BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
-        // TODO LoggingDeprecationHandler probably should be visible to a request
-        // because the requests might be in a separate jar from core
-        source(XContentHelper.convertToMap(source, false, xContentType).v2(), LoggingDeprecationHandler.INSTANCE);
+        source(XContentHelper.convertToMap(source, false, xContentType).v2());
         return this;
     }
 
@@ -383,7 +384,10 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      * Sets the settings and mappings as a single source.
      */
     @SuppressWarnings("unchecked")
-    public CreateIndexRequest source(Map<String, ?> source, DeprecationHandler deprecationHandler) {
+    public CreateIndexRequest source(Map<String, ?> source) {
+        // TODO LoggingDeprecationHandler probably should be visible to a request
+        // because the requests might be in a separate jar from core
+        DeprecationHandler deprecationHandler = ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER;
         for (Map.Entry<String, ?> entry : source.entrySet()) {
             String name = entry.getKey();
             if (SETTINGS.match(name, deprecationHandler)) {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.MapBuilder;
@@ -436,7 +437,10 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
      */
     public PutIndexTemplateRequest aliases(BytesReference source) {
         // EMPTY is safe here because we never call namedObject
-        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, source)) {
+        // TODO LoggingDeprecationHandler shouldn't be visible in requests
+        // because LoggingDeprecationHandler is part of core and the requests would like to move to a separate jar
+        try (XContentParser parser = XContentHelper.createParser(
+                NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, source)) {
             //move to the first alias
             parser.nextToken();
             while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -304,7 +305,10 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
 
             // now parse the action
             // EMPTY is safe here because we never call namedObject
-            try (XContentParser parser = xContent.createParser(NamedXContentRegistry.EMPTY, data.slice(from, nextMarker - from))) {
+            // TODO LoggingDeprecationHandler is probably not appropriate here because this is a request
+            // because LoggingDeprecationHandler is a server side thing but this is a request
+            try (XContentParser parser = xContent.createParser(NamedXContentRegistry.EMPTY,
+                    LoggingDeprecationHandler.INSTANCE, data.slice(from, nextMarker - from))) {
                 // move pointers
                 from = nextMarker + 1;
 
@@ -428,8 +432,10 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
                                 .routing(routing)
                                 .parent(parent);
                         // EMPTY is safe here because we never call namedObject
+                        // TODO LoggingDeprecationHandler is probably not appropriate here because this is a request
+                        // because LoggingDeprecationHandler is a server side thing but this is a request
                         try (XContentParser sliceParser = xContent.createParser(NamedXContentRegistry.EMPTY,
-                                                        sliceTrimmingCarriageReturn(data, from, nextMarker, xContentType))) {
+                                LoggingDeprecationHandler.INSTANCE, sliceTrimmingCarriageReturn(data, from, nextMarker, xContentType))) {
                             updateRequest.fromXContent(sliceParser);
                         }
                         if (fetchSourceContext != null) {

--- a/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -348,45 +348,45 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
                         if (token == XContentParser.Token.FIELD_NAME) {
                             currentFieldName = parser.currentName();
                         } else if (token.isValue()) {
-                            if (INDEX.match(currentFieldName)){
+                            if (INDEX.match(currentFieldName, parser.deprecationHandler())){
                                 if (!allowExplicitIndex) {
                                     throw new IllegalArgumentException("explicit index in bulk is not allowed");
                                 }
                                 index = parser.text();
-                            } else if (TYPE.match(currentFieldName)) {
+                            } else if (TYPE.match(currentFieldName, parser.deprecationHandler())) {
                                 type = parser.text();
-                            } else if (ID.match(currentFieldName)) {
+                            } else if (ID.match(currentFieldName, parser.deprecationHandler())) {
                                 id = parser.text();
-                            } else if (ROUTING.match(currentFieldName)) {
+                            } else if (ROUTING.match(currentFieldName, parser.deprecationHandler())) {
                                 routing = parser.text();
-                            } else if (PARENT.match(currentFieldName)) {
+                            } else if (PARENT.match(currentFieldName, parser.deprecationHandler())) {
                                 parent = parser.text();
-                            } else if (OP_TYPE.match(currentFieldName)) {
+                            } else if (OP_TYPE.match(currentFieldName, parser.deprecationHandler())) {
                                 opType = parser.text();
-                            } else if (VERSION.match(currentFieldName)) {
+                            } else if (VERSION.match(currentFieldName, parser.deprecationHandler())) {
                                 version = parser.longValue();
-                            } else if (VERSION_TYPE.match(currentFieldName)) {
+                            } else if (VERSION_TYPE.match(currentFieldName, parser.deprecationHandler())) {
                                 versionType = VersionType.fromString(parser.text());
-                            } else if (RETRY_ON_CONFLICT.match(currentFieldName)) {
+                            } else if (RETRY_ON_CONFLICT.match(currentFieldName, parser.deprecationHandler())) {
                                 retryOnConflict = parser.intValue();
-                            } else if (PIPELINE.match(currentFieldName)) {
+                            } else if (PIPELINE.match(currentFieldName, parser.deprecationHandler())) {
                                 pipeline = parser.text();
-                            } else if (FIELDS.match(currentFieldName)) {
+                            } else if (FIELDS.match(currentFieldName, parser.deprecationHandler())) {
                                 throw new IllegalArgumentException("Action/metadata line [" + line + "] contains a simple value for parameter [fields] while a list is expected");
-                            } else if (SOURCE.match(currentFieldName)) {
+                            } else if (SOURCE.match(currentFieldName, parser.deprecationHandler())) {
                                 fetchSourceContext = FetchSourceContext.fromXContent(parser);
                             } else {
                                 throw new IllegalArgumentException("Action/metadata line [" + line + "] contains an unknown parameter [" + currentFieldName + "]");
                             }
                         } else if (token == XContentParser.Token.START_ARRAY) {
-                            if (FIELDS.match(currentFieldName)) {
+                            if (FIELDS.match(currentFieldName, parser.deprecationHandler())) {
                                 DEPRECATION_LOGGER.deprecated("Deprecated field [fields] used, expected [_source] instead");
                                 List<Object> values = parser.list();
                                 fields = values.toArray(new String[values.size()]);
                             } else {
                                 throw new IllegalArgumentException("Malformed action/metadata line [" + line + "], expected a simple value for field [" + currentFieldName + "] but found [" + token + "]");
                             }
-                        } else if (token == XContentParser.Token.START_OBJECT && SOURCE.match(currentFieldName)) {
+                        } else if (token == XContentParser.Token.START_OBJECT && SOURCE.match(currentFieldName, parser.deprecationHandler())) {
                             fetchSourceContext = FetchSourceContext.fromXContent(parser);
                         } else if (token != XContentParser.Token.VALUE_NULL) {
                             throw new IllegalArgumentException("Malformed action/metadata line [" + line + "], expected a simple value for field [" + currentFieldName + "] but found [" + token + "]");

--- a/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -391,30 +391,30 @@ public class MultiGetRequest extends ActionRequest implements Iterable<MultiGetR
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if (token.isValue()) {
-                    if (INDEX.match(currentFieldName)) {
+                    if (INDEX.match(currentFieldName, parser.deprecationHandler())) {
                         if (!allowExplicitIndex) {
                             throw new IllegalArgumentException("explicit index in multi get is not allowed");
                         }
                         index = parser.text();
-                    } else if (TYPE.match(currentFieldName)) {
+                    } else if (TYPE.match(currentFieldName, parser.deprecationHandler())) {
                         type = parser.text();
-                    } else if (ID.match(currentFieldName)) {
+                    } else if (ID.match(currentFieldName, parser.deprecationHandler())) {
                         id = parser.text();
-                    } else if (ROUTING.match(currentFieldName)) {
+                    } else if (ROUTING.match(currentFieldName, parser.deprecationHandler())) {
                         routing = parser.text();
-                    } else if (PARENT.match(currentFieldName)) {
+                    } else if (PARENT.match(currentFieldName, parser.deprecationHandler())) {
                         parent = parser.text();
-                    } else if (FIELDS.match(currentFieldName)) {
+                    } else if (FIELDS.match(currentFieldName, parser.deprecationHandler())) {
                         throw new ParsingException(parser.getTokenLocation(),
                             "Unsupported field [fields] used, expected [stored_fields] instead");
-                    } else if (STORED_FIELDS.match(currentFieldName)) {
+                    } else if (STORED_FIELDS.match(currentFieldName, parser.deprecationHandler())) {
                         storedFields = new ArrayList<>();
                         storedFields.add(parser.text());
-                    } else if (VERSION.match(currentFieldName)) {
+                    } else if (VERSION.match(currentFieldName, parser.deprecationHandler())) {
                         version = parser.longValue();
-                    } else if (VERSION_TYPE.match(currentFieldName)) {
+                    } else if (VERSION_TYPE.match(currentFieldName, parser.deprecationHandler())) {
                         versionType = VersionType.fromString(parser.text());
-                    } else if (SOURCE.match(currentFieldName)) {
+                    } else if (SOURCE.match(currentFieldName, parser.deprecationHandler())) {
                         // check lenient to avoid interpreting the value as string but parse strict in order to provoke an error early on.
                         if (parser.isBooleanValueLenient()) {
                             fetchSourceContext = new FetchSourceContext(parser.booleanValue(), fetchSourceContext.includes(),
@@ -429,15 +429,15 @@ public class MultiGetRequest extends ActionRequest implements Iterable<MultiGetR
                         throw new ElasticsearchParseException("failed to parse multi get request. unknown field [{}]", currentFieldName);
                     }
                 } else if (token == XContentParser.Token.START_ARRAY) {
-                    if (FIELDS.match(currentFieldName)) {
+                    if (FIELDS.match(currentFieldName, parser.deprecationHandler())) {
                         throw new ParsingException(parser.getTokenLocation(),
                             "Unsupported field [fields] used, expected [stored_fields] instead");
-                    } else if (STORED_FIELDS.match(currentFieldName)) {
+                    } else if (STORED_FIELDS.match(currentFieldName, parser.deprecationHandler())) {
                         storedFields = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             storedFields.add(parser.text());
                         }
-                    } else if (SOURCE.match(currentFieldName)) {
+                    } else if (SOURCE.match(currentFieldName, parser.deprecationHandler())) {
                         ArrayList<String> includes = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             includes.add(parser.text());
@@ -447,7 +447,7 @@ public class MultiGetRequest extends ActionRequest implements Iterable<MultiGetR
                     }
 
                 } else if (token == XContentParser.Token.START_OBJECT) {
-                    if (SOURCE.match(currentFieldName)) {
+                    if (SOURCE.match(currentFieldName, parser.deprecationHandler())) {
                         List<String> currentList = null, includes = null, excludes = null;
 
                         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {

--- a/core/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/MultiSearchRequest.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.CompositeIndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -206,7 +207,9 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
             IndicesOptions defaultOptions = SearchRequest.DEFAULT_INDICES_OPTIONS;
             // now parse the action
             if (nextMarker - from > 0) {
-                try (XContentParser parser = xContent.createParser(registry, data.slice(from, nextMarker - from))) {
+                // LoggingDeprecationHandler is fine here because this is always run on the server
+                try (XContentParser parser = xContent
+                        .createParser(registry, LoggingDeprecationHandler.INSTANCE, data.slice(from, nextMarker - from))) {
                     Map<String, Object> source = parser.map();
                     for (Map.Entry<String, Object> entry : source.entrySet()) {
                         Object value = entry.getValue();
@@ -240,7 +243,8 @@ public class MultiSearchRequest extends ActionRequest implements CompositeIndice
                 break;
             }
             BytesReference bytes = data.slice(from, nextMarker - from);
-            try (XContentParser parser = xContent.createParser(registry, bytes)) {
+            // LoggingDeprecationHandler is fine here because this is always run on the server
+            try (XContentParser parser = xContent.createParser(registry, LoggingDeprecationHandler.INSTANCE, bytes)) {
                 consumer.accept(searchRequest, parser);
             }
             // move pointers

--- a/core/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -269,15 +269,15 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
             if (token == Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (SCROLL_ID.match(currentFieldName)) {
+                if (SCROLL_ID.match(currentFieldName, parser.deprecationHandler())) {
                     scrollId = parser.text();
-                } else if (TOOK.match(currentFieldName)) {
+                } else if (TOOK.match(currentFieldName, parser.deprecationHandler())) {
                     tookInMillis = parser.longValue();
-                } else if (TIMED_OUT.match(currentFieldName)) {
+                } else if (TIMED_OUT.match(currentFieldName, parser.deprecationHandler())) {
                     timedOut = parser.booleanValue();
-                } else if (TERMINATED_EARLY.match(currentFieldName)) {
+                } else if (TERMINATED_EARLY.match(currentFieldName, parser.deprecationHandler())) {
                     terminatedEarly = parser.booleanValue();
-                } else if (NUM_REDUCE_PHASES.match(currentFieldName)) {
+                } else if (NUM_REDUCE_PHASES.match(currentFieldName, parser.deprecationHandler())) {
                     numReducePhases = parser.intValue();
                 } else {
                     parser.skipChildren();
@@ -291,24 +291,24 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
                     suggest = Suggest.fromXContent(parser);
                 } else if (SearchProfileShardResults.PROFILE_FIELD.equals(currentFieldName)) {
                     profile = SearchProfileShardResults.fromXContent(parser);
-                } else if (RestActions._SHARDS_FIELD.match(currentFieldName)) {
+                } else if (RestActions._SHARDS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     while ((token = parser.nextToken()) != Token.END_OBJECT) {
                         if (token == Token.FIELD_NAME) {
                             currentFieldName = parser.currentName();
                         } else if (token.isValue()) {
-                            if (RestActions.FAILED_FIELD.match(currentFieldName)) {
+                            if (RestActions.FAILED_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 parser.intValue(); // we don't need it but need to consume it
-                            } else if (RestActions.SUCCESSFUL_FIELD.match(currentFieldName)) {
+                            } else if (RestActions.SUCCESSFUL_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 successfulShards = parser.intValue();
-                            } else if (RestActions.TOTAL_FIELD.match(currentFieldName)) {
+                            } else if (RestActions.TOTAL_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 totalShards = parser.intValue();
-                            } else if (RestActions.SKIPPED_FIELD.match(currentFieldName)) {
+                            } else if (RestActions.SKIPPED_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 skippedShards = parser.intValue();
                             } else {
                                 parser.skipChildren();
                             }
                         } else if (token == Token.START_ARRAY) {
-                            if (RestActions.FAILURES_FIELD.match(currentFieldName)) {
+                            if (RestActions.FAILURES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 while((token = parser.nextToken()) != Token.END_ARRAY) {
                                     failures.add(ShardSearchFailure.fromXContent(parser));
                                 }
@@ -319,7 +319,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
                             parser.skipChildren();
                         }
                     }
-                } else if (Clusters._CLUSTERS_FIELD.match(currentFieldName)) {
+                } else if (Clusters._CLUSTERS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     int successful = -1;
                     int total = -1;
                     int skipped = -1;
@@ -327,11 +327,11 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
                         if (token == XContentParser.Token.FIELD_NAME) {
                             currentFieldName = parser.currentName();
                         } else if (token.isValue()) {
-                            if (Clusters.SUCCESSFUL_FIELD.match(currentFieldName)) {
+                            if (Clusters.SUCCESSFUL_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 successful = parser.intValue();
-                            } else if (Clusters.TOTAL_FIELD.match(currentFieldName)) {
+                            } else if (Clusters.TOTAL_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 total = parser.intValue();
-                            } else if (Clusters.SKIPPED_FIELD.match(currentFieldName)) {
+                            } else if (Clusters.SKIPPED_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 skipped = parser.intValue();
                             } else {
                                 parser.skipChildren();

--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -610,7 +610,7 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (currentFieldName != null) {
-                if (FIELDS.match(currentFieldName)) {
+                if (FIELDS.match(currentFieldName, parser.deprecationHandler())) {
                     if (token == XContentParser.Token.START_ARRAY) {
                         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                             fields.add(parser.text());
@@ -618,43 +618,43 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
                     } else {
                         throw new ElasticsearchParseException("failed to parse term vectors request. field [fields] must be an array");
                     }
-                } else if (OFFSETS.match(currentFieldName)) {
+                } else if (OFFSETS.match(currentFieldName, parser.deprecationHandler())) {
                     termVectorsRequest.offsets(parser.booleanValue());
-                } else if (POSITIONS.match(currentFieldName)) {
+                } else if (POSITIONS.match(currentFieldName, parser.deprecationHandler())) {
                     termVectorsRequest.positions(parser.booleanValue());
-                } else if (PAYLOADS.match(currentFieldName)) {
+                } else if (PAYLOADS.match(currentFieldName, parser.deprecationHandler())) {
                     termVectorsRequest.payloads(parser.booleanValue());
                 } else if (currentFieldName.equals("term_statistics") || currentFieldName.equals("termStatistics")) {
                     termVectorsRequest.termStatistics(parser.booleanValue());
                 } else if (currentFieldName.equals("field_statistics") || currentFieldName.equals("fieldStatistics")) {
                     termVectorsRequest.fieldStatistics(parser.booleanValue());
-                } else if (DFS.match(currentFieldName)) {
+                } else if (DFS.match(currentFieldName, parser.deprecationHandler())) {
                     throw new IllegalArgumentException("distributed frequencies is not supported anymore for term vectors");
                 } else if (currentFieldName.equals("per_field_analyzer") || currentFieldName.equals("perFieldAnalyzer")) {
                     termVectorsRequest.perFieldAnalyzer(readPerFieldAnalyzer(parser.map()));
-                } else if (FILTER.match(currentFieldName)) {
+                } else if (FILTER.match(currentFieldName, parser.deprecationHandler())) {
                     termVectorsRequest.filterSettings(readFilterSettings(parser));
-                } else if (INDEX.match(currentFieldName)) { // the following is important for multi request parsing.
+                } else if (INDEX.match(currentFieldName, parser.deprecationHandler())) { // the following is important for multi request parsing.
                     termVectorsRequest.index = parser.text();
-                } else if (TYPE.match(currentFieldName)) {
+                } else if (TYPE.match(currentFieldName, parser.deprecationHandler())) {
                     termVectorsRequest.type = parser.text();
-                } else if (ID.match(currentFieldName)) {
+                } else if (ID.match(currentFieldName, parser.deprecationHandler())) {
                     if (termVectorsRequest.doc != null) {
                         throw new ElasticsearchParseException("failed to parse term vectors request. either [id] or [doc] can be specified, but not both!");
                     }
                     termVectorsRequest.id = parser.text();
-                } else if (DOC.match(currentFieldName)) {
+                } else if (DOC.match(currentFieldName, parser.deprecationHandler())) {
                     if (termVectorsRequest.id != null) {
                         throw new ElasticsearchParseException("failed to parse term vectors request. either [id] or [doc] can be specified, but not both!");
                     }
                     termVectorsRequest.doc(jsonBuilder().copyCurrentStructure(parser));
-                } else if (ROUTING.match(currentFieldName)) {
+                } else if (ROUTING.match(currentFieldName, parser.deprecationHandler())) {
                     termVectorsRequest.routing = parser.text();
-                } else if (PARENT.match(currentFieldName)) {
+                } else if (PARENT.match(currentFieldName, parser.deprecationHandler())) {
                     termVectorsRequest.parent = parser.text();
-                } else if (VERSION.match(currentFieldName)) {
+                } else if (VERSION.match(currentFieldName, parser.deprecationHandler())) {
                     termVectorsRequest.version = parser.longValue();
-                } else if (VERSION_TYPE.match(currentFieldName)) {
+                } else if (VERSION_TYPE.match(currentFieldName, parser.deprecationHandler())) {
                     termVectorsRequest.versionType = VersionType.fromString(parser.text());
                 } else {
                     throw new ElasticsearchParseException("failed to parse term vectors request. unknown field [{}]", currentFieldName);

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.action.support.single.instance.InstanceShardOperationRequest;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
@@ -863,7 +864,9 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         }
         if (doc != null) {
             XContentType xContentType = doc.getContentType();
-            try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, doc.source(), xContentType)) {
+            // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because copyCurrentStructure does not interact with deprecations
+            try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+                    ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, doc.source(), xContentType)) {
                 builder.field("doc");
                 builder.copyCurrentStructure(parser);
             }
@@ -873,7 +876,9 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         }
         if (upsertRequest != null) {
             XContentType xContentType = upsertRequest.getContentType();
-            try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, upsertRequest.source(), xContentType)) {
+            // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because copyCurrentStructure does not interact with deprecations
+            try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+                    ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, upsertRequest.source(), xContentType)) {
                 builder.field("upsert");
                 builder.copyCurrentStructure(parser);
             }

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractComponent;
@@ -120,7 +121,9 @@ public class AliasValidator extends AbstractComponent {
     public void validateAliasFilter(String alias, String filter, QueryShardContext queryShardContext,
             NamedXContentRegistry xContentRegistry) {
         assert queryShardContext != null;
-        try (XContentParser parser = XContentFactory.xContent(filter).createParser(xContentRegistry, filter)) {
+        // LoggingDeprecationHandler is fine here because this is always executed on the server
+        try (XContentParser parser = XContentFactory.xContent(filter)
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, filter)) {
             validateAliasFilter(parser, queryShardContext);
         } catch (Exception e) {
             throw new IllegalArgumentException("failed to parse filter for alias [" + alias + "]", e);
@@ -135,7 +138,9 @@ public class AliasValidator extends AbstractComponent {
     public void validateAliasFilter(String alias, byte[] filter, QueryShardContext queryShardContext,
             NamedXContentRegistry xContentRegistry) {
         assert queryShardContext != null;
-        try (XContentParser parser = XContentFactory.xContent(filter).createParser(xContentRegistry, filter)) {
+        // LoggingDeprecationHandler is fine here because this is always executed on the server
+        try (XContentParser parser = XContentFactory.xContent(filter)
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, filter)) {
             validateAliasFilter(parser, queryShardContext);
         } catch (Exception e) {
             throw new IllegalArgumentException("failed to parse filter for alias [" + alias + "]", e);

--- a/core/src/main/java/org/elasticsearch/common/LoggingDeprecationHandler.java
+++ b/core/src/main/java/org/elasticsearch/common/LoggingDeprecationHandler.java
@@ -22,6 +22,15 @@ import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 
+/**
+ * Logs deprecations to the {@link DeprecationLogger}.
+ * <p>
+ * This is core's primary implementation of {@link DeprecationHandler} and
+ * should <stong>absolutely</strong> be used everywhere where it parses
+ * requests. It is much less appropriate when parsing responses from external
+ * sources because it will report deprecated fields back to the user as
+ * though the user sent them.
+ */
 public class LoggingDeprecationHandler implements DeprecationHandler {
     public static LoggingDeprecationHandler INSTANCE = new LoggingDeprecationHandler();
     private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(ParseField.class));

--- a/core/src/main/java/org/elasticsearch/common/LoggingDeprecationHandler.java
+++ b/core/src/main/java/org/elasticsearch/common/LoggingDeprecationHandler.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.logging.Loggers;
  * Logs deprecations to the {@link DeprecationLogger}.
  * <p>
  * This is core's primary implementation of {@link DeprecationHandler} and
- * should <stong>absolutely</strong> be used everywhere where it parses
+ * should <strong>absolutely</strong> be used everywhere where it parses
  * requests. It is much less appropriate when parsing responses from external
  * sources because it will report deprecated fields back to the user as
  * though the user sent them.

--- a/core/src/main/java/org/elasticsearch/common/LoggingDeprecationHandler.java
+++ b/core/src/main/java/org/elasticsearch/common/LoggingDeprecationHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.common;
+
+import org.elasticsearch.common.ParseField.DeprecationHandler;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+public class LoggingDeprecationHandler implements DeprecationHandler {
+    public static LoggingDeprecationHandler INSTANCE = new LoggingDeprecationHandler();
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(ParseField.class));
+
+    private LoggingDeprecationHandler() {
+        // Singleton
+    }
+
+    @Override
+    public void usedDeprecatedName(String usedName, String modernName) {
+        DEPRECATION_LOGGER.deprecated("Deprecated field [{}] used, expected [{}] instead", usedName, modernName);
+    }
+
+    @Override
+    public void usedDeprecatedField(String usedName, String replacedWith) {
+        DEPRECATION_LOGGER.deprecated("Deprecated field [{}] used, replaced by [{}]", usedName, replacedWith);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -18,9 +18,6 @@
  */
 package org.elasticsearch.common;
 
-import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.logging.Loggers;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -31,8 +28,24 @@ import java.util.Set;
  * variants, which may be deprecated.
  */
 public class ParseField {
-
-    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(ParseField.class));
+    /**
+     * Called when parsing deprecated fields.
+     */
+    public interface DeprecationHandler {
+        /**
+         * Called when the provided field name matches a deprecated name for the field.
+         * @param usedName the provided field name
+         * @param modernName the modern name for the field
+         */
+        void usedDeprecatedName(String usedName, String modernName);
+        /**
+         * Called when the provided field name matches the current field but the entire
+         * field has been marked as deprecated.
+         * @param usedName the provided field name
+         * @param replacedWith the name of the field that replaced this field
+         */
+        void usedDeprecatedField(String usedName, String replacedWith);
+    }
 
     private final String name;
     private final String[] deprecatedNames;
@@ -104,7 +117,7 @@ public class ParseField {
      * @return true if <code>fieldName</code> matches any of the acceptable
      *         names for this {@link ParseField}.
      */
-    public boolean match(String fieldName) {
+    public boolean match(String fieldName, DeprecationHandler deprecationHandler) {
         Objects.requireNonNull(fieldName, "fieldName cannot be null");
         // if this parse field has not been completely deprecated then try to
         // match the preferred name
@@ -114,17 +127,13 @@ public class ParseField {
         // Now try to match against one of the deprecated names. Note that if
         // the parse field is entirely deprecated (allReplacedWith != null) all
         // fields will be in the deprecatedNames array
-        String msg;
         for (String depName : deprecatedNames) {
             if (fieldName.equals(depName)) {
-                msg = "Deprecated field [" + fieldName + "] used, expected [" + name + "] instead";
-                if (allReplacedWith != null) {
-                    // If the field is entirely deprecated then there is no
-                    // preferred name so instead use the `allReplaceWith`
-                    // message to indicate what should be used instead
-                    msg = "Deprecated field [" + fieldName + "] used, replaced by [" + allReplacedWith + "]";
+                if (allReplacedWith == null) {
+                    deprecationHandler.usedDeprecatedName(fieldName, name);
+                } else {
+                    deprecationHandler.usedDeprecatedField(fieldName, allReplacedWith);
                 }
-                DEPRECATION_LOGGER.deprecated(msg);
                 return true;
             }
         }

--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import org.elasticsearch.common.xcontent.XContentParser;
+
 /**
  * Holds a field that can be found in a request while parsing and its different
  * variants, which may be deprecated.
@@ -46,6 +48,11 @@ public class ParseField {
          */
         void usedDeprecatedField(String usedName, String replacedWith);
     }
+    /**
+     * Throws an exception when we hit a deprecated field. Use this when creating an
+     * {@link XContentParser} that won't interact with deprecation logic at all or that
+     * doesn't support deprecated fields.
+     */
     public static final DeprecationHandler UNSUPPORTED_OPERATION_DEPRECATION_HANDLER = new DeprecationHandler() {
         @Override
         public void usedDeprecatedField(String usedName, String replacedWith) {
@@ -57,6 +64,18 @@ public class ParseField {
             throw new UnsupportedOperationException("deprecated fields not supported here but got ["
                 + usedName + "] which has been replaced with [" + modernName + "]");
         }
+    };
+    /**
+     * {@link DeprecationHandler} that does nothing when it is notified
+     * of a deprecated field. Use this when there is no user to notify
+     * but deprecated fields are possible.
+     */
+    public static final DeprecationHandler IGNORING_DEPRECATION_HANDLER = new DeprecationHandler() {
+        @Override
+        public void usedDeprecatedName(String usedName, String modernName) {}
+
+        @Override
+        public void usedDeprecatedField(String usedName, String replacedWith) {}
     };
 
     private final String name;

--- a/core/src/main/java/org/elasticsearch/common/ParseField.java
+++ b/core/src/main/java/org/elasticsearch/common/ParseField.java
@@ -46,6 +46,18 @@ public class ParseField {
          */
         void usedDeprecatedField(String usedName, String replacedWith);
     }
+    public static final DeprecationHandler UNSUPPORTED_OPERATION_DEPRECATION_HANDLER = new DeprecationHandler() {
+        @Override
+        public void usedDeprecatedField(String usedName, String replacedWith) {
+            throw new UnsupportedOperationException("deprecated fields not supported here but got ["
+            + usedName + "] which is a deprecated name for [" + replacedWith + "]");
+        }
+        @Override
+        public void usedDeprecatedName(String usedName, String modernName) {
+            throw new UnsupportedOperationException("deprecated fields not supported here but got ["
+                + usedName + "] which has been replaced with [" + modernName + "]");
+        }
+    };
 
     private final String name;
     private final String[] deprecatedNames;
@@ -112,8 +124,24 @@ public class ParseField {
     }
 
     /**
+     * Does {@code fieldName} match this field? Uses {@link LoggingDeprecationHandler}
+     * to prevent us from having to touch every call to {@code match} in the change
+     * that introduced {@linkplain LoggingDeprecationHandler}. In a followup this will
+     * be removed.
      * @param fieldName
      *            the field name to match against this {@link ParseField}
+     * @return true if <code>fieldName</code> matches any of the acceptable
+     *         names for this {@link ParseField}.
+     */
+    public boolean match(String fieldName) {
+        return match(fieldName, LoggingDeprecationHandler.INSTANCE);
+    }
+
+    /**
+     * Does {@code fieldName} match this field?
+     * @param fieldName
+     *            the field name to match against this {@link ParseField}
+     * @param deprecationHandler called if {@code fieldName} is deprecated
      * @return true if <code>fieldName</code> matches any of the acceptable
      *         names for this {@link ParseField}.
      */

--- a/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -58,7 +58,6 @@ import static java.time.temporal.ChronoField.YEAR;
  * A logger that logs deprecation notices.
  */
 public class DeprecationLogger {
-
     private final Logger logger;
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
+++ b/core/src/main/java/org/elasticsearch/common/logging/DeprecationLogger.java
@@ -58,6 +58,7 @@ import static java.time.temporal.ChronoField.YEAR;
  * A logger that logs deprecation notices.
  */
 public class DeprecationLogger {
+
     private final Logger logger;
 
     /**

--- a/core/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.regex.Regex;
@@ -1106,7 +1107,9 @@ public class Setting<T> implements ToXContentObject {
 
     private static List<String> parseableStringToList(String parsableString) {
         // EMPTY is safe here because we never call namedObject
-        try (XContentParser xContentParser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, parsableString)) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with deprecation
+        try (XContentParser xContentParser = XContentType.JSON.xContent()
+                .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, parsableString)) {
             XContentParser.Token token = xContentParser.nextToken();
             if (token != XContentParser.Token.START_ARRAY) {
                 throw new IllegalArgumentException("expected START_ARRAY but got " + token);

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -25,6 +25,7 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -1114,7 +1115,9 @@ public final class Settings implements ToXContentFragment {
          * Loads settings from the actual string content that represents them using {@link #fromXContent(XContentParser)}
          */
         public Builder loadFromSource(String source, XContentType xContentType) {
-            try (XContentParser parser =  XContentFactory.xContent(xContentType).createParser(NamedXContentRegistry.EMPTY, source)) {
+            // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we do not have deprecated fields
+            try (XContentParser parser =  XContentFactory.xContent(xContentType)
+                    .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, source)) {
                 this.put(fromXContent(parser, true, true));
             } catch (Exception e) {
                 throw new SettingsException("Failed to load settings from [" + source + "]", e);
@@ -1143,7 +1146,9 @@ public final class Settings implements ToXContentFragment {
             } else {
                 throw new IllegalArgumentException("unable to detect content type from resource name [" + resourceName + "]");
             }
-            try (XContentParser parser =  XContentFactory.xContent(xContentType).createParser(NamedXContentRegistry.EMPTY, is)) {
+            // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we do not have deprecated fields
+            try (XContentParser parser =  XContentFactory.xContent(xContentType).createParser(
+                    NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, is)) {
                 if (parser.currentToken() == null) {
                     if (parser.nextToken() == null) {
                         return this; // empty file

--- a/core/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
@@ -134,7 +134,7 @@ public class NamedXContentRegistry {
         if (entry == null) {
             throw new UnknownNamedObjectException(parser.getTokenLocation(), categoryClass, name);
         }
-        if (false == entry.name.match(name)) {
+        if (false == entry.name.match(name, parser.deprecationHandler())) {
             /* Note that this shouldn't happen because we already looked up the entry using the names but we need to call `match` anyway
              * because it is responsible for logging deprecation warnings. */
             throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
@@ -165,7 +165,7 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
                     assert ignoreUnknownFields : "this should only be possible if configured to ignore known fields";
                     parser.skipChildren(); // noop if parser points to a value, skips children if parser is start object or start array
                 } else {
-                    fieldParser.assertSupports(name, token, currentFieldName, parser.getTokenLocation());
+                    fieldParser.assertSupports(name, token, currentFieldName, parser);
                     parseSub(parser, fieldParser, currentFieldName, value, context);
                 }
                 fieldParser = null;
@@ -361,12 +361,13 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
             this.type = type;
         }
 
-        void assertSupports(String parserName, XContentParser.Token token, String currentFieldName, XContentLocation location) {
-            if (parseField.match(currentFieldName) == false) {
-                throw new ParsingException(location, "[" + parserName  + "] parsefield doesn't accept: " + currentFieldName);
+        void assertSupports(String parserName, XContentParser.Token token, String currentFieldName, XContentParser parser) {
+            if (parseField.match(currentFieldName, parser.deprecationHandler()) == false) {
+                throw new ParsingException(parser.getTokenLocation(),
+                        "[" + parserName  + "] parsefield doesn't accept: " + currentFieldName);
             }
             if (supportedTokens.contains(token) == false) {
-                throw new ParsingException(location, 
+                throw new ParsingException(parser.getTokenLocation(),
                         "[" + parserName + "] " + currentFieldName + " doesn't support values of type: " + token);
             }
         }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContent.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContent.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.xcontent;
 
 import org.elasticsearch.common.Booleans;
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.bytes.BytesReference;
 
 import java.io.IOException;
@@ -83,31 +84,47 @@ public interface XContent {
     /**
      * Creates a parser over the provided string content.
      */
-    XContentParser createParser(NamedXContentRegistry xContentRegistry, String content) throws IOException;
+    XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, String content) throws IOException;
 
     /**
      * Creates a parser over the provided input stream.
+     * @param xContentRegistry the named x content objects supported by this parser
+     * @param deprecationHandler handler called if the parser encounters any deprecated fields
      */
-    XContentParser createParser(NamedXContentRegistry xContentRegistry, InputStream is) throws IOException;
+    XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, InputStream is) throws IOException;
 
     /**
      * Creates a parser over the provided bytes.
+     * @param xContentRegistry the named x content objects supported by this parser
+     * @param deprecationHandler handler called if the parser encounters any deprecated fields
      */
-    XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data) throws IOException;
+    XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data) throws IOException;
 
     /**
      * Creates a parser over the provided bytes.
+     * @param xContentRegistry the named x content objects supported by this parser
+     * @param deprecationHandler handler called if the parser encounters any deprecated fields
      */
-    XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data, int offset, int length) throws IOException;
+    XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data, int offset, int length) throws IOException;
 
     /**
      * Creates a parser over the provided bytes.
+     * @param xContentRegistry the named x content objects supported by this parser
+     * @param deprecationHandler handler called if the parser encounters any deprecated fields
      */
-    XContentParser createParser(NamedXContentRegistry xContentRegistry, BytesReference bytes) throws IOException;
+    XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, BytesReference bytes) throws IOException;
 
     /**
      * Creates a parser over the provided reader.
+     * @param xContentRegistry the named x content objects supported by this parser
+     * @param deprecationHandler handler called if the parser encounters any deprecated fields
      */
-    XContentParser createParser(NamedXContentRegistry xContentRegistry, Reader reader) throws IOException;
+    XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, Reader reader) throws IOException;
 
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.common.xcontent;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.lease.Releasable;
 
 import java.io.IOException;
@@ -275,6 +276,11 @@ public interface XContentParser extends Releasable {
      * The registry used to resolve {@link #namedObject(Class, String, Object)}. Use this when building a sub-parser from this parser.
      */
     NamedXContentRegistry getXContentRegistry();
+
+    /**
+     * The place to send deprecation warnings.
+     */
+    DeprecationHandler deprecationHandler();
 
     boolean isClosed();
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -34,7 +34,8 @@ import java.util.Map;
  *
  * <pre>
  *     XContentType xContentType = XContentType.JSON;
- *     XContentParser parser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, "{\"key\" : \"value\"}");
+ *     XContentParser parser = xContentType.xContent()
+ *          .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER"{\"key\" : \"value\"}");
  * </pre>
  */
 public interface XContentParser extends Releasable {

--- a/core/src/main/java/org/elasticsearch/common/xcontent/cbor/CborXContent.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/cbor/CborXContent.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.FastStringReader;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -79,33 +80,39 @@ public class CborXContent implements XContent {
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, String content) throws IOException {
-        return new CborXContentParser(xContentRegistry, cborFactory.createParser(new FastStringReader(content)));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, String content) throws IOException {
+        return new CborXContentParser(xContentRegistry, deprecationHandler, cborFactory.createParser(new FastStringReader(content)));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, InputStream is) throws IOException {
-        return new CborXContentParser(xContentRegistry, cborFactory.createParser(is));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, InputStream is) throws IOException {
+        return new CborXContentParser(xContentRegistry, deprecationHandler, cborFactory.createParser(is));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data) throws IOException {
-        return new CborXContentParser(xContentRegistry, cborFactory.createParser(data));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data) throws IOException {
+        return new CborXContentParser(xContentRegistry, deprecationHandler, cborFactory.createParser(data));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data, int offset, int length) throws IOException {
-        return new CborXContentParser(xContentRegistry, cborFactory.createParser(data, offset, length));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data, int offset, int length) throws IOException {
+        return new CborXContentParser(xContentRegistry, deprecationHandler, cborFactory.createParser(data, offset, length));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, BytesReference bytes) throws IOException {
-        return createParser(xContentRegistry, bytes.streamInput());
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, BytesReference bytes) throws IOException {
+        return createParser(xContentRegistry, deprecationHandler, bytes.streamInput());
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, Reader reader) throws IOException {
-        return new CborXContentParser(xContentRegistry, cborFactory.createParser(reader));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, Reader reader) throws IOException {
+        return new CborXContentParser(xContentRegistry, deprecationHandler, cborFactory.createParser(reader));
     }
 
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.FastStringReader;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -80,32 +81,38 @@ public class JsonXContent implements XContent {
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, String content) throws IOException {
-        return new JsonXContentParser(xContentRegistry, jsonFactory.createParser(new FastStringReader(content)));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, String content) throws IOException {
+        return new JsonXContentParser(xContentRegistry, deprecationHandler, jsonFactory.createParser(new FastStringReader(content)));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, InputStream is) throws IOException {
-        return new JsonXContentParser(xContentRegistry, jsonFactory.createParser(is));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, InputStream is) throws IOException {
+        return new JsonXContentParser(xContentRegistry, deprecationHandler, jsonFactory.createParser(is));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data) throws IOException {
-        return new JsonXContentParser(xContentRegistry, jsonFactory.createParser(data));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data) throws IOException {
+        return new JsonXContentParser(xContentRegistry, deprecationHandler, jsonFactory.createParser(data));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data, int offset, int length) throws IOException {
-        return new JsonXContentParser(xContentRegistry, jsonFactory.createParser(data, offset, length));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data, int offset, int length) throws IOException {
+        return new JsonXContentParser(xContentRegistry, deprecationHandler, jsonFactory.createParser(data, offset, length));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, BytesReference bytes) throws IOException {
-        return createParser(xContentRegistry, bytes.streamInput());
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, BytesReference bytes) throws IOException {
+        return createParser(xContentRegistry, deprecationHandler, bytes.streamInput());
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, Reader reader) throws IOException {
-        return new JsonXContentParser(xContentRegistry, jsonFactory.createParser(reader));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, Reader reader) throws IOException {
+        return new JsonXContentParser(xContentRegistry, deprecationHandler, jsonFactory.createParser(reader));
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonToken;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -37,8 +38,8 @@ public class JsonXContentParser extends AbstractXContentParser {
 
     final JsonParser parser;
 
-    public JsonXContentParser(NamedXContentRegistry xContentRegistry, JsonParser parser) {
-        super(xContentRegistry);
+    public JsonXContentParser(NamedXContentRegistry xContentRegistry, DeprecationHandler deprecationHandler, JsonParser parser) {
+        super(xContentRegistry, deprecationHandler);
         this.parser = parser;
     }
 

--- a/core/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContent.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContent.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
+
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.FastStringReader;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -80,32 +82,38 @@ public class SmileXContent implements XContent {
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, String content) throws IOException {
-        return new SmileXContentParser(xContentRegistry, smileFactory.createParser(new FastStringReader(content)));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, String content) throws IOException {
+        return new SmileXContentParser(xContentRegistry, deprecationHandler, smileFactory.createParser(new FastStringReader(content)));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, InputStream is) throws IOException {
-        return new SmileXContentParser(xContentRegistry, smileFactory.createParser(is));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, InputStream is) throws IOException {
+        return new SmileXContentParser(xContentRegistry, deprecationHandler, smileFactory.createParser(is));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data) throws IOException {
-        return new SmileXContentParser(xContentRegistry, smileFactory.createParser(data));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data) throws IOException {
+        return new SmileXContentParser(xContentRegistry, deprecationHandler, smileFactory.createParser(data));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data, int offset, int length) throws IOException {
-        return new SmileXContentParser(xContentRegistry, smileFactory.createParser(data, offset, length));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data, int offset, int length) throws IOException {
+        return new SmileXContentParser(xContentRegistry, deprecationHandler, smileFactory.createParser(data, offset, length));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, BytesReference bytes) throws IOException {
-        return createParser(xContentRegistry, bytes.streamInput());
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, BytesReference bytes) throws IOException {
+        return createParser(xContentRegistry, deprecationHandler, bytes.streamInput());
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, Reader reader) throws IOException {
-        return new SmileXContentParser(xContentRegistry, smileFactory.createParser(reader));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, Reader reader) throws IOException {
+        return new SmileXContentParser(xContentRegistry, deprecationHandler, smileFactory.createParser(reader));
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContentParser.java
@@ -20,15 +20,15 @@
 package org.elasticsearch.common.xcontent.smile;
 
 import com.fasterxml.jackson.core.JsonParser;
-
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContentParser;
 
 public class SmileXContentParser extends JsonXContentParser {
 
-    public SmileXContentParser(NamedXContentRegistry xContentRegistry, JsonParser parser) {
-        super(xContentRegistry, parser);
+    public SmileXContentParser(NamedXContentRegistry xContentRegistry, DeprecationHandler deprecationHandler, JsonParser parser) {
+        super(xContentRegistry, deprecationHandler, parser);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Numbers;
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 
@@ -52,9 +53,11 @@ public abstract class AbstractXContentParser implements XContentParser {
     }
 
     private final NamedXContentRegistry xContentRegistry;
+    private final DeprecationHandler deprecationHandler;
 
-    public AbstractXContentParser(NamedXContentRegistry xContentRegistry) {
+    public AbstractXContentParser(NamedXContentRegistry xContentRegistry, DeprecationHandler deprecationHandler) {
         this.xContentRegistry = xContentRegistry;
+        this.deprecationHandler = deprecationHandler;
     }
 
     // The 3rd party parsers we rely on are known to silently truncate fractions: see
@@ -405,6 +408,11 @@ public abstract class AbstractXContentParser implements XContentParser {
     @Override
     public NamedXContentRegistry getXContentRegistry() {
         return xContentRegistry;
+    }
+
+    @Override
+    public DeprecationHandler deprecationHandler() {
+        return deprecationHandler;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/xcontent/yaml/YamlXContent.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/yaml/YamlXContent.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.FastStringReader;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -75,32 +76,38 @@ public class YamlXContent implements XContent {
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, String content) throws IOException {
-        return new YamlXContentParser(xContentRegistry, yamlFactory.createParser(new FastStringReader(content)));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, String content) throws IOException {
+        return new YamlXContentParser(xContentRegistry, deprecationHandler, yamlFactory.createParser(new FastStringReader(content)));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, InputStream is) throws IOException {
-        return new YamlXContentParser(xContentRegistry, yamlFactory.createParser(is));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, InputStream is) throws IOException {
+        return new YamlXContentParser(xContentRegistry, deprecationHandler, yamlFactory.createParser(is));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data) throws IOException {
-        return new YamlXContentParser(xContentRegistry, yamlFactory.createParser(data));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data) throws IOException {
+        return new YamlXContentParser(xContentRegistry, deprecationHandler, yamlFactory.createParser(data));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, byte[] data, int offset, int length) throws IOException {
-        return new YamlXContentParser(xContentRegistry, yamlFactory.createParser(data, offset, length));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, byte[] data, int offset, int length) throws IOException {
+        return new YamlXContentParser(xContentRegistry, deprecationHandler, yamlFactory.createParser(data, offset, length));
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, BytesReference bytes) throws IOException {
-        return createParser(xContentRegistry, bytes.streamInput());
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, BytesReference bytes) throws IOException {
+        return createParser(xContentRegistry, deprecationHandler, bytes.streamInput());
     }
 
     @Override
-    public XContentParser createParser(NamedXContentRegistry xContentRegistry, Reader reader) throws IOException {
-        return new YamlXContentParser(xContentRegistry, yamlFactory.createParser(reader));
+    public XContentParser createParser(NamedXContentRegistry xContentRegistry,
+            DeprecationHandler deprecationHandler, Reader reader) throws IOException {
+        return new YamlXContentParser(xContentRegistry, deprecationHandler, yamlFactory.createParser(reader));
     }
 }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/yaml/YamlXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/yaml/YamlXContentParser.java
@@ -20,15 +20,15 @@
 package org.elasticsearch.common.xcontent.yaml;
 
 import com.fasterxml.jackson.core.JsonParser;
-
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContentParser;
 
 public class YamlXContentParser extends JsonXContentParser {
 
-    public YamlXContentParser(NamedXContentRegistry xContentRegistry, JsonParser parser) {
-        super(xContentRegistry, parser);
+    public YamlXContentParser(NamedXContentRegistry xContentRegistry, DeprecationHandler deprecationHandler, JsonParser parser) {
+        super(xContentRegistry, deprecationHandler, parser);
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
+++ b/core/src/main/java/org/elasticsearch/gateway/MetaDataStateFormat.java
@@ -32,6 +32,7 @@ import org.apache.lucene.store.OutputStreamIndexOutput;
 import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
@@ -197,8 +198,9 @@ public abstract class MetaDataStateFormat<T> {
                 long filePointer = indexInput.getFilePointer();
                 long contentSize = indexInput.length() - CodecUtil.footerLength() - filePointer;
                 try (IndexInput slice = indexInput.slice("state_xcontent", filePointer, contentSize)) {
+                    // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is safe here because we don't have deprecated fields
                     try (XContentParser parser = XContentFactory.xContent(xContentType).createParser(namedXContentRegistry,
-                            new InputStreamIndexInput(slice, contentSize))) {
+                            ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, new InputStreamIndexInput(slice, contentSize))) {
                         return fromXContent(parser);
                     }
                 }
@@ -312,7 +314,9 @@ public abstract class MetaDataStateFormat<T> {
                         logger.debug("{}: no data for [{}], ignoring...", prefix, stateFile.toAbsolutePath());
                         continue;
                     }
-                    try (XContentParser parser = XContentHelper.createParser(namedXContentRegistry, new BytesArray(data))) {
+                    // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is safe here because we don't have deprecated fields
+                    try (XContentParser parser = XContentHelper.createParser(namedXContentRegistry,
+                            ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, new BytesArray(data))) {
                         state = fromXContent(parser);
                     }
                     if (state == null) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -162,7 +163,9 @@ public class DocumentMapperParser {
 
     private Tuple<String, Map<String, Object>> extractMapping(String type, String source) throws MapperParsingException {
         Map<String, Object> root;
-        try (XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry, source)) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because mapOrdered does not interact with deprecations
+        try (XContentParser parser = XContentType.JSON.xContent()
+                .createParser(xContentRegistry, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, source)) {
             root = parser.mapOrdered();
         } catch (Exception e) {
             throw new MapperParsingException("failed to parse mapping definition", e);

--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
@@ -61,7 +62,9 @@ final class DocumentParser {
         final ParseContext.InternalParseContext context;
         final XContentType xContentType = source.getXContentType();
 
-        try (XContentParser parser = XContentHelper.createParser(docMapperParser.getXContentRegistry(), source.source(), xContentType)) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because this parsing doesn't interact with deprecated fields
+        try (XContentParser parser = XContentHelper.createParser(docMapperParser.getXContentRegistry(),
+                ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, source.source(), xContentType)) {
             context = new ParseContext.InternalParseContext(indexSettings.getSettings(), docMapperParser, docMapper, source, parser);
             validateStart(parser);
             internalParseDocument(mapping, context, parser);

--- a/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -31,6 +31,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -200,7 +201,9 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
      * Parses the mappings (formatted as JSON) into a map
      */
     public static Map<String, Object> parseMapping(NamedXContentRegistry xContentRegistry, String mappingSource) throws Exception {
-        try (XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry, mappingSource)) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because map doesn't use the deprecation handler
+        try (XContentParser parser = XContentType.JSON.xContent()
+                .createParser(xContentRegistry, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, mappingSource)) {
             return parser.map();
         }
     }

--- a/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/BoostingQueryBuilder.java
@@ -152,21 +152,21 @@ public class BoostingQueryBuilder extends AbstractQueryBuilder<BoostingQueryBuil
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (POSITIVE_FIELD.match(currentFieldName)) {
+                if (POSITIVE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     positiveQuery = parseInnerQueryBuilder(parser);
                     positiveQueryFound = true;
-                } else if (NEGATIVE_FIELD.match(currentFieldName)) {
+                } else if (NEGATIVE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     negativeQuery = parseInnerQueryBuilder(parser);
                     negativeQueryFound = true;
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[boosting] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
-                if (NEGATIVE_BOOST_FIELD.match(currentFieldName)) {
+                if (NEGATIVE_BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     negativeBoost = parser.floatValue();
-                } else if (NAME_FIELD.match(currentFieldName)) {
+                } else if (NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
-                } else if (BOOST_FIELD.match(currentFieldName)) {
+                } else if (BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[boosting] query does not support [" + currentFieldName + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/CommonTermsQueryBuilder.java
@@ -271,15 +271,15 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token == XContentParser.Token.START_OBJECT) {
-                        if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName)) {
+                        if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             String innerFieldName = null;
                             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                                 if (token == XContentParser.Token.FIELD_NAME) {
                                     innerFieldName = parser.currentName();
                                 } else if (token.isValue()) {
-                                    if (LOW_FREQ_FIELD.match(innerFieldName)) {
+                                    if (LOW_FREQ_FIELD.match(innerFieldName, parser.deprecationHandler())) {
                                         lowFreqMinimumShouldMatch = parser.text();
-                                    } else if (HIGH_FREQ_FIELD.match(innerFieldName)) {
+                                    } else if (HIGH_FREQ_FIELD.match(innerFieldName, parser.deprecationHandler())) {
                                         highFreqMinimumShouldMatch = parser.text();
                                     } else {
                                         throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME +
@@ -297,23 +297,23 @@ public class CommonTermsQueryBuilder extends AbstractQueryBuilder<CommonTermsQue
                                     "] query does not support [" + currentFieldName + "]");
                         }
                     } else if (token.isValue()) {
-                        if (QUERY_FIELD.match(currentFieldName)) {
+                        if (QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             text = parser.objectText();
-                        } else if (ANALYZER_FIELD.match(currentFieldName)) {
+                        } else if (ANALYZER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             analyzer = parser.text();
-                        } else if (DISABLE_COORD_FIELD.match(currentFieldName)) {
+                        } else if (DISABLE_COORD_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             // ignore
-                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             boost = parser.floatValue();
-                        } else if (HIGH_FREQ_OPERATOR_FIELD.match(currentFieldName)) {
+                        } else if (HIGH_FREQ_OPERATOR_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             highFreqOperator = Operator.fromString(parser.text());
-                        } else if (LOW_FREQ_OPERATOR_FIELD.match(currentFieldName)) {
+                        } else if (LOW_FREQ_OPERATOR_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             lowFreqOperator = Operator.fromString(parser.text());
-                        } else if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName)) {
+                        } else if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             lowFreqMinimumShouldMatch = parser.text();
-                        } else if (CUTOFF_FREQUENCY_FIELD.match(currentFieldName)) {
+                        } else if (CUTOFF_FREQUENCY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             cutoffFrequency = parser.floatValue();
-                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             queryName = parser.text();
                         } else {
                             throw new ParsingException(parser.getTokenLocation(), "[" + CommonTermsQueryBuilder.NAME +

--- a/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ExistsQueryBuilder.java
@@ -99,11 +99,11 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (FIELD_FIELD.match(currentFieldName)) {
+                if (FIELD_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fieldPattern = parser.text();
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[" + ExistsQueryBuilder.NAME +
@@ -131,7 +131,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     public static Query newFilter(QueryShardContext context, String fieldPattern) {
-        
+
         final FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = (FieldNamesFieldMapper.FieldNamesFieldType) context
                 .getMapperService().fullName(FieldNamesFieldMapper.NAME);
         if (fieldNamesFieldType == null) {
@@ -165,7 +165,7 @@ public class ExistsQueryBuilder extends AbstractQueryBuilder<ExistsQueryBuilder>
     }
 
     private static Query newLegacyExistsQuery(Collection<String> fields) {
-        // We create TermsQuery directly here rather than using FieldNamesFieldType.termsQuery() 
+        // We create TermsQuery directly here rather than using FieldNamesFieldType.termsQuery()
         // so we don't end up with deprecation warnings
         if (fields.size() == 1) {
             Query filter = new TermQuery(new Term(FieldNamesFieldMapper.NAME, fields.iterator().next()));

--- a/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FieldMaskingSpanQueryBuilder.java
@@ -113,7 +113,7 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     QueryBuilder query = parseInnerQueryBuilder(parser);
                     if (query instanceof SpanQueryBuilder == false) {
                         throw new ParsingException(parser.getTokenLocation(), "[field_masking_span] query must be of type span query");
@@ -124,11 +124,11 @@ public class FieldMaskingSpanQueryBuilder extends AbstractQueryBuilder<FieldMask
                             + currentFieldName + "]");
                 }
             } else {
-                if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
-                } else if (FIELD_FIELD.match(currentFieldName)) {
+                } else if (FIELD_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     field = parser.text();
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/FuzzyQueryBuilder.java
@@ -272,23 +272,23 @@ public class FuzzyQueryBuilder extends AbstractQueryBuilder<FuzzyQueryBuilder> i
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token.isValue()) {
-                        if (TERM_FIELD.match(currentFieldName)) {
+                        if (TERM_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             value = parser.objectBytes();
-                        } else if (VALUE_FIELD.match(currentFieldName)) {
+                        } else if (VALUE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             value = parser.objectBytes();
-                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             boost = parser.floatValue();
-                        } else if (Fuzziness.FIELD.match(currentFieldName)) {
+                        } else if (Fuzziness.FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             fuzziness = Fuzziness.parse(parser);
-                        } else if (PREFIX_LENGTH_FIELD.match(currentFieldName)) {
+                        } else if (PREFIX_LENGTH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             prefixLength = parser.intValue();
-                        } else if (MAX_EXPANSIONS_FIELD.match(currentFieldName)) {
+                        } else if (MAX_EXPANSIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             maxExpansions = parser.intValue();
-                        } else if (TRANSPOSITIONS_FIELD.match(currentFieldName)) {
+                        } else if (TRANSPOSITIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             transpositions = parser.booleanValue();
-                        } else if (REWRITE_FIELD.match(currentFieldName)) {
+                        } else if (REWRITE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             rewrite = parser.textOrNull();
-                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             queryName = parser.text();
                         } else {
                             throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -404,30 +404,30 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                         token = parser.nextToken();
-                        if (FIELD_FIELD.match(currentFieldName)) {
+                        if (FIELD_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             fieldName = parser.text();
-                        } else if (TOP_FIELD.match(currentFieldName)) {
+                        } else if (TOP_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             top = parser.doubleValue();
-                        } else if (BOTTOM_FIELD.match(currentFieldName)) {
+                        } else if (BOTTOM_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             bottom = parser.doubleValue();
-                        } else if (LEFT_FIELD.match(currentFieldName)) {
+                        } else if (LEFT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             left = parser.doubleValue();
-                        } else if (RIGHT_FIELD.match(currentFieldName)) {
+                        } else if (RIGHT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             right = parser.doubleValue();
                         } else {
-                            if (TOP_LEFT_FIELD.match(currentFieldName)) {
+                            if (TOP_LEFT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 GeoUtils.parseGeoPoint(parser, sparse);
                                 top = sparse.getLat();
                                 left = sparse.getLon();
-                            } else if (BOTTOM_RIGHT_FIELD.match(currentFieldName)) {
+                            } else if (BOTTOM_RIGHT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 GeoUtils.parseGeoPoint(parser, sparse);
                                 bottom = sparse.getLat();
                                 right = sparse.getLon();
-                            } else if (TOP_RIGHT_FIELD.match(currentFieldName)) {
+                            } else if (TOP_RIGHT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 GeoUtils.parseGeoPoint(parser, sparse);
                                 top = sparse.getLat();
                                 right = sparse.getLon();
-                            } else if (BOTTOM_LEFT_FIELD.match(currentFieldName)) {
+                            } else if (BOTTOM_LEFT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                                 GeoUtils.parseGeoPoint(parser, sparse);
                                 bottom = sparse.getLat();
                                 left = sparse.getLon();
@@ -442,15 +442,15 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
                     }
                 }
             } else if (token.isValue()) {
-                if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
-                } else if (VALIDATION_METHOD_FIELD.match(currentFieldName)) {
+                } else if (VALIDATION_METHOD_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     validationMethod = GeoValidationMethod.fromString(parser.text());
-                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName)) {
+                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     ignoreUnmapped = parser.booleanValue();
-                } else if (TYPE_FIELD.match(currentFieldName)) {
+                } else if (TYPE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     type = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "failed to parse [{}] query. unexpected field [{}]",

--- a/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoPolygonQueryBuilder.java
@@ -243,7 +243,7 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token == XContentParser.Token.START_ARRAY) {
-                        if (POINTS_FIELD.match(currentFieldName)) {
+                        if (POINTS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             shell = new ArrayList<>();
                             while ((token = parser.nextToken()) != Token.END_ARRAY) {
                                 shell.add(GeoUtils.parseGeoPoint(parser));
@@ -262,9 +262,9 @@ public class GeoPolygonQueryBuilder extends AbstractQueryBuilder<GeoPolygonQuery
                     queryName = parser.text();
                 } else if ("boost".equals(currentFieldName)) {
                     boost = parser.floatValue();
-                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName)) {
+                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     ignoreUnmapped = parser.booleanValue();
-                } else if (VALIDATION_METHOD.match(currentFieldName)) {
+                } else if (VALIDATION_METHOD.match(currentFieldName, parser.deprecationHandler())) {
                     validationMethod = GeoValidationMethod.fromString(parser.text());
                 } else {
                     throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -401,7 +401,9 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
                     int currentPathSlot = 0;
 
                     // It is safe to use EMPTY here because this never uses namedObject
-                    try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, response.getSourceAsBytesRef())) {
+                    // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is safe here because we don't interact with deprecations here
+                    try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+                            ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, response.getSourceAsBytesRef())) {
                         XContentParser.Token currentToken;
                         while ((currentToken = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                             if (currentToken == XContentParser.Token.FIELD_NAME) {

--- a/core/src/main/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchPhrasePrefixQueryBuilder.java
@@ -211,17 +211,17 @@ public class MatchPhrasePrefixQueryBuilder extends AbstractQueryBuilder<MatchPhr
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token.isValue()) {
-                        if (MatchQueryBuilder.QUERY_FIELD.match(currentFieldName)) {
+                        if (MatchQueryBuilder.QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             value = parser.objectText();
-                        } else if (MatchQueryBuilder.ANALYZER_FIELD.match(currentFieldName)) {
+                        } else if (MatchQueryBuilder.ANALYZER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             analyzer = parser.text();
-                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             boost = parser.floatValue();
-                        } else if (MatchPhraseQueryBuilder.SLOP_FIELD.match(currentFieldName)) {
+                        } else if (MatchPhraseQueryBuilder.SLOP_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             slop = parser.intValue();
-                        } else if (MAX_EXPANSIONS_FIELD.match(currentFieldName)) {
+                        } else if (MAX_EXPANSIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             maxExpansion = parser.intValue();
-                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             queryName = parser.text();
                         } else {
                             throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
@@ -182,15 +182,15 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token.isValue()) {
-                        if (MatchQueryBuilder.QUERY_FIELD.match(currentFieldName)) {
+                        if (MatchQueryBuilder.QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             value = parser.objectText();
-                        } else if (MatchQueryBuilder.ANALYZER_FIELD.match(currentFieldName)) {
+                        } else if (MatchQueryBuilder.ANALYZER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             analyzer = parser.text();
-                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             boost = parser.floatValue();
-                        } else if (SLOP_FIELD.match(currentFieldName)) {
+                        } else if (SLOP_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             slop = parser.intValue();
-                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             queryName = parser.text();
                         } else {
                             throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -481,31 +481,31 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token.isValue()) {
-                        if (QUERY_FIELD.match(currentFieldName)) {
+                        if (QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             value = parser.objectText();
-                        } else if (ANALYZER_FIELD.match(currentFieldName)) {
+                        } else if (ANALYZER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             analyzer = parser.text();
-                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             boost = parser.floatValue();
-                        } else if (Fuzziness.FIELD.match(currentFieldName)) {
+                        } else if (Fuzziness.FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             fuzziness = Fuzziness.parse(parser);
-                        } else if (PREFIX_LENGTH_FIELD.match(currentFieldName)) {
+                        } else if (PREFIX_LENGTH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             prefixLength = parser.intValue();
-                        } else if (MAX_EXPANSIONS_FIELD.match(currentFieldName)) {
+                        } else if (MAX_EXPANSIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             maxExpansion = parser.intValue();
-                        } else if (OPERATOR_FIELD.match(currentFieldName)) {
+                        } else if (OPERATOR_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             operator = Operator.fromString(parser.text());
-                        } else if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName)) {
+                        } else if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             minimumShouldMatch = parser.textOrNull();
-                        } else if (FUZZY_REWRITE_FIELD.match(currentFieldName)) {
+                        } else if (FUZZY_REWRITE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             fuzzyRewrite = parser.textOrNull();
-                        } else if (FUZZY_TRANSPOSITIONS_FIELD.match(currentFieldName)) {
+                        } else if (FUZZY_TRANSPOSITIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             fuzzyTranspositions = parser.booleanValue();
-                        } else if (LENIENT_FIELD.match(currentFieldName)) {
+                        } else if (LENIENT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             lenient = parser.booleanValue();
-                        } else if (CUTOFF_FREQUENCY_FIELD.match(currentFieldName)) {
+                        } else if (CUTOFF_FREQUENCY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             cutOffFrequency = parser.floatValue();
-                        } else if (ZERO_TERMS_QUERY_FIELD.match(currentFieldName)) {
+                        } else if (ZERO_TERMS_QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             String zeroTermsDocs = parser.text();
                             if ("none".equalsIgnoreCase(zeroTermsDocs)) {
                                 zeroTermsQuery = MatchQuery.ZeroTermsQuery.NONE;
@@ -515,9 +515,9 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
                                 throw new ParsingException(parser.getTokenLocation(),
                                         "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]");
                             }
-                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             queryName = parser.text();
-                        } else if (GENERATE_SYNONYMS_PHRASE_QUERY.match(currentFieldName)) {
+                        } else if (GENERATE_SYNONYMS_PHRASE_QUERY.match(currentFieldName, parser.deprecationHandler())) {
                             autoGenerateSynonymsPhraseQuery = parser.booleanValue();
                         } else {
                             throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -639,7 +639,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
-            } else if (FIELDS_FIELD.match(currentFieldName)) {
+            } else if (FIELDS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                 if (token == XContentParser.Token.START_ARRAY) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         parseFieldAndBoost(parser, fieldsBoosts);
@@ -651,37 +651,37 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
                             "[" + NAME + "] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     value = parser.objectText();
-                } else if (TYPE_FIELD.match(currentFieldName)) {
+                } else if (TYPE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     type = MultiMatchQueryBuilder.Type.parse(parser.text());
-                } else if (ANALYZER_FIELD.match(currentFieldName)) {
+                } else if (ANALYZER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     analyzer = parser.text();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
-                } else if (SLOP_FIELD.match(currentFieldName)) {
+                } else if (SLOP_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     slop = parser.intValue();
-                } else if (Fuzziness.FIELD.match(currentFieldName)) {
+                } else if (Fuzziness.FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fuzziness = Fuzziness.parse(parser);
-                } else if (PREFIX_LENGTH_FIELD.match(currentFieldName)) {
+                } else if (PREFIX_LENGTH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     prefixLength = parser.intValue();
-                } else if (MAX_EXPANSIONS_FIELD.match(currentFieldName)) {
+                } else if (MAX_EXPANSIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     maxExpansions = parser.intValue();
-                } else if (OPERATOR_FIELD.match(currentFieldName)) {
+                } else if (OPERATOR_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     operator = Operator.fromString(parser.text());
-                } else if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName)) {
+                } else if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     minimumShouldMatch = parser.textOrNull();
-                } else if (FUZZY_REWRITE_FIELD.match(currentFieldName)) {
+                } else if (FUZZY_REWRITE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fuzzyRewrite = parser.textOrNull();
-                } else if (USE_DIS_MAX_FIELD.match(currentFieldName)) {
+                } else if (USE_DIS_MAX_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     useDisMax = parser.booleanValue();
-                } else if (TIE_BREAKER_FIELD.match(currentFieldName)) {
+                } else if (TIE_BREAKER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     tieBreaker = parser.floatValue();
-                }  else if (CUTOFF_FREQUENCY_FIELD.match(currentFieldName)) {
+                }  else if (CUTOFF_FREQUENCY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     cutoffFrequency = parser.floatValue();
-                } else if (LENIENT_FIELD.match(currentFieldName)) {
+                } else if (LENIENT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     lenient = parser.booleanValue();
-                } else if (ZERO_TERMS_QUERY_FIELD.match(currentFieldName)) {
+                } else if (ZERO_TERMS_QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     String zeroTermsDocs = parser.text();
                     if ("none".equalsIgnoreCase(zeroTermsDocs)) {
                         zeroTermsQuery = MatchQuery.ZeroTermsQuery.NONE;
@@ -690,11 +690,11 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
                     } else {
                         throw new ParsingException(parser.getTokenLocation(), "Unsupported zero_terms_docs value [" + zeroTermsDocs + "]");
                     }
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
-                } else if (GENERATE_SYNONYMS_PHRASE_QUERY.match(currentFieldName)) {
+                } else if (GENERATE_SYNONYMS_PHRASE_QUERY.match(currentFieldName, parser.deprecationHandler())) {
                     autoGenerateSynonymsPhraseQuery = parser.booleanValue();
-                } else if (FUZZY_TRANSPOSITIONS_FIELD.match(currentFieldName)) {
+                } else if (FUZZY_TRANSPOSITIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fuzzyTranspositions = parser.booleanValue();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -768,7 +768,7 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (FIELDS_FIELD.match(currentFieldName)) {
+                if (FIELDS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     List<String> fields = new ArrayList<>();
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         fields.add(parser.text());
@@ -779,76 +779,76 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
                             "] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryString = parser.text();
-                } else if (DEFAULT_FIELD_FIELD.match(currentFieldName)) {
+                } else if (DEFAULT_FIELD_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     defaultField = parser.text();
-                } else if (DEFAULT_OPERATOR_FIELD.match(currentFieldName)) {
+                } else if (DEFAULT_OPERATOR_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     defaultOperator = Operator.fromString(parser.text());
-                } else if (ANALYZER_FIELD.match(currentFieldName)) {
+                } else if (ANALYZER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     analyzer = parser.text();
-                } else if (QUOTE_ANALYZER_FIELD.match(currentFieldName)) {
+                } else if (QUOTE_ANALYZER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     quoteAnalyzer = parser.text();
-                } else if (ALLOW_LEADING_WILDCARD_FIELD.match(currentFieldName)) {
+                } else if (ALLOW_LEADING_WILDCARD_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     allowLeadingWildcard = parser.booleanValue();
-                } else if (MAX_DETERMINIZED_STATES_FIELD.match(currentFieldName)) {
+                } else if (MAX_DETERMINIZED_STATES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     maxDeterminizedStates = parser.intValue();
-                } else if (ENABLE_POSITION_INCREMENTS_FIELD.match(currentFieldName)) {
+                } else if (ENABLE_POSITION_INCREMENTS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     enablePositionIncrements = parser.booleanValue();
-                } else if (ESCAPE_FIELD.match(currentFieldName)) {
+                } else if (ESCAPE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     escape = parser.booleanValue();
-                } else if (FUZZY_PREFIX_LENGTH_FIELD.match(currentFieldName)) {
+                } else if (FUZZY_PREFIX_LENGTH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fuzzyPrefixLength = parser.intValue();
-                } else if (FUZZY_MAX_EXPANSIONS_FIELD.match(currentFieldName)) {
+                } else if (FUZZY_MAX_EXPANSIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fuzzyMaxExpansions = parser.intValue();
-                } else if (FUZZY_REWRITE_FIELD.match(currentFieldName)) {
+                } else if (FUZZY_REWRITE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fuzzyRewrite = parser.textOrNull();
-                } else if (PHRASE_SLOP_FIELD.match(currentFieldName)) {
+                } else if (PHRASE_SLOP_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     phraseSlop = parser.intValue();
-                } else if (Fuzziness.FIELD.match(currentFieldName)) {
+                } else if (Fuzziness.FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fuzziness = Fuzziness.parse(parser);
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
-                } else if (TYPE_FIELD.match(currentFieldName)) {
+                } else if (TYPE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     type = MultiMatchQueryBuilder.Type.parse(parser.text());
-                } else if (TIE_BREAKER_FIELD.match(currentFieldName)) {
+                } else if (TIE_BREAKER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     tieBreaker = parser.floatValue();
-                } else if (ANALYZE_WILDCARD_FIELD.match(currentFieldName)) {
+                } else if (ANALYZE_WILDCARD_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     analyzeWildcard = parser.booleanValue();
-                } else if (REWRITE_FIELD.match(currentFieldName)) {
+                } else if (REWRITE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     rewrite = parser.textOrNull();
-                } else if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName)) {
+                } else if (MINIMUM_SHOULD_MATCH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     minimumShouldMatch = parser.textOrNull();
-                } else if (QUOTE_FIELD_SUFFIX_FIELD.match(currentFieldName)) {
+                } else if (QUOTE_FIELD_SUFFIX_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     quoteFieldSuffix = parser.textOrNull();
-                } else if (LENIENT_FIELD.match(currentFieldName)) {
+                } else if (LENIENT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     lenient = parser.booleanValue();
-                } else if (ALL_FIELDS_FIELD.match(currentFieldName)) {
+                } else if (ALL_FIELDS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     defaultField = "*";
-                } else if (MAX_DETERMINIZED_STATES_FIELD.match(currentFieldName)) {
+                } else if (MAX_DETERMINIZED_STATES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     maxDeterminizedStates = parser.intValue();
-                } else if (TIME_ZONE_FIELD.match(currentFieldName)) {
+                } else if (TIME_ZONE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     try {
                         timeZone = parser.text();
                     } catch (IllegalArgumentException e) {
                         throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME +
                                 "] time_zone [" + parser.text() + "] is unknown");
                     }
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
-                } else if (GENERATE_SYNONYMS_PHRASE_QUERY.match(currentFieldName)) {
+                } else if (GENERATE_SYNONYMS_PHRASE_QUERY.match(currentFieldName, parser.deprecationHandler())) {
                     autoGenerateSynonymsPhraseQuery = parser.booleanValue();
-                } else if (FUZZY_TRANSPOSITIONS_FIELD.match(currentFieldName)) {
+                } else if (FUZZY_TRANSPOSITIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fuzzyTranspositions = parser.booleanValue();
-                } else if (AUTO_GENERATE_PHRASE_QUERIES_FIELD.match(currentFieldName)) {
+                } else if (AUTO_GENERATE_PHRASE_QUERIES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     // ignore, deprecated setting
-                } else if (LOWERCASE_EXPANDED_TERMS_FIELD.match(currentFieldName)) {
+                } else if (LOWERCASE_EXPANDED_TERMS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     // ignore, deprecated setting
-                } else if (LOCALE_FIELD.match(currentFieldName)) {
+                } else if (LOCALE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     // ignore, deprecated setting
-                } else if (USE_DIS_MAX_FIELD.match(currentFieldName)) {
+                } else if (USE_DIS_MAX_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     // ignore, deprecated setting
-                } else if (SPLIT_ON_WHITESPACE.match(currentFieldName)) {
+                } else if (SPLIT_ON_WHITESPACE.match(currentFieldName, parser.deprecationHandler())) {
                     // ignore, deprecated setting
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[" + QueryStringQueryBuilder.NAME +

--- a/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -96,17 +96,17 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (Script.SCRIPT_PARSE_FIELD.match(currentFieldName)) {
+                if (Script.SCRIPT_PARSE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     script = Script.parse(parser);
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[script] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
-                if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
-                } else if (Script.SCRIPT_PARSE_FIELD.match(currentFieldName)) {
+                } else if (Script.SCRIPT_PARSE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     script = Script.parse(parser);
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[script] query does not support [" + currentFieldName + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanContainingQueryBuilder.java
@@ -111,13 +111,13 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (BIG_FIELD.match(currentFieldName)) {
+                if (BIG_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     QueryBuilder query = parseInnerQueryBuilder(parser);
                     if (query instanceof SpanQueryBuilder == false) {
                         throw new ParsingException(parser.getTokenLocation(), "span_containing [big] must be of type span query");
                     }
                     big = (SpanQueryBuilder) query;
-                } else if (LITTLE_FIELD.match(currentFieldName)) {
+                } else if (LITTLE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     QueryBuilder query = parseInnerQueryBuilder(parser);
                     if (query instanceof SpanQueryBuilder == false) {
                         throw new ParsingException(parser.getTokenLocation(), "span_containing [little] must be of type span query");
@@ -127,9 +127,9 @@ public class SpanContainingQueryBuilder extends AbstractQueryBuilder<SpanContain
                     throw new ParsingException(parser.getTokenLocation(),
                             "[span_containing] query does not support [" + currentFieldName + "]");
                 }
-            } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+            } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                 boost = parser.floatValue();
-            } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+            } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                 queryName = parser.text();
             } else {
                 throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilder.java
@@ -91,7 +91,7 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (MATCH_FIELD.match(currentFieldName)) {
+                if (MATCH_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     QueryBuilder query = parseInnerQueryBuilder(parser);
                     if (query instanceof MultiTermQueryBuilder == false) {
                         throw new ParsingException(parser.getTokenLocation(),
@@ -102,9 +102,9 @@ public class SpanMultiTermQueryBuilder extends AbstractQueryBuilder<SpanMultiTer
                     throw new ParsingException(parser.getTokenLocation(), "[span_multi] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
-                if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[span_multi] query does not support [" + currentFieldName + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanNotQueryBuilder.java
@@ -178,13 +178,13 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (INCLUDE_FIELD.match(currentFieldName)) {
+                if (INCLUDE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     QueryBuilder query = parseInnerQueryBuilder(parser);
                     if (query instanceof SpanQueryBuilder == false) {
                         throw new ParsingException(parser.getTokenLocation(), "spanNot [include] must be of type span query");
                     }
                     include = (SpanQueryBuilder) query;
-                } else if (EXCLUDE_FIELD.match(currentFieldName)) {
+                } else if (EXCLUDE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     QueryBuilder query = parseInnerQueryBuilder(parser);
                     if (query instanceof SpanQueryBuilder == false) {
                         throw new ParsingException(parser.getTokenLocation(), "spanNot [exclude] must be of type span query");
@@ -194,15 +194,15 @@ public class SpanNotQueryBuilder extends AbstractQueryBuilder<SpanNotQueryBuilde
                     throw new ParsingException(parser.getTokenLocation(), "[span_not] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                if (DIST_FIELD.match(currentFieldName)) {
+                if (DIST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     dist = parser.intValue();
-                } else if (PRE_FIELD.match(currentFieldName)) {
+                } else if (PRE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     pre = parser.intValue();
-                } else if (POST_FIELD.match(currentFieldName)) {
+                } else if (POST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     post = parser.intValue();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[span_not] query does not support [" + currentFieldName + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/SpanOrQueryBuilder.java
@@ -109,7 +109,7 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (CLAUSES_FIELD.match(currentFieldName)) {
+                if (CLAUSES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         QueryBuilder query = parseInnerQueryBuilder(parser);
                         if (query instanceof SpanQueryBuilder == false) {
@@ -121,9 +121,9 @@ public class SpanOrQueryBuilder extends AbstractQueryBuilder<SpanOrQueryBuilder>
                     throw new ParsingException(parser.getTokenLocation(), "[span_or] query does not support [" + currentFieldName + "]");
                 }
             } else {
-                if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[span_or] query does not support [" + currentFieldName + "]");

--- a/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -153,15 +153,15 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else {
-                        if (WILDCARD_FIELD.match(currentFieldName)) {
+                        if (WILDCARD_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             value = parser.text();
-                        } else if (VALUE_FIELD.match(currentFieldName)) {
+                        } else if (VALUE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             value = parser.text();
-                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             boost = parser.floatValue();
-                        } else if (REWRITE_FIELD.match(currentFieldName)) {
+                        } else if (REWRITE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             rewrite = parser.textOrNull();
-                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             queryName = parser.text();
                         } else {
                             throw new ParsingException(parser.getTokenLocation(),

--- a/core/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/WrapperQueryBuilder.java
@@ -21,6 +21,7 @@ package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
@@ -158,8 +159,9 @@ public class WrapperQueryBuilder extends AbstractQueryBuilder<WrapperQueryBuilde
 
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext context) throws IOException {
-        try (XContentParser qSourceParser = XContentFactory.xContent(source).createParser(context.getXContentRegistry(), source)) {
-
+        // LoggingDeprecationHandler is correct here because query rewrites are alway executed on the server
+        try (XContentParser qSourceParser = XContentFactory.xContent(source)
+                .createParser(context.getXContentRegistry(), LoggingDeprecationHandler.INSTANCE, source)) {
             final QueryBuilder queryBuilder = parseInnerQueryBuilder(qSourceParser).rewrite(context);
             if (boost() != DEFAULT_BOOST || queryName() != null) {
                 final BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query.functionscore;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoDistance;
@@ -181,7 +182,8 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
     protected ScoreFunction doToFunction(QueryShardContext context) throws IOException {
         AbstractDistanceScoreFunction scoreFunction;
         // EMPTY is safe because parseVariable doesn't use namedObject
-        try (XContentParser parser = XContentFactory.xContent(functionBytes).createParser(NamedXContentRegistry.EMPTY, functionBytes)) {
+        try (XContentParser parser = XContentFactory.xContent(functionBytes)
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, functionBytes)) {
             scoreFunction = parseVariable(fieldName, parser, context, multiValueMode);
         }
         return scoreFunction;

--- a/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -454,7 +454,7 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     if (query != null) {
                         throw new ParsingException(parser.getTokenLocation(), "failed to parse [{}] query. [query] is already defined.",
                                 NAME);
@@ -479,7 +479,7 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
                     filterFunctionBuilders.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(scoreFunction));
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (FUNCTIONS_FIELD.match(currentFieldName)) {
+                if (FUNCTIONS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     if (singleFunctionFound) {
                         String errorString = "already found [" + singleFunctionName + "], now encountering [functions].";
                         handleMisplacedFunctionsDeclaration(parser.getTokenLocation(), errorString);
@@ -492,17 +492,17 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
                 }
 
             } else if (token.isValue()) {
-                if (SCORE_MODE_FIELD.match(currentFieldName)) {
+                if (SCORE_MODE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     scoreMode = FunctionScoreQuery.ScoreMode.fromString(parser.text());
-                } else if (BOOST_MODE_FIELD.match(currentFieldName)) {
+                } else if (BOOST_MODE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     combineFunction = CombineFunction.fromString(parser.text());
-                } else if (MAX_BOOST_FIELD.match(currentFieldName)) {
+                } else if (MAX_BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     maxBoost = parser.floatValue();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     boost = parser.floatValue();
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryName = parser.text();
-                } else if (MIN_SCORE_FIELD.match(currentFieldName)) {
+                } else if (MIN_SCORE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     minScore = parser.floatValue();
                 } else {
                     if (singleFunctionFound) {
@@ -515,7 +515,7 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
                         String errorString = "already found [functions] array, now encountering [" + currentFieldName + "].";
                         handleMisplacedFunctionsDeclaration(parser.getTokenLocation(), errorString);
                     }
-                    if (WEIGHT_FIELD.match(currentFieldName)) {
+                    if (WEIGHT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                         filterFunctionBuilders.add(
                                 new FunctionScoreQueryBuilder.FilterFunctionBuilder(new WeightBuilder().setWeight(parser.floatValue())));
                         singleFunctionFound = true;
@@ -569,7 +569,7 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token == XContentParser.Token.START_OBJECT) {
-                        if (FILTER_FIELD.match(currentFieldName)) {
+                        if (FILTER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             filter = parseInnerQueryBuilder(parser);
                         } else {
                             if (scoreFunction != null) {
@@ -580,7 +580,7 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
                             scoreFunction = parser.namedObject(ScoreFunctionBuilder.class, currentFieldName, null);
                         }
                     } else if (token.isValue()) {
-                        if (WEIGHT_FIELD.match(currentFieldName)) {
+                        if (WEIGHT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             functionWeight = parser.floatValue();
                         } else {
                             throw new ParsingException(parser.getTokenLocation(), "failed to parse [{}] query. field [{}] is not supported",

--- a/core/src/main/java/org/elasticsearch/index/query/support/QueryParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/query/support/QueryParsers.java
@@ -51,7 +51,7 @@ public final class QueryParsers {
 
     public static MultiTermQuery.RewriteMethod parseRewriteMethod(@Nullable String rewriteMethod,
                                                                   @Nullable MultiTermQuery.RewriteMethod defaultRewriteMethod) {
-        // NOCOMMIT verify this is only ever called on the server
+        // TODO LoggingDeprecationHandler should be fine here because it looks like this is only called on the server
         DeprecationHandler deprecationHandler = LoggingDeprecationHandler.INSTANCE;
         if (rewriteMethod == null) {
             return defaultRewriteMethod;

--- a/core/src/main/java/org/elasticsearch/index/query/support/QueryParsers.java
+++ b/core/src/main/java/org/elasticsearch/index/query/support/QueryParsers.java
@@ -20,8 +20,10 @@
 package org.elasticsearch.index.query.support;
 
 import org.apache.lucene.search.MultiTermQuery;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.ParseField.DeprecationHandler;
 
 public final class QueryParsers {
 
@@ -49,16 +51,18 @@ public final class QueryParsers {
 
     public static MultiTermQuery.RewriteMethod parseRewriteMethod(@Nullable String rewriteMethod,
                                                                   @Nullable MultiTermQuery.RewriteMethod defaultRewriteMethod) {
+        // NOCOMMIT verify this is only ever called on the server
+        DeprecationHandler deprecationHandler = LoggingDeprecationHandler.INSTANCE;
         if (rewriteMethod == null) {
             return defaultRewriteMethod;
         }
-        if (CONSTANT_SCORE.match(rewriteMethod)) {
+        if (CONSTANT_SCORE.match(rewriteMethod, deprecationHandler)) {
             return MultiTermQuery.CONSTANT_SCORE_REWRITE;
         }
-        if (SCORING_BOOLEAN.match(rewriteMethod)) {
+        if (SCORING_BOOLEAN.match(rewriteMethod, deprecationHandler)) {
             return MultiTermQuery.SCORING_BOOLEAN_REWRITE;
         }
-        if (CONSTANT_SCORE_BOOLEAN.match(rewriteMethod)) {
+        if (CONSTANT_SCORE_BOOLEAN.match(rewriteMethod, deprecationHandler)) {
             return MultiTermQuery.CONSTANT_SCORE_BOOLEAN_REWRITE;
         }
 
@@ -74,13 +78,13 @@ public final class QueryParsers {
             final int size = Integer.parseInt(rewriteMethod.substring(firstDigit));
             String rewriteMethodName = rewriteMethod.substring(0, firstDigit);
 
-            if (TOP_TERMS.match(rewriteMethodName)) {
+            if (TOP_TERMS.match(rewriteMethodName, deprecationHandler)) {
                 return new MultiTermQuery.TopTermsScoringBooleanQueryRewrite(size);
             }
-            if (TOP_TERMS_BOOST.match(rewriteMethodName)) {
+            if (TOP_TERMS_BOOST.match(rewriteMethodName, deprecationHandler)) {
                 return new MultiTermQuery.TopTermsBoostOnlyBooleanQueryRewrite(size);
             }
-            if (TOP_TERMS_BLENDED_FREQS.match(rewriteMethodName)) {
+            if (TOP_TERMS_BLENDED_FREQS.match(rewriteMethodName, deprecationHandler)) {
                 return new MultiTermQuery.TopTermsBlendedFreqScoringRewrite(size);
             }
         }

--- a/core/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/core/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -42,6 +42,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -1235,8 +1236,10 @@ public class IndicesService extends AbstractLifecycleComponent
     public AliasFilter buildAliasFilter(ClusterState state, String index, String... expressions) {
         /* Being static, parseAliasFilter doesn't have access to whatever guts it needs to parse a query. Instead of passing in a bunch
          * of dependencies we pass in a function that can perform the parsing. */
+        // LoggingDeprecationHandler is fine here because this is always run on the server
         CheckedFunction<byte[], QueryBuilder, IOException> filterParser = bytes -> {
-            try (XContentParser parser = XContentFactory.xContent(bytes).createParser(xContentRegistry, bytes)) {
+            try (XContentParser parser = XContentFactory.xContent(bytes)
+                    .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, bytes)) {
                 return parseInnerQueryBuilder(parser);
             }
         };

--- a/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreFormat.java
+++ b/core/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreFormat.java
@@ -20,6 +20,7 @@ package org.elasticsearch.repositories.blobstore;
 
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -109,7 +110,9 @@ public abstract class BlobStoreFormat<T extends ToXContent> {
     }
 
     protected T read(BytesReference bytes) throws IOException {
-        try (XContentParser parser = XContentHelper.createParser(namedXContentRegistry, bytes)) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine because we don't have deprecated fields in the blob store
+        try (XContentParser parser = XContentHelper.createParser(namedXContentRegistry,
+                ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, bytes)) {
             T obj = reader.apply(parser);
             return obj;
         }

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.CheckedConsumer;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -342,7 +343,7 @@ public abstract class RestRequest implements ToXContent.Params {
      */
     public final XContentParser contentParser() throws IOException {
         BytesReference content = requiredContent(); // will throw exception if body or content type missing
-        return xContentType.get().xContent().createParser(xContentRegistry, content);
+        return xContentType.get().xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, content);
     }
 
     /**
@@ -371,7 +372,7 @@ public abstract class RestRequest implements ToXContent.Params {
      */
     public final XContentParser contentOrSourceParamParser() throws IOException {
         Tuple<XContentType, BytesReference> tuple = contentOrSourceParam();
-        return tuple.v1().xContent().createParser(xContentRegistry, tuple.v2());
+        return tuple.v1().xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, tuple.v2());
     }
 
     /**
@@ -384,7 +385,8 @@ public abstract class RestRequest implements ToXContent.Params {
             Tuple<XContentType, BytesReference> tuple = contentOrSourceParam();
             BytesReference content = tuple.v2();
             XContentType xContentType = tuple.v1();
-            try (XContentParser parser = xContentType.xContent().createParser(xContentRegistry, content)) {
+            try (XContentParser parser = xContentType.xContent()
+                    .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, content)) {
                 withParser.accept(parser);
             }
         } else {

--- a/core/src/main/java/org/elasticsearch/script/Script.java
+++ b/core/src/main/java/org/elasticsearch/script/Script.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.script;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -281,7 +282,9 @@ public final class Script implements ToXContentObject, Writeable {
             builder.startObject();
             settings.toXContent(builder, ToXContent.EMPTY_PARAMS);
             builder.endObject();
-            return parse(JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, builder.bytes()));
+            // LoggingDeprecationHandler *should* be ok here because this should only be on the server.
+            return parse(JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, builder.bytes()));
         } catch (IOException e) {
             // it should not happen since we are not actually reading from a stream but an in-memory byte[]
             throw new IllegalStateException(e);

--- a/core/src/main/java/org/elasticsearch/script/StoredScriptSource.java
+++ b/core/src/main/java/org/elasticsearch/script/StoredScriptSource.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.cluster.storedscripts.GetStoredScriptRespo
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -242,7 +243,9 @@ public class StoredScriptSource extends AbstractDiffable<StoredScriptSource> imp
      * @return        The parsed {@link StoredScriptSource}.
      */
     public static StoredScriptSource parse(BytesReference content, XContentType xContentType) {
-        try (XContentParser parser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, content)) {
+        // TODO LoggingDeprecationHandler shouldn't be visible here because this is client side code
+        try (XContentParser parser = xContentType.xContent().createParser(
+                NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, content)) {
             Token token = parser.nextToken();
 
             if (token != Token.START_OBJECT) {

--- a/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -967,50 +967,50 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (FROM_FIELD.match(currentFieldName)) {
+                if (FROM_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     from = parser.intValue();
-                } else if (SIZE_FIELD.match(currentFieldName)) {
+                } else if (SIZE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     size = parser.intValue();
-                } else if (TIMEOUT_FIELD.match(currentFieldName)) {
+                } else if (TIMEOUT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     timeout = TimeValue.parseTimeValue(parser.text(), null, TIMEOUT_FIELD.getPreferredName());
-                } else if (TERMINATE_AFTER_FIELD.match(currentFieldName)) {
+                } else if (TERMINATE_AFTER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     terminateAfter = parser.intValue();
-                } else if (MIN_SCORE_FIELD.match(currentFieldName)) {
+                } else if (MIN_SCORE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     minScore = parser.floatValue();
-                } else if (VERSION_FIELD.match(currentFieldName)) {
+                } else if (VERSION_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     version = parser.booleanValue();
-                } else if (EXPLAIN_FIELD.match(currentFieldName)) {
+                } else if (EXPLAIN_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     explain = parser.booleanValue();
-                } else if (TRACK_SCORES_FIELD.match(currentFieldName)) {
+                } else if (TRACK_SCORES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     trackScores = parser.booleanValue();
-                } else if (TRACK_TOTAL_HITS_FIELD.match(currentFieldName)) {
+                } else if (TRACK_TOTAL_HITS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     trackTotalHits = parser.booleanValue();
-                } else if (_SOURCE_FIELD.match(currentFieldName)) {
+                } else if (_SOURCE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fetchSourceContext = FetchSourceContext.fromXContent(parser);
-                } else if (STORED_FIELDS_FIELD.match(currentFieldName)) {
+                } else if (STORED_FIELDS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     storedFieldsContext =
                         StoredFieldsContext.fromXContent(SearchSourceBuilder.STORED_FIELDS_FIELD.getPreferredName(), parser);
-                } else if (SORT_FIELD.match(currentFieldName)) {
+                } else if (SORT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     sort(parser.text());
-                } else if (PROFILE_FIELD.match(currentFieldName)) {
+                } else if (PROFILE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     profile = parser.booleanValue();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName + "].",
                             parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (QUERY_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     queryBuilder = parseInnerQueryBuilder(parser);
-                } else if (POST_FILTER_FIELD.match(currentFieldName)) {
+                } else if (POST_FILTER_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     postQueryBuilder = parseInnerQueryBuilder(parser);
-                } else if (_SOURCE_FIELD.match(currentFieldName)) {
+                } else if (_SOURCE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fetchSourceContext = FetchSourceContext.fromXContent(parser);
-                } else if (SCRIPT_FIELDS_FIELD.match(currentFieldName)) {
+                } else if (SCRIPT_FIELDS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     scriptFields = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         scriptFields.add(new ScriptField(parser));
                     }
-                } else if (INDICES_BOOST_FIELD.match(currentFieldName)) {
+                } else if (INDICES_BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     DEPRECATION_LOGGER.deprecated(
                         "Object format in indices_boost is deprecated, please use array format instead");
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -1023,19 +1023,19 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                                 " in [" + currentFieldName + "].", parser.getTokenLocation());
                         }
                     }
-                } else if (AGGREGATIONS_FIELD.match(currentFieldName)
-                        || AGGS_FIELD.match(currentFieldName)) {
+                } else if (AGGREGATIONS_FIELD.match(currentFieldName, parser.deprecationHandler())
+                        || AGGS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     aggregations = AggregatorFactories.parseAggregators(parser);
-                } else if (HIGHLIGHT_FIELD.match(currentFieldName)) {
+                } else if (HIGHLIGHT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     highlightBuilder = HighlightBuilder.fromXContent(parser);
-                } else if (SUGGEST_FIELD.match(currentFieldName)) {
+                } else if (SUGGEST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     suggestBuilder = SuggestBuilder.fromXContent(parser);
-                } else if (SORT_FIELD.match(currentFieldName)) {
+                } else if (SORT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     sorts = new ArrayList<>(SortBuilder.fromXContent(parser));
-                } else if (RESCORE_FIELD.match(currentFieldName)) {
+                } else if (RESCORE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     rescoreBuilders = new ArrayList<>();
                     rescoreBuilders.add(RescorerBuilder.parseFromXContent(parser));
-                } else if (EXT_FIELD.match(currentFieldName)) {
+                } else if (EXT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     extBuilders = new ArrayList<>();
                     String extSectionName = null;
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -1051,18 +1051,18 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                             extBuilders.add(searchExtBuilder);
                         }
                     }
-                } else if (SLICE.match(currentFieldName)) {
+                } else if (SLICE.match(currentFieldName, parser.deprecationHandler())) {
                     sliceBuilder = SliceBuilder.fromXContent(parser);
-                } else if (COLLAPSE.match(currentFieldName)) {
+                } else if (COLLAPSE.match(currentFieldName, parser.deprecationHandler())) {
                     collapse = CollapseBuilder.fromXContent(parser);
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName + "].",
                             parser.getTokenLocation());
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (STORED_FIELDS_FIELD.match(currentFieldName)) {
+                if (STORED_FIELDS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     storedFieldsContext = StoredFieldsContext.fromXContent(STORED_FIELDS_FIELD.getPreferredName(), parser);
-                } else if (DOCVALUE_FIELDS_FIELD.match(currentFieldName)) {
+                } else if (DOCVALUE_FIELDS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     docValueFields = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token == XContentParser.Token.VALUE_STRING) {
@@ -1072,18 +1072,18 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                                 "] in [" + currentFieldName + "] but found [" + token + "]", parser.getTokenLocation());
                         }
                     }
-                } else if (INDICES_BOOST_FIELD.match(currentFieldName)) {
+                } else if (INDICES_BOOST_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         indexBoosts.add(new IndexBoost(parser));
                     }
-                } else if (SORT_FIELD.match(currentFieldName)) {
+                } else if (SORT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     sorts = new ArrayList<>(SortBuilder.fromXContent(parser));
-                } else if (RESCORE_FIELD.match(currentFieldName)) {
+                } else if (RESCORE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     rescoreBuilders = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         rescoreBuilders.add(RescorerBuilder.parseFromXContent(parser));
                     }
-                } else if (STATS_FIELD.match(currentFieldName)) {
+                } else if (STATS_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     stats = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token == XContentParser.Token.VALUE_STRING) {
@@ -1093,9 +1093,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                                     "] in [" + currentFieldName + "] but found [" + token + "]", parser.getTokenLocation());
                         }
                     }
-                } else if (_SOURCE_FIELD.match(currentFieldName)) {
+                } else if (_SOURCE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                     fetchSourceContext = FetchSourceContext.fromXContent(parser);
-                } else if (SEARCH_AFTER.match(currentFieldName)) {
+                } else if (SEARCH_AFTER.match(currentFieldName, parser.deprecationHandler())) {
                     searchAfterBuilder = SearchAfterBuilder.fromXContent(parser);
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName + "].",
@@ -1373,16 +1373,16 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                     if (token == XContentParser.Token.FIELD_NAME) {
                         currentFieldName = parser.currentName();
                     } else if (token.isValue()) {
-                        if (SCRIPT_FIELD.match(currentFieldName)) {
+                        if (SCRIPT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             script = Script.parse(parser);
-                        } else if (IGNORE_FAILURE_FIELD.match(currentFieldName)) {
+                        } else if (IGNORE_FAILURE_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             ignoreFailure = parser.booleanValue();
                         } else {
                             throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName
                                     + "].", parser.getTokenLocation());
                         }
                     } else if (token == XContentParser.Token.START_OBJECT) {
-                        if (SCRIPT_FIELD.match(currentFieldName)) {
+                        if (SCRIPT_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                             script = Script.parse(parser);
                         } else {
                             throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token + " in [" + currentFieldName

--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -143,7 +143,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if (token == XContentParser.Token.START_ARRAY) {
-                    if (INCLUDES_FIELD.match(currentFieldName)) {
+                    if (INCLUDES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                         List<String> includesList = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             if (token == XContentParser.Token.VALUE_STRING) {
@@ -154,7 +154,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                             }
                         }
                         includes = includesList.toArray(new String[includesList.size()]);
-                    } else if (EXCLUDES_FIELD.match(currentFieldName)) {
+                    } else if (EXCLUDES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                         List<String> excludesList = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                             if (token == XContentParser.Token.VALUE_STRING) {
@@ -170,9 +170,9 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                                 + " in [" + currentFieldName + "].", parser.getTokenLocation());
                     }
                 } else if (token == XContentParser.Token.VALUE_STRING) {
-                    if (INCLUDES_FIELD.match(currentFieldName)) {
+                    if (INCLUDES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                         includes = new String[] {parser.text()};
-                    } else if (EXCLUDES_FIELD.match(currentFieldName)) {
+                    } else if (EXCLUDES_FIELD.match(currentFieldName, parser.deprecationHandler())) {
                         excludes = new String[] {parser.text()};
                     } else {
                         throw new ParsingException(parser.getTokenLocation(), "Unknown key for a " + token

--- a/core/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
@@ -176,21 +176,21 @@ public final class ProfileResult implements Writeable, ToXContentObject {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (TYPE.match(currentFieldName)) {
+                if (TYPE.match(currentFieldName, parser.deprecationHandler())) {
                     type = parser.text();
-                } else if (DESCRIPTION.match(currentFieldName)) {
+                } else if (DESCRIPTION.match(currentFieldName, parser.deprecationHandler())) {
                     description = parser.text();
-                } else if (NODE_TIME.match(currentFieldName)) {
+                } else if (NODE_TIME.match(currentFieldName, parser.deprecationHandler())) {
                     // skip, total time is calculate by adding up 'timings' values in ProfileResult ctor
                     parser.text();
-                } else if (NODE_TIME_RAW.match(currentFieldName)) {
+                } else if (NODE_TIME_RAW.match(currentFieldName, parser.deprecationHandler())) {
                     // skip, total time is calculate by adding up 'timings' values in ProfileResult ctor
                     parser.longValue();
                 } else {
                     parser.skipChildren();
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (BREAKDOWN.match(currentFieldName)) {
+                if (BREAKDOWN.match(currentFieldName, parser.deprecationHandler())) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                         ensureExpectedToken(parser.currentToken(), XContentParser.Token.FIELD_NAME, parser::getTokenLocation);
                         String name = parser.currentName();
@@ -202,7 +202,7 @@ public final class ProfileResult implements Writeable, ToXContentObject {
                     parser.skipChildren();
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (CHILDREN.match(currentFieldName)) {
+                if (CHILDREN.match(currentFieldName, parser.deprecationHandler())) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         children.add(ProfileResult.fromXContent(parser));
                     }

--- a/core/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
+++ b/core/src/main/java/org/elasticsearch/search/profile/query/CollectorResult.java
@@ -169,20 +169,20 @@ public class CollectorResult implements ToXContentObject, Writeable {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (NAME.match(currentFieldName)) {
+                if (NAME.match(currentFieldName, parser.deprecationHandler())) {
                     name = parser.text();
-                } else if (REASON.match(currentFieldName)) {
+                } else if (REASON.match(currentFieldName, parser.deprecationHandler())) {
                     reason = parser.text();
-                } else if (TIME.match(currentFieldName)) {
+                } else if (TIME.match(currentFieldName, parser.deprecationHandler())) {
                     // we need to consume this value, but we use the raw nanosecond value
                     parser.text();
-                } else if (TIME_NANOS.match(currentFieldName)) {
+                } else if (TIME_NANOS.match(currentFieldName, parser.deprecationHandler())) {
                     time = parser.longValue();
                 } else {
                     parser.skipChildren();
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (CHILDREN.match(currentFieldName)) {
+                if (CHILDREN.match(currentFieldName, parser.deprecationHandler())) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         children.add(CollectorResult.fromXContent(parser));
                     }

--- a/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -20,6 +20,7 @@ package org.elasticsearch.search.suggest.completion;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -311,7 +312,9 @@ public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSug
 
     static Map<String, List<ContextMapping.InternalQueryContext>> parseContextBytes(BytesReference contextBytes,
             NamedXContentRegistry xContentRegistry, ContextMappings contextMappings) throws IOException {
-        try (XContentParser contextParser = XContentHelper.createParser(xContentRegistry, contextBytes, CONTEXT_BYTES_XCONTENT_TYPE)) {
+        // LoggingDeprecationHandler is fine here because we are on the server side
+        try (XContentParser contextParser = XContentHelper
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, contextBytes, CONTEXT_BYTES_XCONTENT_TYPE)) {
             contextParser.nextToken();
             Map<String, List<ContextMapping.InternalQueryContext>> queryContexts = new HashMap<>(contextMappings.size());
             assert contextParser.currentToken() == XContentParser.Token.START_OBJECT;

--- a/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
+++ b/core/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggester.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.spell.DirectSpellChecker;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CharsRefBuilder;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -115,8 +116,8 @@ public final class PhraseSuggester extends Suggester<PhraseSuggestionContext> {
                     vars.put(SUGGESTION_TEMPLATE_VAR_NAME, spare.toString());
                     QueryShardContext shardContext = suggestion.getShardContext();
                     final String querySource = scriptFactory.newInstance(vars).execute();
-                    try (XContentParser parser = XContentFactory.xContent(querySource).createParser(shardContext.getXContentRegistry(),
-                            querySource)) {
+                    try (XContentParser parser = XContentFactory.xContent(querySource)
+                            .createParser(shardContext.getXContentRegistry(), LoggingDeprecationHandler.INSTANCE, querySource)) {
                         QueryBuilder innerQueryBuilder = AbstractQueryBuilder.parseInnerQueryBuilder(parser);
                         final ParsedQuery parsedQuery = shardContext.toQuery(innerQueryBuilder);
                         collateMatch = Lucene.exists(searcher, parsedQuery.query());

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaDataTests.java
@@ -25,12 +25,9 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 
@@ -39,12 +36,12 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.cluster.metadata.AliasMetaData.newAliasMetaDataBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class IndexTemplateMetaDataTests extends ESTestCase {
-
     // bwc for #21009
     public void testIndexTemplateMetaData510() throws IOException {
         IndexTemplateMetaData metaData = IndexTemplateMetaData.builder("foo")
@@ -102,7 +99,7 @@ public class IndexTemplateMetaDataTests extends ESTestCase {
 
         BytesReference templateBytes = new BytesArray(template);
         final IndexTemplateMetaData indexTemplateMetaData;
-        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, templateBytes, XContentType.JSON)) {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, templateBytes)) {
             indexTemplateMetaData = IndexTemplateMetaData.Builder.fromXContent(parser, "test");
         }
 
@@ -115,7 +112,7 @@ public class IndexTemplateMetaDataTests extends ESTestCase {
         }
 
         final IndexTemplateMetaData indexTemplateMetaDataRoundTrip;
-        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, templateBytesRoundTrip, XContentType.JSON)) {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, templateBytesRoundTrip)) {
             indexTemplateMetaDataRoundTrip = IndexTemplateMetaData.Builder.fromXContent(parser, "test");
         }
         assertThat(indexTemplateMetaData, equalTo(indexTemplateMetaDataRoundTrip));
@@ -141,8 +138,7 @@ public class IndexTemplateMetaDataTests extends ESTestCase {
             randomAlphaOfLength(10) + "\":{\"type\":\"text\"},\"" +
             randomAlphaOfLength(10) + "\":{\"type\":\"keyword\"}}" +
             "}}}";
-        try (XContentParser parser =
-                 XContentHelper.createParser(NamedXContentRegistry.EMPTY, new BytesArray(templateWithEmptyPattern), XContentType.JSON)) {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, templateWithEmptyPattern)) {
             final IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
                 () -> IndexTemplateMetaData.Builder.fromXContent(parser, randomAlphaOfLengthBetween(1, 100)));
             assertThat(ex.getMessage(), equalTo("Index patterns must not be null or empty; got []"));
@@ -155,8 +151,7 @@ public class IndexTemplateMetaDataTests extends ESTestCase {
             randomAlphaOfLength(10) + "\":{\"type\":\"text\"},\"" +
             randomAlphaOfLength(10) + "\":{\"type\":\"keyword\"}}" +
             "}}}";
-        try (XContentParser parser =
-                 XContentHelper.createParser(NamedXContentRegistry.EMPTY, new BytesArray(templateWithoutPattern), XContentType.JSON)) {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, templateWithoutPattern)) {
             final IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
                 () -> IndexTemplateMetaData.Builder.fromXContent(parser, randomAlphaOfLengthBetween(1, 100)));
             assertThat(ex.getMessage(), equalTo("Index patterns must not be null or empty; got null"));

--- a/core/src/test/java/org/elasticsearch/common/LoggingDeprecationHandlerTests.java
+++ b/core/src/test/java/org/elasticsearch/common/LoggingDeprecationHandlerTests.java
@@ -16,23 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.elasticsearch.common;
 
-package org.elasticsearch.common.xcontent.cbor;
+import org.elasticsearch.test.ESTestCase;
 
-import com.fasterxml.jackson.core.JsonParser;
-import org.elasticsearch.common.ParseField.DeprecationHandler;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.json.JsonXContentParser;
-
-public class CborXContentParser extends JsonXContentParser {
-
-    public CborXContentParser(NamedXContentRegistry xContentRegistry, DeprecationHandler deprecationHandler, JsonParser parser) {
-        super(xContentRegistry, deprecationHandler, parser);
+/**
+ * Tests that the {@link LoggingDeprecationHandler} produces deprecation warnings
+ * in the expected way. Tools are built around this way so be weary of changing
+ * the patterns in this test.
+ */
+public class LoggingDeprecationHandlerTests extends ESTestCase {
+    public void testUsedDeprecatedName() {
+        LoggingDeprecationHandler.INSTANCE.usedDeprecatedName("bar_foo", "foo_bar");
+        assertWarnings("Deprecated field [bar_foo] used, expected [foo_bar] instead");
     }
 
-    @Override
-    public XContentType contentType() {
-        return XContentType.CBOR;
+    public void testUsedDeprecatedField() {
+        LoggingDeprecationHandler.INSTANCE.usedDeprecatedField("like_text", "like");
+        assertWarnings("Deprecated field [like_text] used, replaced by [like]");
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -27,6 +27,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -1016,7 +1017,7 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         XContentBuilder b = XContentBuilder.builder(xcontentType().xContent());
         b.value("test");
         XContentParser p = xcontentType().xContent()
-            .createParser(registry, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, b.bytes());
+            .createParser(registry, LoggingDeprecationHandler.INSTANCE, b.bytes());
         assertEquals(test1, p.namedObject(Object.class, "test1", null));
         assertEquals(test2, p.namedObject(Object.class, "test2", null));
         assertEquals(test2, p.namedObject(Object.class, "deprecated", null));

--- a/core/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -753,7 +753,8 @@ public abstract class BaseXContentTestCase extends ESTestCase {
             generator.writeEndObject();
         }
 
-        XContentParser parser = xcontentType().xContent().createParser(NamedXContentRegistry.EMPTY, os.toByteArray());
+        XContentParser parser = xcontentType().xContent()
+            .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, os.toByteArray());
         assertEquals(Token.START_OBJECT, parser.nextToken());
         assertEquals(Token.FIELD_NAME, parser.nextToken());
         assertEquals("bar", parser.currentName());
@@ -787,7 +788,8 @@ public abstract class BaseXContentTestCase extends ESTestCase {
             generator.writeRawValue(new BytesArray(rawData));
         }
 
-        XContentParser parser = xcontentType().xContent().createParser(NamedXContentRegistry.EMPTY, os.toByteArray());
+        XContentParser parser = xcontentType().xContent()
+            .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, os.toByteArray());
         assertEquals(Token.START_OBJECT, parser.nextToken());
         assertEquals(Token.FIELD_NAME, parser.nextToken());
         assertEquals("foo", parser.currentName());
@@ -803,7 +805,8 @@ public abstract class BaseXContentTestCase extends ESTestCase {
             generator.writeEndObject();
         }
 
-        parser = xcontentType().xContent().createParser(NamedXContentRegistry.EMPTY, os.toByteArray());
+        parser = xcontentType().xContent()
+            .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, os.toByteArray());
         assertEquals(Token.START_OBJECT, parser.nextToken());
         assertEquals(Token.FIELD_NAME, parser.nextToken());
         assertEquals("test", parser.currentName());
@@ -831,7 +834,8 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         generator.flush();
         byte[] serialized = os.toByteArray();
 
-        XContentParser parser = xcontentType().xContent().createParser(NamedXContentRegistry.EMPTY, serialized);
+        XContentParser parser = xcontentType().xContent()
+            .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, serialized);
         Map<String, Object> map = parser.map();
         assertEquals("bar", map.get("foo"));
         assertEquals(bigInteger, map.get("bigint"));
@@ -1011,7 +1015,8 @@ public abstract class BaseXContentTestCase extends ESTestCase {
                 new NamedXContentRegistry.Entry(Object.class, new ParseField("str"), p -> p.text())));
         XContentBuilder b = XContentBuilder.builder(xcontentType().xContent());
         b.value("test");
-        XContentParser p = xcontentType().xContent().createParser(registry, b.bytes());
+        XContentParser p = xcontentType().xContent()
+            .createParser(registry, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, b.bytes());
         assertEquals(test1, p.namedObject(Object.class, "test1", null));
         assertEquals(test2, p.namedObject(Object.class, "test2", null));
         assertEquals(test2, p.namedObject(Object.class, "deprecated", null));
@@ -1030,7 +1035,8 @@ public abstract class BaseXContentTestCase extends ESTestCase {
             assertEquals("Unknown namedObject category [java.lang.String]", e.getMessage());
         }
         {
-            XContentParser emptyRegistryParser = xcontentType().xContent().createParser(NamedXContentRegistry.EMPTY, new byte[] {});
+            XContentParser emptyRegistryParser = xcontentType().xContent()
+                .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, new byte[] {});
             Exception e = expectThrows(ElasticsearchException.class,
                     () -> emptyRegistryParser.namedObject(String.class, "doesn't matter", null));
             assertEquals("namedObject is not supported for this parser", e.getMessage());

--- a/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/XContentParserUtilsTests.java
@@ -140,7 +140,8 @@ public class XContentParserUtilsTests extends ESTestCase {
 
         BytesReference bytes = toXContent((builder, params) -> builder.startObject("name").field("field", 0).endObject(), xContentType,
                 randomBoolean());
-        try (XContentParser parser = xContentType.xContent().createParser(namedXContentRegistry, bytes)) {
+        try (XContentParser parser = xContentType.xContent()
+                .createParser(namedXContentRegistry, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, bytes)) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
@@ -155,7 +156,8 @@ public class XContentParserUtilsTests extends ESTestCase {
 
         bytes = toXContent((builder, params) -> builder.startObject("type" + delimiter + "name").field("bool", true).endObject(),
                 xContentType, randomBoolean());
-        try (XContentParser parser = xContentType.xContent().createParser(namedXContentRegistry, bytes)) {
+        try (XContentParser parser = xContentType.xContent()
+                .createParser(namedXContentRegistry, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, bytes)) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
@@ -174,7 +176,8 @@ public class XContentParserUtilsTests extends ESTestCase {
             return builder;
         }, xContentType, randomBoolean());
 
-        try (XContentParser parser = xContentType.xContent().createParser(namedXContentRegistry, bytes)) {
+        try (XContentParser parser = xContentType.xContent()
+                .createParser(namedXContentRegistry, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, bytes)) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
 
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
@@ -200,7 +203,8 @@ public class XContentParserUtilsTests extends ESTestCase {
         {
             BytesReference bytes = toXContent((builder, params) -> builder.startObject("name").field("field", 0).endObject(), xContentType,
                     randomBoolean());
-            try (XContentParser parser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, bytes)) {
+            try (XContentParser parser = xContentType.xContent()
+                    .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, bytes)) {
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
                 ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
                 ParsingException exception = expectThrows(ParsingException.class,
@@ -212,7 +216,8 @@ public class XContentParserUtilsTests extends ESTestCase {
         {
             BytesReference bytes = toXContent((builder, params) -> builder.startObject("").field("field", 0).endObject(), xContentType,
                     randomBoolean());
-            try (XContentParser parser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, bytes)) {
+            try (XContentParser parser = xContentType.xContent()
+                    .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, bytes)) {
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
                 ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.xcontent.support;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -93,7 +94,8 @@ public class XContentHelperTests extends ESTestCase {
             expectThrows(IOException.class, () -> XContentHelper.toXContent(toXContent, xContentType, randomBoolean()));
         } else {
             BytesReference bytes = XContentHelper.toXContent(toXContent, xContentType, randomBoolean());
-            try (XContentParser parser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, bytes)) {
+            try (XContentParser parser = xContentType.xContent()
+                    .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, bytes)) {
                 assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
                 assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
                 assertTrue(parser.nextToken().isValue());

--- a/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
+++ b/core/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.xcontent.support.filtering;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -74,8 +75,10 @@ public abstract class AbstractXContentFilteringTestCase extends AbstractFilterin
     static void assertXContentBuilderAsBytes(final XContentBuilder expected, final XContentBuilder actual) {
         try {
             XContent xContent = XContentFactory.xContent(actual.contentType());
-            XContentParser jsonParser = xContent.createParser(NamedXContentRegistry.EMPTY, expected.bytes());
-            XContentParser testParser = xContent.createParser(NamedXContentRegistry.EMPTY, actual.bytes());
+            XContentParser jsonParser = xContent.createParser(NamedXContentRegistry.EMPTY,
+                ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, expected.bytes());
+            XContentParser testParser = xContent.createParser(NamedXContentRegistry.EMPTY,
+                ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, actual.bytes());
 
             while (true) {
                 XContentParser.Token token1 = jsonParser.nextToken();

--- a/core/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
+++ b/core/src/test/java/org/elasticsearch/ingest/PipelineConfigurationTests.java
@@ -60,7 +60,7 @@ public class PipelineConfigurationTests extends ESTestCase {
             bytes = builder.bytes();
         }
 
-        XContentParser xContentParser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, bytes);
+        XContentParser xContentParser = createParser(xContentType.xContent(), bytes);
         PipelineConfiguration parsed = parser.parse(xContentParser, null);
         assertEquals(xContentType, parsed.getXContentType());
         assertEquals("{}", XContentHelper.convertToJson(parsed.getConfig(), false, parsed.getXContentType()));

--- a/core/src/test/java/org/elasticsearch/script/ScriptMetaDataTests.java
+++ b/core/src/test/java/org/elasticsearch/script/ScriptMetaDataTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.io.IOException;
@@ -37,14 +38,14 @@ public class ScriptMetaDataTests extends AbstractSerializingTestCase<ScriptMetaD
         // failure to load to old namespace scripts with the same id but different langs
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject().field("lang0#id0", "script0").field("lang1#id0", "script1").endObject();
-        XContentParser parser0 = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, builder.bytes());
+        XContentParser parser0 = createParser(JsonXContent.jsonXContent, builder.bytes());
         expectThrows(IllegalArgumentException.class, () -> ScriptMetaData.fromXContent(parser0));
 
         // failure to load a new namespace script and old namespace script with the same id but different langs
         builder = XContentFactory.jsonBuilder();
         builder.startObject().field("lang0#id0", "script0")
             .startObject("id0").field("lang", "lang1").field("source", "script1").endObject().endObject();
-        XContentParser parser1 = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, builder.bytes());
+        XContentParser parser1 = createParser(JsonXContent.jsonXContent, builder.bytes());
         expectThrows(IllegalArgumentException.class, () -> ScriptMetaData.fromXContent(parser1));
 
         // failure to load a new namespace script and old namespace script with the same id but different langs with additional scripts
@@ -52,14 +53,14 @@ public class ScriptMetaDataTests extends AbstractSerializingTestCase<ScriptMetaD
         builder.startObject().field("lang0#id0", "script0").field("lang0#id1", "script1")
             .startObject("id1").field("lang", "lang0").field("source", "script0").endObject()
             .startObject("id0").field("lang", "lang1").field("source", "script1").endObject().endObject();
-        XContentParser parser2 = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, builder.bytes());
+        XContentParser parser2 = createParser(JsonXContent.jsonXContent, builder.bytes());
         expectThrows(IllegalArgumentException.class, () -> ScriptMetaData.fromXContent(parser2));
 
         // okay to load the same script from the new and old namespace if the lang is the same
         builder = XContentFactory.jsonBuilder();
         builder.startObject().field("lang0#id0", "script0")
             .startObject("id0").field("lang", "lang0").field("source", "script1").endObject().endObject();
-        XContentParser parser3 = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, builder.bytes());
+        XContentParser parser3 = createParser(JsonXContent.jsonXContent, builder.bytes());
         ScriptMetaData.fromXContent(parser3);
     }
 

--- a/core/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
@@ -159,7 +159,7 @@ public class ShardSearchTransportRequestTests extends AbstractSearchTestCase {
 
     public QueryBuilder aliasFilter(IndexMetaData indexMetaData, String... aliasNames) {
         CheckedFunction<byte[], QueryBuilder, IOException> filterParser = bytes -> {
-            try (XContentParser parser = XContentFactory.xContent(bytes).createParser(xContentRegistry(), bytes)) {
+            try (XContentParser parser = createParser(XContentFactory.xContent(bytes), bytes)) {
                 return parseInnerQueryBuilder(parser);
             }
         };

--- a/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
+++ b/core/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
@@ -162,7 +162,6 @@ public class SuggestionTests extends ESTestCase {
     }
 
     public void testUnknownSuggestionTypeThrows() throws IOException {
-        XContent xContent = JsonXContent.jsonXContent;
         String suggestionString =
                  "{\"unknownType#suggestionName\":"
                     + "[{\"text\":\"entryText\","
@@ -174,7 +173,7 @@ public class SuggestionTests extends ESTestCase {
                                 + "\"collate_match\":true}]"
                             + "}]"
                 + "}";
-        try (XContentParser parser = xContent.createParser(xContentRegistry(), suggestionString)) {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, suggestionString)) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser::getTokenLocation);
             ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser::getTokenLocation);

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
@@ -22,6 +22,7 @@ package org.elasticsearch.ingest.common;
 import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -76,7 +77,9 @@ public final class JsonProcessor extends AbstractProcessor {
     public void execute(IngestDocument document) throws Exception {
         Object fieldValue = document.getFieldValue(field, Object.class);
         BytesReference bytesRef = (fieldValue == null) ? new BytesArray("null") : new BytesArray(fieldValue.toString());
-        try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, bytesRef)) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with the depraction handler
+        try (XContentParser parser = JsonXContent.jsonXContent
+                .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, bytesRef)) {
             XContentParser.Token token = parser.nextToken();
             Object value = null;
             if (token == XContentParser.Token.VALUE_NULL) {
@@ -134,4 +137,3 @@ public final class JsonProcessor extends AbstractProcessor {
         }
     }
 }
-

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
@@ -21,6 +21,8 @@ package org.elasticsearch.ingest.common;
 
 import com.fasterxml.jackson.core.JsonFactory;
 
+import org.elasticsearch.common.LoggingDeprecationHandler;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -95,8 +97,9 @@ public final class ScriptProcessor extends AbstractProcessor {
         public ScriptProcessor create(Map<String, Processor.Factory> registry, String processorTag,
                                       Map<String, Object> config) throws Exception {
             XContentBuilder builder = XContentBuilder.builder(JsonXContent.jsonXContent).map(config);
+            // LoggingDeprecationHandler is fine here because we are running on the server
             JsonXContentParser parser = new JsonXContentParser(NamedXContentRegistry.EMPTY,
-                JSON_FACTORY.createParser(builder.bytes().streamInput()));
+                LoggingDeprecationHandler.INSTANCE, JSON_FACTORY.createParser(builder.bytes().streamInput()));
             Script script = Script.parse(parser);
 
             Arrays.asList("id", "source", "inline", "lang", "params", "options").forEach(config::remove);

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -108,7 +109,8 @@ public class TransportSearchTemplateAction extends HandledTransportAction<Search
             return null;
         }
 
-        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(xContentRegistry, source)) {
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, source)) {
             SearchSourceBuilder builder = SearchSourceBuilder.searchSource();
             builder.parseXContent(parser);
             builder.explain(searchTemplateRequest.isExplain());

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -105,7 +106,8 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
                 String templateId = ratedRequest.getTemplateId();
                 TemplateScript.Factory templateScript = scriptsWithoutParams.get(templateId);
                 String resolvedRequest = templateScript.newInstance(params).execute();
-                try (XContentParser subParser = createParser(namedXContentRegistry, new BytesArray(resolvedRequest), XContentType.JSON)) {
+                try (XContentParser subParser = createParser(namedXContentRegistry,
+                        LoggingDeprecationHandler.INSTANCE, new BytesArray(resolvedRequest), XContentType.JSON)) {
                     ratedSearchSource = SearchSourceBuilder.fromXContent(subParser);
                 } catch (IOException e) {
                     // if we fail parsing, put the exception into the errors map and continue

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByQueryRestHandler.java
@@ -89,7 +89,8 @@ public abstract class AbstractBulkByQueryRestHandler<
                     consumer.getValue().accept(value);
                 }
             }
-            return parser.contentType().xContent().createParser(parser.getXContentRegistry(), builder.map(body).bytes());
+            return parser.contentType().xContent()
+                .createParser(parser.getXContentRegistry(), parser.deprecationHandler(), builder.map(body).bytes());
         }
     }
 }

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestReindexAction.java
@@ -73,7 +73,8 @@ public class RestReindexAction extends AbstractBaseReindexRestHandler<ReindexReq
             request.setRemoteInfo(buildRemoteInfo(source));
             XContentBuilder builder = XContentFactory.contentBuilder(parser.contentType());
             builder.map(source);
-            try (XContentParser innerParser = parser.contentType().xContent().createParser(parser.getXContentRegistry(), builder.bytes())) {
+            try (XContentParser innerParser = parser.contentType().xContent()
+                    .createParser(parser.getXContentRegistry(), parser.deprecationHandler(), builder.bytes())) {
                 request.getSearchRequest().source().parseXContent(innerParser);
             }
         };

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/TransportReindexAction.java
@@ -49,6 +49,7 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.uid.Versions;
@@ -336,7 +337,9 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
             final XContentType mainRequestXContentType = mainRequest.getDestination().getContentType();
             if (mainRequestXContentType != null && doc.getXContentType() != mainRequestXContentType) {
                 // we need to convert
-                try (XContentParser parser = sourceXContentType.xContent().createParser(NamedXContentRegistry.EMPTY, doc.getSource());
+                // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we're just copying the structure
+                try (XContentParser parser = sourceXContentType.xContent()
+                        .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, doc.getSource());
                      XContentBuilder builder = XContentBuilder.builder(mainRequestXContentType.xContent())) {
                     parser.nextToken();
                     builder.copyCurrentStructure(parser);

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteRequestBuilders.java
@@ -27,6 +27,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.TimeValue;
@@ -128,8 +129,10 @@ final class RemoteRequestBuilders {
 
     static HttpEntity initialSearchEntity(SearchRequest searchRequest, BytesReference query, Version remoteVersion) {
         // EMPTY is safe here because we're not calling namedObject
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we do not interact with deprecation
         try (XContentBuilder entity = JsonXContent.contentBuilder();
-                XContentParser queryParser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, query)) {
+                XContentParser queryParser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+                    ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, query)) {
             entity.startObject();
 
             entity.field("query"); {

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -36,6 +36,7 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -195,8 +196,11 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
                                     }
                                 }
                                 // EMPTY is safe here because we don't call namedObject
+                                /* UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is safe here
+                                 * because we don't have deprecated fields. All fields from
+                                 * all versions of Elasticsearch are considerd supported. */
                                 try (XContentParser xContentParser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY,
-                                    content)) {
+                                        ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, content)) {
                                     parsedResponse = parser.apply(xContentParser, xContentType);
                                 } catch (ParsingException e) {
                                 /* Because we're streaming the response we can't get a copy of it here. The best we can do is hint that it

--- a/plugins/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentParser.java
+++ b/plugins/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentParser.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.ingest.useragent;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -54,7 +55,9 @@ final class UserAgentParser {
 
     private void init(InputStream regexStream) throws IOException {
         // EMPTY is safe here because we don't use namedObject
-        XContentParser yamlParser = XContentFactory.xContent(XContentType.YAML).createParser(NamedXContentRegistry.EMPTY, regexStream);
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is safe here because we don't interact with deprecations
+        XContentParser yamlParser = XContentFactory.xContent(XContentType.YAML)
+            .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, regexStream);
 
         XContentParser.Token token = yamlParser.nextToken();
 

--- a/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
+++ b/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -83,9 +84,11 @@ public class WildflyIT extends LuceneTestCase {
             final HttpGet get = new HttpGet(new URI(str));
             try (
                     CloseableHttpResponse response = client.execute(get);
+                    // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with deprecation
                     XContentParser parser =
                             JsonXContent.jsonXContent.createParser(
                                     new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
+                                    ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER,
                                     response.getEntity().getContent())) {
                 final Map<String, Object> map = parser.map();
                 assertThat(map.get("first_name"), equalTo("John"));

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -22,6 +22,7 @@ package org.elasticsearch.search;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -308,8 +309,8 @@ public class RandomSearchRequestGenerator {
                 }
                 jsonBuilder.endArray();
                 jsonBuilder.endObject();
-                XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY,
-                        jsonBuilder.bytes());
+                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                        .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonBuilder.bytes());
                 parser.nextToken();
                 parser.nextToken();
                 parser.nextToken();

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -38,6 +38,7 @@ import org.elasticsearch.action.termvectors.MultiTermVectorsResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -403,7 +404,8 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
                 BytesStreamOutput out = new BytesStreamOutput();
                 try (
                         XContentGenerator generator = XContentType.JSON.xContent().createGenerator(out);
-                        XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, query);
+                        XContentParser parser = JsonXContent.jsonXContent.createParser(
+                            NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, query);
                 ) {
                     int objectIndex = -1;
                     Deque<String> levels = new LinkedList<>();

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -48,6 +48,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.CheckedRunnable;
+import org.elasticsearch.common.LoggingDeprecationHandler;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.io.PathUtilsForTesting;
@@ -1093,35 +1094,36 @@ public abstract class ESTestCase extends LuceneTestCase {
      * Create a new {@link XContentParser}.
      */
     protected final XContentParser createParser(XContentBuilder builder) throws IOException {
-        return builder.generator().contentType().xContent().createParser(xContentRegistry(), builder.bytes());
+        return builder.generator().contentType().xContent()
+            .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, builder.bytes());
     }
 
     /**
      * Create a new {@link XContentParser}.
      */
     protected final XContentParser createParser(XContent xContent, String data) throws IOException {
-        return xContent.createParser(xContentRegistry(), data);
+        return xContent.createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, data);
     }
 
     /**
      * Create a new {@link XContentParser}.
      */
     protected final XContentParser createParser(XContent xContent, InputStream data) throws IOException {
-        return xContent.createParser(xContentRegistry(), data);
+        return xContent.createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, data);
     }
 
     /**
      * Create a new {@link XContentParser}.
      */
     protected final XContentParser createParser(XContent xContent, byte[] data) throws IOException {
-        return xContent.createParser(xContentRegistry(), data);
+        return xContent.createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, data);
     }
 
     /**
      * Create a new {@link XContentParser}.
      */
     protected final XContentParser createParser(XContent xContent, BytesReference data) throws IOException {
-        return xContent.createParser(xContentRegistry(), data);
+        return xContent.createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, data);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/XContentTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/XContentTestUtils.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.test;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -184,7 +185,9 @@ public final class XContentTestUtils {
         List<String> insertPaths;
 
         // we can use NamedXContentRegistry.EMPTY here because we only traverse the xContent once and don't use it
-        try (XContentParser parser = createParser(NamedXContentRegistry.EMPTY, xContent, contentType)) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with deprecation
+        try (XContentParser parser = createParser(NamedXContentRegistry.EMPTY,
+                ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, xContent, contentType)) {
             parser.nextToken();
             List<String> possiblePaths = XContentTestUtils.getInsertPaths(parser, new Stack<>());
             if (excludeFilter == null) {

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -48,6 +48,7 @@ import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -835,9 +836,12 @@ public class ElasticsearchAssertions {
         //Note that byte[] holding binary values need special treatment as they need to be properly compared item per item.
         Map<String, Object> actualMap = null;
         Map<String, Object> expectedMap = null;
-        try (XContentParser actualParser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, actual)) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with deprecation
+        try (XContentParser actualParser = xContentType.xContent()
+                .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, actual)) {
             actualMap = actualParser.map();
-            try (XContentParser expectedParser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY, expected)) {
+            try (XContentParser expectedParser = xContentType.xContent()
+                    .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, expected)) {
                 expectedMap = expectedParser.map();
                 try {
                     assertMapEquals(expectedMap, actualMap);

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
@@ -22,6 +22,7 @@ import org.apache.http.Header;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -114,7 +115,9 @@ public class ClientYamlTestResponse {
             } else {
                 //if the body is in a binary format and gets requested as a string (e.g. to log a test failure), we convert it to json
                 try (XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()) {
-                    try (XContentParser parser = bodyContentType.xContent().createParser(NamedXContentRegistry.EMPTY, body)) {
+                    // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with the deprecation logic
+                    try (XContentParser parser = bodyContentType.xContent()
+                            .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, body)) {
                         jsonBuilder.copyCurrentStructure(parser);
                     }
                     bodyAsString = jsonBuilder.string();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ObjectPath.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ObjectPath.java
@@ -20,6 +20,7 @@ package org.elasticsearch.test.rest.yaml;
 
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -48,7 +49,9 @@ public class ObjectPath {
     }
 
     public static ObjectPath createFromXContent(XContent xContent, BytesReference input) throws IOException {
-        try (XContentParser parser = xContent.createParser(NamedXContentRegistry.EMPTY, input)) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with the deprecation logic
+        try (XContentParser parser = xContent
+                .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, input)) {
             if (parser.nextToken() == XContentParser.Token.START_ARRAY) {
                 return new ObjectPath(parser.listOrderedMap());
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestSpec.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestSpec.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -94,7 +95,9 @@ public class ClientYamlSuiteRestSpec {
 
     private static void parseSpecFile(ClientYamlSuiteRestApiParser restApiParser, Path jsonFile, ClientYamlSuiteRestSpec restSpec) {
         try (InputStream stream = Files.newInputStream(jsonFile)) {
-            try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, stream)) {
+            // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't have any deprecated fields
+            try (XContentParser parser = JsonXContent.jsonXContent
+                    .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, stream)) {
                 String filename = jsonFile.getFileName().toString();
                 if (filename.equals("_common.json")) {
                     String currentFieldName = null;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.test.rest.yaml.section;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
@@ -62,8 +63,9 @@ public class ClientYamlTestSuite {
             }
         }
 
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't have any deprecated fields
         try (XContentParser parser = YamlXContent.yamlXContent.createParser(ExecutableSection.XCONTENT_REGISTRY,
-                Files.newInputStream(file))) {
+                ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, Files.newInputStream(file))) {
             return parse(api, filename, parser);
         } catch(Exception e) {
             throw new IOException("Error parsing " + api + "/" + filename, e);

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.test.rest.yaml.section;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
@@ -128,7 +129,9 @@ public class DoSection implements ExecutableSection {
                         } else if (token.isValue()) {
                             if ("body".equals(paramName)) {
                                 String body = parser.text();
-                                XContentParser bodyParser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY, body);
+                                // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with deprecation
+                                XContentParser bodyParser = JsonXContent.jsonXContent
+                                    .createParser(NamedXContentRegistry.EMPTY, ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, body);
                                 //multiple bodies are supported e.g. in case of bulk provided as a whole string
                                 while(bodyParser.nextToken() != null) {
                                     apiCallSection.addBody(bodyParser.mapOrdered());

--- a/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.test;
 
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -71,7 +72,9 @@ public class XContentTestUtilsTests extends ESTestCase {
         }
         builder.endObject();
 
-        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, builder.bytes(), builder.contentType())) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with deprecation
+        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+                ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, builder.bytes(), builder.contentType())) {
             parser.nextToken();
             List<String> insertPaths = XContentTestUtils.getInsertPaths(parser, new Stack<>());
             assertEquals(5, insertPaths.size());
@@ -96,7 +99,9 @@ public class XContentTestUtilsTests extends ESTestCase {
                 Collections.singletonList("inn\\.er1"), () -> "inner2", () -> new HashMap<>());
         builder = XContentTestUtils.insertIntoXContent(XContentType.JSON.xContent(), builder.bytes(),
                 Collections.singletonList("inn\\.er1"), () -> "field2", () -> "value2");
-        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, builder.bytes(), builder.contentType())) {
+        // UNSUPPORTED_OPERATION_DEPRECATION_HANDLER is fine here because we don't interact with deprecation
+        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+                ParseField.UNSUPPORTED_OPERATION_DEPRECATION_HANDLER, builder.bytes(), builder.contentType())) {
             Map<String, Object> map = parser.map();
             assertEquals(2, map.size());
             assertEquals("value1", map.get("field1"));


### PR DESCRIPTION
We'd like to separate xcontent from Elasticsearch core so that the high level rest client can depend on it *instead* of Elasticsearch core. Unfortunately xcontent's deprecation handling uses Log4 and our logging utility classes explicitly. We don't want the high level rest client to require log4j2 or the logging utilities.

This proposes a solution: make the deprecation handling pluggable. In particular it proposes to change `ParseField.match(String)` into `ParseField.match(String, DeprecationHandler)`. Core would contain the logging deprecation handler and other users could provide whatever they want.

Further it proposes that we add a member to `XContentParser` to hold the deprecation handler. This is somewhat strange as `XContentParser` doesn't directly call the `DeprecationHandler`. Instead, this PR proposes the idiom of using the `DeprecationHandler` on the `XContentParser` every time we call `ParseField.match`.

This end up forcing you to decide how to handle deprecated fields at parser creation time. This *feels* right to me because it is close to the code that receives that data being parsed in the first place. So you can look at the parser construction and say "oh, this is a user request, I should pitch deprecation warnings into the deprecation logger so they get sent back to the user" or "oh, this is a response from Elasticsearch in the high level rest client, I should ignore deprecated fields." Or not, I'm not sure what the high level rest client should do if it sees deprecated fields, but at least we have the option of changing it.

This does cause the problem of needing to specify the `DeprecationHandler` even in places where you are just doing low level parsing. This is a shame, but it seems worth it to be able to share parses across different parts of our code base.

Finally: this only does half the job. In a followup I'd have to replace all of the calls to `ParseField.match(String)` with `ParseField.match(String, DeprecationHandler)`. I've done a few in this PR but doing them all would make the PR too large to review. It is already too large as is but I wanted to replace a few of the invocations so reviewers would have a taste of what the followup would look like.