### PR TITLE
Remove Gradle cheatsheet

### DIFF
--- a/GRADLE.CHEATSHEET
+++ b/GRADLE.CHEATSHEET
@@ -1,9 +1,0 @@
-As a quick helper, below are the equivalent commands from Maven to Gradle
-(TESTING.md has also been updated). You can also run `./gradlew tasks` to see
-all tasks that are available to run.
-clean -> clean
-test -> test
-verify -> check
-verify -Dskip.unit.tests -> integTest
-package -DskipTests -> assemble
-install -DskipTests -> publishToMavenLocal


### PR DESCRIPTION
We are long past the Maven to Gradle transition, and Gradle is commonplace enough these days that we do not need to devote a top-level file on a Gradle cheatsheet.

