### PR TITLE
fixes a NPE thrown inside tests when assertions are disabled

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogDeletionPolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogDeletionPolicy.java
@@ -35,7 +35,7 @@ public class TranslogDeletionPolicy {
     private final Map<Object, RuntimeException> openTranslogRef;
 
     public void assertNoOpenTranslogRefs() {
-        if (openTranslogRef.isEmpty() == false) {
+        if (openTranslogRef != null && openTranslogRef.isEmpty() == false) {
             AssertionError e = new AssertionError("not all translog generations have been released");
             openTranslogRef.values().forEach(e::addSuppressed);
             throw e;


### PR DESCRIPTION
A public assertion method of the TranslogDeletionPolicy class relies on an internal map variable
which is only instantiated with enabled assertions but the method is always called.