### PR TITLE
Add note to docs regarding multi-get ordering

### DIFF
--- a/docs/reference/docs/multi-get.asciidoc
+++ b/docs/reference/docs/multi-get.asciidoc
@@ -2,10 +2,14 @@
 == Multi Get API
 
 Multi GET API allows to get multiple documents based on an index, type
-(optional) and id (and possibly routing). The response includes a `docs`
-array with all the fetched documents, each element similar in structure
-to a document provided by the <<docs-get,get>>
-API. Here is an example:
+(optional) and id (and possibly routing). The response includes a `docs` array
+with all the fetched documents in order corresponding to the original multi-get
+request (if there was a failure for a specific get, an object containing this
+error is included in place in the response instead). The structure of a
+successful get is similar in structure to a document provided by the
+<<docs-get,get>> API.
+
+Here is an example:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
The implementation maintains the order of the original requests yet this functionality is not documented. This commit adds a note to the docs regarding the ordering of responses to an multi-get request.

Closes #28343

