### PR TITLE
[docs] Fix typoes in comment in source code

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -313,7 +313,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
         // optimize search type for cases where there is only one shard group to search on
         if (shardIterators.size() == 1) {
-            // if we only have one group, then we always want Q_A_F, no need for DFS, and no need to do THEN since we hit one shard
+            // if we only have one group, then we always want Q_T_F, no need for DFS, and no need to do THEN since we hit one shard
             searchRequest.searchType(QUERY_THEN_FETCH);
         }
         if (searchRequest.isSuggestOnly()) {
@@ -338,8 +338,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         if (searchRequest.isMaxConcurrentShardRequestsSet() == false) {
             // we try to set a default of max concurrent shard requests based on
             // the node count but upper-bound it by 256 by default to keep it sane. A single
-            // search request that fans out lots of shards should hit a cluster too hard while 256 is already a lot
-            // we multiply is by the default number of shards such that a single request in a cluster of 1 would hit all shards of a
+            // search request that fans out lots of shards should hit a cluster too hard while 256 is already a lot.
+            // we multiply it by the default number of shards such that a single request in a cluster of 1 would hit all shards of a
             // default index.
             searchRequest.setMaxConcurrentShardRequests(Math.min(256, nodeCount
                 * IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getDefault(Settings.EMPTY)));

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -855,7 +855,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     /**
      * Shortcut ids to load, we load only "from" and up to "size". The phase controller
-     * handles this as well since the result is always size * shards for Q_A_F
+     * handles this as well since the result is always size * shards for Q_T_F
      */
     private void shortcutDocIdsToLoad(SearchContext context) {
         final int[] docIdsToLoad;
@@ -963,7 +963,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     }
 
     /**
-     * Returns true iff the given search source builder can be early terminated by rewriting to a match none query. Or in other words
+     * Returns true if the given search source builder can be early terminated by rewriting to a match none query. Or in other words
      * if the execution of a the search request can be early terminated without executing it. This is for instance not possible if
      * a global aggregation is part of this request or if there is a suggest builder present.
      */

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -964,7 +964,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     /**
      * Returns true if the given search source builder can be early terminated by rewriting to a match none query. Or in other words
-     * if the execution of a the search request can be early terminated without executing it. This is for instance not possible if
+     * iff the execution of a the search request can be early terminated without executing it. This is for instance not possible if
      * a global aggregation is part of this request or if there is a suggest builder present.
      */
     public static boolean canRewriteToMatchNone(SearchSourceBuilder source) {

--- a/core/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/core/src/main/java/org/elasticsearch/search/SearchService.java
@@ -963,8 +963,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     }
 
     /**
-     * Returns true if the given search source builder can be early terminated by rewriting to a match none query. Or in other words
-     * iff the execution of a the search request can be early terminated without executing it. This is for instance not possible if
+     * Returns true iff the given search source builder can be early terminated by rewriting to a match none query. Or in other words
+     * if the execution of a the search request can be early terminated without executing it. This is for instance not possible if
      * a global aggregation is part of this request or if there is a suggest builder present.
      */
     public static boolean canRewriteToMatchNone(SearchSourceBuilder source) {


### PR DESCRIPTION
While reading some code, I have found out some typoes.

* Gramatical Typoes
* Comment on query_and_fetch, which has already been removed. (#22996)