### PR TITLE
Allow update of `eager_global_ordinals` on `_parent`.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
@@ -303,15 +303,16 @@ public class ParentFieldMapper extends MetadataFieldMapper {
     @Override
     protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
         ParentFieldMapper fieldMergeWith = (ParentFieldMapper) mergeWith;
-        ParentFieldType currentFieldType = (ParentFieldType) fieldType.clone();
-        super.doMerge(mergeWith, updateAllTypes);
         if (fieldMergeWith.parentType != null && Objects.equals(parentType, fieldMergeWith.parentType) == false) {
             throw new IllegalArgumentException("The _parent field's type option can't be changed: [" + parentType + "]->[" + fieldMergeWith.parentType + "]");
         }
-
-        if (active()) {
-            fieldType = currentFieldType;
+        // If fieldMergeWith is not active it means the user provided a mapping
+        // update that does not explicitly configure the _parent field, so we
+        // ignore it.
+        if (fieldMergeWith.active()) {
+            super.doMerge(mergeWith, updateAllTypes);
         }
+
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParentFieldMapperTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.test.InternalSettingsPlugin;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -138,4 +139,23 @@ public class ParentFieldMapperTests extends ESSingleNodeTestCase {
         return numFieldWithParentPrefix;
     }
 
+    public void testUpdateEagerGlobalOrds() throws IOException {
+        String parentMapping = XContentFactory.jsonBuilder().startObject().startObject("parent_type")
+                .endObject().endObject().string();
+        String childMapping = XContentFactory.jsonBuilder().startObject().startObject("child_type")
+                .startObject("_parent").field("type", "parent_type").endObject()
+                .endObject().endObject().string();
+        IndexService indexService = createIndex("test", Settings.builder().put("index.version.created", Version.V_5_6_0).build());
+        indexService.mapperService().merge("parent_type", new CompressedXContent(parentMapping), MergeReason.MAPPING_UPDATE, false);
+        indexService.mapperService().merge("child_type", new CompressedXContent(childMapping), MergeReason.MAPPING_UPDATE, false);
+
+        assertTrue(indexService.mapperService().documentMapper("child_type").parentFieldMapper().fieldType().eagerGlobalOrdinals());
+
+        String childMappingUpdate = XContentFactory.jsonBuilder().startObject().startObject("child_type")
+                .startObject("_parent").field("type", "parent_type").field("eager_global_ordinals", false).endObject()
+                .endObject().endObject().string();
+        indexService.mapperService().merge("child_type", new CompressedXContent(childMappingUpdate), MergeReason.MAPPING_UPDATE, false);
+
+        assertFalse(indexService.mapperService().documentMapper("child_type").parentFieldMapper().fieldType().eagerGlobalOrdinals());
+    }
 }


### PR DESCRIPTION
A bug introduced in #24407 currently prevents `eager_global_ordinals` from
being updated. This new approach should fix the issue while still allowing
mapping updates to not specify the `_parent` field if it doesn't need
updating, which was the goal of #24407.