### PR TITLE
High level rest client : code clean up

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
@@ -29,9 +29,9 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
-import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
@@ -481,7 +481,7 @@ public final class Request {
             throw new IllegalArgumentException("existsAlias requires at least an alias or an index");
         }
         String endpoint = endpoint(getAliasesRequest.indices(), "_alias", getAliasesRequest.aliases());
-        return new Request("HEAD", endpoint, params.getParams(), null);
+        return new Request(HttpHead.METHOD_NAME, endpoint, params.getParams(), null);
     }
 
     private static HttpEntity createEntity(ToXContent toXContent, XContentType xContentType) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CrudIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.client;
 
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.elasticsearch.ElasticsearchException;
@@ -144,7 +145,8 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
         }
         String document = "{\"field1\":\"value1\",\"field2\":\"value2\"}";
         StringEntity stringEntity = new StringEntity(document, ContentType.APPLICATION_JSON);
-        Response response = client().performRequest("PUT", "/index/type/id", Collections.singletonMap("refresh", "wait_for"), stringEntity);
+        Response response = client().performRequest(HttpPut.METHOD_NAME, "/index/type/id", Collections.singletonMap("refresh", "wait_for"),
+                stringEntity);
         assertEquals(201, response.getStatusLine().getStatusCode());
         {
             GetRequest getRequest = new GetRequest("index", "type", "id");
@@ -172,7 +174,8 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
 
         String document = "{\"field1\":\"value1\",\"field2\":\"value2\"}";
         StringEntity stringEntity = new StringEntity(document, ContentType.APPLICATION_JSON);
-        Response response = client().performRequest("PUT", "/index/type/id", Collections.singletonMap("refresh", "wait_for"), stringEntity);
+        Response response = client().performRequest(HttpPut.METHOD_NAME, "/index/type/id", Collections.singletonMap("refresh", "wait_for"),
+                stringEntity);
         assertEquals(201, response.getStatusLine().getStatusCode());
         {
             GetRequest getRequest = new GetRequest("index", "type", "id").version(2);
@@ -267,12 +270,13 @@ public class CrudIT extends ESRestHighLevelClientTestCase {
 
         String document = "{\"field\":\"value1\"}";
         StringEntity stringEntity = new StringEntity(document, ContentType.APPLICATION_JSON);
-        Response r = client().performRequest("PUT", "/index/type/id1", Collections.singletonMap("refresh", "true"), stringEntity);
+        Response r = client().performRequest(HttpPut.METHOD_NAME, "/index/type/id1", Collections.singletonMap("refresh", "true"),
+                stringEntity);
         assertEquals(201, r.getStatusLine().getStatusCode());
 
         document = "{\"field\":\"value2\"}";
         stringEntity = new StringEntity(document, ContentType.APPLICATION_JSON);
-        r = client().performRequest("PUT", "/index/type/id2", Collections.singletonMap("refresh", "true"), stringEntity);
+        r = client().performRequest(HttpPut.METHOD_NAME, "/index/type/id2", Collections.singletonMap("refresh", "true"), stringEntity);
         assertEquals(201, r.getStatusLine().getStatusCode());
 
         {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
@@ -79,7 +79,6 @@ public class CustomRestHighLevelClientTests extends ESTestCase {
     private CustomRestClient restHighLevelClient;
 
     @Before
-    @SuppressWarnings("unchecked")
     public void initClients() throws IOException {
         if (restHighLevelClient == null) {
             final RestClient restClient = mock(RestClient.class);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/IndicesClientIT.java
@@ -19,15 +19,19 @@
 
 package org.elasticsearch.client;
 
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
-import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
-import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
-import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
+import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -55,7 +59,7 @@ import static org.hamcrest.Matchers.not;
 
 public class IndicesClientIT extends ESRestHighLevelClientTestCase {
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testCreateIndex() throws IOException {
         {
             // Create index
@@ -118,7 +122,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public void testPutMapping() throws IOException {
         {
             // Add mappings to index
@@ -268,7 +272,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         String index = "index";
         createIndex(index);
         closeIndex(index);
-        ResponseException exception = expectThrows(ResponseException.class, () -> client().performRequest("GET", index + "/_search"));
+        ResponseException exception = expectThrows(ResponseException.class,
+                () -> client().performRequest(HttpGet.METHOD_NAME, index + "/_search"));
         assertThat(exception.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.BAD_REQUEST.getStatus()));
         assertThat(exception.getMessage().contains(index), equalTo(true));
 
@@ -277,7 +282,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
                 highLevelClient().indices()::openAsync);
         assertTrue(openIndexResponse.isAcknowledged());
 
-        Response response = client().performRequest("GET", index + "/_search");
+        Response response = client().performRequest(HttpGet.METHOD_NAME, index + "/_search");
         assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
     }
 
@@ -306,7 +311,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
     public void testCloseExistingIndex() throws IOException {
         String index = "index";
         createIndex(index);
-        Response response = client().performRequest("GET", index + "/_search");
+        Response response = client().performRequest(HttpGet.METHOD_NAME, index + "/_search");
         assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
 
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest(index);
@@ -314,7 +319,8 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
                 highLevelClient().indices()::closeAsync);
         assertTrue(closeIndexResponse.isAcknowledged());
 
-        ResponseException exception = expectThrows(ResponseException.class, () -> client().performRequest("GET", index + "/_search"));
+        ResponseException exception = expectThrows(ResponseException.class,
+                () -> client().performRequest(HttpGet.METHOD_NAME, index + "/_search"));
         assertThat(exception.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.BAD_REQUEST.getStatus()));
         assertThat(exception.getMessage().contains(index), equalTo(true));
     }
@@ -330,27 +336,27 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
     }
 
     private static void createIndex(String index) throws IOException {
-        Response response = client().performRequest("PUT", index);
+        Response response = client().performRequest(HttpPut.METHOD_NAME, index);
         assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
     }
 
     private static boolean indexExists(String index) throws IOException {
-        Response response = client().performRequest("HEAD", index);
+        Response response = client().performRequest(HttpHead.METHOD_NAME, index);
         return RestStatus.OK.getStatus() == response.getStatusLine().getStatusCode();
     }
 
     private static void closeIndex(String index) throws IOException {
-        Response response = client().performRequest("POST", index + "/_close");
+        Response response = client().performRequest(HttpPost.METHOD_NAME, index + "/_close");
         assertThat(response.getStatusLine().getStatusCode(), equalTo(RestStatus.OK.getStatus()));
     }
 
     private static boolean aliasExists(String alias) throws IOException {
-        Response response = client().performRequest("HEAD", "/_alias/" + alias);
+        Response response = client().performRequest(HttpHead.METHOD_NAME, "/_alias/" + alias);
         return RestStatus.OK.getStatus() == response.getStatusLine().getStatusCode();
     }
 
     private static boolean aliasExists(String index, String alias) throws IOException {
-        Response response = client().performRequest("HEAD", "/" + index + "/_alias/" + alias);
+        Response response = client().performRequest(HttpHead.METHOD_NAME, "/" + index + "/_alias/" + alias);
         return RestStatus.OK.getStatus() == response.getStatusLine().getStatusCode();
     }
 
@@ -359,7 +365,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertFalse(execute(getAliasesRequest, highLevelClient().indices()::existsAlias, highLevelClient().indices()::existsAliasAsync));
 
         createIndex("index");
-        client().performRequest("PUT", "/index/_alias/alias");
+        client().performRequest(HttpPut.METHOD_NAME, "/index/_alias/alias");
         assertTrue(execute(getAliasesRequest, highLevelClient().indices()::existsAlias, highLevelClient().indices()::existsAliasAsync));
 
         GetAliasesRequest getAliasesRequest2 = new GetAliasesRequest();
@@ -370,9 +376,9 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
         assertFalse(execute(getAliasesRequest2, highLevelClient().indices()::existsAlias, highLevelClient().indices()::existsAliasAsync));
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private Map<String, Object> getIndexMetadata(String index) throws IOException {
-        Response response = client().performRequest("GET", index);
+        Response response = client().performRequest(HttpGet.METHOD_NAME, index);
 
         XContentType entityContentType = XContentType.fromMediaTypeOrFormat(response.getEntity().getContentType().getValue());
         Map<String, Object> responseEntity = XContentHelper.convertToMap(entityContentType.xContent(), response.getEntity().getContent(),
@@ -398,7 +404,7 @@ public class IndicesClientIT extends ESRestHighLevelClientTestCase {
     }
 
     private static Map<String, Object> performGet(final String endpoint) throws IOException {
-        Response response = client().performRequest("GET", endpoint);
+        Response response = client().performRequest(HttpGet.METHOD_NAME, endpoint);
         XContentType entityContentType = XContentType.fromMediaTypeOrFormat(response.getEntity().getContentType().getValue());
         Map<String, Object> responseEntity = XContentHelper.convertToMap(entityContentType.xContent(), response.getEntity().getContent(),
                 false);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.client;
 
+import org.apache.http.client.methods.HttpGet;
 import org.elasticsearch.action.main.MainResponse;
 
 import java.io.IOException;
@@ -34,7 +35,7 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
     public void testInfo() throws IOException {
         MainResponse info = highLevelClient().info();
         // compare with what the low level client outputs
-        Map<String, Object> infoAsMap = entityAsMap(adminClient().performRequest("GET", "/"));
+        Map<String, Object> infoAsMap = entityAsMap(adminClient().performRequest(HttpGet.METHOD_NAME, "/"));
         assertEquals(infoAsMap.get("cluster_name"), info.getClusterName().value());
         assertEquals(infoAsMap.get("cluster_uuid"), info.getClusterUuid());
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -241,7 +241,7 @@ public class RequestTests extends ESTestCase {
         Request request = Request.delete(deleteRequest);
         assertEquals("/" + index + "/" + type + "/" + id, request.getEndpoint());
         assertEquals(expectedParams, request.getParameters());
-        assertEquals("DELETE", request.getMethod());
+        assertEquals(HttpDelete.METHOD_NAME, request.getMethod());
         assertNull(request.getEntity());
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -28,6 +28,10 @@ import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.RequestLine;
 import org.apache.http.StatusLine;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -104,7 +108,7 @@ import static org.mockito.Mockito.when;
 public class RestHighLevelClientTests extends ESTestCase {
 
     private static final ProtocolVersion HTTP_PROTOCOL = new ProtocolVersion("http", 1, 1);
-    private static final RequestLine REQUEST_LINE = new BasicRequestLine("GET", "/", HTTP_PROTOCOL);
+    private static final RequestLine REQUEST_LINE = new BasicRequestLine(HttpGet.METHOD_NAME, "/", HTTP_PROTOCOL);
 
     private RestClient restClient;
     private RestHighLevelClient restHighLevelClient;
@@ -131,7 +135,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         when(restClient.performRequest(anyString(), anyString(), anyMapOf(String.class, String.class),
                 anyObject(), anyVararg())).thenReturn(response);
         assertTrue(restHighLevelClient.ping(headers));
-        verify(restClient).performRequest(eq("HEAD"), eq("/"), eq(Collections.emptyMap()),
+        verify(restClient).performRequest(eq(HttpHead.METHOD_NAME), eq("/"), eq(Collections.emptyMap()),
                 isNull(HttpEntity.class), argThat(new HeadersVarargMatcher(headers)));
     }
 
@@ -142,7 +146,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         when(restClient.performRequest(anyString(), anyString(), anyMapOf(String.class, String.class),
                 anyObject(), anyVararg())).thenReturn(response);
         assertFalse(restHighLevelClient.ping(headers));
-        verify(restClient).performRequest(eq("HEAD"), eq("/"), eq(Collections.emptyMap()),
+        verify(restClient).performRequest(eq(HttpHead.METHOD_NAME), eq("/"), eq(Collections.emptyMap()),
                 isNull(HttpEntity.class), argThat(new HeadersVarargMatcher(headers)));
     }
 
@@ -151,7 +155,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         when(restClient.performRequest(anyString(), anyString(), anyMapOf(String.class, String.class),
                 anyObject(), anyVararg())).thenThrow(new SocketTimeoutException());
         expectThrows(SocketTimeoutException.class, () -> restHighLevelClient.ping(headers));
-        verify(restClient).performRequest(eq("HEAD"), eq("/"), eq(Collections.emptyMap()),
+        verify(restClient).performRequest(eq(HttpHead.METHOD_NAME), eq("/"), eq(Collections.emptyMap()),
                 isNull(HttpEntity.class), argThat(new HeadersVarargMatcher(headers)));
     }
 
@@ -162,7 +166,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         mockResponse(testInfo);
         MainResponse receivedInfo = restHighLevelClient.info(headers);
         assertEquals(testInfo, receivedInfo);
-        verify(restClient).performRequest(eq("GET"), eq("/"), eq(Collections.emptyMap()),
+        verify(restClient).performRequest(eq(HttpGet.METHOD_NAME), eq("/"), eq(Collections.emptyMap()),
                 isNull(HttpEntity.class), argThat(new HeadersVarargMatcher(headers)));
     }
 
@@ -179,7 +183,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         assertEquals(5, searchResponse.getTotalShards());
         assertEquals(5, searchResponse.getSuccessfulShards());
         assertEquals(100, searchResponse.getTook().getMillis());
-        verify(restClient).performRequest(eq("POST"), eq("/_search/scroll"), eq(Collections.emptyMap()),
+        verify(restClient).performRequest(eq(HttpPost.METHOD_NAME), eq("/_search/scroll"), eq(Collections.emptyMap()),
                 isNotNull(HttpEntity.class), argThat(new HeadersVarargMatcher(headers)));
     }
 
@@ -192,7 +196,7 @@ public class RestHighLevelClientTests extends ESTestCase {
         ClearScrollResponse clearScrollResponse = restHighLevelClient.clearScroll(clearScrollRequest, headers);
         assertEquals(mockClearScrollResponse.isSucceeded(), clearScrollResponse.isSucceeded());
         assertEquals(mockClearScrollResponse.getNumFreed(), clearScrollResponse.getNumFreed());
-        verify(restClient).performRequest(eq("DELETE"), eq("/_search/scroll"), eq(Collections.emptyMap()),
+        verify(restClient).performRequest(eq(HttpDelete.METHOD_NAME), eq("/_search/scroll"), eq(Collections.emptyMap()),
                 isNotNull(HttpEntity.class), argThat(new HeadersVarargMatcher(headers)));
     }
 
@@ -331,7 +335,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testPerformRequestOnSuccess() throws IOException {
         MainRequest mainRequest = new MainRequest();
         CheckedFunction<MainRequest, Request, IOException> requestConverter = request ->
-                new Request("GET", "/", Collections.emptyMap(), null);
+                new Request(HttpGet.METHOD_NAME, "/", Collections.emptyMap(), null);
         RestStatus restStatus = randomFrom(RestStatus.values());
         HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(restStatus));
         Response mockResponse = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
@@ -353,7 +357,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testPerformRequestOnResponseExceptionWithoutEntity() throws IOException {
         MainRequest mainRequest = new MainRequest();
         CheckedFunction<MainRequest, Request, IOException> requestConverter = request ->
-                new Request("GET", "/", Collections.emptyMap(), null);
+                new Request(HttpGet.METHOD_NAME, "/", Collections.emptyMap(), null);
         RestStatus restStatus = randomFrom(RestStatus.values());
         HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(restStatus));
         Response mockResponse = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
@@ -371,7 +375,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testPerformRequestOnResponseExceptionWithEntity() throws IOException {
         MainRequest mainRequest = new MainRequest();
         CheckedFunction<MainRequest, Request, IOException> requestConverter = request ->
-                new Request("GET", "/", Collections.emptyMap(), null);
+                new Request(HttpGet.METHOD_NAME, "/", Collections.emptyMap(), null);
         RestStatus restStatus = randomFrom(RestStatus.values());
         HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(restStatus));
         httpResponse.setEntity(new StringEntity("{\"error\":\"test error message\",\"status\":" + restStatus.getStatus() + "}",
@@ -391,7 +395,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testPerformRequestOnResponseExceptionWithBrokenEntity() throws IOException {
         MainRequest mainRequest = new MainRequest();
         CheckedFunction<MainRequest, Request, IOException> requestConverter = request ->
-                new Request("GET", "/", Collections.emptyMap(), null);
+                new Request(HttpGet.METHOD_NAME, "/", Collections.emptyMap(), null);
         RestStatus restStatus = randomFrom(RestStatus.values());
         HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(restStatus));
         httpResponse.setEntity(new StringEntity("{\"error\":", ContentType.APPLICATION_JSON));
@@ -411,7 +415,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testPerformRequestOnResponseExceptionWithBrokenEntity2() throws IOException {
         MainRequest mainRequest = new MainRequest();
         CheckedFunction<MainRequest, Request, IOException> requestConverter = request ->
-                new Request("GET", "/", Collections.emptyMap(), null);
+                new Request(HttpGet.METHOD_NAME, "/", Collections.emptyMap(), null);
         RestStatus restStatus = randomFrom(RestStatus.values());
         HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(restStatus));
         httpResponse.setEntity(new StringEntity("{\"status\":" + restStatus.getStatus() + "}", ContentType.APPLICATION_JSON));
@@ -431,7 +435,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testPerformRequestOnResponseExceptionWithIgnores() throws IOException {
         MainRequest mainRequest = new MainRequest();
         CheckedFunction<MainRequest, Request, IOException> requestConverter = request ->
-                new Request("GET", "/", Collections.emptyMap(), null);
+                new Request(HttpGet.METHOD_NAME, "/", Collections.emptyMap(), null);
         HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(RestStatus.NOT_FOUND));
         Response mockResponse = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
         ResponseException responseException = new ResponseException(mockResponse);
@@ -445,7 +449,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testPerformRequestOnResponseExceptionWithIgnoresErrorNoBody() throws IOException {
         MainRequest mainRequest = new MainRequest();
         CheckedFunction<MainRequest, Request, IOException> requestConverter = request ->
-                new Request("GET", "/", Collections.emptyMap(), null);
+                new Request(HttpGet.METHOD_NAME, "/", Collections.emptyMap(), null);
         HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(RestStatus.NOT_FOUND));
         Response mockResponse = new Response(REQUEST_LINE, new HttpHost("localhost", 9200), httpResponse);
         ResponseException responseException = new ResponseException(mockResponse);
@@ -462,7 +466,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testPerformRequestOnResponseExceptionWithIgnoresErrorValidBody() throws IOException {
         MainRequest mainRequest = new MainRequest();
         CheckedFunction<MainRequest, Request, IOException> requestConverter = request ->
-                new Request("GET", "/", Collections.emptyMap(), null);
+                new Request(HttpGet.METHOD_NAME, "/", Collections.emptyMap(), null);
         HttpResponse httpResponse = new BasicHttpResponse(newStatusLine(RestStatus.NOT_FOUND));
         httpResponse.setEntity(new StringEntity("{\"error\":\"test error message\",\"status\":404}",
                 ContentType.APPLICATION_JSON));

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SearchIT.java
@@ -20,10 +20,11 @@
 package org.elasticsearch.client;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.nio.entity.NStringEntity;
-import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.search.ClearScrollRequest;
@@ -35,9 +36,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.ScriptQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.join.aggregations.Children;
@@ -83,30 +82,30 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
     @Before
     public void indexDocuments() throws IOException {
         StringEntity doc1 = new StringEntity("{\"type\":\"type1\", \"num\":10, \"num2\":50}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index/type/1", Collections.emptyMap(), doc1);
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/1", Collections.emptyMap(), doc1);
         StringEntity doc2 = new StringEntity("{\"type\":\"type1\", \"num\":20, \"num2\":40}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index/type/2", Collections.emptyMap(), doc2);
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/2", Collections.emptyMap(), doc2);
         StringEntity doc3 = new StringEntity("{\"type\":\"type1\", \"num\":50, \"num2\":35}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index/type/3", Collections.emptyMap(), doc3);
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/3", Collections.emptyMap(), doc3);
         StringEntity doc4 = new StringEntity("{\"type\":\"type2\", \"num\":100, \"num2\":10}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index/type/4", Collections.emptyMap(), doc4);
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/4", Collections.emptyMap(), doc4);
         StringEntity doc5 = new StringEntity("{\"type\":\"type2\", \"num\":100, \"num2\":10}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index/type/5", Collections.emptyMap(), doc5);
-        client().performRequest("POST", "/index/_refresh");
+        client().performRequest(HttpPut.METHOD_NAME, "/index/type/5", Collections.emptyMap(), doc5);
+        client().performRequest(HttpPost.METHOD_NAME, "/index/_refresh");
 
         StringEntity doc = new StringEntity("{\"field\":\"value1\"}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index1/doc/1", Collections.emptyMap(), doc);
+        client().performRequest(HttpPut.METHOD_NAME, "/index1/doc/1", Collections.emptyMap(), doc);
         doc = new StringEntity("{\"field\":\"value2\"}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index1/doc/2", Collections.emptyMap(), doc);
+        client().performRequest(HttpPut.METHOD_NAME, "/index1/doc/2", Collections.emptyMap(), doc);
         doc = new StringEntity("{\"field\":\"value1\"}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index2/doc/3", Collections.emptyMap(), doc);
+        client().performRequest(HttpPut.METHOD_NAME, "/index2/doc/3", Collections.emptyMap(), doc);
         doc = new StringEntity("{\"field\":\"value2\"}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index2/doc/4", Collections.emptyMap(), doc);
+        client().performRequest(HttpPut.METHOD_NAME, "/index2/doc/4", Collections.emptyMap(), doc);
         doc = new StringEntity("{\"field\":\"value1\"}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index3/doc/5", Collections.emptyMap(), doc);
+        client().performRequest(HttpPut.METHOD_NAME, "/index3/doc/5", Collections.emptyMap(), doc);
         doc = new StringEntity("{\"field\":\"value2\"}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/index3/doc/6", Collections.emptyMap(), doc);
-        client().performRequest("POST", "/index1,index2,index3/_refresh");
+        client().performRequest(HttpPut.METHOD_NAME, "/index3/doc/6", Collections.emptyMap(), doc);
+        client().performRequest(HttpPost.METHOD_NAME, "/index1,index2,index3/_refresh");
     }
 
     public void testSearchNoQuery() throws IOException {
@@ -316,7 +315,7 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
                 "        }\n" +
                 "    }" +
                 "}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/" + indexName, Collections.emptyMap(), parentMapping);
+        client().performRequest(HttpPut.METHOD_NAME, "/" + indexName, Collections.emptyMap(), parentMapping);
         StringEntity questionDoc = new StringEntity("{\n" +
                 "    \"body\": \"<p>I have Windows 2003 server and i bought a new Windows 2008 server...\",\n" +
                 "    \"title\": \"Whats the best way to file transfer my site from server to a newer one?\",\n" +
@@ -327,7 +326,7 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
                 "    ],\n" +
                 "    \"qa_join_field\" : \"question\"\n" +
                 "}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/" + indexName + "/qa/1", Collections.emptyMap(), questionDoc);
+        client().performRequest(HttpPut.METHOD_NAME, "/" + indexName + "/qa/1", Collections.emptyMap(), questionDoc);
         StringEntity answerDoc1 = new StringEntity("{\n" +
                 "    \"owner\": {\n" +
                 "        \"location\": \"Norfolk, United Kingdom\",\n" +
@@ -341,7 +340,7 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
                 "    },\n" +
                 "    \"creation_date\": \"2009-05-04T13:45:37.030\"\n" +
                 "}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/" + indexName + "/qa/2", Collections.singletonMap("routing", "1"), answerDoc1);
+        client().performRequest(HttpPut.METHOD_NAME, "/" + indexName + "/qa/2", Collections.singletonMap("routing", "1"), answerDoc1);
         StringEntity answerDoc2 = new StringEntity("{\n" +
                 "    \"owner\": {\n" +
                 "        \"location\": \"Norfolk, United Kingdom\",\n" +
@@ -355,8 +354,8 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
                 "    },\n" +
                 "    \"creation_date\": \"2009-05-05T13:45:37.030\"\n" +
                 "}", ContentType.APPLICATION_JSON);
-        client().performRequest("PUT", "/" + indexName + "/qa/3", Collections.singletonMap("routing", "1"), answerDoc2);
-        client().performRequest("POST", "/_refresh");
+        client().performRequest(HttpPut.METHOD_NAME, "/" + indexName + "/qa/3", Collections.singletonMap("routing", "1"), answerDoc2);
+        client().performRequest(HttpPost.METHOD_NAME, "/_refresh");
 
         TermsAggregationBuilder leafTermAgg = new TermsAggregationBuilder("top-names", ValueType.STRING)
                 .field("owner.display_name.keyword").size(10);
@@ -437,9 +436,9 @@ public class SearchIT extends ESRestHighLevelClientTestCase {
         for (int i = 0; i < 100; i++) {
             XContentBuilder builder = jsonBuilder().startObject().field("field", i).endObject();
             HttpEntity entity = new NStringEntity(builder.string(), ContentType.APPLICATION_JSON);
-            client().performRequest("PUT", "test/type1/" + Integer.toString(i), Collections.emptyMap(), entity);
+            client().performRequest(HttpPut.METHOD_NAME, "test/type1/" + Integer.toString(i), Collections.emptyMap(), entity);
         }
-        client().performRequest("POST", "/test/_refresh");
+        client().performRequest(HttpPost.METHOD_NAME, "/test/_refresh");
 
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().size(35).sort("field", SortOrder.ASC);
         SearchRequest searchRequest = new SearchRequest("test").scroll(TimeValue.timeValueMinutes(2)).source(searchSourceBuilder);


### PR DESCRIPTION
Replace http methods with the corresponding constants.
Remove compiler warning.