### PR TITLE
Fixing typo in param name: values => sources

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -84,7 +84,7 @@ for the aggregation:
 
 ==== Values source
 
-The `values` parameter controls the sources that should be used to build the composite buckets.
+The `sources` parameter controls the sources that should be used to build the composite buckets.
 There are three different types of values source:
 
 ===== Terms


### PR DESCRIPTION
I think the first sentence in https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html#_values_source_2 should say:

> The `sources` parameter controls... composite buckets. 

Instead of what it currently says:

> The `values` parameter controls... composite buckets. 

This PR fixes this small typo.