### PR TITLE
Clarify that dynamic date formats are only checked for values that contain `-`, `/` or `:`.

### DIFF
--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -35,9 +35,10 @@ customised with <<dynamic-templates,`dynamic_templates`>>.
 ==== Date detection
 
 If `date_detection` is enabled (default), then new string fields are checked
-to see whether their contents match any of the date patterns specified in
-`dynamic_date_formats`.  If a match is found, a new <<date,`date`>> field is
-added with the corresponding format.
+to see whether their content contains either `:`, `-` or `/`, as well as
+whether it matches any of the date patterns specified in `dynamic_date_formats`.
+If a match is found, a new <<date,`date`>> field is added with the corresponding
+format.
 
 The default value for `dynamic_date_formats` is:
 


### PR DESCRIPTION
This only applies to 5.x and earlier versions, it was addressed in 6.0.

Closes #26499
