### PR TITLE
Fix GeoDistance query example in java-api documentation

### DIFF
--- a/docs/java-api/query-dsl/geo-distance-query.asciidoc
+++ b/docs/java-api/query-dsl/geo-distance-query.asciidoc
@@ -5,7 +5,7 @@ See {ref}/query-dsl-geo-distance-query.html[Geo Distance Query]
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{query-dsl-test}[geo_bounding_box]
+include-tagged::{query-dsl-test}[geo_distance]
 --------------------------------------------------
 <1> field
 <2> center point


### PR DESCRIPTION
Was just a copy and paste error I guess. :) 