### PR TITLE
Increase the REST test timeout.

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -129,7 +129,7 @@ class ClusterConfiguration {
      * condition is executed.
      */
     @Input
-    int nodeStartupWaitSeconds = 30
+    int nodeStartupWaitSeconds = 120
 
     public ClusterConfiguration(Project project) {
         this.project = project


### PR DESCRIPTION
By default we wait for 30 seconds for nodes to start. Looking at CI,
even for passing builds, the startup time is frequently over 20 seconds
(grep for `#wait (Thread[Task worker for ':',5,main]) completed` in any
console log), which is close to the threshold. This commit sets a
default timeout of 120 seconds instead, so that REST tests are less
likely to hit a timeout.
