### PR TITLE
Docs: Remove references to elasticsearch directory in plugins

### DIFF
--- a/buildSrc/src/main/resources/meta-plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/meta-plugin-descriptor.properties
@@ -1,13 +1,12 @@
 # Elasticsearch meta plugin descriptor file
-# This file must exist as 'meta-plugin-descriptor.properties' in a folder named `elasticsearch`.
+# This file must exist as 'meta-plugin-descriptor.properties' inside a plugin.
 #
 ### example meta plugin for "meta-foo"
 #
 # meta-foo.zip <-- zip file for the meta plugin, with this structure:
-#|____elasticsearch/
-#| |____   <bundled_plugin_1> <-- The plugin files for bundled_plugin_1 (the content of the elastisearch directory)
-#| |____   <bundled_plugin_2>  <-- The plugin files for bundled_plugin_2
-#| |____   meta-plugin-descriptor.properties <-- example contents below:
+# |____   <bundled_plugin_1> <-- The plugin files for bundled_plugin_1
+# |____   <bundled_plugin_2>  <-- The plugin files for bundled_plugin_2
+# |____   meta-plugin-descriptor.properties <-- example contents below:
 #
 # description=My meta plugin
 # name=meta-foo

--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -1,14 +1,12 @@
 # Elasticsearch plugin descriptor file
-# This file must exist as 'plugin-descriptor.properties' in a folder named `elasticsearch`
-# inside all plugins.
+# This file must exist as 'plugin-descriptor.properties' inside a plugin.
 #
 ### example plugin for "foo"
 #
 # foo.zip <-- zip file for the plugin, with this structure:
-#|____elasticsearch/
-#| |____   <arbitrary name1>.jar <-- classes, resources, dependencies
-#| |____   <arbitrary nameN>.jar <-- any number of jars
-#| |____   plugin-descriptor.properties <-- example contents below:
+# |____   <arbitrary name1>.jar <-- classes, resources, dependencies
+# |____   <arbitrary nameN>.jar <-- any number of jars
+# |____   plugin-descriptor.properties <-- example contents below:
 #
 # classname=foo.bar.BazPlugin
 # description=My cool plugin

--- a/docs/plugins/authors.asciidoc
+++ b/docs/plugins/authors.asciidoc
@@ -21,14 +21,9 @@ information about how to write a plugin, we recommend looking at the plugins
 listed in this documentation for inspiration.
 
 [float]
-=== Plugin Structure
-
-All plugin files must be contained in a directory called `elasticsearch`.
-
-[float]
 === Plugin descriptor file
 
-All plugins must contain a file called `plugin-descriptor.properties` in the folder named `elasticsearch`.
+All plugins must contain a file called `plugin-descriptor.properties`.
 The format for this file is described in detail in this example:
 
 ["source","properties",subs="attributes"]
@@ -63,7 +58,7 @@ of nonnegative decimal integers separated by "."'s and may have leading zeros.
 
 |=======================================================================
 
-Note that only jar files in the 'elasticsearch' directory are added to the classpath for the plugin!
+Note that only jar files at the root of the plugin are added to the classpath for the plugin!
 If you need other resources, package them into a resources jar.
 
 [IMPORTANT]


### PR DESCRIPTION
This directory was removed from plugins in #28589, but docs still
referenced it. This commit cleans up the plugin author docs to no longer
refer to it.