### PR TITLE
Fix cluster.routing.allocation.enable and cluster.routing.rebalance.enable case

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -63,17 +63,17 @@ public class EnableAllocationDecider extends AllocationDecider {
     public static final String NAME = "enable";
 
     public static final Setting<Allocation> CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING =
-        new Setting<>("cluster.routing.allocation.enable", Allocation.ALL.name(), Allocation::parse,
+        new Setting<>("cluster.routing.allocation.enable", Allocation.ALL.toString(), Allocation::parse,
             Property.Dynamic, Property.NodeScope);
     public static final Setting<Allocation> INDEX_ROUTING_ALLOCATION_ENABLE_SETTING =
-        new Setting<>("index.routing.allocation.enable", Allocation.ALL.name(), Allocation::parse,
+        new Setting<>("index.routing.allocation.enable", Allocation.ALL.toString(), Allocation::parse,
             Property.Dynamic, Property.IndexScope);
 
     public static final Setting<Rebalance> CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING =
-        new Setting<>("cluster.routing.rebalance.enable", Rebalance.ALL.name(), Rebalance::parse,
+        new Setting<>("cluster.routing.rebalance.enable", Rebalance.ALL.toString(), Rebalance::parse,
             Property.Dynamic, Property.NodeScope);
     public static final Setting<Rebalance> INDEX_ROUTING_REBALANCE_ENABLE_SETTING =
-        new Setting<>("index.routing.rebalance.enable", Rebalance.ALL.name(), Rebalance::parse,
+        new Setting<>("index.routing.rebalance.enable", Rebalance.ALL.toString(), Rebalance::parse,
             Property.Dynamic, Property.IndexScope);
 
     private volatile Rebalance enableRebalance;
@@ -219,14 +219,22 @@ public class EnableAllocationDecider extends AllocationDecider {
         public static Allocation parse(String strValue) {
             if (strValue == null) {
                 return null;
+            } else if ("all".equalsIgnoreCase(strValue)) {
+                return ALL;
+            } else if ("primaries".equalsIgnoreCase(strValue)) {
+                return PRIMARIES;
+            } else if ("new_primaries".equalsIgnoreCase(strValue) || "newPrimaries".equalsIgnoreCase(strValue)) {
+                return NEW_PRIMARIES;
+            } else if ("none".equalsIgnoreCase(strValue)) {
+                return NONE;
             } else {
-                strValue = strValue.toUpperCase(Locale.ROOT);
-                try {
-                    return Allocation.valueOf(strValue);
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException("Illegal allocation.enable value [" + strValue + "]");
-                }
+                throw new IllegalArgumentException("Illegal allocation.enable value [" + strValue + "]");
             }
+        }
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ROOT);
         }
     }
 
@@ -246,14 +254,22 @@ public class EnableAllocationDecider extends AllocationDecider {
         public static Rebalance parse(String strValue) {
             if (strValue == null) {
                 return null;
+            } else if ("all".equalsIgnoreCase(strValue)) {
+                return ALL;
+            } else if ("primaries".equalsIgnoreCase(strValue)) {
+                return PRIMARIES;
+            } else if ("replicas".equalsIgnoreCase(strValue)) {
+                return REPLICAS;
+            } else if ("none".equalsIgnoreCase(strValue)) {
+                return NONE;
             } else {
-                strValue = strValue.toUpperCase(Locale.ROOT);
-                try {
-                    return Rebalance.valueOf(strValue);
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException("Illegal rebalance.enable value [" + strValue + "]");
-                }
+                throw new IllegalArgumentException("Illegal rebalance.enable value [" + strValue + "]");
             }
+        }
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ROOT);
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -219,16 +219,13 @@ public class EnableAllocationDecider extends AllocationDecider {
         public static Allocation parse(String strValue) {
             if (strValue == null) {
                 return null;
-            } else if ("all".equalsIgnoreCase(strValue)) {
-                return ALL;
-            } else if ("primaries".equalsIgnoreCase(strValue)) {
-                return PRIMARIES;
-            } else if ("new_primaries".equalsIgnoreCase(strValue) || "newPrimaries".equalsIgnoreCase(strValue)) {
-                return NEW_PRIMARIES;
-            } else if ("none".equalsIgnoreCase(strValue)) {
-                return NONE;
             } else {
-                throw new IllegalArgumentException("Illegal allocation.enable value [" + strValue + "]");
+                strValue = strValue.toUpperCase(Locale.ROOT);
+                try {
+                    return Allocation.valueOf(strValue);
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException("Illegal allocation.enable value [" + strValue + "]");
+                }
             }
         }
 
@@ -254,16 +251,13 @@ public class EnableAllocationDecider extends AllocationDecider {
         public static Rebalance parse(String strValue) {
             if (strValue == null) {
                 return null;
-            } else if ("all".equalsIgnoreCase(strValue)) {
-                return ALL;
-            } else if ("primaries".equalsIgnoreCase(strValue)) {
-                return PRIMARIES;
-            } else if ("replicas".equalsIgnoreCase(strValue)) {
-                return REPLICAS;
-            } else if ("none".equalsIgnoreCase(strValue)) {
-                return NONE;
             } else {
-                throw new IllegalArgumentException("Illegal rebalance.enable value [" + strValue + "]");
+                strValue = strValue.toUpperCase(Locale.ROOT);
+                try {
+                    return Rebalance.valueOf(strValue);
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException("Illegal rebalance.enable value [" + strValue + "]");
+                }
             }
         }
 

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationTests.java
@@ -301,32 +301,4 @@ public class EnableAllocationTests extends ESAllocationTestCase {
 
     }
 
-    public void testParseAllocation() {
-        assertNull(Allocation.parse(null));
-        assertEquals(Allocation.ALL, Allocation.parse("all"));
-        assertEquals(Allocation.ALL, Allocation.parse("ALL"));
-        assertEquals(Allocation.NONE, Allocation.parse("none"));
-        assertEquals(Allocation.NONE, Allocation.parse("NONE"));
-        assertEquals(Allocation.PRIMARIES, Allocation.parse("primaries"));
-        assertEquals(Allocation.PRIMARIES, Allocation.parse("PRIMARIES"));
-        assertEquals(Allocation.NEW_PRIMARIES, Allocation.parse("NEW_PRIMARIES"));
-        assertEquals(Allocation.NEW_PRIMARIES, Allocation.parse("new_primaries"));
-        assertEquals(Allocation.NEW_PRIMARIES, Allocation.parse("newPrimaries"));
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> Allocation.parse("invalid"));
-        assertEquals(ex.getMessage(), "Illegal allocation.enable value [invalid]");
-    }
-
-    public void testParseRebalance() {
-        assertNull(Rebalance.parse(null));
-        assertEquals(Rebalance.ALL, Rebalance.parse("all"));
-        assertEquals(Rebalance.ALL, Rebalance.parse("ALL"));
-        assertEquals(Rebalance.NONE, Rebalance.parse("none"));
-        assertEquals(Rebalance.NONE, Rebalance.parse("NONE"));
-        assertEquals(Rebalance.PRIMARIES, Rebalance.parse("primaries"));
-        assertEquals(Rebalance.PRIMARIES, Rebalance.parse("PRIMARIES"));
-        assertEquals(Rebalance.REPLICAS, Rebalance.parse("REPLICAS"));
-        assertEquals(Rebalance.REPLICAS, Rebalance.parse("replicas"));
-        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> Rebalance.parse("invalid"));
-        assertEquals(ex.getMessage(), "Illegal rebalance.enable value [invalid]");
-    }
 }

--- a/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationTests.java
@@ -301,4 +301,32 @@ public class EnableAllocationTests extends ESAllocationTestCase {
 
     }
 
+    public void testParseAllocation() {
+        assertNull(Allocation.parse(null));
+        assertEquals(Allocation.ALL, Allocation.parse("all"));
+        assertEquals(Allocation.ALL, Allocation.parse("ALL"));
+        assertEquals(Allocation.NONE, Allocation.parse("none"));
+        assertEquals(Allocation.NONE, Allocation.parse("NONE"));
+        assertEquals(Allocation.PRIMARIES, Allocation.parse("primaries"));
+        assertEquals(Allocation.PRIMARIES, Allocation.parse("PRIMARIES"));
+        assertEquals(Allocation.NEW_PRIMARIES, Allocation.parse("NEW_PRIMARIES"));
+        assertEquals(Allocation.NEW_PRIMARIES, Allocation.parse("new_primaries"));
+        assertEquals(Allocation.NEW_PRIMARIES, Allocation.parse("newPrimaries"));
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> Allocation.parse("invalid"));
+        assertEquals(ex.getMessage(), "Illegal allocation.enable value [invalid]");
+    }
+
+    public void testParseRebalance() {
+        assertNull(Rebalance.parse(null));
+        assertEquals(Rebalance.ALL, Rebalance.parse("all"));
+        assertEquals(Rebalance.ALL, Rebalance.parse("ALL"));
+        assertEquals(Rebalance.NONE, Rebalance.parse("none"));
+        assertEquals(Rebalance.NONE, Rebalance.parse("NONE"));
+        assertEquals(Rebalance.PRIMARIES, Rebalance.parse("primaries"));
+        assertEquals(Rebalance.PRIMARIES, Rebalance.parse("PRIMARIES"));
+        assertEquals(Rebalance.REPLICAS, Rebalance.parse("REPLICAS"));
+        assertEquals(Rebalance.REPLICAS, Rebalance.parse("replicas"));
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> Rebalance.parse("invalid"));
+        assertEquals(ex.getMessage(), "Illegal rebalance.enable value [invalid]");
+    }
 }


### PR DESCRIPTION
Fixes the default value of `cluster.routing.allocation.enable` and `cluster.routing.rebalance.enable` to be lower-case.

Closes #28007 


  