### PR TITLE
Make decision for shards at a node level to prevent increase in the pending tasks.

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/AllocationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/AllocationBenchmark.java
@@ -24,10 +24,14 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -41,6 +45,9 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Fork(3)
@@ -86,6 +93,13 @@ public class AllocationBenchmark {
         "      100|      1|        2|    10",
         "      100|      3|        2|    10",
         "      100|     10|        2|    10",
+        
+        "       10|      1|        1|    20",
+        "       10|      3|        1|    20",
+        "       10|     10|        1|    20",
+        "      100|      1|        1|    20",
+        "      100|      3|        1|    20",
+        "      100|     10|        1|    20",
 
         "       10|      1|        0|    50",
         "       10|      3|        0|    50",
@@ -106,35 +120,53 @@ public class AllocationBenchmark {
         "       10|     10|        2|    50",
         "      100|      1|        2|    50",
         "      100|      3|        2|    50",
-        "      100|     10|        2|    50"
+        "      100|     10|        2|    50",
+        
+        "       50|     60|        1|    200",
+        "      500|     60|        1|    400"
+        
     })
     public String indicesShardsReplicasNodes = "10|1|0|1";
 
     public int numTags = 2;
+    public int numZone = 3;
+    public int concurrentRecoveries = 6;
+    public int numIndices;
+    public int numShards;
+    public int numReplicas;
+    public int numNodes;
 
     private AllocationService strategy;
+    private AllocationService clusterExcludeStrategy;
     private ClusterState initialClusterState;
-
+    
     @Setup
     public void setUp() throws Exception {
         final String[] params = indicesShardsReplicasNodes.split("\\|");
 
-        int numIndices = toInt(params[0]);
-        int numShards = toInt(params[1]);
-        int numReplicas = toInt(params[2]);
-        int numNodes = toInt(params[3]);
+        numIndices = toInt(params[0]);
+        numShards = toInt(params[1]);
+        numReplicas = toInt(params[2]);
+        numNodes = toInt(params[3]);
+
+        int totalShardCount = (numReplicas + 1) * numShards * numIndices;
 
         strategy = Allocators.createAllocationService(Settings.builder()
-                .put("cluster.routing.allocation.awareness.attributes", "tag")
-                .build());
+        .put("cluster.routing.allocation.awareness.attributes", "zone")
+        .put("cluster.routing.allocation.node_concurrent_recoveries", "30")
+        .put("cluster.routing.allocation.exclude.tag", "tag_0").build());
+        
+        //We'll try to move nodes from tag_1 to tag_0
+        clusterExcludeStrategy = Allocators.createAllocationService(
+        Settings.builder()
+        .put("cluster.routing.allocation.node_concurrent_recoveries", String.valueOf(concurrentRecoveries))
+        .put("cluster.routing.allocation.awareness.attributes", "zone")
+        .put("cluster.routing.allocation.exclude.tag", "tag_1").build());
 
         MetaData.Builder mb = MetaData.builder();
         for (int i = 1; i <= numIndices; i++) {
-            mb.put(IndexMetaData.builder("test_" + i)
-                    .settings(Settings.builder().put("index.version.created", Version.CURRENT))
-                    .numberOfShards(numShards)
-                    .numberOfReplicas(numReplicas)
-            );
+            mb.put(IndexMetaData.builder("test_" + i).settings(Settings.builder().put("index.version.created", Version.CURRENT))
+            .numberOfShards(numShards).numberOfReplicas(numReplicas));
         }
         MetaData metaData = mb.build();
         RoutingTable.Builder rb = RoutingTable.builder();
