### PR TITLE
Only sync translog when global checkpoint increased

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/core/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -255,7 +255,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
      */
     public boolean syncNeeded() {
         return totalOffset != lastSyncedCheckpoint.offset ||
-            globalCheckpointSupplier.getAsLong() != lastSyncedCheckpoint.globalCheckpoint ||
+            globalCheckpointSupplier.getAsLong() > lastSyncedCheckpoint.globalCheckpoint ||
             minTranslogGenerationSupplier.getAsLong() != lastSyncedCheckpoint.minTranslogGeneration;
     }
 


### PR DESCRIPTION
Today we did not set the global checkpoint when opening an engine from an existing store. If we are forced to close an engine before advancing the global checkpoint, we will also close translog which in turn sync a new checkpoint with an unassigned global checkpoint. This is not caught until the global checkpoint assertion was introduced in PR #27837.

This commit tightens the `syncNeeded` conditions.

Relates #27970