### PR TITLE
[Plugin] Remove redundant argument for buildConfiguration of s3 plugin

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/InternalAwsS3Service.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/InternalAwsS3Service.java
@@ -73,7 +73,7 @@ class InternalAwsS3Service extends AbstractLifecycleComponent implements AwsS3Se
         logger.debug("creating S3 client with client_name [{}], endpoint [{}]", clientName, clientSettings.endpoint);
 
         AWSCredentialsProvider credentials = buildCredentials(logger, deprecationLogger, clientSettings, repositorySettings);
-        ClientConfiguration configuration = buildConfiguration(clientSettings, repositorySettings);
+        ClientConfiguration configuration = buildConfiguration(clientSettings);
 
         client = new AmazonS3Client(credentials, configuration);
 
@@ -86,7 +86,7 @@ class InternalAwsS3Service extends AbstractLifecycleComponent implements AwsS3Se
     }
 
     // pkg private for tests
-    static ClientConfiguration buildConfiguration(S3ClientSettings clientSettings, Settings repositorySettings) {
+    static ClientConfiguration buildConfiguration(S3ClientSettings clientSettings) {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         // the response metadata cache is only there for diagnostics purposes,
         // but can force objects from every response to the old generation.

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AwsS3ServiceImplTests.java
@@ -95,7 +95,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
     }
 
     public void testAWSDefaultConfiguration() {
-        launchAWSConfigurationTest(Settings.EMPTY, Settings.EMPTY, Protocol.HTTPS, null, -1, null, null, 3,
+        launchAWSConfigurationTest(Settings.EMPTY, Protocol.HTTPS, null, -1, null, null, 3,
             ClientConfiguration.DEFAULT_THROTTLE_RETRIES, ClientConfiguration.DEFAULT_SOCKET_TIMEOUT);
     }
 
@@ -110,7 +110,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
             .put("s3.client.default.proxy.port", 8080)
             .put("s3.client.default.read_timeout", "10s")
             .build();
-        launchAWSConfigurationTest(settings, Settings.EMPTY, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
+        launchAWSConfigurationTest(settings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username",
             "aws_proxy_password", 3, ClientConfiguration.DEFAULT_THROTTLE_RETRIES, 10000);
     }
 
@@ -118,7 +118,7 @@ public class AwsS3ServiceImplTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put("s3.client.default.max_retries", 5)
             .build();
-        launchAWSConfigurationTest(settings, Settings.EMPTY, Protocol.HTTPS, null, -1, null,
+        launchAWSConfigurationTest(settings, Protocol.HTTPS, null, -1, null,
             null, 5, ClientConfiguration.DEFAULT_THROTTLE_RETRIES, 50000);
     }
 
@@ -126,22 +126,21 @@ public class AwsS3ServiceImplTests extends ESTestCase {
         final boolean throttling = randomBoolean();
 
         Settings settings = Settings.builder().put("s3.client.default.use_throttle_retries", throttling).build();
-        launchAWSConfigurationTest(settings, Settings.EMPTY, Protocol.HTTPS, null, -1, null, null, 3, throttling, 50000);
+        launchAWSConfigurationTest(settings, Protocol.HTTPS, null, -1, null, null, 3, throttling, 50000);
     }
 
     private void launchAWSConfigurationTest(Settings settings,
-                                              Settings singleRepositorySettings,
-                                              Protocol expectedProtocol,
-                                              String expectedProxyHost,
-                                              int expectedProxyPort,
-                                              String expectedProxyUsername,
-                                              String expectedProxyPassword,
-                                              Integer expectedMaxRetries,
-                                              boolean expectedUseThrottleRetries,
-                                              int expectedReadTimeout) {
+                                            Protocol expectedProtocol,
+                                            String expectedProxyHost,
+                                            int expectedProxyPort,
+                                            String expectedProxyUsername,
+                                            String expectedProxyPassword,
+                                            Integer expectedMaxRetries,
+                                            boolean expectedUseThrottleRetries,
+                                            int expectedReadTimeout) {
 
         S3ClientSettings clientSettings = S3ClientSettings.getClientSettings(settings, "default");
-        ClientConfiguration configuration = InternalAwsS3Service.buildConfiguration(clientSettings, singleRepositorySettings);
+        ClientConfiguration configuration = InternalAwsS3Service.buildConfiguration(clientSettings);
 
         assertThat(configuration.getResponseMetadataCacheSize(), is(0));
         assertThat(configuration.getProtocol(), is(expectedProtocol));


### PR DESCRIPTION
The ```repositorySettings``` of method ```buildConfiguration``` is never used. We can remove it so the test can be also much easier. 