### PR TITLE
Limit the analyzed text for highlighting (#27934)

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -186,7 +186,7 @@ specific index module:
 
      The maximum number of characters that will be analyzed for a highlight request.
      This setting is only applicable when highlighting is requested on a text that was indexed without offsets or term vectors.
-     Defaults to `10000`.
+     By default this settings is unset in 6.x, defaults to `-1`.
 
  `index.max_terms_count`::
 

--- a/docs/reference/migration/migrate_6_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_6_0/analysis.asciidoc
@@ -16,6 +16,8 @@ created in 5.x.
 Highlighting a text that was indexed without offsets or term vectors,
 requires analysis of this text in memory real time during the search request.
 For large texts this analysis may take substantial amount of time and memory.
-To protect against this, the maximum number of characters that will be analyzed has been
-limited to 10000. This default limit can be changed
-for a particular index with the index setting `index.highlight.max_analyzed_offset`.
+To protect against this, the maximum number of characters that to be analyzed will be
+limited to 10000 in the next major Elastic version. For this version, by default the limit
+is not set. A deprecation warning will be issued when an analyzed text exceeds 10000.
+ The limit can be set for a particular index with the index setting
+`index.highlight.max_analyzed_offset`.

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -106,9 +106,9 @@ needs highlighting. The `plain` highlighter always uses plain highlighting.
 
 [WARNING]
 Plain highlighting for large texts may require substantial amount of time and memory.
-To protect against this, the maximum number of text characters that will be analyzed has been
-limited to 10000. This default limit can be changed
-for a particular index with the index setting `index.highlight.max_analyzed_offset`.
+To protect against this, the maximum number of text characters to be analyzed will be
+limited to 10000 in the next major Elastic version. The default limit is not set for this version,
+but can be set for a particular index with the index setting `index.highlight.max_analyzed_offset`.
 
 [[highlighting-settings]]
 ==== Highlighting Settings

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.highlight/30_max_analyzed_offset.yml
@@ -33,27 +33,24 @@ setup:
   - skip:
       version: " - 6.1.99"
       reason: index.highlight.max_analyzed_offset setting has been added in 6.2
-      features: "warnings"
   - do:
+      catch: bad_request
       search:
           index: test1
           body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "unified", "fields" : {"field1" : {}}}}
-      warnings:
-          - Deprecated large text to be analyzed for highlighting! The length has exceeded the allowed maximum of [10]. This maximum can be set by changing the [index.highlight.max_analyzed_offset] index level setting. For large texts, indexing with offsets or term vectors is recommended!
-
+  - match: { error.root_cause.0.type: "illegal_argument_exception" }
 
 ---
 "Plain highlighter on a field WITHOUT OFFSETS exceeding index.highlight.max_analyzed_offset should FAIL":
   - skip:
       version: " - 6.1.99"
       reason: index.highlight.max_analyzed_offset setting has been added in 6.2
-      features: "warnings"
   - do:
+      catch: bad_request
       search:
           index: test1
           body: {"query" : {"match" : {"field1" : "fox"}}, "highlight" : {"type" : "plain", "fields" : {"field1" : {}}}}
-      warnings:
-          - Deprecated large text to be analyzed for highlighting! The length has exceeded the allowed maximum of [10]. This maximum can be set by changing the [index.highlight.max_analyzed_offset] index level setting. For large texts, indexing with offsets or term vectors, and highlighting with unified or fvh highlighter is recommended!
+  - match: { error.root_cause.0.type: "illegal_argument_exception" }
 
 ---
 "Unified highlighter on a field WITH OFFSETS exceeding index.highlight.max_analyzed_offset should SUCCEED":
@@ -72,10 +69,9 @@ setup:
   - skip:
       version: " - 6.1.99"
       reason: index.highlight.max_analyzed_offset setting has been added in 6.2
-      features: "warnings"
   - do:
+      catch: bad_request
       search:
           index: test1
           body: {"query" : {"match" : {"field2" : "fox"}}, "highlight" : {"type" : "plain", "fields" : {"field2" : {}}}}
-      warnings:
-          - Deprecated large text to be analyzed for highlighting! The length has exceeded the allowed maximum of [10]. This maximum can be set by changing the [index.highlight.max_analyzed_offset] index level setting. For large texts, indexing with offsets or term vectors, and highlighting with unified or fvh highlighter is recommended!
+  - match: { error.root_cause.0.type: "illegal_argument_exception" }

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -126,11 +126,11 @@ public final class IndexSettings {
      * A setting describing the maximum number of characters that will be analyzed for a highlight request.
      * This setting is only applicable when highlighting is requested on a text that was indexed without
      * offsets or term vectors.
-     * The default maximum of 10000 characters is defensive as for highlighting larger texts,
-     * indexing with offsets or term vectors is recommended.
+     * This setting is defensive as for highlighting larger texts, indexing with offsets or term vectors is recommended.
+     * For 6.x the default value is not set or equals to -1.
      */
     public static final Setting<Integer> MAX_ANALYZED_OFFSET_SETTING =
-        Setting.intSetting("index.highlight.max_analyzed_offset", 10000, 1, Property.Dynamic, Property.IndexScope);
+        Setting.intSetting("index.highlight.max_analyzed_offset", -1, -1, Property.Dynamic, Property.IndexScope);
 
 
     /**
@@ -727,7 +727,13 @@ public final class IndexSettings {
      */
     public int getHighlightMaxAnalyzedOffset() { return this.maxAnalyzedOffset; }
 
-    private void setHighlightMaxAnalyzedOffset(int maxAnalyzedOffset) { this.maxAnalyzedOffset = maxAnalyzedOffset; }
+    private void setHighlightMaxAnalyzedOffset(int maxAnalyzedOffset) {
+        if (maxAnalyzedOffset < 1) {
+            throw new IllegalArgumentException(
+                "[" + MAX_ANALYZED_OFFSET_SETTING.getKey() + "] must be >= 1");
+        }
+        this.maxAnalyzedOffset = maxAnalyzedOffset;
+    }
 
     /**
      *  Returns the maximum number of terms that can be used in a Terms Query request

--- a/server/src/test/java/org/apache/lucene/search/uhighlight/CustomUnifiedHighlighterTests.java
+++ b/server/src/test/java/org/apache/lucene/search/uhighlight/CustomUnifiedHighlighterTests.java
@@ -79,7 +79,7 @@ public class CustomUnifiedHighlighterTests extends ESTestCase {
         String rawValue = Strings.arrayToDelimitedString(inputs, String.valueOf(MULTIVAL_SEP_CHAR));
         CustomUnifiedHighlighter highlighter = new CustomUnifiedHighlighter(searcher, analyzer, null,
                 new CustomPassageFormatter("<b>", "</b>", new DefaultEncoder()), locale,
-                breakIterator, rawValue, noMatchSize, 10000);
+                breakIterator, rawValue, noMatchSize, -1);
         highlighter.setFieldMatcher((name) -> "text".equals(name));
         final Snippet[] snippets =
             highlighter.highlightField("text", query, topDocs.scoreDocs[0].doc, expectedPassages.length);


### PR DESCRIPTION
- Introduce index level setting "index.highlight.max_analyzed_offset"
to control the max number of character to be analyzed for highlighting
- Make this setting to be unset by default (equal to -1)
- Issue a deprecation warning if setting is unset and analysis is required
 on a text larger than ES v 7.x max setting (10000)
- Throw IllegalArgumentException is setting is set by a user, and
analysis is required on a text larger than the user's set value.

Closes #27517