### PR TITLE
Missing `timeout` parameter from the REST API spec JSON files (#28200)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -16,6 +16,10 @@
         "wait_for_completion": {
           "type": "boolean",
           "description": "Wait for the matching tasks to complete (default: false)"
+        },
+        "timeout": {
+          "type": "time",
+          "description": "Explicit operation timeout"
         }
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -36,6 +36,10 @@
           "description": "Group tasks by nodes or parent/child relationships",
           "options" : ["nodes", "parents", "none"],
           "default" : "nodes"
+        },
+        "timeout": {
+          "type": "time",
+          "description": "Explicit operation timeout"
         }
 
       }


### PR DESCRIPTION
The timeout parameter is missing from the REST API spec for the tasks.list and tasks.get JSON files. Any client code or test validations that rely on these JSON files will be in error because of this missing param.

https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html