### PR TITLE
Build: Add pom generation to meta plugins

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/MetaPluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/MetaPluginBuildPlugin.groovy
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.gradle.plugin
 
-import org.elasticsearch.gradle.test.RestIntegTestTask
+import org.elasticsearch.gradle.BuildPlugin
 import org.elasticsearch.gradle.test.RestTestPlugin
 import org.elasticsearch.gradle.test.RunTask
 import org.elasticsearch.gradle.test.StandaloneRestTestPlugin
@@ -41,6 +41,10 @@ class MetaPluginBuildPlugin implements Plugin<Project> {
         project.integTestCluster {
             dependsOn(project.bundlePlugin)
             plugin(project.path)
+        }
+        BuildPlugin.configurePomGeneration(project)
+        project.afterEvaluate {
+            PluginBuildPlugin.addZipPomGeneration(project)
         }
 
         RunTask run = project.tasks.create('run', RunTask)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.gradle.plugin
 
+import nebula.plugin.info.scm.ScmInfoPlugin
 import org.elasticsearch.gradle.BuildPlugin
 import org.elasticsearch.gradle.NoticeTask
 import org.elasticsearch.gradle.test.RestIntegTestTask
@@ -220,7 +221,8 @@ public class PluginBuildPlugin extends BuildPlugin {
     }
 
     /** Adds a task to generate a pom file for the zip distribution. */
-    protected void addZipPomGeneration(Project project) {
+    public static void addZipPomGeneration(Project project) {
+        project.plugins.apply(ScmInfoPlugin.class)
         project.plugins.apply(MavenPublishPlugin.class)
 
         project.publishing {


### PR DESCRIPTION
This commit adds pom generation to meta plugins by using the same hacks
that PluginBuildPlugin already uses to get around "pom" type poms (ie
zip files).