### PR TITLE
Make sure that we don't detect files as maven coordinate when installing a plugin

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -232,14 +232,14 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
 
         // now try as maven coordinates, a valid URL would only have a colon and slash
         String[] coordinates = pluginId.split(":");
-        if (coordinates.length == 3 && pluginId.contains("/") == false) {
+        if (coordinates.length == 3 && pluginId.contains("/") == false && pluginId.startsWith("file:") == false) {
             String mavenUrl = getMavenUrl(terminal, coordinates, Platforms.PLATFORM_NAME);
             terminal.println("-> Downloading " + pluginId + " from maven central");
             return downloadZipAndChecksum(terminal, mavenUrl, tmpDir, true);
         }
 
         // fall back to plain old URL
-        if (pluginId.contains(":/") == false) {
+        if (pluginId.contains(":") == false) {
             // definitely not a valid url, so assume it is a plugin name
             List<String> plugins = checkMisspelledPlugin(pluginId);
             String msg = "Unknown plugin " + pluginId;

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -44,6 +44,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
@@ -428,6 +429,14 @@ public class InstallPluginCommandTests extends ESTestCase {
         // has two colons, so it appears similar to maven coordinates
         MalformedURLException e = expectThrows(MalformedURLException.class, () -> installPlugin("://host:1234", env.v1()));
         assertTrue(e.getMessage(), e.getMessage().contains("no protocol"));
+    }
+
+    public void testFileNotMaven() throws Exception {
+        Tuple<Path, Environment> env = createEnv(fs, temp);
+        // has two colons, so it appears similar to maven coordinates
+        FileNotFoundException e = expectThrows(FileNotFoundException.class,
+            () -> installPlugin("file:C:\\path\\to\\plugin\\does_not_exists.zip", env.v1()));
+        assertTrue(e.getMessage(), e.getMessage().startsWith("C:\\path\\to\\plugin\\does_not_exists.zip"));
     }
 
     public void testUnknownPlugin() throws Exception {

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.plugins;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.cli.ExitCodes;
@@ -433,10 +434,12 @@ public class InstallPluginCommandTests extends ESTestCase {
 
     public void testFileNotMaven() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
-        // has two colons, so it appears similar to maven coordinates
-        FileNotFoundException e = expectThrows(FileNotFoundException.class,
-            () -> installPlugin("file:C:\\path\\to\\plugin\\does_not_exists.zip", env.v1()));
-        assertTrue(e.getMessage(), e.getMessage().startsWith("C:\\path\\to\\plugin\\does_not_exists.zip"));
+        String dir = randomAlphaOfLength(10) + ":" + randomAlphaOfLength(5) + "\\" + randomAlphaOfLength(5);
+        Exception e = expectThrows(Exception.class,
+            // has two colons, so it appears similar to maven coordinates
+            () -> installPlugin("file:" + dir, env.v1()));
+        assertFalse(e.getMessage(), e.getMessage().contains("maven.org"));
+        assertTrue(e.getMessage(), e.getMessage().contains(dir));
     }
 
     public void testUnknownPlugin() throws Exception {

--- a/plugins/examples/meta-plugin/build.gradle
+++ b/plugins/examples/meta-plugin/build.gradle
@@ -50,10 +50,7 @@ integTestCluster {
     distribution = 'zip'
 
     // Install the meta plugin before start.
-    /**
-     * NORELEASE Tests fail on windows, see https://github.com/elastic/elasticsearch/pull/28163
-     */
-    //setupCommand 'installMetaPlugin',
-      //      'bin/elasticsearch-plugin', 'install', 'file:' + buildZip.archivePath
+    setupCommand 'installMetaPlugin',
+            'bin/elasticsearch-plugin', 'install', 'file:' + buildZip.archivePath
 }
 check.dependsOn integTest

--- a/plugins/examples/meta-plugin/src/test/resources/rest-api-spec/test/smoke_test_plugins/10_basic.yml
+++ b/plugins/examples/meta-plugin/src/test/resources/rest-api-spec/test/smoke_test_plugins/10_basic.yml
@@ -10,6 +10,5 @@
     - do:
         nodes.info: {}
 
-# NORELEASE Tests fail on windows, see https://github.com/elastic/elasticsearch/pull/28163
-#    - match:  { nodes.$master.plugins.0.name: dummy-plugin1  }
-#    - match:  { nodes.$master.plugins.1.name: dummy-plugin2  }
+    - match:  { nodes.$master.plugins.0.name: dummy-plugin1  }
+    - match:  { nodes.$master.plugins.1.name: dummy-plugin2  }


### PR DESCRIPTION
This change makes sure that we don't detect a file path containing a ':' as
a maven coordinate (e.g.: `file:C:\path\to\zip`)