### PR TITLE
Start switching to non-deprecated ParseField.match method

### DIFF
--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsParser.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsParser.java
@@ -19,6 +19,7 @@
 package org.elasticsearch.search.aggregations.matrix.stats;
 
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceParser.NumericValuesSourceParser;
@@ -39,7 +40,7 @@ public class MatrixStatsParser extends NumericValuesSourceParser {
     @Override
     protected boolean token(String aggregationName, String currentFieldName, XContentParser.Token token, XContentParser parser,
                             Map<ParseField, Object> otherOptions) throws IOException {
-        if (MULTIVALUE_MODE_FIELD.match(currentFieldName)) {
+        if (MULTIVALUE_MODE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
             if (token == XContentParser.Token.VALUE_STRING) {
                 otherOptions.put(MULTIVALUE_MODE_FIELD, parser.text());
                 return true;

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceParser.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceParser.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.support;
 
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.aggregations.AggregationBuilder.CommonFields;
@@ -88,11 +89,11 @@ public abstract class MultiValuesSourceParser<VS extends ValuesSource> implement
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (CommonFields.FIELDS.match(currentFieldName)) {
+                if (CommonFields.FIELDS.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     fields = Collections.singletonList(parser.text());
-                } else if (formattable && CommonFields.FORMAT.match(currentFieldName)) {
+                } else if (formattable && CommonFields.FORMAT.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     format = parser.text();
-                } else if (CommonFields.VALUE_TYPE.match(currentFieldName)) {
+                } else if (CommonFields.VALUE_TYPE.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     throw new ParsingException(parser.getTokenLocation(),
                         "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "]. " +
                             "Multi-field aggregations do not support scripts.");
@@ -101,12 +102,12 @@ public abstract class MultiValuesSourceParser<VS extends ValuesSource> implement
                             "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "].");
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (CommonFields.MISSING.match(currentFieldName)) {
+                if (CommonFields.MISSING.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     missingMap = new HashMap<>();
                     while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
                         parseMissingAndAdd(aggregationName, currentFieldName, parser, missingMap);
                     }
-                } else if (Script.SCRIPT_PARSE_FIELD.match(currentFieldName)) {
+                } else if (Script.SCRIPT_PARSE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     throw new ParsingException(parser.getTokenLocation(),
                         "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "]. " +
                             "Multi-field aggregations do not support scripts.");
@@ -116,11 +117,11 @@ public abstract class MultiValuesSourceParser<VS extends ValuesSource> implement
                             "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "].");
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (Script.SCRIPT_PARSE_FIELD.match(currentFieldName)) {
+                if (Script.SCRIPT_PARSE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     throw new ParsingException(parser.getTokenLocation(),
                         "Unexpected token " + token + " [" + currentFieldName + "] in [" + aggregationName + "]. " +
                             "Multi-field aggregations do not support scripts.");
-                } else if (CommonFields.FIELDS.match(currentFieldName)) {
+                } else if (CommonFields.FIELDS.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     fields = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token == XContentParser.Token.VALUE_STRING) {

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
@@ -257,27 +258,27 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (QUERY_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     iqb = parseInnerQueryBuilder(parser);
-                } else if (INNER_HITS_FIELD.match(currentFieldName)) {
+                } else if (INNER_HITS_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     innerHitBuilder = InnerHitBuilder.fromXContent(parser);
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[has_child] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
-                if (TYPE_FIELD.match(currentFieldName)) {
+                if (TYPE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     childType = parser.text();
-                } else if (SCORE_MODE_FIELD.match(currentFieldName)) {
+                } else if (SCORE_MODE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     scoreMode = NestedQueryBuilder.parseScoreMode(parser.text());
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     boost = parser.floatValue();
-                } else if (MIN_CHILDREN_FIELD.match(currentFieldName)) {
+                } else if (MIN_CHILDREN_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     minChildren = parser.intValue(true);
-                } else if (MAX_CHILDREN_FIELD.match(currentFieldName)) {
+                } else if (MAX_CHILDREN_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     maxChildren = parser.intValue(true);
-                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName)) {
+                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     ignoreUnmapped = parser.booleanValue();
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     queryName = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[has_child] query does not support [" + currentFieldName + "]");

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasParentQueryBuilder.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.fielddata.plain.SortedSetDVOrdinalsIndexFieldData;
@@ -295,24 +296,24 @@ public class HasParentQueryBuilder extends AbstractQueryBuilder<HasParentQueryBu
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (QUERY_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     iqb = parseInnerQueryBuilder(parser);
-                } else if (INNER_HITS_FIELD.match(currentFieldName)) {
+                } else if (INNER_HITS_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     innerHits = InnerHitBuilder.fromXContent(parser);
                 } else {
                     throw new ParsingException(parser.getTokenLocation(),
                         "[has_parent] query does not support [" + currentFieldName + "]");
                 }
             } else if (token.isValue()) {
-                if (TYPE_FIELD.match(currentFieldName)) {
+                if (TYPE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     parentType = parser.text();
-                } else if (SCORE_FIELD.match(currentFieldName)) {
+                } else if (SCORE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     score = parser.booleanValue();
-                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName)) {
+                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     ignoreUnmapped = parser.booleanValue();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     boost = parser.floatValue();
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     queryName = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(),

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -132,15 +133,15 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (TYPE_FIELD.match(currentFieldName)) {
+                if (TYPE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     type = parser.text();
-                } else if (ID_FIELD.match(currentFieldName)) {
+                } else if (ID_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     id = parser.text();
-                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName)) {
+                } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     ignoreUnmapped = parser.booleanValue();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     boost = parser.floatValue();
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     queryName = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[parent_id] query does not support [" + currentFieldName + "]");

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -57,6 +57,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -403,7 +404,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
-                if (DOCUMENTS_FIELD.match(currentFieldName)) {
+                if (DOCUMENTS_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     if (documentSpecified) {
                         throw new IllegalArgumentException("[" + PercolateQueryBuilder.NAME +
                             "] Either specified [document] or [documents], not both");
@@ -426,7 +427,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
                         "] query does not field name [" + currentFieldName + "]");
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (DOCUMENT_FIELD.match(currentFieldName)) {
+                if (DOCUMENT_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     if (documentsSpecified) {
                         throw new IllegalArgumentException("[" + PercolateQueryBuilder.NAME +
                             "] Either specified [document] or [documents], not both");
@@ -442,27 +443,27 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
                             "] query does not support field name [" + currentFieldName + "]");
                 }
             } else if (token.isValue() || token == XContentParser.Token.VALUE_NULL) {
-                if (QUERY_FIELD.match(currentFieldName)) {
+                if (QUERY_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     field = parser.text();
-                } else if (NAME_FIELD.match(currentFieldName)) {
+                } else if (NAME_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     name = parser.textOrNull();
-                } else if (DOCUMENT_TYPE_FIELD.match(currentFieldName)) {
+                } else if (DOCUMENT_TYPE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     documentType = parser.textOrNull();
-                } else if (INDEXED_DOCUMENT_FIELD_INDEX.match(currentFieldName)) {
+                } else if (INDEXED_DOCUMENT_FIELD_INDEX.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     indexedDocumentIndex = parser.text();
-                } else if (INDEXED_DOCUMENT_FIELD_TYPE.match(currentFieldName)) {
+                } else if (INDEXED_DOCUMENT_FIELD_TYPE.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     indexedDocumentType = parser.text();
-                } else if (INDEXED_DOCUMENT_FIELD_ID.match(currentFieldName)) {
+                } else if (INDEXED_DOCUMENT_FIELD_ID.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     indexedDocumentId = parser.text();
-                } else if (INDEXED_DOCUMENT_FIELD_ROUTING.match(currentFieldName)) {
+                } else if (INDEXED_DOCUMENT_FIELD_ROUTING.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     indexedDocumentRouting = parser.text();
-                } else if (INDEXED_DOCUMENT_FIELD_PREFERENCE.match(currentFieldName)) {
+                } else if (INDEXED_DOCUMENT_FIELD_PREFERENCE.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     indexedDocumentPreference = parser.text();
-                } else if (INDEXED_DOCUMENT_FIELD_VERSION.match(currentFieldName)) {
+                } else if (INDEXED_DOCUMENT_FIELD_VERSION.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     indexedDocumentVersion = parser.longValue();
-                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     boost = parser.floatValue();
-                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName)) {
+                } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                     queryName = parser.text();
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[" + PercolateQueryBuilder.NAME +

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.script.Script;
@@ -91,26 +92,26 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
                 Map.Entry<String, Object> entry = itr.next();
                 String parameterName = entry.getKey();
                 Object parameterValue = entry.getValue();
-                if (Script.LANG_PARSE_FIELD.match(parameterName)) {
+                if (Script.LANG_PARSE_FIELD.match(parameterName, LoggingDeprecationHandler.INSTANCE)) {
                     if (parameterValue instanceof String || parameterValue == null) {
                         lang = (String) parameterValue;
                     } else {
                         throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
                     }
-                } else if (Script.PARAMS_PARSE_FIELD.match(parameterName)) {
+                } else if (Script.PARAMS_PARSE_FIELD.match(parameterName, LoggingDeprecationHandler.INSTANCE)) {
                     if (parameterValue instanceof Map || parameterValue == null) {
                         params = (Map<String, Object>) parameterValue;
                     } else {
                         throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
                     }
-                } else if (ScriptType.INLINE.getParseField().match(parameterName)) {
+                } else if (ScriptType.INLINE.getParseField().match(parameterName, LoggingDeprecationHandler.INSTANCE)) {
                     if (parameterValue instanceof String || parameterValue == null) {
                         script = (String) parameterValue;
                         type = ScriptType.INLINE;
                     } else {
                         throw new ElasticsearchParseException("Value must be of type String: [" + parameterName + "]");
                     }
-                } else if (ScriptType.STORED.getParseField().match(parameterName)) {
+                } else if (ScriptType.STORED.getParseField().match(parameterName, LoggingDeprecationHandler.INSTANCE)) {
                     if (parameterValue instanceof String || parameterValue == null) {
                         script = (String) parameterValue;
                         type = ScriptType.STORED;

--- a/server/src/test/java/org/elasticsearch/common/ParseFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/common/ParseFieldTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.common;
 
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -32,16 +33,16 @@ public class ParseFieldTests extends ESTestCase {
         String[] deprecated = new String[]{"barFoo", "bar_foo", "Foobar"};
         ParseField withDeprecations = field.withDeprecation(deprecated);
         assertThat(field, not(sameInstance(withDeprecations)));
-        assertThat(field.match(name), is(true));
-        assertThat(field.match("foo bar"), is(false));
+        assertThat(field.match(name, LoggingDeprecationHandler.INSTANCE), is(true));
+        assertThat(field.match("foo bar", LoggingDeprecationHandler.INSTANCE), is(false));
         for (String deprecatedName : deprecated) {
-            assertThat(field.match(deprecatedName), is(false));
+            assertThat(field.match(deprecatedName, LoggingDeprecationHandler.INSTANCE), is(false));
         }
 
-        assertThat(withDeprecations.match(name), is(true));
-        assertThat(withDeprecations.match("foo bar"), is(false));
+        assertThat(withDeprecations.match(name, LoggingDeprecationHandler.INSTANCE), is(true));
+        assertThat(withDeprecations.match("foo bar", LoggingDeprecationHandler.INSTANCE), is(false));
         for (String deprecatedName : deprecated) {
-            assertThat(withDeprecations.match(deprecatedName), is(true));
+            assertThat(withDeprecations.match(deprecatedName, LoggingDeprecationHandler.INSTANCE), is(true));
             assertWarnings("Deprecated field [" + deprecatedName + "] used, expected [foo_bar] instead");
         }
     }
@@ -50,12 +51,12 @@ public class ParseFieldTests extends ESTestCase {
         String name = "like_text";
         String[] deprecated = new String[]{"text", "same_as_text"};
         ParseField field = new ParseField(name).withDeprecation(deprecated).withAllDeprecated("like");
-        assertFalse(field.match("not a field name"));
-        assertTrue(field.match("text"));
+        assertFalse(field.match("not a field name", LoggingDeprecationHandler.INSTANCE));
+        assertTrue(field.match("text", LoggingDeprecationHandler.INSTANCE));
         assertWarnings("Deprecated field [text] used, replaced by [like]");
-        assertTrue(field.match("same_as_text"));
+        assertTrue(field.match("same_as_text", LoggingDeprecationHandler.INSTANCE));
         assertWarnings("Deprecated field [same_as_text] used, replaced by [like]");
-        assertTrue(field.match("like_text"));
+        assertTrue(field.match("like_text", LoggingDeprecationHandler.INSTANCE));
         assertWarnings("Deprecated field [like_text] used, replaced by [like]");
     }
 

--- a/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchModuleTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.inject.ModuleTestCase;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -187,13 +188,17 @@ public class SearchModuleTests extends ModuleTestCase {
             }
         }));
         assertEquals(1, module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.match("term")).count());
+                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
+                    e.name.match("term", LoggingDeprecationHandler.INSTANCE)).count());
         assertEquals(1, module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.match("phrase")).count());
+                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
+                    e.name.match("phrase", LoggingDeprecationHandler.INSTANCE)).count());
         assertEquals(1, module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.match("completion")).count());
+                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
+                    e.name.match("completion", LoggingDeprecationHandler.INSTANCE)).count());
         assertEquals(1, module.getNamedXContents().stream()
-                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.match("custom")).count());
+                .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) &&
+                    e.name.match("custom", LoggingDeprecationHandler.INSTANCE)).count());
 
         assertEquals(1, module.getNamedWriteables().stream()
                 .filter(e -> e.categoryClass.equals(SuggestionBuilder.class) && e.name.equals("term")).count());
