### PR TITLE
Replace more deprecated ParseField.match calls with non-deprecated call

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
@@ -205,16 +205,16 @@ public class Alias implements Streamable, ToXContentObject {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_OBJECT) {
-                if (FILTER.match(currentFieldName)) {
+                if (FILTER.match(currentFieldName, parser.getDeprecationHandler())) {
                     Map<String, Object> filter = parser.mapOrdered();
                     alias.filter(filter);
                 }
             } else if (token == XContentParser.Token.VALUE_STRING) {
-                if (ROUTING.match(currentFieldName)) {
+                if (ROUTING.match(currentFieldName, parser.getDeprecationHandler())) {
                     alias.routing(parser.text());
-                } else if (INDEX_ROUTING.match(currentFieldName)) {
+                } else if (INDEX_ROUTING.match(currentFieldName, parser.getDeprecationHandler())) {
                     alias.indexRouting(parser.text());
-                } else if (SEARCH_ROUTING.match(currentFieldName)) {
+                } else if (SEARCH_ROUTING.match(currentFieldName, parser.getDeprecationHandler())) {
                     alias.searchRouting(parser.text());
                 }
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -36,7 +36,9 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContentObject;
@@ -370,7 +372,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      */
     public CreateIndexRequest source(BytesReference source, XContentType xContentType) {
         Objects.requireNonNull(xContentType);
-        source(XContentHelper.convertToMap(source, false, xContentType).v2());
+        source(XContentHelper.convertToMap(source, false, xContentType).v2(), LoggingDeprecationHandler.INSTANCE);
         return this;
     }
 
@@ -378,17 +380,17 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      * Sets the settings and mappings as a single source.
      */
     @SuppressWarnings("unchecked")
-    public CreateIndexRequest source(Map<String, ?> source) {
+    public CreateIndexRequest source(Map<String, ?> source, DeprecationHandler deprecationHandler) {
         for (Map.Entry<String, ?> entry : source.entrySet()) {
             String name = entry.getKey();
-            if (SETTINGS.match(name, LoggingDeprecationHandler.INSTANCE)) {
+            if (SETTINGS.match(name, deprecationHandler)) {
                 settings((Map<String, Object>) entry.getValue());
-            } else if (MAPPINGS.match(name, LoggingDeprecationHandler.INSTANCE)) {
+            } else if (MAPPINGS.match(name, deprecationHandler)) {
                 Map<String, Object> mappings = (Map<String, Object>) entry.getValue();
                 for (Map.Entry<String, Object> entry1 : mappings.entrySet()) {
                     mapping(entry1.getKey(), (Map<String, Object>) entry1.getValue());
                 }
-            } else if (ALIASES.match(name, LoggingDeprecationHandler.INSTANCE)) {
+            } else if (ALIASES.match(name, deprecationHandler)) {
                 aliases((Map<String, Object>) entry.getValue());
             } else {
                 // maybe custom?

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -380,14 +381,14 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     public CreateIndexRequest source(Map<String, ?> source) {
         for (Map.Entry<String, ?> entry : source.entrySet()) {
             String name = entry.getKey();
-            if (SETTINGS.match(name)) {
+            if (SETTINGS.match(name, LoggingDeprecationHandler.INSTANCE)) {
                 settings((Map<String, Object>) entry.getValue());
-            } else if (MAPPINGS.match(name)) {
+            } else if (MAPPINGS.match(name, LoggingDeprecationHandler.INSTANCE)) {
                 Map<String, Object> mappings = (Map<String, Object>) entry.getValue();
                 for (Map.Entry<String, Object> entry1 : mappings.entrySet()) {
                     mapping(entry1.getKey(), (Map<String, Object>) entry1.getValue());
                 }
-            } else if (ALIASES.match(name)) {
+            } else if (ALIASES.match(name, LoggingDeprecationHandler.INSTANCE)) {
                 aliases((Map<String, Object>) entry.getValue());
             } else {
                 // maybe custom?

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 
@@ -219,7 +220,7 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<Create
      * Sets the settings and mappings as a single source.
      */
     public CreateIndexRequestBuilder setSource(Map<String, ?> source) {
-        request.source(source);
+        request.source(source, LoggingDeprecationHandler.INSTANCE);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -348,45 +348,45 @@ public class BulkRequest extends ActionRequest implements CompositeIndicesReques
                         if (token == XContentParser.Token.FIELD_NAME) {
                             currentFieldName = parser.currentName();
                         } else if (token.isValue()) {
-                            if (INDEX.match(currentFieldName)){
+                            if (INDEX.match(currentFieldName, parser.getDeprecationHandler())){
                                 if (!allowExplicitIndex) {
                                     throw new IllegalArgumentException("explicit index in bulk is not allowed");
                                 }
                                 index = parser.text();
-                            } else if (TYPE.match(currentFieldName)) {
+                            } else if (TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                                 type = parser.text();
-                            } else if (ID.match(currentFieldName)) {
+                            } else if (ID.match(currentFieldName, parser.getDeprecationHandler())) {
                                 id = parser.text();
-                            } else if (ROUTING.match(currentFieldName)) {
+                            } else if (ROUTING.match(currentFieldName, parser.getDeprecationHandler())) {
                                 routing = parser.text();
-                            } else if (PARENT.match(currentFieldName)) {
+                            } else if (PARENT.match(currentFieldName, parser.getDeprecationHandler())) {
                                 parent = parser.text();
-                            } else if (OP_TYPE.match(currentFieldName)) {
+                            } else if (OP_TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                                 opType = parser.text();
-                            } else if (VERSION.match(currentFieldName)) {
+                            } else if (VERSION.match(currentFieldName, parser.getDeprecationHandler())) {
                                 version = parser.longValue();
-                            } else if (VERSION_TYPE.match(currentFieldName)) {
+                            } else if (VERSION_TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                                 versionType = VersionType.fromString(parser.text());
-                            } else if (RETRY_ON_CONFLICT.match(currentFieldName)) {
+                            } else if (RETRY_ON_CONFLICT.match(currentFieldName, parser.getDeprecationHandler())) {
                                 retryOnConflict = parser.intValue();
-                            } else if (PIPELINE.match(currentFieldName)) {
+                            } else if (PIPELINE.match(currentFieldName, parser.getDeprecationHandler())) {
                                 pipeline = parser.text();
-                            } else if (FIELDS.match(currentFieldName)) {
+                            } else if (FIELDS.match(currentFieldName, parser.getDeprecationHandler())) {
                                 throw new IllegalArgumentException("Action/metadata line [" + line + "] contains a simple value for parameter [fields] while a list is expected");
-                            } else if (SOURCE.match(currentFieldName)) {
+                            } else if (SOURCE.match(currentFieldName, parser.getDeprecationHandler())) {
                                 fetchSourceContext = FetchSourceContext.fromXContent(parser);
                             } else {
                                 throw new IllegalArgumentException("Action/metadata line [" + line + "] contains an unknown parameter [" + currentFieldName + "]");
                             }
                         } else if (token == XContentParser.Token.START_ARRAY) {
-                            if (FIELDS.match(currentFieldName)) {
+                            if (FIELDS.match(currentFieldName, parser.getDeprecationHandler())) {
                                 DEPRECATION_LOGGER.deprecated("Deprecated field [fields] used, expected [_source] instead");
                                 List<Object> values = parser.list();
                                 fields = values.toArray(new String[values.size()]);
                             } else {
                                 throw new IllegalArgumentException("Malformed action/metadata line [" + line + "], expected a simple value for field [" + currentFieldName + "] but found [" + token + "]");
                             }
-                        } else if (token == XContentParser.Token.START_OBJECT && SOURCE.match(currentFieldName)) {
+                        } else if (token == XContentParser.Token.START_OBJECT && SOURCE.match(currentFieldName, parser.getDeprecationHandler())) {
                             fetchSourceContext = FetchSourceContext.fromXContent(parser);
                         } else if (token != XContentParser.Token.VALUE_NULL) {
                             throw new IllegalArgumentException("Malformed action/metadata line [" + line + "], expected a simple value for field [" + currentFieldName + "] but found [" + token + "]");

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -418,30 +418,30 @@ public class MultiGetRequest extends ActionRequest
                 if (token == Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
                 } else if (token.isValue()) {
-                    if (INDEX.match(currentFieldName)) {
+                    if (INDEX.match(currentFieldName, parser.getDeprecationHandler())) {
                         if (!allowExplicitIndex) {
                             throw new IllegalArgumentException("explicit index in multi get is not allowed");
                         }
                         index = parser.text();
-                    } else if (TYPE.match(currentFieldName)) {
+                    } else if (TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                         type = parser.text();
-                    } else if (ID.match(currentFieldName)) {
+                    } else if (ID.match(currentFieldName, parser.getDeprecationHandler())) {
                         id = parser.text();
-                    } else if (ROUTING.match(currentFieldName)) {
+                    } else if (ROUTING.match(currentFieldName, parser.getDeprecationHandler())) {
                         routing = parser.text();
-                    } else if (PARENT.match(currentFieldName)) {
+                    } else if (PARENT.match(currentFieldName, parser.getDeprecationHandler())) {
                         parent = parser.text();
-                    } else if (FIELDS.match(currentFieldName)) {
+                    } else if (FIELDS.match(currentFieldName, parser.getDeprecationHandler())) {
                         throw new ParsingException(parser.getTokenLocation(),
                             "Unsupported field [fields] used, expected [stored_fields] instead");
-                    } else if (STORED_FIELDS.match(currentFieldName)) {
+                    } else if (STORED_FIELDS.match(currentFieldName, parser.getDeprecationHandler())) {
                         storedFields = new ArrayList<>();
                         storedFields.add(parser.text());
-                    } else if (VERSION.match(currentFieldName)) {
+                    } else if (VERSION.match(currentFieldName, parser.getDeprecationHandler())) {
                         version = parser.longValue();
-                    } else if (VERSION_TYPE.match(currentFieldName)) {
+                    } else if (VERSION_TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                         versionType = VersionType.fromString(parser.text());
-                    } else if (SOURCE.match(currentFieldName)) {
+                    } else if (SOURCE.match(currentFieldName, parser.getDeprecationHandler())) {
                         // check lenient to avoid interpreting the value as string but parse strict in order to provoke an error early on.
                         if (parser.isBooleanValueLenient()) {
                             fetchSourceContext = new FetchSourceContext(parser.booleanValue(), fetchSourceContext.includes(),
@@ -456,15 +456,15 @@ public class MultiGetRequest extends ActionRequest
                         throw new ElasticsearchParseException("failed to parse multi get request. unknown field [{}]", currentFieldName);
                     }
                 } else if (token == Token.START_ARRAY) {
-                    if (FIELDS.match(currentFieldName)) {
+                    if (FIELDS.match(currentFieldName, parser.getDeprecationHandler())) {
                         throw new ParsingException(parser.getTokenLocation(),
                             "Unsupported field [fields] used, expected [stored_fields] instead");
-                    } else if (STORED_FIELDS.match(currentFieldName)) {
+                    } else if (STORED_FIELDS.match(currentFieldName, parser.getDeprecationHandler())) {
                         storedFields = new ArrayList<>();
                         while ((token = parser.nextToken()) != Token.END_ARRAY) {
                             storedFields.add(parser.text());
                         }
-                    } else if (SOURCE.match(currentFieldName)) {
+                    } else if (SOURCE.match(currentFieldName, parser.getDeprecationHandler())) {
                         ArrayList<String> includes = new ArrayList<>();
                         while ((token = parser.nextToken()) != Token.END_ARRAY) {
                             includes.add(parser.text());
@@ -474,7 +474,7 @@ public class MultiGetRequest extends ActionRequest
                     }
 
                 } else if (token == Token.START_OBJECT) {
-                    if (SOURCE.match(currentFieldName)) {
+                    if (SOURCE.match(currentFieldName, parser.getDeprecationHandler())) {
                         List<String> currentList = null, includes = null, excludes = null;
 
                         while ((token = parser.nextToken()) != Token.END_OBJECT) {

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
@@ -204,10 +204,10 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
             switch (token) {
                 case FIELD_NAME:
                     currentFieldName = parser.currentName();
-                    if (INDEX.match(currentFieldName, parser.getDeprecationHandler()) == false &&
-                        TYPE.match(currentFieldName, parser.getDeprecationHandler()) == false &&
-                        ID.match(currentFieldName, parser.getDeprecationHandler()) == false &&
-                        ERROR.match(currentFieldName, parser.getDeprecationHandler()) == false) {
+                    if (INDEX.match(currentFieldName, parser.getDeprecationHandler()) == false
+                            && TYPE.match(currentFieldName, parser.getDeprecationHandler()) == false
+                            && ID.match(currentFieldName, parser.getDeprecationHandler()) == false
+                            && ERROR.match(currentFieldName, parser.getDeprecationHandler()) == false) {
                         getResult = GetResult.fromXContentEmbedded(parser, index, type, id);
                     }
                     break;

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetResponse.java
@@ -204,22 +204,24 @@ public class MultiGetResponse extends ActionResponse implements Iterable<MultiGe
             switch (token) {
                 case FIELD_NAME:
                     currentFieldName = parser.currentName();
-                    if (INDEX.match(currentFieldName) == false && TYPE.match(currentFieldName) == false &&
-                            ID.match(currentFieldName) == false && ERROR.match(currentFieldName) == false) {
+                    if (INDEX.match(currentFieldName, parser.getDeprecationHandler()) == false &&
+                        TYPE.match(currentFieldName, parser.getDeprecationHandler()) == false &&
+                        ID.match(currentFieldName, parser.getDeprecationHandler()) == false &&
+                        ERROR.match(currentFieldName, parser.getDeprecationHandler()) == false) {
                         getResult = GetResult.fromXContentEmbedded(parser, index, type, id);
                     }
                     break;
                 case VALUE_STRING:
-                    if (INDEX.match(currentFieldName)) {
+                    if (INDEX.match(currentFieldName, parser.getDeprecationHandler())) {
                         index = parser.text();
-                    } else if (TYPE.match(currentFieldName)) {
+                    } else if (TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                         type = parser.text();
-                    } else if (ID.match(currentFieldName)) {
+                    } else if (ID.match(currentFieldName, parser.getDeprecationHandler())) {
                         id = parser.text();
                     }
                     break;
                 case START_OBJECT:
-                    if (ERROR.match(currentFieldName)) {
+                    if (ERROR.match(currentFieldName, parser.getDeprecationHandler())) {
                         exception = ElasticsearchException.fromXContent(parser);
                     }
                     break;

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -269,15 +269,15 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
             if (token == Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (token.isValue()) {
-                if (SCROLL_ID.match(currentFieldName)) {
+                if (SCROLL_ID.match(currentFieldName, parser.getDeprecationHandler())) {
                     scrollId = parser.text();
-                } else if (TOOK.match(currentFieldName)) {
+                } else if (TOOK.match(currentFieldName, parser.getDeprecationHandler())) {
                     tookInMillis = parser.longValue();
-                } else if (TIMED_OUT.match(currentFieldName)) {
+                } else if (TIMED_OUT.match(currentFieldName, parser.getDeprecationHandler())) {
                     timedOut = parser.booleanValue();
-                } else if (TERMINATED_EARLY.match(currentFieldName)) {
+                } else if (TERMINATED_EARLY.match(currentFieldName, parser.getDeprecationHandler())) {
                     terminatedEarly = parser.booleanValue();
-                } else if (NUM_REDUCE_PHASES.match(currentFieldName)) {
+                } else if (NUM_REDUCE_PHASES.match(currentFieldName, parser.getDeprecationHandler())) {
                     numReducePhases = parser.intValue();
                 } else {
                     parser.skipChildren();
@@ -291,24 +291,24 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
                     suggest = Suggest.fromXContent(parser);
                 } else if (SearchProfileShardResults.PROFILE_FIELD.equals(currentFieldName)) {
                     profile = SearchProfileShardResults.fromXContent(parser);
-                } else if (RestActions._SHARDS_FIELD.match(currentFieldName)) {
+                } else if (RestActions._SHARDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     while ((token = parser.nextToken()) != Token.END_OBJECT) {
                         if (token == Token.FIELD_NAME) {
                             currentFieldName = parser.currentName();
                         } else if (token.isValue()) {
-                            if (RestActions.FAILED_FIELD.match(currentFieldName)) {
+                            if (RestActions.FAILED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                                 parser.intValue(); // we don't need it but need to consume it
-                            } else if (RestActions.SUCCESSFUL_FIELD.match(currentFieldName)) {
+                            } else if (RestActions.SUCCESSFUL_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                                 successfulShards = parser.intValue();
-                            } else if (RestActions.TOTAL_FIELD.match(currentFieldName)) {
+                            } else if (RestActions.TOTAL_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                                 totalShards = parser.intValue();
-                            } else if (RestActions.SKIPPED_FIELD.match(currentFieldName)) {
+                            } else if (RestActions.SKIPPED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                                 skippedShards = parser.intValue();
                             } else {
                                 parser.skipChildren();
                             }
                         } else if (token == Token.START_ARRAY) {
-                            if (RestActions.FAILURES_FIELD.match(currentFieldName)) {
+                            if (RestActions.FAILURES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                                 while((token = parser.nextToken()) != Token.END_ARRAY) {
                                     failures.add(ShardSearchFailure.fromXContent(parser));
                                 }
@@ -319,7 +319,7 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
                             parser.skipChildren();
                         }
                     }
-                } else if (Clusters._CLUSTERS_FIELD.match(currentFieldName)) {
+                } else if (Clusters._CLUSTERS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     int successful = -1;
                     int total = -1;
                     int skipped = -1;
@@ -327,11 +327,11 @@ public class SearchResponse extends ActionResponse implements StatusToXContentOb
                         if (token == XContentParser.Token.FIELD_NAME) {
                             currentFieldName = parser.currentName();
                         } else if (token.isValue()) {
-                            if (Clusters.SUCCESSFUL_FIELD.match(currentFieldName)) {
+                            if (Clusters.SUCCESSFUL_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                                 successful = parser.intValue();
-                            } else if (Clusters.TOTAL_FIELD.match(currentFieldName)) {
+                            } else if (Clusters.TOTAL_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                                 total = parser.intValue();
-                            } else if (Clusters.SKIPPED_FIELD.match(currentFieldName)) {
+                            } else if (Clusters.SKIPPED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                                 skipped = parser.intValue();
                             } else {
                                 parser.skipChildren();

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -610,7 +610,7 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
             } else if (currentFieldName != null) {
-                if (FIELDS.match(currentFieldName)) {
+                if (FIELDS.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (token == XContentParser.Token.START_ARRAY) {
                         while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                             fields.add(parser.text());
@@ -618,43 +618,43 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
                     } else {
                         throw new ElasticsearchParseException("failed to parse term vectors request. field [fields] must be an array");
                     }
-                } else if (OFFSETS.match(currentFieldName)) {
+                } else if (OFFSETS.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.offsets(parser.booleanValue());
-                } else if (POSITIONS.match(currentFieldName)) {
+                } else if (POSITIONS.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.positions(parser.booleanValue());
-                } else if (PAYLOADS.match(currentFieldName)) {
+                } else if (PAYLOADS.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.payloads(parser.booleanValue());
                 } else if (currentFieldName.equals("term_statistics") || currentFieldName.equals("termStatistics")) {
                     termVectorsRequest.termStatistics(parser.booleanValue());
                 } else if (currentFieldName.equals("field_statistics") || currentFieldName.equals("fieldStatistics")) {
                     termVectorsRequest.fieldStatistics(parser.booleanValue());
-                } else if (DFS.match(currentFieldName)) {
+                } else if (DFS.match(currentFieldName, parser.getDeprecationHandler())) {
                     throw new IllegalArgumentException("distributed frequencies is not supported anymore for term vectors");
                 } else if (currentFieldName.equals("per_field_analyzer") || currentFieldName.equals("perFieldAnalyzer")) {
                     termVectorsRequest.perFieldAnalyzer(readPerFieldAnalyzer(parser.map()));
-                } else if (FILTER.match(currentFieldName)) {
+                } else if (FILTER.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.filterSettings(readFilterSettings(parser));
-                } else if (INDEX.match(currentFieldName)) { // the following is important for multi request parsing.
+                } else if (INDEX.match(currentFieldName, parser.getDeprecationHandler())) { // the following is important for multi request parsing.
                     termVectorsRequest.index = parser.text();
-                } else if (TYPE.match(currentFieldName)) {
+                } else if (TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.type = parser.text();
-                } else if (ID.match(currentFieldName)) {
+                } else if (ID.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (termVectorsRequest.doc != null) {
                         throw new ElasticsearchParseException("failed to parse term vectors request. either [id] or [doc] can be specified, but not both!");
                     }
                     termVectorsRequest.id = parser.text();
-                } else if (DOC.match(currentFieldName)) {
+                } else if (DOC.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (termVectorsRequest.id != null) {
                         throw new ElasticsearchParseException("failed to parse term vectors request. either [id] or [doc] can be specified, but not both!");
                     }
                     termVectorsRequest.doc(jsonBuilder().copyCurrentStructure(parser));
-                } else if (ROUTING.match(currentFieldName)) {
+                } else if (ROUTING.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.routing = parser.text();
-                } else if (PARENT.match(currentFieldName)) {
+                } else if (PARENT.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.parent = parser.text();
-                } else if (VERSION.match(currentFieldName)) {
+                } else if (VERSION.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.version = parser.longValue();
-                } else if (VERSION_TYPE.match(currentFieldName)) {
+                } else if (VERSION_TYPE.match(currentFieldName, parser.getDeprecationHandler())) {
                     termVectorsRequest.versionType = VersionType.fromString(parser.text());
                 } else {
                     throw new ElasticsearchParseException("failed to parse term vectors request. unknown field [{}]", currentFieldName);

--- a/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoJsonParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/parsers/GeoJsonParser.java
@@ -57,7 +57,7 @@ abstract class GeoJsonParser {
             if (token == XContentParser.Token.FIELD_NAME) {
                 String fieldName = parser.currentName();
 
-                if (ShapeParser.FIELD_TYPE.match(fieldName)) {
+                if (ShapeParser.FIELD_TYPE.match(fieldName, parser.getDeprecationHandler())) {
                     parser.nextToken();
                     final GeoShapeType type = GeoShapeType.forName(parser.text());
                     if (shapeType != null && shapeType.equals(type) == false) {
@@ -66,10 +66,10 @@ abstract class GeoJsonParser {
                     } else {
                         shapeType = type;
                     }
-                } else if (ShapeParser.FIELD_COORDINATES.match(fieldName)) {
+                } else if (ShapeParser.FIELD_COORDINATES.match(fieldName, parser.getDeprecationHandler())) {
                     parser.nextToken();
                     coordinateNode = parseCoordinates(parser);
-                } else if (ShapeParser.FIELD_GEOMETRIES.match(fieldName)) {
+                } else if (ShapeParser.FIELD_GEOMETRIES.match(fieldName, parser.getDeprecationHandler())) {
                     if (shapeType == null) {
                         shapeType = GeoShapeType.GEOMETRYCOLLECTION;
                     } else if (shapeType.equals(GeoShapeType.GEOMETRYCOLLECTION) == false) {
@@ -78,7 +78,7 @@ abstract class GeoJsonParser {
                     }
                     parser.nextToken();
                     geometryCollections = parseGeometries(parser, shapeMapper);
-                } else if (CircleBuilder.FIELD_RADIUS.match(fieldName)) {
+                } else if (CircleBuilder.FIELD_RADIUS.match(fieldName, parser.getDeprecationHandler())) {
                     if (shapeType == null) {
                         shapeType = GeoShapeType.CIRCLE;
                     } else if (shapeType != null && shapeType.equals(GeoShapeType.CIRCLE) == false) {
@@ -87,7 +87,7 @@ abstract class GeoJsonParser {
                     }
                     parser.nextToken();
                     radius = DistanceUnit.Distance.parseDistance(parser.text());
-                } else if (ShapeParser.FIELD_ORIENTATION.match(fieldName)) {
+                } else if (ShapeParser.FIELD_ORIENTATION.match(fieldName, parser.getDeprecationHandler())) {
                     if (shapeType != null
                         && (shapeType.equals(GeoShapeType.POLYGON) || shapeType.equals(GeoShapeType.MULTIPOLYGON)) == false) {
                         malformedException = "cannot have [" + ShapeParser.FIELD_ORIENTATION + "] with type set to [" + shapeType + "]";

--- a/server/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/NamedXContentRegistry.java
@@ -134,7 +134,7 @@ public class NamedXContentRegistry {
         if (entry == null) {
             throw new UnknownNamedObjectException(parser.getTokenLocation(), categoryClass, name);
         }
-        if (false == entry.name.match(name)) {
+        if (false == entry.name.match(name, parser.getDeprecationHandler())) {
             /* Note that this shouldn't happen because we already looked up the entry using the names but we need to call `match` anyway
              * because it is responsible for logging deprecation warnings. */
             throw new ParsingException(parser.getTokenLocation(),

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
@@ -363,7 +363,7 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
         }
 
         void assertSupports(String parserName, XContentParser parser, String currentFieldName) {
-            if (parseField.match(currentFieldName) == false) {
+            if (parseField.match(currentFieldName, parser.getDeprecationHandler()) == false) {
                 throw new ParsingException(parser.getTokenLocation(),
                         "[" + parserName  + "] parsefield doesn't accept: " + currentFieldName);
             }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ParseFieldRegistry.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ParseFieldRegistry.java
@@ -99,7 +99,7 @@ public class ParseFieldRegistry<T> {
         }
         ParseField parseField = parseFieldAndValue.v1();
         T value = parseFieldAndValue.v2();
-        boolean match = parseField.match(name);
+        boolean match = parseField.match(name, LoggingDeprecationHandler.INSTANCE);
         //this is always expected to match, ParseField is useful for deprecation warnings etc. here
         assert match : "ParseField did not match registered name [" + name + "][" + registryName + "]";
         return value;

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.NumberType;
@@ -128,22 +129,22 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
                 if (fieldName.equals("type")) {
                     continue;
                 }
-                if (Fields.ANALYZER.match(fieldName)) {
+                if (Fields.ANALYZER.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
                     indexAnalyzer = getNamedAnalyzer(parserContext, fieldNode.toString());
                     iterator.remove();
-                } else if (Fields.SEARCH_ANALYZER.match(fieldName)) {
+                } else if (Fields.SEARCH_ANALYZER.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
                     searchAnalyzer = getNamedAnalyzer(parserContext, fieldNode.toString());
                     iterator.remove();
-                } else if (Fields.PRESERVE_SEPARATORS.match(fieldName)) {
+                } else if (Fields.PRESERVE_SEPARATORS.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
                     builder.preserveSeparators(Boolean.parseBoolean(fieldNode.toString()));
                     iterator.remove();
-                } else if (Fields.PRESERVE_POSITION_INCREMENTS.match(fieldName)) {
+                } else if (Fields.PRESERVE_POSITION_INCREMENTS.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
                     builder.preservePositionIncrements(Boolean.parseBoolean(fieldNode.toString()));
                     iterator.remove();
-                } else if (Fields.MAX_INPUT_LENGTH.match(fieldName)) {
+                } else if (Fields.MAX_INPUT_LENGTH.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
                     builder.maxInputLength(Integer.parseInt(fieldNode.toString()));
                     iterator.remove();
-                } else if (Fields.CONTEXTS.match(fieldName)) {
+                } else if (Fields.CONTEXTS.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
                     builder.contextMappings(ContextMappings.load(fieldNode, parserContext.indexVersionCreated()));
                     iterator.remove();
                 } else if (parseMultiField(builder, name, parserContext, fieldName, fieldNode)) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParentFieldMapper.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -116,7 +117,7 @@ public class ParentFieldMapper extends MetadataFieldMapper {
                 if (fieldName.equals("type")) {
                     builder.type(fieldNode.toString());
                     iterator.remove();
-                } else if (FIELDDATA.match(fieldName)) {
+                } else if (FIELDDATA.match(fieldName, LoggingDeprecationHandler.INSTANCE)) {
                     // for bw compat only
                     Map<String, Object> fieldDataSettings = nodeMapValue(fieldNode, "fielddata");
                     if (fieldDataSettings.containsKey("loading")) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
@@ -86,9 +86,11 @@ public class RestAnalyzeAction extends BaseRestHandler {
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
-                } else if (Fields.TEXT.match(currentFieldName) && token == XContentParser.Token.VALUE_STRING) {
+                } else if (Fields.TEXT.match(currentFieldName, parser.getDeprecationHandler()) &&
+                    token == XContentParser.Token.VALUE_STRING) {
                     analyzeRequest.text(parser.text());
-                } else if (Fields.TEXT.match(currentFieldName) && token == XContentParser.Token.START_ARRAY) {
+                } else if (Fields.TEXT.match(currentFieldName, parser.getDeprecationHandler()) &&
+                    token == XContentParser.Token.START_ARRAY) {
                     List<String> texts = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token.isValue() == false) {
@@ -97,11 +99,13 @@ public class RestAnalyzeAction extends BaseRestHandler {
                         texts.add(parser.text());
                     }
                     analyzeRequest.text(texts.toArray(new String[texts.size()]));
-                } else if (Fields.ANALYZER.match(currentFieldName) && token == XContentParser.Token.VALUE_STRING) {
+                } else if (Fields.ANALYZER.match(currentFieldName, parser.getDeprecationHandler()) &&
+                    token == XContentParser.Token.VALUE_STRING) {
                     analyzeRequest.analyzer(parser.text());
-                } else if (Fields.FIELD.match(currentFieldName) && token == XContentParser.Token.VALUE_STRING) {
+                } else if (Fields.FIELD.match(currentFieldName, parser.getDeprecationHandler()) &&
+                    token == XContentParser.Token.VALUE_STRING) {
                     analyzeRequest.field(parser.text());
-                } else if (Fields.TOKENIZER.match(currentFieldName)) {
+                } else if (Fields.TOKENIZER.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (token == XContentParser.Token.VALUE_STRING) {
                         analyzeRequest.tokenizer(parser.text());
                     } else if (token == XContentParser.Token.START_OBJECT) {
@@ -109,7 +113,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
                     } else {
                         throw new IllegalArgumentException(currentFieldName + " should be tokenizer's name or setting");
                     }
-                } else if (Fields.TOKEN_FILTERS.match(currentFieldName)
+                } else if (Fields.TOKEN_FILTERS.match(currentFieldName, parser.getDeprecationHandler())
                         && token == XContentParser.Token.START_ARRAY) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token == XContentParser.Token.VALUE_STRING) {
@@ -121,7 +125,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
                                     + " array element should contain filter's name or setting");
                         }
                     }
-                } else if (Fields.CHAR_FILTERS.match(currentFieldName)
+                } else if (Fields.CHAR_FILTERS.match(currentFieldName, parser.getDeprecationHandler())
                         && token == XContentParser.Token.START_ARRAY) {
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token == XContentParser.Token.VALUE_STRING) {
@@ -133,13 +137,14 @@ public class RestAnalyzeAction extends BaseRestHandler {
                                     + " array element should contain char filter's name or setting");
                         }
                     }
-                } else if (Fields.EXPLAIN.match(currentFieldName)) {
+                } else if (Fields.EXPLAIN.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (parser.isBooleanValue()) {
                         analyzeRequest.explain(parser.booleanValue());
                     } else {
                         throw new IllegalArgumentException(currentFieldName + " must be either 'true' or 'false'");
                     }
-                } else if (Fields.ATTRIBUTES.match(currentFieldName) && token == XContentParser.Token.START_ARRAY) {
+                } else if (Fields.ATTRIBUTES.match(currentFieldName, parser.getDeprecationHandler()) &&
+                    token == XContentParser.Token.START_ARRAY) {
                     List<String> attributes = new ArrayList<>();
                     while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                         if (token.isValue() == false) {
@@ -148,7 +153,7 @@ public class RestAnalyzeAction extends BaseRestHandler {
                         attributes.add(parser.text());
                     }
                     analyzeRequest.attributes(attributes.toArray(new String[attributes.size()]));
-                } else if (Fields.NORMALIZER.match(currentFieldName)) {
+                } else if (Fields.NORMALIZER.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (token == XContentParser.Token.VALUE_STRING) {
                         analyzeRequest.normalizer(parser.text());
                     } else {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeAction.java
@@ -99,8 +99,8 @@ public class RestAnalyzeAction extends BaseRestHandler {
                         texts.add(parser.text());
                     }
                     analyzeRequest.text(texts.toArray(new String[texts.size()]));
-                } else if (Fields.ANALYZER.match(currentFieldName, parser.getDeprecationHandler()) &&
-                    token == XContentParser.Token.VALUE_STRING) {
+                } else if (Fields.ANALYZER.match(currentFieldName, parser.getDeprecationHandler())
+                        && token == XContentParser.Token.VALUE_STRING) {
                     analyzeRequest.analyzer(parser.text());
                 } else if (Fields.FIELD.match(currentFieldName, parser.getDeprecationHandler()) &&
                     token == XContentParser.Token.VALUE_STRING) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -83,13 +84,13 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
     public static ClearIndicesCacheRequest fromRequest(final RestRequest request, ClearIndicesCacheRequest clearIndicesCacheRequest) {
 
         for (Map.Entry<String, String> entry : request.params().entrySet()) {
-            if (Fields.QUERY.match(entry.getKey())) {
+            if (Fields.QUERY.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
                 clearIndicesCacheRequest.queryCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.queryCache()));
-            } else if (Fields.REQUEST.match(entry.getKey())) {
+            } else if (Fields.REQUEST.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
                 clearIndicesCacheRequest.requestCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.requestCache()));
-            } else if (Fields.FIELD_DATA.match(entry.getKey())) {
+            } else if (Fields.FIELD_DATA.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
                 clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.fieldDataCache()));
-            } else  if (Fields.FIELDS.match(entry.getKey())) {
+            } else  if (Fields.FIELDS.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
                 clearIndicesCacheRequest.fields(request.paramAsStringArray(entry.getKey(), clearIndicesCacheRequest.fields()));
             }
         }


### PR DESCRIPTION
This replaces more of the `ParseField.match` calls with the same call using a
deprecation handler.

Relates to #28504