### PR TITLE
RandomDocumentPicks#randomFieldName can produce invalid field name

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/RandomDocumentPicks.java
@@ -43,12 +43,16 @@ public final class RandomDocumentPicks {
     public static String randomFieldName(Random random) {
         int numLevels = RandomNumbers.randomIntBetween(random, 1, 5);
         StringBuilder fieldName = new StringBuilder();
-        for (int i = 0; i < numLevels; i++) {
+        for (int i = 0; i < numLevels-1; i++) {
             if (i > 0) {
                 fieldName.append('.');
             }
             fieldName.append(randomString(random));
         }
+        if (numLevels > 1) {
+            fieldName.append('.');
+        }
+        fieldName.append(randomLeafFieldName(random));
         return fieldName.toString();
     }
 


### PR DESCRIPTION
This change makes sure that this function does not create field names that end with a '.', more precisely it only allows
alpha-numeric characters to compose the leaf field name.

Closes #27373