### PR TITLE
Implement socket and server ChannelContexts

### DIFF
--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/AbstractNioChannel.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/AbstractNioChannel.java
@@ -52,7 +52,6 @@ public abstract class AbstractNioChannel<S extends SelectableChannel & NetworkCh
     private final CompletableFuture<Void> closeContext = new CompletableFuture<>();
     private final ESSelector selector;
     private SelectionKey selectionKey;
-    private ChannelContext context;
 
     AbstractNioChannel(S socketChannel, ESSelector selector) throws IOException {
         this.socketChannel = socketChannel;
@@ -122,11 +121,7 @@ public abstract class AbstractNioChannel<S extends SelectableChannel & NetworkCh
 
     @Override
     public void close() {
-        context.closeChannel();
-    }
-
-    void setContext(ChannelContext context) {
-        this.context = context;
+        getContext().closeChannel();
     }
 
     // Package visibility for testing

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/AcceptorEventHandler.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/AcceptorEventHandler.java
@@ -67,7 +67,7 @@ public class AcceptorEventHandler extends EventHandler {
         ChannelFactory<?, ?> channelFactory = nioServerChannel.getChannelFactory();
         SocketSelector selector = selectorSupplier.get();
         NioSocketChannel nioSocketChannel = channelFactory.acceptNioChannel(nioServerChannel, selector);
-        nioServerChannel.getAcceptContext().accept(nioSocketChannel);
+        nioServerChannel.getContext().acceptChannel(nioSocketChannel);
     }
 
     /**

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/ChannelContext.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/ChannelContext.java
@@ -30,5 +30,16 @@ public interface ChannelContext {
      */
     void closeFromSelector() throws IOException;
 
-    default void handleException(Exception e) {}
+    /**
+     * Schedules a channel to be closed by the selector event loop with which it is registered.
+     *
+     * If the channel is open and the state can be transitioned to closed, the close operation will
+     * be scheduled with the event loop.
+     *
+     * Depending on the underlying protocol of the channel, a close operation might simply close the socket
+     * channel or may involve reading and writing messages.
+     */
+    void closeChannel();
+
+    void handleException(Exception e);
 }

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/ChannelContext.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/ChannelContext.java
@@ -20,52 +20,8 @@
 package org.elasticsearch.nio;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.function.BiConsumer;
 
