### PR TITLE
Fix NPE on composite aggregation with sub-aggregations that need scores

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -104,21 +104,20 @@ final class CompositeAggregator extends BucketsAggregator {
             final CompositeValuesSource.Collector collector =
                 array.getLeafCollector(context.ctx, getSecondPassCollector(context.subCollector));
             int docID;
-            DocIdSetIterator docIt = null;
-            if (needsScores()) {
+            DocIdSetIterator scorerIt = null;
+            if (needsScores) {
                 Scorer scorer = weight.scorer(context.ctx);
                 // We don't need to check if the scorer is null
                 // since we are sure that there are documents to replay (docIdSetIterator it not empty).
-                docIt = scorer.iterator();
+                scorerIt = scorer.iterator();
                 context.subCollector.setScorer(scorer);
             }
             while ((docID = docIdSetIterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 if (needsScores) {
-                    if (docIt.docID() < docID) {
-                        docIt.advance(docID);
-                    }
+                    assert scorerIt.docID() < docID;
+                    scorerIt.advance(docID);
                     // aggregations should only be replayed on matching documents
-                    assert docIt.docID() == docID;
+                    assert scorerIt.docID() == docID;
                 }
                 collector.collect(docID);
             }


### PR DESCRIPTION
The composite aggregation defers the collection of sub-aggregations to a second pass that visits documents only if they
appear in the top buckets. Though the scorer for sub-aggregations is not set on this second pass and generates an NPE if any sub-aggregation
tries to access the score. This change creates a scorer for the second pass and makes sure that sub-aggs can use it safely to check the score of
the collected documents.