### PR TITLE
Painless: Add public member read/write access test.

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/FeatureTest.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/FeatureTest.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 public class FeatureTest {
     private int x;
     private int y;
+    public int z;
 
     /** empty ctor */
     public FeatureTest() {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.txt
@@ -139,6 +139,7 @@ class org.elasticsearch.index.mapper.IpFieldMapper$IpFieldType$IpScriptDocValues
 # for testing.
 # currently FeatureTest exposes overloaded constructor, field load store, and overloaded static methods
 class org.elasticsearch.painless.FeatureTest only_fqn {
+  int z
   ()
   (int,int)
   int getX()

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
@@ -124,4 +124,9 @@ public class BasicAPITests extends ScriptTestCase {
         assertEquals("5", exec("int x = 5; return x.toString();"));
         assertEquals(0, exec("int x = 5; return x.compareTo(5);"));
     }
+
+    public void testPublicMemberAccess() {
+        assertEquals(5, exec("org.elasticsearch.painless.FeatureTest ft = new org.elasticsearch.painless.FeatureTest();" +
+            "ft.z = 5; return ft.z;"));
+    }
 }


### PR DESCRIPTION
There was missing coverage for testing read/write access of public member variables as part of a whitelist.  This is a follow up to a previously fixed bug that was discovered about how only static members could be accessed within a whitelisted class.