### PR TITLE
Disable nio test transport

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -896,7 +896,9 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     @BeforeClass
     public static void setUseNio() throws Exception {
-        useNio = randomBoolean();
+//        useNio = randomBoolean();
+        // TODO: Temporarily disable nio as it does not work with intellij testrunner
+        useNio = false;
     }
 
     public static String getTestTransportType() {


### PR DESCRIPTION
This commit disables the nio transport as an option for the test
transport in integration tests. This is because it does not currently
run properly in intellij due to socket permissions. It should be
reenabled once #27881 is merged (and the proper permissions are added).