### PR TITLE
[Test] Fix SizeBlockingQueueTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueueTests.java
@@ -58,9 +58,9 @@ public class SizeBlockingQueueTests extends ESTestCase {
             } catch (final InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            while (spin.get()) {
+            do {
                 maxSize.set(Math.max(maxSize.get(), sizeBlockingQueue.size()));
-            }
+            } while (spin.get());
         });
         queueSizeThread.start();
 


### PR DESCRIPTION
If the offering thread runs very quick, `maxSize.set` might not be
called at all. This change makes sure it is called at least once.

Closes #28579