### PR TITLE
Allow including/excluding _source fields iteratively

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -721,6 +721,34 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     }
 
     /**
+     * Indicate that the field given by {@code fieldName} should be returned
+     * from the document's {@code _source}. Subsequent calls to this method
+     * are additive.
+     *
+     * @param fieldName The field to include from a document's {@code _source}
+     */
+    public SearchSourceBuilder includeSourceField(String fieldName) {
+        FetchSourceContext fetchSourceContext = this.fetchSourceContext == null ? FetchSourceContext.FETCH_SOURCE
+                : this.fetchSourceContext;
+        fetchSourceContext.include(fieldName);
+        return this;
+    }
+
+    /**
+     * Indicate that the field given by {@code fieldName} should be excluded
+     * from the document's {@code _source}. Subsequent calls to this method
+     * are additive.
+     *
+     * @param fieldName The field to exclude from a document's {@code _source}
+     */
+    public SearchSourceBuilder excludeSourceField(String fieldName) {
+        FetchSourceContext fetchSourceContext = this.fetchSourceContext == null ? FetchSourceContext.FETCH_SOURCE
+                : this.fetchSourceContext;
+        fetchSourceContext.exclude(fieldName);
+        return this;
+    }
+
+    /**
      * Adds a stored field to load and return as part of the
      * search request. If none are specified, the source of the document will be
      * return.

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -48,10 +48,12 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 
@@ -108,6 +110,12 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                 SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
                 assertArrayEquals(new String[]{"*.field2"}, searchSourceBuilder.fetchSource().excludes());
                 assertArrayEquals(new String[]{"include"}, searchSourceBuilder.fetchSource().includes());
+                searchSourceBuilder.includeSourceField("foo");
+                searchSourceBuilder.includeSourceField("bar");
+                searchSourceBuilder.excludeSourceField("baz");
+                searchSourceBuilder.excludeSourceField("eggplant");
+                assertThat(Arrays.asList(searchSourceBuilder.fetchSource().includes()), containsInAnyOrder("include", "foo", "bar"));
+                assertThat(Arrays.asList(searchSourceBuilder.fetchSource().excludes()), containsInAnyOrder("*.field2", "baz", "eggplant"));
             }
         }
         {


### PR DESCRIPTION
Previously all `_source` includes and excludes had to be specified up front,
instead of being able to "build" the includes and excludes programatically. This
changes to allow specifying the fields one at a time if desired.