### PR TITLE
Read and write metrics represented in bytes and printed as byteSizeField

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -147,12 +147,12 @@ information that concern the file system:
     The total number of write operations for the device completed since
     starting Elasticsearch.
 
-`fs.io_stats.devices.read_kilobytes` (Linux only)::
-    The total number of kilobytes read for the device since starting
+`fs.io_stats.devices.read_bytes` (Linux only)::
+    The total number of bytes read for the device since starting
     Elasticsearch.
 
-`fs.io_stats.devices.write_kilobytes` (Linux only)::
-    The total number of kilobytes written for the device since
+`fs.io_stats.devices.write_bytes` (Linux only)::
+    The total number of bytes written for the device since
     starting Elasticsearch.
 
 `fs.io_stats.operations` (Linux only)::
@@ -167,12 +167,12 @@ information that concern the file system:
     The total number of write operations across all devices used by
     Elasticsearch completed since starting Elasticsearch.
 
-`fs.io_stats.read_kilobytes` (Linux only)::
-    The total number of kilobytes read across all devices used by
+`fs.io_stats.read_bytes` (Linux only)::
+    The total number of bytes read across all devices used by
     Elasticsearch since starting Elasticsearch.
 
-`fs.io_stats.write_kilobytes` (Linux only)::
-    The total number of kilobytes written across all devices used by
+`fs.io_stats.write_bytes` (Linux only)::
+    The total number of bytes written across all devices used by
     Elasticsearch since starting Elasticsearch.
 
 [float]

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -197,18 +197,18 @@ public class NodeStatsTests extends ESTestCase {
                     FsInfo.IoStats ioStats = fs.getIoStats();
                     FsInfo.IoStats deserializedIoStats = deserializedFs.getIoStats();
                     assertEquals(ioStats.getTotalOperations(), deserializedIoStats.getTotalOperations());
-                    assertEquals(ioStats.getTotalReadKilobytes(), deserializedIoStats.getTotalReadKilobytes());
+                    assertEquals(ioStats.getTotalReadBytes(), deserializedIoStats.getTotalReadBytes());
                     assertEquals(ioStats.getTotalReadOperations(), deserializedIoStats.getTotalReadOperations());
-                    assertEquals(ioStats.getTotalWriteKilobytes(), deserializedIoStats.getTotalWriteKilobytes());
+                    assertEquals(ioStats.getTotalWriteBytes(), deserializedIoStats.getTotalWriteBytes());
                     assertEquals(ioStats.getTotalWriteOperations(), deserializedIoStats.getTotalWriteOperations());
                     assertEquals(ioStats.getDevicesStats().length, deserializedIoStats.getDevicesStats().length);
                     for (int i = 0; i < ioStats.getDevicesStats().length; i++) {
                         FsInfo.DeviceStats deviceStats = ioStats.getDevicesStats()[i];
                         FsInfo.DeviceStats deserializedDeviceStats = deserializedIoStats.getDevicesStats()[i];
                         assertEquals(deviceStats.operations(), deserializedDeviceStats.operations());
-                        assertEquals(deviceStats.readKilobytes(), deserializedDeviceStats.readKilobytes());
+                        assertEquals(deviceStats.readBytes(), deserializedDeviceStats.readBytes());
                         assertEquals(deviceStats.readOperations(), deserializedDeviceStats.readOperations());
-                        assertEquals(deviceStats.writeKilobytes(), deserializedDeviceStats.writeKilobytes());
+                        assertEquals(deviceStats.writeBytes(), deserializedDeviceStats.writeBytes());
                         assertEquals(deviceStats.writeOperations(), deserializedDeviceStats.writeOperations());
                     }
                 }

--- a/server/src/test/java/org/elasticsearch/monitor/fs/DeviceStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/fs/DeviceStatsTests.java
@@ -55,8 +55,8 @@ public class DeviceStatsTests extends ESTestCase {
         assertThat(current.operations(), equalTo(1024L + 2048L));
         assertThat(current.readOperations(), equalTo(1024L));
         assertThat(current.writeOperations(), equalTo(2048L));
-        assertThat(current.readKilobytes(), equalTo(16384L / 2));
-        assertThat(current.writeKilobytes(), equalTo(32768L / 2));
+        assertThat(current.readBytes(), equalTo(16777216L / 2));
+        assertThat(current.writeBytes(), equalTo(33554432L / 2));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
@@ -239,8 +239,8 @@ public class FsProbeTests extends ESTestCase {
         assertThat(second.totalOperations, equalTo(575L));
         assertThat(second.totalReadOperations, equalTo(261L));
         assertThat(second.totalWriteOperations, equalTo(314L));
-        assertThat(second.totalReadKilobytes, equalTo(2392L));
-        assertThat(second.totalWriteKilobytes, equalTo(1236L));
+        assertThat(second.totalReadBytes, equalTo(2449408L));
+        assertThat(second.totalWriteBytes, equalTo(1265664L));
     }
 
     public void testAdjustForHugeFilesystems() throws Exception {


### PR DESCRIPTION
This is a proposed solution to https://github.com/elastic/elasticsearch/issues/27037