### PR TITLE
Build: Add run task to meta plugins

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/MetaPluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/MetaPluginBuildPlugin.groovy
@@ -21,6 +21,7 @@ package org.elasticsearch.gradle.plugin
 
 import org.elasticsearch.gradle.test.RestIntegTestTask
 import org.elasticsearch.gradle.test.RestTestPlugin
+import org.elasticsearch.gradle.test.RunTask
 import org.elasticsearch.gradle.test.StandaloneRestTestPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -42,6 +43,10 @@ class MetaPluginBuildPlugin implements Plugin<Project> {
             distribution = 'zip'
             setupCommand('installMetaPlugin', 'bin/elasticsearch-plugin', 'install', 'file:' + project.bundlePlugin.archivePath)
         }
+
+        RunTask run = project.tasks.create('run', RunTask)
+        run.dependsOn(project.bundlePlugin)
+        run.clusterConfig.plugin(project.path)
     }
 
     private static void createBundleTask(Project project) {
@@ -62,6 +67,10 @@ class MetaPluginBuildPlugin implements Plugin<Project> {
 
         }
         project.assemble.dependsOn(bundle)
+
+        // also make the zip available as a configuration (used when depending on this project)
+        project.configurations.create('zip')
+        project.artifacts.add('zip', bundle)
 
         // a super hacky way to inject code to run at the end of each of the bundled plugin's configuration
         // to add itself back to this meta plugin zip


### PR DESCRIPTION
This commit adds a run task to projects using the meta plugin plugin. It
also makes the project installable via ClusterConfiguration.plugin.
