### PR TITLE
Fix DeadlockAnalyzer printer

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/DeadlockAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/DeadlockAnalyzer.java
@@ -137,9 +137,7 @@ public class DeadlockAnalyzer {
             for (int x = 0; x < members.length; x++) {
                 ThreadInfo ti = members[x];
                 sb.append(ti.getThreadName());
-                if (x < members.length) {
-                    sb.append(" > ");
-                }
+                sb.append(" > ");
                 if (x == members.length - 1) {
                     sb.append(ti.getLockOwnerName());
                 }


### PR DESCRIPTION
Remove `if` block that was always true.

(Pulled out of #27772)