### PR TITLE
[Docs] Clarify numeric datatype ranges

### DIFF
--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -8,9 +8,9 @@ The following numeric types are supported:
 `integer`::      A signed 32-bit integer with a minimum value of +-2^31^+ and a maximum value of +2^31^-1+.
 `short`::        A signed 16-bit integer with a minimum value of +-32,768+ and a maximum value of +32,767+.
 `byte`::         A signed 8-bit integer with a minimum value of +-128+ and a maximum value of +127+.
-`double`::       A double-precision 64-bit IEEE 754 floating point number.
-`float`::        A single-precision 32-bit IEEE 754 floating point number.
-`half_float`::   A half-precision 16-bit IEEE 754 floating point number.
+`double`::       A double-precision 64-bit IEEE 754 floating point number, restricted to finite values.
+`float`::        A single-precision 32-bit IEEE 754 floating point number, restricted to finite values.
+`half_float`::   A half-precision 16-bit IEEE 754 floating point number, restricted to finite values.
 `scaled_float`:: A floating point number that is backed by a `long`, scaled by a fixed `double` scaling factor.
 
 Below is an example of configuring a mapping with numeric fields:


### PR DESCRIPTION
Since #25826 we reject infinite values for float, double and half_float
datatypes. This change adds this restriction to the documentation for the
supported datatypes.

Closes #27653