### PR TITLE
[TEST] Ensure that Stash is used by the same thread that created it

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestResponse.java
@@ -134,7 +134,7 @@ public class ClientYamlTestResponse {
      * Parses the response body and extracts a specific value from it (identified by the provided path)
      */
     public Object evaluate(String path) throws IOException {
-        return evaluate(path, Stash.EMPTY);
+        return evaluate(path, new Stash());
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ObjectPath.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/ObjectPath.java
@@ -66,7 +66,7 @@ public class ObjectPath {
      * the result of calling {@link #evaluate(String)} on it.
      */
     public static <T> T evaluate(Object object, String path) throws IOException {
-        return new ObjectPath(object).evaluate(path, Stash.EMPTY);
+        return new ObjectPath(object).evaluate(path, new Stash());
     }
 
 
@@ -74,7 +74,7 @@ public class ObjectPath {
      * Returns the object corresponding to the provided path if present, null otherwise
      */
     public <T> T evaluate(String path) throws IOException {
-        return evaluate(path, Stash.EMPTY);
+        return evaluate(path, new Stash());
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Stash.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Stash.java
@@ -46,8 +46,6 @@ public class Stash implements ToXContentFragment {
 
     private static final Logger logger = Loggers.getLogger(Stash.class);
 
-    public static final Stash EMPTY = new Stash();
-
     private final Map<String, Object> stash = new HashMap<>();
     private final ObjectPath stashObjectPath = new ObjectPath(stash);
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Stash.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/Stash.java
@@ -37,6 +37,8 @@ import java.util.regex.Pattern;
 /**
  * Allows to cache the last obtained test response and or part of it within variables
  * that can be used as input values in following requests and assertions.
+ *
+ * Note that this class is not thread safe.
  */
 public class Stash implements ToXContentFragment {
     private static final Pattern EXTENDED_KEY = Pattern.compile("\\$\\{([^}]+)\\}");
@@ -49,10 +51,13 @@ public class Stash implements ToXContentFragment {
     private final Map<String, Object> stash = new HashMap<>();
     private final ObjectPath stashObjectPath = new ObjectPath(stash);
 
+    private final Thread creationThread = Thread.currentThread();
+
     /**
      * Allows to saved a specific field in the stash as key-value pair
      */
     public void stashValue(String key, Object value) {
+        assertThread();
         logger.trace("stashing [{}]=[{}]", key, value);
         Object old = stash.put(key, value);
         if (old != null && old != value) {
@@ -64,6 +69,7 @@ public class Stash implements ToXContentFragment {
      * Clears the previously stashed values
      */
     public void clear() {
+        assertThread();
         stash.clear();
     }
 
@@ -74,6 +80,7 @@ public class Stash implements ToXContentFragment {
      * as arguments for following requests (e.g. scroll_id)
      */
     public boolean containsStashedValue(Object key) {
+        assertThread();
         if (key == null || false == key instanceof CharSequence) {
             return false;
         }
@@ -93,6 +100,7 @@ public class Stash implements ToXContentFragment {
      * as arguments for following requests (e.g. scroll_id)
      */
     public Object getValue(String key) throws IOException {
+        assertThread();
         if (key.charAt(0) == '$' && key.charAt(1) != '{') {
             return unstash(key.substring(1));
         }
@@ -126,6 +134,7 @@ public class Stash implements ToXContentFragment {
      */
     @SuppressWarnings("unchecked") // Safe because we check that all the map keys are string in unstashObject
     public Map<String, Object> replaceStashedValues(Map<String, Object> map) throws IOException {
+        assertThread();
         return (Map<String, Object>) unstashObject(new ArrayList<>(), map);
     }
 
@@ -201,7 +210,16 @@ public class Stash implements ToXContentFragment {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        assertThread();
         builder.field("stash", stash);
         return builder;
+    }
+
+    private void assertThread() {
+        if (creationThread != Thread.currentThread()) {
+            throw new AssertionError(this + " are only supposed to be consumed in "
+                    + "the thread in which they have been acquired. But was acquired in "
+                    + creationThread + " and consumed in " + Thread.currentThread() + ".");
+        }
     }
 }


### PR DESCRIPTION
There have been yaml rest test failures where the printed stashed requests in logs didn't match with the api call that failed in the yaml file. These assertions may catch threading issues, which may help fix this issue.