### PR TITLE
MetaDataIndexAliasesService wrong get type

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -133,7 +133,7 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
                     Function<String, IndexMetaData> indexLookup = name -> metadata.get(name);
                     aliasValidator.validateAlias(alias, action.getIndex(), indexRouting, indexLookup);
                     if (Strings.hasLength(filter)) {
-                        IndexService indexService = indices.get(index.getIndex());
+                        IndexService indexService = indices.get(index.getIndex().getName());
                         if (indexService == null) {
                             indexService = indicesService.indexService(index.getIndex());
                             if (indexService == null) {


### PR DESCRIPTION
A get of the wrong type would always have returned null so these
indices would have been inserted into the map repeatedly.

(Pulled out of https://github.com/elastic/elasticsearch/pull/27772)