### PR TITLE
Clarify that the `null_value` option doesn't modify the `_source` document.

### DIFF
--- a/docs/reference/mapping/params/null-value.asciidoc
+++ b/docs/reference/mapping/params/null-value.asciidoc
@@ -50,3 +50,6 @@ GET my_index/_search
 
 IMPORTANT: The `null_value` needs to be the same datatype as the field.  For
 instance, a `long` field cannot have a string `null_value`.
+
+NOTE: The `null_value` only influences how data is indexed, it doesn't modify
+the `_source` document.


### PR DESCRIPTION
Closes #15959
