### PR TITLE
Docs: Clear watermarks after setting them

### DIFF
--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -98,3 +98,20 @@ PUT _cluster/settings
 --------------------------------------------------
 // CONSOLE
 
+/////////////////////
+
+Clear the settings so they don't leak into subsequent snippets.
+
+[source,js]
+--------------------------------------------------
+PUT _cluster/settings
+{
+  "transient": {
+    "cluster.*" : null
+  }
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[continued]
+
+/////////////////////


### PR DESCRIPTION
Clear the disk watermark after the snippet showing users how to set it.
Without this our tests will fail if the disks have less than 10GB free.

Closes #28325