@@ -144,11 +176,41 @@ public class AllocationBenchmark {
         RoutingTable routingTable = rb.build();
         DiscoveryNodes.Builder nb = DiscoveryNodes.builder();
         for (int i = 1; i <= numNodes; i++) {
-            nb.add(Allocators.newNode("node" + i, Collections.singletonMap("tag", "tag_" + (i % numTags))));
+            Map<String, String> attributes = new HashMap<>();
+            attributes.put("tag", "tag_" + (i % numTags));
+            attributes.put("zone", "zone_" + (i % numZone));
+            nb.add(Allocators.newNode("node_" + i, attributes));
         }
-        initialClusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
-            .metaData(metaData).routingTable(routingTable).nodes
-                (nb).build();
+
+        initialClusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)).metaData(metaData)
+        .routingTable(routingTable).nodes(nb).build();
+        // Start all unassigned shards
+        while (initialClusterState.getRoutingNodes().hasUnassignedShards()) {
+            initialClusterState = strategy.applyStartedShards(initialClusterState,
+            initialClusterState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING));
+            initialClusterState = strategy.reroute(initialClusterState, "reroute");
+        }
+        // Ensure all shards are started
+        while (initialClusterState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size() > 0) {
+            initialClusterState = strategy.applyStartedShards(initialClusterState,
+            initialClusterState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING));
+
+        }
+        assert(initialClusterState.getRoutingNodes().shardsWithState(ShardRoutingState.STARTED).size() == totalShardCount);
+        assert(initialClusterState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING).size() == 0);
+        assert(initialClusterState.getRoutingNodes().shardsWithState(ShardRoutingState.RELOCATING).size() == 0);
+        // make sure shards are only allocated on tag1
+        for (ShardRouting startedShard : initialClusterState.getRoutingNodes().shardsWithState(ShardRoutingState.STARTED)) {
+            assert(Integer.valueOf(startedShard.currentNodeId().split("_")[1]) % numTags == 1);
+        }
+        // Ensure shards are relocating at max concurrent recoveries
+        ClusterState clusterState = initialClusterState;
+        clusterState = clusterExcludeStrategy.applyStartedShards(clusterState,
+        clusterState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING));
+        clusterState = clusterExcludeStrategy.reroute(clusterState, "reroute");
+        assert (clusterState.getRoutingNodes().shardsWithState(ShardRoutingState.RELOCATING).size() == numNodes / numTags
+        * concurrentRecoveries);
+
     }
 
     private int toInt(String v) {
@@ -156,13 +218,29 @@ public class AllocationBenchmark {
     }
 
     @Benchmark
-    public ClusterState measureAllocation() {
+    public ClusterState measureExclusionAllocationApplyStartedShardZoneAware() {
         ClusterState clusterState = initialClusterState;
-        while (clusterState.getRoutingNodes().hasUnassignedShards()) {
-            clusterState = strategy.applyStartedShards(clusterState, clusterState.getRoutingNodes()
-                    .shardsWithState(ShardRoutingState.INITIALIZING));
-            clusterState = strategy.reroute(clusterState, "reroute");
-        }
+        clusterState = clusterExcludeStrategy.applyStartedShards(clusterState,
+        clusterState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING));
+        clusterState = clusterExcludeStrategy.reroute(clusterState, "reroute");
         return clusterState;
+
     }
+    
+    @Benchmark
+    public ClusterState measureExclusionAllocationApplyStartedShardZoneUnaware() throws Exception{
+        AllocationService clusterExcludeZoneUnawareStrategy = Allocators.createAllocationService(
+        Settings.builder()
+        .put("cluster.routing.allocation.node_concurrent_recoveries", String.valueOf(concurrentRecoveries))
+        .put("cluster.routing.allocation.exclude.tag", "tag_1").build());
+        ClusterState clusterState = initialClusterState;
+        clusterState = clusterExcludeZoneUnawareStrategy.applyStartedShards(clusterState,
+        clusterState.getRoutingNodes().shardsWithState(ShardRoutingState.INITIALIZING));
+        clusterState = clusterExcludeZoneUnawareStrategy.reroute(clusterState, "reroute");
+        return clusterState;
+
+    }
+
+   
+
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecider.java
@@ -99,6 +99,26 @@ public abstract class AllocationDecider extends AbstractComponent {
     public Decision canRebalance(RoutingAllocation allocation) {
         return Decision.ALWAYS;
     }
+    
+    /**
+     * Returns a {@link Decision} whether all the shards on the given {@link RoutingNode}} can be remain
+     * The default is {@link Decision#ALWAYS}.
+     * All implementations that override this behaviour must take a {@link Decision}} whether or not to skip
+     * iterating over all the shards of this node.
+     */
+    public Decision canRemainOnNode(RoutingNode node, RoutingAllocation allocation){
+        return Decision.ALWAYS;
+    }
+    
+    /**
+     * Returns a {@link Decision} whether all the shards on the given {@link RoutingNode}} can be remain
+     * The default is {@link Decision#ALWAYS}.
+     * All implementations that override this behaviour must take a {@link Decision}} whether or not to skip
+     * iterating over the remaining deciders over all the shards of this node.
+     */
+    public Decision canMoveAnyShardFromNode(RoutingNode node, RoutingAllocation allocation){
+        return Decision.ALWAYS;
+    }
 
     /**
      * Returns a {@link Decision} whether the given primary shard can be

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import com.carrotsearch.hppc.ObjectIntHashMap;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.Strings;
@@ -33,6 +34,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.ShardId;
 
 /**
  * This {@link AllocationDecider} controls shard allocation based on
@@ -146,13 +148,10 @@ public class AwarenessAllocationDecider extends AllocationDecider {
 
             // build the count of shards per attribute value
             ObjectIntHashMap<String> shardPerAttribute = new ObjectIntHashMap<>();
-            for (ShardRouting assignedShard : allocation.routingNodes().assignedShards(shardRouting.shardId())) {
-                if (assignedShard.started() || assignedShard.initializing()) {
-                    // Note: this also counts relocation targets as that will be the new location of the shard.
-                    // Relocation sources should not be counted as the shard is moving away
-                    RoutingNode routingNode = allocation.routingNodes().node(assignedShard.currentNodeId());
-                    shardPerAttribute.addTo(routingNode.node().getAttributes().get(awarenessAttribute), 1);
-                }
+            Map<String, ObjectIntHashMap<String>> shardIdMap = allocation.routingNodes().getShardIdPerAttributeMap()
+            .get(shardRouting.shardId());
+            if (shardIdMap != null && shardIdMap.get(awarenessAttribute) != null) {
+                shardPerAttribute = shardIdMap.get(awarenessAttribute).clone();
             }
 
             if (moveToNode) {
@@ -212,5 +211,31 @@ public class AwarenessAllocationDecider extends AllocationDecider {
         }
 
         return allocation.decision(Decision.YES, NAME, "node meets all awareness attribute requirements");
+    }
+    
+    /**
+     * Loop over all the shards on the node to see if any of the awareness attribute
+     * across the same {@link ShardId}} is unbalanced, in which case the current
+     * {@link RoutingNode}} hosting the shard returns a decision
+     * {@link Decision#NO}}
+     * 
+     * TODO : Add caching support for awarenessAttributes for {@link ShardId} across
+     * {@link RoutingNodes}} after running micro-benchmark
+     * 
+     */
+    @Override
+    public Decision canRemainOnNode(RoutingNode node, RoutingAllocation allocation) {
+        Decision decision = null;
+        if (awarenessAttributes.length == 0) {
+            return allocation.decision(Decision.YES, NAME, "allocation awareness is not enabled");
+        }
+        for (ShardRouting shardRouting : node) {
+            decision = underCapacity(shardRouting, node, allocation, false);
+            if (decision == Decision.NO) {
+                return decision;
+            }
+        }
+        return allocation.decision(Decision.YES, NAME, "node meets all awareness attribute requirements");
+
     }
 }

--- a/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/core/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -205,4 +205,16 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
         assert initializingShard.initializing();
         return initializingShard;
     }
