### PR TITLE
Further Removal of Painless Type from Lambdas and References.

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.painless;
 
 import org.elasticsearch.painless.Definition.Method;
+import org.objectweb.asm.Type;
 
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Modifier;
@@ -61,9 +62,9 @@ public class FunctionRef {
     /** factory method type descriptor */
     public final String factoryDescriptor;
     /** functional interface method as type */
-    public final org.objectweb.asm.Type interfaceType;
+    public final Type interfaceType;
     /** delegate method type method as type */
-    public final org.objectweb.asm.Type delegateType;
+    public final Type delegateType;
 
     /**
      * Creates a new FunctionRef, which will resolve {@code type::call} from the whitelist.
@@ -119,8 +120,8 @@ public class FunctionRef {
         this.delegateMethod = delegateMethod;
 
         factoryDescriptor = factoryMethodType.toMethodDescriptorString();
-        interfaceType = org.objectweb.asm.Type.getMethodType(interfaceMethodType.toMethodDescriptorString());
-        delegateType = org.objectweb.asm.Type.getMethodType(this.delegateMethodType.toMethodDescriptorString());
+        interfaceType = Type.getMethodType(interfaceMethodType.toMethodDescriptorString());
+        delegateType = Type.getMethodType(this.delegateMethodType.toMethodDescriptorString());
     }
 
     /**

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECapturingFunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECapturingFunctionRef.java
@@ -76,17 +76,16 @@ public final class ECapturingFunctionRef extends AExpression implements ILambda 
             // static case
             if (captured.type.dynamic == false) {
                 try {
-                    ref = new FunctionRef(
-                        locals.getDefinition(), expected, captured.type.name, call, 1);
+                    ref = new FunctionRef(locals.getDefinition(), expected, captured.type.name, call, 1);
 
                     // check casts between the interface method and the delegate method are legal
                     for (int i = 0; i < ref.interfaceMethod.arguments.size(); ++i) {
-                        Definition.Type from = ref.interfaceMethod.arguments.get(i);
-                        Definition.Type to = ref.delegateMethod.arguments.get(i);
-                        AnalyzerCaster.getLegalCast(location, Definition.TypeToClass(from), Definition.TypeToClass(to), false, true);
+                        Class<?> from = Definition.TypeToClass(ref.interfaceMethod.arguments.get(i));
+                        Class<?> to = Definition.TypeToClass(ref.delegateMethod.arguments.get(i));
+                        AnalyzerCaster.getLegalCast(location, from, to, false, true);
                     }
 
-                    if (ref.interfaceMethod.rtn.equals(locals.getDefinition().voidType) == false) {
+                    if (ref.interfaceMethod.rtn.clazz != void.class) {
                         AnalyzerCaster.getLegalCast(location,
                             Definition.TypeToClass(ref.delegateMethod.rtn), Definition.TypeToClass(ref.interfaceMethod.rtn), false, true);
                     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EFunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EFunctionRef.java
@@ -80,12 +80,12 @@ public final class EFunctionRef extends AExpression implements ILambda {
 
                     // check casts between the interface method and the delegate method are legal
                     for (int i = 0; i < interfaceMethod.arguments.size(); ++i) {
-                        Definition.Type from = interfaceMethod.arguments.get(i);
-                        Definition.Type to = delegateMethod.arguments.get(i);
-                        AnalyzerCaster.getLegalCast(location, Definition.TypeToClass(from), Definition.TypeToClass(to), false, true);
+                        Class<?> from = Definition.TypeToClass(interfaceMethod.arguments.get(i));
+                        Class<?> to = Definition.TypeToClass(delegateMethod.arguments.get(i));
+                        AnalyzerCaster.getLegalCast(location, from, to, false, true);
                     }
 
-                    if (interfaceMethod.rtn.equals(locals.getDefinition().voidType) == false) {
+                    if (interfaceMethod.rtn.clazz != void.class) {
                         AnalyzerCaster.getLegalCast(
                             location, Definition.TypeToClass(delegateMethod.rtn), Definition.TypeToClass(interfaceMethod.rtn), false, true);
                     }


### PR DESCRIPTION
Removes Painless Type in favor of Java Class from the expression nodes related to function references and lambdas. 