### PR TITLE
Fix reproduction info to point to Gradle wrapper

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -344,7 +344,7 @@ class VagrantTestPlugin implements Plugin<Project> {
                 @Override
                 void afterExecute(Task task, TaskState state) {
                     if (state.failure != null) {
-                        println "REPRODUCE WITH: gradle ${packaging.path} " +
+                        println "REPRODUCE WITH: ./gradlew ${packaging.path} " +
                             "-Dtests.seed=${project.testSeed} "
                     }
                 }

--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -71,7 +71,7 @@ public class ReproduceInfoPrinter extends RunListener {
             return;
         }
 
-        final StringBuilder b = new StringBuilder("REPRODUCE WITH: gradle ");
+        final StringBuilder b = new StringBuilder("REPRODUCE WITH: ./gradlew ");
         String task = System.getProperty("tests.task");
         // TODO: enforce (intellij still runs the runner?) or use default "test" but that won't work for integ
         b.append(task);


### PR DESCRIPTION
With the Gradle wrapper in place, we should point the reproduction info to specify using the Gradle wrapper too.

Relates #28065
  