### PR TITLE
Enable Wildfly tests on JDK 9 and JDK 10

### DIFF
--- a/qa/wildfly/build.gradle
+++ b/qa/wildfly/build.gradle
@@ -84,7 +84,7 @@ task deploy(type: Copy) {
 }
 
 task writeElasticsearchProperties {
-    onlyIf { !Os.isFamily(Os.FAMILY_WINDOWS) && project.rootProject.ext.javaVersion == JavaVersion.VERSION_1_8 }
+    onlyIf { !Os.isFamily(Os.FAMILY_WINDOWS) }
     dependsOn 'integTestCluster#wait', deploy
     doLast {
         final File elasticsearchProperties = file("${wildflyInstall}/standalone/configuration/elasticsearch.properties")
@@ -177,7 +177,7 @@ task stopWildfly(type: LoggedExec) {
     commandLine "${wildflyInstall}/bin/jboss-cli.sh", "--controller=localhost:${-> managementPort}", "--connect", "command=shutdown"
 }
 
-if (!Os.isFamily(Os.FAMILY_WINDOWS) && project.rootProject.ext.javaVersion == JavaVersion.VERSION_1_8) {
+if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
     integTestRunner.dependsOn(configureTransportClient)
     final TaskExecutionAdapter logDumpListener = new TaskExecutionAdapter() {
         @Override


### PR DESCRIPTION
Previously we disabled these tests on JDK 9 and JDK 10 because Wildfly 10 did not support JDK 9 and JDK 10. With the release of Wildfly 11 supporting JDK 9 and JDK 10 and now that we depend on Wildfly 11 in these tests, we can enable these tests on JDK 9 and JDK 10.
