### PR TITLE
Adds metadata to rewritten aggregations

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -101,7 +101,7 @@ public abstract class AggregationBuilder
         if (rewritten == this) {
             return rewritten;
         }
-        if (getMetaData() != null && rewritten.getMetaData() == null) {
+        if (getMetaData() != null && (rewritten.getMetaData() == null || rewritten.getMetaData().isEmpty())) {
             rewritten.setMetaData(getMetaData());
         }
         AggregatorFactories.Builder rewrittenSubAggs = factoriesBuilder.rewrite(context);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -101,9 +101,7 @@ public abstract class AggregationBuilder
         if (rewritten == this) {
             return rewritten;
         }
-        if (getMetaData() != null && (rewritten.getMetaData() == null || rewritten.getMetaData().isEmpty())) {
-            rewritten.setMetaData(getMetaData());
-        }
+        rewritten.setMetaData(getMetaData());
         AggregatorFactories.Builder rewrittenSubAggs = factoriesBuilder.rewrite(context);
         rewritten.subAggregations(rewrittenSubAggs);
         return rewritten;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/FiltersAggsRewriteIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/FiltersAggsRewriteIT.java
@@ -32,6 +32,8 @@ import org.elasticsearch.search.aggregations.bucket.filter.InternalFilters;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class FiltersAggsRewriteIT extends ESSingleNodeTestCase {
 
@@ -58,10 +60,14 @@ public class FiltersAggsRewriteIT extends ESSingleNodeTestCase {
         }
         FiltersAggregationBuilder builder = new FiltersAggregationBuilder("titles", new FiltersAggregator.KeyedFilter("titleterms",
                 new WrapperQueryBuilder(bytesReference)));
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
+        builder.setMetaData(metadata);
         SearchResponse searchResponse = client().prepareSearch("test").setSize(0).addAggregation(builder).get();
         assertEquals(3, searchResponse.getHits().getTotalHits());
         InternalFilters filters = searchResponse.getAggregations().get("titles");
         assertEquals(1, filters.getBuckets().size());
         assertEquals(2, filters.getBuckets().get(0).getDocCount());
+        assertEquals(metadata, filters.getMetaData());
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregationBui
 import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator.KeyedFilter;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -123,6 +124,7 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregationBuil
     public void testRewrite() throws IOException {
         // test non-keyed filter that doesn't rewrite
         AggregationBuilder original = new FiltersAggregationBuilder("my-agg", new MatchAllQueryBuilder());
+        original.setMetaData(Collections.singletonMap(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20)));
         AggregationBuilder rewritten = original.rewrite(new QueryRewriteContext(xContentRegistry(), null, null, () -> 0L));
         assertSame(original, rewritten);
 


### PR DESCRIPTION
Previous to this change, if any filters in the filters aggregation were rewritten, the rewritten version of the FiltersAggregationBuilder would not contain the metadata form the original. This is because `AbstractAggregationBuilder.getMetadata()` returns an empty map when not metadata is set.

Closes #28170