@@ -250,7 +255,8 @@ public class SearchModuleTests extends ModuleTestCase {
 
         assertThat(
                 module.getNamedXContents().stream()
-                    .filter(entry -> entry.categoryClass.equals(BaseAggregationBuilder.class) && entry.name.match("test"))
+                    .filter(entry -> entry.categoryClass.equals(BaseAggregationBuilder.class) &&
+                        entry.name.match("test", LoggingDeprecationHandler.INSTANCE))
                     .collect(toList()),
                 hasSize(1));
     }
@@ -266,7 +272,8 @@ public class SearchModuleTests extends ModuleTestCase {
 
         assertThat(
                 module.getNamedXContents().stream()
-                    .filter(entry -> entry.categoryClass.equals(BaseAggregationBuilder.class) && entry.name.match("test"))
+                    .filter(entry -> entry.categoryClass.equals(BaseAggregationBuilder.class) &&
+                        entry.name.match("test", LoggingDeprecationHandler.INSTANCE))
                     .collect(toList()),
                 hasSize(1));
     }
@@ -280,7 +287,8 @@ public class SearchModuleTests extends ModuleTestCase {
         }));
         assertThat(
                 module.getNamedXContents().stream()
-                    .filter(entry -> entry.categoryClass.equals(RescorerBuilder.class) && entry.name.match("test"))
+                    .filter(entry -> entry.categoryClass.equals(RescorerBuilder.class) &&
+                        entry.name.match("test", LoggingDeprecationHandler.INSTANCE))
                     .collect(toList()),
                 hasSize(1));
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/IncludeExcludeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/IncludeExcludeTests.java
@@ -24,6 +24,7 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LongBitSet;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -268,10 +269,10 @@ public class IncludeExcludeTests extends ESTestCase {
         IncludeExclude exc = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             assertEquals(XContentParser.Token.FIELD_NAME, token);
-            if (IncludeExclude.INCLUDE_FIELD.match(parser.currentName())) {
+            if (IncludeExclude.INCLUDE_FIELD.match(parser.currentName(), LoggingDeprecationHandler.INSTANCE)) {
                 token = parser.nextToken();
                 inc = IncludeExclude.parseInclude(parser);
-            } else if (IncludeExclude.EXCLUDE_FIELD.match(parser.currentName())) {
+            } else if (IncludeExclude.EXCLUDE_FIELD.match(parser.currentName(), LoggingDeprecationHandler.INSTANCE)) {
                 token = parser.nextToken();
                 exc = IncludeExclude.parseExclude(parser);
             } else {

--- a/server/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchIT.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/CustomSuggesterSearchIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryShardContext;
@@ -160,15 +161,15 @@ public class CustomSuggesterSearchIT extends ESIntegTestCase {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if (token.isValue()) {
-                    if (SuggestionBuilder.ANALYZER_FIELD.match(currentFieldName)) {
+                    if (SuggestionBuilder.ANALYZER_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                         analyzer = parser.text();
-                    } else if (SuggestionBuilder.FIELDNAME_FIELD.match(currentFieldName)) {
+                    } else if (SuggestionBuilder.FIELDNAME_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                         fieldname = parser.text();
-                    } else if (SuggestionBuilder.SIZE_FIELD.match(currentFieldName)) {
+                    } else if (SuggestionBuilder.SIZE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                         sizeField = parser.intValue();
-                    } else if (SuggestionBuilder.SHARDSIZE_FIELD.match(currentFieldName)) {
+                    } else if (SuggestionBuilder.SHARDSIZE_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                         shardSize = parser.intValue();
-                    } else if (RANDOM_SUFFIX_FIELD.match(currentFieldName)) {
+                    } else if (RANDOM_SUFFIX_FIELD.match(currentFieldName, LoggingDeprecationHandler.INSTANCE)) {
                         suffix = parser.text();
                     }
                 } else {


### PR DESCRIPTION
This commit switches all the modules and server test code to use the
non-deprecated `ParseField.match` method, passing in the logging deprecation
handler.

Relates to #28449
