### PR TITLE
Fix environment variable substitutions in list setting

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -1216,13 +1216,12 @@ public final class Settings implements ToXContentFragment {
                     continue;
                 }
                 if (entry.getValue() instanceof List) {
-                    List<String> ls = (List<String>) entry.getValue();
-                    ListIterator<String> li = ls.listIterator();
-                    while(li.hasNext()){
-                        String value = li.next();
-                        String value2 = propertyPlaceholder.replacePlaceholders(value, placeholderResolver);
-                        if (! value.equals(value2)){
-                            li.set(value2);
+                    final ListIterator<String> li = ((List<String>) entry.getValue()).listIterator();
+                    while (li.hasNext()){
+                        final String settingValueRaw = li.next();
+                        final String settingValueResolved = propertyPlaceholder.replacePlaceholders(settingValueRaw, placeholderResolver);
+                        if (!settingValueRaw.equals(settingValueResolved)){
+                            li.set(settingValueResolved);
                         }
                     }
                     continue;

--- a/core/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -1217,12 +1217,10 @@ public final class Settings implements ToXContentFragment {
                 }
                 if (entry.getValue() instanceof List) {
                     final ListIterator<String> li = ((List<String>) entry.getValue()).listIterator();
-                    while (li.hasNext()){
+                    while (li.hasNext()) {
                         final String settingValueRaw = li.next();
                         final String settingValueResolved = propertyPlaceholder.replacePlaceholders(settingValueRaw, placeholderResolver);
-                        if (!settingValueRaw.equals(settingValueResolved)){
-                            li.set(settingValueResolved);
-                        }
+                        li.set(settingValueResolved);
                     }
                     continue;
                 }

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -70,11 +70,12 @@ public class SettingsTests extends ESTestCase {
 
     public void testReplacePropertiesPlaceholderSystemPropertyList() {
         final String hostname = randomAlphaOfLength(16);
+        final String hostip = randomAlphaOfLength(16);
         final Settings settings = Settings.builder()
-            .putList("setting1", "${HOSTNAME}", "${HOSTNAME}")
-            .replacePropertyPlaceholders(name -> "HOSTNAME".equals(name) ? hostname : null)
+            .putList("setting1", "${HOSTNAME}", "${HOSTIP}")
+            .replacePropertyPlaceholders(name -> name.equals("HOSTNAME") ? hostname : name.equals("HOSTIP") ? hostip : null)
             .build();
-        assertThat(settings.getAsList("setting1"), contains(hostname, hostname));
+        assertThat(settings.getAsList("setting1"), contains(hostname, hostip));
     }
 
     public void testReplacePropertiesPlaceholderSystemVariablesHaveNoEffect() {

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -69,14 +69,12 @@ public class SettingsTests extends ESTestCase {
     }
 
     public void testReplacePropertiesPlaceholderSystemPropertyList() {
-        String value = System.getProperty("java.home");
-        assertFalse(value.isEmpty());
-        Settings settings = Settings.builder()
-            .put("property.placeholder", value)
-            .putList("setting1", "${property.placeholder}", "${property.placeholder}")
-            .replacePropertyPlaceholders()
+        final String hostname = randomAlphaOfLength(16);
+        final Settings settings = Settings.builder()
+            .putList("setting1", "${HOSTNAME}", "${HOSTNAME}")
+            .replacePropertyPlaceholders(name -> "HOSTNAME".equals(name) ? hostname : null)
             .build();
-        assertThat(settings.getAsList("setting1"), contains(value, value));
+        assertThat(settings.getAsList("setting1"), contains(hostname, hostname));
     }
 
     public void testReplacePropertiesPlaceholderSystemVariablesHaveNoEffect() {

--- a/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/core/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -68,6 +68,17 @@ public class SettingsTests extends ESTestCase {
         assertThat(settings.get("setting1"), equalTo(value));
     }
 
+    public void testReplacePropertiesPlaceholderSystemPropertyList() {
+        String value = System.getProperty("java.home");
+        assertFalse(value.isEmpty());
+        Settings settings = Settings.builder()
+            .put("property.placeholder", value)
+            .putList("setting1", "${property.placeholder}", "${property.placeholder}")
+            .replacePropertyPlaceholders()
+            .build();
+        assertThat(settings.getAsList("setting1"), contains(value, value));
+    }
+
     public void testReplacePropertiesPlaceholderSystemVariablesHaveNoEffect() {
         final String value = System.getProperty("java.home");
         assertNotNull(value);


### PR DESCRIPTION
Since Elasticsearch 6.1.0 environment variable substitutions in lists do not work
This commit fixes it.

Closes #27926