### PR TITLE
Discontinue archiving broken cluster settings

### DIFF
--- a/docs/reference/migration/migrate_7_0/cluster.asciidoc
+++ b/docs/reference/migration/migrate_7_0/cluster.asciidoc
@@ -14,3 +14,9 @@ primary shards of the opened index to be allocated.
 
 ==== Shard preferences `_primary`, `_primary_first`, `_replica`, and `_replica_first` are removed
 These shard preferences are removed in favour of the `_prefer_nodes` and `_only_nodes` preferences.
+
+==== Discontinue archiving broken cluster settings
+We will no longer archive unknown or invalid cluster settings (prepending "archived." to a broken setting's name).
+Instead, we will fail to recover a cluster state with broken cluster settings.
+The solution for users in an upgrade case would be to rollback to the previous version,
+address the settings that would be unknown or invalid in the next major version, and then proceed with the upgrade.

--- a/server/src/main/java/org/elasticsearch/gateway/Gateway.java
+++ b/server/src/main/java/org/elasticsearch/gateway/Gateway.java
@@ -137,27 +137,25 @@ public class Gateway extends AbstractComponent {
             }
         }
         final ClusterSettings clusterSettings = clusterService.getClusterSettings();
-        metaDataBuilder.persistentSettings(
-            clusterSettings.archiveUnknownOrInvalidSettings(
-                metaDataBuilder.persistentSettings(),
-                e -> logUnknownSetting("persistent", e),
-                (e, ex) -> logInvalidSetting("persistent", e, ex)));
-        metaDataBuilder.transientSettings(
-            clusterSettings.archiveUnknownOrInvalidSettings(
-                metaDataBuilder.transientSettings(),
-                e -> logUnknownSetting("transient", e),
-                (e, ex) -> logInvalidSetting("transient", e, ex)));
+        clusterSettings.checkUnknownOrInvalidSettings(
+            metaDataBuilder.persistentSettings(),
+            e -> logUnknownSetting("persistent", e),
+            (e, ex) -> logInvalidSetting("persistent", e, ex));
+        clusterSettings.checkUnknownOrInvalidSettings(
+            metaDataBuilder.transientSettings(),
+            e -> logUnknownSetting("transient", e),
+            (e, ex) -> logInvalidSetting("transient", e, ex));
         ClusterState.Builder builder = clusterService.newClusterStateBuilder();
         builder.metaData(metaDataBuilder);
         listener.onSuccess(builder.build());
     }
 
     private void logUnknownSetting(String settingType, Map.Entry<String, String> e) {
-        logger.warn("ignoring unknown {} setting: [{}] with value [{}]; archiving", settingType, e.getKey(), e.getValue());
+        logger.warn("unknown {} setting: [{}] with value [{}]", settingType, e.getKey(), e.getValue());
     }
 
     private void logInvalidSetting(String settingType, Map.Entry<String, String> e, IllegalArgumentException ex) {
-        logger.warn(() -> new ParameterizedMessage("ignoring invalid {} setting: [{}] with value [{}]; archiving",
+        logger.warn(() -> new ParameterizedMessage("invalid {} setting: [{}] with value [{}]",
                     settingType, e.getKey(), e.getValue()), ex);
     }
 


### PR DESCRIPTION
Currently unknown or invalid cluster settings get archived.

For a better user experience, we stop archving broken cluster settings.
Instead, we will fail to recover the cluster state.
The solution for users in an upgrade case would be to rollback
to the previous version, address the settings that would be unknown
or  invalid the next major version, and then proceed with the upgrade.

Closes #28026