### PR TITLE
Add information when master node left to DiscoveryNodes' shortSummary()

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -477,9 +477,13 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
             final StringBuilder summary = new StringBuilder();
             if (masterNodeChanged()) {
                 summary.append("master node changed {previous [");
-                summary.append(previousMasterNode());
+                if (previousMasterNode() != null) {
+                    summary.append(previousMasterNode());
+                }
                 summary.append("], current [");
-                summary.append(newMasterNode());
+                if (newMasterNode() != null) {
+                    summary.append(newMasterNode());
+                }
                 summary.append("]}");
             }
             if (removed()) {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -206,12 +206,14 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
     }
 
     /**
-     * Get the master node
-     *
-     * @return master node
+     * Returns the master node, or {@code null} if there is no master node
      */
+    @Nullable
     public DiscoveryNode getMasterNode() {
-        return nodes.get(masterNodeId);
+        if (masterNodeId != null) {
+            return nodes.get(masterNodeId);
+        }
+        return null;
     }
 
     /**
@@ -399,16 +401,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
             }
         }
 
-        DiscoveryNode previousMasterNode = null;
-        if (other.masterNodeId != null) {
-            previousMasterNode = other.getMasterNode();
-        }
-        DiscoveryNode newMasterNode = null;
-        if (masterNodeId != null) {
-            newMasterNode = getMasterNode();
-        }
-
-        return new Delta(previousMasterNode, newMasterNode, localNodeId, Collections.unmodifiableList(removed),
+        return new Delta(other.getMasterNode(), getMasterNode(), localNodeId, Collections.unmodifiableList(removed),
             Collections.unmodifiableList(added));
     }
 
@@ -432,8 +425,8 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
     public static class Delta {
 
         private final String localNodeId;
-        private final DiscoveryNode previousMasterNode;
-        private final DiscoveryNode newMasterNode;
+        @Nullable private final DiscoveryNode previousMasterNode;
+        @Nullable private final DiscoveryNode newMasterNode;
         private final List<DiscoveryNode> removed;
         private final List<DiscoveryNode> added;
 
@@ -451,15 +444,15 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         }
 
         public boolean masterNodeChanged() {
-            String newMasterId = (newMasterNode != null) ? newMasterNode.getEphemeralId() : null;
-            String previousMasterId = (previousMasterNode != null) ? previousMasterNode.getEphemeralId() : null;
-            return Objects.equals(newMasterId, previousMasterId) == false;
+            return Objects.equals(newMasterNode, previousMasterNode) == false;
         }
 
+        @Nullable
         public DiscoveryNode previousMasterNode() {
             return previousMasterNode;
         }
 
+        @Nullable
         public DiscoveryNode newMasterNode() {
             return newMasterNode;
         }
@@ -483,7 +476,7 @@ public class DiscoveryNodes extends AbstractDiffable<DiscoveryNodes> implements 
         public String shortSummary() {
             final StringBuilder summary = new StringBuilder();
             if (masterNodeChanged()) {
-                summary.append("master node updated {previous [");
+                summary.append("master node changed {previous [");
                 summary.append(previousMasterNode());
                 summary.append("], current [");
                 summary.append(newMasterNode());

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -140,15 +140,14 @@ public class DiscoveryNodesTests extends ESTestCase {
 
         DiscoveryNodes.Delta delta = discoNodesB.delta(discoNodesA);
 
-        if (masterB == null || Objects.equals(masterAId, masterBId)) {
+        if (Objects.equals(masterAId, masterBId)) {
             assertFalse(delta.masterNodeChanged());
             assertThat(delta.previousMasterNode(), nullValue());
             assertThat(delta.newMasterNode(), nullValue());
         } else {
             assertTrue(delta.masterNodeChanged());
-            assertThat(delta.newMasterNode().getId(), equalTo(masterBId));
-            assertThat(delta.previousMasterNode() != null ? delta.previousMasterNode().getId() : null,
-                equalTo(masterAId));
+            assertThat(delta.newMasterNode() != null ? delta.newMasterNode().getId() : null, equalTo(masterBId));
+            assertThat(delta.previousMasterNode() != null ? delta.previousMasterNode().getId() : null, equalTo(masterAId));
         }
 
         Set<DiscoveryNode> newNodes = new HashSet<>(nodesB);


### PR DESCRIPTION
This commit changes `DiscoveryNodes.Delta.shortSummary()` in order to
add information to the summary when the master node left.

Related to #28169