### PR TITLE
Replace Bits with new abstract class  (#24088)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/DocValueBits.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/DocValueBits.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import java.io.IOException;
+
+public abstract class DocValueBits {
+
+    /**
+     * Advance this instance to the given document id
+     *
+     * @return true if there is a value for this document
+     */
+    public abstract boolean advanceExact(int doc) throws IOException;
+}

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
@@ -24,7 +24,6 @@ import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.GeoPoint;
 
@@ -92,109 +91,64 @@ public enum FieldData {
     }
 
     /**
-     * Returns a {@link Bits} representing all documents from <code>dv</code> that have a value.
+     * Returns a {@link DocValueBits} representing all documents from <code>values</code> that have a value.
      */
-    public static Bits docsWithValue(final SortedBinaryDocValues dv, final int maxDoc) {
-        return new Bits() {
+    public static DocValueBits docsWithValue(final SortedBinaryDocValues values) {
+        return new DocValueBits() {
             @Override
-            public boolean get(int index) {
-                try {
-                    return dv.advanceExact(index);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            @Override
-            public int length() {
-                return maxDoc;
+            public boolean advanceExact(int doc) throws IOException {
+                return values.advanceExact(doc);
             }
         };
     }
 
     /**
-     * Returns a {@link Bits} representing all documents from <code>dv</code>
+     * Returns a {@link DocValueBits} representing all documents from <code>docValues</code>
      * that have a value.
      */
-    public static Bits docsWithValue(final SortedSetDocValues dv, final int maxDoc) {
-        return new Bits() {
+    public static DocValueBits docsWithValue(final SortedSetDocValues docValues) {
+        return new DocValueBits() {
             @Override
-            public boolean get(int index) {
-                try {
-                    return dv.advanceExact(index);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            @Override
-            public int length() {
-                return maxDoc;
+            public boolean advanceExact(int doc) throws IOException {
+                return docValues.advanceExact(doc);
             }
         };
     }
 
     /**
-     * Returns a Bits representing all documents from <code>dv</code> that have
+     * Returns a {@link DocValueBits} representing all documents from <code>pointValues</code> that have
      * a value.
      */
-    public static Bits docsWithValue(final MultiGeoPointValues dv, final int maxDoc) {
-        return new Bits() {
+    public static DocValueBits docsWithValue(final MultiGeoPointValues pointValues) {
+        return new DocValueBits() {
             @Override
-            public boolean get(int index) {
-                try {
-                    return dv.advanceExact(index);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            @Override
-            public int length() {
-                return maxDoc;
+            public boolean advanceExact(int doc) throws IOException {
+                return pointValues.advanceExact(doc);
             }
         };
     }
 
     /**
-     * Returns a Bits representing all documents from <code>dv</code> that have a value.
+     * Returns a {@link DocValueBits} representing all documents from <code>doubleValues</code> that have a value.
      */
-    public static Bits docsWithValue(final SortedNumericDoubleValues dv, final int maxDoc) {
-        return new Bits() {
+    public static DocValueBits docsWithValue(final SortedNumericDoubleValues doubleValues) {
+        return new DocValueBits() {
             @Override
-            public boolean get(int index) {
-                try {
-                    return dv.advanceExact(index);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            @Override
-            public int length() {
-                return maxDoc;
+            public boolean advanceExact(int doc) throws IOException {
+                return doubleValues.advanceExact(doc);
             }
         };
     }
 
     /**
-     * Returns a Bits representing all documents from <code>dv</code> that have
+     * Returns a {@link DocValueBits} representing all documents from <code>docValues</code> that have
      * a value.
      */
-    public static Bits docsWithValue(final SortedNumericDocValues dv, final int maxDoc) {
-        return new Bits() {
+    public static DocValueBits docsWithValue(final SortedNumericDocValues docValues) {
+        return new DocValueBits() {
             @Override
-            public boolean get(int index) {
-                try {
-                    return dv.advanceExact(index);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            @Override
-            public int length() {
-                return maxDoc;
+            public boolean advanceExact(int doc) throws IOException {
+                return docValues.advanceExact(doc);
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -27,12 +27,12 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Scorer;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.ScorerAware;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.fielddata.AbstractSortingNumericDocValues;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.DocValueBits;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -58,7 +58,7 @@ public abstract class ValuesSource {
      */
     public abstract SortedBinaryDocValues bytesValues(LeafReaderContext context) throws IOException;
 
-    public abstract Bits docsWithValue(LeafReaderContext context) throws IOException;
+    public abstract DocValueBits docsWithValue(LeafReaderContext context) throws IOException;
 
     /** Whether this values source needs scores. */
     public boolean needsScores() {
@@ -68,10 +68,9 @@ public abstract class ValuesSource {
     public abstract static class Bytes extends ValuesSource {
 
         @Override
-        public Bits docsWithValue(LeafReaderContext context) throws IOException {
+        public DocValueBits docsWithValue(LeafReaderContext context) throws IOException {
             final SortedBinaryDocValues bytes = bytesValues(context);
-            return org.elasticsearch.index.fielddata.FieldData.docsWithValue(bytes,
-                    context.reader().maxDoc());
+            return org.elasticsearch.index.fielddata.FieldData.docsWithValue(bytes);
         }
 
         public abstract static class WithOrdinals extends Bytes {
@@ -101,10 +100,9 @@ public abstract class ValuesSource {
             };
 
             @Override
-            public Bits docsWithValue(LeafReaderContext context) throws IOException {
+            public DocValueBits docsWithValue(LeafReaderContext context) throws IOException {
                 final SortedSetDocValues ordinals = ordinalsValues(context);
-                return org.elasticsearch.index.fielddata.FieldData.docsWithValue(ordinals,
-                        context.reader().maxDoc());
+                return org.elasticsearch.index.fielddata.FieldData.docsWithValue(ordinals);
             }
 
             public abstract SortedSetDocValues ordinalsValues(LeafReaderContext context)
@@ -241,15 +239,13 @@ public abstract class ValuesSource {
         public abstract SortedNumericDoubleValues doubleValues(LeafReaderContext context) throws IOException;
 
         @Override
-        public Bits docsWithValue(LeafReaderContext context) throws IOException {
+        public DocValueBits docsWithValue(LeafReaderContext context) throws IOException {
             if (isFloatingPoint()) {
                 final SortedNumericDoubleValues values = doubleValues(context);
-                return org.elasticsearch.index.fielddata.FieldData.docsWithValue(values,
-                        context.reader().maxDoc());
+                return org.elasticsearch.index.fielddata.FieldData.docsWithValue(values);
             } else {
                 final SortedNumericDocValues values = longValues(context);
-                return org.elasticsearch.index.fielddata.FieldData.docsWithValue(values,
-                        context.reader().maxDoc());
+                return org.elasticsearch.index.fielddata.FieldData.docsWithValue(values);
             }
         }
 
@@ -493,10 +489,9 @@ public abstract class ValuesSource {
         };
 
         @Override
-        public Bits docsWithValue(LeafReaderContext context) {
+        public DocValueBits docsWithValue(LeafReaderContext context) throws IOException {
             final MultiGeoPointValues geoPoints = geoPointValues(context);
-            return org.elasticsearch.index.fielddata.FieldData.docsWithValue(geoPoints,
-                    context.reader().maxDoc());
+            return org.elasticsearch.index.fielddata.FieldData.docsWithValue(geoPoints);
         }
 
         public abstract MultiGeoPointValues geoPointValues(LeafReaderContext context);


### PR DESCRIPTION
Move ```org.apache.lucene.util.Bits``` away and use a new abstract class ```DocValueBits ``` to represent documents that have a value. 

Closes #24088 