### PR TITLE
Add client actions to action plugin

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.GenericAction;
 import org.elasticsearch.client.support.AbstractClient;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -195,8 +196,16 @@ public abstract class TransportClient extends AbstractClient {
             final TransportClientNodesService nodesService =
                 new TransportClientNodesService(settings, transportService, threadPool, failureListner == null
                     ? (t, e) -> {} : failureListner);
-            final TransportProxyClient proxy = new TransportProxyClient(settings, transportService, nodesService,
-                actionModule.getActions().values().stream().map(x -> x.getAction()).collect(Collectors.toList()));
+
+            // construct the list of client actions
+            final List<ActionPlugin> actionPlugins = pluginsService.filterPlugins(ActionPlugin.class);
+            final List<GenericAction> clientActions =
+                    actionPlugins.stream().flatMap(p -> p.getClientActions().stream()).collect(Collectors.toList());
+            // add all the base actions
+            final List<? extends GenericAction<?, ?>> baseActions =
+                    actionModule.getActions().values().stream().map(ActionPlugin.ActionHandler::getAction).collect(Collectors.toList());
+            clientActions.addAll(baseActions);
+            final TransportProxyClient proxy = new TransportProxyClient(settings, transportService, nodesService, clientActions);
 
             List<LifecycleComponent> pluginLifecycleComponents = new ArrayList<>(pluginsService.getGuiceServiceClasses().stream()
                 .map(injector::getInstance).collect(Collectors.toList()));

--- a/server/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ActionPlugin.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
 
 /**
  * An additional extension point for {@link Plugin}s that extends Elasticsearch's scripting functionality. Implement it like this:
@@ -62,6 +63,15 @@ public interface ActionPlugin {
     default List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return Collections.emptyList();
     }
+
+    /**
+     * Client actions added by this plugin. This defaults to all of the {@linkplain GenericAction} in
+     * {@linkplain ActionPlugin#getActions()}.
+     */
+    default List<GenericAction> getClientActions() {
+        return getActions().stream().map(a -> a.action).collect(Collectors.toList());
+    }
+
     /**
      * Action filters added by this plugin.
      */


### PR DESCRIPTION
This commit adds an extension point for client actions to action plugins. This is useful for plugins to expose the client-side actions without exposing the server-side implementations to the client. The default implementation, of course, delegates to extracting the client-side action from the server-side implementation.

Supersedes #27759
