### PR TITLE
[TEST] Remove unnecessary condition check

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1146,12 +1146,12 @@ public class IndexShardTests extends IndexShardTestCase {
         assertEquals(shard.shardPath().getRootStatePath().toString(), stats.getStatePath());
         assertEquals(shard.shardPath().isCustomDataPath(), stats.isCustomDataPath());
 
-        if (randomBoolean() || true) { // try to serialize it to ensure values survive the serialization
-            BytesStreamOutput out = new BytesStreamOutput();
-            stats.writeTo(out);
-            StreamInput in = out.bytes().streamInput();
-            stats = ShardStats.readShardStats(in);
-        }
+        // try to serialize it to ensure values survive the serialization
+        BytesStreamOutput out = new BytesStreamOutput();
+        stats.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        stats = ShardStats.readShardStats(in);
+
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
         stats.toXContent(builder, EMPTY_PARAMS);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -121,9 +121,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
 
         // random cities with no location
         for (String cityName : Arrays.asList("london", "singapour", "tokyo", "milan")) {
-            if (randomBoolean() || true) {
-                cities.add(indexCity("idx-multi", cityName));
-            }
+            cities.add(indexCity("idx-multi", cityName));
         }
         indexRandom(true, cities);
         prepareCreate("empty_bucket_idx")


### PR DESCRIPTION
Currently, there are some conditions check are a little wired. The condition value is definite no matter what the ```randomBoolean()``` returns. Simplify the conditions by removing the condition blocks.