### PR TITLE
Use Gradle wrapper when building BWC

### DIFF
--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -115,17 +115,34 @@ if (project.hasProperty('bwcVersion')) {
   File bwcDeb = file("${checkoutDir}/distribution/deb/build/distributions/elasticsearch-${bwcVersion}.deb")
   File bwcRpm = file("${checkoutDir}/distribution/rpm/build/distributions/elasticsearch-${bwcVersion}.rpm")
   File bwcZip = file("${checkoutDir}/distribution/zip/build/distributions/elasticsearch-${bwcVersion}.zip")
-  task buildBwcVersion(type: GradleBuild) {
+  task buildBwcVersion(type: Exec) { Exec exec ->
     dependsOn checkoutBwcBranch, writeBuildMetadata
-    dir = checkoutDir
-    tasks = [':distribution:deb:assemble', ':distribution:rpm:assemble', ':distribution:zip:assemble']
-    startParameter.systemPropertiesArgs = ['build.snapshot': System.getProperty("build.snapshot") ?: "true"]
+    exec.workingDir = checkoutDir
+    exec.executable = new File(checkoutDir, 'gradlew').toString()
+    final ArrayList<String> args = [
+            ":distribution:deb:assemble",
+            ":distribution:rpm:assemble",
+            ":distribution:zip:assemble",
+            "-Dbuild.snapshot=${System.getProperty('build.snapshot') ?: 'true'}"]
+    final LogLevel logLevel = gradle.startParameter.logLevel
+    if ([LogLevel.QUIET, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG].contains(logLevel)) {
+      args << "--${logLevel.name().toLowerCase(Locale.ENGLISH)}"
+    }
+    final String showStacktraceName = gradle.startParameter.showStacktrace.name()
+    assert ["INTERNAL_EXCEPTIONS", "ALWAYS", "ALWAYS_FULL"].contains(showStacktraceName)
+    if (showStacktraceName.equals("ALWAYS")) {
+      args << "--stacktrace"
+    } else if (showStacktraceName.equals("ALWAYS_FULL")) {
+      args << "--full-stacktrace"
+    }
+    exec.args = args
     doLast {
       List missing = [bwcDeb, bwcRpm, bwcZip].grep { file ->
-        false == file.exists() }
+        false == file.exists()
+      }
       if (false == missing.empty) {
         throw new InvalidUserDataException(
-          "Building bwc version didn't generate expected files ${missing}")
+                "Building bwc version didn't generate expected files ${missing}")
       }
     }
   }

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -115,27 +115,27 @@ if (project.hasProperty('bwcVersion')) {
   File bwcDeb = file("${checkoutDir}/distribution/deb/build/distributions/elasticsearch-${bwcVersion}.deb")
   File bwcRpm = file("${checkoutDir}/distribution/rpm/build/distributions/elasticsearch-${bwcVersion}.rpm")
   File bwcZip = file("${checkoutDir}/distribution/zip/build/distributions/elasticsearch-${bwcVersion}.zip")
-  task buildBwcVersion(type: Exec) { Exec exec ->
+  task buildBwcVersion(type: Exec) {
     dependsOn checkoutBwcBranch, writeBuildMetadata
-    exec.workingDir = checkoutDir
-    exec.executable = new File(checkoutDir, 'gradlew').toString()
-    final ArrayList<String> args = [
+    workingDir = checkoutDir
+    executable = new File(checkoutDir, 'gradlew').toString()
+    final ArrayList<String> commandLineArgs = [
             ":distribution:deb:assemble",
             ":distribution:rpm:assemble",
             ":distribution:zip:assemble",
             "-Dbuild.snapshot=${System.getProperty('build.snapshot') ?: 'true'}"]
     final LogLevel logLevel = gradle.startParameter.logLevel
     if ([LogLevel.QUIET, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG].contains(logLevel)) {
-      args << "--${logLevel.name().toLowerCase(Locale.ENGLISH)}"
+      commandLineArgs << "--${logLevel.name().toLowerCase(Locale.ENGLISH)}"
     }
     final String showStacktraceName = gradle.startParameter.showStacktrace.name()
     assert ["INTERNAL_EXCEPTIONS", "ALWAYS", "ALWAYS_FULL"].contains(showStacktraceName)
     if (showStacktraceName.equals("ALWAYS")) {
-      args << "--stacktrace"
+      commandLineArgs << "--stacktrace"
     } else if (showStacktraceName.equals("ALWAYS_FULL")) {
-      args << "--full-stacktrace"
+      commandLineArgs << "--full-stacktrace"
     }
-    exec.args = args
+    args = commandLineArgs
     doLast {
       List missing = [bwcDeb, bwcRpm, bwcZip].grep { file ->
         false == file.exists()


### PR DESCRIPTION
This commit modifies the BWC build to invoke the Gradle wrapper. The motivation for this is two-fold:
 - BWC versions might be dependent on a different version of Gradle than the current version of Gradle
 - in a follow-up we are going to need to be able to set JAVA_HOME to a different value than the current value of JAVA_HOME

Relates #28065, #28071

  