-/**
- * This context should implement the specific logic for a channel. When a channel receives a notification
- * that it is ready to perform certain operations (read, write, etc) the {@link ChannelContext} will be
- * called. This context will need to implement all protocol related logic. Additionally, if any special
- * close behavior is required, it should be implemented in this context.
- *
- * The only methods of the context that should ever be called from a non-selector thread are
- * {@link #closeChannel()} and {@link #sendMessage(ByteBuffer[], BiConsumer)}.
- */
 public interface ChannelContext {
-
-    void channelRegistered() throws IOException;
-
-    int read() throws IOException;
-
-    void sendMessage(ByteBuffer[] buffers, BiConsumer<Void, Throwable> listener);
-
-    void queueWriteOperation(WriteOperation writeOperation);
-
-    void flushChannel() throws IOException;
-
-    boolean hasQueuedWriteOps();
-
-    /**
-     * Schedules a channel to be closed by the selector event loop with which it is registered.
-     * <p>
-     * If the channel is open and the state can be transitioned to closed, the close operation will
-     * be scheduled with the event loop.
-     * <p>
-     * If the channel is already set to closed, it is assumed that it is already scheduled to be closed.
-     * <p>
-     * Depending on the underlying protocol of the channel, a close operation might simply close the socket
-     * channel or may involve reading and writing messages.
-     */
-    void closeChannel();
-
-    /**
-     * This method indicates if a selector should close this channel.
-     *
-     * @return a boolean indicating if the selector should close
-     */
-    boolean selectorShouldClose();
-
     /**
      * This method cleans up any context resources that need to be released when a channel is closed. It
      * should only be called by the selector thread.
@@ -74,8 +30,5 @@ public interface ChannelContext {
      */
     void closeFromSelector() throws IOException;
 
-    @FunctionalInterface
-    interface ReadConsumer {
-        int consumeReads(InboundChannelBuffer channelBuffer) throws IOException;
-    }
+    default void handleException(Exception e) {}
 }

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/ChannelFactory.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/ChannelFactory.java
@@ -89,7 +89,6 @@ public abstract class ChannelFactory<ServerSocket extends NioServerSocketChannel
         try {
             Socket channel = createChannel(selector, rawChannel);
             assert channel.getContext() != null : "channel context should have been set on channel";
-            assert channel.getExceptionContext() != null : "exception handler should have been set on channel";
             return channel;
         } catch (Exception e) {
             closeRawChannel(rawChannel, e);

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/EventHandler.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/EventHandler.java
@@ -69,7 +69,7 @@ public abstract class EventHandler {
      */
     protected void handleClose(NioChannel channel) {
         try {
-            channel.closeFromSelector();
+            channel.getContext().closeFromSelector();
         } catch (IOException e) {
             closeException(channel, e);
         }

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/InboundChannelBuffer.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/InboundChannelBuffer.java
@@ -59,6 +59,10 @@ public final class InboundChannelBuffer implements AutoCloseable {
         ensureCapacity(PAGE_SIZE);
     }
 
+    public static InboundChannelBuffer allocatingInstance() {
+        return new InboundChannelBuffer(() -> new Page(ByteBuffer.allocate(PAGE_SIZE), () -> {}));
+    }
+
     @Override
     public void close() {
         if (isClosed.compareAndSet(false, true)) {

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioChannel.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioChannel.java
@@ -26,7 +26,7 @@ import java.nio.channels.NetworkChannel;
 import java.nio.channels.SelectionKey;
 import java.util.function.BiConsumer;
 
-public interface NioChannel extends AutoCloseable {
+public interface NioChannel {
 
     boolean isOpen();
 

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioChannel.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioChannel.java
@@ -42,6 +42,8 @@ public interface NioChannel {
 
     NetworkChannel getRawChannel();
 
+    ChannelContext getContext();
+
     /**
      * Adds a close listener to the channel. Multiple close listeners can be added. There is no guarantee
      * about the order in which close listeners will be executed. If the channel is already closed, the

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioChannel.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioChannel.java
@@ -32,6 +32,8 @@ public interface NioChannel {
 
     InetSocketAddress getLocalAddress();
 
+    void close();
+
     void closeFromSelector() throws IOException;
 
     void register() throws ClosedChannelException;

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioChannel.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioChannel.java
@@ -26,7 +26,7 @@ import java.nio.channels.NetworkChannel;
 import java.nio.channels.SelectionKey;
 import java.util.function.BiConsumer;
 
-public interface NioChannel {
+public interface NioChannel extends AutoCloseable {
 
     boolean isOpen();
 

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioServerSocketChannel.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioServerSocketChannel.java
@@ -48,7 +48,6 @@ public class NioServerSocketChannel extends AbstractNioChannel<ServerSocketChann
     public void setContext(ServerChannelContext context) {
         if (contextSet.compareAndSet(false, true)) {
             this.context = context;
-            super.setContext(context);
         } else {
             throw new IllegalStateException("Context on this channel were already set. It should only be once.");
         }

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioServerSocketChannel.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioServerSocketChannel.java
@@ -21,12 +21,11 @@ package org.elasticsearch.nio;
 
 import java.io.IOException;
 import java.nio.channels.ServerSocketChannel;
-import java.util.function.Consumer;
 
 public class NioServerSocketChannel extends AbstractNioChannel<ServerSocketChannel> {
 
     private final ChannelFactory<?, ?> channelFactory;
-    private Consumer<NioSocketChannel> acceptContext;
+    private ServerChannelContext context;
 
     public NioServerSocketChannel(ServerSocketChannel socketChannel, ChannelFactory<?, ?> channelFactory, AcceptingSelector selector)
         throws IOException {
@@ -39,17 +38,18 @@ public class NioServerSocketChannel extends AbstractNioChannel<ServerSocketChann
     }
 
     /**
-     * This method sets the accept context for a server socket channel. The accept context is called when a
-     * new channel is accepted. The parameter passed to the context is the new channel.
+     * This method sets the context for a server socket channel. The context is called when a new channel is
+     * accepted, an exception occurs, or it is time to close the channel.
      *
-     * @param acceptContext to call
+     * @param context to call
      */
-    public void setAcceptContext(Consumer<NioSocketChannel> acceptContext) {
-        this.acceptContext = acceptContext;
+    public void setContext(ServerChannelContext context) {
+        this.context = context;
     }
 
-    public Consumer<NioSocketChannel> getAcceptContext() {
-        return acceptContext;
+    @Override
+    public ServerChannelContext getContext() {
+        return context;
     }
 
     @Override

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioSocketChannel.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioSocketChannel.java
@@ -32,7 +32,7 @@ public class NioSocketChannel extends AbstractNioChannel<SocketChannel> {
     private final InetSocketAddress remoteAddress;
     private final CompletableFuture<Void> connectContext = new CompletableFuture<>();
     private final SocketSelector socketSelector;
-    private final AtomicBoolean contextsSet = new AtomicBoolean(false);
+    private final AtomicBoolean contextSet = new AtomicBoolean(false);
     private SocketChannelContext context;
     private Exception connectException;
 
@@ -72,8 +72,9 @@ public class NioSocketChannel extends AbstractNioChannel<SocketChannel> {
     }
 
     public void setContext(SocketChannelContext context) {
-        if (contextsSet.compareAndSet(false, true)) {
+        if (contextSet.compareAndSet(false, true)) {
             this.context = context;
+            super.setContext(context);
         } else {
             throw new IllegalStateException("Context on this channel were already set. It should only be once.");
         }

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioSocketChannel.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/NioSocketChannel.java
@@ -74,12 +74,12 @@ public class NioSocketChannel extends AbstractNioChannel<SocketChannel> {
     public void setContext(SocketChannelContext context) {
         if (contextSet.compareAndSet(false, true)) {
             this.context = context;
-            super.setContext(context);
         } else {
             throw new IllegalStateException("Context on this channel were already set. It should only be once.");
         }
     }
 
+    @Override
     public SocketChannelContext getContext() {
         return context;
     }

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/ServerChannelContext.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/ServerChannelContext.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.nio;
+
+import java.io.IOException;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public class ServerChannelContext implements ChannelContext {
+
+    private final NioServerSocketChannel channel;
+    private final Consumer<NioSocketChannel> acceptor;
+    private final BiConsumer<NioServerSocketChannel, Exception> exceptionHandler;
+
+    public ServerChannelContext(NioServerSocketChannel channel, Consumer<NioSocketChannel> acceptor,
+                                BiConsumer<NioServerSocketChannel, Exception> exceptionHandler) {
+        this.channel = channel;
+        this.acceptor = acceptor;
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    public void acceptChannel(NioSocketChannel acceptedChannel) {
+        acceptor.accept(acceptedChannel);
+    }
+
+    @Override
+    public void closeFromSelector() throws IOException {
+        channel.closeFromSelector();
+    }
+
+    @Override
+    public void handleException(Exception e) {
+        exceptionHandler.accept(channel, e);
+    }
+}

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/SocketChannelContext.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/SocketChannelContext.java
@@ -62,19 +62,6 @@ public abstract class SocketChannelContext implements ChannelContext {
     public abstract boolean hasQueuedWriteOps();
 
     /**
-     * Schedules a channel to be closed by the selector event loop with which it is registered.
-     * <p>
-     * If the channel is open and the state can be transitioned to closed, the close operation will
-     * be scheduled with the event loop.
-     * <p>
-     * If the channel is already set to closed, it is assumed that it is already scheduled to be closed.
-     * <p>
-     * Depending on the underlying protocol of the channel, a close operation might simply close the socket
-     * channel or may involve reading and writing messages.
-     */
-    public abstract void closeChannel();
-
-    /**
      * This method indicates if a selector should close this channel.
      *
      * @return a boolean indicating if the selector should close

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/SocketChannelContext.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/SocketChannelContext.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.nio;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.function.BiConsumer;
+
+/**
+ * This context should implement the specific logic for a channel. When a channel receives a notification
+ * that it is ready to perform certain operations (read, write, etc) the {@link SocketChannelContext} will
+ * be called. This context will need to implement all protocol related logic. Additionally, if any special
+ * close behavior is required, it should be implemented in this context.
+ *
+ * The only methods of the context that should ever be called from a non-selector thread are
+ * {@link #closeChannel()} and {@link #sendMessage(ByteBuffer[], BiConsumer)}.
+ */
+public abstract class SocketChannelContext implements ChannelContext {
+
+    protected final NioSocketChannel channel;
+    private final BiConsumer<NioSocketChannel, Exception> exceptionHandler;
+    private boolean ioException;
+    private boolean peerClosed;
+
+    protected SocketChannelContext(NioSocketChannel channel, BiConsumer<NioSocketChannel, Exception> exceptionHandler) {
+        this.channel = channel;
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    @Override
+    public void handleException(Exception e) {
+        exceptionHandler.accept(channel, e);
+    }
+
+    public void channelRegistered() throws IOException {}
+
+    public abstract int read() throws IOException;
+
+    public abstract void sendMessage(ByteBuffer[] buffers, BiConsumer<Void, Throwable> listener);
+
+    public abstract void queueWriteOperation(WriteOperation writeOperation);
+
+    public abstract void flushChannel() throws IOException;
+
+    public abstract boolean hasQueuedWriteOps();
+
+    /**
+     * Schedules a channel to be closed by the selector event loop with which it is registered.
+     * <p>
+     * If the channel is open and the state can be transitioned to closed, the close operation will
+     * be scheduled with the event loop.
+     * <p>
+     * If the channel is already set to closed, it is assumed that it is already scheduled to be closed.
+     * <p>
+     * Depending on the underlying protocol of the channel, a close operation might simply close the socket
+     * channel or may involve reading and writing messages.
+     */
+    public abstract void closeChannel();
+
+    /**
+     * This method indicates if a selector should close this channel.
+     *
+     * @return a boolean indicating if the selector should close
+     */
+    public abstract boolean selectorShouldClose();
+
+    protected boolean hasIOException() {
+        return ioException;
+    }
+
+    protected boolean isPeerClosed() {
+        return peerClosed;
+    }
+
+    protected int readFromChannel(ByteBuffer buffer) throws IOException {
+        try {
+            int bytesRead = channel.read(buffer);
+            if (bytesRead < 0) {
+                peerClosed = true;
+                bytesRead = 0;
+            }
+            return bytesRead;
+        } catch (IOException e) {
+            ioException = true;
+            throw e;
+        }
+    }
+
+    protected int readFromChannel(ByteBuffer[] buffers) throws IOException {
+        try {
+            int bytesRead = channel.read(buffers);
+            if (bytesRead < 0) {
+                peerClosed = true;
+                bytesRead = 0;
+            }
+            return bytesRead;
+        } catch (IOException e) {
+            ioException = true;
+            throw e;
+        }
+    }
+
+    protected int flushToChannel(ByteBuffer buffer) throws IOException {
+        try {
+            return channel.write(buffer);
+        } catch (IOException e) {
+            ioException = true;
+            throw e;
+        }
+    }
+
+    protected int flushToChannel(ByteBuffer[] buffers) throws IOException {
+        try {
+            return channel.write(buffers);
+        } catch (IOException e) {
+            ioException = true;
+            throw e;
+        }
+    }
+
+    @FunctionalInterface
+    public interface ReadConsumer {
+        int consumeReads(InboundChannelBuffer channelBuffer) throws IOException;
+    }
+}

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/SocketSelector.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/SocketSelector.java
@@ -122,7 +122,7 @@ public class SocketSelector extends ESSelector {
     public void queueWriteInChannelBuffer(WriteOperation writeOperation) {
         assertOnSelectorThread();
         NioSocketChannel channel = writeOperation.getChannel();
-        ChannelContext context = channel.getContext();
+        SocketChannelContext context = channel.getContext();
         try {
             SelectionKeyUtils.setWriteInterested(channel);
             context.queueWriteOperation(writeOperation);

--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/WriteOperation.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/WriteOperation.java
@@ -24,7 +24,7 @@ import java.util.function.BiConsumer;
 /**
  * This is a basic write operation that can be queued with a channel. The only requirements of a write
  * operation is that is has a listener and a reference to its channel. The actual conversion of the write
- * operation implementation to bytes will be performed by the {@link ChannelContext}.
+ * operation implementation to bytes will be performed by the {@link SocketChannelContext}.
  */
 public interface WriteOperation {
 

--- a/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/ChannelFactoryTests.java
+++ b/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/ChannelFactoryTests.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.util.function.BiConsumer;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.same;
@@ -139,7 +138,7 @@ public class ChannelFactoryTests extends ESTestCase {
         @Override
         public NioSocketChannel createChannel(SocketSelector selector, SocketChannel channel) throws IOException {
             NioSocketChannel nioSocketChannel = new NioSocketChannel(channel, selector);
-            nioSocketChannel.setContexts(mock(ChannelContext.class), mock(BiConsumer.class));
+            nioSocketChannel.setContext(mock(SocketChannelContext.class));
             return nioSocketChannel;
         }
 

--- a/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/NioServerSocketChannelTests.java
+++ b/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/NioServerSocketChannelTests.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.nio.channels.ServerSocketChannel;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.mockito.Mockito.mock;
@@ -56,11 +58,14 @@ public class NioServerSocketChannelTests extends ESTestCase {
         thread.join();
     }
 
+    @SuppressWarnings("unchecked")
     public void testClose() throws Exception {
         AtomicBoolean isClosed = new AtomicBoolean(false);
         CountDownLatch latch = new CountDownLatch(1);
 
-        NioChannel channel = new DoNotCloseServerChannel(mock(ServerSocketChannel.class), mock(ChannelFactory.class), selector);
+        ServerSocketChannel rawChannel = mock(ServerSocketChannel.class);
+        NioServerSocketChannel channel = new DoNotCloseServerChannel(rawChannel, mock(ChannelFactory.class), selector);
+        channel.setContext(new ServerChannelContext(channel, mock(Consumer.class), mock(BiConsumer.class)));
 
         channel.addCloseListener(ActionListener.toBiConsumer(new ActionListener<Void>() {
             @Override

--- a/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/NioServerSocketChannelTests.java
+++ b/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/NioServerSocketChannelTests.java
@@ -63,50 +63,37 @@ public class NioServerSocketChannelTests extends ESTestCase {
         AtomicBoolean isClosed = new AtomicBoolean(false);
         CountDownLatch latch = new CountDownLatch(1);
 
-        ServerSocketChannel rawChannel = mock(ServerSocketChannel.class);
-        NioServerSocketChannel channel = new DoNotCloseServerChannel(rawChannel, mock(ChannelFactory.class), selector);
-        channel.setContext(new ServerChannelContext(channel, mock(Consumer.class), mock(BiConsumer.class)));
+        try (ServerSocketChannel rawChannel = ServerSocketChannel.open()) {
+            NioServerSocketChannel channel = new NioServerSocketChannel(rawChannel, mock(ChannelFactory.class), selector);
+            channel.setContext(new ServerChannelContext(channel, mock(Consumer.class), mock(BiConsumer.class)));
+            channel.addCloseListener(ActionListener.toBiConsumer(new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void o) {
+                    isClosed.set(true);
+                    latch.countDown();
+                }
 
-        channel.addCloseListener(ActionListener.toBiConsumer(new ActionListener<Void>() {
-            @Override
-            public void onResponse(Void o) {
-                isClosed.set(true);
-                latch.countDown();
-            }
+                @Override
+                public void onFailure(Exception e) {
+                    isClosed.set(true);
+                    latch.countDown();
+                }
+            }));
 
-            @Override
-            public void onFailure(Exception e) {
-                isClosed.set(true);
-                latch.countDown();
-            }
-        }));
+            assertTrue(channel.isOpen());
+            assertTrue(rawChannel.isOpen());
+            assertFalse(isClosed.get());
 
-        assertTrue(channel.isOpen());
-        assertFalse(closedRawChannel.get());
-        assertFalse(isClosed.get());
-
-        PlainActionFuture<Void> closeFuture = PlainActionFuture.newFuture();
-        channel.addCloseListener(ActionListener.toBiConsumer(closeFuture));
-        selector.queueChannelClose(channel);
-        closeFuture.actionGet();
+            PlainActionFuture<Void> closeFuture = PlainActionFuture.newFuture();
+            channel.addCloseListener(ActionListener.toBiConsumer(closeFuture));
+            selector.queueChannelClose(channel);
+            closeFuture.actionGet();
 
 
-        assertTrue(closedRawChannel.get());
-        assertFalse(channel.isOpen());
-        latch.await();
-        assertTrue(isClosed.get());
-    }
-
-    private class DoNotCloseServerChannel extends DoNotRegisterServerChannel {
-
-        private DoNotCloseServerChannel(ServerSocketChannel channel, ChannelFactory<?, ?> channelFactory, AcceptingSelector selector)
-            throws IOException {
-            super(channel, channelFactory, selector);
-        }
-
-        @Override
-        void closeRawChannel() throws IOException {
-            closedRawChannel.set(true);
+            assertFalse(rawChannel.isOpen());
+            assertFalse(channel.isOpen());
+            latch.await();
+            assertTrue(isClosed.get());
         }
     }
 }

--- a/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/NioSocketChannelTests.java
+++ b/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/NioSocketChannelTests.java
@@ -34,16 +34,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class NioSocketChannelTests extends ESTestCase {
 
     private SocketSelector selector;
-    private AtomicBoolean closedRawChannel;
     private Thread thread;
 
     @Before
@@ -51,7 +48,6 @@ public class NioSocketChannelTests extends ESTestCase {
     public void startSelector() throws IOException {
         selector = new SocketSelector(new SocketEventHandler(logger));
         thread = new Thread(selector::runLoop);
-        closedRawChannel = new AtomicBoolean(false);
         thread.start();
         FutureUtils.get(selector.isRunningFuture());
     }
@@ -67,42 +63,45 @@ public class NioSocketChannelTests extends ESTestCase {
         AtomicBoolean isClosed = new AtomicBoolean(false);
         CountDownLatch latch = new CountDownLatch(1);
 
-        NioSocketChannel socketChannel = new DoNotCloseChannel(mock(SocketChannel.class), selector);
-        socketChannel.setContext(new BytesChannelContext(socketChannel, mock(BiConsumer.class),
-            mock(SocketChannelContext.ReadConsumer.class), InboundChannelBuffer.allocatingInstance()));
-        socketChannel.addCloseListener(ActionListener.toBiConsumer(new ActionListener<Void>() {
-            @Override
-            public void onResponse(Void o) {
-                isClosed.set(true);
-                latch.countDown();
-            }
-            @Override
-            public void onFailure(Exception e) {
-                isClosed.set(true);
-                latch.countDown();
-            }
-        }));
+        try(SocketChannel rawChannel = SocketChannel.open()) {
+            NioSocketChannel socketChannel = new NioSocketChannel(rawChannel, selector);
+            socketChannel.setContext(new BytesChannelContext(socketChannel, mock(BiConsumer.class),
+                mock(SocketChannelContext.ReadConsumer.class), InboundChannelBuffer.allocatingInstance()));
+            socketChannel.addCloseListener(ActionListener.toBiConsumer(new ActionListener<Void>() {
+                @Override
+                public void onResponse(Void o) {
+                    isClosed.set(true);
+                    latch.countDown();
+                }
 
-        assertTrue(socketChannel.isOpen());
-        assertFalse(closedRawChannel.get());
-        assertFalse(isClosed.get());
+                @Override
+                public void onFailure(Exception e) {
+                    isClosed.set(true);
+                    latch.countDown();
+                }
+            }));
 
-        PlainActionFuture<Void> closeFuture = PlainActionFuture.newFuture();
-        socketChannel.addCloseListener(ActionListener.toBiConsumer(closeFuture));
-        selector.queueChannelClose(socketChannel);
-        closeFuture.actionGet();
+            assertTrue(socketChannel.isOpen());
+            assertTrue(rawChannel.isOpen());
+            assertFalse(isClosed.get());
 
-        assertTrue(closedRawChannel.get());
-        assertFalse(socketChannel.isOpen());
-        latch.await();
-        assertTrue(isClosed.get());
+            PlainActionFuture<Void> closeFuture = PlainActionFuture.newFuture();
+            socketChannel.addCloseListener(ActionListener.toBiConsumer(closeFuture));
+            selector.queueChannelClose(socketChannel);
+            closeFuture.actionGet();
+
+            assertFalse(rawChannel.isOpen());
+            assertFalse(socketChannel.isOpen());
+            latch.await();
+            assertTrue(isClosed.get());
+        }
     }
 
     @SuppressWarnings("unchecked")
     public void testConnectSucceeds() throws Exception {
         SocketChannel rawChannel = mock(SocketChannel.class);
         when(rawChannel.finishConnect()).thenReturn(true);
-        NioSocketChannel socketChannel = new DoNotCloseChannel(rawChannel, selector);
+        NioSocketChannel socketChannel = new DoNotRegisterChannel(rawChannel, selector);
         socketChannel.setContext(mock(SocketChannelContext.class));
         selector.scheduleForRegistration(socketChannel);
 
@@ -112,14 +111,13 @@ public class NioSocketChannelTests extends ESTestCase {
 
         assertTrue(socketChannel.isConnectComplete());
         assertTrue(socketChannel.isOpen());
-        assertFalse(closedRawChannel.get());
     }
 
     @SuppressWarnings("unchecked")
     public void testConnectFails() throws Exception {
         SocketChannel rawChannel = mock(SocketChannel.class);
         when(rawChannel.finishConnect()).thenThrow(new ConnectException());
-        NioSocketChannel socketChannel = new DoNotCloseChannel(rawChannel, selector);
+        NioSocketChannel socketChannel = new DoNotRegisterChannel(rawChannel, selector);
         socketChannel.setContext(mock(SocketChannelContext.class));
         selector.scheduleForRegistration(socketChannel);
 
@@ -131,17 +129,5 @@ public class NioSocketChannelTests extends ESTestCase {
         assertFalse(socketChannel.isConnectComplete());
         // Even if connection fails the channel is 'open' until close() is called
         assertTrue(socketChannel.isOpen());
-    }
-
-    private class DoNotCloseChannel extends DoNotRegisterChannel {
-
-        private DoNotCloseChannel(SocketChannel channel, SocketSelector selector) throws IOException {
-            super(channel, selector);
-        }
-
-        @Override
-        void closeRawChannel() throws IOException {
-            closedRawChannel.set(true);
-        }
     }
 }

--- a/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/SocketSelectorTests.java
+++ b/libs/elasticsearch-nio/src/test/java/org/elasticsearch/nio/SocketSelectorTests.java
@@ -49,7 +49,7 @@ public class SocketSelectorTests extends ESTestCase {
     private SocketEventHandler eventHandler;
     private NioSocketChannel channel;
     private TestSelectionKey selectionKey;
-    private ChannelContext channelContext;
+    private SocketChannelContext channelContext;
     private BiConsumer<Void, Throwable> listener;
     private ByteBuffer[] buffers = {ByteBuffer.allocate(1)};
     private Selector rawSelector;
@@ -60,7 +60,7 @@ public class SocketSelectorTests extends ESTestCase {
         super.setUp();
         eventHandler = mock(SocketEventHandler.class);
         channel = mock(NioSocketChannel.class);
-        channelContext = mock(ChannelContext.class);
+        channelContext = mock(SocketChannelContext.class);
         listener = mock(BiConsumer.class);
         selectionKey = new TestSelectionKey(0);
         selectionKey.attach(channel);

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/TcpNioServerSocketChannel.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/transport/nio/TcpNioServerSocketChannel.java
@@ -39,8 +39,8 @@ public class TcpNioServerSocketChannel extends NioServerSocketChannel implements
     private final String profile;
 
     public TcpNioServerSocketChannel(String profile, ServerSocketChannel socketChannel,
-                              ChannelFactory<TcpNioServerSocketChannel, TcpNioSocketChannel> channelFactory,
-                              AcceptingSelector selector) throws IOException {
+                                     ChannelFactory<TcpNioServerSocketChannel, TcpNioSocketChannel> channelFactory,
+                                     AcceptingSelector selector) throws IOException {
         super(socketChannel, channelFactory, selector);
         this.profile = profile;
     }


### PR DESCRIPTION
This commit is related to #27260. Currently have a channel context that
implements reading and writing logic for socket channels. Additionally,
we have exception contexts to handle exceptions. And accepting contexts
to handle accepted channels. This PR introduces a ChannelContext that 
handles close and exception handling for all channel types. 
Additionally, it has implementers that provide specific functionality
for socket channels (read and writing). And specific functionality for
server channels (accepting).