### PR TITLE
Postpone aliases resolution until execution of alias update command

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/40_postpone_aliases_resolution_to_execution.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.update_aliases/40_postpone_aliases_resolution_to_execution.yml
@@ -1,0 +1,41 @@
+---
+"Remove operation should be able to consistently see an alias created in the same request":
+  - skip:
+      version: " - 6.99.99"
+      reason: since 7.0 aliases are resolved against the cluster state we are modifying, and not in advance
+
+  - do:
+      indices.create:
+          index: test_index
+
+  - do:
+      indices.update_aliases:
+          body:
+              actions:
+                  - add:
+                      index: test_index
+                      alias: test_alias
+                  - remove:
+                      index: test_index
+                      alias: test_alias
+
+  - do:
+       indices.exists_alias:
+            name: test_alias
+  - is_false: ''
+
+  - do:
+      indices.update_aliases:
+          body:
+              actions:
+                  - add:
+                      index: test_index
+                      alias: test_alias
+                  - remove:
+                      index: test_index
+                      alias: test_alias
+
+  - do:
+       indices.exists_alias:
+            name: test_alias
+  - is_false: ''

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -1081,6 +1081,36 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
                                 customs.build(), allIndicesArray, allOpenIndicesArray, allClosedIndicesArray, aliasAndIndexLookup);
         }
 
+        /**
+         * Finds the specific index aliases that match with the specified alias directly or partially via wildcards and
+         * that point to the specified concrete index or match partially with the index via wildcards.
+         *
+         * @param alias         The names of the index alias to find, could be a pattern to resolve
+         * @param concreteIndex The concrete index, the index aliases must point to in order to be returned
+         * @return a list of concrete aliases corresponding to the given alias and concrete index
+         */
+        public List<String> findAliases(final String alias, String concreteIndex) {
+            List<String> concreteAliases = new ArrayList<>();
+            if (alias.length() == 0) {
+                return concreteAliases;
+            }
+            if (!indices.keys().contains(concreteIndex)) {
+                return concreteAliases;
+            }
+            boolean matchAllAliases = (alias.equals(ALL)) ? true : false;
+            IndexMetaData indexMetaData = indices.get(concreteIndex);
+            for (ObjectCursor<AliasMetaData> cursor : indexMetaData.getAliases().values()) {
+               final String concreteAlias = cursor.value.alias();
+                if (matchAllAliases || Regex.simpleMatch(alias, concreteAlias)) {
+                    concreteAliases.add(concreteAlias);
+                }
+            }
+            if (concreteAliases.size() > 1) {
+                Collections.sort(concreteAliases);
+            }
+            return concreteAliases;
+        }
+
         public static String toXContent(MetaData metaData) throws IOException {
             XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
             builder.startObject();


### PR DESCRIPTION
Currently aliases' names are resolved in advance against the cluster state
at the point of time before executing an alias update command command.
This means that if an alias was not there when we started this command,
but created as a part of this command, the subsequent remove operation within
the same command on the same alias will not be able to find this alias,
and will not be executed.

This is not correct as there is no correlation between the cluster state
that the alias resolution is run on and the cluster state which actually serves
as base for the commands execution.
On top of this, the current situation doesn't account
for relationship between commands.

This commit postpones aliases' wild card resolution
until we execute the commands on the cluster state thread,
so the resolution is run on the cluster state
we are modifying.

Closes #27689