### PR TITLE
Pass `java.locale.providers=COMPAT` to Java 9 onwards

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/core/src/test/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -220,43 +220,6 @@ public class SimpleSearchIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 2L);
     }
 
-    public void testLocaleDependentDate() throws Exception {
-        assumeFalse("Locals are buggy on JDK9EA", Constants.JRE_IS_MINIMUM_JAVA9 && systemPropertyAsBoolean("tests.security.manager", false));
-        assertAcked(prepareCreate("test")
-                .addMapping("type1",
-                        jsonBuilder().startObject()
-                                .startObject("type1")
-                                .startObject("properties")
-                                .startObject("date_field")
-                                .field("type", "date")
-                                .field("format", "E, d MMM yyyy HH:mm:ss Z")
-                                .field("locale", "de")
-                                .endObject()
-                                .endObject()
-                                .endObject()
-                                .endObject()));
-        ensureGreen();
-        for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test", "type1", "" + i).setSource("date_field", "Mi, 06 Dez 2000 02:55:00 -0800").execute().actionGet();
-            client().prepareIndex("test", "type1", "" + (10 + i)).setSource("date_field", "Do, 07 Dez 2000 02:55:00 -0800").execute().actionGet();
-        }
-
-        refresh();
-        for (int i = 0; i < 10; i++) {
-            SearchResponse searchResponse = client().prepareSearch("test")
-                    .setQuery(QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Do, 07 Dez 2000 00:00:00 -0800"))
-                    .execute().actionGet();
-            assertHitCount(searchResponse, 10L);
-
-
-            searchResponse = client().prepareSearch("test")
-                    .setQuery(QueryBuilders.rangeQuery("date_field").gte("Di, 05 Dez 2000 02:55:00 -0800").lte("Fr, 08 Dez 2000 00:00:00 -0800"))
-                    .execute().actionGet();
-            assertHitCount(searchResponse, 20L);
-
-        }
-    }
-
     public void testSimpleTerminateAfterCount() throws Exception {
         prepareCreate("test").setSettings(Settings.builder().put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, 0)).get();
         ensureGreen();
@@ -273,7 +236,6 @@ public class SimpleSearchIT extends ESIntegTestCase {
         refresh();
 
         SearchResponse searchResponse;
-
         for (int i = 1; i <= max; i++) {
             searchResponse = client().prepareSearch("test")
                     .setQuery(QueryBuilders.rangeQuery("field").gte(1).lte(max))

--- a/distribution/src/main/resources/config/jvm.options
+++ b/distribution/src/main/resources/config/jvm.options
@@ -94,3 +94,6 @@ ${heap.dump.path}
 
 # JDK 9+ GC logging
 9-:-Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/180_local_dependent_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/180_local_dependent_mapping.yml
@@ -1,0 +1,38 @@
+---
+"Test Index and Search locale dependent mappings / dates":
+  - skip:
+      version: " - 6.99.99"
+      reason: JDK9 only supports this with a special sysproperty added in 7.0.0
+  - do:
+      indices.create:
+          index: test_index
+          body:
+              settings:
+                  number_of_shards: 1
+              mappings:
+                  doc:
+                      properties:
+                          date_field:
+                              type: date
+                              format: "E, d MMM yyyy HH:mm:ss Z"
+                              locale: "de"
+  - do:
+      bulk:
+          refresh: true
+          body:
+              - '{"index": {"_index": "test_index", "_type": "doc", "_id": "1"}}'
+              - '{"date_field": "Mi, 06 Dez 2000 02:55:00 -0800"}'
+              - '{"index": {"_index": "test_index", "_type": "doc", "_id": "2"}}'
+              - '{"date_field": "Do, 07 Dez 2000 02:55:00 -0800"}'
+
+  - do:
+      search:
+          index: test_index
+          body: {"query" : {"range" : {"date_field" : {"gte": "Di, 05 Dez 2000 02:55:00 -0800", "lte": "Do, 07 Dez 2000 00:00:00 -0800"}}}}
+  - match: { hits.total: 1 }
+
+  - do:
+      search:
+          index: test_index
+          body: {"query" : {"range" : {"date_field" : {"gte": "Di, 05 Dez 2000 02:55:00 -0800", "lte": "Fr, 08 Dez 2000 00:00:00 -0800"}}}}
+  - match: { hits.total: 2 }


### PR DESCRIPTION
Java 9 added some enhancements to the internationalization support that
impact our date parsing support. To ensure flawless BWC and consistent
behavior going forward Java 9 runtimes requrie the system property
`java.locale.providers=COMPAT` to be set.

Closes #10984