### PR TITLE
Fix time rounding for Newfoundland

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/rounding/Rounding.java
+++ b/core/src/main/java/org/elasticsearch/common/rounding/Rounding.java
@@ -127,8 +127,6 @@ public abstract class Rounding implements Streamable {
 
         @Override
         public long round(long utcMillis) {
-            int transitionCount = 0;
-
             while (true) {
                 long rounded = field.roundFloor(utcMillis);
                 long transitionTime = timeZone.previousTransition(utcMillis);
@@ -153,19 +151,7 @@ public abstract class Rounding implements Streamable {
                  * times in the current period-of-constant-offset. Go back to the previous transition time and round
                  * _that_ down instead.
                  */
-                transitionCount += 1;
                 utcMillis = transitionTime;
-
-                // We round by at most one year, which may contain up to 4 transitions (e.g. Morocco, or double-DST in the UK)
-                assert transitionCount <= 4;
-
-                /*
-                 * Bound the iterations to prevent an infinite loop, but allow for more than 4 transitions
-                 * in case the previous assertion is wrong.
-                 */
-                if (transitionCount > 10) {
-                    throw new IllegalStateException("Too many timezone transitions found");
-                }
             }
         }
 

--- a/core/src/main/java/org/elasticsearch/common/rounding/Rounding.java
+++ b/core/src/main/java/org/elasticsearch/common/rounding/Rounding.java
@@ -160,7 +160,9 @@ public abstract class Rounding implements Streamable {
             long guess = utcMillis;
             long rounded;
             do {
-                guess = field.roundCeiling(guess + 1);
+                long newGuess = field.roundCeiling(guess + 1);
+                assert newGuess > guess;
+                guess = newGuess;
                 rounded = round(guess);
             } while (rounded <= utcMillis);
 

--- a/core/src/main/java/org/elasticsearch/common/rounding/Rounding.java
+++ b/core/src/main/java/org/elasticsearch/common/rounding/Rounding.java
@@ -160,7 +160,7 @@ public abstract class Rounding implements Streamable {
             long guess = utcMillis;
             long rounded;
             do {
-                guess = field.add(guess, 1);
+                guess = field.roundCeiling(guess + 1);
                 rounded = round(guess);
             } while (rounded <= utcMillis);
 

--- a/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -577,11 +577,15 @@ public class TimeZoneRoundingTests extends ESTestCase {
 
         // Sunday, 29 October 2000, 01:00:00 clocks were turned backward 1 hour
         // to Sunday, 29 October 2000, 00:00:00 local standard time instead
+        // which means there were two midnights that day.
 
         long midnightBeforeTransition = time("2000-10-29T00:00:00", tz);
+        long midnightOfTransition = time("2000-10-29T00:00:00-01:00");
+        assertEquals(60L * 60L * 1000L, midnightOfTransition - midnightBeforeTransition);
         long nextMidnight = time("2000-10-30T00:00:00", tz);
 
-        assertInterval(midnightBeforeTransition, nextMidnight, rounding, 25 * 60, tz);
+        assertInterval(midnightBeforeTransition, midnightOfTransition, rounding, 60, tz);
+        assertInterval(midnightOfTransition, nextMidnight, rounding, 24 * 60, tz);
 
         // Second case, dst happens at 0am local time, switching back one hour to 23pm local time.
         // We want the overlapping hour to count for the previous day here

--- a/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -627,7 +627,7 @@ public class TimeZoneRoundingTests extends ESTestCase {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("Expected: " + new DateTime(expected, tz) + " [" + expected + "] ");
+                description.appendText(new DateTime(expected, tz) + " [" + expected + "] ");
             }
 
             @Override

--- a/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -600,8 +600,8 @@ public class TimeZoneRoundingTests extends ESTestCase {
     }
 
     private static long dateBetween(long lower, long upper) {
-        long dateBetween = lower + Math.abs((randomLong() % (upper - lower)));
-        assert lower <= dateBetween && dateBetween <= upper;
+        long dateBetween = randomLongBetween(lower, upper - 1);
+        assert lower <= dateBetween && dateBetween < upper;
         return dateBetween;
     }
 

--- a/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -584,9 +584,7 @@ public class TimeZoneRoundingTests extends ESTestCase {
      * @param nextRoundingValue the expected upper end of the rounding interval
      * @param rounding the rounding instance
      */
-    private static void assertInterval(long rounded, long unrounded, long nextRoundingValue, Rounding rounding,
-            DateTimeZone tz) {
-        assert rounded <= unrounded && unrounded <= nextRoundingValue;
+    private static void assertInterval(long rounded, long unrounded, long nextRoundingValue, Rounding rounding, DateTimeZone tz) {
         assertThat("rounding should be idempotent ", rounding.round(rounded), isDate(rounded, tz));
         assertThat("rounded value smaller or equal than unrounded" + rounding, rounded, lessThanOrEqualTo(unrounded));
         assertThat("values less than rounded should round further down" + rounding, rounding.round(rounded - 1), lessThan(rounded));

--- a/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
+++ b/core/src/test/java/org/elasticsearch/common/rounding/TimeZoneRoundingTests.java
@@ -594,9 +594,10 @@ public class TimeZoneRoundingTests extends ESTestCase {
                 isDate(nextRoundingValue, tz));
 
         long dateBetween = dateBetween(rounded, nextRoundingValue);
-        assertThat("dateBetween should round down to roundedDate", rounding.round(dateBetween), isDate(rounded, tz));
-        assertThat("dateBetween should round up to nextRoundingValue", rounding.nextRoundingValue(dateBetween),
-                isDate(nextRoundingValue, tz));
+        assertThat("dateBetween [" + new DateTime(dateBetween, tz) + "] should round down to roundedDate",
+            rounding.round(dateBetween), isDate(rounded, tz));
+        assertThat("dateBetween [" + new DateTime(dateBetween, tz) + "] should round up to nextRoundingValue",
+            rounding.nextRoundingValue(dateBetween), isDate(nextRoundingValue, tz));
     }
 
     private static long dateBetween(long lower, long upper) {


### PR DESCRIPTION
Resolves #27966. I do love a good timezone puzzle.

I updated `testDST_END_Edgecases` because I think the test itself is wrong. In its original form it failed:

```
java.lang.AssertionError: dateBetween [2000-10-29T22:10:11.747-01:00] should round down to roundedDate
Expected: 2000-10-29T00:00:00.000Z [972777600000] 
     but:  was "2000-10-29T00:00:00.000-01:00 [972781200000]"
```

Rounding to `DAY_OF_MONTH` should round down to the _closest_ earlier local-time midnight. However, in `Atlantic/Azores` there are two midnights on 2000-10-29 because the clocks went back by an hour at 0100. The test originally expected the first of them, but the second is closer. @cbuescher WDYT?

Don't know a good label for this bit of code, so I'm just labelling this PR as 'test'.