### PR TITLE
Deprecate the `update_all_types` option.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -440,7 +440,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         return updateAllTypes;
     }
 
-    /** See {@link #updateAllTypes()} */
+    /** See {@link #updateAllTypes()}
+     * @deprecated useless with 6.x indices which may only have one type */
+    @Deprecated
     public CreateIndexRequest updateAllTypes(boolean updateAllTypes) {
         this.updateAllTypes = updateAllTypes;
         return this;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -239,7 +239,9 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<Create
         return this;
     }
 
-    /** True if all fields that span multiple types should be updated, false otherwise */
+    /** True if all fields that span multiple types should be updated, false otherwise
+     * @deprecated useless with 6.x indices which may only have one type */
+    @Deprecated
     public CreateIndexRequestBuilder setUpdateAllTypes(boolean updateAllTypes) {
         request.updateAllTypes(updateAllTypes);
         return this;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -298,7 +298,6 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
     /**
      * True if all fields that span multiple types should be updated, false otherwise.
      * @deprecated useless with 6.x indices which may only have one type
-     * @see {@link #updateAllTypes()}
      */
     @Deprecated
     public PutMappingRequest updateAllTypes(boolean updateAllTypes) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -295,7 +295,12 @@ public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> im
         return updateAllTypes;
     }
 
-    /** See {@link #updateAllTypes()} */
+    /**
+     * True if all fields that span multiple types should be updated, false otherwise.
+     * @deprecated useless with 6.x indices which may only have one type
+     * @see {@link #updateAllTypes()}
+     */
+    @Deprecated
     public PutMappingRequest updateAllTypes(boolean updateAllTypes) {
         this.updateAllTypes = updateAllTypes;
         return this;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
@@ -98,7 +98,9 @@ public class PutMappingRequestBuilder extends AcknowledgedRequestBuilder<PutMapp
         return this;
     }
 
-    /** True if all fields that span multiple types should be updated, false otherwise */
+    /** True if all fields that span multiple types should be updated, false otherwise
+     * @deprecated useless with 6.x indices which may only have one type */
+    @Deprecated
     public PutMappingRequestBuilder setUpdateAllTypes(boolean updateAllTypes) {
         request.updateAllTypes(updateAllTypes);
         return this;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
@@ -23,6 +23,8 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -33,6 +35,9 @@ import org.elasticsearch.rest.action.AcknowledgedRestListener;
 import java.io.IOException;
 
 public class RestCreateIndexAction extends BaseRestHandler {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(RestCreateIndexAction.class));
+
     public RestCreateIndexAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(RestRequest.Method.PUT, "/{index}", this);
@@ -48,6 +53,9 @@ public class RestCreateIndexAction extends BaseRestHandler {
         CreateIndexRequest createIndexRequest = new CreateIndexRequest(request.param("index"));
         if (request.hasContent()) {
             createIndexRequest.source(request.content(), request.getXContentType());
+        }
+        if (request.hasParam("update_all_types")) {
+            DEPRECATION_LOGGER.deprecated("[update_all_types] is deprecated since indices may not have more than one type anymore");
         }
         createIndexRequest.updateAllTypes(request.paramAsBoolean("update_all_types", false));
         createIndexRequest.timeout(request.paramAsTime("timeout", createIndexRequest.timeout()));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -23,6 +23,8 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
@@ -36,6 +38,9 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 public class RestPutMappingAction extends BaseRestHandler {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(RestPutMappingAction.class));
+
     public RestPutMappingAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(PUT, "/{index}/_mapping/", this);
@@ -70,6 +75,9 @@ public class RestPutMappingAction extends BaseRestHandler {
         PutMappingRequest putMappingRequest = putMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));
         putMappingRequest.type(request.param("type"));
         putMappingRequest.source(request.requiredContent(), request.getXContentType());
+        if (request.hasParam("update_all_types")) {
+            DEPRECATION_LOGGER.deprecated("[update_all_types] is deprecated since indices may not have more than one type anymore");
+        }
         putMappingRequest.updateAllTypes(request.paramAsBoolean("update_all_types", false));
         putMappingRequest.timeout(request.paramAsTime("timeout", putMappingRequest.timeout()));
         putMappingRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putMappingRequest.masterNodeTimeout()));


### PR DESCRIPTION
This option makes no sense on indices that have only one type, which is
enforced since 6.0.