### PR TITLE
Remove the `update_all_types` option.

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
@@ -173,7 +173,6 @@ public final class Request {
         parameters.withTimeout(createIndexRequest.timeout());
         parameters.withMasterTimeout(createIndexRequest.masterNodeTimeout());
         parameters.withWaitForActiveShards(createIndexRequest.waitForActiveShards());
-        parameters.withUpdateAllTypes(createIndexRequest.updateAllTypes());
 
         HttpEntity entity = createEntity(createIndexRequest, REQUEST_BODY_CONTENT_TYPE);
         return new Request(HttpPut.METHOD_NAME, endpoint, parameters.getParams(), entity);
@@ -583,13 +582,6 @@ public final class Request {
 
         Params withTimeout(TimeValue timeout) {
             return putParam("timeout", timeout);
-        }
-
-        Params withUpdateAllTypes(boolean updateAllTypes) {
-            if (updateAllTypes) {
-                return putParam("update_all_types", Boolean.TRUE.toString());
-            }
-            return this;
         }
 
         Params withVersion(long version) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -310,14 +310,6 @@ public class RequestTests extends ESTestCase {
         setRandomMasterTimeout(createIndexRequest, expectedParams);
         setRandomWaitForActiveShards(createIndexRequest::waitForActiveShards, expectedParams);
 
-        if (randomBoolean()) {
-            boolean updateAllTypes = randomBoolean();
-            createIndexRequest.updateAllTypes(updateAllTypes);
-            if (updateAllTypes) {
-                expectedParams.put("update_all_types", Boolean.TRUE.toString());
-            }
-        }
-
         Request request = Request.createIndex(createIndexRequest);
         assertEquals("/" + indexName, request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());

--- a/docs/reference/migration/migrate_7_0/mappings.asciidoc
+++ b/docs/reference/migration/migrate_7_0/mappings.asciidoc
@@ -14,3 +14,7 @@ The `index_options` field for numeric  fields has been deprecated in 6 and has n
 To safeguard against out of memory errors, the number of nested json objects within a single
 document across all fields has been limited to 10000. This default limit can be changed with
 the index setting `index.mapping.nested_objects.limit`.
+
+==== The `update_all_types` option has been removed
+
+This option is useless now that all indices have at most one type.

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/ScaledFloatFieldMapper.java
@@ -207,8 +207,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
-        public void checkCompatibility(MappedFieldType other, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(other, conflicts, strict);
+        public void checkCompatibility(MappedFieldType other, List<String> conflicts) {
+            super.checkCompatibility(other, conflicts);
             if (scalingFactor != ((ScaledFloatFieldType) other).getScalingFactor()) {
                 conflicts.add("mapper [" + name() + "] has different [scaling_factor] values");
             }
@@ -424,8 +424,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         ScaledFloatFieldMapper other = (ScaledFloatFieldMapper) mergeWith;
         if (other.ignoreMalformed.explicit()) {
             this.ignoreMalformed = other.ignoreMalformed;

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/TokenCountFieldMapper.java
@@ -202,8 +202,8 @@ public class TokenCountFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         this.analyzer = ((TokenCountFieldMapper) mergeWith).analyzer;
         this.enablePositionIncrements = ((TokenCountFieldMapper) mergeWith).enablePositionIncrements;
     }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
@@ -63,7 +63,7 @@ public class TokenCountFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
         DocumentMapper stage1 = mapperService.merge("person",
-                new CompressedXContent(stage1Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+                new CompressedXContent(stage1Mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         String stage2Mapping = XContentFactory.jsonBuilder().startObject()
                 .startObject("person")
@@ -75,7 +75,7 @@ public class TokenCountFieldMapperTests extends ESSingleNodeTestCase {
                     .endObject()
                 .endObject().endObject().string();
         DocumentMapper stage2 = mapperService.merge("person",
-                new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+                new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         // previous mapper has not been modified
         assertThat(((TokenCountFieldMapper) stage1.mappers().smartNameFieldMapper("tc")).analyzer(), equalTo("keyword"));

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentIdFieldMapper.java
@@ -194,8 +194,8 @@ public final class ParentIdFieldMapper extends FieldMapper {
 
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         ParentIdFieldMapper parentMergeWith = (ParentIdFieldMapper) mergeWith;
         this.children = parentMergeWith.children;
     }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -316,8 +316,8 @@ public final class ParentJoinFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         ParentJoinFieldMapper joinMergeWith = (ParentJoinFieldMapper) mergeWith;
         List<String> conflicts = new ArrayList<>();
         for (ParentIdFieldMapper mapper : parentIdFields) {
@@ -347,7 +347,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
                         conflicts.add("cannot remove child [" + child + "] in join field [" + name() + "]");
                     }
                 }
-                ParentIdFieldMapper merged = (ParentIdFieldMapper) self.merge(mergeWithMapper, updateAllTypes);
+                ParentIdFieldMapper merged = (ParentIdFieldMapper) self.merge(mergeWithMapper);
                 newParentIdFields.add(merged);
             }
         }
@@ -356,7 +356,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
         }
         this.eagerGlobalOrdinals = joinMergeWith.eagerGlobalOrdinals;
         this.parentIdFields = Collections.unmodifiableList(newParentIdFields);
-        this.uniqueFieldMapper = (MetaJoinFieldMapper) uniqueFieldMapper.merge(joinMergeWith.uniqueFieldMapper, updateAllTypes);
+        this.uniqueFieldMapper = (MetaJoinFieldMapper) uniqueFieldMapper.merge(joinMergeWith.uniqueFieldMapper);
         uniqueFieldMapper.setFieldMapper(this);
     }
 

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -57,7 +57,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().string();
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
         assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
 
         // Doc without join
@@ -106,7 +106,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().string();
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
         ParsedDocument doc = docMapper.parse(SourceToParse.source("test", "type", "2",
             XContentFactory.jsonBuilder().startObject()
                 .startObject("join_field")
@@ -141,7 +141,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().string();
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
         assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
 
         // Doc without join
@@ -221,7 +221,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject().string();
         IndexService indexService = createIndex("test");
         DocumentMapper docMapper = indexService.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
         assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
 
         {
@@ -235,7 +235,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
             IllegalStateException exc = expectThrows(IllegalStateException.class,
                 () -> indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                    MapperService.MergeReason.MAPPING_UPDATE, false));
+                    MapperService.MergeReason.MAPPING_UPDATE));
             assertThat(exc.getMessage(), containsString("cannot remove parent [parent] in join field [join_field]"));
         }
 
@@ -251,7 +251,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
             IllegalStateException exc = expectThrows(IllegalStateException.class,
                 () -> indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                    MapperService.MergeReason.MAPPING_UPDATE, false));
+                    MapperService.MergeReason.MAPPING_UPDATE));
             assertThat(exc.getMessage(), containsString("cannot remove child [grand_child2] in join field [join_field]"));
         }
 
@@ -268,7 +268,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
             IllegalStateException exc = expectThrows(IllegalStateException.class,
                 () -> indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                    MapperService.MergeReason.MAPPING_UPDATE, false));
+                    MapperService.MergeReason.MAPPING_UPDATE));
             assertThat(exc.getMessage(), containsString("cannot create child [parent] from an existing parent"));
         }
 
@@ -285,7 +285,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
             IllegalStateException exc = expectThrows(IllegalStateException.class,
                 () -> indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                    MapperService.MergeReason.MAPPING_UPDATE, false));
+                    MapperService.MergeReason.MAPPING_UPDATE));
             assertThat(exc.getMessage(), containsString("cannot create parent [grand_child2] from an existing child]"));
         }
 
@@ -300,7 +300,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject().endObject().string();
             docMapper = indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                MapperService.MergeReason.MAPPING_UPDATE, true);
+                MapperService.MergeReason.MAPPING_UPDATE);
             assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
             ParentJoinFieldMapper mapper = ParentJoinFieldMapper.getMapper(indexService.mapperService());
             assertTrue(mapper.hasChild("child2"));
@@ -321,7 +321,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject().endObject().string();
             docMapper = indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
-                MapperService.MergeReason.MAPPING_UPDATE, true);
+                MapperService.MergeReason.MAPPING_UPDATE);
             assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
             ParentJoinFieldMapper mapper = ParentJoinFieldMapper.getMapper(indexService.mapperService());
             assertTrue(mapper.hasParent("other"));
@@ -349,7 +349,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("test");
         MapperParsingException exc = expectThrows(MapperParsingException.class,
             () -> indexService.mapperService().merge("type", new CompressedXContent(mapping),
-                MapperService.MergeReason.MAPPING_UPDATE, false));
+                MapperService.MergeReason.MAPPING_UPDATE));
         assertThat(exc.getRootCause().getMessage(),
             containsString("join field [object.join_field] cannot be added inside an object or in a multi-field"));
     }
@@ -371,7 +371,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("test");
         MapperParsingException exc = expectThrows(MapperParsingException.class,
             () -> indexService.mapperService().merge("type", new CompressedXContent(mapping),
-                MapperService.MergeReason.MAPPING_UPDATE, false));
+                MapperService.MergeReason.MAPPING_UPDATE));
         assertThat(exc.getRootCause().getMessage(),
             containsString("join field [number.join_field] cannot be added inside an object or in a multi-field"));
     }
@@ -397,7 +397,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject().string();
             IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> indexService.mapperService().merge("type",
-                new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false));
+                new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE));
             assertThat(exc.getMessage(), containsString("Field [_parent_join] is defined twice in [type]"));
         }
 
@@ -414,7 +414,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject().string();
             indexService.mapperService().merge("type",
-                new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+                new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
             String updateMapping = XContentFactory.jsonBuilder().startObject()
                 .startObject("properties")
                     .startObject("another_join_field")
@@ -423,7 +423,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject().string();
             IllegalArgumentException exc = expectThrows(IllegalArgumentException.class, () -> indexService.mapperService().merge("type",
-                new CompressedXContent(updateMapping), MapperService.MergeReason.MAPPING_UPDATE, false));
+                new CompressedXContent(updateMapping), MapperService.MergeReason.MAPPING_UPDATE));
             assertThat(exc.getMessage(), containsString("Field [_parent_join] is defined twice in [type]"));
         }
     }
@@ -442,7 +442,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().string();
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
         assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
         assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
         assertNotNull(service.mapperService().fullName("join_field#parent"));
