### PR TITLE
Add released major logic to version utils

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -105,6 +105,16 @@ public class VersionUtils {
             }
 
             return new Tuple<>(unmodifiableList(versions), unmodifiableList(Arrays.asList(earlierUnreleased, unreleased, current)));
+        } else if (unreleased.major == current.major) {
+            // need to remove one more of the last major's minor set
+            do {
+                unreleasedIndex--;
+            } while (unreleasedIndex > 0 && versions.get(unreleasedIndex).major == current.major);
+            if (unreleasedIndex > 0) {
+                // some of the test cases return very small lists, so its possible this is just the end of the list, if so, dont include it
+                Version earlierMajorsMinor = versions.remove(unreleasedIndex);
+                return new Tuple<>(unmodifiableList(versions), unmodifiableList(Arrays.asList(earlierMajorsMinor, unreleased, current)));
+            }
         }
         return new Tuple<>(unmodifiableList(versions), unmodifiableList(Arrays.asList(unreleased, current)));
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -254,13 +254,13 @@ public class VersionUtilsTests extends ESTestCase {
         assertThat(released, equalTo(Arrays.asList(
             TestVersionBumpIn6x.V_5_6_0,
             TestVersionBumpIn6x.V_5_6_1,
-            TestVersionBumpIn6x.V_5_6_2,
             TestVersionBumpIn6x.V_6_0_0_alpha1,
             TestVersionBumpIn6x.V_6_0_0_alpha2,
             TestVersionBumpIn6x.V_6_0_0_beta1,
             TestVersionBumpIn6x.V_6_0_0_beta2,
             TestVersionBumpIn6x.V_6_0_0)));
         assertThat(unreleased, equalTo(Arrays.asList(
+            TestVersionBumpIn6x.V_5_6_2,
             TestVersionBumpIn6x.V_6_0_1,
             TestVersionBumpIn6x.V_6_1_0)));
     }
@@ -291,7 +291,6 @@ public class VersionUtilsTests extends ESTestCase {
         assertThat(released, equalTo(Arrays.asList(
             TestNewMinorBranchIn6x.V_5_6_0,
             TestNewMinorBranchIn6x.V_5_6_1,
-            TestNewMinorBranchIn6x.V_5_6_2,
             TestNewMinorBranchIn6x.V_6_0_0_alpha1,
             TestNewMinorBranchIn6x.V_6_0_0_alpha2,
             TestNewMinorBranchIn6x.V_6_0_0_beta1,
@@ -301,6 +300,7 @@ public class VersionUtilsTests extends ESTestCase {
             TestNewMinorBranchIn6x.V_6_1_0,
             TestNewMinorBranchIn6x.V_6_1_1)));
         assertThat(unreleased, equalTo(Arrays.asList(
+            TestNewMinorBranchIn6x.V_5_6_2,
             TestNewMinorBranchIn6x.V_6_1_2,
             TestNewMinorBranchIn6x.V_6_2_0)));
     }


### PR DESCRIPTION
Version Utils did not previously have logic that removed the last majors
minor snapshot if there was a next bugfix and maintenance bugfix
release. This adds the logic and fixes some broken assumptions in tests
as well.

relates #28505