### PR TITLE
Fixes Eclipse build after secure-sm project was added

### DIFF
--- a/libs/secure-sm/src/main/eclipse-build.gradle
+++ b/libs/secure-sm/src/main/eclipse-build.gradle
@@ -1,0 +1,3 @@
+
+// this is just shell gradle file for eclipse to have separate projects for secure-sm src and tests
+apply from: '../../build.gradle'

--- a/libs/secure-sm/src/test/eclipse-build.gradle
+++ b/libs/secure-sm/src/test/eclipse-build.gradle
@@ -1,0 +1,7 @@
+
+// this is just shell gradle file for eclipse to have separate projects for secure-sm src and tests
+apply from: '../../build.gradle'
+
+dependencies {
+  testCompile project(':libs:secure-sm')
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -90,6 +90,7 @@ if (isEclipse) {
   projects << 'server-tests'
   projects << 'libs:elasticsearch-core-tests'
   projects << 'libs:elasticsearch-nio-tests'
+  projects << 'libs:secure-sm-tests'
 }
 
 include projects.toArray(new String[0])
@@ -115,6 +116,10 @@ if (isEclipse) {
   project(":libs:elasticsearch-nio").buildFileName = 'eclipse-build.gradle'
   project(":libs:elasticsearch-nio-tests").projectDir = new File(rootProject.projectDir, 'libs/elasticsearch-nio/src/test')
   project(":libs:elasticsearch-nio-tests").buildFileName = 'eclipse-build.gradle'
+  project(":libs:secure-sm").projectDir = new File(rootProject.projectDir, 'libs/secure-sm/src/main')
+  project(":libs:secure-sm").buildFileName = 'eclipse-build.gradle'
+  project(":libs:secure-sm-tests").projectDir = new File(rootProject.projectDir, 'libs/secure-sm/src/test')
+  project(":libs:secure-sm-tests").buildFileName = 'eclipse-build.gradle'
 }
 
 // look for extra plugins for elasticsearch


### PR DESCRIPTION
There were a few eclipse specific puts of the build that were forgotten when the secure-sm module was added. This change adds those missing pieces