### PR TITLE
Doc: Invalid geohash aggregation precision field

### DIFF
--- a/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/geohashgrid-aggregation.asciidoc
@@ -149,15 +149,9 @@ field::         Mandatory. The name of the field indexed with GeoPoints.
 
 precision::     Optional. The string length of the geohashes used to define
                 cells/buckets in the results. Defaults to 5.
-                The precision can either be defined in terms of the integer
+                The precision value is defined in terms of the integer
                 precision levels mentioned above. Values outside of [1,12] will
                 be rejected.
-                Alternatively, the precision level can be approximated from a
-                distance measure like "1km", "10m". The precision level is
-                calculate such that cells will not exceed the specified
-                size (diagonal) of the required precision. When this would lead
-                to precision levels higher than the supported 12 levels,
-                (e.g. for distances <5.6cm) the value is rejected.
 
 size::          Optional. The maximum number of geohash buckets to return
                 (defaults to 10,000). When results are trimmed, buckets are


### PR DESCRIPTION
Updating the documentation to be consistent with the support for only integer precision levels. It looks like an older version of ES supported a value other than an integer (i.e. - `10km`)