### PR TITLE
Fix third-party audit tasks on JDK 8

### DIFF
--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -75,11 +75,16 @@ thirdPartyAudit.excludes = [
   'software.amazon.ion.system.IonSystemBuilder',
   'software.amazon.ion.system.IonTextWriterBuilder',
   'software.amazon.ion.system.IonWriterBuilder',
-  'javax.xml.bind.DatatypeConverter',
-  'javax.xml.bind.JAXBContext',
   'javax.servlet.ServletContextEvent', 
   'javax.servlet.ServletContextListener', 
   'org.apache.avalon.framework.logger.Logger', 
   'org.apache.log.Hierarchy', 
   'org.apache.log.Logger',
 ]
+
+if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+  thirdPartyAudit.excludes += [
+    'javax.xml.bind.DatatypeConverter',
+    'javax.xml.bind.JAXBContext'
+  ]
+}

--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -495,17 +495,6 @@ thirdPartyAudit.excludes = [
   'de.l3s.boilerpipe.document.TextDocument',
   'de.l3s.boilerpipe.extractors.DefaultExtractor',
   'de.l3s.boilerpipe.sax.BoilerpipeHTMLContentHandler',
-  'javax.activation.ActivationDataFlavor',
-  'javax.activation.CommandMap',
-  'javax.activation.DataContentHandler',
-  'javax.activation.DataHandler',
-  'javax.activation.DataSource',
-  'javax.activation.FileDataSource',
-  'javax.activation.MailcapCommandMap',
-  'javax.xml.bind.DatatypeConverter',
-  'javax.xml.bind.JAXBContext',
-  'javax.xml.bind.JAXBElement',
-  'javax.xml.bind.Unmarshaller',
   'javax.mail.BodyPart',
   'javax.mail.Header',
   'javax.mail.Message$RecipientType',
@@ -2102,3 +2091,19 @@ thirdPartyAudit.excludes = [
   'ucar.nc2.Variable',
   'ucar.nc2.dataset.NetcdfDataset'
 ]
+
+if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+  thirdPartyAudit.excludes += [
+    'javax.activation.ActivationDataFlavor',
+    'javax.activation.CommandMap',
+    'javax.activation.DataContentHandler',
+    'javax.activation.DataHandler',
+    'javax.activation.DataSource',
+    'javax.activation.FileDataSource',
+    'javax.activation.MailcapCommandMap',
+    'javax.xml.bind.DatatypeConverter',
+    'javax.xml.bind.JAXBContext',
+    'javax.xml.bind.JAXBElement',
+    'javax.xml.bind.Unmarshaller'
+  ]
+}

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -353,7 +353,6 @@ thirdPartyAudit.excludes = [
   'io.netty.handler.stream.ChunkedWriteHandler',
   'io.netty.util.concurrent.GlobalEventExecutor',
   'io.netty.util.ReferenceCountUtil',
-  'javax.xml.bind.annotation.adapters.HexBinaryAdapter',
   'javax.ws.rs.core.Context',
   'javax.ws.rs.core.MediaType', 
   'javax.ws.rs.core.MultivaluedMap', 
@@ -568,3 +567,7 @@ thirdPartyAudit.excludes = [
   'com.squareup.okhttp.Response',
   'com.squareup.okhttp.ResponseBody'
 ]
+
+if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+  thirdPartyAudit.excludes += ['javax.xml.bind.annotation.adapters.HexBinaryAdapter']
+}


### PR DESCRIPTION
This one is interesting. The third party audit task runs inside the Gradle JVM. This means that if Gradle is started on JDK 8, the third party audit tasks will fail as a result of the changes to support building Elasticsearch with the JDK 9 compiler. This commit reverts the third party audit changes to support running this task when Gradle is started with JDK 8.

Relates #28252
