### PR TITLE
Make index rollover action atomic

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -88,12 +88,12 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
 
                 @Override
                 public ClusterState execute(ClusterState currentState) {
-                    return innerExecute(currentState, request.actions());
+                    return executeAliasActions(currentState, request.actions());
                 }
             });
     }
 
-    ClusterState innerExecute(ClusterState currentState, Iterable<AliasAction> actions) {
+    ClusterState executeAliasActions(ClusterState currentState, Iterable<AliasAction> actions) {
         List<Index> indicesToClose = new ArrayList<>();
         Map<String, IndexService> indices = new HashMap<>();
         try {

--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexRolloverService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexRolloverService.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesClusterStateUpdateRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
+import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.inject.Inject;
+
+/**
+ * A service is responsible for rollover index including creating a new index and updating index aliases.
+ */
+public class MetaDataIndexRolloverService {
+    private final MetaDataCreateIndexService createIndexService;
+    private final MetaDataIndexAliasesService aliasesService;
+    private final ClusterService clusterService;
+
+    @Inject
+    public MetaDataIndexRolloverService(MetaDataCreateIndexService createIndexService, MetaDataIndexAliasesService aliasesService,
+                                        ClusterService clusterService) {
+        this.createIndexService = createIndexService;
+        this.aliasesService = aliasesService;
+        this.clusterService = clusterService;
+    }
+
+    /**
+     * Executes a create index request and an update index alias in a single cluster task action.
+     */
+    public void rollover(final CreateIndexClusterStateUpdateRequest createIndexRequest,
+                         final IndicesAliasesClusterStateUpdateRequest updateAliasRequest,
+                         final ActionListener<ClusterStateUpdateResponse> listener) {
+        final MetaDataCreateIndexService.IndexCreationTask indexCreationTask = createIndexService.indexCreationTask(createIndexRequest);
+        clusterService.submitStateUpdateTask("rollover",
+            new AckedClusterStateUpdateTask<ClusterStateUpdateResponse>(Priority.URGENT, updateAliasRequest, listener) {
+                @Override
+                protected ClusterStateUpdateResponse newResponse(boolean acknowledged) {
+                    return new ClusterStateUpdateResponse(acknowledged);
+                }
+
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    final ClusterState newClusterState = indexCreationTask.execute(currentState);
+                    return aliasesService.executeAliasActions(newClusterState, updateAliasRequest.actions());
+                }
+            });
+    }
+}

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.cluster.metadata;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.Sort;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
 import org.elasticsearch.action.admin.indices.shrink.ResizeType;
@@ -87,7 +86,6 @@ public class IndexCreationTaskTests extends ESTestCase {
     private final Logger logger = mock(Logger.class);
     private final AllocationService allocationService = mock(AllocationService.class);
     private final MetaDataCreateIndexService.IndexValidator validator = mock(MetaDataCreateIndexService.IndexValidator.class);
-    private final ActionListener listener = mock(ActionListener.class);
     private final ClusterState state = mock(ClusterState.class);
     private final Settings.Builder clusterStateSettings = Settings.builder();
     private final MapperService mapper = mock(MapperService.class);
@@ -387,7 +385,7 @@ public class IndexCreationTaskTests extends ESTestCase {
         setupState();
         setupRequest();
         final MetaDataCreateIndexService.IndexCreationTask task = new MetaDataCreateIndexService.IndexCreationTask(
-            logger, allocationService, request, listener, indicesService, aliasValidator, xContentRegistry, clusterStateSettings.build(),
+            logger, allocationService, request, indicesService, aliasValidator, xContentRegistry, clusterStateSettings.build(),
             validator
         );
         return task.execute(state);

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesServiceTests.java
@@ -64,7 +64,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         ClusterState before = createIndex(ClusterState.builder(ClusterName.DEFAULT).build(), index);
 
         // Add an alias to it
-        ClusterState after = service.innerExecute(before, singletonList(new AliasAction.Add(index, "test", null, null, null)));
+        ClusterState after = service.executeAliasActions(before, singletonList(new AliasAction.Add(index, "test", null, null, null)));
         AliasOrIndex alias = after.metaData().getAliasAndIndexLookup().get("test");
         assertNotNull(alias);
         assertTrue(alias.isAlias());
@@ -72,7 +72,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
 
         // Remove the alias from it while adding another one
         before = after;
-        after = service.innerExecute(before, Arrays.asList(
+        after = service.executeAliasActions(before, Arrays.asList(
                 new AliasAction.Remove(index, "test"),
                 new AliasAction.Add(index, "test_2", null, null, null)));
         assertNull(after.metaData().getAliasAndIndexLookup().get("test"));
@@ -83,7 +83,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
 
         // Now just remove on its own
         before = after;
-        after = service.innerExecute(before, singletonList(new AliasAction.Remove(index, "test_2")));
+        after = service.executeAliasActions(before, singletonList(new AliasAction.Remove(index, "test_2")));
         assertNull(after.metaData().getAliasAndIndexLookup().get("test"));
         assertNull(after.metaData().getAliasAndIndexLookup().get("test_2"));
     }
@@ -94,7 +94,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         before = createIndex(before, "test_2");
 
         // Now remove "test" and add an alias to "test" to "test_2" in one go
-        ClusterState after = service.innerExecute(before, Arrays.asList(
+        ClusterState after = service.executeAliasActions(before, Arrays.asList(
                 new AliasAction.Add("test_2", "test", null, null, null),
                 new AliasAction.RemoveIndex("test")));
         AliasOrIndex alias = after.metaData().getAliasAndIndexLookup().get("test");
@@ -108,7 +108,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         ClusterState before = createIndex(ClusterState.builder(ClusterName.DEFAULT).build(), "test");
 
         // Attempt to add an alias to "test" at the same time as we remove it
-        IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> service.innerExecute(before, Arrays.asList(
+        IndexNotFoundException e = expectThrows(IndexNotFoundException.class, () -> service.executeAliasActions(before, Arrays.asList(
                 new AliasAction.Add("test", "alias", null, null, null),
                 new AliasAction.RemoveIndex("test"))));
         assertEquals("test", e.getIndex().getName());
@@ -119,7 +119,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         ClusterState before = createIndex(ClusterState.builder(ClusterName.DEFAULT).build(), "test");
 
         // Try to remove an index twice. This should just remove the index once....
-        ClusterState after = service.innerExecute(before, Arrays.asList(
+        ClusterState after = service.executeAliasActions(before, Arrays.asList(
                 new AliasAction.RemoveIndex("test"),
                 new AliasAction.RemoveIndex("test")));
         assertNull(after.metaData().getAliasAndIndexLookup().get("test"));


### PR DESCRIPTION
Today when executing a rollover request, we create an index with alias
(via template), then update index aliases in two separate cluster tasks.
In the interval between these two actions, the alias will associate to
two indices. This causes indexing requests to that alias to be rejected.

This commit merges these two actions into a single cluster update task.

Closes #26976