### PR TITLE
[Tests] Skip some ingest-attachment tests on java 10

### DIFF
--- a/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
+++ b/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.ingest.attachment;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
@@ -117,6 +118,8 @@ public class AttachmentProcessorTests extends ESTestCase {
     }
 
     public void testWordDocument() throws Exception {
+        assumeFalse("parsing doesn't work with Java 10, see https://github.com/elastic/elasticsearch/issues/28568",
+                Constants.JAVA_VERSION.startsWith("10-"));
         Map<String, Object> attachmentData = parseDocument("issue-104.docx", processor);
 
         assertThat(attachmentData.keySet(), containsInAnyOrder("content", "language", "date", "author", "content_type",
@@ -131,6 +134,8 @@ public class AttachmentProcessorTests extends ESTestCase {
     }
 
     public void testWordDocumentWithVisioSchema() throws Exception {
+        assumeFalse("parsing doesn't work with Java 10, see https://github.com/elastic/elasticsearch/issues/28568",
+                Constants.JAVA_VERSION.startsWith("10-"));
         Map<String, Object> attachmentData = parseDocument("issue-22077.docx", processor);
 
         assertThat(attachmentData.keySet(), containsInAnyOrder("content", "language", "date", "author", "content_type",
@@ -167,6 +172,8 @@ public class AttachmentProcessorTests extends ESTestCase {
     }
 
     public void testVisioIsExcluded() throws Exception {
+        assumeFalse("parsing doesn't work with Java 10, see https://github.com/elastic/elasticsearch/issues/28568",
+                Constants.JAVA_VERSION.startsWith("10-"));
         Map<String, Object> attachmentData = parseDocument("issue-22077.vsdx", processor);
         assertThat(attachmentData.get("content"), nullValue());
         assertThat(attachmentData.get("content_type"), is("application/vnd.ms-visio.drawing"));

--- a/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaDocTests.java
+++ b/plugins/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaDocTests.java
@@ -1,5 +1,7 @@
 package org.elasticsearch.ingest.attachment;
 
+import org.apache.lucene.util.Constants;
+
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -41,6 +43,8 @@ public class TikaDocTests extends ESTestCase {
     static final String TIKA_FILES = "/org/elasticsearch/ingest/attachment/test/tika-files/";
 
     public void testFiles() throws Exception {
+        assumeFalse("parsing doesn't work with Java 10, see https://github.com/elastic/elasticsearch/issues/28568",
+                Constants.JAVA_VERSION.startsWith("10-"));
         Path tmp = createTempDir();
         logger.debug("unzipping all tika sample files");
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(PathUtils.get(getClass().getResource(TIKA_FILES).toURI()))) {


### PR DESCRIPTION
Some ingest-attachment tests that parse word documents using tika and 
fail because parsing doesn't seem to work for java 10 yet. This commit 
disables running those tests.

Relates to #28568