### PR TITLE
Tests: Wipe cluster settings after every test

### DIFF
--- a/docs/reference/modules/cluster/allocation_filtering.asciidoc
+++ b/docs/reference/modules/cluster/allocation_filtering.asciidoc
@@ -65,4 +65,3 @@ PUT _cluster/settings
 }
 ------------------------
 // CONSOLE
-// TEST[skip:indexes don't assign]

--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -97,21 +97,3 @@ PUT _cluster/settings
 }
 --------------------------------------------------
 // CONSOLE
-
-/////////////////////
-
-Clear the settings so they don't leak into subsequent snippets.
-
-[source,js]
---------------------------------------------------
-PUT _cluster/settings
-{
-  "transient": {
-    "cluster.*" : null
-  }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[continued]
-
-/////////////////////


### PR DESCRIPTION
Cluster settings shouldn't leak into the next test.

I played with failing the test if it left over any settings but that
felt like it added more ceremony then it was worth. The advantage would be
that any test that intentionally wants to leave settings in place after
the test would fail and require looking at but, so far as I can tell, we
don't have any such tests.
