### PR TITLE
Fix link to "parent join"

### DIFF
--- a/docs/reference/search/request/inner-hits.asciidoc
+++ b/docs/reference/search/request/inner-hits.asciidoc
@@ -1,7 +1,7 @@
 [[search-request-inner-hits]]
 === Inner hits
 
-The <<parent-join, parent-join> and <<nested, nested>> features allow the return of documents that
+The <<parent-join, parent-join>> and <<nested, nested>> features allow the return of documents that
 have matches in a different scope. In the parent/child case, parent documents are returned based on matches in child
 documents or child documents are returned based on matches in parent documents. In the nested case, documents are returned
 based on matches in nested inner objects.


### PR DESCRIPTION
(Signed CLA)

Fixed a missing `>` that merged two links by accident.