### PR TITLE
[Test] Fix CRUDDocumentationIT

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientExtTests.java
@@ -44,7 +44,7 @@ public class RestHighLevelClientExtTests extends ESTestCase {
     private RestHighLevelClient restHighLevelClient;
 
     @Before
-    public void initClient() throws IOException {
+    public void initClient() {
         RestClient restClient = mock(RestClient.class);
         restHighLevelClient = new RestHighLevelClientExt(restClient);
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -242,13 +242,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             });
             // end::index-execute-async
 
-            assertTrue(awaitBusy(() -> {
-                try {
-                    return client.exists(new GetRequest("posts", "doc", "async"));
-                } catch (IOException e) {
-                    return false;
-                }
-            }));
+            assertBusy(() -> assertTrue(client.exists(new GetRequest("posts", "doc", "async"))));
         }
     }
 
@@ -510,13 +504,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             });
             // end::update-execute-async
 
-            assertTrue(awaitBusy(() -> {
-                try {
-                    return client.exists(new GetRequest("posts", "doc", "async"));
-                } catch (IOException e) {
-                    return false;
-                }
-            }));
+            assertBusy(() -> assertTrue(client.exists(new GetRequest("posts", "doc", "async"))));
         }
     }
 
@@ -628,13 +616,7 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             });
             // end::delete-execute-async
 
-            assertTrue(awaitBusy(() -> {
-                try {
-                    return client.exists(new GetRequest("posts", "doc", "async")) == false;
-                } catch (IOException e) {
-                    return false;
-                }
-            }));
+            assertBusy(() -> assertFalse(client.exists(new GetRequest("posts", "doc", "async"))));
         }
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/CRUDDocumentationIT.java
@@ -59,7 +59,6 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
-import org.elasticsearch.threadpool.Scheduler;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -87,7 +86,7 @@ import static java.util.Collections.singletonMap;
  */
 public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
 
-    public void testIndex() throws IOException {
+    public void testIndex() throws Exception {
         RestHighLevelClient client = highLevelClient();
 
         {
@@ -167,20 +166,6 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
                 }
             }
             // end::index-response
-
-            // tag::index-execute-async
-            client.indexAsync(request, new ActionListener<IndexResponse>() {
-                @Override
-                public void onResponse(IndexResponse indexResponse) {
-                    // <1>
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    // <2>
-                }
-            });
-            // end::index-execute-async
         }
         {
             IndexRequest request = new IndexRequest("posts", "doc", "1");
@@ -240,9 +225,34 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             }
             // end::index-optype
         }
+        {
+            IndexRequest request = new IndexRequest("posts", "doc", "async").source("field", "value");
+
+            // tag::index-execute-async
+            client.indexAsync(request, new ActionListener<IndexResponse>() {
+                @Override
+                public void onResponse(IndexResponse indexResponse) {
+                    // <1>
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    // <2>
+                }
+            });
+            // end::index-execute-async
+
+            assertTrue(awaitBusy(() -> {
+                try {
+                    return client.exists(new GetRequest("posts", "doc", "async"));
+                } catch (IOException e) {
+                    return false;
+                }
+            }));
+        }
     }
 
-    public void testUpdate() throws IOException {
+    public void testUpdate() throws Exception {
         RestHighLevelClient client = highLevelClient();
         {
             IndexRequest indexRequest = new IndexRequest("posts", "doc", "1").source("field", 0);
@@ -378,20 +388,6 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
                 }
             }
             // end::update-failure
-
-            // tag::update-execute-async
-            client.updateAsync(request, new ActionListener<UpdateResponse>() {
-                @Override
-                public void onResponse(UpdateResponse updateResponse) {
-                    // <1>
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    // <2>
-                }
-            });
-            // end::update-execute-async
         }
         {
             //tag::update-docnotfound
@@ -497,9 +493,34 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
             request.waitForActiveShards(ActiveShardCount.ALL); // <2>
             // end::update-request-active-shards
         }
+        {
+            UpdateRequest request = new UpdateRequest("posts", "doc", "async").doc("reason", "async update").docAsUpsert(true);
+
+            // tag::update-execute-async
+            client.updateAsync(request, new ActionListener<UpdateResponse>() {
+                @Override
+                public void onResponse(UpdateResponse updateResponse) {
+                    // <1>
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    // <2>
+                }
+            });
+            // end::update-execute-async
+
+            assertTrue(awaitBusy(() -> {
+                try {
+                    return client.exists(new GetRequest("posts", "doc", "async"));
+                } catch (IOException e) {
+                    return false;
+                }
+            }));
+        }
     }
 
-    public void testDelete() throws IOException {
+    public void testDelete() throws Exception {
         RestHighLevelClient client = highLevelClient();
 
         {
@@ -536,20 +557,6 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
                 }
             }
             // end::delete-response
-
-            // tag::delete-execute-async
-            client.deleteAsync(request, new ActionListener<DeleteResponse>() {
-                @Override
-                public void onResponse(DeleteResponse deleteResponse) {
-                    // <1>
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    // <2>
-                }
-            });
-            // end::delete-execute-async
         }
 
         {
@@ -600,6 +607,34 @@ public class CRUDDocumentationIT extends ESRestHighLevelClientTestCase {
                 }
             }
             // end::delete-conflict
+        }
+        {
+            IndexResponse indexResponse = client.index(new IndexRequest("posts", "doc", "async").source("field", "value"));
+            assertSame(indexResponse.status(), RestStatus.CREATED);
+
+            DeleteRequest request = new DeleteRequest("posts", "doc", "async");
+
+            // tag::delete-execute-async
+            client.deleteAsync(request, new ActionListener<DeleteResponse>() {
+                @Override
+                public void onResponse(DeleteResponse deleteResponse) {
+                    // <1>
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    // <2>
+                }
+            });
+            // end::delete-execute-async
+
+            assertTrue(awaitBusy(() -> {
+                try {
+                    return client.exists(new GetRequest("posts", "doc", "async")) == false;
+                } catch (IOException e) {
+                    return false;
+                }
+            }));
         }
     }
 


### PR DESCRIPTION
Similarly to other documentation tests in the high level client, the
asynchronous operation like update, index or delete can make the test
fail if it sneak in between the middle of another operation.

This commit moves the async doc tests to be the last ones executed and
adds await busy loops to ensure that the asynchronous operations are
correctly terminated.

closes #28446
