### PR TITLE
Build: Fix test task to explicitly depend on testClasses task

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/RandomizedTestingPlugin.groovy
@@ -62,6 +62,9 @@ class RandomizedTestingPlugin implements Plugin<Project> {
         RandomizedTestingTask newTestTask = tasks.create(properties)
         newTestTask.classpath = oldTestTask.classpath
         newTestTask.testClassesDir = oldTestTask.project.sourceSets.test.output.classesDir
+        // since gradle 4.5, tasks immutable dependencies are "hidden" (do not show up in dependsOn)
+        // so we must explicitly add a dependency on generating the test classpath
+        newTestTask.dependsOn('testClasses')
 
         // hack so check task depends on custom test
         Task checkTask = tasks.findByPath('check')


### PR DESCRIPTION
Gradle 4.5 now hides immutable task dependencies. We previously copied
the existing dependencies from the builtin test task to the
randomizedtesting task. This commit adds testClasses as an extra
dependency of the randomizedtesting task, to ensure the classes are
built.