### PR TITLE
Fix NullPointerException in MockUncasedHostProvider

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/discovery/MockUncasedHostProvider.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/discovery/MockUncasedHostProvider.java
@@ -20,6 +20,7 @@ package org.elasticsearch.test.discovery;
 
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.discovery.zen.UnicastHostsProvider;
 
@@ -27,6 +28,7 @@ import java.io.Closeable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -54,15 +56,19 @@ public final class MockUncasedHostProvider implements UnicastHostsProvider, Clos
 
     @Override
     public List<DiscoveryNode> buildDynamicNodes() {
+        final DiscoveryNode localNode = getNode();
+        assert localNode != null;
         synchronized (activeNodesPerCluster) {
             Set<MockUncasedHostProvider> activeNodes = getActiveNodesForCurrentCluster();
             return activeNodes.stream()
                 .map(MockUncasedHostProvider::getNode)
-                .filter(n -> !localNodeSupplier.get().equals(n))
+                .filter(Objects::nonNull)
+                .filter(n -> localNode.equals(n) == false)
                 .collect(Collectors.toList());
         }
     }
 
+    @Nullable
     private DiscoveryNode getNode() {
         return localNodeSupplier.get();
     }


### PR DESCRIPTION
When investigating test failures, we saw `NullPointerException` in the logs (see https://github.com/elastic/elasticsearch/issues/21658#issuecomment-360832032). I opened PR #28406 as a fix for this. @dnhatn noticed that there were still NPEs occurring after the PR was merged. So I had another look, and noticed another possible source for NPEs (which were confirmed by adding assertions): The `MockUncasedHostProvider` accesses nodes that are not fully built yet, where `TransportService.getNode()` returns null, which means that the null entries end up in the list of seedNodes that `UnicastZenPing` then uses.