### PR TITLE
Add a note regarding rescore and sort

### DIFF
--- a/docs/reference/search/request/rescore.asciidoc
+++ b/docs/reference/search/request/rescore.asciidoc
@@ -15,7 +15,8 @@ Currently the rescore API has only one implementation: the query
 rescorer, which uses a query to tweak the scoring. In the future,
 alternative rescorers may be made available, for example, a pair-wise rescorer.
 
-NOTE: the `rescore` phase is not executed when <<search-request-sort,`sort`>> is used.
+NOTE: An error will be thrown if an explicit <<search-request-sort,`sort`>> (other than `_score`)
+is provided with a `rescore` query.
 
 NOTE: when exposing pagination to your users, you should not change
 `window_size` as you step through each page (by passing different


### PR DESCRIPTION
This change adds a note to the rescorer docs indicating that using `rescore` and `sort` in the same request will throw an error in 6x.

Closes #28250