### PR TITLE
Mark the composite aggregation as a beta feature

### DIFF
--- a/docs/reference/aggregations/bucket.asciidoc
+++ b/docs/reference/aggregations/bucket.asciidoc
@@ -21,6 +21,8 @@ include::bucket/adjacency-matrix-aggregation.asciidoc[]
 
 include::bucket/children-aggregation.asciidoc[]
 
+include::bucket/composite-aggregation.asciidoc[]
+
 include::bucket/datehistogram-aggregation.asciidoc[]
 
 include::bucket/daterange-aggregation.asciidoc[]
@@ -56,6 +58,4 @@ include::bucket/significantterms-aggregation.asciidoc[]
 include::bucket/significanttext-aggregation.asciidoc[]
 
 include::bucket/terms-aggregation.asciidoc[]
-
-include::bucket/composite-aggregation.asciidoc[]
 

--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -1,7 +1,7 @@
 [[search-aggregations-bucket-composite-aggregation]]
 === Composite Aggregation
 
-experimental[]
+beta[]
 
 A multi-bucket aggregation that creates composite buckets from different sources.
 


### PR DESCRIPTION
The `composite` aggregation should be marked as beta (rather than experimental) in the documentation.