### PR TITLE
Fix task ordering in rolling upgrade tests

### DIFF
--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -74,11 +74,10 @@ for (Version version : versionCollection.versionsWireCompatibleWithCurrent) {
     finalizedBy "${baseName}#oldClusterTestCluster#node0.stop"
   }
 
-  Task upgradedClusterTest = tasks.create(name: "${baseName}#upgradedClusterTest", type: RestIntegTestTask) {
-    dependsOn(mixedClusterTestRunner, "${baseName}#oldClusterTestCluster#node0.stop")
-  }
+  Task upgradedClusterTest = tasks.create(name: "${baseName}#upgradedClusterTest", type: RestIntegTestTask)
 
   configure(extensions.findByName("${baseName}#upgradedClusterTestCluster")) {
+    dependsOn mixedClusterTestRunner, "${baseName}#oldClusterTestCluster#node0.stop"
     distribution = 'zip'
     clusterName = 'rolling-upgrade'
     unicastTransportUri = { seedNode, node, ant -> mixedClusterTest.nodes.get(0).transportUri() }


### PR DESCRIPTION
The configuration of the upgraded cluster task was missing a dependency on the stopping of the second old node in the cluster. In some cases (e.g., --parallel) Gradle would then try to run the configuration of a node in the upgraded cluster before it had even configured the old nodes in the cluster.