@@ -463,7 +463,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject().string();
         service.mapperService().merge("type", new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
         assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
         assertNotNull(service.mapperService().fullName("join_field#parent"));
         assertFalse(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
@@ -132,7 +132,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
             .endObject().endObject().endObject();
 
         mapperService.merge(TYPE,
-            new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     /**

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
@@ -112,7 +112,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
             .endObject().endObject().endObject();
 
         mapperService.merge(TYPE,
-            new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     /**

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyHasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyHasChildQueryBuilderTests.java
@@ -97,7 +97,7 @@ public class LegacyHasChildQueryBuilderTests extends AbstractQueryTestCase<HasCh
                 BOOLEAN_FIELD_NAME, "type=boolean",
                 DATE_FIELD_NAME, "type=date",
                 OBJECT_FIELD_NAME, "type=object"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
         mapperService.merge(CHILD_TYPE, new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef(CHILD_TYPE,
                 "_parent", "type=" + PARENT_TYPE,
                 STRING_FIELD_NAME, "type=text",
@@ -107,7 +107,7 @@ public class LegacyHasChildQueryBuilderTests extends AbstractQueryTestCase<HasCh
                 BOOLEAN_FIELD_NAME, "type=boolean",
                 DATE_FIELD_NAME, "type=date",
                 OBJECT_FIELD_NAME, "type=object"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyHasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyHasParentQueryBuilderTests.java
@@ -88,7 +88,7 @@ public class LegacyHasParentQueryBuilderTests extends AbstractQueryTestCase<HasP
                 BOOLEAN_FIELD_NAME, "type=boolean",
                 DATE_FIELD_NAME, "type=date",
                 OBJECT_FIELD_NAME, "type=object"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
         mapperService.merge(CHILD_TYPE, new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef(CHILD_TYPE,
                 "_parent", "type=" + PARENT_TYPE,
                 STRING_FIELD_NAME, "type=text",
@@ -98,9 +98,9 @@ public class LegacyHasParentQueryBuilderTests extends AbstractQueryTestCase<HasP
                 BOOLEAN_FIELD_NAME, "type=boolean",
                 DATE_FIELD_NAME, "type=date",
                 OBJECT_FIELD_NAME, "type=object"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
         mapperService.merge("just_a_type", new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef("just_a_type"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     /**

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyParentIdQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/LegacyParentIdQueryBuilderTests.java
@@ -72,7 +72,7 @@ public class LegacyParentIdQueryBuilderTests extends AbstractQueryTestCase<Paren
                 BOOLEAN_FIELD_NAME, "type=boolean",
                 DATE_FIELD_NAME, "type=date",
                 OBJECT_FIELD_NAME, "type=object"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
         mapperService.merge(CHILD_TYPE, new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef(CHILD_TYPE,
                 "_parent", "type=" + PARENT_TYPE,
                 STRING_FIELD_NAME, "type=text",
@@ -81,7 +81,7 @@ public class LegacyParentIdQueryBuilderTests extends AbstractQueryTestCase<Paren
                 BOOLEAN_FIELD_NAME, "type=boolean",
                 DATE_FIELD_NAME, "type=date",
                 OBJECT_FIELD_NAME, "type=object"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
@@ -104,7 +104,7 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
             .endObject().endObject().endObject();
 
         mapperService.merge(TYPE,
-            new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -136,13 +136,13 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
                 .startObject("ip_field").field("type", "ip").endObject()
                 .startObject("field").field("type", "keyword").endObject()
                 .endObject().endObject().endObject().string();
-        documentMapper = mapperService.merge("type", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE, true);
+        documentMapper = mapperService.merge("type", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE);
 
         String queryField = "query_field";
         String percolatorMapper = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject(queryField).field("type", "percolator").endObject().endObject()
                 .endObject().endObject().string();
-        mapperService.merge("type", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE, true);
+        mapperService.merge("type", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
         fieldMapper = (PercolatorFieldMapper) mapperService.documentMapper("type").mappers().getMapper(queryField);
         fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
@@ -98,10 +98,10 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
         String docType = "_doc";
         mapperService.merge(docType, new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef(docType,
                 queryField, "type=percolator"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
         mapperService.merge(docType, new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef(docType,
                 STRING_FIELD_NAME, "type=text"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
         if (mapperService.getIndexSettings().isSingleType() == false) {
             PercolateQueryBuilderTests.docType = docType;
         }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -156,7 +156,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 .startObject("number_field7").field("type", "ip").endObject()
                 .startObject("date_field").field("type", "date").endObject()
             .endObject().endObject().endObject().string();
-        mapperService.merge("doc", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("doc", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     private void addQueryFieldMappings() throws Exception {
@@ -164,7 +164,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         String percolatorMapper = XContentFactory.jsonBuilder().startObject().startObject("doc")
                 .startObject("properties").startObject(fieldName).field("type", "percolator").endObject().endObject()
                 .endObject().endObject().string();
-        mapperService.merge("doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
         fieldType = (PercolatorFieldMapper.FieldType) mapperService.fullName(fieldName);
     }
 
@@ -578,7 +578,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
             .startObject("properties").startObject(fieldName).field("type", "percolator").field("index", "no").endObject().endObject()
             .endObject().endObject().string();
         MapperParsingException e = expectThrows(MapperParsingException.class, () ->
-            mapperService.merge("doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE, true));
+            mapperService.merge("doc", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), containsString("Mapping definition for [" + fieldName + "] has unsupported parameters:  [index : no]"));
     }
 
@@ -592,7 +592,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                     .startObject("query_field2").field("type", "percolator").endObject()
                 .endObject()
                 .endObject().endObject().string();
-        mapperService.merge(typeName, new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE, true);
+        mapperService.merge(typeName, new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
 
         QueryBuilder queryBuilder = matchQuery("field", "value");
         ParsedDocument doc = mapperService.documentMapper(typeName).parse(SourceToParse.source("test", typeName, "1",
@@ -623,7 +623,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject()
                 .endObject().endObject().string();
-        mapperService.merge(typeName, new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE, true);
+        mapperService.merge(typeName, new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
 
         QueryBuilder queryBuilder = matchQuery("field", "value");
         ParsedDocument doc = mapperService.documentMapper(typeName).parse(SourceToParse.source("test", typeName, "1",

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapper.java
@@ -99,8 +99,8 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        public void checkCompatibility(MappedFieldType otherFT, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(otherFT, conflicts, strict);
+        public void checkCompatibility(MappedFieldType otherFT, List<String> conflicts) {
+            super.checkCompatibility(otherFT, conflicts);
             CollationFieldType other = (CollationFieldType) otherFT;
             if (!Objects.equals(collator, other.collator)) {
                 conflicts.add("mapper [" + name() + "] has different [collator]");
@@ -619,8 +619,8 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
 
         List<String> conflicts = new ArrayList<>();
         ICUCollationKeywordFieldMapper icuMergeWith = (ICUCollationKeywordFieldMapper) mergeWith;

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperTests.java
@@ -434,7 +434,7 @@ public class ICUCollationKeywordFieldMapperTests extends ESSingleNodeTestCase {
             .field("language", "tr")
             .field("strength", "primary")
             .endObject().endObject().endObject().endObject().string();
-        indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean());
+        indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
 
         String mapping2 = XContentFactory.jsonBuilder().startObject().startObject("type")
             .startObject("properties").startObject("field")
@@ -443,7 +443,7 @@ public class ICUCollationKeywordFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject().endObject().endObject().string();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
             () -> indexService.mapperService().merge("type",
-                new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, randomBoolean()));
+                new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE));
         assertEquals("Can't merge because of conflicts: [Cannot update language setting for [" + FIELD_TYPE
             + "], Cannot update strength setting for [" + FIELD_TYPE + "]]", e.getMessage());
     }

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
@@ -183,7 +183,7 @@ public class SizeFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         SizeFieldMapper sizeFieldMapperMergeWith = (SizeFieldMapper) mergeWith;
         if (sizeFieldMapperMergeWith.enabledState != enabledState && !sizeFieldMapperMergeWith.enabledState.unset()) {
             this.enabledState = sizeFieldMapperMergeWith.enabledState;

--- a/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
+++ b/plugins/mapper-size/src/test/java/org/elasticsearch/index/mapper/size/SizeMappingTests.java
@@ -110,7 +110,7 @@ public class SizeMappingTests extends ESSingleNodeTestCase {
             .startObject("_size").field("enabled", false).endObject()
             .endObject().endObject().string();
         docMapper = service.mapperService().merge("type", new CompressedXContent(disabledMapping),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
 
         assertThat(docMapper.metadataMapper(SizeFieldMapper.class).enabled(), is(false));
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -24,10 +24,6 @@
         "master_timeout": {
           "type" : "time",
           "description" : "Specify timeout for connection to master"
-        },
-        "update_all_types": {
-          "type": "boolean",
-          "description": "Whether to update the mapping for all fields with the same name across all types or not"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -38,10 +38,6 @@
           "options" : ["open","closed","none","all"],
           "default" : "open",
           "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
-        },
-        "update_all_types": {
-          "type": "boolean",
-          "description": "Whether to update the mapping for all fields with the same name across all types or not"
         }
       }
     },

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexClusterStateUpdateRequest.java
@@ -43,7 +43,6 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
     private final String cause;
     private final String index;
     private final String providedName;
-    private final boolean updateAllTypes;
     private Index recoverFrom;
     private ResizeType resizeType;
 
@@ -61,12 +60,10 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
 
-    public CreateIndexClusterStateUpdateRequest(TransportMessage originalMessage, String cause, String index, String providedName,
-                                                boolean updateAllTypes) {
+    public CreateIndexClusterStateUpdateRequest(TransportMessage originalMessage, String cause, String index, String providedName) {
         this.originalMessage = originalMessage;
         this.cause = cause;
         this.index = index;
-        this.updateAllTypes = updateAllTypes;
         this.providedName = providedName;
     }
 
@@ -153,11 +150,6 @@ public class CreateIndexClusterStateUpdateRequest extends ClusterStateUpdateRequ
 
     public Index recoverFrom() {
         return recoverFrom;
-    }
-
-    /** True if all fields that span multiple types should be updated, false otherwise */
-    public boolean updateAllTypes() {
-        return updateAllTypes;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -85,8 +85,6 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
 
     private final Map<String, IndexMetaData.Custom> customs = new HashMap<>();
 
-    private boolean updateAllTypes = false;
-
     private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
 
     public CreateIndexRequest() {
@@ -429,17 +427,6 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         return this.customs;
     }
 
-    /** True if all fields that span multiple types should be updated, false otherwise */
-    public boolean updateAllTypes() {
-        return updateAllTypes;
-    }
-
-    /** See {@link #updateAllTypes()} */
-    public CreateIndexRequest updateAllTypes(boolean updateAllTypes) {
-        this.updateAllTypes = updateAllTypes;
-        return this;
-    }
-
     public ActiveShardCount waitForActiveShards() {
         return waitForActiveShards;
     }
@@ -499,7 +486,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         for (int i = 0; i < aliasesSize; i++) {
             aliases.add(Alias.read(in));
         }
-        updateAllTypes = in.readBoolean();
+        if (in.getVersion().before(Version.V_7_0_0_alpha1)) {
+            in.readBoolean(); // updateAllTypes
+        }
         waitForActiveShards = ActiveShardCount.readFrom(in);
     }
 
@@ -523,7 +512,9 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         for (Alias alias : aliases) {
             alias.writeTo(out);
         }
-        out.writeBoolean(updateAllTypes);
+        if (out.getVersion().before(Version.V_7_0_0_alpha1)) {
+            out.writeBoolean(true); // updateAllTypes
+        }
         waitForActiveShards.writeTo(out);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -239,12 +239,6 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<Create
         return this;
     }
 
-    /** True if all fields that span multiple types should be updated, false otherwise */
-    public CreateIndexRequestBuilder setUpdateAllTypes(boolean updateAllTypes) {
-        request.updateAllTypes(updateAllTypes);
-        return this;
-    }
-
     /**
      * Sets the number of shard copies that should be active for index creation to return.
      * Defaults to {@link ActiveShardCount#DEFAULT}, which will wait for one shard copy

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -72,7 +72,7 @@ public class TransportCreateIndexAction extends TransportMasterNodeAction<Create
         }
 
         final String indexName = indexNameExpressionResolver.resolveDateMathExpression(request.index());
-        final CreateIndexClusterStateUpdateRequest updateRequest = new CreateIndexClusterStateUpdateRequest(request, cause, indexName, request.index(), request.updateAllTypes())
+        final CreateIndexClusterStateUpdateRequest updateRequest = new CreateIndexClusterStateUpdateRequest(request, cause, indexName, request.index())
                 .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                 .settings(request.settings()).mappings(request.mappings())
                 .aliases(request.aliases()).customs(request.customs())

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingClusterStateUpdateRequest.java
@@ -30,8 +30,6 @@ public class PutMappingClusterStateUpdateRequest extends IndicesClusterStateUpda
 
     private String source;
 
-    private boolean updateAllTypes = false;
-
     public PutMappingClusterStateUpdateRequest() {
 
     }
@@ -51,15 +49,6 @@ public class PutMappingClusterStateUpdateRequest extends IndicesClusterStateUpda
 
     public PutMappingClusterStateUpdateRequest source(String source) {
         this.source = source;
-        return this;
-    }
-
-    public boolean updateAllTypes() {
-        return updateAllTypes;
-    }
-
-    public PutMappingClusterStateUpdateRequest updateAllTypes(boolean updateAllTypes) {
-        this.updateAllTypes = updateAllTypes;
         return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
@@ -98,10 +98,4 @@ public class PutMappingRequestBuilder extends AcknowledgedRequestBuilder<PutMapp
         return this;
     }
 
-    /** True if all fields that span multiple types should be updated, false otherwise */
-    public PutMappingRequestBuilder setUpdateAllTypes(boolean updateAllTypes) {
-        request.updateAllTypes(updateAllTypes);
-        return this;
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -82,7 +82,6 @@ public class TransportPutMappingAction extends TransportMasterNodeAction<PutMapp
             PutMappingClusterStateUpdateRequest updateRequest = new PutMappingClusterStateUpdateRequest()
                     .ackTimeout(request.timeout()).masterNodeTimeout(request.masterNodeTimeout())
                     .indices(concreteIndices).type(request.type())
-                    .updateAllTypes(request.updateAllTypes())
                     .source(request.source());
 
             metaDataMappingService.putMapping(updateRequest, new ActionListener<ClusterStateUpdateResponse>() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -232,7 +232,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         createIndexRequest.cause("rollover_index");
         createIndexRequest.index(targetIndexName);
         return new CreateIndexClusterStateUpdateRequest(createIndexRequest,
-            "rollover_index", targetIndexName, providedIndexName, true)
+            "rollover_index", targetIndexName, providedIndexName)
             .ackTimeout(createIndexRequest.timeout())
             .masterNodeTimeout(createIndexRequest.masterNodeTimeout())
             .settings(createIndexRequest.settings())

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -179,7 +179,7 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
         targetIndex.settings(settingsBuilder);
 
         return new CreateIndexClusterStateUpdateRequest(targetIndex,
-            cause, targetIndex.index(), targetIndexName, true)
+            cause, targetIndex.index(), targetIndexName)
             // mappings are updated on the node when creating in the shards, this prevents race-conditions since all mapping must be
             // applied once we took the snapshot and if somebody messes things up and switches the index read/write and adds docs we miss
             // the mappings for everything is corrupted and hard to debug

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -444,7 +444,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                 // now add the mappings
                 MapperService mapperService = indexService.mapperService();
                 try {
-                    mapperService.merge(mappings, MergeReason.MAPPING_UPDATE, request.updateAllTypes());
+                    mapperService.merge(mappings, MergeReason.MAPPING_UPDATE);
                 } catch (Exception e) {
                     removalExtraInfo = "failed on parsing default mapping/mappings on index creation";
                     throw e;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -144,7 +144,7 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
                                 } catch (IOException e) {
                                     throw new ElasticsearchException("Failed to create temporary index for parsing the alias", e);
                                 }
-                                indexService.mapperService().merge(index, MapperService.MergeReason.MAPPING_RECOVERY, false);
+                                indexService.mapperService().merge(index, MapperService.MergeReason.MAPPING_RECOVERY);
                             }
                             indices.put(action.getIndex(), indexService);
                         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -250,7 +250,7 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
                 mappingsForValidation.put(entry.getKey(), MapperService.parseMapping(xContentRegistry, entry.getValue()));
             }
 
