### PR TITLE
Build: Print warn logs from cluster on failure

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RestIntegTestTask.groovy
@@ -162,7 +162,7 @@ public class RestIntegTestTask extends DefaultTask {
                 if (line.startsWith("[")) {
                     inExcerpt = false // clear with the next log message
                 }
-                if (line =~ /(\[WARN\])|(\[ERROR\])/) {
+                if (line =~ /(\[WARN *\])|(\[ERROR *\])/) {
                     inExcerpt = true // show warnings and errors
                 }
                 if (inStartup || inExcerpt) {


### PR DESCRIPTION
Prints the warning level logs from the integration testing cluster if
there is a failure. We'd attempted to print those logs but I believe our
regex was missing a space.
