### PR TITLE
Document that highlighting `terms` queries is best-effort.

### DIFF
--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -15,6 +15,10 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
+NOTE: Highlighting `terms` queries is best-effort only, so terms of a `terms`
+query might not be highlighted depending on the highlighter implementation that
+is selected and on the number of terms in the `terms` query.
+
 [float]
 [[query-dsl-terms-lookup]]
 ===== Terms lookup mechanism


### PR DESCRIPTION
The `terms` query is really designed for filtering and highlighting it might
cause performance issues if it wraps many terms, so I am documenting
highlighting these queries as a best-effort only.

Closes #28099
