### PR TITLE
Build: Replace provided configuration with compileOnly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,7 +245,7 @@ subprojects {
         }
       }
       project.configurations.compile.dependencies.findAll().toSorted(sortClosure).each(depJavadocClosure)
-      project.configurations.provided.dependencies.findAll().toSorted(sortClosure).each(depJavadocClosure)
+      project.configurations.compileOnly.dependencies.findAll().toSorted(sortClosure).each(depJavadocClosure)
     }
   }
 }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -260,8 +260,9 @@ class BuildPlugin implements Plugin<Project> {
      * to iterate the transitive dependencies and add excludes.
      */
     static void configureConfigurations(Project project) {
-        // TODO: this should really be in upstream gradle, no reason provided deps for compile shouldn't be used by tests
-        project.configurations.testCompileOnly.extendsFrom(project.configurations.compileOnly)
+        // we want to test compileOnly deps!
+        project.configurations.testCompile.extendsFrom(project.configurations.compileOnly)
+
         // we are not shipping these jars, we act like dumb consumers of these things
         if (project.path.startsWith(':test:fixtures') || project.path == ':build-tools') {
             return

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -260,6 +260,8 @@ class BuildPlugin implements Plugin<Project> {
      * to iterate the transitive dependencies and add excludes.
      */
     static void configureConfigurations(Project project) {
+        // TODO: this should really be in upstream gradle, no reason provided deps for compile shouldn't be used by tests
+        project.configurations.testCompileOnly.extendsFrom(project.configurations.compileOnly)
         // we are not shipping these jars, we act like dumb consumers of these things
         if (project.path.startsWith(':test:fixtures') || project.path == ':build-tools') {
             return

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -76,7 +76,6 @@ class BuildPlugin implements Plugin<Project> {
         project.pluginManager.apply('nebula.info-java')
         project.pluginManager.apply('nebula.info-scm')
         project.pluginManager.apply('nebula.info-jar')
-        project.pluginManager.apply(ProvidedBasePlugin)
 
         globalBuildInfo(project)
         configureRepositories(project)
@@ -297,7 +296,7 @@ class BuildPlugin implements Plugin<Project> {
 
         project.configurations.compile.dependencies.all(disableTransitiveDeps)
         project.configurations.testCompile.dependencies.all(disableTransitiveDeps)
-        project.configurations.provided.dependencies.all(disableTransitiveDeps)
+        project.configurations.compileOnly.dependencies.all(disableTransitiveDeps)
     }
 
     /** Adds repositories used by ES dependencies */
@@ -665,7 +664,7 @@ class BuildPlugin implements Plugin<Project> {
         // only require dependency licenses for non-elasticsearch deps
         project.dependencyLicenses.dependencies = project.configurations.runtime.fileCollection {
             it.group.startsWith('org.elasticsearch') == false
-        } - project.configurations.provided
+        } - project.configurations.compileOnly
     }
 
     private static configureDependenciesInfo(Project project) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -90,15 +90,15 @@ public class PluginBuildPlugin extends BuildPlugin {
 
     private static void configureDependencies(Project project) {
         project.dependencies {
-            provided "org.elasticsearch:elasticsearch:${project.versions.elasticsearch}"
+            compileOnly "org.elasticsearch:elasticsearch:${project.versions.elasticsearch}"
             testCompile "org.elasticsearch.test:framework:${project.versions.elasticsearch}"
             // we "upgrade" these optional deps to provided for plugins, since they will run
             // with a full elasticsearch server that includes optional deps
-            provided "org.locationtech.spatial4j:spatial4j:${project.versions.spatial4j}"
-            provided "com.vividsolutions:jts:${project.versions.jts}"
-            provided "org.apache.logging.log4j:log4j-api:${project.versions.log4j}"
-            provided "org.apache.logging.log4j:log4j-core:${project.versions.log4j}"
-            provided "org.elasticsearch:jna:${project.versions.jna}"
+            compileOnly "org.locationtech.spatial4j:spatial4j:${project.versions.spatial4j}"
+            compileOnly "com.vividsolutions:jts:${project.versions.jts}"
+            compileOnly "org.apache.logging.log4j:log4j-api:${project.versions.log4j}"
+            compileOnly "org.apache.logging.log4j:log4j-core:${project.versions.log4j}"
+            compileOnly "org.elasticsearch:jna:${project.versions.jna}"
         }
     }
 
@@ -133,7 +133,7 @@ public class PluginBuildPlugin extends BuildPlugin {
             }
             from pluginMetadata // metadata (eg custom security policy)
             from project.jar // this plugin's jar
-            from project.configurations.runtime - project.configurations.provided // the dep jars
+            from project.configurations.runtime - project.configurations.compileOnly // the dep jars
             // extra files for the plugin to go into the zip
             from('src/main/packaging') // TODO: move all config/bin/_size/etc into packaging
             from('src/main') {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/NamingConventionsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/NamingConventionsTask.groovy
@@ -74,10 +74,10 @@ public class NamingConventionsTask extends LoggedExec {
                     "org.elasticsearch.gradle:build-tools:${VersionProperties.elasticsearch}")
             buildToolsDep.transitive = false // We don't need gradle in the classpath. It conflicts.
         }
-        FileCollection extraClasspath = project.configurations.namingConventions
-        dependsOn(extraClasspath)
-
-        FileCollection classpath = project.sourceSets.test.runtimeClasspath
+        FileCollection classpath = project.files(project.configurations.namingConventions,
+                                                 project.sourceSets.test.compileClasspath,
+                                                 project.sourceSets.test.output)
+        dependsOn(classpath)
         inputs.files(classpath)
         description = "Tests that test classes aren't misnamed or misplaced"
         executable = new File(project.runtimeJavaHome, 'bin/java')
@@ -95,7 +95,7 @@ public class NamingConventionsTask extends LoggedExec {
         project.afterEvaluate {
             doFirst {
                 args('-Djna.nosys=true')
-                args('-cp', (classpath + extraClasspath).asPath, 'org.elasticsearch.test.NamingConventionsCheck')
+                args('-cp', classpath.asPath, 'org.elasticsearch.test.NamingConventionsCheck')
                 args('--test-class', testClass)
                 if (skipIntegTestInDisguise) {
                     args('--skip-integ-tests-in-disguise')

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.groovy
@@ -74,14 +74,19 @@ public class ThirdPartyAuditTask extends AntTask {
         description = "Checks third party JAR bytecode for missing classes, use of internal APIs, and other horrors'";
 
         project.afterEvaluate {
-            Configuration configuration = project.configurations.findByName('runtime');
+            Configuration configuration = project.configurations.findByName('runtime')
+            Configuration compileOnly = project.configurations.findByName('compileOnly')
             if (configuration == null) {
                 // some projects apparently do not have 'runtime'? what a nice inconsistency,
                 // basically only serves to waste time in build logic!
-                configuration = project.configurations.findByName('testCompile');
+                configuration = project.configurations.findByName('testCompile')
             }
-            assert configuration != null;
-            classpath = configuration
+            assert configuration != null
+            if (compileOnly == null) {
+                classpath = configuration
+            } else {
+                classpath = project.files(configuration, compileOnly)
+            }
 
             // we only want third party dependencies.
             jars = configuration.fileCollection({ dependency ->
@@ -90,7 +95,6 @@ public class ThirdPartyAuditTask extends AntTask {
 
             // we don't want provided dependencies, which we have already scanned. e.g. don't
             // scan ES core's dependencies for every single plugin
-            Configuration compileOnly = project.configurations.findByName('compileOnly')
             if (compileOnly != null) {
                 jars -= compileOnly
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/ThirdPartyAuditTask.groovy
@@ -90,9 +90,9 @@ public class ThirdPartyAuditTask extends AntTask {
 
             // we don't want provided dependencies, which we have already scanned. e.g. don't
             // scan ES core's dependencies for every single plugin
-            Configuration provided = project.configurations.findByName('provided')
-            if (provided != null) {
-                jars -= provided
+            Configuration compileOnly = project.configurations.findByName('compileOnly')
+            if (compileOnly != null) {
+                jars -= compileOnly
             }
             inputs.files(jars)
             onlyIf { jars.isEmpty() == false }

--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -20,8 +20,8 @@
 apply plugin: 'elasticsearch.build'
 
 dependencies {
-  provided "org.elasticsearch:elasticsearch:${version}"
-  provided "org.elasticsearch:elasticsearch-cli:${version}"
+  compileOnly "org.elasticsearch:elasticsearch:${version}"
+  compileOnly "org.elasticsearch:elasticsearch-cli:${version}"
   testCompile "org.elasticsearch.test:framework:${version}"
   testCompile 'com.google.jimfs:jimfs:1.1'
   testCompile 'com.google.guava:guava:18.0'

--- a/modules/percolator/build.gradle
+++ b/modules/percolator/build.gradle
@@ -31,7 +31,7 @@ dependencyLicenses {
   // Don't check the client's license. We know it.
   dependencies = project.configurations.runtime.fileCollection {
     it.group.startsWith('org.elasticsearch') == false
-  } - project.configurations.provided
+  } - project.configurations.compileOnly
 }
 
 compileJava.options.compilerArgs << "-Xlint:-deprecation,-rawtypes"


### PR DESCRIPTION
When elasticsearch was originally moved to gradle, the "provided" equivalent in maven had to be done through a plugin. Since then, gradle added the "compileOnly" configuration. This commit removes the `provided` plugin and replaces all uses with `compileOnly`.