### PR TITLE
Add missing runtime permission to TikaImpl

### DIFF
--- a/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
+++ b/plugins/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/TikaImpl.java
@@ -52,8 +52,8 @@ import java.security.SecurityPermission;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.Set;
 import java.util.PropertyPermission;
+import java.util.Set;
 
 /**
  * Runs tika with limited parsers and limited permissions.
@@ -161,6 +161,8 @@ final class TikaImpl {
         perms.add(new ReflectPermission("suppressAccessChecks"));
         // xmlbeans, use by POI, needs to get the context classloader
         perms.add(new RuntimePermission("getClassLoader"));
+        // ZipFile needs accessDeclaredMembers on Java 10
+        perms.add(new RuntimePermission("accessDeclaredMembers"));
         perms.setReadOnly();
         return perms;
     }

--- a/plugins/ingest-attachment/src/main/plugin-metadata/plugin-security.policy
+++ b/plugins/ingest-attachment/src/main/plugin-metadata/plugin-security.policy
@@ -29,4 +29,6 @@ grant {
   permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   // needed by xmlbeans, as part of POI for MS xml docs
   permission java.lang.RuntimePermission "getClassLoader";
+  // ZipFile needs accessDeclaredMembers on Java 10
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
 };


### PR DESCRIPTION
Tests on jdk10 were failing because of a change in java 10s ZipFile
implementation that now needs `accessDeclaredMembers` permissions.
Adding this to the policy file and TikaImpl for tests.

Closes #28568
