### PR TITLE
Adds test name to MockPageCacheRecycler exception

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -21,10 +21,11 @@ package org.elasticsearch.common.util;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.SeedUtils;
+
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.settings.Settings;
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
@@ -32,6 +33,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
@@ -59,8 +61,17 @@ public class MockBigArrays extends BigArrays {
                 masterCopy.keySet().retainAll(ACQUIRED_ARRAYS.keySet());
                 ACQUIRED_ARRAYS.keySet().removeAll(masterCopy.keySet()); // remove all existing master copy we will report on
                 if (!masterCopy.isEmpty()) {
-                    final Object cause = masterCopy.entrySet().iterator().next().getValue();
-                    throw new RuntimeException(masterCopy.size() + " arrays have not been released", cause instanceof Throwable ? (Throwable) cause : null);
+                    Iterator<Object> causes = masterCopy.values().iterator();
+                    Object firstCause = causes.next();
+                    RuntimeException exception = new RuntimeException(masterCopy.size() + " arrays have not been released",
+                            firstCause instanceof Throwable ? (Throwable) firstCause : null);
+                    while (causes.hasNext()) {
+                        Object cause = causes.next();
+                        if (cause instanceof Throwable) {
+                            exception.addSuppressed((Throwable) cause);
+                        }
+                    }
+                    throw exception;
                 }
             }
         }
@@ -249,7 +260,9 @@ public class MockBigArrays extends BigArrays {
         AbstractArrayWrapper(boolean clearOnResize) {
             this.clearOnResize = clearOnResize;
             this.originalRelease = new AtomicReference<>();
-            ACQUIRED_ARRAYS.put(this, TRACK_ALLOCATIONS ? new RuntimeException() : Boolean.TRUE);
+            ACQUIRED_ARRAYS.put(this,
+                    TRACK_ALLOCATIONS ? new RuntimeException("Unreleased array from test: " + LuceneTestCase.getTestClass().getName())
+                            : Boolean.TRUE);
         }
 
         protected abstract BigArray getDelegate();

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockPageCacheRecycler.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockPageCacheRecycler.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.util;
 
+import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.common.recycler.Recycler.V;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
@@ -27,6 +28,7 @@ import org.elasticsearch.test.ESTestCase;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,8 +50,13 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
                 masterCopy.keySet().retainAll(ACQUIRED_PAGES.keySet());
                 ACQUIRED_PAGES.keySet().removeAll(masterCopy.keySet()); // remove all existing master copy we will report on
                 if (!masterCopy.isEmpty()) {
-                    final Throwable t = masterCopy.entrySet().iterator().next().getValue();
-                    throw new RuntimeException(masterCopy.size() + " pages have not been released", t);
+                    Iterator<Throwable> causes = masterCopy.values().iterator();
+                    Throwable firstCause = causes.next();
+                    RuntimeException exception = new RuntimeException(masterCopy.size() + " pages have not been released", firstCause);
+                    while (causes.hasNext()) {
+                        exception.addSuppressed(causes.next());
+                    }
+                    throw exception;
                 }
             }
         }
@@ -66,7 +73,7 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
     }
 
     private <T> V<T> wrap(final V<T> v) {
-        ACQUIRED_PAGES.put(v, new Throwable());
+        ACQUIRED_PAGES.put(v, new Throwable("Unreleased Page from test: " + LuceneTestCase.getTestClass().getName()));
         return new V<T>() {
 
             @Override


### PR DESCRIPTION
This change adds the test name to the exceptions thrown by the MockPageCacheRecycler and MockBigArrays. Also, if there is more than one page/array which are not released it will add the first one as the cause of the thrown exception and the others as suppressed exceptions.

Relates to #21315