### PR TITLE
Consistent updates of IndexShardSnapshotStatus

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexShardStatus.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.admin.cluster.snapshots.status;
 import org.elasticsearch.action.support.broadcast.BroadcastShardResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.shard.ShardId;
@@ -49,13 +48,13 @@ public class SnapshotIndexShardStatus extends BroadcastShardResponse implements 
         this.stats = new SnapshotStats();
     }
 
-    SnapshotIndexShardStatus(ShardId shardId, IndexShardSnapshotStatus indexShardStatus) {
+    SnapshotIndexShardStatus(ShardId shardId, IndexShardSnapshotStatus.Copy indexShardStatus) {
         this(shardId, indexShardStatus, null);
     }
 
-    SnapshotIndexShardStatus(ShardId shardId, IndexShardSnapshotStatus indexShardStatus, String nodeId) {
+    SnapshotIndexShardStatus(ShardId shardId, IndexShardSnapshotStatus.Copy indexShardStatus, String nodeId) {
         super(shardId);
-        switch (indexShardStatus.stage()) {
+        switch (indexShardStatus.getStage()) {
             case INIT:
                 stage = SnapshotIndexShardStage.INIT;
                 break;
@@ -72,10 +71,12 @@ public class SnapshotIndexShardStatus extends BroadcastShardResponse implements 
                 stage = SnapshotIndexShardStage.FAILURE;
                 break;
             default:
-                throw new IllegalArgumentException("Unknown stage type " + indexShardStatus.stage());
+                throw new IllegalArgumentException("Unknown stage type " + indexShardStatus.getStage());
         }
-        stats = new SnapshotStats(indexShardStatus);
-        failure = indexShardStatus.failure();
+        this.stats = new SnapshotStats(indexShardStatus.getStartTime(), indexShardStatus.getTotalTime(),
+                                        indexShardStatus.getNumberOfFiles(), indexShardStatus.getProcessedFiles(),
+                                        indexShardStatus.getTotalSize(), indexShardStatus.getProcessedSize());
+        this.failure = indexShardStatus.getFailure();
         this.nodeId = nodeId;
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStats.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStats.java
@@ -25,33 +25,28 @@ import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
 
 import java.io.IOException;
 
 public class SnapshotStats implements Streamable, ToXContentFragment {
+
     private long startTime;
-
     private long time;
-
     private int numberOfFiles;
-
     private int processedFiles;
-
     private long totalSize;
-
     private long processedSize;
 
     SnapshotStats() {
     }
 
-    SnapshotStats(IndexShardSnapshotStatus indexShardStatus) {
-        startTime = indexShardStatus.startTime();
-        time = indexShardStatus.time();
-        numberOfFiles = indexShardStatus.numberOfFiles();
-        processedFiles = indexShardStatus.processedFiles();
-        totalSize = indexShardStatus.totalSize();
-        processedSize = indexShardStatus.processedSize();
+    SnapshotStats(long startTime, long time, int numberOfFiles, int processedFiles, long totalSize, long processedSize) {
+        this.startTime = startTime;
+        this.time = time;
+        this.numberOfFiles = numberOfFiles;
+        this.processedFiles = processedFiles;
+        this.totalSize = totalSize;
+        this.processedSize = processedSize;
     }
 
     /**

--- a/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -233,7 +233,8 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
                     Map<ShardId, IndexShardSnapshotStatus> shardStatues =
                         snapshotsService.snapshotShards(request.repository(), snapshotInfo);
                     for (Map.Entry<ShardId, IndexShardSnapshotStatus> shardStatus : shardStatues.entrySet()) {
-                        shardStatusBuilder.add(new SnapshotIndexShardStatus(shardStatus.getKey(), shardStatus.getValue()));
+                        IndexShardSnapshotStatus.Copy lastSnapshotStatus = shardStatus.getValue().asCopy();
+                        shardStatusBuilder.add(new SnapshotIndexShardStatus(shardStatus.getKey(), lastSnapshotStatus));
                     }
                     final SnapshotsInProgress.State state;
                     switch (snapshotInfo.state()) {

--- a/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.index.snapshots;
 
-import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.unit.TimeValue;
-
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -245,12 +242,17 @@ public class IndexShardSnapshotStatus {
 
         @Override
         public String toString() {
-            return new StringBuilder()
-                .append("took [").append(TimeValue.timeValueMillis(getTotalTime())).append("], ")
-                .append("index version [").append(getIndexVersion()).append("], ")
-                .append("number_of_files [").append(getNumberOfFiles()).append("], ")
-                .append("total_size [").append(new ByteSizeValue(getTotalSize())).append("]")
-                .toString();
+            return "index shard snapshot status (" +
+                "stage=" + stage +
+                ", startTime=" + startTime +
+                ", totalTime=" + totalTime +
+                ", numberOfFiles=" + numberOfFiles +
+                ", processedFiles=" + processedFiles +
+                ", totalSize=" + totalSize +
+                ", processedSize=" + processedSize +
+                ", indexVersion=" + indexVersion +
+                ", failure='" + failure + '\'' +
+                ')';
         }
     }
 }

--- a/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/core/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -113,13 +113,6 @@ public class IndexShardSnapshotStatus {
         return asCopy();
     }
 
-    public synchronized Copy moveToAborted(final String failure) {
-        if (stage.getAndSet(Stage.ABORTED) != Stage.ABORTED) {
-            this.failure = failure;
-        }
-        return asCopy();
-    }
-
     public synchronized Copy abortIfNotCompleted(final String failure) {
         if (stage.compareAndSet(Stage.INIT, Stage.ABORTED) || stage.compareAndSet(Stage.STARTED, Stage.ABORTED)) {
             this.failure = failure;
@@ -134,10 +127,8 @@ public class IndexShardSnapshotStatus {
         }
     }
 
-    public void ensureNotAborted() {
-        if (stage.get() == Stage.ABORTED) {
-            throw new IllegalStateException("Aborted");
-        }
+    public boolean isAborted() {
+        return stage.get() == Stage.ABORTED;
     }
 
     /**
@@ -164,6 +155,7 @@ public class IndexShardSnapshotStatus {
     }
 
     public static IndexShardSnapshotStatus newFailed(final String failure) {
+        assert failure != null : "expecting non null failure for a failed IndexShardSnapshotStatus";
         if (failure == null) {
             throw new IllegalArgumentException("A failure description is required for a failed IndexShardSnapshotStatus");
         }

--- a/core/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -180,7 +180,7 @@ public interface Repository extends LifecycleComponent {
      * Repository implementations shouldn't release the snapshot index commit point. It is done by the method caller.
      * <p>
      * As snapshot process progresses, implementation of this method should update {@link IndexShardSnapshotStatus} object and check
-     * {@link IndexShardSnapshotStatus#ensureNotAborted()} to see if the snapshot process should be aborted.
+     * {@link IndexShardSnapshotStatus#isAborted()} to see if the snapshot process should be aborted.
      *
      * @param shard               shard to be snapshotted
      * @param snapshotId          snapshot id

--- a/core/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -180,7 +180,7 @@ public interface Repository extends LifecycleComponent {
      * Repository implementations shouldn't release the snapshot index commit point. It is done by the method caller.
      * <p>
      * As snapshot process progresses, implementation of this method should update {@link IndexShardSnapshotStatus} object and check
-     * {@link IndexShardSnapshotStatus#aborted()} to see if the snapshot process should be aborted.
+     * {@link IndexShardSnapshotStatus#ensureNotAborted()} to see if the snapshot process should be aborted.
      *
      * @param shard               shard to be snapshotted
      * @param snapshotId          snapshot id

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -187,7 +187,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             Map<ShardId, IndexShardSnapshotStatus> shards = snapshotShards.getValue().shards;
             if (shards.containsKey(shardId)) {
                 logger.debug("[{}] shard closing, abort snapshotting for snapshot [{}]", shardId, snapshotShards.getKey().getSnapshotId());
-                shards.get(shardId).moveToAborted("shard is closing, aborting");
+                shards.get(shardId).abortIfNotCompleted("shard is closing, aborting");
             }
         }
     }
@@ -229,7 +229,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 // running shards is missed, then the snapshot is removed is a subsequent cluster
                 // state update, which is being processed here
                 for (IndexShardSnapshotStatus snapshotStatus : entry.getValue().shards.values()) {
-                    final IndexShardSnapshotStatus.Stage stage = snapshotStatus.asCopy().getStage();
                     snapshotStatus.abortIfNotCompleted("snapshot has been removed in cluster state, aborting");
                 }
             }

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -395,7 +395,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                 repository.snapshotShard(indexShard, snapshot.getSnapshotId(), indexId, snapshotRef.getIndexCommit(), snapshotStatus);
                 if (logger.isDebugEnabled()) {
                     final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.asCopy();
-                    logger.debug("snapshot ({}) completed to {} {}", snapshot, repository, lastSnapshotStatus);
+                    logger.debug("snapshot ({}) completed to {} with {}", snapshot, repository, lastSnapshotStatus);
                 }
             }
         } catch (SnapshotFailedEngineException | IndexShardSnapshotFailedException e) {

--- a/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/core/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -598,10 +598,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     ShardId shardId = new ShardId(indexMetaData.getIndex(), i);
                     SnapshotShardFailure shardFailure = findShardFailure(snapshotInfo.shardFailures(), shardId);
                     if (shardFailure != null) {
-                        IndexShardSnapshotStatus shardSnapshotStatus = new IndexShardSnapshotStatus();
-                        shardSnapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.FAILURE);
-                        shardSnapshotStatus.failure(shardFailure.reason());
-                        shardStatus.put(shardId, shardSnapshotStatus);
+                        shardStatus.put(shardId, IndexShardSnapshotStatus.newFailed(shardFailure.reason()));
                     } else {
                         final IndexShardSnapshotStatus shardSnapshotStatus;
                         if (snapshotInfo.state() == SnapshotState.FAILED) {
@@ -612,9 +609,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                             // snapshot status will throw an exception.  Instead, we create
                             // a status for the shard to indicate that the shard snapshot
                             // could not be taken due to partial being set to false.
-                            shardSnapshotStatus = new IndexShardSnapshotStatus();
-                            shardSnapshotStatus.updateStage(IndexShardSnapshotStatus.Stage.FAILURE);
-                            shardSnapshotStatus.failure("skipped");
+                            shardSnapshotStatus = IndexShardSnapshotStatus.newFailed("skipped");
                         } else {
                             shardSnapshotStatus = repository.getShardSnapshotStatus(
                                 snapshotInfo.snapshotId(),

--- a/core/src/test/java/org/elasticsearch/snapshots/SnapshotShardsServiceIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/SnapshotShardsServiceIT.java
@@ -93,7 +93,7 @@ public class SnapshotShardsServiceIT extends AbstractSnapshotIntegTestCase {
         assertBusy(() -> {
             final Snapshot snapshot = new Snapshot("test-repo", snapshotId);
             List<IndexShardSnapshotStatus.Stage> stages = snapshotShardsService.currentSnapshotShards(snapshot)
-                .values().stream().map(IndexShardSnapshotStatus::stage).collect(Collectors.toList());
+                .values().stream().map(status -> status.asCopy().getStage()).collect(Collectors.toList());
             assertThat(stages, hasSize(shards));
             assertThat(stages, everyItem(equalTo(IndexShardSnapshotStatus.Stage.DONE)));
         });

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -619,16 +619,18 @@ public abstract class IndexShardTestCase extends ESTestCase {
     protected void snapshotShard(final IndexShard shard,
                                  final Snapshot snapshot,
                                  final Repository repository) throws IOException {
-        final IndexShardSnapshotStatus snapshotStatus = new IndexShardSnapshotStatus();
+        final IndexShardSnapshotStatus snapshotStatus = IndexShardSnapshotStatus.newInitializing();
         try (Engine.IndexCommitRef indexCommitRef = shard.acquireIndexCommit(true)) {
             Index index = shard.shardId().getIndex();
             IndexId indexId = new IndexId(index.getName(), index.getUUID());
 
             repository.snapshotShard(shard, snapshot.getSnapshotId(), indexId, indexCommitRef.getIndexCommit(), snapshotStatus);
         }
-        assertEquals(IndexShardSnapshotStatus.Stage.DONE, snapshotStatus.stage());
-        assertEquals(shard.snapshotStoreMetadata().size(), snapshotStatus.numberOfFiles());
-        assertNull(snapshotStatus.failure());
+
+        final IndexShardSnapshotStatus.Copy lastSnapshotStatus = snapshotStatus.asCopy();
+        assertEquals(IndexShardSnapshotStatus.Stage.DONE, lastSnapshotStatus.getStage());
+        assertEquals(shard.snapshotStoreMetadata().size(), lastSnapshotStatus.getNumberOfFiles());
+        assertNull(lastSnapshotStatus.getFailure());
     }
 
     /**


### PR DESCRIPTION
IndexShardSnapshotStatus represents the status of an index shard
snapshot. During the snapshot process it can be updated multiple times,
it can also be aborted and the the Get Snapshot and Snapshot Status APIs
are susceptible to read the snapshot statuses.

Right now, the information are not updated in a coherent manner, meaning
that a IndexShardSnapshotStatus can be FAILED but the failure is not
updated yet. Or it could be FINALIZE with no index version.

This commit changes IndexShardSnapshotStatus so that the Stage is updated
coherently with any required information. It also provides a asCopy()
method that returns the status of a IndexShardSnapshotStatus at a given
point in time, ensuring that all information are coherent.

Closes #26480
