### PR TITLE
Improve failure message when restoring an index that already exists in the cluster

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -363,7 +363,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                     if (currentIndexMetaData.getState() != IndexMetaData.State.CLOSE) {
                         // TODO: Enable restore for open indices
                         throw new SnapshotRestoreException(snapshot, "cannot restore index [" + renamedIndex + "] because an open index with same name already exists in the cluster. " +
-                            "Either close or delete the existing index in the cluster or restore the index from the snapshot under a different name by providing a replacement name using a rename pattern");
+                            "Either close or delete the existing index or restore the index under a different name by providing a rename pattern and replacement name");
                     }
                     // Index exist - checking if it's partial restore
                     if (partial) {

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -362,7 +362,8 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                     // Index exist - checking that it's closed
                     if (currentIndexMetaData.getState() != IndexMetaData.State.CLOSE) {
                         // TODO: Enable restore for open indices
-                        throw new SnapshotRestoreException(snapshot, "cannot restore index [" + renamedIndex + "] because it's open");
+                        throw new SnapshotRestoreException(snapshot, "cannot restore index [" + renamedIndex + "] because an open index with same name already exists in the cluster. " +
+                            "Either close or delete the existing index in the cluster or restore the index from the snapshot under a different name by providing a replacement name using a rename pattern");
                     }
                     // Index exist - checking if it's partial restore
                     if (partial) {


### PR DESCRIPTION
Makes the message more actionable and removes the focus on the fact that the index is open.