### PR TITLE
Fix race condition in queue size test

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/SizeBlockingQueueTests.java
@@ -51,7 +51,6 @@ public class SizeBlockingQueueTests extends ESTestCase {
         final CountDownLatch latch = new CountDownLatch(1);
         final CyclicBarrier barrier = new CyclicBarrier(2);
 
-        final AtomicBoolean spin = new AtomicBoolean(true);
         final AtomicInteger maxSize = new AtomicInteger();
 
         // this thread will repeatedly poll the size of the queue keeping track of the maximum size that it sees
@@ -96,11 +95,8 @@ public class SizeBlockingQueueTests extends ESTestCase {
         // synchronize the start of the two threads
         latch.countDown();
 
-        // wait for the offering thread to finish
+        // wait for the threads to finish
         queueOfferThread.join();
-
-        // stop the queue size thread
-        spin.set(false);
         queueSizeThread.join();
 
         // the maximum size of the queue should be equal to the capacity


### PR DESCRIPTION
The queue size test has a race condition. Namely the offering thread can run so quickly completing all of its offering iterations before the queue size thread ever has a chance to run a single size poll iteration. This means that the size will never actually be polled and the test can spuriously fail. What we really want to do here, since this test is checking for a race condition between polling the size of the queue and offers to the queue, we want to execute each iteration in lockstep giving the threads multiple changes for the race between polling the size and offers to occur. This commit addresses this by running the two threads in lockstep for multiple iterations so that they have multiple chances to race.

Closes #28579