### PR TITLE
Fix AIOOB on indexed geo_shape query

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoShapeQueryBuilder.java
@@ -409,6 +409,7 @@ public class GeoShapeQueryBuilder extends AbstractQueryBuilder<GeoShapeQueryBuil
                                     parser.nextToken();
                                     if (++currentPathSlot == pathElements.length) {
                                         listener.onResponse(ShapeParser.parse(parser));
+                                        return;
                                     }
                                 } else {
                                     parser.nextToken();

--- a/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoShapeQueryBuilderTests.java
@@ -119,6 +119,7 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
             XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
             builder.startObject();
             builder.field(expectedShapePath, indexedShapeToReturn);
+            builder.field(randomAlphaOfLengthBetween(10, 20), "something");
             builder.endObject();
             json = builder.string();
         } catch (IOException ex) {
@@ -227,13 +228,7 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
 
     @Override
     public void testMustRewrite() throws IOException {
-        GeoShapeQueryBuilder sqb;
-        do {
-            sqb = doCreateTestQueryBuilder();
-            // do this until we get one without a shape
-        } while (sqb.shape() != null);
-
-        GeoShapeQueryBuilder query = sqb;
+        GeoShapeQueryBuilder query = doCreateTestQueryBuilder(true);
 
         UnsupportedOperationException e = expectThrows(UnsupportedOperationException.class, () -> query.toQuery(createShardContext()));
         assertEquals("query must be rewritten first", e.getMessage());
@@ -242,6 +237,23 @@ public class GeoShapeQueryBuilderTests extends AbstractQueryTestCase<GeoShapeQue
         geoShapeQueryBuilder.strategy(query.strategy());
         geoShapeQueryBuilder.relation(query.relation());
         assertEquals(geoShapeQueryBuilder, rewrite);
+    }
+
+    public void testMultipleRewrite() throws IOException {
+        GeoShapeQueryBuilder shape = doCreateTestQueryBuilder(true);
+        QueryBuilder builder = new BoolQueryBuilder()
+            .should(shape)
+            .should(shape);
+
+        builder = rewriteAndFetch(builder, createShardContext());
+
+        GeoShapeQueryBuilder expectedShape = new GeoShapeQueryBuilder(GEO_SHAPE_FIELD_NAME, indexedShapeToReturn);
+        expectedShape.strategy(shape.strategy());
+        expectedShape.relation(shape.relation());
+        QueryBuilder expected = new BoolQueryBuilder()
+            .should(expectedShape)
+            .should(expectedShape);
+        assertEquals(expected, builder);
     }
 
     public void testIgnoreUnmapped() throws IOException {


### PR DESCRIPTION
This change fixes a possible AIOOB during the parsing of the document that contains the indexed shape.
This change ensures that the parsing does not continue when the field that contains the shape has been found.

Closes #28456