### PR TITLE
 Fix setting notification for complex setting (affixMap settings) that could cause transient settings to be ignored

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -597,21 +597,7 @@ public class Setting<T> implements ToXContentObject {
 
                 @Override
                 public boolean hasChanged(Settings current, Settings previous) {
-                    return Stream.concat(matchStream(current), matchStream(previous)).distinct().anyMatch(aKey -> {
-                        String namespace = key.getNamespace(aKey);
-                        Setting<T> concreteSetting = getConcreteSetting(aKey);
-                        AbstractScopedSettings.SettingUpdater<T> updater =
-                            concreteSetting.newUpdater((v) -> {}, logger, (v) -> validator.accept(namespace, v));
-                        T value = updater.getValue(current, previous);
-                        if (updater.hasChanged(current, previous)) {
-                            // only the ones that have changed otherwise we might get too many updates
-                            // the hasChanged above checks only if there are any changes
-                            if ((omitDefaults && value.equals(concreteSetting.getDefault(current))) == false) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    });
+                    return current.filter(k -> match(k)).equals(previous.filter(k -> match(k))) == false;
                 }
 
                 @Override
@@ -623,8 +609,14 @@ public class Setting<T> implements ToXContentObject {
                         Setting<T> concreteSetting = getConcreteSetting(aKey);
                         AbstractScopedSettings.SettingUpdater<T> updater =
                             concreteSetting.newUpdater((v) -> {}, logger, (v) -> validator.accept(namespace, v));
-                        T value = updater.getValue(current, previous);
-                        result.put(namespace, value);
+                        if (updater.hasChanged(current, previous)) {
+                            // only the ones that have changed otherwise we might get too many updates
+                            // the hasChanged above checks only if there are any changes
+                            T value = updater.getValue(current, previous);
+                            if ((omitDefaults && value.equals(concreteSetting.getDefault(current))) == false) {
+                                result.put(namespace, value);
+                            }
+                        }
                     });
                     return result;
                 }

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -270,18 +270,19 @@ public class ScopedSettingsTests extends ESTestCase {
             .putList("foo.test_list.list", "16", "17")
             .putNull("foo.test_list_1.list")
             .build());
-        assertNull("test wasn't changed", intResults.get("test"));
+        // TODO: should this assertion be kept?
+        // assertNull("test wasn't changed", intResults.get("test"));
         assertEquals(8, intResults.get("test_1").intValue());
-        assertNull("test_list wasn't changed", listResults.get("test_list"));
+        // assertNull("test_list wasn't changed", listResults.get("test_list"));
         if (omitDefaults) {
             assertNull(listResults.get("test_list_1"));
             assertFalse(listResults.containsKey("test_list_1"));
             assertEquals(0, listResults.size());
-            assertEquals(1, intResults.size());
+            assertEquals(2, intResults.size());
         } else {
             assertEquals(Arrays.asList(1), listResults.get("test_list_1")); // reset to default
-            assertEquals(1, listResults.size());
-            assertEquals(1, intResults.size());
+            assertEquals(2, listResults.size());
+            assertEquals(2, intResults.size());
         }
 
     }

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -261,6 +261,21 @@ public class ScopedSettingsTests extends ESTestCase {
         assertEquals(2, listResults.size());
         assertEquals(2, intResults.size());
 
+        service.applySettings(Settings.builder()
+            .put("foo.test.bar", 2)
+            .put("foo.test_1.bar", 7)
+            .putList("foo.test_list.list", "16", "17")
+            .putList("foo.test_list_1.list", "18", "19", "20")
+            .build());
+
+        assertEquals(2, intResults.get("test").intValue());
+        assertEquals(7, intResults.get("test_1").intValue());
+        assertEquals(Arrays.asList(16, 17), listResults.get("test_list"));
+        assertEquals(Arrays.asList(18, 19, 20), listResults.get("test_list_1"));
+        assertEquals(2, listResults.size());
+        assertEquals(2, intResults.size());
+
+
         listResults.clear();
         intResults.clear();
 
@@ -270,19 +285,18 @@ public class ScopedSettingsTests extends ESTestCase {
             .putList("foo.test_list.list", "16", "17")
             .putNull("foo.test_list_1.list")
             .build());
-        // TODO: should this assertion be kept?
-        // assertNull("test wasn't changed", intResults.get("test"));
+        assertNull("test wasn't changed", intResults.get("test"));
         assertEquals(8, intResults.get("test_1").intValue());
-        // assertNull("test_list wasn't changed", listResults.get("test_list"));
+        assertNull("test_list wasn't changed", listResults.get("test_list"));
         if (omitDefaults) {
             assertNull(listResults.get("test_list_1"));
             assertFalse(listResults.containsKey("test_list_1"));
             assertEquals(0, listResults.size());
-            assertEquals(2, intResults.size());
+            assertEquals(1, intResults.size());
         } else {
             assertEquals(Arrays.asList(1), listResults.get("test_list_1")); // reset to default
-            assertEquals(2, listResults.size());
-            assertEquals(2, intResults.size());
+            assertEquals(1, listResults.size());
+            assertEquals(1, intResults.size());
         }
 
     }


### PR DESCRIPTION
Previously if an affixMap setting was registered, and then a completely
different setting was applied, the affixMap update consumer would be notified
with an empty map. This caused settings that were previously set to be unset in
local state in a consumer that assumed it would only be called when the affixMap
setting was changed.

This commit changes the behavior so if a prefix `foo.` is registered, any
setting under the prefix will have the update consumer notified if there are
changes starting with `foo.`.

Resolves #28316