### PR TITLE
[docs] Remove Kerberos/SPNEGO Shield plugin

### DIFF
--- a/docs/plugins/security.asciidoc
+++ b/docs/plugins/security.asciidoc
@@ -20,8 +20,5 @@ today, X-Pack provides peace of mind when it comes to protecting your data.
 
 The following plugins have been contributed by our community:
 
-* https://github.com/codecentric/elasticsearch-shield-kerberos-realm[Kerberos/SPNEGO Realm]:
-  Custom Shield realm to Authenticate HTTP and Transport requests via Kerberos/SPNEGO (by codecentric AG)
-
 * https://github.com/sscarduzio/elasticsearch-readonlyrest-plugin[Readonly REST]:
   High performance access control for Elasticsearch native REST API (by Simone Scarduzio)


### PR DESCRIPTION
Plugin has not been updated in over two years and requires Shield and ES 2.3.1