### PR TITLE
Removed unused local variable from ScriptClassInfo

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptClassInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ScriptClassInfo.java
@@ -84,8 +84,7 @@ public class ScriptClassInfo {
                 componentType -> "Painless can only implement execute methods returning a whitelisted type but [" + baseClass.getName()
                         + "#execute] returns [" + componentType.getName() + "] which isn't whitelisted.");
 
-        // Look up the argument names
-        Set<String> argumentNames = new LinkedHashSet<>();
+        // Look up the argument
         List<MethodArgument> arguments = new ArrayList<>();
         String[] argumentNamesConstant = readArgumentNamesConstant(baseClass);
         Class<?>[] types = executeMethod.getParameterTypes();
@@ -95,7 +94,6 @@ public class ScriptClassInfo {
         }
         for (int arg = 0; arg < types.length; arg++) {
             arguments.add(methodArgument(definition, types[arg], argumentNamesConstant[arg]));
-            argumentNames.add(argumentNamesConstant[arg]);
         }
         this.executeArguments = unmodifiableList(arguments);
         this.needsMethods = unmodifiableList(needsMethods);


### PR DESCRIPTION
Following [8999104](https://lgtm.com/projects/g/elastic/elasticsearch/rev/8999104b14baeaad58215363c113087a517c3adb)
  the local variable `argumentNames` is no longer used, so removed.

(Pulled out of #27772)