### PR TITLE
fix description of from and size example

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -691,7 +691,7 @@ curl -XPOST 'localhost:9200/bank/_search?pretty' -d '
 
 Note that if `size` is not specified, it defaults to 10.
 
-This example does a `match_all` and returns documents 11 through 20:
+This example does a `match_all` and returns documents 10 through 19:
 
 [source,sh]
 --------------------------------------------------


### PR DESCRIPTION
`from` means where to start and `size` means how many results so the response cannot be elements from 11 to 20, the response is elements from 10 to 19.