### PR TITLE
Index shard should roll generation via the engine

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2251,7 +2251,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                                     getLocalCheckpoint(),
                                     localCheckpoint);
                             getEngine().getLocalCheckpointTracker().resetCheckpoint(localCheckpoint);
-                            getEngine().getTranslog().rollGeneration();
+                            getEngine().rollTranslogGeneration();
                         });
                         globalCheckpointUpdated = true;
                     } catch (final Exception e) {


### PR DESCRIPTION
Today when a replica shard detects a new primary shard (via a primary term transition), we roll the translog generation. However, the mechanism that we are using here is by reaching through the engine to the translog directly. By poking all the way through rather than asking the engine to manage the roll for us we miss:
 - taking a read lock in the engine while the roll is occurring
 - trimming unreferenced readers

This commit addresses this by asking the engine to roll the translog generation for us.
