### PR TITLE
Never return null from Strings.tokenizeToStringArray

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -474,6 +474,9 @@ public class Strings {
      * @see #delimitedListToStringArray
      */
     public static String[] tokenizeToStringArray(final String s, final String delimiters) {
+        if (s == null) {
+            return EMPTY_ARRAY;
+        }
         return toStringArray(tokenizeToCollection(s, delimiters, ArrayList::new));
     }
 
@@ -536,7 +539,7 @@ public class Strings {
      */
     public static String[] delimitedListToStringArray(String str, String delimiter, String charsToDelete) {
         if (str == null) {
-            return new String[0];
+            return EMPTY_ARRAY;
         }
         if (delimiter == null) {
             return new String[]{str};

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -194,6 +194,14 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
         assertEquals("invalid IP address [" + invalidIP + "] for [" + filterSetting.getKey() + ipKey + "]", e.getMessage());
     }
 
+    public void testNull() {
+        Setting<String> filterSetting = randomFrom(IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING,
+            IndexMetaData.INDEX_ROUTING_INCLUDE_GROUP_SETTING, IndexMetaData.INDEX_ROUTING_EXCLUDE_GROUP_SETTING);
+
+        IndexMetaData.builder("test")
+            .settings(settings(Version.CURRENT).putNull(filterSetting.getKey() + "name")).numberOfShards(2).numberOfReplicas(0).build();
+    }
+
     public void testWildcardIPFilter() {
         String ipKey = randomFrom("_ip", "_host_ip", "_publish_ip");
         Setting<String> filterSetting = randomFrom(IndexMetaData.INDEX_ROUTING_REQUIRE_GROUP_SETTING,


### PR DESCRIPTION
This method has a different contract than all the other methods in this class, returning null instead of an empty array when receiving a null input. While switching over some methods from `delimitedListToStringArray` to this method `tokenizeToStringArray`, this resulted in unexpected `null`s in some places of our code.

Relates #28213