### PR TITLE
Remove I/O pool blocking sniffing call from onFailure callback, add some logic around host exclusion

### DIFF
--- a/client/sniffer/src/main/java/org/elasticsearch/client/sniff/SnifferBuilder.java
+++ b/client/sniffer/src/main/java/org/elasticsearch/client/sniff/SnifferBuilder.java
@@ -30,10 +30,12 @@ import java.util.concurrent.TimeUnit;
 public final class SnifferBuilder {
     public static final long DEFAULT_SNIFF_INTERVAL = TimeUnit.MINUTES.toMillis(5);
     public static final long DEFAULT_SNIFF_AFTER_FAILURE_DELAY = TimeUnit.MINUTES.toMillis(1);
+    public static final int DEFAULT_HOST_EXCLUDED_SNIFF_ROUNDS = 1;
 
     private final RestClient restClient;
     private long sniffIntervalMillis = DEFAULT_SNIFF_INTERVAL;
     private long sniffAfterFailureDelayMillis = DEFAULT_SNIFF_AFTER_FAILURE_DELAY;
+    private int maxExcludedRounds = DEFAULT_HOST_EXCLUDED_SNIFF_ROUNDS;
     private HostsSniffer hostsSniffer;
 
     /**
@@ -80,12 +82,23 @@ public final class SnifferBuilder {
     }
 
     /**
+     * Sets the amount of future sniffing calls from which a host that had failed a request would be excluded. Will not
+     * be used if client wasn't built utilizing
+     * {@link org.elasticsearch.client.RestClientBuilder#setFailureListener(RestClient.FailureListener)}
+     * @param maxExcludedRounds the number of sniffing calls to exclude a host from
+     */
+    public SnifferBuilder setMaxExcludedRounds(int maxExcludedRounds) {
+        this.maxExcludedRounds = maxExcludedRounds;
+        return this;
+    }
+
+    /**
      * Creates the {@link Sniffer} based on the provided configuration.
      */
     public Sniffer build() {
         if (hostsSniffer == null) {
             this.hostsSniffer = new ElasticsearchHostsSniffer(restClient);
         }
-        return new Sniffer(restClient, hostsSniffer, sniffIntervalMillis, sniffAfterFailureDelayMillis);
+        return new Sniffer(restClient, hostsSniffer, sniffIntervalMillis, sniffAfterFailureDelayMillis, maxExcludedRounds);
     }
 }

--- a/client/sniffer/src/test/java/org/elasticsearch/client/sniff/documentation/SnifferDocumentation.java
+++ b/client/sniffer/src/test/java/org/elasticsearch/client/sniff/documentation/SnifferDocumentation.java
@@ -82,8 +82,9 @@ public class SnifferDocumentation {
                     .build();
             Sniffer sniffer = Sniffer.builder(restClient)
                     .setSniffAfterFailureDelayMillis(30000) // <2>
+                    .setMaxExcludedRounds(3) // <3>
                     .build();
-            sniffOnFailureListener.setSniffer(sniffer); // <3>
+            sniffOnFailureListener.setSniffer(sniffer); // <4>
             //end::sniff-on-failure
         }
         {

--- a/docs/java-rest/low-level/sniffer.asciidoc
+++ b/docs/java-rest/low-level/sniffer.asciidoc
@@ -98,7 +98,8 @@ normal and we want to detect that as soon as possible. Said interval can be
 customized  at `Sniffer` creation time through the `setSniffAfterFailureDelayMillis`
 method. Note that this last configuration parameter has no effect in case sniffing
 on failure is not enabled like explained above.
-<3> Set the `Sniffer` instance to the failure listener
+<3> Set the amount of sniffing rounds to exclude a failed host for
+<4> Set the `Sniffer` instance to the failure listener
 
 The Elasticsearch Nodes Info api doesn't return the protocol to use when
 connecting to the nodes but only their `host:port` key-pair, hence `http`


### PR DESCRIPTION
Addressing: https://github.com/elastic/elasticsearch/issues/27984

In addition to the bugfix, I tried making the mechanism a bit clearer in a mutlithread context. Beforehand the onFailure execution stack would call the sniffing code in the callback (bad). In that context it kinda made sense to exclude a single host, but since we're now delaying the execution (and because other requests might be running concurrently) it's clearer to use a list of hosts that need to be excluded.

This list expires its values after a certain number of sniffing cycles (sniffing calls) had passed. This number defaults to 1 to mimic the existing behavior more closely.