### PR TITLE
Simplify RankEvalResponse output

### DIFF
--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalResponse.java
@@ -112,7 +112,6 @@ public class RankEvalResponse extends ActionResponse implements ToXContentObject
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.startObject("rank_eval");
         builder.field("quality_level", evaluationResult);
         builder.startObject("details");
         for (String key : details.keySet()) {
@@ -125,7 +124,6 @@ public class RankEvalResponse extends ActionResponse implements ToXContentObject
             ElasticsearchException.generateFailureXContent(builder, params, failures.get(key), false);
             builder.endObject();
         }
-        builder.endObject();
         builder.endObject();
         builder.endObject();
         return builder;

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalResponseTests.java
@@ -92,23 +92,21 @@ public class RankEvalResponseTests extends ESTestCase {
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         String xContent = response.toXContent(builder, ToXContent.EMPTY_PARAMS).bytes().utf8ToString();
         assertEquals(("{" +
-                "    \"rank_eval\": {" +
-                "        \"quality_level\": 0.123," +
-                "        \"details\": {" +
-                "            \"coffee_query\": {" +
-                "                \"quality_level\": 0.1," +
-                "                \"unknown_docs\": [{\"_index\":\"index\",\"_id\":\"456\"}]," +
-                "                \"hits\":[{\"hit\":{\"_index\":\"index\",\"_type\":\"\",\"_id\":\"123\",\"_score\":1.0}," +
-                "                           \"rating\":5}," +
-                "                          {\"hit\":{\"_index\":\"index\",\"_type\":\"\",\"_id\":\"456\",\"_score\":1.0}," +
-                "                           \"rating\":null}" +
-                "                         ]" +
-                "            }" +
-                "        }," +
-                "        \"failures\": {" +
-                "            \"beer_query\": {" +
-                "                \"error\": \"ParsingException[someMsg]\"" +
-                "            }" +
+                "    \"quality_level\": 0.123," +
+                "    \"details\": {" +
+                "        \"coffee_query\": {" +
+                "            \"quality_level\": 0.1," +
+                "            \"unknown_docs\": [{\"_index\":\"index\",\"_id\":\"456\"}]," +
+                "            \"hits\":[{\"hit\":{\"_index\":\"index\",\"_type\":\"\",\"_id\":\"123\",\"_score\":1.0}," +
+                "                       \"rating\":5}," +
+                "                      {\"hit\":{\"_index\":\"index\",\"_type\":\"\",\"_id\":\"456\",\"_score\":1.0}," +
+                "                       \"rating\":null}" +
+                "                     ]" +
+                "        }" +
+                "    }," +
+                "    \"failures\": {" +
+                "        \"beer_query\": {" +
+                "            \"error\": \"ParsingException[someMsg]\"" +
                 "        }" +
                 "    }" +
                 "}").replaceAll("\\s+", ""), xContent);

--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/10_basic.yml
@@ -64,27 +64,27 @@
           "metric" : { "precision": { "ignore_unlabeled" : true }}
         }
 
-  - match: { rank_eval.quality_level: 1}
-  - match: { rank_eval.details.amsterdam_query.quality_level: 1.0}
-  - match: { rank_eval.details.amsterdam_query.unknown_docs:  [ {"_index": "foo", "_id": "doc4"}]}
-  - match: { rank_eval.details.amsterdam_query.metric_details: {"relevant_docs_retrieved": 2, "docs_retrieved": 2}}
+  - match: { quality_level: 1}
+  - match: { details.amsterdam_query.quality_level: 1.0}
+  - match: { details.amsterdam_query.unknown_docs:  [ {"_index": "foo", "_id": "doc4"}]}
+  - match: { details.amsterdam_query.metric_details: {"relevant_docs_retrieved": 2, "docs_retrieved": 2}}
   
-  - length: { rank_eval.details.amsterdam_query.hits: 3}
-  - match: { rank_eval.details.amsterdam_query.hits.0.hit._id:  "doc2"}
-  - match: { rank_eval.details.amsterdam_query.hits.0.rating: 1}
-  - match: { rank_eval.details.amsterdam_query.hits.1.hit._id:  "doc3"}
-  - match: { rank_eval.details.amsterdam_query.hits.1.rating: 1}
-  - match: { rank_eval.details.amsterdam_query.hits.2.hit._id:  "doc4"}
-  - is_false: rank_eval.details.amsterdam_query.hits.2.rating
+  - length: { details.amsterdam_query.hits: 3}
+  - match: { details.amsterdam_query.hits.0.hit._id:  "doc2"}
+  - match: { details.amsterdam_query.hits.0.rating: 1}
+  - match: { details.amsterdam_query.hits.1.hit._id:  "doc3"}
+  - match: { details.amsterdam_query.hits.1.rating: 1}
+  - match: { details.amsterdam_query.hits.2.hit._id:  "doc4"}
+  - is_false: details.amsterdam_query.hits.2.rating
   