-            dummyIndexService.mapperService().merge(mappingsForValidation, MergeReason.MAPPING_UPDATE, false);
+            dummyIndexService.mapperService().merge(mappingsForValidation, MergeReason.MAPPING_UPDATE);
 
         } finally {
             if (createdIndex != null) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -187,7 +187,7 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
             try (IndexAnalyzers fakeIndexAnalzyers = new IndexAnalyzers(indexSettings, fakeDefault, fakeDefault, fakeDefault, analyzerMap, analyzerMap)) {
                 MapperService mapperService = new MapperService(indexSettings, fakeIndexAnalzyers, xContentRegistry, similarityService,
                         mapperRegistry, () -> null);
-                mapperService.merge(indexMetaData, MapperService.MergeReason.MAPPING_RECOVERY, false);
+                mapperService.merge(indexMetaData, MapperService.MergeReason.MAPPING_RECOVERY);
             }
         } catch (Exception ex) {
             // Wrap the inner exception so we have the index name in the exception message

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -147,7 +147,7 @@ public class MetaDataMappingService extends AbstractComponent {
                 // we need to create the index here, and add the current mapping to it, so we can merge
                 indexService = indicesService.createIndex(indexMetaData, Collections.emptyList());
                 removeIndex = true;
-                indexService.mapperService().merge(indexMetaData, MergeReason.MAPPING_RECOVERY, true);
+                indexService.mapperService().merge(indexMetaData, MergeReason.MAPPING_RECOVERY);
             }
 
             IndexMetaData.Builder builder = IndexMetaData.builder(indexMetaData);
@@ -224,7 +224,7 @@ public class MetaDataMappingService extends AbstractComponent {
                                 MapperService mapperService = indicesService.createIndexMapperService(indexMetaData);
                                 indexMapperServices.put(index, mapperService);
                                 // add mappings for all types, we need them for cross-type validation
-                                mapperService.merge(indexMetaData, MergeReason.MAPPING_RECOVERY, request.updateAllTypes());
+                                mapperService.merge(indexMetaData, MergeReason.MAPPING_RECOVERY);
                             }
                         }
                         currentState = applyRequest(currentState, request, indexMapperServices);
