### PR TITLE
Introduce random-access translog

### DIFF
--- a/buildSrc/src/main/resources/checkstyle_suppressions.xml
+++ b/buildSrc/src/main/resources/checkstyle_suppressions.xml
@@ -334,7 +334,6 @@
   <suppress files="server[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]translog[/\\]BaseTranslogReader.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]translog[/\\]Translog.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]translog[/\\]TranslogReader.java" checks="LineLength" />
-  <suppress files="server[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]translog[/\\]TranslogSnapshot.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]index[/\\]translog[/\\]TranslogWriter.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]indices[/\\]IndexingMemoryController.java" checks="LineLength" />
   <suppress files="server[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]indices[/\\]IndicesService.java" checks="LineLength" />

--- a/server/src/main/java/org/elasticsearch/index/translog/BaseTranslogReader.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/BaseTranslogReader.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.translog;
 
+import com.carrotsearch.hppc.LongLongMap;
 import org.elasticsearch.common.io.stream.ByteBufferStreamInput;
 
 import java.io.IOException;
@@ -77,15 +78,30 @@ public abstract class BaseTranslogReader implements Comparable<BaseTranslogReade
         return size;
     }
 
+    /**
+     * Creates a new snapshot.
+     *
+     * @return a snapshot
+     */
     public TranslogSnapshot newSnapshot() {
         return new TranslogSnapshot(this, sizeInBytes());
+    }
+
+    /**
+     * Creates a new random-access snapshot using the specified index to access the underlying snapshot by sequence number.
+     *
+     * @param index the random-access index for this snapshot
+     * @return a random-access snapshot
+     */
+    public RandomAccessTranslogSnapshot newRandomAccessSnapshot(final LongLongMap index) {
+        return new RandomAccessTranslogSnapshot(this, sizeInBytes(), index);
     }
 
     /**
      * reads an operation at the given position and returns it. The buffer length is equal to the number
      * of bytes reads.
      */
