### PR TITLE
Update 5.6 Breaking Changes doc

### DIFF
--- a/docs/reference/migration/migrate_5_6.asciidoc
+++ b/docs/reference/migration/migrate_5_6.asciidoc
@@ -33,3 +33,8 @@ previous behavior, Elasticsearch would skip the bootstrap checks if bound to a
 link-local address. Now that Elasticsearch no longer binds to such addresses
 when binding to localhost, the bootstrap checks now apply to link-local
 addresses.
+
+[float]
+=== Referencing Parent Documents
+
+Previously in Elasticsearch parent documents could be aggregated on or referenced in a script using `_parent`. Now in order to reference a parent document in an aggregation or script you must do `_parent#my_parent` as stated in the https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping-parent-field.html#CO211-2[mapping a parent field documentation].

--- a/docs/reference/migration/migrate_5_6.asciidoc
+++ b/docs/reference/migration/migrate_5_6.asciidoc
@@ -37,4 +37,7 @@ addresses.
 [float]
 === Referencing Parent Documents
 
-Previously in Elasticsearch parent documents could be aggregated on or referenced in a script using `_parent`. Now in order to reference a parent document in an aggregation or script you must do `_parent#my_parent` as stated in the https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping-parent-field.html#CO211-2[mapping a parent field documentation].
+Previously in Elasticsearch parent documents could be aggregated on or 
+referenced in a script using `_parent`. Now in order to reference a parent 
+document in an aggregation or script you must do `_parent#my_parent` as stated 
+in the <<mapping-parent-field,mapping a parent field documentation>>.


### PR DESCRIPTION
Added a section about the breaking changes made to referencing parent docs in aggregations and scripts. This broke when my company upgraded to 5.6 and we were not expecting it since it was not listed here under breaking changes. 