@@ -264,7 +264,7 @@ public class MetaDataMappingService extends AbstractComponent {
                     newMapper = mapperService.parse(request.type(), mappingUpdateSource, existingMapper == null);
                     if (existingMapper != null) {
                         // first, simulate: just call merge and ignore the result
-                        existingMapper.merge(newMapper.mapping(), request.updateAllTypes());
+                        existingMapper.merge(newMapper.mapping());
                     } else {
                         // TODO: can we find a better place for this validation?
                         // The reason this validation is here is that the mapper service doesn't learn about
@@ -310,7 +310,7 @@ public class MetaDataMappingService extends AbstractComponent {
                 if (existingMapper != null) {
                     existingSource = existingMapper.mappingSource();
                 }
-                DocumentMapper mergedMapper = mapperService.merge(mappingType, mappingUpdateSource, MergeReason.MAPPING_UPDATE, request.updateAllTypes());
+                DocumentMapper mergedMapper = mapperService.merge(mappingType, mappingUpdateSource, MergeReason.MAPPING_UPDATE);
                 CompressedXContent updatedSource = mergedMapper.mappingSource();
 
                 if (existingSource != null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -324,8 +324,8 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
         }
 
         @Override
-        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(fieldType, conflicts, strict);
+        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts) {
+            super.checkCompatibility(fieldType, conflicts);
             CompletionFieldType other = (CompletionFieldType)fieldType;
 
             if (preservePositionIncrements != other.preservePositionIncrements) {
@@ -607,8 +607,8 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         CompletionFieldMapper fieldMergeWith = (CompletionFieldMapper) mergeWith;
         this.maxInputLength = fieldMergeWith.maxInputLength;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -219,8 +219,8 @@ public class DateFieldMapper extends FieldMapper {
         }
 
         @Override
-        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(fieldType, conflicts, strict);
+        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts) {
+            super.checkCompatibility(fieldType, conflicts);
             DateFieldType other = (DateFieldType) fieldType;
             if (Objects.equals(dateTimeFormatter().format(), other.dateTimeFormatter().format()) == false) {
                 conflicts.add("mapper [" + name() + "] has different [format] values");
@@ -472,8 +472,8 @@ public class DateFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         final DateFieldMapper other = (DateFieldMapper) mergeWith;
         if (other.ignoreMalformed.explicit()) {
             this.ignoreMalformed = other.ignoreMalformed;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -296,8 +296,8 @@ public class DocumentMapper implements ToXContentFragment {
         return mapperService.getParentTypes().contains(type);
     }
 
-    public DocumentMapper merge(Mapping mapping, boolean updateAllTypes) {
-        Mapping merged = this.mapping.merge(mapping, updateAllTypes);
+    public DocumentMapper merge(Mapping mapping) {
+        Mapping merged = this.mapping.merge(mapping);
         return new DocumentMapper(mapperService, merged);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -218,7 +218,7 @@ final class DocumentParser {
                 // We can see the same mapper more than once, for example, if we had foo.bar and foo.baz, where
                 // foo did not yet exist. This will create 2 copies in dynamic mappings, which should be identical.
                 // Here we just skip over the duplicates, but we merge them to ensure there are no conflicts.
-                newMapper.merge(previousMapper, false);
+                newMapper.merge(previousMapper);
                 continue;
             }
             previousMapper = newMapper;
@@ -275,7 +275,7 @@ final class DocumentParser {
         int lastIndex = parentMappers.size() - 1;
         ObjectMapper withNewMapper = parentMappers.get(lastIndex).mappingUpdate(mapper);
         if (merge) {
-            withNewMapper = parentMappers.get(lastIndex).merge(withNewMapper, false);
+            withNewMapper = parentMappers.get(lastIndex).merge(withNewMapper);
         }
         parentMappers.set(lastIndex, withNewMapper);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -312,17 +312,16 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     }
 
     @Override
-    public FieldMapper merge(Mapper mergeWith, boolean updateAllTypes) {
+    public FieldMapper merge(Mapper mergeWith) {
         FieldMapper merged = clone();
-        merged.doMerge(mergeWith, updateAllTypes);
+        merged.doMerge(mergeWith);
         return merged;
     }
 
     /**
      * Merge changes coming from {@code mergeWith} in place.
-     * @param updateAllTypes TODO
      */
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         if (!this.getClass().equals(mergeWith.getClass())) {
             String mergedType = mergeWith.getClass().getSimpleName();
             if (mergeWith instanceof FieldMapper) {
@@ -553,7 +552,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                 if (mergeIntoMapper == null) {
                     newMappersBuilder.put(mergeWithMapper.simpleName(), mergeWithMapper);
                 } else {
-                    FieldMapper merged = mergeIntoMapper.merge(mergeWithMapper, false);
+                    FieldMapper merged = mergeIntoMapper.merge(mergeWithMapper);
                     newMappersBuilder.put(merged.simpleName(), merged); // override previous definition
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -165,17 +165,6 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
             return CONTENT_TYPE;
         }
 
-        @Override
-        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(fieldType, conflicts, strict);
-            if (strict) {
-                FieldNamesFieldType other = (FieldNamesFieldType)fieldType;
-                if (isEnabled() != other.isEnabled()) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [enabled] across all types.");
-                }
-            }
-        }
-
         public void setEnabled(boolean enabled) {
             checkIfFrozen();
             this.enabled = enabled;

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.regex.Regex;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -39,37 +38,13 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
     /** Full field name to field type */
     final CopyOnWriteHashMap<String, MappedFieldType> fullNameToFieldType;
 
-    /** Full field name to types containing a mapping for this full name. */
-    final CopyOnWriteHashMap<String, Set<String>> fullNameToTypes;
-
     /** Create a new empty instance. */
     FieldTypeLookup() {
         fullNameToFieldType = new CopyOnWriteHashMap<>();
-        fullNameToTypes = new CopyOnWriteHashMap<>();
     }
 
-    private FieldTypeLookup(
-            CopyOnWriteHashMap<String, MappedFieldType> fullName,
-            CopyOnWriteHashMap<String, Set<String>> fullNameToTypes) {
+    private FieldTypeLookup(CopyOnWriteHashMap<String, MappedFieldType> fullName) {
         this.fullNameToFieldType = fullName;
-        this.fullNameToTypes = fullNameToTypes;
-    }
-
-    private static CopyOnWriteHashMap<String, Set<String>> addType(CopyOnWriteHashMap<String, Set<String>> map, String key, String type) {
-        Set<String> types = map.get(key);
-        if (types == null) {
-            return map.copyAndPut(key, Collections.singleton(type));
-        } else if (types.contains(type)) {
-            // noting to do
-            return map;
-        } else {
-            Set<String> newTypes = new HashSet<>(types.size() + 1);
-            newTypes.addAll(types);
-            newTypes.add(type);
-            assert newTypes.size() == types.size() + 1;
-            newTypes = Collections.unmodifiableSet(newTypes);
-            return map.copyAndPut(key, newTypes);
-        }
     }
 
     /**
@@ -77,73 +52,47 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
      * from the provided fields. If a field already exists, the field type will be updated
      * to use the new mappers field type.
      */
-    public FieldTypeLookup copyAndAddAll(String type, Collection<FieldMapper> fieldMappers, boolean updateAllTypes) {
+    public FieldTypeLookup copyAndAddAll(String type, Collection<FieldMapper> fieldMappers) {
         Objects.requireNonNull(type, "type must not be null");
         if (MapperService.DEFAULT_MAPPING.equals(type)) {
             throw new IllegalArgumentException("Default mappings should not be added to the lookup");
         }
 
         CopyOnWriteHashMap<String, MappedFieldType> fullName = this.fullNameToFieldType;
-        CopyOnWriteHashMap<String, Set<String>> fullNameToTypes = this.fullNameToTypes;
 
         for (FieldMapper fieldMapper : fieldMappers) {
             MappedFieldType fieldType = fieldMapper.fieldType();
             MappedFieldType fullNameFieldType = fullName.get(fieldType.name());
 
-            // is the update even legal?
-            checkCompatibility(type, fieldMapper, updateAllTypes);
-
-            if (fieldType.equals(fullNameFieldType) == false) {
+            if (fullNameFieldType == null) {
+                // introduction of a new field
                 fullName = fullName.copyAndPut(fieldType.name(), fieldMapper.fieldType());
+            } else {
+                // modification of an existing field
+                checkCompatibility(fullNameFieldType, fieldType);
+                if (fieldType.equals(fullNameFieldType) == false) {
+                    fullName = fullName.copyAndPut(fieldType.name(), fieldMapper.fieldType());
+                }
             }
-
-            fullNameToTypes = addType(fullNameToTypes, fieldType.name(), type);
         }
-        return new FieldTypeLookup(fullName, fullNameToTypes);
-    }
-
-    private static boolean beStrict(String type, Set<String> types, boolean updateAllTypes) {
-        assert types.size() >= 1;
-        if (updateAllTypes) {
-            return false;
-        } else if (types.size() == 1 && types.contains(type)) {
-            // we are implicitly updating all types
-            return false;
-        } else {
-            return true;
-        }
+        return new FieldTypeLookup(fullName);
     }
 
     /**
      * Checks if the given field type is compatible with an existing field type.
      * An IllegalArgumentException is thrown in case of incompatibility.
-     * If updateAllTypes is true, only basic compatibility is checked.
      */
-    private void checkCompatibility(String type, FieldMapper fieldMapper, boolean updateAllTypes) {
-        MappedFieldType fieldType = fullNameToFieldType.get(fieldMapper.fieldType().name());
-        if (fieldType != null) {
-            List<String> conflicts = new ArrayList<>();
-            final Set<String> types = fullNameToTypes.get(fieldMapper.fieldType().name());
-            boolean strict = beStrict(type, types, updateAllTypes);
-            fieldType.checkCompatibility(fieldMapper.fieldType(), conflicts, strict);
-            if (conflicts.isEmpty() == false) {
-                throw new IllegalArgumentException("Mapper for [" + fieldMapper.fieldType().name() + "] conflicts with existing mapping in other types:\n" + conflicts.toString());
-            }
+    private void checkCompatibility(MappedFieldType existingFieldType, MappedFieldType newFieldType) {
+        List<String> conflicts = new ArrayList<>();
+        existingFieldType.checkCompatibility(newFieldType, conflicts);
+        if (conflicts.isEmpty() == false) {
+            throw new IllegalArgumentException("Mapper for [" + newFieldType.name() + "] conflicts with existing mapping:\n" + conflicts.toString());
         }
     }
 
     /** Returns the field for the given field */
     public MappedFieldType get(String field) {
         return fullNameToFieldType.get(field);
-    }
-
-    /** Get the set of types that have a mapping for the given field. */
-    public Set<String> getTypes(String field) {
-        Set<String> types = fullNameToTypes.get(field);
-        if (types == null) {
-            types = Collections.emptySet();
-        }
-        return types;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -142,8 +142,8 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         GeoPointFieldMapper gpfmMergeWith = (GeoPointFieldMapper) mergeWith;
         if (gpfmMergeWith.ignoreMalformed.explicit()) {
             this.ignoreMalformed = gpfmMergeWith.ignoreMalformed;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -309,8 +309,8 @@ public class GeoShapeFieldMapper extends FieldMapper {
         }
 
         @Override
-        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(fieldType, conflicts, strict);
+        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts) {
+            super.checkCompatibility(fieldType, conflicts);
             GeoShapeFieldType other = (GeoShapeFieldType)fieldType;
             // prevent user from changing strategies
             if (strategyName().equals(other.strategyName()) == false) {
@@ -333,15 +333,6 @@ public class GeoShapeFieldMapper extends FieldMapper {
             }
             if (precisionInMeters() != other.precisionInMeters()) {
                 conflicts.add("mapper [" + name() + "] has different [precision]");
-            }
-
-            if (strict) {
-                if (orientation() != other.orientation()) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [orientation] across all types.");
-                }
-                if (distanceErrorPct() != other.distanceErrorPct()) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [distance_error_pct] across all types.");
-                }
             }
         }
 
@@ -511,8 +502,8 @@ public class GeoShapeFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
 
         GeoShapeFieldMapper gsfm = (GeoShapeFieldMapper)mergeWith;
         if (gsfm.coerce.explicit()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -314,7 +314,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         // do nothing here, no merging, but also no exception
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -189,7 +189,7 @@ public class IndexFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         // nothing to do
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -390,8 +390,8 @@ public class IpFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         IpFieldMapper other = (IpFieldMapper) mergeWith;
         if (other.ignoreMalformed.explicit()) {
             this.ignoreMalformed = other.ignoreMalformed;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -187,8 +187,8 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         @Override
-        public void checkCompatibility(MappedFieldType otherFT, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(otherFT, conflicts, strict);
+        public void checkCompatibility(MappedFieldType otherFT, List<String> conflicts) {
+            super.checkCompatibility(otherFT, conflicts);
             KeywordFieldType other = (KeywordFieldType) otherFT;
             if (Objects.equals(normalizer, other.normalizer) == false) {
                 conflicts.add("mapper [" + name() + "] has different [normalizer]");
@@ -352,8 +352,8 @@ public final class KeywordFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         this.ignoreAbove = ((KeywordFieldMapper) mergeWith).ignoreAbove;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -157,7 +157,7 @@ public abstract class MappedFieldType extends FieldType {
      * If strict is true, all properties must be equal.
      * Otherwise, only properties which must never change in an index are checked.
      */
-    public void checkCompatibility(MappedFieldType other, List<String> conflicts, boolean strict) {
+    public void checkCompatibility(MappedFieldType other, List<String> conflicts) {
         checkTypeName(other);
 
         boolean indexed =  indexOptions() != IndexOptions.NONE;
@@ -201,27 +201,6 @@ public abstract class MappedFieldType extends FieldType {
 
         if (Objects.equals(similarity(), other.similarity()) == false) {
             conflicts.add("mapper [" + name() + "] has different [similarity]");
-        }
-
-        if (strict) {
-            if (omitNorms() != other.omitNorms()) {
-                conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [omit_norms] across all types.");
-            }
-            if (boost() != other.boost()) {
-                conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [boost] across all types.");
-            }
-            if (Objects.equals(searchAnalyzer(), other.searchAnalyzer()) == false) {
-                conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [search_analyzer] across all types.");
-            }
-            if (Objects.equals(searchQuoteAnalyzer(), other.searchQuoteAnalyzer()) == false) {
-                conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [search_quote_analyzer] across all types.");
-            }
-            if (Objects.equals(nullValue(), other.nullValue()) == false) {
-                conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [null_value] across all types.");
-            }
-            if (eagerGlobalOrdinals() != other.eagerGlobalOrdinals()) {
-                conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [eager_global_ordinals] across all types.");
-            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -175,7 +175,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
     /** Return the merge of {@code mergeWith} into this.
      *  Both {@code this} and {@code mergeWith} will be left unmodified. */
-    public abstract Mapper merge(Mapper mergeWith, boolean updateAllTypes);
+    public abstract Mapper merge(Mapper mergeWith);
 
     /**
      * Update the field type of this mapper. This is necessary because some mapping updates

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -84,9 +84,9 @@ public final class Mapping implements ToXContentFragment {
         return (T) metadataMappersMap.get(clazz);
     }
 
-    /** @see DocumentMapper#merge(Mapping, boolean) */
-    public Mapping merge(Mapping mergeWith, boolean updateAllTypes) {
-        RootObjectMapper mergedRoot = root.merge(mergeWith.root, updateAllTypes);
+    /** @see DocumentMapper#merge(Mapping) */
+    public Mapping merge(Mapping mergeWith) {
+        RootObjectMapper mergedRoot = root.merge(mergeWith.root);
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> mergedMetaDataMappers = new HashMap<>(metadataMappersMap);
         for (MetadataFieldMapper metaMergeWith : mergeWith.metadataMappers) {
             MetadataFieldMapper mergeInto = mergedMetaDataMappers.get(metaMergeWith.getClass());
@@ -94,7 +94,7 @@ public final class Mapping implements ToXContentFragment {
             if (mergeInto == null) {
                 merged = metaMergeWith;
             } else {
-                merged = mergeInto.merge(metaMergeWith, updateAllTypes);
+                merged = mergeInto.merge(metaMergeWith);
             }
             mergedMetaDataMappers.put(merged.getClass(), merged);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -67,7 +67,7 @@ public abstract class MetadataFieldMapper extends FieldMapper {
     public abstract void postParse(ParseContext context) throws IOException;
 
     @Override
-    public MetadataFieldMapper merge(Mapper mergeWith, boolean updateAllTypes) {
-        return (MetadataFieldMapper) super.merge(mergeWith, updateAllTypes);
+    public MetadataFieldMapper merge(Mapper mergeWith) {
+        return (MetadataFieldMapper) super.merge(mergeWith);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1019,8 +1019,8 @@ public class NumberFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         NumberFieldMapper other = (NumberFieldMapper) mergeWith;
         if (other.ignoreMalformed.explicit()) {
             this.ignoreMalformed = other.ignoreMalformed;

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.fielddata.ScriptDocValues;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -139,7 +138,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 Mapper mapper = builder.build(context);
                 Mapper existing = mappers.get(mapper.simpleName());
                 if (existing != null) {
-                    mapper = existing.merge(mapper, false);
+                    mapper = existing.merge(mapper);
                 }
                 mappers.put(mapper.simpleName(), mapper);
             }
@@ -426,17 +425,17 @@ public class ObjectMapper extends Mapper implements Cloneable {
     }
 
     @Override
-    public ObjectMapper merge(Mapper mergeWith, boolean updateAllTypes) {
+    public ObjectMapper merge(Mapper mergeWith) {
         if (!(mergeWith instanceof ObjectMapper)) {
             throw new IllegalArgumentException("Can't merge a non object mapping [" + mergeWith.name() + "] with an object mapping [" + name() + "]");
         }
         ObjectMapper mergeWithObject = (ObjectMapper) mergeWith;
         ObjectMapper merged = clone();
-        merged.doMerge(mergeWithObject, updateAllTypes);
+        merged.doMerge(mergeWithObject);
         return merged;
     }
 
-    protected void doMerge(final ObjectMapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(final ObjectMapper mergeWith) {
         if (nested().isNested()) {
             if (!mergeWith.nested().isNested()) {
                 throw new IllegalArgumentException("object mapping [" + name() + "] can't be changed from nested to non-nested");
@@ -459,7 +458,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 merged = mergeWithMapper;
             } else {
                 // root mappers can only exist here for backcompat, and are merged in Mapping
-                merged = mergeIntoMapper.merge(mergeWithMapper, updateAllTypes);
+                merged = mergeIntoMapper.merge(mergeWithMapper);
             }
             putMapper(merged);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
@@ -301,7 +301,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         ParentFieldMapper fieldMergeWith = (ParentFieldMapper) mergeWith;
         if (fieldMergeWith.parentType != null && Objects.equals(parentType, fieldMergeWith.parentType) == false) {
             throw new IllegalArgumentException("The _parent field's type option can't be changed: [" + parentType + "]->[" + fieldMergeWith.parentType + "]");
@@ -310,7 +310,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
         // update that does not explicitly configure the _parent field, so we
         // ignore it.
         if (fieldMergeWith.active()) {
-            super.doMerge(mergeWith, updateAllTypes);
+            super.doMerge(mergeWith);
         }
 
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
@@ -131,7 +131,7 @@ public class ParsedDocument {
         if (dynamicMappingsUpdate == null) {
             dynamicMappingsUpdate = update;
         } else {
-            dynamicMappingsUpdate = dynamicMappingsUpdate.merge(update, false);
+            dynamicMappingsUpdate = dynamicMappingsUpdate.merge(update);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -256,29 +256,6 @@ public class RangeFieldMapper extends FieldMapper {
             return rangeType.name;
         }
 
-        @Override
-        public void checkCompatibility(MappedFieldType fieldType, List<String> conflicts, boolean strict) {
-            super.checkCompatibility(fieldType, conflicts, strict);
-            if (strict) {
-                RangeFieldType other = (RangeFieldType)fieldType;
-                if (this.rangeType != other.rangeType) {
-                    conflicts.add("mapper [" + name()
-                        + "] is attempting to update from type [" + rangeType.name
-                        + "] to incompatible type [" + other.rangeType.name + "].");
-                }
-                if (this.rangeType == RangeType.DATE) {
-                    if (Objects.equals(dateTimeFormatter().format(), other.dateTimeFormatter().format()) == false) {
-                        conflicts.add("mapper [" + name()
-                            + "] is used by multiple types. Set update_all_types to true to update [format] across all types.");
-                    }
-                    if (Objects.equals(dateTimeFormatter().locale(), other.dateTimeFormatter().locale()) == false) {
-                        conflicts.add("mapper [" + name()
-                            + "] is used by multiple types. Set update_all_types to true to update [locale] across all types.");
-                    }
-                }
-            }
-        }
-
         public FormatDateTimeFormatter dateTimeFormatter() {
             return dateTimeFormatter;
         }
@@ -416,8 +393,8 @@ public class RangeFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
         RangeFieldMapper other = (RangeFieldMapper) mergeWith;
         if (other.coerce.explicit()) {
             this.coerce = other.coerce;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -268,13 +268,13 @@ public class RootObjectMapper extends ObjectMapper {
     }
 
     @Override
-    public RootObjectMapper merge(Mapper mergeWith, boolean updateAllTypes) {
-        return (RootObjectMapper) super.merge(mergeWith, updateAllTypes);
+    public RootObjectMapper merge(Mapper mergeWith) {
+        return (RootObjectMapper) super.merge(mergeWith);
     }
 
     @Override
-    protected void doMerge(ObjectMapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(ObjectMapper mergeWith) {
+        super.doMerge(mergeWith);
         RootObjectMapper mergeWithObject = (RootObjectMapper) mergeWith;
         if (mergeWithObject.numericDetection.explicit()) {
             this.numericDetection = mergeWithObject.numericDetection;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -201,7 +201,7 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         // do nothing here, no merging, but also no exception
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -278,7 +278,7 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         // nothing to do
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -291,7 +291,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         SourceFieldMapper sourceMergeWith = (SourceFieldMapper) mergeWith;
         List<String> conflicts = new ArrayList<>();
         if (this.enabled != sourceMergeWith.enabled) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -212,31 +212,6 @@ public class TextFieldMapper extends FieldMapper {
                     fielddataMinFrequency, fielddataMaxFrequency, fielddataMinSegmentSize);
         }
 
-        @Override
-        public void checkCompatibility(MappedFieldType other,
-                List<String> conflicts, boolean strict) {
-            super.checkCompatibility(other, conflicts, strict);
-            TextFieldType otherType = (TextFieldType) other;
-            if (strict) {
-                if (fielddata() != otherType.fielddata()) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update [fielddata] "
-                            + "across all types.");
-                }
-                if (fielddataMinFrequency() != otherType.fielddataMinFrequency()) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update "
-                            + "[fielddata_frequency_filter.min] across all types.");
-                }
-                if (fielddataMaxFrequency() != otherType.fielddataMaxFrequency()) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update "
-                            + "[fielddata_frequency_filter.max] across all types.");
-                }
-                if (fielddataMinSegmentSize() != otherType.fielddataMinSegmentSize()) {
-                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update "
-                            + "[fielddata_frequency_filter.min_segment_size] across all types.");
-                }
-            }
-        }
-
         public boolean fielddata() {
             return fielddata;
         }
@@ -357,8 +332,8 @@ public class TextFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
@@ -316,7 +316,7 @@ public class TypeFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         // do nothing here, no merging, but also no exception
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
@@ -229,7 +229,7 @@ public class UidFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         // do nothing here, no merging, but also no exception
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
@@ -145,7 +145,7 @@ public class VersionFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         // nothing to do
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -112,7 +112,7 @@ final class StoreRecovery {
             for (ObjectObjectCursor<String, MappingMetaData> mapping : sourceMetaData.getMappings()) {
                 mappingUpdateConsumer.accept(mapping.key, mapping.value);
             }
-            indexShard.mapperService().merge(sourceMetaData, MapperService.MergeReason.MAPPING_RECOVERY, true);
+            indexShard.mapperService().merge(sourceMetaData, MapperService.MergeReason.MAPPING_RECOVERY);
             // now that the mapping is merged we can validate the index sort configuration.
             Sort indexSort = indexShard.getIndexSort();
             final boolean hasNested = indexShard.mapperService().hasNested();

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -495,7 +495,7 @@ public class IndicesService extends AbstractLifecycleComponent
             final IndexService service =
                 createIndexService("metadata verification", metaData, indicesQueryCache, indicesFieldDataCache, emptyList());
             closeables.add(() -> service.close("metadata verification", false));
-            service.mapperService().merge(metaData, MapperService.MergeReason.MAPPING_RECOVERY, true);
+            service.mapperService().merge(metaData, MapperService.MergeReason.MAPPING_RECOVERY);
             if (metaData.equals(metaDataUpdate) == false) {
                 service.updateMetaData(metaDataUpdate);
             }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCreateIndexAction.java
@@ -49,7 +49,6 @@ public class RestCreateIndexAction extends BaseRestHandler {
         if (request.hasContent()) {
             createIndexRequest.source(request.content(), request.getXContentType());
         }
-        createIndexRequest.updateAllTypes(request.paramAsBoolean("update_all_types", false));
         createIndexRequest.timeout(request.paramAsTime("timeout", createIndexRequest.timeout()));
         createIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", createIndexRequest.masterNodeTimeout()));
         createIndexRequest.waitForActiveShards(ActiveShardCount.parseString(request.param("wait_for_active_shards")));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -70,7 +70,6 @@ public class RestPutMappingAction extends BaseRestHandler {
         PutMappingRequest putMappingRequest = putMappingRequest(Strings.splitStringByCommaToArray(request.param("index")));
         putMappingRequest.type(request.param("type"));
         putMappingRequest.source(request.requiredContent(), request.getXContentType());
-        putMappingRequest.updateAllTypes(request.paramAsBoolean("update_all_types", false));
         putMappingRequest.timeout(request.paramAsTime("timeout", putMappingRequest.timeout()));
         putMappingRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putMappingRequest.masterNodeTimeout()));
         putMappingRequest.indicesOptions(IndicesOptions.fromRequest(request, putMappingRequest.indicesOptions()));

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -280,7 +280,7 @@ public class CreateIndexIT extends ESIntegTestCase {
                     .field("type", "text")
                 .endObject().endObject().endObject());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> b.get());
-        assertThat(e.getMessage(), containsString("mapper [text] is used by multiple types"));
+        assertThat(e.getMessage(), containsString("Mapper for [text] conflicts with existing mapping:"));
     }
 
     public void testRestartIndexCreationAfterFullClusterRestart() throws Exception {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexCreationTaskTests.java
@@ -249,7 +249,7 @@ public class IndexCreationTaskTests extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     public void testIndexRemovalOnFailure() throws Exception {
-        doThrow(new RuntimeException("oops")).when(mapper).merge(anyMap(), anyObject(), anyBoolean());
+        doThrow(new RuntimeException("oops")).when(mapper).merge(anyMap(), anyObject());
 
         expectThrows(RuntimeException.class, this::executeTask);
 
@@ -333,7 +333,7 @@ public class IndexCreationTaskTests extends ESTestCase {
     @SuppressWarnings("unchecked")
     private Map<String, Map<String, Object>> getMappingsFromResponse() {
         final ArgumentCaptor<Map> argument = ArgumentCaptor.forClass(Map.class);
-        verify(mapper).merge(argument.capture(), anyObject(), anyBoolean());
+        verify(mapper).merge(argument.capture(), anyObject());
         return argument.getValue();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/AllFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/AllFieldMapperTests.java
@@ -33,7 +33,7 @@ public class AllFieldMapperTests extends ESSingleNodeTestCase {
                 .put("index.analysis.analyzer.default_search.type", "custom")
                 .put("index.analysis.analyzer.default_search.tokenizer", "standard").build());
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("_doc").endObject().endObject().string();
-        indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+        indexService.mapperService().merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, indexService.mapperService().documentMapper("_doc").mapping().toString());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -211,7 +211,7 @@ public class BooleanFieldMapperTests extends ESSingleNodeTestCase {
                     .endObject().endObject()
                 .endObject().endObject().string();
         DocumentMapper mapper = indexService.mapperService()
-            .merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+            .merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, mapper.mappingSource().toString());
         BytesReference source = XContentFactory.jsonBuilder()
                 .startObject()

--- a/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
@@ -306,11 +306,11 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().endObject().string();
 
         MapperService mapperService = createIndex("test").mapperService();
-        DocumentMapper docMapperBefore = mapperService.merge("type1", new CompressedXContent(mappingBefore), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper docMapperBefore = mapperService.merge("type1", new CompressedXContent(mappingBefore), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertEquals(Arrays.asList("foo", "bar"), docMapperBefore.mappers().getMapper("copy_test").copyTo().copyToFields());
 
-        DocumentMapper docMapperAfter = mapperService.merge("type1", new CompressedXContent(mappingAfter), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper docMapperAfter = mapperService.merge("type1", new CompressedXContent(mappingAfter), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertEquals(Arrays.asList("baz", "bar"), docMapperAfter.mappers().getMapper("copy_test").copyTo().copyToFields());
         assertEquals(Arrays.asList("foo", "bar"), docMapperBefore.mappers().getMapper("copy_test").copyTo().copyToFields());
@@ -438,7 +438,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
             .endObject();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> indexService.mapperService().merge("_doc", new CompressedXContent(rootToNestedMapping.bytes()),
-                        MergeReason.MAPPING_UPDATE, false));
+                        MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), Matchers.startsWith("Illegal combination of [copy_to] and [nested] mappings"));
 
         XContentBuilder nestedToNestedMapping = jsonBuilder().startObject()
@@ -466,7 +466,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
             .endObject();
         e = expectThrows(IllegalArgumentException.class,
                 () -> indexService.mapperService().merge("_doc", new CompressedXContent(nestedToNestedMapping.bytes()),
-                        MergeReason.MAPPING_UPDATE, false));
+                        MergeReason.MAPPING_UPDATE));
     }
 
     public void testCopyToSiblingNested() throws Exception {
@@ -496,7 +496,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
             .endObject();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> indexService.mapperService().merge("_doc", new CompressedXContent(rootToNestedMapping.bytes()),
-                        MergeReason.MAPPING_UPDATE, false));
+                        MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), Matchers.startsWith("Illegal combination of [copy_to] and [nested] mappings"));
     }
 
@@ -517,7 +517,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
             .endObject();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> indexService.mapperService().merge("_doc", new CompressedXContent(rootToNestedMapping.bytes()),
-                        MergeReason.MAPPING_UPDATE, false));
+                        MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), Matchers.startsWith("Cannot copy to field [target] since it is mapped as an object"));
     }
 
@@ -585,7 +585,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
 
         MapperService mapperService = createIndex("test").mapperService();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> mapperService.merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean()));
+                () -> mapperService.merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE));
         assertEquals("[copy_to] may not be used to copy to a multi-field: [my_field.bar]", e.getMessage());
     }
 
@@ -608,7 +608,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
 
         MapperService mapperService = createIndex("test").mapperService();
-        mapperService.merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean()); // no exception
+        mapperService.merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE); // no exception
     }
 
     public void testNestedCopyToMultiField() throws Exception {
@@ -633,7 +633,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
 
         MapperService mapperService = createIndex("test").mapperService();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> mapperService.merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean()));
+                () -> mapperService.merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE));
         assertEquals("[copy_to] may not be used to copy to a multi-field: [n.my_field.bar]", e.getMessage());
     }
 
@@ -654,7 +654,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
 
         MapperService mapperService = createIndex("test").mapperService();
         MapperParsingException e = expectThrows(MapperParsingException.class,
-                () -> mapperService.merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean()));
+                () -> mapperService.merge("_doc", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(),
                 Matchers.containsString("copy_to in multi fields is not allowed. Found the copy_to in field [bar] " +
                         "which is within a multi field."));

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -380,7 +380,7 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
             .startObject("release_date").field("type", "date").field("format", "yyyy/MM/dd").endObject()
             .endObject().endObject().endObject().string();
         DocumentMapper initMapper = indexService.mapperService().merge("movie", new CompressedXContent(initMapping),
-            MapperService.MergeReason.MAPPING_UPDATE, randomBoolean());
+            MapperService.MergeReason.MAPPING_UPDATE);
 
         assertThat(initMapper.mappers().getMapper("release_date"), notNullValue());
         assertFalse(initMapper.mappers().getMapper("release_date").fieldType().stored());
@@ -392,7 +392,7 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
 
         Exception e = expectThrows(IllegalArgumentException.class,
             () -> indexService.mapperService().merge("movie", new CompressedXContent(updateFormatMapping),
-                MapperService.MergeReason.MAPPING_UPDATE, randomBoolean()));
+                MapperService.MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), containsString("[mapper [release_date] has different [format] values]"));
     }
 
@@ -408,7 +408,7 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper update = indexService.mapperService().parse("_doc", new CompressedXContent(mappingUpdate), false);
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> mapper.merge(update.mapping(), randomBoolean()));
+                () -> mapper.merge(update.mapping()));
         assertEquals("mapper [date] of different type, current_type [date], merged_type [text]", e.getMessage());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperMergeTests.java
@@ -53,7 +53,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
                 .endObject().endObject().endObject().string();
         DocumentMapper stage2 = parser.parse("person", new CompressedXContent(stage2Mapping));
 
-        DocumentMapper merged = stage1.merge(stage2.mapping(), false);
+        DocumentMapper merged = stage1.merge(stage2.mapping());
         // stage1 mapping should not have been modified
         assertThat(stage1.mappers().smartNameFieldMapper("age"), nullValue());
         assertThat(stage1.mappers().smartNameFieldMapper("obj1.prop1"), nullValue());
@@ -72,7 +72,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
         DocumentMapper withDynamicMapper = parser.parse("type1", new CompressedXContent(withDynamicMapping));
         assertThat(withDynamicMapper.root().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
 
-        DocumentMapper merged = mapper.merge(withDynamicMapper.mapping(), false);
+        DocumentMapper merged = mapper.merge(withDynamicMapper.mapping());
         assertThat(merged.root().dynamic(), equalTo(ObjectMapper.Dynamic.FALSE));
     }
 
@@ -88,14 +88,14 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
         DocumentMapper nestedMapper = parser.parse("type1", new CompressedXContent(nestedMapping));
 
         try {
-            objectMapper.merge(nestedMapper.mapping(), false);
+            objectMapper.merge(nestedMapper.mapping());
             fail();
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("object mapping [obj] can't be changed from non-nested to nested"));
         }
 
         try {
-            nestedMapper.merge(objectMapper.mapping(), false);
+            nestedMapper.merge(objectMapper.mapping());
             fail();
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("object mapping [obj] can't be changed from nested to non-nested"));
@@ -115,7 +115,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
         DocumentMapper changed = parser.parse("type", new CompressedXContent(mapping2));
 
         assertThat(((NamedAnalyzer) existing.mappers().getMapper("field").fieldType().searchAnalyzer()).name(), equalTo("whitespace"));
-        DocumentMapper merged = existing.merge(changed.mapping(), false);
+        DocumentMapper merged = existing.merge(changed.mapping());
 
         assertThat(((NamedAnalyzer) merged.mappers().getMapper("field").fieldType().searchAnalyzer()).name(), equalTo("keyword"));
     }
@@ -129,8 +129,8 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
                 .startObject("properties").startObject("field").field("type", "text").field("analyzer", "standard").endObject().endObject()
                 .endObject().endObject().string();
 
-        DocumentMapper existing = mapperService.merge("type", new CompressedXContent(mapping1), MapperService.MergeReason.MAPPING_UPDATE, false);
-        DocumentMapper merged = mapperService.merge("type", new CompressedXContent(mapping2), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper existing = mapperService.merge("type", new CompressedXContent(mapping1), MapperService.MergeReason.MAPPING_UPDATE);
+        DocumentMapper merged = mapperService.merge("type", new CompressedXContent(mapping2), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertThat(((NamedAnalyzer) existing.mappers().getMapper("field").fieldType().searchAnalyzer()).name(), equalTo("whitespace"));
 
@@ -139,7 +139,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
 
     public void testConcurrentMergeTest() throws Throwable {
         final MapperService mapperService = createIndex("test").mapperService();
-        mapperService.merge("test", new CompressedXContent("{\"test\":{}}"), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("test", new CompressedXContent("{\"test\":{}}"), MapperService.MergeReason.MAPPING_UPDATE);
         final DocumentMapper documentMapper = mapperService.documentMapper("test");
 
         DocumentFieldMappers dfm = documentMapper.mappers();
@@ -169,7 +169,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
                         Mapping update = doc.dynamicMappingsUpdate();
                         assert update != null;
                         lastIntroducedFieldName.set(fieldName);
-                        mapperService.merge("test", new CompressedXContent(update.toString()), MapperService.MergeReason.MAPPING_UPDATE, false);
+                        mapperService.merge("test", new CompressedXContent(update.toString()), MapperService.MergeReason.MAPPING_UPDATE);
                     }
                 } catch (Exception e) {
                     error.set(e);
@@ -213,7 +213,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
                     .endObject()
                 .endObject().endObject().bytes());
         MapperService mapperService = createIndex("test").mapperService();
-        mapperService.merge("type", mapping, MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("type", mapping, MapperService.MergeReason.MAPPING_UPDATE);
 
         CompressedXContent update = new CompressedXContent(XContentFactory.jsonBuilder().startObject()
                 .startObject("type")
@@ -223,7 +223,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
                         .endObject()
                     .endObject()
                 .endObject().endObject().bytes());
-        DocumentMapper mapper = mapperService.merge("type", update, MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", update, MapperService.MergeReason.MAPPING_UPDATE);
 
         assertNotNull(mapper.mappers().getMapper("foo"));
         assertFalse(mapper.sourceMapper().enabled());
@@ -244,7 +244,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
             .startObject("name").field("type", "text").endObject()
             .endObject().endObject().endObject().string();
         DocumentMapper updatedMapper1 = parser.parse("child", new CompressedXContent(updatedMapping1));
-        DocumentMapper mergedMapper1 = initMapper.merge(updatedMapper1.mapping(), false);
+        DocumentMapper mergedMapper1 = initMapper.merge(updatedMapper1.mapping());
 
         assertThat(mergedMapper1.mappers().getMapper("_parent#parent"), notNullValue());
         assertThat(mergedMapper1.mappers().getMapper("name"), notNullValue());
@@ -255,7 +255,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
             .startObject("age").field("type", "byte").endObject()
             .endObject().endObject().endObject().string();
         DocumentMapper updatedMapper2 = parser.parse("child", new CompressedXContent(updatedMapping2));
-        DocumentMapper mergedMapper2 = mergedMapper1.merge(updatedMapper2.mapping(), false);
+        DocumentMapper mergedMapper2 = mergedMapper1.merge(updatedMapper2.mapping());
 
         assertThat(mergedMapper2.mappers().getMapper("_parent#parent"), notNullValue());
         assertThat(mergedMapper2.mappers().getMapper("name"), notNullValue());
@@ -265,7 +265,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
             .startObject("_parent").field("type", "new_parent").endObject()
             .endObject().endObject().string();
         DocumentMapper modParentMapper = parser.parse("child", new CompressedXContent(modParentMapping));
-        Exception e = expectThrows(IllegalArgumentException.class, () -> initMapper.merge(modParentMapper.mapping(), false));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> initMapper.merge(modParentMapper.mapping()));
         assertThat(e.getMessage(), containsString("The _parent field's type option can't be changed: [parent]->[new_parent]"));
     }
 
@@ -286,7 +286,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
             .startObject("age").field("type", "byte").endObject()
             .endObject().endObject().endObject().string();
         DocumentMapper updatedMapper = parser.parse("cowboy", new CompressedXContent(updatedMapping));
-        Exception e = expectThrows(IllegalArgumentException.class, () -> initMapper.merge(updatedMapper.mapping(), false));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> initMapper.merge(updatedMapper.mapping()));
         assertThat(e.getMessage(), containsString("The _parent field's type option can't be changed: [null]->[parent]"));
     }
 
@@ -317,7 +317,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
             .string();
         DocumentMapper updatedMapper = parser.parse("test", new CompressedXContent(updateMapping));
 
-        assertThat(initMapper.merge(updatedMapper.mapping(), true).meta().get("foo"), equalTo("bar"));
+        assertThat(initMapper.merge(updatedMapper.mapping()).meta().get("foo"), equalTo("bar"));
 
         updateMapping = XContentFactory.jsonBuilder()
             .startObject()
@@ -330,6 +330,6 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
             .string();
         updatedMapper = parser.parse("test", new CompressedXContent(updateMapping));
 
-        assertThat(initMapper.merge(updatedMapper.mapping(), true).meta().get("foo"), equalTo("new_bar"));
+        assertThat(initMapper.merge(updatedMapper.mapping()).meta().get("foo"), equalTo("new_bar"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -552,7 +552,7 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
                     .endArray()
                 .endObject().endObject();
         indexService.mapperService().merge("_doc", new CompressedXContent(mappings1.bytes()),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
 
         XContentBuilder json = XContentFactory.jsonBuilder().startObject()
                     .field("field", "foo")
@@ -564,7 +564,7 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
         assertNotNull(parsed.dynamicMappingsUpdate());
 
         indexService.mapperService().merge("_doc", new CompressedXContent(parsed.dynamicMappingsUpdate().toString()),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
         mapper = indexService.mapperService().documentMapper("_doc");
         assertNotNull(mapper.mappers().getMapper("field.raw"));
         parsed = mapper.parse(source);
@@ -591,7 +591,7 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
             .endObject()
             .endArray()
             .endObject().endObject();
-        indexService.mapperService().merge("type1", new CompressedXContent(mappings1.bytes()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        indexService.mapperService().merge("type1", new CompressedXContent(mappings1.bytes()), MapperService.MergeReason.MAPPING_UPDATE);
         XContentBuilder mappings2 = jsonBuilder().startObject()
             .startObject("type2")
             .startObject("properties")
@@ -600,7 +600,7 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject().endObject();
-        indexService.mapperService().merge("type2", new CompressedXContent(mappings2.bytes()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        indexService.mapperService().merge("type2", new CompressedXContent(mappings2.bytes()), MapperService.MergeReason.MAPPING_UPDATE);
 
         XContentBuilder json = XContentFactory.jsonBuilder().startObject()
             .field("field", "foo")
@@ -611,7 +611,7 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
         ParsedDocument parsed = mapper.parse(source);
         assertNotNull(parsed.dynamicMappingsUpdate());
 
-        indexService.mapperService().merge("type1", new CompressedXContent(parsed.dynamicMappingsUpdate().toString()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        indexService.mapperService().merge("type1", new CompressedXContent(parsed.dynamicMappingsUpdate().toString()), MapperService.MergeReason.MAPPING_UPDATE);
         mapper = indexService.mapperService().documentMapper("type1");
         assertNotNull(mapper.mappers().getMapper("field.raw"));
         parsed = mapper.parse(source);
@@ -624,7 +624,7 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
                 .startObject("type")
                     .field("numeric_detection", true)
                 .endObject().endObject().string();
-        mapperService.merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         DocumentMapper mapper = mapperService.documentMapper("type");
         doTestDefaultFloatingPointMappings(mapper, XContentFactory.jsonBuilder());
         doTestDefaultFloatingPointMappings(mapper, XContentFactory.yamlBuilder());

--- a/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ExternalMapper.java
@@ -199,7 +199,7 @@ public class ExternalMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
+    protected void doMerge(Mapper mergeWith) {
         // ignore this for now
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FakeStringFieldMapper.java
@@ -156,8 +156,8 @@ public class FakeStringFieldMapper extends FieldMapper {
     }
 
     @Override
-    protected void doMerge(Mapper mergeWith, boolean updateAllTypes) {
-        super.doMerge(mergeWith, updateAllTypes);
+    protected void doMerge(Mapper mergeWith) {
+        super.doMerge(mergeWith);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
@@ -137,11 +137,11 @@ public class FieldNamesFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
 
-        DocumentMapper mapperEnabled = mapperService.merge("type", new CompressedXContent(enabledMapping), MapperService.MergeReason.MAPPING_UPDATE, false);
-        DocumentMapper mapperDisabled = mapperService.merge("type", new CompressedXContent(disabledMapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapperEnabled = mapperService.merge("type", new CompressedXContent(enabledMapping), MapperService.MergeReason.MAPPING_UPDATE);
+        DocumentMapper mapperDisabled = mapperService.merge("type", new CompressedXContent(disabledMapping), MapperService.MergeReason.MAPPING_UPDATE);
         assertFalse(mapperDisabled.metadataMapper(FieldNamesFieldMapper.class).fieldType().isEnabled());
 
-        mapperEnabled = mapperService.merge("type", new CompressedXContent(enabledMapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperEnabled = mapperService.merge("type", new CompressedXContent(enabledMapping), MapperService.MergeReason.MAPPING_UPDATE);
         assertTrue(mapperEnabled.metadataMapper(FieldNamesFieldMapper.class).fieldType().isEnabled());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
@@ -417,13 +417,13 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .field("precision", "1m").field("tree_levels", 8).field("distance_error_pct", 0.01).field("orientation", "ccw")
                 .endObject().endObject().endObject().endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
-        DocumentMapper docMapper = mapperService.merge("type", new CompressedXContent(stage1Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper docMapper = mapperService.merge("type", new CompressedXContent(stage1Mapping), MapperService.MergeReason.MAPPING_UPDATE);
         String stage2Mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("shape").field("type", "geo_shape").field("tree", "quadtree")
                 .field("strategy", "term").field("precision", "1km").field("tree_levels", 26).field("distance_error_pct", 26)
                 .field("orientation", "cw").endObject().endObject().endObject().endObject().string();
         try {
-            mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("mapper [shape] has different [strategy]"));
@@ -449,7 +449,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
         stage2Mapping = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("shape").field("type", "geo_shape").field("precision", "1m")
                 .field("tree_levels", 8).field("distance_error_pct", 0.001).field("orientation", "cw").endObject().endObject().endObject().endObject().string();
-        docMapper = mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        docMapper = mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         fieldMapper = docMapper.mappers().getMapper("shape");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));

--- a/server/src/test/java/org/elasticsearch/index/mapper/IdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IdFieldMapperTests.java
@@ -62,7 +62,7 @@ public class IdFieldMapperTests extends ESSingleNodeTestCase {
                 .put("index.version.created", Version.V_5_6_0)
                 .build();
         MapperService mapperService = createIndex("test", indexSettings).mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE);
         ParsedDocument document = mapper.parse(SourceToParse.source("index", "type", "id", new BytesArray("{}"), XContentType.JSON));
         assertEquals(Collections.<IndexableField>emptyList(), Arrays.asList(document.rootDoc().getFields(IdFieldMapper.NAME)));
     }
@@ -70,7 +70,7 @@ public class IdFieldMapperTests extends ESSingleNodeTestCase {
     public void testDefaultsSingleType() throws IOException {
         Settings indexSettings = Settings.EMPTY;
         MapperService mapperService = createIndex("test", indexSettings).mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE);
         ParsedDocument document = mapper.parse(SourceToParse.source("index", "type", "id", new BytesArray("{}"), XContentType.JSON));
         IndexableField[] fields = document.rootDoc().getFields(IdFieldMapper.NAME);
         assertEquals(1, fields.length);

--- a/server/src/test/java/org/elasticsearch/index/mapper/JavaMultiFieldMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JavaMultiFieldMergeTests.java
@@ -40,7 +40,7 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping1.json");
         MapperService mapperService = createIndex("test").mapperService();
 
-        DocumentMapper docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
         assertThat(docMapper.mappers().getMapper("name.indexed"), nullValue());
@@ -53,7 +53,7 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         assertThat(f, nullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping2.json");
-        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
@@ -70,7 +70,7 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         assertThat(f, notNullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping3.json");
-        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
@@ -81,7 +81,7 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping4.json");
-        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
@@ -96,7 +96,7 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping1.json");
         MapperService mapperService = createIndex("test").mapperService();
 
-        DocumentMapper docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
         assertThat(docMapper.mappers().getMapper("name.indexed"), nullValue());
@@ -110,7 +110,7 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
 
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade1.json");
-        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
@@ -127,7 +127,7 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         assertThat(f, notNullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade2.json");
-        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
 
@@ -140,7 +140,7 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade3.json");
         try {
-            mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("mapper [name] has different [index] values"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -358,7 +358,7 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
                 .startObject("properties").startObject("field")
                 .field("type", "keyword").field("normalizer", "my_lowercase").endObject().endObject()
                 .endObject().endObject().string();
-        indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean());
+        indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
 
         String mapping2 = XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("field")
@@ -366,9 +366,9 @@ public class KeywordFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> indexService.mapperService().merge("type",
-                        new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, randomBoolean()));
+                        new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE));
         assertEquals(
-                "Mapper for [field] conflicts with existing mapping in other types:\n[mapper [field] has different [normalizer]]",
+                "Mapper for [field] conflicts with existing mapping:\n[mapper [field] has different [normalizer]]",
                 e.getMessage());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -89,15 +89,15 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
         MapperService mapperService = indexService1.mapperService();
         assertEquals(Collections.emptySet(), mapperService.types());
 
-        mapperService.merge("type1", new CompressedXContent("{\"type1\":{}}"), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("type1", new CompressedXContent("{\"type1\":{}}"), MapperService.MergeReason.MAPPING_UPDATE);
         assertNull(mapperService.documentMapper(MapperService.DEFAULT_MAPPING));
         assertEquals(Collections.singleton("type1"), mapperService.types());
 
-        mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent("{\"_default_\":{}}"), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent("{\"_default_\":{}}"), MapperService.MergeReason.MAPPING_UPDATE);
         assertNotNull(mapperService.documentMapper(MapperService.DEFAULT_MAPPING));
         assertEquals(Collections.singleton("type1"), mapperService.types());
 
-        mapperService.merge("type2", new CompressedXContent("{\"type2\":{}}"), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("type2", new CompressedXContent("{\"type2\":{}}"), MapperService.MergeReason.MAPPING_UPDATE);
         assertNotNull(mapperService.documentMapper(MapperService.DEFAULT_MAPPING));
         assertEquals(new HashSet<>(Arrays.asList("type1", "type2")), mapperService.types());
     }
@@ -148,11 +148,11 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
                 throw new UncheckedIOException(e);
             }
         };
-        createIndex("test1").mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE, false);
+        createIndex("test1").mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE);
         //set total number of fields to 1 to trigger an exception
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
             createIndex("test2", Settings.builder().put(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), 1).build())
-                .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE, false);
+                .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE);
         });
         assertTrue(e.getMessage(), e.getMessage().contains("Limit of total fields [1] in index [test2] has been exceeded"));
     }
@@ -166,7 +166,7 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
                 .endObject().endObject().bytes());
         IndexService indexService1 = createIndex("test1", Settings.builder().put(MapperService.INDEX_MAPPING_DEPTH_LIMIT_SETTING.getKey(), 1).build());
         // no exception
-        indexService1.mapperService().merge("type", simpleMapping, MergeReason.MAPPING_UPDATE, false);
+        indexService1.mapperService().merge("type", simpleMapping, MergeReason.MAPPING_UPDATE);
 
         CompressedXContent objectMapping = new CompressedXContent(XContentFactory.jsonBuilder().startObject()
                 .startObject("properties")
@@ -177,10 +177,10 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
 
         IndexService indexService2 = createIndex("test2");
         // no exception
-        indexService2.mapperService().merge("type", objectMapping, MergeReason.MAPPING_UPDATE, false);
+        indexService2.mapperService().merge("type", objectMapping, MergeReason.MAPPING_UPDATE);
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> indexService1.mapperService().merge("type2", objectMapping, MergeReason.MAPPING_UPDATE, false));
+                () -> indexService1.mapperService().merge("type2", objectMapping, MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), containsString("Limit of mapping depth [1] in index [test1] has been exceeded"));
     }
 
@@ -200,14 +200,14 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
 
         mappings.put(MapperService.DEFAULT_MAPPING, MapperService.parseMapping(xContentRegistry(), "{}"));
         MapperException e = expectThrows(MapperParsingException.class,
-            () -> mapperService.merge(mappings, MergeReason.MAPPING_UPDATE, false));
+            () -> mapperService.merge(mappings, MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), startsWith("Failed to parse mapping [" + MapperService.DEFAULT_MAPPING + "]: "));
 
         mappings.clear();
         mappings.put("type1", MapperService.parseMapping(xContentRegistry(), "{}"));
 
         e = expectThrows( MapperParsingException.class,
-            () -> mapperService.merge(mappings, MergeReason.MAPPING_UPDATE, false));
+            () -> mapperService.merge(mappings, MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), startsWith("Failed to parse mapping [type1]: "));
     }
 
@@ -223,7 +223,7 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
         Set<String> parentTypes = mapperService.getParentTypes();
 
         Map<String, Map<String, Object>> mappings = new HashMap<>();
-        mapperService.merge(mappings, MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge(mappings, MergeReason.MAPPING_UPDATE);
         assertSame(parentTypes, mapperService.getParentTypes());
     }
 
@@ -238,10 +238,10 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject().endObject().bytes());
 
-        indexService.mapperService().merge("type1", simpleMapping, MergeReason.MAPPING_UPDATE, true);
+        indexService.mapperService().merge("type1", simpleMapping, MergeReason.MAPPING_UPDATE);
         DocumentMapper documentMapper = indexService.mapperService().documentMapper("type1");
 
-        indexService.mapperService().merge("type2", simpleMapping, MergeReason.MAPPING_UPDATE, true);
+        indexService.mapperService().merge("type2", simpleMapping, MergeReason.MAPPING_UPDATE);
         assertSame(indexService.mapperService().documentMapper("type1"), documentMapper);
 
         CompressedXContent normsDisabledMapping = new CompressedXContent(XContentFactory.jsonBuilder().startObject()
@@ -252,7 +252,7 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject().endObject().bytes());
 
-        indexService.mapperService().merge("type3", normsDisabledMapping, MergeReason.MAPPING_UPDATE, true);
+        indexService.mapperService().merge("type3", normsDisabledMapping, MergeReason.MAPPING_UPDATE);
         assertNotSame(indexService.mapperService().documentMapper("type1"), documentMapper);
     }
 
@@ -307,7 +307,7 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
             .endObject().endObject().bytes());
         invalidNestedException = expectThrows(IllegalArgumentException.class,
             () -> indexService.mapperService().merge("t", nestedFieldMapping,
-                MergeReason.MAPPING_UPDATE, true));
+                MergeReason.MAPPING_UPDATE));
         assertThat(invalidNestedException.getMessage(),
             containsString("cannot have nested fields when index sort is activated"));
     }
@@ -315,18 +315,18 @@ public class MapperServiceTests extends ESSingleNodeTestCase {
     public void testForbidMultipleTypes() throws IOException {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").endObject().endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
-        mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean());
+        mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
 
         String mapping2 = XContentFactory.jsonBuilder().startObject().startObject("type2").endObject().endObject().string();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> mapperService.merge("type2", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, randomBoolean()));
+                () -> mapperService.merge("type2", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), Matchers.startsWith("Rejecting mapping update to [test] as the final mapping would have more than 1 type: "));
     }
 
     public void testDefaultMappingIsDeprecated() throws IOException {
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("_default_").endObject().endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
-        mapperService.merge("_default_", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, randomBoolean());
+        mapperService.merge("_default_", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         assertWarnings("[_default_] mapping is deprecated since it is not useful anymore now that indexes " +
                 "cannot have more than one type");
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -444,23 +444,23 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
         };
 
         // default limit allows at least two nested fields
-        createIndex("test1").mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE, false);
+        createIndex("test1").mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE);
 
         // explicitly setting limit to 0 prevents nested fields
         Exception e = expectThrows(IllegalArgumentException.class, () ->
             createIndex("test2", Settings.builder().put(MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.getKey(), 0).build())
-                .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE, false));
+                .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), containsString("Limit of nested fields [0] in index [test2] has been exceeded"));
 
         // setting limit to 1 with 2 nested fields fails
         e = expectThrows(IllegalArgumentException.class, () ->
             createIndex("test3", Settings.builder().put(MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.getKey(), 1).build())
-                .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE, false));
+                .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), containsString("Limit of nested fields [1] in index [test3] has been exceeded"));
 
         // do not check nested fields limit if mapping is not updated
         createIndex("test4", Settings.builder().put(MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.getKey(), 0).build())
