### PR TITLE
Fail resync-failed shards in subsequent writes

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/ResyncFailedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ResyncFailedInfo.java
@@ -43,7 +43,7 @@ public final class ResyncFailedInfo implements Writeable, ToXContentFragment {
     }
 
     ResyncFailedInfo(StreamInput in) throws IOException {
-        this.reason = in.readOptionalString();
+        this.reason = in.readString();
         this.failure = in.readException();
     }
 
@@ -57,7 +57,7 @@ public final class ResyncFailedInfo implements Writeable, ToXContentFragment {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeOptionalString(reason);
+        out.writeString(reason);
         out.writeException(failure);
     }
 
@@ -80,7 +80,9 @@ public final class ResyncFailedInfo implements Writeable, ToXContentFragment {
 
     @Override
     public int hashCode() {
-        return Objects.hash(reason, failure);
+        int result = reason.hashCode();
+        result = 31 * result + failure.hashCode();
+        return result;
     }
 
     @Override

--- a/core/src/main/java/org/elasticsearch/cluster/routing/ResyncFailedInfo.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/ResyncFailedInfo.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * {@link ResyncFailedInfo} holds additional information why the shard was failed in resync.
+ */
+public final class ResyncFailedInfo implements Writeable, ToXContentFragment {
+    private final String reason;
+    private final Exception failure;
+
+    public ResyncFailedInfo(String reason, Exception failure) {
+        this.reason = reason;
+        this.failure = failure;
+    }
+
+    ResyncFailedInfo(StreamInput in) throws IOException {
+        this.reason = in.readOptionalString();
+        this.failure = in.readException();
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public Exception getFailure() {
+        return failure;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(reason);
+        out.writeException(failure);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("resync_failed_info");
+        builder.field("reason", reason);
+        builder.field("failure", ExceptionsHelper.detailedMessage(failure));
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResyncFailedInfo that = (ResyncFailedInfo) o;
+        return Objects.equals(this.reason, that.reason) && Objects.equals(this.failure, that.failure);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(reason, failure);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT, "resync_failed{reason [%s], failure [%s]}", reason, failure);
+    }
+}

--- a/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -627,6 +627,16 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             " was matched but wasn't removed";
     }
 
