### PR TITLE
[Test] Fix InstallPluginCommandTests failure on Windows

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -21,6 +21,7 @@ package org.elasticsearch.plugins;
 
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+
 import org.apache.lucene.search.spell.LevensteinDistance;
 import org.apache.lucene.util.CollectionUtil;
 import org.apache.lucene.util.IOUtils;
@@ -60,13 +61,9 @@ import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.MessageDigest;
-import java.security.Permission;
-import java.security.PermissionCollection;
-import java.security.Permissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/InstallPluginCommandTests.java
@@ -1191,7 +1191,6 @@ public class InstallPluginCommandTests extends ESTestCase {
         return bytes -> MessageDigests.toHexString(digest.digest(bytes)) + s;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/28415")
     public void testMetaPluginPolicyConfirmation() throws Exception {
         Tuple<Path, Environment> env = createEnv(fs, temp);
         Path metaDir = createPluginDir(temp);
@@ -1210,7 +1209,9 @@ public class InstallPluginCommandTests extends ESTestCase {
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
         assertEquals("installation aborted by user", e.getMessage());
         assertThat(terminal.getOutput(), containsString("WARNING: plugin requires additional permissions"));
-        assertThat(Files.list(env.v2().pluginsFile()).collect(Collectors.toList()), empty());
+        try (Stream<Path> fileStream = Files.list(env.v2().pluginsFile())) {
+            assertThat(fileStream.collect(Collectors.toList()), empty());
+        }
 
         // explicitly do not install
         terminal.reset();
@@ -1218,7 +1219,9 @@ public class InstallPluginCommandTests extends ESTestCase {
         e = expectThrows(UserException.class, () -> installPlugin(pluginZip, env.v1()));
         assertEquals("installation aborted by user", e.getMessage());
         assertThat(terminal.getOutput(), containsString("WARNING: plugin requires additional permissions"));
-        assertThat(Files.list(env.v2().pluginsFile()).collect(Collectors.toList()), empty());
+        try (Stream<Path> fileStream = Files.list(env.v2().pluginsFile())) {
+            assertThat(fileStream.collect(Collectors.toList()), empty());
+        }
 
         // allow installation
         terminal.reset();


### PR DESCRIPTION
The `testMetaPluginPolicyConfirmation` needs to close some file stream it is
iterating over, otherwise some OSes (like Windows) might not be able to delete
all temporary folders, which in turn leads to test failures.

Closes #28415