-            .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_RECOVERY, false);
+            .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_RECOVERY);
     }
 
     public void testLimitOfNestedFieldsWithMultiTypePerIndex() throws Exception {
@@ -479,19 +479,19 @@ public class NestedObjectMapperTests extends ESSingleNodeTestCase {
         MapperService mapperService = createIndex("test4", Settings.builder()
             .put("index.version.created", Version.V_5_6_0)
             .put(MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.getKey(), 2).build()).mapperService();
-        mapperService.merge("type1", new CompressedXContent(mapping.apply("type1")), MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("type1", new CompressedXContent(mapping.apply("type1")), MergeReason.MAPPING_UPDATE);
         // merging same fields, but different type is ok
-        mapperService.merge("type2", new CompressedXContent(mapping.apply("type2")), MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("type2", new CompressedXContent(mapping.apply("type2")), MergeReason.MAPPING_UPDATE);
         // adding new fields from different type is not ok
         String mapping2 = XContentFactory.jsonBuilder().startObject().startObject("type3").startObject("properties").startObject("nested3")
             .field("type", "nested").startObject("properties").endObject().endObject().endObject().endObject().endObject().string();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->
-            mapperService.merge("type3", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, false));
+            mapperService.merge("type3", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), containsString("Limit of nested fields [2] in index [test4] has been exceeded"));
 
         // do not check nested fields limit if mapping is not updated
         createIndex("test5", Settings.builder().put(MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.getKey(), 0).build())
-            .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_RECOVERY, false);
+            .mapperService().merge("type", new CompressedXContent(mapping.apply("type")), MergeReason.MAPPING_RECOVERY);
     }
 
     public void testParentObjectMapperAreNested() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -181,13 +181,13 @@ public class ObjectMapperTests extends ESSingleNodeTestCase {
                     .endObject()
                 .endObject().endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         assertNull(mapper.root().dynamic());
         String update = XContentFactory.jsonBuilder().startObject()
                 .startObject("type")
                     .field("dynamic", "strict")
                 .endObject().endObject().string();
-        mapper = mapperService.merge("type", new CompressedXContent(update), MergeReason.MAPPING_UPDATE, false);
+        mapper = mapperService.merge("type", new CompressedXContent(update), MergeReason.MAPPING_UPDATE);
         assertEquals(Dynamic.STRICT, mapper.root().dynamic());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParentFieldMapperTests.java
@@ -78,8 +78,8 @@ public class ParentFieldMapperTests extends ESSingleNodeTestCase {
                 .startObject("_parent").field("type", "parent_type").endObject()
                 .endObject().endObject().string();
         IndexService indexService = createIndex("test", Settings.builder().put("index.version.created", Version.V_5_6_0).build());
-        indexService.mapperService().merge("parent_type", new CompressedXContent(parentMapping), MergeReason.MAPPING_UPDATE, false);
-        indexService.mapperService().merge("child_type", new CompressedXContent(childMapping), MergeReason.MAPPING_UPDATE, false);
+        indexService.mapperService().merge("parent_type", new CompressedXContent(parentMapping), MergeReason.MAPPING_UPDATE);
+        indexService.mapperService().merge("child_type", new CompressedXContent(childMapping), MergeReason.MAPPING_UPDATE);
 
         // Indexing parent doc:
         DocumentMapper parentDocMapper = indexService.mapperService().documentMapper("parent_type");
@@ -121,7 +121,7 @@ public class ParentFieldMapperTests extends ESSingleNodeTestCase {
             .startObject("properties")
             .endObject()
             .endObject().endObject();
-        mapperService.merge("some_type", new CompressedXContent(mappingSource.string()), MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("some_type", new CompressedXContent(mappingSource.string()), MergeReason.MAPPING_UPDATE);
         Set<String> allFields = new HashSet<>(mapperService.simpleMatchToIndexNames("*"));
         assertTrue(allFields.contains("_parent"));
         assertFalse(allFields.contains("_parent#null"));
@@ -146,15 +146,15 @@ public class ParentFieldMapperTests extends ESSingleNodeTestCase {
                 .startObject("_parent").field("type", "parent_type").endObject()
                 .endObject().endObject().string();
         IndexService indexService = createIndex("test", Settings.builder().put("index.version.created", Version.V_5_6_0).build());
-        indexService.mapperService().merge("parent_type", new CompressedXContent(parentMapping), MergeReason.MAPPING_UPDATE, false);
-        indexService.mapperService().merge("child_type", new CompressedXContent(childMapping), MergeReason.MAPPING_UPDATE, false);
+        indexService.mapperService().merge("parent_type", new CompressedXContent(parentMapping), MergeReason.MAPPING_UPDATE);
+        indexService.mapperService().merge("child_type", new CompressedXContent(childMapping), MergeReason.MAPPING_UPDATE);
 
         assertTrue(indexService.mapperService().documentMapper("child_type").parentFieldMapper().fieldType().eagerGlobalOrdinals());
 
         String childMappingUpdate = XContentFactory.jsonBuilder().startObject().startObject("child_type")
                 .startObject("_parent").field("type", "parent_type").field("eager_global_ordinals", false).endObject()
                 .endObject().endObject().string();
-        indexService.mapperService().merge("child_type", new CompressedXContent(childMappingUpdate), MergeReason.MAPPING_UPDATE, false);
+        indexService.mapperService().merge("child_type", new CompressedXContent(childMappingUpdate), MergeReason.MAPPING_UPDATE);
 
         assertFalse(indexService.mapperService().documentMapper("child_type").parentFieldMapper().fieldType().eagerGlobalOrdinals());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
@@ -61,7 +61,7 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
             DOUBLE_RANGE_FIELD_NAME, "type=double_range",
             DATE_RANGE_FIELD_NAME, "type=date_range",
             IP_RANGE_FIELD_NAME, "type=ip_range"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
 
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -36,7 +36,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                     .endObject()
                 .endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, mapper.mappingSource().toString());
 
         // update with a different explicit value
@@ -46,7 +46,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                     .field("numeric_detection", true)
                 .endObject()
             .endObject().string();
-        mapper = mapperService.merge("type", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, false);
+        mapper = mapperService.merge("type", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping2, mapper.mappingSource().toString());
 
         // update with an implicit value: no change
@@ -55,7 +55,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                 .startObject("type")
                 .endObject()
             .endObject().string();
-        mapper = mapperService.merge("type", new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE, false);
+        mapper = mapperService.merge("type", new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping2, mapper.mappingSource().toString());
     }
 
@@ -67,7 +67,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                     .endObject()
                 .endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, mapper.mappingSource().toString());
 
         // update with a different explicit value
@@ -77,7 +77,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                     .field("date_detection", false)
                 .endObject()
             .endObject().string();
-        mapper = mapperService.merge("type", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, false);
+        mapper = mapperService.merge("type", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping2, mapper.mappingSource().toString());
 
         // update with an implicit value: no change
@@ -86,7 +86,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                 .startObject("type")
                 .endObject()
             .endObject().string();
-        mapper = mapperService.merge("type", new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE, false);
+        mapper = mapperService.merge("type", new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping2, mapper.mappingSource().toString());
     }
 
@@ -98,7 +98,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                     .endObject()
                 .endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, mapper.mappingSource().toString());
 
         // no update if formatters are not set explicitly
