### PR TITLE
Painless: Add a simple cache for whitelist methods and fields.

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -878,7 +878,7 @@ public final class Definition {
 
             painlessConstructor = new Method("<init>", ownerStruct, null, getTypeInternal("void"), painlessParametersTypes,
                 asmConstructor, javaConstructor.getModifiers(), javaHandle);
-            ownerStruct.constructors.put(painlessMethodKey, painlessConstructor);
+            ownerStruct.constructors.put(painlessMethodKey, putMethodInCache(painlessConstructor));
         } else if (painlessConstructor.arguments.equals(painlessParametersTypes) == false){
             throw new IllegalArgumentException(
                     "illegal duplicate constructors [" + painlessMethodKey + "] found within the struct [" + ownerStruct.name + "] " +


### PR DESCRIPTION
With support for multiple contexts we are adding some caching to the whitelist to keep the memory footprint for definitions from exploding.
  