### PR TITLE
Add missing delegate methods to NodeIndicesStats

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/core/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
@@ -43,6 +42,8 @@ import org.elasticsearch.index.search.stats.SearchStats;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.shard.IndexingStats;
 import org.elasticsearch.index.store.StoreStats;
+import org.elasticsearch.index.translog.TranslogStats;
+import org.elasticsearch.index.warmer.WarmerStats;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 
 import java.io.IOException;
@@ -118,6 +119,11 @@ public class NodeIndicesStats implements Streamable, ToXContentFragment {
     }
 
     @Nullable
+    public WarmerStats getWarmer() {
+        return stats.getWarmer();
+    }
+
+    @Nullable
     public FieldDataStats getFieldData() {
         return stats.getFieldData();
     }
@@ -140,6 +146,11 @@ public class NodeIndicesStats implements Streamable, ToXContentFragment {
     @Nullable
     public SegmentsStats getSegments() {
         return stats.getSegments();
+    }
+
+    @Nullable
+    public TranslogStats getTranslog() {
+        return stats.getTranslog();
     }
 
     @Nullable


### PR DESCRIPTION
When calling the node stats action via the Java API it was not able to return information about the translog even though that is available through the REST API. I've added the missing methods to make the responses consistent.