### PR TITLE
Fork Groovy compiler onto compile Java home

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -459,6 +459,8 @@ class BuildPlugin implements Plugin<Project> {
             // also apply release flag to groovy, which is used in build-tools
             project.tasks.withType(GroovyCompile) {
                 final JavaVersion targetCompatibilityVersion = JavaVersion.toVersion(it.targetCompatibility)
+                options.fork = true
+                options.forkOptions.javaHome = new File(project.compilerJavaHome)
                 options.compilerArgs << '--release' << targetCompatibilityVersion.majorVersion
             }
         }


### PR DESCRIPTION
We use the --release flag which is only available starting in JDK 9. Since Gradle could be running on JDK 8 without forking the compiler, compilation will occur with the Java home of Gradle. This commit adds a fork flag to the compiler Java home so that we use the right compiler.
