### PR TITLE
Fix parsing of script fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
+++ b/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.parseStoredFieldsValue;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.parseFieldsValue;
 
 /**
  * A single field name and values part of {@link SearchHit} and {@link GetResult}.
@@ -139,7 +139,7 @@ public class DocumentField implements Streamable, ToXContentFragment, Iterable<O
         ensureExpectedToken(XContentParser.Token.START_ARRAY, token, parser::getTokenLocation);
         List<Object> values = new ArrayList<>();
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-            values.add(parseStoredFieldsValue(parser));
+            values.add(parseFieldsValue(parser));
         }
         return new DocumentField(fieldName, values);
     }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
@@ -39,8 +39,8 @@ public final class XContentParserUtils {
     }
 
     /**
-     * Makes sure that current token is of type {@link XContentParser.Token#FIELD_NAME} and the field name is equal to the provided one
-     * @throws ParsingException if the token is not of type {@link XContentParser.Token#FIELD_NAME} or is not equal to the given field name
+     * Makes sure that current token is of type {@link Token#FIELD_NAME} and the field name is equal to the provided one
+     * @throws ParsingException if the token is not of type {@link Token#FIELD_NAME} or is not equal to the given field name
      */
     public static void ensureFieldName(XContentParser parser, Token token, String fieldName) throws IOException {
         ensureExpectedToken(Token.FIELD_NAME, token, parser::getTokenLocation);
@@ -62,7 +62,7 @@ public final class XContentParserUtils {
     /**
      * @throws ParsingException with a "unknown token found" reason
      */
-    public static void throwUnknownToken(XContentParser.Token token, XContentLocation location) {
+    public static void throwUnknownToken(Token token, XContentLocation location) {
         String message = "Failed to parse object: unexpected token [%s] found";
         throw new ParsingException(location, String.format(Locale.ROOT, message, token));
     }
@@ -83,27 +83,36 @@ public final class XContentParserUtils {
      * Parse the current token depending on its token type. The following token types will be
      * parsed by the corresponding parser methods:
      * <ul>
-     *    <li>XContentParser.Token.VALUE_STRING: parser.text()</li>
-     *    <li>XContentParser.Token.VALUE_NUMBER: parser.numberValue()</li>
-     *    <li>XContentParser.Token.VALUE_BOOLEAN: parser.booleanValue()</li>
-     *    <li>XContentParser.Token.VALUE_EMBEDDED_OBJECT: parser.binaryValue()</li>
+     *    <li>{@link Token#VALUE_STRING}: {@link XContentParser#text()}</li>
+     *    <li>{@link Token#VALUE_NUMBER}: {@link XContentParser#numberValue()} ()}</li>
+     *    <li>{@link Token#VALUE_BOOLEAN}: {@link XContentParser#booleanValue()} ()}</li>
+     *    <li>{@link Token#VALUE_EMBEDDED_OBJECT}: {@link XContentParser#binaryValue()} ()}</li>
+     *    <li>{@link Token#VALUE_NULL}: returns null</li>
+     *    <li>{@link Token#START_OBJECT}: {@link XContentParser#mapOrdered()} ()}</li>
+     *    <li>{@link Token#START_ARRAY}: {@link XContentParser#listOrderedMap()} ()}</li>
      * </ul>
      *
-     * @throws ParsingException if the token none of the allowed values
+     * @throws ParsingException if the token is none of the allowed values
      */
-    public static Object parseStoredFieldsValue(XContentParser parser) throws IOException {
-        XContentParser.Token token = parser.currentToken();
+    public static Object parseFieldsValue(XContentParser parser) throws IOException {
+        Token token = parser.currentToken();
         Object value = null;
-        if (token == XContentParser.Token.VALUE_STRING) {
+        if (token == Token.VALUE_STRING) {
             //binary values will be parsed back and returned as base64 strings when reading from json and yaml
             value = parser.text();
-        } else if (token == XContentParser.Token.VALUE_NUMBER) {
+        } else if (token == Token.VALUE_NUMBER) {
             value = parser.numberValue();
-        } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
+        } else if (token == Token.VALUE_BOOLEAN) {
             value = parser.booleanValue();
-        } else if (token == XContentParser.Token.VALUE_EMBEDDED_OBJECT) {
+        } else if (token == Token.VALUE_EMBEDDED_OBJECT) {
             //binary values will be parsed back and returned as BytesArray when reading from cbor and smile
             value = new BytesArray(parser.binaryValue());
+        } else if (token == Token.VALUE_NULL) {
+            value = null;
+        } else if (token == Token.START_OBJECT) {
+            value = parser.mapOrdered();
+        } else if (token == Token.START_ARRAY) {
+            value = parser.listOrderedMap();
         } else {
             throwUnknownToken(token, parser.getTokenLocation());
         }
@@ -132,7 +141,7 @@ public final class XContentParserUtils {
      */
     public static <T> void parseTypedKeysObject(XContentParser parser, String delimiter, Class<T> objectClass, Consumer<T> consumer)
             throws IOException {
-        if (parser.currentToken() != XContentParser.Token.START_OBJECT && parser.currentToken() != XContentParser.Token.START_ARRAY) {
+        if (parser.currentToken() != Token.START_OBJECT && parser.currentToken() != Token.START_ARRAY) {
             throwUnknownToken(parser.currentToken(), parser.getTokenLocation());
         }
         String currentFieldName = parser.currentName();

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -69,7 +69,7 @@ import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constru
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.parseStoredFieldsValue;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.parseFieldsValue;
 import static org.elasticsearch.search.fetch.subphase.highlight.HighlightField.readHighlightField;
 
 /**
@@ -604,7 +604,7 @@ public final class SearchHit implements Streamable, ToXContentObject, Iterable<D
                     fieldMap.put(field.getName(), field);
                 }, (p, c) -> {
                     List<Object> values = new ArrayList<>();
-                    values.add(parseStoredFieldsValue(p));
+                    values.add(parseFieldsValue(p));
                     return new DocumentField(metadatafield, values);
                 }, new ParseField(metadatafield), ValueType.VALUE);
             }
@@ -649,7 +649,7 @@ public final class SearchHit implements Streamable, ToXContentObject, Iterable<D
         String description = null;
         List<Explanation> details = new ArrayList<>();
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, () -> parser.getTokenLocation());
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser::getTokenLocation);
             String currentFieldName = parser.currentName();
             token = parser.nextToken();
             if (Fields.VALUE.equals(currentFieldName)) {
@@ -657,7 +657,7 @@ public final class SearchHit implements Streamable, ToXContentObject, Iterable<D
             } else if (Fields.DESCRIPTION.equals(currentFieldName)) {
                 description = parser.textOrNull();
             } else if (Fields.DETAILS.equals(currentFieldName)) {
-                ensureExpectedToken(XContentParser.Token.START_ARRAY, token, () -> parser.getTokenLocation());
+                ensureExpectedToken(XContentParser.Token.START_ARRAY, token, parser::getTokenLocation);
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                     details.add(parseExplanation(parser));
                 }

--- a/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -56,6 +56,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -258,7 +259,7 @@ public class SearchHitTests extends ESTestCase {
         assertThat(results.getAt(1).getShard(), equalTo(target));
     }
 
-    public void testNullSource() throws Exception {
+    public void testNullSource() {
         SearchHit searchHit = new SearchHit(0, "_id", new Text("_type"), null);
 
         assertThat(searchHit.getSourceAsMap(), nullValue());
@@ -275,6 +276,73 @@ public class SearchHitTests extends ESTestCase {
         assertFalse(searchHit.hasSource());
         searchHit.sourceRef(new BytesArray("{}"));
         assertTrue(searchHit.hasSource());
+    }
+
+    public void testWeirdScriptFields() throws Exception {
+        {
+            XContentParser parser = createParser(XContentType.JSON.xContent(), "{\n" +
+                    "  \"_index\": \"twitter\",\n" +
+                    "  \"_type\": \"tweet\",\n" +
+                    "  \"_id\": \"1\",\n" +
+                    "  \"_score\": 1.0,\n" +
+                    "  \"fields\": {\n" +
+                    "    \"result\": [null]\n" +
+                    "  }\n" +
+                    "}");
+            SearchHit searchHit = SearchHit.fromXContent(parser);
+            Map<String, DocumentField> fields = searchHit.getFields();
+            assertEquals(1, fields.size());
+            DocumentField result = fields.get("result");
+            assertNotNull(result);
+            assertEquals(1, result.getValues().size());
+            assertNull(result.getValues().get(0));
+        }
+        {
+            XContentParser parser = createParser(XContentType.JSON.xContent(), "{\n" +
+                    "  \"_index\": \"twitter\",\n" +
+                    "  \"_type\": \"tweet\",\n" +
+                    "  \"_id\": \"1\",\n" +
+                    "  \"_score\": 1.0,\n" +
+                    "  \"fields\": {\n" +
+                    "    \"result\": [{}]\n" +
+                    "  }\n" +
+                    "}");
+
+            SearchHit searchHit = SearchHit.fromXContent(parser);
+            Map<String, DocumentField> fields = searchHit.getFields();
+            assertEquals(1, fields.size());
+            DocumentField result = fields.get("result");
+            assertNotNull(result);
+            assertEquals(1, result.getValues().size());
+            Object value = result.getValues().get(0);
+            assertThat(value, instanceOf(Map.class));
+            Map<?, ?> map = (Map<?, ?>) value;
+            assertEquals(0, map.size());
+        }
+        {
+            XContentParser parser = createParser(JsonXContent.jsonXContent, "{\n" +
+                    "  \"_index\": \"twitter\",\n" +
+                    "  \"_type\": \"tweet\",\n" +
+                    "  \"_id\": \"1\",\n" +
+                    "  \"_score\": 1.0,\n" +
+                    "  \"fields\": {\n" +
+                    "    \"result\": [\n" +
+                    "      []\n" +
+                    "    ]\n" +
+                    "  }\n" +
+                    "}");
+
+            SearchHit searchHit = SearchHit.fromXContent(parser);
+            Map<String, DocumentField> fields = searchHit.getFields();
+            assertEquals(1, fields.size());
+            DocumentField result = fields.get("result");
+            assertNotNull(result);
+            assertEquals(1, result.getValues().size());
+            Object value = result.getValues().get(0);
+            assertThat(value, instanceOf(List.class));
+            List<?> list = (List<?>) value;
+            assertEquals(0, list.size());
+        }
     }
 
     private static Explanation createExplanation(int depth) {


### PR DESCRIPTION
Script fields can get a bit more complicated than just stored fields. A script can return null, an object and also an array. Extended parsing to support such valid values. Also renamed util method from `parseStoredFieldsValue` to `parseFieldsValue` given that it can parse stored fields but also script fields, anything that's returned as `fields`.

Closes #28380