### PR TITLE
TEST: Fix unassigned maxSize in testQueueSize

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueueTests.java
@@ -58,7 +58,7 @@ public class SizeBlockingQueueTests extends ESTestCase {
             } catch (final InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            while (spin.get()) {
+            while (spin.get() || maxSize.get() == 0) {
                 maxSize.set(Math.max(maxSize.get(), sizeBlockingQueue.size()));
             }
         });


### PR DESCRIPTION
The maxSize won't be updated if an unlucky schedule happens as follows
1. The `queueSizeThread` starts and gets paused before the spin loop
2. The `queueOfferThread` starts and finishes, thus the `spin` flag is set to false
3. The `queueSizeThread` is scheduled but the `spin` is false already, therefore it won't pull the queue size

This commit makes the `queueSizeThread` keep polling the queue size until the spin flag is off and the max size is assigned at least one.

Relates #28557