### PR TITLE
when start recover,check the tomstones and indices to aviod deleted index rejoining cluster

### DIFF
--- a/core/src/main/java/org/elasticsearch/gateway/Gateway.java
+++ b/core/src/main/java/org/elasticsearch/gateway/Gateway.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateApplier;
+import org.elasticsearch.cluster.metadata.IndexGraveyard;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -38,8 +39,10 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.indices.IndicesService;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class Gateway extends AbstractComponent implements ClusterStateApplier {
 
@@ -128,6 +131,26 @@ public class Gateway extends AbstractComponent implements ClusterStateApplier {
                 if (electedIndexMetaData != null) {
                     if (indexMetaDataCount < requiredAllocation) {
                         logger.debug("[{}] found [{}], required [{}], not adding", index, indexMetaDataCount, requiredAllocation);
+                        
+                        //if we have 5 nodes cluster(such as 1,2,3,4,5 node),when 5 node leave the cluster,and now cluster delete one index.
+                        //then restart all nodes,if 1,2,5 join and find master,then 3,4 join the cluster.After started, this cluster state is red,
+                        //because the delete index(lose some shards) is still part of the cluster metedata.
+                        //to avoid this problem,this check the tomstones and indices,if tomston has index which is same in indices,
+                        //don't put index in metedata                  
+                        List<IndexGraveyard.Tombstone> tombstones = electedGlobalState.indexGraveyard().getTombstones();
+                        List<Index> deleteIndexList = tombstones.stream().map(IndexGraveyard.Tombstone::getIndex).collect(Collectors.toList());
+                        boolean isAlreadyDelete = false;
+                        for (Index deleteIndex : deleteIndexList) {
+                            if (deleteIndex.getName().equals(electedIndexMetaData.getIndex().getName()) &&
+                                deleteIndex.getUUID().equals(electedIndexMetaData.getIndexUUID())) {
+                                logger.trace("[{}] index delete in some node but not in allNode, so need't put into metaData", index.getName());
+                                isAlreadyDelete = true;
+                                break;
+                            }
+                        }
+                        if (isAlreadyDelete == true) {
+                            continue;
+                        }
                     } // TODO if this logging statement is correct then we are missing an else here
                     try {
                         if (electedIndexMetaData.getState() == IndexMetaData.State.OPEN) {


### PR DESCRIPTION
if we have 5 nodes cluster(such as 1,2,3,4,5 node),when 5 node leave the cluster,and now cluster delete one index.
then restart all nodes,if 1,2,5 join and find master,then 3,4 join the cluster.After started, this cluster state is red,
because the delete index(lose some shards) is still part of the cluster metedata.
to avoid this problem,this check the tomstones and indices,if tomston has index which is same in indices,
don't put index in metedata

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
