### PR TITLE
Set the elasticsearch-nio codebase for tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -135,6 +135,7 @@ public class BootstrapForTesting {
                 if (System.getProperty("tests.gradle") == null) {
                     // intellij and eclipse don't package our internal libs, so we need to set the codebases for them manually
                     addClassCodebase(codebases,"plugin-classloader", "org.elasticsearch.plugins.ExtendedPluginsClassLoader");
+                    addClassCodebase(codebases,"elasticsearch-nio", "org.elasticsearch.nio.ChannelFactory");
                 }
                 final Policy testFramework = Security.readPolicy(Bootstrap.class.getResource("test-framework.policy"), codebases);
                 final Policy esPolicy = new ESPolicy(codebases, perms, getPluginPermissions(), true);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -896,9 +896,7 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     @BeforeClass
     public static void setUseNio() throws Exception {
-//        useNio = randomBoolean();
-        // TODO: Temporarily disable nio as it does not work with intellij testrunner
-        useNio = false;
+        useNio = randomBoolean();
     }
 
     public static String getTestTransportType() {


### PR DESCRIPTION
This commit sets the elasticsearch-nio code base in the
BootstrapForTesting class. This is necessary as that codebase needs
socket permissions. Setting the codebase manually is necessary as
intellij does not package our internal libraries when running tests.

Additionally, this commit reenables nio transport as a test option.