-    protected final BufferedChecksumStreamInput checksummedStream(ByteBuffer reusableBuffer, long position, int opSize, BufferedChecksumStreamInput reuse) throws IOException {
+    final BufferedChecksumStreamInput checksumStream(ByteBuffer reusableBuffer, long position, int opSize, BufferedChecksumStreamInput reuse) throws IOException {
         final ByteBuffer buffer;
         if (reusableBuffer.capacity() >= opSize) {
             buffer = reusableBuffer;
@@ -106,7 +122,7 @@ public abstract class BaseTranslogReader implements Comparable<BaseTranslogReade
     /**
      * reads bytes at position into the given buffer, filling it.
      */
-    protected abstract  void readBytes(ByteBuffer buffer, long position) throws IOException;
+    protected abstract void readBytes(ByteBuffer buffer, long position) throws IOException;
 
     @Override
     public String toString() {

--- a/server/src/main/java/org/elasticsearch/index/translog/MultiSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/MultiSnapshot.java
@@ -66,8 +66,9 @@ final class MultiSnapshot implements Translog.Snapshot {
     public Translog.Operation next() throws IOException {
         for (; index >= 0; index--) {
             final TranslogSnapshot current = translogs[index];
-            Translog.Operation op;
-            while ((op = current.next()) != null) {
+            Translog.OperationWithPosition it;
+            while ((it = current.next()) != null) {
+                final Translog.Operation op = it.operation();
                 if (op.seqNo() == SequenceNumbers.UNASSIGNED_SEQ_NO || seenSeqNo.getAndSet(op.seqNo()) == false) {
                     return op;
                 } else {

--- a/server/src/main/java/org/elasticsearch/index/translog/RandomAccessMultiSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/RandomAccessMultiSnapshot.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.translog;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * A random-access multi-snapshot providing random access to a collection of indexed snapshots.
+ */
+final class RandomAccessMultiSnapshot implements Translog.RandomAccessSnapshot {
+
+    private final RandomAccessTranslogSnapshot[] snapshots;
+    private final Closeable onClose;
+
+    /**
+     * Creates a new random-access multi-snapshot from the specified random-access snapshots.
+     *
+     * @param snapshots the random-access snapshots to wrap in this multi-snapshot
+     * @param onClose resource to close when this snapshot is closed
+     */
+    RandomAccessMultiSnapshot(final RandomAccessTranslogSnapshot[] snapshots, final Closeable onClose) {
+        this.snapshots = snapshots;
+        this.onClose = onClose;
+    }
+
+    @Override
+    public Translog.Operation operation(final long seqNo) throws IOException {
+        for (int i = snapshots.length - 1; i >= 0; i--) {
+            final Translog.Operation operation = snapshots[i].operation(seqNo);
+            if (operation != null) {
+                return operation;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        onClose.close();
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogSnapshotReader.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogSnapshotReader.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.translog;
+
+import org.elasticsearch.common.io.Channels;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Locale;
+
+public class TranslogSnapshotReader extends BaseTranslogReader {
+
+    private final int totalOperations;
+
+    @Override
+    public int totalOperations() {
+        return totalOperations;
+    }
+
+    private final Checkpoint checkpoint;
+    protected final long length;
+
+    private final ByteBuffer reusableBuffer;
+    private long position;
+
+    public long getPosition() {
+        return position;
+    }
+
+    private int readOperations;
+
+    public int getReadOperations() {
+        return readOperations;
+    }
+
+    private BufferedChecksumStreamInput reuse;
+
+    TranslogSnapshotReader(final BaseTranslogReader reader, final long length) {
+        super(reader.generation, reader.channel, reader.path, reader.firstOperationOffset);
+        this.length = length;
+        this.totalOperations = reader.totalOperations();
+        this.checkpoint = reader.getCheckpoint();
+        this.reusableBuffer = ByteBuffer.allocate(1024);
+        readOperations = 0;
+        position = firstOperationOffset;
+        reuse = null;
+    }
+
+    protected Translog.OperationWithPosition readOperation() throws IOException {
+        return readOperationWithPosition(position);
+    }
+
+    protected Translog.Operation readOperation(final long readPosition) throws IOException {
+        return readOperationWithPosition(readPosition).operation();
+    }
+
+    private Translog.OperationWithPosition readOperationWithPosition(final long readPosition) throws IOException {
+        final int size = readSize(reusableBuffer, readPosition);
+        reuse = checksumStream(reusableBuffer, readPosition, size, reuse);
+        final Translog.Operation op = read(reuse);
+        position += size;
+        readOperations++;
+        return new Translog.OperationWithPosition(op, position);
+    }
+
+    @Override
+    public long sizeInBytes() {
+        return length;
+    }
+
+    @Override
+    Checkpoint getCheckpoint() {
+        return checkpoint;
+    }
+
+    /**
+     * reads an operation at the given position into the given buffer.
+     */
+    @Override
+    protected void readBytes(ByteBuffer buffer, long position) throws IOException {
+        if (position >= length) {
+            final String message = String.format(
+                    Locale.ROOT,
+                    "read requested at [%d] past EOF [%d] of generation [%d] at [%s]",
+                    position,
+                    length,
+                    getGeneration(),
+                    path);
+            throw new EOFException(message);
+        }
+        if (position < getFirstOperationOffset()) {
+            final String message = String.format(
+                    Locale.ROOT,
+                    "read requested at [%d] before position [%d] of first operation of generation [%d] at [%s]",
+                    position,
+                    getFirstOperationOffset(),
+                    getGeneration(),
+                    path);
+            throw new IOException(message);
+        }
+        Channels.readFromFileChannelWithEofException(channel, position, buffer);
+    }
+
+    @Override
+    public String toString() {
+        return "TranslogSnapshot{" +
+                "readOperations=" + readOperations +
+                ", position=" + position +
+                ", estimateTotalOperations=" + totalOperations +
+                ", length=" + length +
+                ", generation=" + generation +
+                ", reusableBuffer=" + reusableBuffer +
+                '}';
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogDeletionPolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogDeletionPolicyTests.java
@@ -181,7 +181,7 @@ public class TranslogDeletionPolicyTests extends ESTestCase {
             for (int ops = randomIntBetween(0, 20); ops > 0; ops--) {
                 out.reset(bytes);
                 out.writeInt(ops);
-                writer.add(new BytesArray(bytes), ops);
+                writer.add(new BytesArray(bytes), ops, position -> {});
             }
         }
         return new Tuple<>(readers, writer);


### PR DESCRIPTION
Today, the only way of reading the translog is by taking a snapshot and consuming the snapshot using a forward-only iterator. If the consumer only wants a portion of the translog, they might read large portions of the translog off of disk until they find the portion that they are looking for. If this consumer returns to the translog to later consume a following portion of the translog, they will be forced to repeatedly read the head of the translog over and over. This can be expensive, and is unfriendly to caches. Thus, it appears that some consumers of the translog would benefit from optimized access to specific operations in the translog.

For example, one use case could be recovery where the recovery source only wants to send operations above a certain sequence number to the recovery target. Yet, a snapshot covering this range of operations might be prefixed by a large number of operations that they would have to read before they can start sending to the target.

This commit introduces a random-access snapshot of the translog. This allows a consumer to read from disk only the operations that they are concerned with, ignoring all other operations. While this does not give the most optimal disk read pattern (sequential), it will be fairly close as the translog tends to be roughly ordered. To take a random-access snapshot of the translog, we lazily build per-generation indices over the open readers mapping sequence numbers to their position in the generation. For the current writer, we maintain this index as we go and this index is folded over when the writer is folded into a reader. These per-generation maps are trimmed when a reader is trimmed.

We are not attempting to make the most optimal implementation in this pull request. For example, it seems reasonable to believe that such an index could benefit from delta compression due to the rough ordering of the translog by sequence number. We will consider such optimizations in follow-ups. Additionally, we do not make any applications of the random-access translog in this changeset; we leave that for follow-ups.

