### PR TITLE
Improve logging in ClusterFormationTasks#configureWaitTask

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterFormationTasks.groovy
@@ -601,11 +601,18 @@ class ClusterFormationTasks {
                     }
                 }
             }
+            if (ant.properties.containsKey("failed${name}".toString())) {
+                waitFailed(project, nodes, logger, "Failed to start elasticsearch: timed out after ${waitSeconds} seconds")
+            }
+
             boolean anyNodeFailed = false
             for (NodeInfo node : nodes) {
-                anyNodeFailed |= node.failedMarker.exists()
+                if (node.failedMarker.exists()) {
+                    logger.error("Failed to start elasticsearch: ${node.failedMarker.toString()} exists")
+                    anyNodeFailed = true
+                }
             }
-            if (ant.properties.containsKey("failed${name}".toString()) || anyNodeFailed) {
+            if (anyNodeFailed) {
                 waitFailed(project, nodes, logger, 'Failed to start elasticsearch')
             }
 


### PR DESCRIPTION
We suspect a build failure might be due to a startup timeout, but there is insufficient information in the logs. This change enhances the information available so we will be better-informed next time.