-  - match: { rank_eval.details.berlin_query.quality_level: 1.0}
-  - match: { rank_eval.details.berlin_query.unknown_docs:  [ {"_index": "foo", "_id": "doc4"}]}
-  - match: { rank_eval.details.berlin_query.metric_details: {"relevant_docs_retrieved": 1, "docs_retrieved": 1}}
-  - length: { rank_eval.details.berlin_query.hits: 2}
-  - match: { rank_eval.details.berlin_query.hits.0.hit._id: "doc1" }
-  - match: { rank_eval.details.berlin_query.hits.0.rating: 1}
-  - match: { rank_eval.details.berlin_query.hits.1.hit._id: "doc4" }
-  - is_false: rank_eval.details.berlin_query.hits.1.rating 
+  - match: { details.berlin_query.quality_level: 1.0}
+  - match: { details.berlin_query.unknown_docs:  [ {"_index": "foo", "_id": "doc4"}]}
+  - match: { details.berlin_query.metric_details: {"relevant_docs_retrieved": 1, "docs_retrieved": 1}}
+  - length: { details.berlin_query.hits: 2}
+  - match: { details.berlin_query.hits.0.hit._id: "doc1" }
+  - match: { details.berlin_query.hits.0.rating: 1}
+  - match: { details.berlin_query.hits.1.hit._id: "doc4" }
+  - is_false: details.berlin_query.hits.1.rating 
 
 ---
 "Mean Reciprocal Rank":
@@ -152,14 +152,14 @@
         }
 
 # average is (1/3 + 1/2)/2 = 5/12 ~ 0.41666666666666663
-  - gt: {rank_eval.quality_level: 0.416}
-  - lt: {rank_eval.quality_level: 0.417}
-  - gt: {rank_eval.details.amsterdam_query.quality_level: 0.333}
-  - lt: {rank_eval.details.amsterdam_query.quality_level: 0.334}
-  - match: {rank_eval.details.amsterdam_query.metric_details: {"first_relevant": 3}}
-  - match: {rank_eval.details.amsterdam_query.unknown_docs:  [ {"_index": "foo", "_id": "doc2"},
+  - gt: {quality_level: 0.416}
+  - lt: {quality_level: 0.417}
+  - gt: {details.amsterdam_query.quality_level: 0.333}
+  - lt: {details.amsterdam_query.quality_level: 0.334}
+  - match: {details.amsterdam_query.metric_details: {"first_relevant": 3}}
+  - match: {details.amsterdam_query.unknown_docs:  [ {"_index": "foo", "_id": "doc2"},
                                                                {"_index": "foo", "_id": "doc3"} ]}
-  - match: {rank_eval.details.berlin_query.quality_level: 0.5}
-  - match: {rank_eval.details.berlin_query.metric_details: {"first_relevant": 2}}
-  - match: {rank_eval.details.berlin_query.unknown_docs:  [ {"_index": "foo", "_id": "doc1"}]}
+  - match: {details.berlin_query.quality_level: 0.5}
+  - match: {details.berlin_query.metric_details: {"first_relevant": 2}}
+  - match: {details.berlin_query.unknown_docs:  [ {"_index": "foo", "_id": "doc1"}]}
 

--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/20_dcg.yml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/20_dcg.yml
@@ -69,11 +69,11 @@
           "metric" : { "dcg": {}}
         }
 
-  - gt: {rank_eval.quality_level: 13.848263 }
-  - lt: {rank_eval.quality_level: 13.848264 }
-  - gt: {rank_eval.details.dcg_query.quality_level: 13.848263}
-  - lt: {rank_eval.details.dcg_query.quality_level: 13.848264}
-  - match: {rank_eval.details.dcg_query.unknown_docs: [ ]}
+  - gt: {quality_level: 13.848263 }
+  - lt: {quality_level: 13.848264 }
+  - gt: {details.dcg_query.quality_level: 13.848263}
+  - lt: {details.dcg_query.quality_level: 13.848264}
+  - match: {details.dcg_query.unknown_docs: [ ]}
 
 # reverse the order in which the results are returned (less relevant docs first)
 
@@ -96,11 +96,11 @@
           "metric" : { "dcg": { }}
         }
 
