### PR TITLE
Build: Fix meta plugin integ test installation

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/MetaPluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/MetaPluginBuildPlugin.groovy
@@ -39,8 +39,7 @@ class MetaPluginBuildPlugin implements Plugin<Project> {
 
         project.integTestCluster {
             dependsOn(project.bundlePlugin)
-            distribution = 'zip'
-            setupCommand('installMetaPlugin', 'bin/elasticsearch-plugin', 'install', 'file:' + project.bundlePlugin.archivePath)
+            plugin(project.path)
         }
     }
 


### PR DESCRIPTION
Integ test clusters should use the plugin method of ClusterConfiguration
to install plugins. Without it, meta plugins install based on the name
of the project directory, rather than the actual configured plugin name.
This commit fixes that, and also corrects the distribution used to be
the default integ-test-zip, to match that of PluginBuildPlugin. This
ensures plugins are tested in isolation by default.