### PR TITLE
Truncate tlog cli should assign global checkpoint

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/translog/TruncateTranslogIT.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TruncateTranslogIT.java
@@ -217,9 +217,10 @@ public class TruncateTranslogIT extends ESIntegTestCase {
         final RecoveryState replicaRecoveryState = recoveryResponse.shardRecoveryStates().get("test").stream()
             .filter(recoveryState -> recoveryState.getPrimary() == false).findFirst().get();
         assertThat(replicaRecoveryState.getIndex().toString(), replicaRecoveryState.getIndex().recoveredFileCount(), greaterThan(0));
-        // Ensure that the global checkpoint is restored from the max seqno of the last commit.
+        // Ensure that the global checkpoint and local checkpoint are restored from the max seqno of the last commit.
         final SeqNoStats seqNoStats = getSeqNoStats("test", 0);
         assertThat(seqNoStats.getGlobalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
+        assertThat(seqNoStats.getLocalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
     }
 
     public void testCorruptTranslogTruncationOfReplica() throws Exception {
@@ -322,9 +323,10 @@ public class TruncateTranslogIT extends ESIntegTestCase {
             .filter(recoveryState -> recoveryState.getPrimary() == false).findFirst().get();
         // the replica translog was disabled so it doesn't know what hte global checkpoint is and thus can't do ops based recovery
         assertThat(replicaRecoveryState.getIndex().toString(), replicaRecoveryState.getIndex().recoveredFileCount(), greaterThan(0));
-        // Ensure that the global checkpoint is restored from the max seqno of the last commit.
+        // Ensure that the global checkpoint and local checkpoint are restored from the max seqno of the last commit.
         final SeqNoStats seqNoStats = getSeqNoStats("test", 0);
         assertThat(seqNoStats.getGlobalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
+        assertThat(seqNoStats.getLocalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
     }
 
     private Set<Path> getTranslogDirs(String indexName) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/translog/TruncateTranslogIT.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TruncateTranslogIT.java
@@ -75,7 +75,6 @@ import static org.elasticsearch.common.util.CollectionUtils.iterableAsArrayList;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -150,7 +149,6 @@ public class TruncateTranslogIT extends ESIntegTestCase {
             replica.flush(new FlushRequest());
             logger.info("--> performed extra flushing on replica");
         }
-        final SeqNoStats oldSeqNoStats = getSeqNoStats("test", 0);
 
         // shut down the replica node to be tested later
         internalCluster().stopRandomNode(InternalTestCluster.nameFilter(replicaNode));
@@ -221,7 +219,7 @@ public class TruncateTranslogIT extends ESIntegTestCase {
         assertThat(replicaRecoveryState.getIndex().toString(), replicaRecoveryState.getIndex().recoveredFileCount(), greaterThan(0));
         // Ensure that the global checkpoint is restored from the max seqno of the last commit.
         final SeqNoStats seqNoStats = getSeqNoStats("test", 0);
-        assertThat(seqNoStats.getGlobalCheckpoint(), allOf(equalTo(seqNoStats.getMaxSeqNo()), equalTo(oldSeqNoStats.getMaxSeqNo())));
+        assertThat(seqNoStats.getGlobalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
     }
 
     public void testCorruptTranslogTruncationOfReplica() throws Exception {
@@ -269,7 +267,6 @@ public class TruncateTranslogIT extends ESIntegTestCase {
         final ShardId shardId = new ShardId(resolveIndex("test"), 0);
         Set<Path> translogDirs = getTranslogDirs(replicaNode, shardId);
 
-        final SeqNoStats oldSeqNoStats = getSeqNoStats("test", 0);
         // stop the cluster nodes. we don't use full restart so the node start up order will be the same
         // and shard roles will be maintained
         internalCluster().stopRandomDataNode();
@@ -327,7 +324,7 @@ public class TruncateTranslogIT extends ESIntegTestCase {
         assertThat(replicaRecoveryState.getIndex().toString(), replicaRecoveryState.getIndex().recoveredFileCount(), greaterThan(0));
         // Ensure that the global checkpoint is restored from the max seqno of the last commit.
         final SeqNoStats seqNoStats = getSeqNoStats("test", 0);
-        assertThat(seqNoStats.getGlobalCheckpoint(), allOf(equalTo(seqNoStats.getMaxSeqNo()), equalTo(oldSeqNoStats.getMaxSeqNo())));
+        assertThat(seqNoStats.getGlobalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
     }
 
     private Set<Path> getTranslogDirs(String indexName) throws IOException {


### PR DESCRIPTION
We are targeting to always have a safe index once the recovery is done. This invariant does not hold if the translog is manually truncated by users because the truncate translog cli resets the global checkpoint to unassigned. This commit assigns the global checkpoint to the max_seqno  of the last commit when truncating translog. We can only safely do it because the truncate translog command will generate a new history uuid for that shard. With a new history UUID, sequence-based recovery between that shard and other old shards will be disabled.

Relates #28181