### PR TITLE
[Docs] Move callouts in range.asciidoc

### DIFF
--- a/docs/reference/mapping/types/range.asciidoc
+++ b/docs/reference/mapping/types/range.asciidoc
@@ -47,6 +47,11 @@ PUT range_index/_doc/1
 --------------------------------------------------
 //CONSOLE
 
+<1> `date_range` types accept the same field parameters defined by the <<date, `date`>> type.
+<2> Example indexing a meeting with 10 to 20 attendees.
+<3> Date ranges accept the same format as described in <<ranges-on-dates, date range queries>>.
+<4> Example date range using date time stamp. This also accepts <<date-math, date math>> formatting, or "now" for system time.
+
 The following is an example of a <<query-dsl-term-query, term query>> on the `integer_range` field named "expected_attendees".
 
 [source,js]
@@ -102,7 +107,6 @@ The result produced by the above query.
 --------------------------------------------------
 // TESTRESPONSE[s/"took": 13/"took" : $body.took/]
 
-
 The following is an example of a `date_range` query over the `date_range` field named "time_frame".
 
 [source,js]
@@ -111,10 +115,10 @@ GET range_index/_search
 {
   "query" : {
     "range" : {
-      "time_frame" : { <5>
+      "time_frame" : { <1>
         "gte" : "2015-10-31",
         "lte" : "2015-11-01",
-        "relation" : "within" <6>
+        "relation" : "within" <2>
       }
     }
   }
@@ -123,12 +127,8 @@ GET range_index/_search
 // CONSOLE
 // TEST[setup:range_index]
 
-<1> `date_range` types accept the same field parameters defined by the <<date, `date`>> type.
-<2> Example indexing a meeting with 10 to 20 attendees.
-<3> Date ranges accept the same format as described in <<ranges-on-dates, date range queries>>.
-<4> Example date range using date time stamp. This also accepts <<date-math, date math>> formatting, or "now" for system time.
-<5> Range queries work the same as described in <<query-dsl-range-query, range query>>.
-<6> Range queries over range <<mapping-types, fields>> support a `relation` parameter which can be one of `WITHIN`, `CONTAINS`,
+<1> Range queries work the same as described in <<query-dsl-range-query, range query>>.
+<2> Range queries over range <<mapping-types, fields>> support a `relation` parameter which can be one of `WITHIN`, `CONTAINS`,
     `INTERSECTS` (default).
 
 This query produces a similar result:


### PR DESCRIPTION
Currently the callouts for this section are below all the examples, making it
harder to relate them to the snippets. Instead they should be moved close to the
examples.