### PR TITLE
Use ephemeral ports in Wildfly tests

### DIFF
--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -29,14 +29,10 @@ apply plugin: 'war'
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.rest-test'
 
-final String wildflyVersion = '10.0.0.Final'
+final String wildflyVersion = '11.0.0.Final'
 final String wildflyDir = "${buildDir}/wildfly"
 final String wildflyInstall = "${buildDir}/wildfly/wildfly-${wildflyVersion}"
-// TODO: use ephemeral ports
-final int portOffset = 30000
-final int managementPort = 9990 + portOffset
-// we skip these tests on Windows so we do not need to worry about compatibility here
-final String stopWildflyCommand = "${wildflyInstall}/bin/jboss-cli.sh --controller=localhost:${managementPort} --connect command=shutdown"
+int managementPort
 
 repositories {
     mavenCentral()
@@ -114,31 +110,53 @@ task enableIPv6 {
 
 task startWildfly {
     dependsOn enableIPv6, writeElasticsearchProperties
-    doFirst {
-        // we skip these tests on Windows so we do no need to worry about compatibility here
-        final File script = new File(project.buildDir, "wildfly/wildfly.killer.sh")
-        script.setText(
-                ["function shutdown {",
-                 "  ${stopWildflyCommand}",
-                 "}",
-                 "trap shutdown EXIT",
-                 // will wait indefinitely for input, but we never pass input, and the pipe is only closed when the build dies
-                 "read line"].join('\n'), 'UTF-8')
-        final ProcessBuilder pb = new ProcessBuilder("bash", script.absolutePath)
-        pb.start()
-    }
     doLast {
         // we skip these tests on Windows so we do no need to worry about compatibility here
-        final ProcessBuilder pb =
-                new ProcessBuilder("${wildflyInstall}/bin/standalone.sh", "-Djboss.socket.binding.port-offset=${portOffset}")
-        final Process process = pb.start()
+        final ProcessBuilder wildfly = new ProcessBuilder(
+                "${wildflyInstall}/bin/standalone.sh",
+                "-Djboss.http.port=0",
+                "-Djboss.https.port=0",
+                "-Djboss.management.http.port=0")
+        final Process process = wildfly.start()
         new BufferedReader(new InputStreamReader(process.getInputStream())).withReader { br ->
             String line
+            int httpPort = 0
             while ((line = br.readLine()) != null) {
-                if (line.matches(".*WildFly Full \\d+\\.\\d+\\.\\d+\\.Final \\(WildFly Core \\d+\\.\\d+\\.\\d+\\.Final\\) started.*")) {
+                if (line.matches('.*Undertow HTTP listener default listening on .*:\\d+$')) {
+                    final int index = line.lastIndexOf(":")
+                    assert index >= 0
+                    httpPort = Integer.parseInt(line.substring(index + 1))
+                    // set this system property so the test runner knows the port Wildfly is listening for HTTP requests on
+                    integTestRunner.systemProperty("tests.jboss.http.port", httpPort)
+                } else if (line.matches('.*Http management interface listening on http://.*:\\d+/management$')) {
+                    final int colonIndex = line.lastIndexOf(":")
+                    assert colonIndex >= 0
+                    final int slashIndex = line.lastIndexOf("/")
+                    assert slashIndex >= 0
+                    managementPort = Integer.parseInt(line.substring(colonIndex + 1, slashIndex))
+
+                    /*
+                     * As soon as we know the management port, we fork a process that will ensure the Wildfly process is killed if we
+                     * teardown abnormally. We skip these tests on Windows so we do no need to worry about CLI compatibility here.
+                     */
+                    final File script = new File(project.buildDir, "wildfly/wildfly.killer.sh")
+                    script.setText(
+                            ["function shutdown {",
+                             "  ${wildflyInstall}/bin/jboss-cli.sh --controller=localhost:${-> managementPort} --connect command=shutdown",
+                             "}",
+                             "trap shutdown EXIT",
+                             // will wait indefinitely for input, but we never pass input, and the pipe is only closed when the build dies
+                             "read line\n"].join('\n'), 'UTF-8')
+                    final ProcessBuilder killer = new ProcessBuilder("bash", script.absolutePath)
+                    killer.start()
+
+                } else if (line.matches(".*WildFly Full \\d+\\.\\d+\\.\\d+\\.Final \\(WildFly Core \\d+\\.\\d+\\.\\d+\\.Final\\) started.*")) {
                     break
                 }
             }
+
+            assert httpPort > 0
+            assert managementPort > 0
         }
     }
 }
@@ -147,13 +165,14 @@ task configureTransportClient(type: LoggedExec) {
     dependsOn startWildfly
     // we skip these tests on Windows so we do not need to worry about compatibility here
     commandLine "${wildflyInstall}/bin/jboss-cli.sh",
-            "--controller=localhost:${managementPort}",
+            "--controller=localhost:${-> managementPort}",
             "--connect",
             "--command=/system-property=elasticsearch.properties:add(value=\${jboss.server.config.dir}/elasticsearch.properties)"
 }
 
 task stopWildfly(type: LoggedExec) {
-    commandLine stopWildflyCommand.split(' ')
+    // we skip these tests on Windows so we do no need to worry about CLI compatibility here
+    commandLine "${wildflyInstall}/bin/jboss-cli.sh", "--controller=localhost:${-> managementPort}", "--connect", "command=shutdown"
 }
 
 if (!Os.isFamily(Os.FAMILY_WINDOWS) && project.rootProject.ext.javaVersion == JavaVersion.VERSION_1_8) {

--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -123,12 +123,14 @@ task startWildfly {
             int httpPort = 0
             while ((line = br.readLine()) != null) {
                 if (line.matches('.*Undertow HTTP listener default listening on .*:\\d+$')) {
+                    assert httpPort == 0
                     final int index = line.lastIndexOf(":")
                     assert index >= 0
                     httpPort = Integer.parseInt(line.substring(index + 1))
                     // set this system property so the test runner knows the port Wildfly is listening for HTTP requests on
                     integTestRunner.systemProperty("tests.jboss.http.port", httpPort)
                 } else if (line.matches('.*Http management interface listening on http://.*:\\d+/management$')) {
+                    assert managementPort
                     final int colonIndex = line.lastIndexOf(":")
                     assert colonIndex >= 0
                     final int slashIndex = line.lastIndexOf("/")

--- a/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
+++ b/qa/wildfly/src/test/java/org/elasticsearch/wildfly/WildflyIT.java
@@ -53,7 +53,8 @@ public class WildflyIT extends LuceneTestCase {
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             final String str = String.format(
                     Locale.ROOT,
-                    "http://localhost:38080/wildfly-%s%s/transport/employees/1",
+                    "http://localhost:%d/wildfly-%s%s/transport/employees/1",
+                    Integer.parseInt(System.getProperty("tests.jboss.http.port")),
                     Version.CURRENT,
                     Build.CURRENT.isSnapshot() ? "-SNAPSHOT" : "");
             final HttpPut put = new HttpPut(new URI(str));


### PR DESCRIPTION
The Wildfly tests previously needed hardcoded ports which would sometimes already be in use leading to Wildfly test failures because the server could not bind during startup. We had to wait until some upstream changes (wildfly/wildfly#9943) and (wildfly/wildfly-core#2390) were released before we could use ephemeral ports in these tests. These changes are released now so this commit changes the Wildfly tests to use ephemeral ports when starting Wildfly.

Closes #24436
