### PR TITLE
NXYSignificanceHeuristic equality update

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/NXYSignificanceHeuristic.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/significant/heuristics/NXYSignificanceHeuristic.java
@@ -68,8 +68,19 @@ public abstract class NXYSignificanceHeuristic extends SignificanceHeuristic {
     }
 
     @Override
-    public boolean equals(Object other) {
-        return ((NXYSignificanceHeuristic) other).includeNegatives == includeNegatives && ((NXYSignificanceHeuristic) other).backgroundIsSuperset == backgroundIsSuperset;
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        NXYSignificanceHeuristic other = (NXYSignificanceHeuristic) obj;
+        if (backgroundIsSuperset != other.backgroundIsSuperset)
+            return false;
+        if (includeNegatives != other.includeNegatives)
+            return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
* NXYSignificanceHeuristic.java: implementation of equality would have
  failed with a ClassCastException when comparing to another type.
  Replaced with the Eclipse generated form.

(Pulled out of #27772)