### PR TITLE
remove recommended junit intellij setting change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,8 +126,8 @@ Alternatively, `idea.no.launcher=true` can be set in the
 [`idea.properties`](https://www.jetbrains.com/help/idea/file-idea-properties.html)
 file which can be accessed under Help > Edit Custom Properties (this will require a
 restart of IDEA). For IDEA 2017.3 and above, in addition to the JVM option, you will need to go to
-`Run->Edit Configurations->...->Defaults->JUnit` and change the value for the `Shorten command line` setting from
-`user-local default: none` to `classpath file`. You may also need to [remove `ant-javafx.jar` from your
+`Run->Edit Configurations->...->Defaults->JUnit` and verify that the `Shorten command line` setting is set to
+`user-local default: none`. You may also need to [remove `ant-javafx.jar` from your
 classpath](https://github.com/elastic/elasticsearch/issues/14348) if that is
 reported as a source of jar hell.
 


### PR DESCRIPTION
The "Shorten Command Line" setting in Intellij's JUnit test configuration
was recommended to change to `classpath file`. This setting has been
causing issues with JDK9 where some modules were not being found at
runtime. This PR removes the recommendation to change this setting and
instead asks that users verify that it is set to `user-local default:none`.

recommended configuration screenshot:
<img width="908" alt="screen shot 2018-01-17 at 2 40 46 pm" src="https://user-images.githubusercontent.com/388837/35071387-5c3609a8-fb95-11e7-8924-f765f7fe102c.png">
