### PR TITLE
Use final fields in UnicastZenPing request/response objects

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
@@ -91,7 +91,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
-import static org.elasticsearch.discovery.zen.ZenPing.PingResponse.readPingResponse;
 
 public class UnicastZenPing extends AbstractComponent implements ZenPing {
 
@@ -162,7 +161,7 @@ public class UnicastZenPing extends AbstractComponent implements ZenPing {
             concurrentConnects,
             resolveTimeout);
 
-        transportService.registerRequestHandler(ACTION_NAME, UnicastPingRequest::new, ThreadPool.Names.SAME,
+        transportService.registerRequestHandler(ACTION_NAME, ThreadPool.Names.SAME, UnicastPingRequest::new,
             new UnicastPingRequestHandler());
 
         final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory(settings, "[unicast_connect]");
@@ -456,12 +455,8 @@ public class UnicastZenPing extends AbstractComponent implements ZenPing {
 
 
     protected void sendPings(final TimeValue timeout, final PingingRound pingingRound) {
-        final UnicastPingRequest pingRequest = new UnicastPingRequest();
-        pingRequest.id = pingingRound.id();
-        pingRequest.timeout = timeout;
-        ClusterState lastState = contextProvider.clusterState();
-
-        pingRequest.pingResponse = createPingResponse(lastState);
+        final ClusterState lastState = contextProvider.clusterState();
+        final UnicastPingRequest pingRequest = new UnicastPingRequest(pingingRound.id(), timeout, createPingResponse(lastState));
 
         Set<DiscoveryNode> nodesFromResponses = temporalResponses.stream().map(pingResponse -> {
             assert clusterName.equals(pingResponse.clusterName()) :
@@ -553,8 +548,8 @@ public class UnicastZenPing extends AbstractComponent implements ZenPing {
         return new TransportResponseHandler<UnicastPingResponse>() {
 
             @Override
-            public UnicastPingResponse newInstance() {
-                return new UnicastPingResponse();
+            public UnicastPingResponse read(StreamInput in) throws IOException {
+                return new UnicastPingResponse(in);
             }
 
             @Override
@@ -599,11 +594,7 @@ public class UnicastZenPing extends AbstractComponent implements ZenPing {
         List<PingResponse> pingResponses = CollectionUtils.iterableAsArrayList(temporalResponses);
         pingResponses.add(createPingResponse(contextProvider.clusterState()));
 
-        UnicastPingResponse unicastPingResponse = new UnicastPingResponse();
-        unicastPingResponse.id = request.id;
-        unicastPingResponse.pingResponses = pingResponses.toArray(new PingResponse[pingResponses.size()]);
-
-        return unicastPingResponse;
+        return new UnicastPingResponse(request.id, pingResponses.toArray(new PingResponse[pingResponses.size()]));
     }
 
     class UnicastPingRequestHandler implements TransportRequestHandler<UnicastPingRequest> {
@@ -627,21 +618,23 @@ public class UnicastZenPing extends AbstractComponent implements ZenPing {
 
     }
 
-    public static class UnicastPingRequest extends TransportRequest {
+    static class UnicastPingRequest extends TransportRequest {
 
-        int id;
-        TimeValue timeout;
-        PingResponse pingResponse;
+        final int id;
+        final TimeValue timeout;
+        final PingResponse pingResponse;
 
-        public UnicastPingRequest() {
+        UnicastPingRequest(int id, TimeValue timeout, PingResponse pingResponse) {
+            this.id = id;
+            this.timeout = timeout;
+            this.pingResponse = pingResponse;
         }
 
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
+        UnicastPingRequest(StreamInput in) throws IOException {
+            super(in);
             id = in.readInt();
             timeout = new TimeValue(in);
-            pingResponse = readPingResponse(in);
+            pingResponse = new PingResponse(in);
         }
 
         @Override
@@ -660,20 +653,20 @@ public class UnicastZenPing extends AbstractComponent implements ZenPing {
 
     static class UnicastPingResponse extends TransportResponse {
 
-        int id;
+        final int id;
 
-        PingResponse[] pingResponses;
+        final PingResponse[] pingResponses;
 
-        UnicastPingResponse() {
+        UnicastPingResponse(int id, PingResponse[] pingResponses) {
+            this.id = id;
+            this.pingResponses = pingResponses;
         }
 
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            super.readFrom(in);
+        UnicastPingResponse(StreamInput in) throws IOException {
             id = in.readInt();
             pingResponses = new PingResponse[in.readVInt()];
             for (int i = 0; i < pingResponses.length; i++) {
-                pingResponses[i] = readPingResponse(in);
+                pingResponses[i] = new PingResponse(in);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
+++ b/server/src/main/java/org/elasticsearch/discovery/zen/UnicastZenPing.java
@@ -638,6 +638,11 @@ public class UnicastZenPing extends AbstractComponent implements ZenPing {
         }
 
         @Override
+        public void readFrom(StreamInput in) throws IOException {
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
+        }
+
+        @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeInt(id);
@@ -668,6 +673,11 @@ public class UnicastZenPing extends AbstractComponent implements ZenPing {
             for (int i = 0; i < pingResponses.length; i++) {
                 pingResponses[i] = new PingResponse(in);
             }
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
         }
 
         @Override


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/21658#issuecomment-360832032