+    /**
+     * Marks a shard resync-failed.
+     */
+    public ShardRouting markShardResyncFailed(ShardRouting shardToMark, ResyncFailedInfo resyncFailedInfo) {
+        ensureMutable();
+        final ShardRouting markedShard = shardToMark.markResyncFailed(resyncFailedInfo);
+        updateAssigned(shardToMark, markedShard);
+        return markedShard;
+    }
+
     private void promoteReplicaToPrimary(ShardRouting activeReplica, IndexMetaData indexMetaData,
                                          RoutingChangesObserver routingChangesObserver) {
         // if the activeReplica was relocating before this call to failShard, its relocation was cancelled earlier when we

--- a/core/src/test/java/org/elasticsearch/action/resync/ResyncReplicationIT.java
+++ b/core/src/test/java/org/elasticsearch/action/resync/ResyncReplicationIT.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.resync;
+
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.IndexModuleHelper;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.MockEngineFactoryPlugin;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.engine.EngineConfig;
+import org.elasticsearch.index.engine.EngineFactory;
+import org.elasticsearch.index.engine.InternalEngine;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.index.shard.IndexShardTests.getEngineFromShard;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, transportClientRatio = 0)
+public class ResyncReplicationIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getMockPlugins() {
+        final ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>(super.getMockPlugins());
+        // We can only set the engine factory at most one.
+        plugins.remove(MockEngineFactoryPlugin.class);
+        plugins.add(InterceptEngineFactoryPlugin.class);
+        return Collections.unmodifiableList(plugins);
+    }
+
+    public void testResyncFailedShardFailInNextWrites() throws Exception {
+        final AtomicInteger docId = new AtomicInteger();
+        internalCluster().startMasterOnlyNode();
+        final String primaryNode = internalCluster().startDataOnlyNode();
+        assertAcked(prepareCreate("test", Settings.builder().put(indexSettings())
+            .put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 2)));
+        ensureYellow("test");
+        final List<String> replicaNodes = internalCluster().startDataOnlyNodes(2);
+        ensureGreen("test");
+        final ShardId shardId = new ShardId(clusterService().state().metaData().index("test").getIndex(), 0);
+        logger.info("--> Indexing with a gap in the sequence number to ensure that some ops will be replayed in resync");
+        IntStream.range(0, between(1, 10)).forEach(n -> index("test", "doc", Integer.toString(docId.getAndIncrement())));
+        getEngine(primaryNode, shardId).getLocalCheckpointTracker().generateSeqNo();
+        IntStream.range(0, between(1, 10)).forEach(n -> index("test", "doc", Integer.toString(docId.getAndIncrement())));
+        logger.info("--> Make replicas failed to index resync operations");
+        replicaNodes.forEach(node -> getEngine(node, shardId).preventIndexing(true));
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(primaryNode));
+        assertBusy(() -> {
+            final List<ShardRouting> resyncFailedShards = clusterService().state().routingTable().allShards("test").stream()
+                .filter(shardRouting -> shardRouting.resyncFailedInfo() != null).collect(Collectors.toList());
+            assertThat(resyncFailedShards, hasSize(1));
+            assertThat(clusterService().state().metaData().getIndexSafe(shardId.getIndex()).inSyncAllocationIds(shardId.id()), hasSize(3));
+        });
+        logger.info("--> Resync-failed shards will be failed in next writes");
+        List<BlockingEngineFactory> engineFactories = replicaNodes.stream()
+            .map(node -> getEngineFactory(node, shardId)).collect(Collectors.toList());
+        engineFactories.forEach(BlockingEngineFactory::preventCreateNewEngine);
+        replicaNodes.forEach(node -> getEngine(node, shardId).preventIndexing(false));
+        IntStream.range(0, between(1, 10)).forEach(n -> index("test", "doc", Integer.toString(docId.getAndIncrement())));
+        assertBusy(() -> {
+            final List<ShardRouting> resyncFailedShards = clusterService().state().routingTable().allShards("test").stream()
+                .filter(shardRouting -> shardRouting.resyncFailedInfo() != null).collect(Collectors.toList());
+            assertThat(resyncFailedShards, empty());
+            assertThat(clusterService().state().metaData().getIndexSafe(shardId.getIndex()).inSyncAllocationIds(shardId.id()), hasSize(1));
+        });
+        logger.info("--> Resync-failed shards will recover via peer-recovery");
+        engineFactories.forEach(BlockingEngineFactory::allowCreateNewEngine);
+        assertBusy(() -> {
+            final List<ShardRouting> resyncFailedShards = clusterService().state().routingTable().allShards("test").stream()
+                .filter(shardRouting -> shardRouting.resyncFailedInfo() != null).collect(Collectors.toList());
+            assertThat(resyncFailedShards, empty());
+            assertThat(clusterService().state().metaData().getIndexSafe(shardId.getIndex()).inSyncAllocationIds(shardId.id()), hasSize(2));
+        });
+    }
+
+    public void testResyncFailedShardStillInSyncSet() throws Exception {
+        final AtomicInteger docId = new AtomicInteger();
+        internalCluster().startMasterOnlyNode();
+        final String oldPrimaryNode = internalCluster().startDataOnlyNode();
+        assertAcked(prepareCreate("test", Settings.builder().put(indexSettings())
+            .put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 2)));
+        ensureYellow("test");
+        final List<String> replicaNodes = internalCluster().startDataOnlyNodes(2);
+        ensureGreen("test");
+        final ShardId shardId = new ShardId(clusterService().state().metaData().index("test").getIndex(), 0);
+        logger.info("--> Indexing with a gap in the sequence number to ensure that some ops will be replayed in resync");
+        IntStream.range(0, between(1, 10)).forEach(n -> index("test", "doc", Integer.toString(docId.getAndIncrement())));
+        getEngine(oldPrimaryNode, shardId).getLocalCheckpointTracker().generateSeqNo();
+        IntStream.range(0, between(1, 10)).forEach(n -> index("test", "doc", Integer.toString(docId.getAndIncrement())));
+        logger.info("--> Make replicas failed to index resync operations");
+        replicaNodes.forEach(node -> getEngine(node, shardId).preventIndexing(true));
+        internalCluster().stopRandomNode(InternalTestCluster.nameFilter(oldPrimaryNode));
+        assertBusy(() -> {
+            final List<ShardRouting> resyncFailedShards = clusterService().state().routingTable().allShards("test").stream()
+                .filter(shardRouting -> shardRouting.resyncFailedInfo() != null).collect(Collectors.toList());
+            assertThat(resyncFailedShards, hasSize(1));
+            assertThat(clusterService().state().metaData().getIndexSafe(shardId.getIndex()).inSyncAllocationIds(shardId.id()), hasSize(3));
+        });
+        replicaNodes.forEach(node -> getEngine(node, shardId).preventIndexing(false));
+        logger.info("--> Promote the resync-failed replica to primary");
+        final IndexShard firstShard = internalCluster().getInstance(IndicesService.class, replicaNodes.get(0))
+            .indexServiceSafe(shardId.getIndex()).getShard(shardId.id());
+        final String newPrimaryNode = firstShard.routingEntry().resyncFailedInfo() == null ? replicaNodes.get(0) : replicaNodes.get(1);
+        internalCluster().restartNode(newPrimaryNode, new InternalTestCluster.RestartCallback());
+        ensureYellow("test");
+        assertBusy(() -> {
+            final List<ShardRouting> resyncFailedShards = clusterService().state().routingTable().allShards("test").stream()
+                .filter(shardRouting -> shardRouting.resyncFailedInfo() != null).collect(Collectors.toList());
+            assertThat(resyncFailedShards, empty());
+            assertThat(clusterService().state().metaData().getIndexSafe(shardId.getIndex()).inSyncAllocationIds(shardId.id()), hasSize(3));
+        });
+    }
+
+    InterceptEngine getEngine(String node, ShardId shardId) {
+        final IndexShard shard = internalCluster().getInstance(IndicesService.class, node)
+            .indexServiceSafe(shardId.getIndex()).getShard(shardId.id());
+        return (InterceptEngine) getEngineFromShard(shard);
+    }
+
+    BlockingEngineFactory getEngineFactory(String node, ShardId shardId) {
+        final IndexService indexService = internalCluster().getInstance(IndicesService.class, node)
+            .indexServiceSafe(shardId.getIndex());
+        return (BlockingEngineFactory) (IndexModuleHelper.getEngineFactory(indexService));
+    }
+
+    static class InterceptEngine extends InternalEngine {
+        final AtomicBoolean preventIndexing = new AtomicBoolean();
+
+        InterceptEngine(EngineConfig engineConfig) {
+            super(engineConfig);
+        }
+
+        @Override
+        public IndexResult index(Index index) throws IOException {
+            if (preventIndexing.get()) {
+                throw new IOException("Engine is intercepted to fail index [" + index.id() + "]");
+            }
+            logger.info("Indexing [{}]", index.id());
+            return super.index(index);
+        }
+
+        void preventIndexing(boolean prevent) {
+            preventIndexing.set(prevent);
+        }
+    }
+
+    static class BlockingEngineFactory implements EngineFactory {
+        final Semaphore sem = new Semaphore(1);
+
+        void preventCreateNewEngine() {
+            sem.acquireUninterruptibly();
+        }
+
+        void allowCreateNewEngine() {
+            sem.release();
+        }
+
+        @Override
+        public Engine newReadWriteEngine(EngineConfig config) {
+            sem.acquireUninterruptibly();
+            try {
+                return new InterceptEngine(config);
+            } finally {
+                sem.release();
+            }
+        }
+    }
+
+    public static class InterceptEngineFactoryPlugin extends Plugin {
+        @Override
+        public void onIndexModule(IndexModule module) {
+            IndexModuleHelper.setEngineFactory(module, new BlockingEngineFactory());
+        }
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionIT.java
+++ b/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionIT.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.action.shard;
+
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class ShardStateActionIT extends ESIntegTestCase {
+    public void testMarkShardsResyncFailed() throws Exception {
+        internalCluster().startDataOnlyNodes(between(1, 3));
+        int numberOfShards = between(1, 10);
+        assertAcked(prepareCreate("test", Settings.builder().put(indexSettings())
+            .put(SETTING_NUMBER_OF_SHARDS, numberOfShards)
+            .put(SETTING_NUMBER_OF_REPLICAS, internalCluster().numDataNodes() - 1)));
+        ensureGreen("test");
+        final Index index = clusterService().state().metaData().index("test").getIndex();
+        final IndexShard shardToMark = internalCluster().getDataNodeInstance(IndicesService.class)
+            .indexServiceSafe(index).getShard(between(0, numberOfShards - 1));
+        final ShardStateAction shardStateAction = internalCluster().getInstance(ShardStateAction.class);
+        shardStateAction.markShardResyncFailed(shardToMark.shardId(),
+            shardToMark.routingEntry().allocationId().getId(), shardToMark.getPrimaryTerm(),
+            "testMessage", new IOException("TestException"), new ShardStateAction.Listener() {});
+
+        assertBusy(() -> {
+            final ShardId shardId = shardToMark.shardId();
+            final IndexRoutingTable indexRoutingTable = clusterService().state().routingTable().index(shardId.getIndex());
+            final List<ShardRouting> markedShards = indexRoutingTable.shard(shardId.id()).getShards().stream()
+                .filter(s -> s.resyncFailedInfo() != null).collect(Collectors.toList());
+            assertThat(markedShards, hasSize(1));
+            assertThat(markedShards.get(0).allocationId(), equalTo(shardToMark.routingEntry().allocationId()));
+            assertThat(markedShards.get(0).resyncFailedInfo().getReason(), equalTo("testMessage"));
+            assertThat(markedShards.get(0).resyncFailedInfo().getFailure().getMessage(), equalTo("TestException"));
+        });
+        ensureGreen("test");
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/action/shard/ShardStateActionTests.java
@@ -20,10 +20,12 @@
 package org.elasticsearch.cluster.action.shard;
 
 import org.apache.lucene.index.CorruptIndexException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.NotMasterException;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingService;
@@ -89,9 +91,9 @@ public class ShardStateActionTests extends ESTestCase {
         }
 
         @Override
-        protected void waitForNewMasterAndRetry(String actionName, ClusterStateObserver observer, ShardEntry shardEntry, Listener listener, Predicate<ClusterState> changePredicate) {
+        protected void waitForNewMasterAndRetry(String actionName, ClusterStateObserver observer, ShardEntry shardEntry, Listener listener, Predicate<ClusterState> changePredicate, Version masterNodeMinimumVersion) {
             onBeforeWaitForNewMasterAndRetry.run();
-            super.waitForNewMasterAndRetry(actionName, observer, shardEntry, listener, changePredicate);
+            super.waitForNewMasterAndRetry(actionName, observer, shardEntry, listener, changePredicate, masterNodeMinimumVersion);
             onAfterWaitForNewMasterAndRetry.run();
         }
     }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/RoutingNodesTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/RoutingNodesTests.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.routing;
+
+import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class RoutingNodesTests extends ESTestCase {
+    public void testMarkShardAsResyncFailed() throws Exception {
+        ClusterState clusterState = ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicas(
+            generateRandomStringArray(10, 100, false, false), between(5, 10), between(1, 3));
+        final ShardRouting shardToMark = randomFrom(clusterState.routingTable().allShards());
+        RoutingNodes routingNodes = new RoutingNodes(clusterState, false);
+        final List<ShardRouting> shardsBeforeMarking = routingNodes.shards(shardRouting -> true);
+        ResyncFailedInfo resyncFailedInfo = new ResyncFailedInfo(randomAlphaOfLengthBetween(10, 100),
+            new IOException(randomAlphaOfLengthBetween(10, 100)));
+        final ShardRouting markedShard = routingNodes.markShardResyncFailed(shardToMark, resyncFailedInfo);
+        assertThat(markedShard.equalsIgnoringMetaData(shardToMark), equalTo(true));
+        assertThat(markedShard.resyncFailedInfo(), equalTo(resyncFailedInfo));
+        final List<ShardRouting> shardsAfterMarking = routingNodes.shards(shardRouting -> true);
+        final Set<ShardRouting> markedShards = Sets.difference(new HashSet<>(shardsAfterMarking), new HashSet<>(shardsBeforeMarking));
+        assertThat(markedShards, hasSize(1));
+        assertThat(markedShards, contains(markedShard));
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -58,8 +58,10 @@ public class ShardRoutingTests extends ESTestCase {
 
     private ShardRouting randomShardRouting(String index, int shard) {
         ShardRoutingState state = randomFrom(ShardRoutingState.values());
+        final ResyncFailedInfo resyncFailedInfo = randomBoolean() ? null :
+            new ResyncFailedInfo(randomAlphaOfLengthBetween(10, 100), new IOException(randomAlphaOfLengthBetween(10, 100)));
         return TestShardRouting.newShardRouting(index, shard, state == ShardRoutingState.UNASSIGNED ? null : "1",
-            state == ShardRoutingState.RELOCATING ? "2" : null, state != ShardRoutingState.UNASSIGNED && randomBoolean(), state);
+            state == ShardRoutingState.RELOCATING ? "2" : null, state != ShardRoutingState.UNASSIGNED && randomBoolean(), state, resyncFailedInfo);
     }
 
     public void testIsSourceTargetRelocation() {
@@ -122,13 +124,13 @@ public class ShardRoutingTests extends ESTestCase {
                     ShardId shardId = new ShardId(new Index("blubb", randomAlphaOfLength(10)), otherRouting.id());
                     otherRouting = new ShardRouting(shardId, otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                             otherRouting.primary(), otherRouting.state(), otherRouting.recoverySource(), otherRouting.unassignedInfo(),
-                            otherRouting.allocationId(), otherRouting.getExpectedShardSize());
+                            otherRouting.allocationId(), otherRouting.getExpectedShardSize(), null);
                     break;
                 case 1:
                     // change shard id
                     otherRouting = new ShardRouting(new ShardId(otherRouting.index(), otherRouting.id() + 1), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                             otherRouting.primary(), otherRouting.state(), otherRouting.recoverySource(), otherRouting.unassignedInfo(),
-                            otherRouting.allocationId(), otherRouting.getExpectedShardSize());
+                            otherRouting.allocationId(), otherRouting.getExpectedShardSize(), null);
                     break;
                 case 2:
                     // change current node
@@ -137,7 +139,7 @@ public class ShardRoutingTests extends ESTestCase {
                     } else {
                         otherRouting = new ShardRouting(otherRouting.shardId(), otherRouting.currentNodeId() + "_1", otherRouting.relocatingNodeId(),
                             otherRouting.primary(), otherRouting.state(), otherRouting.recoverySource(), otherRouting.unassignedInfo(),
-                            otherRouting.allocationId(), otherRouting.getExpectedShardSize());
+                            otherRouting.allocationId(), otherRouting.getExpectedShardSize(), null);
                     }
                     break;
                 case 3:
@@ -147,7 +149,7 @@ public class ShardRoutingTests extends ESTestCase {
                     } else {
                         otherRouting = new ShardRouting(otherRouting.shardId(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId() + "_1",
                             otherRouting.primary(), otherRouting.state(), otherRouting.recoverySource(), otherRouting.unassignedInfo(),
-                            otherRouting.allocationId(), otherRouting.getExpectedShardSize());
+                            otherRouting.allocationId(), otherRouting.getExpectedShardSize(), null);
                     }
                     break;
                 case 4:
@@ -158,7 +160,7 @@ public class ShardRoutingTests extends ESTestCase {
                         otherRouting = new ShardRouting(otherRouting.shardId(), otherRouting.currentNodeId(), otherRouting.relocatingNodeId(),
                             otherRouting.primary(), otherRouting.state(),
                             new RecoverySource.SnapshotRecoverySource(new Snapshot("test", new SnapshotId("s1", UUIDs.randomBase64UUID())), Version.CURRENT, "test"),
-                            otherRouting.unassignedInfo(), otherRouting.allocationId(), otherRouting.getExpectedShardSize());
+                            otherRouting.unassignedInfo(), otherRouting.allocationId(), otherRouting.getExpectedShardSize(), null);
                     }
                     break;
                 case 5:

--- a/core/src/test/java/org/elasticsearch/index/IndexModuleHelper.java
+++ b/core/src/test/java/org/elasticsearch/index/IndexModuleHelper.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index;
+
+import org.elasticsearch.index.engine.EngineFactory;
+
+/**
+ * A helper class that allows access to package private APIs for testing.
+ */
+public class IndexModuleHelper {
+    /**
+     * Injects a custom engine factory for the index module. This should be called at most one for each index module.
+     */
+    public static void setEngineFactory(IndexModule module, EngineFactory engineFactory) {
+        module.engineFactory.set(engineFactory);
+    }
+
+    public static EngineFactory getEngineFactory(IndexService indexService) {
+        return indexService.getEngineFactory();
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/ShardRoutingHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/ShardRoutingHelper.java
@@ -49,7 +49,7 @@ public class ShardRoutingHelper {
     public static ShardRouting initWithSameId(ShardRouting copy, RecoverySource recoverySource) {
         return new ShardRouting(copy.shardId(), copy.currentNodeId(), copy.relocatingNodeId(),
             copy.primary(), ShardRoutingState.INITIALIZING, recoverySource, new UnassignedInfo(UnassignedInfo.Reason.REINITIALIZED, null),
-            copy.allocationId(), copy.getExpectedShardSize());
+            copy.allocationId(), copy.getExpectedShardSize(), copy.resyncFailedInfo());
     }
 
     public static ShardRouting moveToUnassigned(ShardRouting routing, UnassignedInfo info) {
@@ -58,6 +58,6 @@ public class ShardRoutingHelper {
 
     public static ShardRouting newWithRestoreSource(ShardRouting routing, SnapshotRecoverySource recoverySource) {
         return new ShardRouting(routing.shardId(), routing.currentNodeId(), routing.relocatingNodeId(), routing.primary(), routing.state(),
-            recoverySource, routing.unassignedInfo(), routing.allocationId(), routing.getExpectedShardSize());
+            recoverySource, routing.unassignedInfo(), routing.allocationId(), routing.getExpectedShardSize(), routing.resyncFailedInfo());
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
@@ -40,23 +40,27 @@ public class TestShardRouting {
     }
 
     public static ShardRouting newShardRouting(ShardId shardId, String currentNodeId, boolean primary, RecoverySource recoverySource, ShardRoutingState state) {
-        return new ShardRouting(shardId, currentNodeId, null, primary, state, recoverySource, buildUnassignedInfo(state), buildAllocationId(state), -1);
+        return new ShardRouting(shardId, currentNodeId, null, primary, state, recoverySource, buildUnassignedInfo(state), buildAllocationId(state), -1, null);
     }
 
     public static ShardRouting newShardRouting(ShardId shardId, String currentNodeId, boolean primary, ShardRoutingState state) {
-        return new ShardRouting(shardId, currentNodeId, null, primary, state, buildRecoveryTarget(primary, state), buildUnassignedInfo(state), buildAllocationId(state), -1);
+        return new ShardRouting(shardId, currentNodeId, null, primary, state, buildRecoveryTarget(primary, state), buildUnassignedInfo(state), buildAllocationId(state), -1, null);
     }
 
     public static ShardRouting newShardRouting(ShardId shardId, String currentNodeId, boolean primary, ShardRoutingState state, RecoverySource recoverySource) {
-        return new ShardRouting(shardId, currentNodeId, null, primary, state, recoverySource, buildUnassignedInfo(state), buildAllocationId(state), -1);
+        return new ShardRouting(shardId, currentNodeId, null, primary, state, recoverySource, buildUnassignedInfo(state), buildAllocationId(state), -1, null);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state) {
         return newShardRouting(new ShardId(index, IndexMetaData.INDEX_UUID_NA_VALUE, shardId), currentNodeId, relocatingNodeId, primary, state);
     }
 
+    public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state, ResyncFailedInfo resyncFailedInfo) {
+        return new ShardRouting(new ShardId(index, IndexMetaData.INDEX_UUID_NA_VALUE, shardId), currentNodeId, relocatingNodeId, primary, state, buildRecoveryTarget(primary, state), buildUnassignedInfo(state), buildAllocationId(state), -1, resyncFailedInfo);
+    }
+
     public static ShardRouting newShardRouting(ShardId shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state) {
-        return new ShardRouting(shardId, currentNodeId, relocatingNodeId, primary, state, buildRecoveryTarget(primary, state), buildUnassignedInfo(state), buildAllocationId(state), -1);
+        return new ShardRouting(shardId, currentNodeId, relocatingNodeId, primary, state, buildRecoveryTarget(primary, state), buildUnassignedInfo(state), buildAllocationId(state), -1, null);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state, AllocationId allocationId) {
@@ -64,7 +68,7 @@ public class TestShardRouting {
     }
 
     public static ShardRouting newShardRouting(ShardId shardId, String currentNodeId, String relocatingNodeId, boolean primary, ShardRoutingState state, AllocationId allocationId) {
-        return new ShardRouting(shardId, currentNodeId, relocatingNodeId, primary, state, buildRecoveryTarget(primary, state), buildUnassignedInfo(state), allocationId, -1);
+        return new ShardRouting(shardId, currentNodeId, relocatingNodeId, primary, state, buildRecoveryTarget(primary, state), buildUnassignedInfo(state), allocationId, -1, null);
     }
 
     public static ShardRouting newShardRouting(String index, int shardId, String currentNodeId,
@@ -76,7 +80,7 @@ public class TestShardRouting {
     public static ShardRouting newShardRouting(ShardId shardId, String currentNodeId,
                                                String relocatingNodeId, boolean primary, ShardRoutingState state,
                                                UnassignedInfo unassignedInfo) {
-        return new ShardRouting(shardId, currentNodeId, relocatingNodeId, primary, state, buildRecoveryTarget(primary, state), unassignedInfo, buildAllocationId(state), -1);
+        return new ShardRouting(shardId, currentNodeId, relocatingNodeId, primary, state, buildRecoveryTarget(primary, state), unassignedInfo, buildAllocationId(state), -1, null);
     }
 
     public static ShardRouting relocate(ShardRouting shardRouting, String relocatingNodeId, long expectedShardSize) {


### PR DESCRIPTION
Today we treat the resync as best-effort and don't mark unavailable
shard copies as stale. This may be problematic if a replica is failed in
a resync but just fine in the subsequent writes. This commit marks
shards that failed in resync as resync-failed, then fail those shards in
subsequent writes if those shards did not remove their marker.