### PR TITLE
Add missing "aggregations" word

### DIFF
--- a/docs/reference/mapping/types/nested.asciidoc
+++ b/docs/reference/mapping/types/nested.asciidoc
@@ -189,7 +189,7 @@ The following parameters are accepted by `nested` fields:
 
 Because nested documents are indexed as separate documents, they can only be
 accessed  within the scope of the `nested` query, the
-`nested`/`reverse_nested`, or <<nested-inner-hits,nested inner hits>>.
+`nested`/`reverse_nested` aggregations, or <<nested-inner-hits,nested inner hits>>.
 
 For instance, if a string field within a nested document has
 <<index-options,`index_options`>> set to `offsets` to allow use of the postings


### PR DESCRIPTION
I think that the sentence "they can only be
accessed  within the scope of the `nested` query, the
`nested`/`reverse_nested`, or nested-inner-hits" is missing the explanation about what are the `nested` and `reverse_nested` terms. And I guess it must be related to the aggregations that exist for nested objects/documents.

Could you apply this change in all ElasticSearch documentation versions?

In addition, could you please take the issue I created (https://github.com/elastic/elasticsearch/issues/28363) about the last paragraph of this same page? I think it is missing a lot of explanations as it is just a short sentence for something that I think it is really important.

Thanks.