### PR TITLE
Always return the after_key in composite aggregation response

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -422,6 +422,11 @@ GET /_search
 
 <1> The last composite bucket returned by the query.
 
+NOTE: The `after_key` is equals to the last bucket returned in the response before
+any filtering that could be done by <<search-aggregations-pipeline, Pipeline aggregations>>.
+If all buckets are filtered/removed by a pipeline aggregation, the `after_key` will contain
+the last bucket before filtering.
+
 The `after` parameter can be used to retrieve the composite buckets that are **after**
 the last composite buckets returned in a previous round.
 For the example below the last bucket can be found in `after_key` and the next

--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -394,6 +394,10 @@ GET /_search
     ...
     "aggregations": {
         "my_buckets": {
+            "after_key": { <1>
+                "date": 1494288000000,
+                "product": "mad max"
+            },
             "buckets": [
                 {
                     "key": {
@@ -403,7 +407,7 @@ GET /_search
                     "doc_count": 1
                 },
                 {
-                    "key": {     <1>
+                    "key": {
                         "date": 1494288000000,
                         "product": "mad max"
                     },
@@ -420,7 +424,7 @@ GET /_search
 
 The `after` parameter can be used to retrieve the composite buckets that are **after**
 the last composite buckets returned in a previous round.
-For the example below the last bucket is `"key": [1494288000000, "mad max"]` so the next
+For the example below the last bucket can be found in `after_key` and the next
 round of result can be retrieved with:
 
 [source,js]
@@ -485,6 +489,10 @@ GET /_search
     ...
     "aggregations": {
         "my_buckets": {
+            "after_key": {
+                "date": 1494201600000,
+                "product": "rocky"
+            },
             "buckets": [
                 {
                     "key": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -182,8 +182,8 @@ setup:
 ---
 "Aggregate After Missing":
   - skip:
-      version: " - 6.99.99"
-      reason:  bug fixed in 7.0.0
+      version: " - 6.1.99"
+      reason:  bug fixed in 6.2.0
 
 
   - do:
@@ -295,3 +295,31 @@ setup:
   - length: { aggregations.test.buckets: 1 }
   - match: { aggregations.test.buckets.0.key.date: "2017-10-21" }
   - match: { aggregations.test.buckets.0.doc_count: 1 }
+
+---
+"Composite aggregation with after_key in the response":
+  - skip:
+      version: " - 6.99.99"
+      reason:  starting in 7.0.0 after_key is returned in the response
+
+  - do:
+        search:
+          index: test
+          body:
+            aggregations:
+              test:
+                composite:
+                  sources: [
+                    {
+                      "keyword": {
+                        "terms": {
+                          "field": "keyword",
+                        }
+                      }
+                    }
+                  ]
+
+  - match: {hits.total: 6}
+  - length: { aggregations.test.buckets: 1 }
+  - length: { aggregations.test.after_key: 1 }
+  - match: { aggregations.test.after_key.field:  "foo" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -322,4 +322,4 @@ setup:
   - match: {hits.total: 6}
   - length: { aggregations.test.buckets: 2 }
   - length: { aggregations.test.after_key: 1 }
-  - match: { aggregations.test.after_key.field:  "foo" }
+  - match: { aggregations.test.after_key.keyword:  "foo" }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -320,6 +320,6 @@ setup:
                   ]
 
   - match: {hits.total: 6}
-  - length: { aggregations.test.buckets: 1 }
+  - length: { aggregations.test.buckets: 2 }
   - length: { aggregations.test.after_key: 1 }
   - match: { aggregations.test.after_key.field:  "foo" }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregation.java
@@ -52,6 +52,9 @@ public interface CompositeAggregation extends MultiBucketsAggregation {
     }
 
     static XContentBuilder toXContentFragment(CompositeAggregation aggregation, XContentBuilder builder, Params params) throws IOException {
+        if (aggregation.afterKey() != null) {
+            buildCompositeMap("after_key", aggregation.afterKey(), builder);
+        }
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (CompositeAggregation.Bucket bucket : aggregation.getBuckets()) {
             bucketToXContent(bucket, builder, params);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -136,14 +136,15 @@ final class CompositeAggregator extends BucketsAggregator {
             int docCount = bucketDocCount(slot);
             buckets[pos++] = new InternalComposite.InternalBucket(sourceNames, formats, key, reverseMuls, docCount, aggs);
         }
-        return new InternalComposite(name, size, sourceNames, formats, Arrays.asList(buckets), reverseMuls,
+        CompositeKey lastBucket = num > 0 ? buckets[num-1].getRawKey() : null;
+        return new InternalComposite(name, size, sourceNames, formats, Arrays.asList(buckets), lastBucket, reverseMuls,
             pipelineAggregators(), metaData());
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
         final int[] reverseMuls = getReverseMuls();
-        return new InternalComposite(name, size, sourceNames, formats, Collections.emptyList(), reverseMuls,
+        return new InternalComposite(name, size, sourceNames, formats, Collections.emptyList(), null, reverseMuls,
             pipelineAggregators(), metaData());
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeKey.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeKey.java
@@ -19,16 +19,36 @@
 
 package org.elasticsearch.search.aggregations.bucket.composite;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
 import java.util.Arrays;
 
 /**
  * A key that is composed of multiple {@link Comparable} values.
  */
-class CompositeKey {
+class CompositeKey implements Writeable {
     private final Comparable<?>[] values;
 
     CompositeKey(Comparable<?>... values) {
         this.values = values;
+    }
+
+    CompositeKey(StreamInput in) throws IOException {
+        values = new Comparable<?>[in.readVInt()];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = (Comparable<?>) in.readGenericValue();
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(values.length);
+        for (int i = 0; i < values.length; i++) {
+            out.writeGenericValue(values[i]);
+        }
     }
 
     Comparable<?>[] values() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -37,7 +37,6 @@ import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -50,17 +49,19 @@ public class InternalComposite
 
     private final int size;
     private final List<InternalBucket> buckets;
+    private final CompositeKey afterKey;
     private final int[] reverseMuls;
     private final List<String> sourceNames;
     private final List<DocValueFormat> formats;
 
     InternalComposite(String name, int size, List<String> sourceNames, List<DocValueFormat> formats,
-                      List<InternalBucket> buckets, int[] reverseMuls,
+                      List<InternalBucket> buckets, CompositeKey afterKey, int[] reverseMuls,
                       List<PipelineAggregator> pipelineAggregators, Map<String, Object> metaData) {
         super(name, pipelineAggregators, metaData);
         this.sourceNames = sourceNames;
         this.formats = formats;
         this.buckets = buckets;
+        this.afterKey = afterKey;
         this.size = size;
         this.reverseMuls = reverseMuls;
     }
@@ -79,6 +80,11 @@ public class InternalComposite
         }
         this.reverseMuls = in.readIntArray();
         this.buckets = in.readList((input) -> new InternalBucket(input, sourceNames, formats, reverseMuls));
+        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+            this.afterKey = in.readBoolean() ? new CompositeKey(in) : null;
+        } else {
+            this.afterKey = buckets.size() > 0 ? buckets.get(buckets.size()-1).key : null;
+        }
     }
 
     @Override
@@ -92,6 +98,12 @@ public class InternalComposite
         }
         out.writeIntArray(reverseMuls);
         out.writeList(buckets);
+        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+            out.writeBoolean(afterKey != null);
+            if (afterKey != null) {
+                afterKey.writeTo(out);
+            }
+        }
     }
 
     @Override
@@ -105,8 +117,14 @@ public class InternalComposite
     }
 
     @Override
-    public InternalComposite create(List<InternalBucket> buckets) {
-        return new InternalComposite(name, size, sourceNames, formats, buckets, reverseMuls, pipelineAggregators(), getMetaData());
+    public InternalComposite create(List<InternalBucket> newBuckets) {
+        /**
+         * This is used by pipeline aggregations to filter/remove buckets so we
+         * keep the <code>afterKey</code> of the original aggregation in order
+         * to be able to retrieve the next page even if all buckets have been filtered.
+         */
+        return new InternalComposite(name, size, sourceNames, formats, newBuckets, afterKey,
+            reverseMuls, pipelineAggregators(), getMetaData());
     }
 
     @Override
@@ -126,7 +144,10 @@ public class InternalComposite
 
     @Override
     public Map<String, Object> afterKey() {
-        return buckets.size() > 0 ? buckets.get(buckets.size()-1).getKey() : null;
+        if (afterKey != null) {
+            return new ArrayMap(sourceNames, formats, afterKey.values());
+        }
+        return null;
     }
 
     // Visible for tests
@@ -169,7 +190,8 @@ public class InternalComposite
             reduceContext.consumeBucketsAndMaybeBreak(1);
             result.add(reduceBucket);
         }
-        return new InternalComposite(name, size, sourceNames, formats, result, reverseMuls, pipelineAggregators(), metaData);
+        final CompositeKey lastKey = result.size() > 0 ? result.get(result.size()-1).getRawKey() : null;
+        return new InternalComposite(name, size, sourceNames, formats, result, lastKey, reverseMuls, pipelineAggregators(), metaData);
     }
 
     @Override
@@ -177,12 +199,13 @@ public class InternalComposite
         InternalComposite that = (InternalComposite) obj;
         return Objects.equals(size, that.size) &&
             Objects.equals(buckets, that.buckets) &&
+            Objects.equals(afterKey, that.afterKey) &&
             Arrays.equals(reverseMuls, that.reverseMuls);
     }
 
     @Override
     protected int doHashCode() {
-        return Objects.hash(size, buckets, Arrays.hashCode(reverseMuls));
+        return Objects.hash(size, buckets, afterKey, Arrays.hashCode(reverseMuls));
     }
 
     private static class BucketIterator implements Comparable<BucketIterator> {
@@ -226,11 +249,7 @@ public class InternalComposite
 
         @SuppressWarnings("unchecked")
         InternalBucket(StreamInput in, List<String> sourceNames, List<DocValueFormat> formats, int[] reverseMuls) throws IOException {
-            final Comparable<?>[] values = new Comparable<?>[in.readVInt()];
-            for (int i = 0; i < values.length; i++) {
-                values[i] = (Comparable<?>) in.readGenericValue();
-            }
-            this.key = new CompositeKey(values);
+            this.key = new CompositeKey(in);
             this.docCount = in.readVLong();
             this.aggregations = InternalAggregations.readAggregations(in);
             this.reverseMuls = reverseMuls;
@@ -240,10 +259,7 @@ public class InternalComposite
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeVInt(key.size());
-            for (int i = 0; i < key.size(); i++) {
-                out.writeGenericValue(key.get(i));
-            }
+            key.writeTo(out);
             out.writeVLong(docCount);
             aggregations.writeTo(out);
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -129,6 +129,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
             }, (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{keyword=d}", result.afterKey().toString());
                 assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=c}", result.getBuckets().get(1).getKeyAsString());
@@ -146,6 +147,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     .aggregateAfter(Collections.singletonMap("keyword", "a"));
             }, (result) -> {
                 assertEquals(2, result.getBuckets().size());
+                assertEquals("{keyword=d}", result.afterKey().toString());
                 assertEquals("{keyword=c}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=d}", result.getBuckets().get(1).getKeyAsString());
@@ -174,6 +176,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
             }, (result) -> {
                 assertEquals(4, result.getBuckets().size());
+                assertEquals("{keyword=zoo}", result.afterKey().toString());
                 assertEquals("{keyword=bar}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=delta}", result.getBuckets().get(1).getKeyAsString());
@@ -193,6 +196,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     .aggregateAfter(Collections.singletonMap("keyword", "car"));
             }, (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{keyword=zoo}", result.afterKey().toString());
                 assertEquals("{keyword=delta}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=foo}", result.getBuckets().get(1).getKeyAsString());
@@ -210,6 +214,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     .aggregateAfter(Collections.singletonMap("keyword", "mar"));
             }, (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{keyword=bar}", result.afterKey().toString());
                 assertEquals("{keyword=foo}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=delta}", result.getBuckets().get(1).getKeyAsString());
@@ -240,6 +245,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
             }, (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{keyword=a}", result.afterKey().toString());
                 assertEquals("{keyword=a}", result.getBuckets().get(2).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(2).getDocCount());
                 assertEquals("{keyword=c}", result.getBuckets().get(1).getKeyAsString());
@@ -258,6 +264,8 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     .aggregateAfter(Collections.singletonMap("keyword", "c"));
 
             }, (result) -> {
+                assertEquals(result.afterKey().toString(), "{keyword=a}");
+                assertEquals("{keyword=a}", result.afterKey().toString());
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
@@ -285,6 +293,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
 
             }, (result) -> {
                     assertEquals(5, result.getBuckets().size());
+                    assertEquals("{keyword=z}", result.afterKey().toString());
                     assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
                     assertEquals(2L, result.getBuckets().get(0).getDocCount());
                     assertEquals("{keyword=b}", result.getBuckets().get(1).getKeyAsString());
@@ -307,6 +316,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
 
             }, (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{keyword=z}", result.afterKey().toString());
                 assertEquals("{keyword=c}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=d}", result.getBuckets().get(1).getKeyAsString());
@@ -338,6 +348,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
 
             }, (result) -> {
                 assertEquals(5, result.getBuckets().size());
+                assertEquals("{keyword=a}", result.afterKey().toString());
                 assertEquals("{keyword=a}", result.getBuckets().get(4).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(4).getDocCount());
                 assertEquals("{keyword=b}", result.getBuckets().get(3).getKeyAsString());
@@ -361,6 +372,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
 
             }, (result) -> {
                 assertEquals(2, result.getBuckets().size());
+                assertEquals("{keyword=a}", result.afterKey().toString());
                 assertEquals("{keyword=a}", result.getBuckets().get(1).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(1).getDocCount());
                 assertEquals("{keyword=b}", result.getBuckets().get(0).getKeyAsString());
@@ -395,6 +407,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             ),
             (result) -> {
                 assertEquals(4, result.getBuckets().size());
+                assertEquals("{keyword=d, long=10}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=a, long=100}", result.getBuckets().get(1).getKeyAsString());
@@ -416,6 +429,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             ),
             (result) -> {
                 assertEquals(2, result.getBuckets().size());
+                assertEquals("{keyword=d, long=10}", result.afterKey().toString());
                 assertEquals("{keyword=c, long=100}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=d, long=10}", result.getBuckets().get(1).getKeyAsString());
@@ -451,6 +465,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ),
             (result) -> {
                 assertEquals(4, result.getBuckets().size());
+                assertEquals("{keyword=a, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(3).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(3).getDocCount());
                 assertEquals("{keyword=a, long=100}", result.getBuckets().get(2).getKeyAsString());
@@ -471,6 +486,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     )).aggregateAfter(createAfterKey("keyword", "d", "long", 10L)
                 ), (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{keyword=a, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(2).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(2).getDocCount());
                 assertEquals("{keyword=a, long=100}", result.getBuckets().get(1).getKeyAsString());
@@ -503,6 +519,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     ))
             , (result) -> {
                 assertEquals(10, result.getBuckets().size());
+                assertEquals("{keyword=z, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=a, long=100}", result.getBuckets().get(1).getKeyAsString());
@@ -536,6 +553,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ).aggregateAfter(createAfterKey("keyword", "c", "long", 10L))
             , (result) -> {
                 assertEquals(6, result.getBuckets().size());
+                assertEquals("{keyword=z, long=100}", result.afterKey().toString());
                 assertEquals("{keyword=c, long=100}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=d, long=10}", result.getBuckets().get(1).getKeyAsString());
@@ -577,6 +595,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ),
             (result) -> {
                 assertEquals(10, result.getBuckets().size());
+                assertEquals("{keyword=a, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(9).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(9).getDocCount());
                 assertEquals("{keyword=a, long=100}", result.getBuckets().get(8).getKeyAsString());
@@ -611,6 +630,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ),
             (result) -> {
                 assertEquals(2, result.getBuckets().size());
+                assertEquals("{keyword=a, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(1).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(1).getDocCount());
                 assertEquals("{keyword=a, long=100}", result.getBuckets().get(0).getKeyAsString());
@@ -644,6 +664,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 )
             , (result) -> {
                 assertEquals(10, result.getBuckets().size());
+                assertEquals("{keyword=c, long=100, double=0.4}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0, double=0.09}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(1).getDocCount());
                 assertEquals("{keyword=a, long=0, double=0.4}", result.getBuckets().get(1).getKeyAsString());
@@ -678,6 +699,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ).aggregateAfter(createAfterKey("keyword", "a", "long", 100L, "double", 0.4d))
             ,(result) -> {
                 assertEquals(10, result.getBuckets().size());
+                assertEquals("{keyword=z, long=0, double=0.09}", result.afterKey().toString());
                 assertEquals("{keyword=b, long=100, double=0.4}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=c, long=0, double=0.09}", result.getBuckets().get(1).getKeyAsString());
@@ -712,6 +734,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ).aggregateAfter(createAfterKey("keyword", "z", "long", 100L, "double", 0.4d))
             , (result) -> {
                 assertEquals(0, result.getBuckets().size());
+                assertNull(result.afterKey());
             }
         );
     }
@@ -738,6 +761,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             },
             (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{date=1508457600000}", result.afterKey().toString());
                 assertEquals("{date=1474329600000}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{date=1508371200000}", result.getBuckets().get(1).getKeyAsString());
@@ -757,6 +781,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
 
             }, (result) -> {
                 assertEquals(2, result.getBuckets().size());
+                assertEquals("{date=1508457600000}", result.afterKey().toString());
                 assertEquals("{date=1508371200000}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{date=1508457600000}", result.getBuckets().get(1).getKeyAsString());
@@ -788,6 +813,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             },
             (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{date=2017-10-20}", result.afterKey().toString());
                 assertEquals("{date=2016-09-20}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{date=2017-10-19}", result.getBuckets().get(1).getKeyAsString());
@@ -808,6 +834,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
 
             }, (result) -> {
                 assertEquals(2, result.getBuckets().size());
+                assertEquals("{date=2017-10-20}", result.afterKey().toString());
                 assertEquals("{date=2017-10-19}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{date=2017-10-20}", result.getBuckets().get(1).getKeyAsString());
@@ -871,6 +898,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             },
             (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{date=1508454000000}", result.afterKey().toString());
                 assertEquals("{date=1474326000000}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{date=1508367600000}", result.getBuckets().get(1).getKeyAsString());
@@ -891,6 +919,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
 
             }, (result) -> {
                 assertEquals(2, result.getBuckets().size());
+                assertEquals("{date=1508454000000}", result.afterKey().toString());
                 assertEquals("{date=1508367600000}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{date=1508454000000}", result.getBuckets().get(1).getKeyAsString());
@@ -924,6 +953,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ),
             (result) -> {
                 assertEquals(7, result.getBuckets().size());
+                assertEquals("{date=1508457600000, keyword=d}", result.afterKey().toString());
                 assertEquals("{date=1474329600000, keyword=b}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{date=1474329600000, keyword=c}", result.getBuckets().get(1).getKeyAsString());
@@ -954,6 +984,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ).aggregateAfter(createAfterKey("date", 1508371200000L, "keyword", "g"))
             , (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{date=1508457600000, keyword=d}", result.afterKey().toString());
                 assertEquals("{date=1508457600000, keyword=a}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{date=1508457600000, keyword=c}", result.getBuckets().get(1).getKeyAsString());
@@ -986,6 +1017,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 )
             , (result) -> {
                 assertEquals(7, result.getBuckets().size());
+                assertEquals("{keyword=z, price=50.0}", result.afterKey().toString());
                 assertEquals("{keyword=a, price=100.0}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=b, price=50.0}", result.getBuckets().get(1).getKeyAsString());
@@ -1013,6 +1045,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ).aggregateAfter(createAfterKey("keyword", "c", "price", 50.0))
             , (result) -> {
                 assertEquals(4, result.getBuckets().size());
+                assertEquals("{keyword=z, price=50.0}", result.afterKey().toString());
                 assertEquals("{keyword=c, price=100.0}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=d, price=100.0}", result.getBuckets().get(1).getKeyAsString());
@@ -1052,6 +1085,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 )
             , (result) -> {
                 assertEquals(8, result.getBuckets().size());
+                assertEquals("{histo=0.9, keyword=d}", result.afterKey().toString());
                 assertEquals("{histo=0.4, keyword=a}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{histo=0.4, keyword=b}", result.getBuckets().get(1).getKeyAsString());
@@ -1081,6 +1115,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ).aggregateAfter(createAfterKey("histo", 0.8d, "keyword", "b"))
             , (result) -> {
                 assertEquals(3, result.getBuckets().size());
+                assertEquals("{histo=0.9, keyword=d}", result.afterKey().toString());
                 assertEquals("{histo=0.8, keyword=z}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{histo=0.9, keyword=a}", result.getBuckets().get(1).getKeyAsString());
@@ -1114,6 +1149,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 )
             , (result) -> {
                 assertEquals(7, result.getBuckets().size());
+                assertEquals("{keyword=z, date_histo=1474329600000}", result.afterKey().toString());
                 assertEquals("{keyword=a, date_histo=1508457600000}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=b, date_histo=1474329600000}", result.getBuckets().get(1).getKeyAsString());
@@ -1142,6 +1178,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 ).aggregateAfter(createAfterKey("keyword","c", "date_histo", 1474329600000L))
             , (result) -> {
                 assertEquals(4, result.getBuckets().size());
+                assertEquals("{keyword=z, date_histo=1474329600000}", result.afterKey().toString());
                 assertEquals("{keyword=c, date_histo=1508457600000}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(1L, result.getBuckets().get(0).getDocCount());
                 assertEquals("{keyword=d, date_histo=1508457600000}", result.getBuckets().get(1).getKeyAsString());
@@ -1306,7 +1343,6 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             }
         }
     }
-
 
     @SuppressWarnings("unchecked")
     private static Map<String, Object> createAfterKey(Object... fields) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
@@ -161,7 +161,9 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
             buckets.add(bucket);
         }
         Collections.sort(buckets, (o1, o2) -> o1.compareKey(o2));
-        return new InternalComposite(name, size, sourceNames, formats, buckets, reverseMuls, Collections.emptyList(), metaData);
+        CompositeKey lastBucket = buckets.size() > 0 ? buckets.get(buckets.size()-1).getRawKey() : null;
+        return new InternalComposite(name, size, sourceNames, formats, buckets, lastBucket, reverseMuls,
+            Collections.emptyList(), metaData);
     }
 
     @Override
@@ -195,7 +197,8 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
             default:
                 throw new AssertionError("illegal branch");
         }
-        return new InternalComposite(instance.getName(), instance.getSize(), sourceNames, formats, buckets, reverseMuls,
+        CompositeKey lastBucket = buckets.size() > 0 ? buckets.get(buckets.size()-1).getRawKey() : null;
+        return new InternalComposite(instance.getName(), instance.getSize(), sourceNames, formats, buckets, lastBucket, reverseMuls,
             instance.pipelineAggregators(), metaData);
     }
 


### PR DESCRIPTION
This change adds the `after_key` of a composite aggregation directly in the response.
It is redundant when all buckets are not filtered/removed by a pipeline aggregation since in this case the `after_key` is always the last bucket
in the response. Though when using a pipeline aggregation to filter composite buckets, the `after_key` can be lost if the last bucket is filtered.
This commit fixes this situation by always returning the `after_key` in a dedicated section.