-  - gt: {rank_eval.quality_level: 10.299674}
-  - lt: {rank_eval.quality_level: 10.299675}
-  - gt: {rank_eval.details.dcg_query_reverse.quality_level: 10.299674}
-  - lt: {rank_eval.details.dcg_query_reverse.quality_level: 10.299675}
-  - match: {rank_eval.details.dcg_query_reverse.unknown_docs: [ ]}
+  - gt: {quality_level: 10.299674}
+  - lt: {quality_level: 10.299675}
+  - gt: {details.dcg_query_reverse.quality_level: 10.299674}
+  - lt: {details.dcg_query_reverse.quality_level: 10.299675}
+  - match: {details.dcg_query_reverse.unknown_docs: [ ]}
 
 # if we mix both, we should get the average
   
@@ -134,11 +134,11 @@
           "metric" : { "dcg": { }}
         }
 
-  - gt: {rank_eval.quality_level: 12.073969}
-  - lt: {rank_eval.quality_level: 12.073970}
-  - gt: {rank_eval.details.dcg_query.quality_level: 13.848263}
-  - lt: {rank_eval.details.dcg_query.quality_level: 13.848264}
-  - match: {rank_eval.details.dcg_query.unknown_docs: [ ]}
-  - gt: {rank_eval.details.dcg_query_reverse.quality_level: 10.299674}
-  - lt: {rank_eval.details.dcg_query_reverse.quality_level: 10.299675}
-  - match: {rank_eval.details.dcg_query_reverse.unknown_docs: [ ]}
+  - gt: {quality_level: 12.073969}
+  - lt: {quality_level: 12.073970}
+  - gt: {details.dcg_query.quality_level: 13.848263}
+  - lt: {details.dcg_query.quality_level: 13.848264}
+  - match: {details.dcg_query.unknown_docs: [ ]}
+  - gt: {details.dcg_query_reverse.quality_level: 10.299674}
+  - lt: {details.dcg_query_reverse.quality_level: 10.299675}
+  - match: {details.dcg_query_reverse.unknown_docs: [ ]}

--- a/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/30_failures.yml
+++ b/modules/rank-eval/src/test/resources/rest-api-spec/test/rank_eval/30_failures.yml
@@ -34,9 +34,9 @@
           "metric" : { "precision": { "ignore_unlabeled" : true }}
         }
 
-  - match: { rank_eval.quality_level: 1}
-  - match: { rank_eval.details.amsterdam_query.quality_level: 1.0}
-  - match: { rank_eval.details.amsterdam_query.unknown_docs:  [ ]}
-  - match: { rank_eval.details.amsterdam_query.metric_details: {"relevant_docs_retrieved": 1, "docs_retrieved": 1}}
+  - match: { quality_level: 1}
+  - match: { details.amsterdam_query.quality_level: 1.0}
+  - match: { details.amsterdam_query.unknown_docs:  [ ]}
+  - match: { details.amsterdam_query.metric_details: {"relevant_docs_retrieved": 1, "docs_retrieved": 1}}
 
-  - is_true: rank_eval.failures.invalid_query
+  - is_true: failures.invalid_query

--- a/qa/smoke-test-rank-eval-with-mustache/src/test/resources/rest-api-spec/test/rank-eval/30_template.yml
+++ b/qa/smoke-test-rank-eval-with-mustache/src/test/resources/rest-api-spec/test/rank-eval/30_template.yml
@@ -67,6 +67,6 @@
           "metric" : { "precision": { }}
         }
 
-  - match: {rank_eval.quality_level: 0.5833333333333333}
-  - match: {rank_eval.details.berlin_query.unknown_docs.0._id:  "doc4"}
-  - match: {rank_eval.details.amsterdam_query.unknown_docs.0._id:  "doc4"}
+  - match: {quality_level: 0.5833333333333333}
+  - match: {details.berlin_query.unknown_docs.0._id:  "doc4"}
+  - match: {details.amsterdam_query.unknown_docs.0._id:  "doc4"}


### PR DESCRIPTION
Currenty the rest response of the ranking evaluation API wraps all its output
inside an enclosing `rank_eval` object. This is redundant and doesn't 
provide any other useful information, so this change removes it.