### PR TITLE
Ignore empty completion input

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -457,6 +457,10 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
                 }
                 input = input.substring(0, len);
             }
+            if (input.length() == 0) {
+                // Ignore empty inputs
+                continue;
+            }
             CompletionInputMetaData metaData = completionInput.getValue();
             if (fieldType().hasContextMappings()) {
                 fieldType().getContextMappings().addField(context.doc(), fieldType().name(),

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -395,6 +395,16 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             assertThat(cause, instanceOf(IllegalArgumentException.class));
             assertThat(cause.getMessage(), containsString("[0x1e]"));
         }
+
+        // empty inputs are ignored
+        ParsedDocument doc = defaultMapper.parse(SourceToParse.source("test", "type1", "1", XContentFactory.jsonBuilder()
+                .startObject()
+                    .field("completion", "")
+                .endObject()
+                .bytes(),
+            XContentType.JSON));
+        assertThat(doc.docs().size(), equalTo(1));
+        assertNull(doc.docs().get(0).get("completion"));
     }
 
     public void testPrefixQueryType() throws Exception {


### PR DESCRIPTION
This change makes sure that an empty completion input does not throw an IAE when indexing.
Instead the input is simply ignored.

Closes #23121