### PR TITLE
Skip rolling upgrades for buggy cgroup2 handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,11 @@ task verifyVersions {
  */
 allprojects {
   ext.bwc_tests_enabled = true
+  /*
+   * Versions of Elasticsearch 5.1.1 through 5.3.0 inclusive did not start on versions of Linux with cgroups v2 enabled (kernel >= 4.5).
+   * This property is provided to all projects that need to check conditionally if they should skip a BWC test task.
+   */
+  ext.cgroupsV2Enabled = Os.isFamily(Os.FAMILY_UNIX) && "mount".execute().text.readLines().any { it =~ /.*type cgroup2.*/ }
 }
 
 task verifyBwcTestsEnabled {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/Version.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/Version.groovy
@@ -81,4 +81,15 @@ public class Version {
     public boolean after(String compareTo) {
         return id > fromString(compareTo).id
     }
+
+    /**
+     * Elasticsearch versions 5.1.1 through 5.3.0 fail to start on versions of Linux that support cgroups v2 (kernel >= 4.5). This is a
+     * convenience method for checking if the current version falls into that range.
+     *
+     * @return true if the version is one impacted by the cgroups v2 bug, otherwise false
+     */
+    public boolean isVersionBrokenIfCgroupsV2Enabled() {
+        return onOrAfter("5.1.1") && onOrBefore("5.3.0")
+    }
+
 }

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-import org.elasticsearch.gradle.test.RestIntegTestTask
+
 import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'elasticsearch.standalone-test'
 
@@ -29,6 +30,10 @@ task bwcTest {
 }
 
 for (Version version : wireCompatVersions) {
+  if (project.cgroupsV2Enabled && version.isVersionBrokenIfCgroupsV2Enabled()) {
+    continue
+  }
+
   String baseName = "v${version}"
 
   Task oldClusterTest = tasks.create(name: "${baseName}#oldClusterTest", type: RestIntegTestTask) {


### PR DESCRIPTION
Versions 5.1.1 to 5.3.0 of Elasticsearch had a problem where these versions did not handle new kernels properly due to improper handling of cgroup v2. On Linux kernels that support cgroup2 and the unified hierarchy is mounted, Elasticsearch would never start. This means rolling upgrade tests on such systems will never succeed. This commit skips these tests on OS that have the unified cgroup v2 hierarchy.

Relates #26968, relates #23493
