### PR TITLE
Fixed typo in search for wrong type

### DIFF
--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -93,7 +93,7 @@ GET /tweets/_search
         "terms" : {
             "user" : {
                 "index" : "users",
-                "type" : "user",
+                "type" : "_doc",
                 "id" : "2",
                 "path" : "followers"
             }


### PR DESCRIPTION
Noticed the example doesn't work: the type for the search is incorrect, not matching the `PUT` request types (`_doc`). I would change all type references from `_doc` to `doc`, but left that unchanged in this PR. 

ICA signed 👍 


