### PR TITLE
Tests: Decrease log level for adding a header value

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestClient.java
@@ -165,7 +165,7 @@ public class ClientYamlTestClient {
         Header[] requestHeaders = new Header[headers.size()];
         int index = 0;
         for (Map.Entry<String, String> header : headers.entrySet()) {
-            logger.info("Adding header {} with value {}", header.getKey(), header.getValue());
+            logger.debug("Adding header {} with value {}", header.getKey(), header.getValue());
             requestHeaders[index++] = new BasicHeader(header.getKey(), header.getValue());
         }
 


### PR DESCRIPTION
This logging message adds considerable noise to many REST tests, if you
are using something HTTP basic auth in every API call or set any other custom
header.

It should go into debug level.
