### PR TITLE
Don't require JAVA_HOME to run build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ task verifyVersions {
  * after the backport of the backcompat code is complete.
  */
 allprojects {
-  ext.bwc_tests_enabled = true
+  ext.bwc_tests_enabled = false
 }
 
 task verifyBwcTestsEnabled {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -92,8 +92,8 @@ class BuildPlugin implements Plugin<Project> {
     /** Performs checks on the build environment and prints information about the build environment. */
     static void globalBuildInfo(Project project) {
         if (project.rootProject.ext.has('buildChecksDone') == false) {
-            String javaHome = findJavaHome()
             File gradleJavaHome = Jvm.current().javaHome
+
             String javaVendor = System.getProperty('java.vendor')
             String javaVersion = System.getProperty('java.version')
             String gradleJavaVersionDetails = "${javaVendor} ${javaVersion}" +
@@ -101,6 +101,12 @@ class BuildPlugin implements Plugin<Project> {
 
             String javaVersionDetails = gradleJavaVersionDetails
             JavaVersion javaVersionEnum = JavaVersion.current()
+
+            String javaHome = System.getenv('JAVA_HOME')
+            if (javaHome == null || javaHome.isEmpty()) {
+                javaHome = gradleJavaHome.toString()
+            }
+
             if (new File(javaHome).canonicalPath != gradleJavaHome.canonicalPath) {
                 javaVersionDetails = findJavaVersionDetails(project, javaHome)
                 javaVersionEnum = JavaVersion.toVersion(findJavaSpecificationVersion(project, javaHome))
@@ -166,20 +172,6 @@ class BuildPlugin implements Plugin<Project> {
         // set java home for each project, so they dont have to find it in the root project
         project.ext.javaHome = project.rootProject.ext.javaHome
         project.ext.javaVersion = project.rootProject.ext.javaVersion
-    }
-
-    /** Finds and enforces JAVA_HOME is set */
-    private static String findJavaHome() {
-        String javaHome = System.getenv('JAVA_HOME')
-        if (javaHome == null) {
-            if (System.getProperty("idea.active") != null || System.getProperty("eclipse.launcher") != null) {
-                // intellij doesn't set JAVA_HOME, so we use the jdk gradle was run with
-                javaHome = Jvm.current().javaHome
-            } else {
-                throw new GradleException('JAVA_HOME must be set to build Elasticsearch')
-            }
-        }
-        return javaHome
     }
 
     /** Finds printable java version of the given JAVA_HOME */

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -57,8 +57,10 @@ for (Version version : versionCollection.versionsIndexCompatibleWithCurrent) {
 test.enabled = false
 
 task integTest {
-    for (final def version : versionCollection.basicIntegrationTestVersions) {
-        dependsOn "v${version}#bwcTest"
+    if (project.bwc_tests_enabled) {
+        for (final def version : versionCollection.basicIntegrationTestVersions) {
+            dependsOn "v${version}#bwcTest"
+        }
     }
 }
 


### PR DESCRIPTION
The build currently enforces `JAVA_HOME` to be set (when not run from an IDE). All tools (gradle wrapper, our bash scripts to run ES, etc.) also work though when the `java` executable is somewhere on the `PATH` without `JAVA_HOME` defined.

This requires one less step of setup to get started developing on ES. Note that this still uses JAVA_HOME if it's defined.
  