### PR TITLE
[DOCS] Highlight the "hidden" REST API test suite

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -264,6 +264,8 @@ The REST layer is tested through specific tests that are shared between all
 the elasticsearch official clients and consist of YAML files that describe the
 operations to be executed and the obtained results that need to be tested.
 
+The YAML files support various operators defined in the link:/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc[rest-api-spec] and adhere to the link:/rest-api-spec/README.markdown[Elasticsearch REST API JSON specification]
+
 The REST tests are run automatically when executing the "./gradlew check" command. To run only the
 REST tests use the following command:
 


### PR DESCRIPTION
I always thought that this documentation was missing since hacking on internals is rarely documented. Turns out in was in a README that was buried below the fold in a deeply nested directory. Very useful information, so it should be highlighted in the top-level TESTING doc

Not sure if I got the syntax for an internal absolute link correct. Do not want a full URL to the file in master (https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc)