### PR TITLE
Move to POST when calling API to retrieve which support request body

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
@@ -348,7 +348,7 @@ public final class Request {
         parameters.withRealtime(multiGetRequest.realtime());
         parameters.withRefresh(multiGetRequest.refresh());
         HttpEntity entity = createEntity(multiGetRequest, REQUEST_BODY_CONTENT_TYPE);
-        return new Request(HttpGet.METHOD_NAME, "/_mget", parameters.getParams(), entity);
+        return new Request(HttpPost.METHOD_NAME, "/_mget", parameters.getParams(), entity);
     }
 
     static Request index(IndexRequest indexRequest) {
@@ -437,17 +437,17 @@ public final class Request {
         if (searchRequest.source() != null) {
             entity = createEntity(searchRequest.source(), REQUEST_BODY_CONTENT_TYPE);
         }
-        return new Request(HttpGet.METHOD_NAME, endpoint, params.getParams(), entity);
+        return new Request(HttpPost.METHOD_NAME, endpoint, params.getParams(), entity);
     }
 
     static Request searchScroll(SearchScrollRequest searchScrollRequest) throws IOException {
         HttpEntity entity = createEntity(searchScrollRequest, REQUEST_BODY_CONTENT_TYPE);
-        return new Request("GET", "/_search/scroll", Collections.emptyMap(), entity);
+        return new Request(HttpPost.METHOD_NAME, "/_search/scroll", Collections.emptyMap(), entity);
     }
 
     static Request clearScroll(ClearScrollRequest clearScrollRequest) throws IOException {
         HttpEntity entity = createEntity(clearScrollRequest, REQUEST_BODY_CONTENT_TYPE);
-        return new Request("DELETE", "/_search/scroll", Collections.emptyMap(), entity);
+        return new Request(HttpDelete.METHOD_NAME, "/_search/scroll", Collections.emptyMap(), entity);
     }
 
     static Request multiSearch(MultiSearchRequest multiSearchRequest) throws IOException {
@@ -459,7 +459,7 @@ public final class Request {
         XContent xContent = REQUEST_BODY_CONTENT_TYPE.xContent();
         byte[] source = MultiSearchRequest.writeMultiLineFormat(multiSearchRequest, xContent);
         HttpEntity entity = new ByteArrayEntity(source, createContentType(xContent.type()));
-        return new Request("GET", "/_msearch", params.getParams(), entity);
+        return new Request(HttpPost.METHOD_NAME, "/_msearch", params.getParams(), entity);
     }
 
     private static HttpEntity createEntity(ToXContent toXContent, XContentType xContentType) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -20,6 +20,11 @@
 package org.elasticsearch.client;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -135,7 +140,7 @@ public class RequestTests extends ESTestCase {
         assertEquals("/", request.getEndpoint());
         assertEquals(0, request.getParameters().size());
         assertNull(request.getEntity());
-        assertEquals("HEAD", request.getMethod());
+        assertEquals(HttpHead.METHOD_NAME, request.getMethod());
     }
 
     public void testInfo() {
@@ -143,11 +148,11 @@ public class RequestTests extends ESTestCase {
         assertEquals("/", request.getEndpoint());
         assertEquals(0, request.getParameters().size());
         assertNull(request.getEntity());
-        assertEquals("GET", request.getMethod());
+        assertEquals(HttpGet.METHOD_NAME, request.getMethod());
     }
 
     public void testGet() {
-        getAndExistsTest(Request::get, "GET");
+        getAndExistsTest(Request::get, HttpGet.METHOD_NAME);
     }
 
     public void testMultiGet() throws IOException {
@@ -197,7 +202,7 @@ public class RequestTests extends ESTestCase {
         }
 
         Request request = Request.multiGet(multiGetRequest);
-        assertEquals("GET", request.getMethod());
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertEquals("/_mget", request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());
         assertToXContentBody(multiGetRequest, request.getEntity());
@@ -237,7 +242,7 @@ public class RequestTests extends ESTestCase {
     }
 
     public void testExists() {
-        getAndExistsTest(Request::exists, "HEAD");
+        getAndExistsTest(Request::exists, HttpHead.METHOD_NAME);
     }
 
     private static void getAndExistsTest(Function<GetRequest, Request> requestConverter, String method) {
@@ -314,7 +319,7 @@ public class RequestTests extends ESTestCase {
         Request request = Request.createIndex(createIndexRequest);
         assertEquals("/" + indexName, request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());
-        assertEquals("PUT", request.getMethod());
+        assertEquals(HttpPut.METHOD_NAME, request.getMethod());
         assertToXContentBody(createIndexRequest, request.getEntity());
     }
 
@@ -347,7 +352,7 @@ public class RequestTests extends ESTestCase {
         assertEquals(endpoint.toString(), request.getEndpoint());
 
         assertEquals(expectedParams, request.getParameters());
-        assertEquals("PUT", request.getMethod());
+        assertEquals(HttpPut.METHOD_NAME, request.getMethod());
         assertToXContentBody(putMappingRequest, request.getEntity());
     }
 
@@ -364,7 +369,7 @@ public class RequestTests extends ESTestCase {
         Request request = Request.deleteIndex(deleteIndexRequest);
         assertEquals("/" + String.join(",", indices), request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());
-        assertEquals("DELETE", request.getMethod());
+        assertEquals(HttpDelete.METHOD_NAME, request.getMethod());
         assertNull(request.getEntity());
     }
 
@@ -383,7 +388,7 @@ public class RequestTests extends ESTestCase {
         StringJoiner endpoint = new StringJoiner("/", "/", "").add(String.join(",", indices)).add("_open");
         assertThat(endpoint.toString(), equalTo(request.getEndpoint()));
         assertThat(expectedParams, equalTo(request.getParameters()));
-        assertThat(request.getMethod(), equalTo("POST"));
+        assertThat(request.getMethod(), equalTo(HttpPost.METHOD_NAME));
         assertThat(request.getEntity(), nullValue());
     }
 
@@ -400,7 +405,7 @@ public class RequestTests extends ESTestCase {
         StringJoiner endpoint = new StringJoiner("/", "/", "").add(String.join(",", indices)).add("_close");
         assertThat(endpoint.toString(), equalTo(request.getEndpoint()));
         assertThat(expectedParams, equalTo(request.getParameters()));
-        assertThat(request.getMethod(), equalTo("POST"));
+        assertThat(request.getMethod(), equalTo(HttpPost.METHOD_NAME));
         assertThat(request.getEntity(), nullValue());
     }
 
@@ -414,9 +419,9 @@ public class RequestTests extends ESTestCase {
 
         Map<String, String> expectedParams = new HashMap<>();
 
-        String method = "POST";
+        String method = HttpPost.METHOD_NAME;
         if (id != null) {
-            method = "PUT";
+            method = HttpPut.METHOD_NAME;
             if (randomBoolean()) {
                 indexRequest.opType(DocWriteRequest.OpType.CREATE);
             }
@@ -551,7 +556,7 @@ public class RequestTests extends ESTestCase {
         Request request = Request.update(updateRequest);
         assertEquals("/" + index + "/" + type + "/" + id + "/_update", request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());
-        assertEquals("POST", request.getMethod());
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
 
         HttpEntity entity = request.getEntity();
         assertTrue(entity instanceof ByteArrayEntity);
@@ -665,7 +670,7 @@ public class RequestTests extends ESTestCase {
         Request request = Request.bulk(bulkRequest);
         assertEquals("/_bulk", request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());
-        assertEquals("POST", request.getMethod());
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertEquals(xContentType.mediaTypeWithoutParameters(), request.getEntity().getContentType().getValue());
         byte[] content = new byte[(int) request.getEntity().getContentLength()];
         try (InputStream inputStream = request.getEntity().getContent()) {
@@ -876,6 +881,7 @@ public class RequestTests extends ESTestCase {
             endpoint.add(type);
         }
         endpoint.add("_search");
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertEquals(endpoint.toString(), request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());
         assertToXContentBody(searchSourceBuilder, request.getEntity());
@@ -914,6 +920,7 @@ public class RequestTests extends ESTestCase {
 
         Request request = Request.multiSearch(multiSearchRequest);
         assertEquals("/_msearch", request.getEndpoint());
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertEquals(expectedParams, request.getParameters());
 
         List<SearchRequest> requests = new ArrayList<>();
@@ -937,7 +944,7 @@ public class RequestTests extends ESTestCase {
             searchScrollRequest.scroll(randomPositiveTimeValue());
         }
         Request request = Request.searchScroll(searchScrollRequest);
-        assertEquals("GET", request.getMethod());
+        assertEquals(HttpPost.METHOD_NAME, request.getMethod());
         assertEquals("/_search/scroll", request.getEndpoint());
         assertEquals(0, request.getParameters().size());
         assertToXContentBody(searchScrollRequest, request.getEntity());
@@ -951,7 +958,7 @@ public class RequestTests extends ESTestCase {
             clearScrollRequest.addScrollId(randomAlphaOfLengthBetween(5, 10));
         }
         Request request = Request.clearScroll(clearScrollRequest);
-        assertEquals("DELETE", request.getMethod());
+        assertEquals(HttpDelete.METHOD_NAME, request.getMethod());
         assertEquals("/_search/scroll", request.getEndpoint());
         assertEquals(0, request.getParameters().size());
         assertToXContentBody(clearScrollRequest, request.getEntity());

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -179,7 +179,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         assertEquals(5, searchResponse.getTotalShards());
         assertEquals(5, searchResponse.getSuccessfulShards());
         assertEquals(100, searchResponse.getTook().getMillis());
-        verify(restClient).performRequest(eq("GET"), eq("/_search/scroll"), eq(Collections.emptyMap()),
+        verify(restClient).performRequest(eq("POST"), eq("/_search/scroll"), eq(Collections.emptyMap()),
                 isNotNull(HttpEntity.class), argThat(new HeadersVarargMatcher(headers)));
     }
 


### PR DESCRIPTION
It has been pointed out that GET with body may cause problems to some proxies. We are then switching to POST the API that retrieve info and support a request body.

Closes #28326