### PR TITLE
Change on the ignore_above default value.

### DIFF
--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -62,8 +62,8 @@ The following parameters are accepted by `keyword` fields:
 
 <<ignore-above,`ignore_above`>>::
 
-    Do not index any string longer than this value.  Defaults to
-    `2147483647` so that all values would be accepted.
+    Do not index any string longer than this value, but store it.  Defaults to
+    `256`.
 
 <<mapping-index,`index`>>::
 


### PR DESCRIPTION
I think the ignore_above default value is wrong on the documentation. 
I tried a little example:
- First create an index:
`
curl -XPUT 'localhost:9200/test?pretty' -H 'Content-Type: application/json' -d'
{
    "settings" : {
        "index" : {
        }
    }
}'
`
- Then insert some value:
`
curl -XPUT 'localhost:9200/test/testType/1?pretty' -H 'Content-Type: application/json' -d'
{
    "user" : "kimchy",
    "post_date" : "2009-11-15T14:12:12",
    "message" : "trying out Elasticsearch"
}
'
`

When I get the mapping info for that index (curl -XGET 'localhost:9200/test/_mapping/testType?pretty') it returns:
```
{
  "test" : {
    "mappings" : {
      "testType" : {
        "properties" : {
          "message" : {
            "type" : "text",
            "fields" : {
              "keyword" : {
                "type" : "keyword",
                "ignore_above" : 256
              }
            }
          },
          "post_date" : {
            "type" : "date"
          },
          "user" : {
            "type" : "text",
            "fields" : {
              "keyword" : {
                "type" : "keyword",
                "ignore_above" : 256
              }
            }
          }
        }
      }
    }
  }
}
```
In addition to this, there is a [blog post](https://www.elastic.co/blog/strings-are-dead-long-live-strings) by Adrien Grand saying that the default ignore_above value is 256.

I also tried inserting data with a keyword field value longer than 256. Elastic will store it, but i am not able to search on it.
