### PR TITLE
Also skip Javadoc task for client JARs on JDK 10

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -22,6 +22,7 @@ import org.elasticsearch.gradle.BuildPlugin
 import org.elasticsearch.gradle.NoticeTask
 import org.elasticsearch.gradle.test.RestIntegTestTask
 import org.elasticsearch.gradle.test.RunTask
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.XmlProvider
@@ -168,10 +169,12 @@ public class PluginBuildPlugin extends BuildPlugin {
             Files.copy(jarFile.resolveSibling(sourcesFileName), jarFile.resolveSibling(clientSourcesFileName),
                     StandardCopyOption.REPLACE_EXISTING)
 
-            String javadocFileName = jarFile.fileName.toString().replace('.jar', '-javadoc.jar')
-            String clientJavadocFileName = clientFileName.replace('.jar', '-javadoc.jar')
-            Files.copy(jarFile.resolveSibling(javadocFileName), jarFile.resolveSibling(clientJavadocFileName),
-                    StandardCopyOption.REPLACE_EXISTING)
+            if (project.javaVersion < JavaVersion.VERSION_1_10) {
+                String javadocFileName = jarFile.fileName.toString().replace('.jar', '-javadoc.jar')
+                String clientJavadocFileName = clientFileName.replace('.jar', '-javadoc.jar')
+                Files.copy(jarFile.resolveSibling(javadocFileName), jarFile.resolveSibling(clientJavadocFileName),
+                        StandardCopyOption.REPLACE_EXISTING)
+            }
         }
         project.assemble.dependsOn(clientJar)
     }


### PR DESCRIPTION
We disabled the Javadoc task on JDK 10 due to an apparent bug in Javadoc generation on JDK 10. However, the client JAR task sets up its own Javadoc task for client JARs (because it merely copies the non-client Javadoc JAR). This commit diables that task too, since the Javadocs for the non-client JAR will not exist.

Closes #27961