### PR TITLE
Reload secret store

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
@@ -19,12 +19,11 @@
 
 package org.elasticsearch.action.admin.cluster.settings;
 
-import com.google.common.base.Strings;
-
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
@@ -62,6 +62,9 @@ public class RestClusterUpdateSettingsAction extends BaseRestHandler {
         if (source.containsKey("persistent")) {
             clusterUpdateSettingsRequest.persistentSettings((Map) source.get("persistent"));
         }
+        if (source.containsKey("secretStorePassword")) {
+            clusterUpdateSettingsRequest.secretStorePassword((String) source.get("secretStorePassword"));
+        }
 
         return channel -> client.admin().cluster().updateSettings(clusterUpdateSettingsRequest,
                 new AcknowledgedRestListener<ClusterUpdateSettingsResponse>(channel) {


### PR DESCRIPTION
This is another take on the 'reloadable keystore' issue, after a discussion with @simonw .
I will link to https://github.com/elastic/elasticsearch/pull/28001 for consistency, although they are independent from each other.

This change adds the `secretStorePassword` field to the `ClusterUpdateSettingsRequest` (in addition to the `persistent` and `transient` existing ones). If this field is present on the request, the `TransportClusterUpdateSettingsAction` will send a newly defined node transport action to **each** node (conveying the secret store password), **after** the cluster state has been acknowledged. The newly defined node action handler has the responsibility to 'reinitialize' the components with 'reloadabale' `SecureSetting`s (this latter part is not included in this PR, the handler only re-opens and decrypts the `KeyStoreWrapper`). Note that there is a slim delay between plain text settings push (via cluster state apply) and secure settings re-read (via node actions). It works on simple manual tests, but it is sketchy and does not have tests, see below.

The rationale behind this was that it is simpler to have a one-stop API to update all cluster settings and, more importantly, to account for the case of dependencies between clear text and secure settings. If this is the case, one would require transactional update of all settings to prevent inconsistencies.
Nevertheless the *semantics for the secure settings update is different*: you don't specify values or keys and you don't get them in response either; what you should get back in response is an acknowledgement from each node, coupled with some aggregation safety check that all settings on all the nodes are consistent (same key-value hashes). Moreover, true transactional setting updates would require pushing the decrypt password via the cluster state update, together with all the other settings (I haven't given much thought on this). Given that we don't allow dependencies between 'persistent' and 'transient' it might be easier to forbid dependencies between secure and plain text ones in a similar fashion.
For these reasons, and after getting through with this implementation sketch, **I think this API should stand alone as a specialization of the `TransportNodesAction`, leaving `TransportClusterUpdateSettingsAction` to handle only clear text settings. Dependencies between plain text and secure settings should not be permitted. Transactional setting updates are not available across plain text and secure settings. This proposed API would be similar to a node reinit/refresh/restart flavor.**

What do you think?

 