### PR TITLE
[docs] Fix gradle to gradlew in a document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,13 +99,13 @@ We support development in the Eclipse and IntelliJ IDEs. For Eclipse, the
 minimum version that we support is [Eclipse Oxygen][eclipse] (version 4.7). For
 IntelliJ, the minimum version that we support is [IntelliJ 2017.2][intellij].
 
-Eclipse users can automatically configure their IDE: `gradle eclipse`
+Eclipse users can automatically configure their IDE: `./gradlew eclipse`
 then `File: Import: Existing Projects into Workspace`. Select the
 option `Search for nested projects`. Additionally you will want to
 ensure that Eclipse is using 2048m of heap by modifying `eclipse.ini`
 accordingly to avoid GC overhead errors.
 
-IntelliJ users can automatically configure their IDE: `gradle idea`
+IntelliJ users can automatically configure their IDE: `./gradlew idea`
 then `File->New Project From Existing Sources`. Point to the root of
 the source directory, select
 `Import project from external model->Gradle`, enable
@@ -123,7 +123,7 @@ restart of IDEA). For IDEA 2017.3 and above, in addition to the JVM option, you 
 classpath](https://github.com/elastic/elasticsearch/issues/14348) if that is
 reported as a source of jar hell.
 
-To run an instance of elasticsearch from the source code run `gradle run`
+To run an instance of elasticsearch from the source code run `./gradlew run`
 
 The Elasticsearch codebase makes heavy use of Java `assert`s and the
 test runner requires that assertions be enabled within the JVM. This
@@ -151,7 +151,7 @@ To create a distribution from the source, simply run:
 
 ```sh
 cd elasticsearch/
-gradle assemble
+./gradlew assemble
 ```
 
 You will find the newly built packages under: `./distribution/(deb|rpm|tar|zip)/build/distributions/`.
@@ -159,7 +159,7 @@ You will find the newly built packages under: `./distribution/(deb|rpm|tar|zip)/
 Before submitting your changes, run the test suite to make sure that nothing is broken, with:
 
 ```sh
-gradle check
+./gradlew check
 ```
 
 Contributing as part of a class
@@ -187,7 +187,7 @@ code review process because it wastes our time.
 * We don't have the capacity to absorb an entire class full of new contributors,
 especially when they are unlikely to become long time contributors.
 
-Finally, we require that you run `gradle check` before submitting a
+Finally, we require that you run `./gradlew check` before submitting a
 non-documentation contribution. This is mentioned above, but it is worth
 repeating in this section because it has come up in this context.
 


### PR DESCRIPTION
There are some parts that were confused about gradle in the document.
So I fixed that.
This commit is related to https://github.com/elastic/elasticsearch/issues/28094