+
+    @Override
+    public Decision canMoveAnyShardFromNode(RoutingNode node, RoutingAllocation allocation) {
+        int outgoingRecoveries = allocation.routingNodes().getOutgoingRecoveries(node.nodeId());
+        if (outgoingRecoveries >= concurrentOutgoingRecoveries) {
+            return allocation.decision(Decision.NO, NAME, "too many outgoing shards are currently recovering [%d], limit: [%d]",
+            outgoingRecoveries, concurrentOutgoingRecoveries);
+        } else {
+            return allocation.decision(YES, NAME, "below shard recovery limit of outgoing: [%d < %d]", outgoingRecoveries,
+            concurrentOutgoingRecoveries);
+        }
+    }
 }


### PR DESCRIPTION
We iterate through all shards and make a decision, while most of the decisions can be taken at a node level and all shards for that node can be skipped
as ultimately a don’t move decision will anyway be taken for all shards of that node #27427. So we have implemented `canRemainOnNode` method per decider which is equivalent to `canRemain` method except that decision is at a node level. This PR primarily addresses the review comments from the last PR #27628

TODO
- [ ] Add UTs around the changes

### Optimized
````
Benchmark                                                                          (indicesShardsReplicasNodes)  Mode  Cnt     Score     Error  Units
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        0|     1  avgt   30     0.015 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        0|     1  avgt   30     0.042 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        0|     1  avgt   30     0.142 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        0|     1  avgt   30     0.161 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        0|     1  avgt   30     0.465 ±   0.005  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        0|     1  avgt   30     1.638 ±   0.018  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        0|    10  avgt   30     0.110 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        0|    10  avgt   30     0.246 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        0|    10  avgt   30     0.453 ±   0.006  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        0|    10  avgt   30     0.861 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        0|    10  avgt   30     1.594 ±   0.019  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        0|    10  avgt   30     4.444 ±   0.036  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        1|    10  avgt   30     0.185 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        1|    10  avgt   30     0.379 ±   0.018  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        1|    10  avgt   30     1.265 ±   0.050  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        1|    10  avgt   30     1.593 ±   0.098  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        1|    10  avgt   30     3.504 ±   0.183  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        1|    10  avgt   30    12.796 ±   0.186  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        2|    10  avgt   30     0.300 ±   0.008  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        2|    10  avgt   30     1.005 ±   0.049  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        2|    10  avgt   30     4.499 ±   0.174  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        2|    10  avgt   30     4.070 ±   0.406  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        2|    10  avgt   30    11.305 ±   0.386  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        2|    10  avgt   30    44.129 ±   4.061  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        1|    20  avgt   30     0.269 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        1|    20  avgt   30     0.641 ±   0.013  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        1|    20  avgt   30     1.388 ±   0.085  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        1|    20  avgt   30     2.511 ±   0.261  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        1|    20  avgt   30     4.256 ±   0.061  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        1|    20  avgt   30    14.321 ±   1.211  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        0|    50  avgt   30     0.322 ±   0.004  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        0|    50  avgt   30     0.633 ±   0.010  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        0|    50  avgt   30     1.604 ±   0.017  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        0|    50  avgt   30     3.568 ±   0.031  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        0|    50  avgt   30     4.158 ±   0.027  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        0|    50  avgt   30     7.820 ±   0.177  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        1|    50  avgt   30     0.470 ±   0.011  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        1|    50  avgt   30     1.107 ±   0.023  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        1|    50  avgt   30     2.638 ±   0.101  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        1|    50  avgt   30     4.802 ±   0.028  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        1|    50  avgt   30     8.252 ±   0.084  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        1|    50  avgt   30    15.532 ±   0.745  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        2|    50  avgt   30     0.724 ±   0.012  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        2|    50  avgt   30     1.844 ±   0.016  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        2|    50  avgt   30     6.474 ±   0.311  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        2|    50  avgt   30     7.623 ±   0.440  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        2|    50  avgt   30    18.376 ±   1.621  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        2|    50  avgt   30    85.732 ±  13.253  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           50|     60|        1|    200  avgt   30   122.678 ±   3.976  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware          500|     60|        1|    400  avgt   30  1851.066 ± 120.655  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        0|     1  avgt   30     0.994 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        0|     1  avgt   30     1.031 ±   0.005  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        0|     1  avgt   30     1.141 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        0|     1  avgt   30     1.158 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        0|     1  avgt   30     1.482 ±   0.013  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        0|     1  avgt   30     2.656 ±   0.018  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        0|    10  avgt   30     1.126 ±   0.008  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        0|    10  avgt   30     1.272 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        0|    10  avgt   30     1.474 ±   0.010  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        0|    10  avgt   30     1.884 ±   0.020  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        0|    10  avgt   30     2.548 ±   0.021  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        0|    10  avgt   30     5.248 ±   0.062  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        1|    10  avgt   30     1.210 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        1|    10  avgt   30     1.383 ±   0.022  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        1|    10  avgt   30     2.057 ±   0.025  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        1|    10  avgt   30     2.417 ±   0.058  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        1|    10  avgt   30     4.103 ±   0.042  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        1|    10  avgt   30    10.845 ±   0.201  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        2|    10  avgt   30     1.255 ±   0.006  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        2|    10  avgt   30     1.639 ±   0.026  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        2|    10  avgt   30     3.306 ±   0.066  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        2|    10  avgt   30     3.112 ±   0.095  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        2|    10  avgt   30     6.252 ±   0.249  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        2|    10  avgt   30    22.881 ±   0.264  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        1|    20  avgt   30     1.284 ±   0.008  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        1|    20  avgt   30     1.617 ±   0.025  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        1|    20  avgt   30     2.227 ±   0.022  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        1|    20  avgt   30     3.183 ±   0.044  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        1|    20  avgt   30     4.693 ±   0.051  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        1|    20  avgt   30     9.496 ±   0.058  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        0|    50  avgt   30     1.342 ±   0.013  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        0|    50  avgt   30     1.656 ±   0.015  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        0|    50  avgt   30     2.643 ±   0.023  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        0|    50  avgt   30     4.540 ±   0.042  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        0|    50  avgt   30     5.082 ±   0.027  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        0|    50  avgt   30     8.193 ±   0.119  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        1|    50  avgt   30     1.489 ±   0.013  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        1|    50  avgt   30     2.088 ±   0.016  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        1|    50  avgt   30     3.602 ±   0.020  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        1|    50  avgt   30     5.504 ±   0.030  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        1|    50  avgt   30     8.149 ±   0.133  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        1|    50  avgt   30    15.274 ±   1.028  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        2|    50  avgt   30     1.719 ±   0.016  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        2|    50  avgt   30     2.598 ±   0.050  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        2|    50  avgt   30     5.833 ±   0.603  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        2|    50  avgt   30     7.111 ±   0.327  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        2|    50  avgt   30    11.996 ±   0.270  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        2|    50  avgt   30    26.521 ±   0.688  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         50|     60|        1|    200  avgt   30   110.173 ±   3.668  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware        500|     60|        1|    400  avgt   30  1864.587 ±  12.901  ms/op
````

### Present
````
Benchmark                                                                          (indicesShardsReplicasNodes)  Mode  Cnt      Score     Error  Units
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        0|     1  avgt   30      0.006 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        0|     1  avgt   30      0.016 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        0|     1  avgt   30      0.053 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        0|     1  avgt   30      0.068 ±   0.002  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        0|     1  avgt   30      0.190 ±   0.002  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        0|     1  avgt   30      0.673 ±   0.005  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        0|    10  avgt   30      0.087 ±   0.001  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        0|    10  avgt   30      0.178 ±   0.003  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        0|    10  avgt   30      0.865 ±   0.004  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        0|    10  avgt   30      1.268 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        0|    10  avgt   30      3.499 ±   0.028  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        0|    10  avgt   30     11.008 ±   0.100  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        1|    10  avgt   30      0.147 ±   0.002  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        1|    10  avgt   30      0.513 ±   0.009  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        1|    10  avgt   30      2.498 ±   0.034  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        1|    10  avgt   30      2.764 ±   0.043  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        1|    10  avgt   30      8.046 ±   0.039  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        1|    10  avgt   30     27.887 ±   0.148  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        2|    10  avgt   30      0.258 ±   0.003  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        2|    10  avgt   30      1.180 ±   0.012  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        2|    10  avgt   30      5.691 ±   0.055  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        2|    10  avgt   30      4.859 ±   0.023  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        2|    10  avgt   30     16.553 ±   0.053  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        2|    10  avgt   30     62.204 ±   1.033  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        1|    20  avgt   30      0.211 ±   0.002  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        1|    20  avgt   30      0.570 ±   0.018  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        1|    20  avgt   30      3.302 ±   0.014  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        1|    20  avgt   30      4.155 ±   0.023  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        1|    20  avgt   30     12.912 ±   0.089  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        1|    20  avgt   30     41.554 ±   0.243  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        0|    50  avgt   30      0.284 ±   0.003  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        0|    50  avgt   30      0.536 ±   0.010  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        0|    50  avgt   30      1.318 ±   0.013  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        0|    50  avgt   30      3.139 ±   0.037  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        0|    50  avgt   30      9.568 ±   0.056  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        0|    50  avgt   30     39.958 ±   0.356  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        1|    50  avgt   30      0.391 ±   0.002  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        1|    50  avgt   30      0.917 ±   0.017  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        1|    50  avgt   30      4.129 ±   0.039  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        1|    50  avgt   30      6.294 ±   0.038  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        1|    50  avgt   30     26.342 ±   0.099  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        1|    50  avgt   30     95.725 ±   1.401  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      1|        2|    50  avgt   30      0.656 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|      3|        2|    50  avgt   30      1.626 ±   0.019  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware            10|     10|        2|    50  avgt   30     10.458 ±   0.259  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      1|        2|    50  avgt   30     12.020 ±   0.168  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|      3|        2|    50  avgt   30     46.647 ±   0.413  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           100|     10|        2|    50  avgt   30    180.962 ±   1.044  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware           50|     60|        1|    200  avgt   30   1124.667 ±  16.246  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneAware          500|     60|        1|    400  avgt   30  26716.339 ± 541.176  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        0|     1  avgt   30      0.946 ±   0.004  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        0|     1  avgt   30      0.953 ±   0.003  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        0|     1  avgt   30      1.010 ±   0.005  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        0|     1  avgt   30      1.013 ±   0.005  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        0|     1  avgt   30      1.141 ±   0.004  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        0|     1  avgt   30      1.626 ±   0.011  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        0|    10  avgt   30      1.040 ±   0.006  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        0|    10  avgt   30      1.152 ±   0.005  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        0|    10  avgt   30      1.755 ±   0.012  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        0|    10  avgt   30      2.174 ±   0.022  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        0|    10  avgt   30      4.004 ±   0.021  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        0|    10  avgt   30     10.412 ±   0.152  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        1|    10  avgt   30      1.101 ±   0.005  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        1|    10  avgt   30      1.423 ±   0.011  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        1|    10  avgt   30      3.034 ±   0.030  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        1|    10  avgt   30      3.343 ±   0.015  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        1|    10  avgt   30      7.622 ±   0.173  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        1|    10  avgt   30     22.362 ±   0.302  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        2|    10  avgt   30      1.162 ±   0.006  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        2|    10  avgt   30      1.880 ±   0.014  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        2|    10  avgt   30      4.841 ±   0.019  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        2|    10  avgt   30      4.511 ±   0.029  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        2|    10  avgt   30     11.743 ±   0.052  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        2|    10  avgt   30     41.365 ±   0.224  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        1|    20  avgt   30      1.188 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        1|    20  avgt   30      1.482 ±   0.012  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        1|    20  avgt   30      3.838 ±   0.064  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        1|    20  avgt   30      4.555 ±   0.021  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        1|    20  avgt   30     12.210 ±   0.163  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        1|    20  avgt   30     34.932 ±   0.513  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        0|    50  avgt   30      1.243 ±   0.005  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        0|    50  avgt   30      1.499 ±   0.011  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        0|    50  avgt   30      2.266 ±   0.012  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        0|    50  avgt   30      4.113 ±   0.020  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        0|    50  avgt   30      9.354 ±   0.045  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        0|    50  avgt   30     34.636 ±   0.352  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        1|    50  avgt   30      1.370 ±   0.007  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        1|    50  avgt   30      1.861 ±   0.023  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        1|    50  avgt   30      4.542 ±   0.063  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        1|    50  avgt   30      6.605 ±   0.041  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        1|    50  avgt   30     22.138 ±   0.178  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        1|    50  avgt   30     78.104 ±   1.149  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      1|        2|    50  avgt   30      1.557 ±   0.017  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|      3|        2|    50  avgt   30      2.332 ±   0.025  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware          10|     10|        2|    50  avgt   30      8.733 ±   0.073  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      1|        2|    50  avgt   30     10.731 ±   0.056  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|      3|        2|    50  avgt   30     36.247 ±   0.405  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         100|     10|        2|    50  avgt   30    131.322 ±   0.699  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware         50|     60|        1|    200  avgt   30    946.197 ±  24.020  ms/op
AllocationBenchmark.measureExclusionAllocationApplyStartedShardZoneUnaware        500|     60|        1|    400  avgt   30  21997.197 ± 254.773  ms/op
````
_Benchmarks have been done on m4.4xlarge EC2 instance type
Amazon Linux AMI release 2017.09_