### PR TITLE
Skip packaging upgrade test when cgroups v2 enabled

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/tests/80_upgrade.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/80_upgrade.bats
@@ -42,6 +42,10 @@ load $BATS_UTILS/packages.bash
 # Cleans everything for the 1st execution
 setup() {
     skip_not_dpkg_or_rpm
+    mount | grep "type cgroup2"
+    if [[ "$?" == 0 && "$(cat upgrade_from_version)" =~ 5\.1\.[12]|5\.2\.[012]|5\.3\.0 ]]; then
+      skip "version $(cat upgrade_from_version) is broken when cgroups v2 are enabled"
+    fi
 
     sameVersion="false"
     if [ "$(cat upgrade_from_version)" == "$(cat version)" ]; then


### PR DESCRIPTION
Versions 5.1.1 to 5.3.0 of Elasticsearch had a problem where these versions did not handle new kernels properly due to improper handling of cgroup v2. On Linux kernels that support cgroup2 and the unified hierarchy is mounted, Elasticsearch would never start. This means that the packaging upgrade tests on such systems will never succeed. This commit skips these tests on OS that have the unified cgroup v2 hierarchy.

Relates #26968