@@ -107,7 +107,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                 .startObject("type")
                 .endObject()
             .endObject().string();
-        mapper = mapperService.merge("type", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, false);
+        mapper = mapperService.merge("type", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, mapper.mappingSource().toString());
 
         String mapping3 = XContentFactory.jsonBuilder()
@@ -116,7 +116,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                     .field("dynamic_date_formats", Arrays.asList())
                 .endObject()
             .endObject().string();
-        mapper = mapperService.merge("type", new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE, false);
+        mapper = mapperService.merge("type", new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
     }
 
@@ -137,7 +137,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                     .endObject()
                 .endObject().string();
         MapperService mapperService = createIndex("test").mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, mapper.mappingSource().toString());
 
         // no update if templates are not set explicitly
@@ -146,7 +146,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                 .startObject("type")
                 .endObject()
             .endObject().string();
-        mapper = mapperService.merge("type", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, false);
+        mapper = mapperService.merge("type", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, mapper.mappingSource().toString());
 
         String mapping3 = XContentFactory.jsonBuilder()
@@ -155,7 +155,7 @@ public class RootObjectMapperTests extends ESSingleNodeTestCase {
                     .field("dynamic_templates", Arrays.asList())
                 .endObject()
             .endObject().string();
-        mapper = mapperService.merge("type", new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE, false);
+        mapper = mapperService.merge("type", new CompressedXContent(mapping3), MergeReason.MAPPING_UPDATE);
         assertEquals(mapping3, mapper.mappingSource().toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
@@ -164,7 +164,7 @@ public class SourceFieldMapperTests extends ESSingleNodeTestCase {
 
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_5_6_0).build();
         MapperService mapperService = createIndex("test", settings).mapperService();
-        mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent(defaultMapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent(defaultMapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         DocumentMapper mapper = mapperService.documentMapperWithAutoCreate("my_type").getDocumentMapper();
         assertThat(mapper.type(), equalTo("my_type"));
@@ -178,12 +178,12 @@ public class SourceFieldMapperTests extends ESSingleNodeTestCase {
 
         Settings settings = Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_5_6_0).build();
         MapperService mapperService = createIndex("test", settings).mapperService();
-        mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent(defaultMapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedXContent(defaultMapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         String mapping = XContentFactory.jsonBuilder().startObject().startObject("my_type")
                 .startObject("_source").field("enabled", true).endObject()
                 .endObject().endObject().string();
-        mapperService.merge("my_type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("my_type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         DocumentMapper mapper = mapperService.documentMapper("my_type");
         assertThat(mapper.type(), equalTo("my_type"));
@@ -194,10 +194,10 @@ public class SourceFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper docMapper = parser.parse("type", new CompressedXContent(mapping1));
         docMapper = parser.parse("type", docMapper.mappingSource());
         if (conflicts.length == 0) {
-            docMapper.merge(parser.parse("type", new CompressedXContent(mapping2)).mapping(), false);
+            docMapper.merge(parser.parse("type", new CompressedXContent(mapping2)).mapping());
         } else {
             try {
-                docMapper.merge(parser.parse("type", new CompressedXContent(mapping2)).mapping(), false);
+                docMapper.merge(parser.parse("type", new CompressedXContent(mapping2)).mapping());
                 fail();
             } catch (IllegalArgumentException e) {
                 for (String conflict : conflicts) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/StoredNumericValuesTests.java
@@ -62,7 +62,7 @@ public class StoredNumericValuesTests extends ESSingleNodeTestCase {
                 .endObject()
                 .string();
         MapperService mapperService = createIndex("test").mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
 
         ParsedDocument doc = mapper.parse(SourceToParse.source("test", "type", "1", XContentFactory.jsonBuilder()
                 .startObject()

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -205,7 +205,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
 
         DocumentMapper mapper = indexService.mapperService().merge("type",
-                new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+                new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
 
         assertEquals(mapping, mapper.mappingSource().toString());
 
@@ -247,7 +247,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
 
         DocumentMapper mapper = indexService.mapperService().merge("type",
-                new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+                new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
 
         assertEquals(mapping, mapper.mappingSource().toString());
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeFieldMapperTests.java
@@ -66,7 +66,7 @@ public class TypeFieldMapperTests extends ESSingleNodeTestCase {
                 .put("index.version.created", Version.V_5_6_0)
                 .build();
         MapperService mapperService = createIndex("test", indexSettings).mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE);
         ParsedDocument document = mapper.parse(SourceToParse.source("index", "type", "id", new BytesArray("{}"), XContentType.JSON));
 
         Directory dir = newDirectory();
@@ -93,7 +93,7 @@ public class TypeFieldMapperTests extends ESSingleNodeTestCase {
                 .put("index.version.created", Version.V_5_6_0)
                 .build();
         MapperService mapperService = createIndex("test", indexSettings).mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE);
         ParsedDocument document = mapper.parse(SourceToParse.source("index", "type", "id", new BytesArray("{}"), XContentType.JSON));
         IndexableField[] fields = document.rootDoc().getFields(TypeFieldMapper.NAME);
         assertEquals(IndexOptions.DOCS, fields[0].fieldType().indexOptions());
@@ -103,7 +103,7 @@ public class TypeFieldMapperTests extends ESSingleNodeTestCase {
     public void testDefaultsSingleType() throws IOException {
         Settings indexSettings = Settings.EMPTY;
         MapperService mapperService = createIndex("test", indexSettings).mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE);
         ParsedDocument document = mapper.parse(SourceToParse.source("index", "type", "id", new BytesArray("{}"), XContentType.JSON));
         assertEquals(Collections.<IndexableField>emptyList(), Arrays.asList(document.rootDoc().getFields(TypeFieldMapper.NAME)));
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/UidFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/UidFieldMapperTests.java
@@ -48,7 +48,7 @@ public class UidFieldMapperTests extends ESSingleNodeTestCase {
                 .put("index.version.created", Version.V_5_6_0)
                 .build();
         MapperService mapperService = createIndex("test", indexSettings).mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE);
         ParsedDocument document = mapper.parse(SourceToParse.source("index", "type", "id", new BytesArray("{}"), XContentType.JSON));
         IndexableField[] fields = document.rootDoc().getFields(UidFieldMapper.NAME);
         assertEquals(1, fields.length);
@@ -60,7 +60,7 @@ public class UidFieldMapperTests extends ESSingleNodeTestCase {
     public void testDefaultsSingleType() throws IOException {
         Settings indexSettings = Settings.EMPTY;
         MapperService mapperService = createIndex("test", indexSettings).mapperService();
-        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE, false);
+        DocumentMapper mapper = mapperService.merge("type", new CompressedXContent("{\"type\":{}}"), MergeReason.MAPPING_UPDATE);
         ParsedDocument document = mapper.parse(SourceToParse.source("index", "type", "id", new BytesArray("{}"), XContentType.JSON));
         assertEquals(Collections.<IndexableField>emptyList(), Arrays.asList(document.rootDoc().getFields(UidFieldMapper.NAME)));
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/UpdateMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/UpdateMappingTests.java
@@ -76,7 +76,7 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
         CompressedXContent mappingBeforeUpdate = indexService.mapperService().documentMapper("type").mappingSource();
         // simulate like in MetaDataMappingService#putMapping
         try {
-            indexService.mapperService().merge("type", new CompressedXContent(mappingUpdate.bytes()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            indexService.mapperService().merge("type", new CompressedXContent(mappingUpdate.bytes()), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             // expected
@@ -97,14 +97,14 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject().endObject();
 
         try {
-            mapperService.merge("type", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("type", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("mapper [foo] cannot be changed from type [long] to [double]"));
         }
 
         try {
-            mapperService.merge("type", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("type", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("mapper [foo] cannot be changed from type [long] to [double]"));
@@ -125,7 +125,7 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject().endObject();
 
         try {
-            mapperService.merge("type2", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("type2", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             // expected
@@ -133,7 +133,7 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
         }
 
         try {
-            mapperService.merge("type2", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("type2", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             // expected
@@ -154,15 +154,15 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
         MapperService mapperService = createIndex("test", Settings.builder().put("index.version.created",
             Version.V_5_6_0).build()).mapperService();
 
-        mapperService.merge("type1", new CompressedXContent(mapping1.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
-        mapperService.merge("type2", new CompressedXContent(mapping2.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("type1", new CompressedXContent(mapping1.string()), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge("type2", new CompressedXContent(mapping2.string()), MapperService.MergeReason.MAPPING_UPDATE);
 
         XContentBuilder update = XContentFactory.jsonBuilder().startObject().startObject("type2")
                 .startObject("properties").startObject("foo").field("type", "double").endObject()
                 .endObject().endObject().endObject();
 
         try {
-            mapperService.merge("type2", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("type2", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             // expected
@@ -170,7 +170,7 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
         }
 
         try {
-            mapperService.merge("type2", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("type2", new CompressedXContent(update.string()), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             // expected
@@ -190,14 +190,14 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
         MapperService mapperService = createIndex("test", Settings.builder().build()).mapperService();
 
         try {
-            mapperService.merge("type", new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("type", new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Field [_id] is defined twice in [type]"));
         }
 
         try {
-            mapperService.merge("type", new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+            mapperService.merge("type", new CompressedXContent(mapping.string()), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Field [_id] is defined twice in [type]"));
@@ -223,16 +223,16 @@ public class UpdateMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject().string();
 
         MapperService mapperService1 = createIndex("test1").mapperService();
-        mapperService1.merge("type1", new CompressedXContent(mapping1), MergeReason.MAPPING_UPDATE, false);
+        mapperService1.merge("type1", new CompressedXContent(mapping1), MergeReason.MAPPING_UPDATE);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> mapperService1.merge("type2", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, false));
+                () -> mapperService1.merge("type2", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), equalTo("[foo] is defined as a field in mapping [type2"
                 + "] but this name is already used for an object in other types"));
 
         MapperService mapperService2 = createIndex("test2").mapperService();
-        mapperService2.merge("type2", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE, false);
+        mapperService2.merge("type2", new CompressedXContent(mapping2), MergeReason.MAPPING_UPDATE);
         e = expectThrows(IllegalArgumentException.class,
-                () -> mapperService2.merge("type1", new CompressedXContent(mapping1), MergeReason.MAPPING_UPDATE, false));
+                () -> mapperService2.merge("type1", new CompressedXContent(mapping1), MergeReason.MAPPING_UPDATE));
         assertThat(e.getMessage(), equalTo("[foo] is defined as an object in mapping [type1"
                 + "] but this name is already used for a field in other types"));
     }

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -355,7 +355,7 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
                 "string_boost", "type=text,boost=4", "string_no_pos",
                 "type=text,index_options=docs").string()
             ),
-            MapperService.MergeReason.MAPPING_UPDATE, false);
+            MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     public void testMatchPhrasePrefixWithBoost() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -67,7 +67,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
                 OBJECT_FIELD_NAME, "type=object",
                 GEO_POINT_FIELD_NAME, "type=geo_point",
                 "nested1", "type=nested"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -835,7 +835,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 PutMappingRequest.buildFromSimplifiedDef("_doc",
                     "foo", "type=text",
                     "_field_names", "enabled=false").string()),
-            MapperService.MergeReason.MAPPING_UPDATE, true);
+            MapperService.MergeReason.MAPPING_UPDATE);
         try {
             QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder("foo:*");
             Query query = queryBuilder.toQuery(context);
@@ -848,7 +848,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                     PutMappingRequest.buildFromSimplifiedDef("_doc",
                         "foo", "type=text",
                         "_field_names", "enabled=true").string()),
-                MapperService.MergeReason.MAPPING_UPDATE, true);
+                MapperService.MergeReason.MAPPING_UPDATE);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
@@ -52,7 +52,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
                 .endObject()
             .endObject().endObject().string();
         indexService.mapperService().merge("type",
-                new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+                new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         QueryRewriteContext context = new QueryShardContext(0, indexService.getIndexSettings(), null, null, indexService.mapperService(),
                 null, null, xContentRegistry(), writableRegistry(), null, null, null, null);
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
@@ -70,7 +70,7 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
                 .endObject()
             .endObject().endObject().string();
         indexService.mapperService().merge("type",
-                new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE, false);
+                new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
         IndexReader reader = new MultiReader();
         QueryRewriteContext context = new QueryShardContext(0, indexService.getIndexSettings(), null, null, indexService.mapperService(),
                 null, null, xContentRegistry(), writableRegistry(), null, reader, null, null);

--- a/server/src/test/java/org/elasticsearch/index/query/TermsSetQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermsSetQueryBuilderTests.java
@@ -76,7 +76,7 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
         String docType = "_doc";
         mapperService.merge(docType, new CompressedXContent(PutMappingRequest.buildFromSimplifiedDef(docType,
                 "m_s_m", "type=long"
-        ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+        ).string()), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/search/MultiMatchQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/MultiMatchQueryTests.java
@@ -87,7 +87,7 @@ public class MultiMatchQueryTests extends ESSingleNodeTestCase {
                 "        }\n" +
                 "    }\n" +
                 "}";
-        mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE, false);
+        mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         this.indexService = indexService;
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -353,7 +353,6 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
 
         assertAcked(client().admin().indices().preparePutMapping("index")
                 .setType("type1")
-                .setUpdateAllTypes(true)
                 .setSource("f", "type=keyword,null_value=n/a")
                 .get());
 

--- a/server/src/test/java/org/elasticsearch/search/child/ParentFieldLoadingIT.java
+++ b/server/src/test/java/org/elasticsearch/search/child/ParentFieldLoadingIT.java
@@ -129,7 +129,6 @@ public class ParentFieldLoadingIT extends ESIntegTestCase {
 
         PutMappingResponse putMappingResponse = client().admin().indices().preparePutMapping("test").setType("child")
                 .setSource(childMapping(true))
-                .setUpdateAllTypes(true)
                 .get();
         assertAcked(putMappingResponse);
         Index test = resolveIndex("test");

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -80,7 +80,7 @@ public class TranslogHandler implements EngineConfig.TranslogRecoveryRunner {
                 Engine.Index engineIndex = (Engine.Index) operation;
                 Mapping update = engineIndex.parsedDoc().dynamicMappingsUpdate();
                 if (engineIndex.parsedDoc().dynamicMappingsUpdate() != null) {
-                    recoveredTypes.compute(engineIndex.type(), (k, mapping) -> mapping == null ? update : mapping.merge(update, false));
+                    recoveredTypes.compute(engineIndex.type(), (k, mapping) -> mapping == null ? update : mapping.merge(update));
                 }
                 engine.index(engineIndex);
                 break;

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -287,7 +287,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
             IndexCache indexCache = new IndexCache(indexSettings, new DisabledQueryCache(indexSettings), null);
             MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(),
                     indexSettings.getSettings(), "index");
-            mapperService.merge(indexMetaData, MapperService.MergeReason.MAPPING_RECOVERY, true);
+            mapperService.merge(indexMetaData, MapperService.MergeReason.MAPPING_RECOVERY);
             SimilarityService similarityService = new SimilarityService(indexSettings, null, Collections.emptyMap());
             final IndexEventListener indexEventListener = new IndexEventListener() {
             };
@@ -579,7 +579,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
 
     protected void updateMappings(IndexShard shard, IndexMetaData indexMetadata) {
         shard.indexSettings().updateIndexMetaData(indexMetadata);
-        shard.mapperService().merge(indexMetadata, MapperService.MergeReason.MAPPING_UPDATE, true);
+        shard.mapperService().merge(indexMetadata, MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     protected Engine.DeleteResult deleteDoc(IndexShard shard, String type, String id) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -1083,12 +1083,12 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
                         OBJECT_FIELD_NAME, "type=object",
                         GEO_POINT_FIELD_NAME, "type=geo_point",
                         GEO_SHAPE_FIELD_NAME, "type=geo_shape"
-                ).string()), MapperService.MergeReason.MAPPING_UPDATE, false);
+                ).string()), MapperService.MergeReason.MAPPING_UPDATE);
                 // also add mappings for two inner field in the object field
                 mapperService.merge(type, new CompressedXContent("{\"properties\":{\"" + OBJECT_FIELD_NAME + "\":{\"type\":\"object\","
                                 + "\"properties\":{\"" + DATE_FIELD_NAME + "\":{\"type\":\"date\"},\"" +
                                 INT_FIELD_NAME + "\":{\"type\":\"integer\"}}}}}"),
-                        MapperService.MergeReason.MAPPING_UPDATE, false);
+                        MapperService.MergeReason.MAPPING_UPDATE);
             }
             testCase.initializeAdditionalMappings(mapperService);
         }


### PR DESCRIPTION
This option is not useful in 7.x since no indices may have more than one type
anymore.