### PR TITLE
Add startup logging for standalone tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -163,6 +163,7 @@ class NodeInfo {
         }
 
         env = ['JAVA_HOME': project.runtimeJavaHome]
+        args.addAll("-E", "logger.org.elasticsearch.bootstrap=debug", "-E", "logger.org.elasticsearch.common.network=debug")
         args.addAll("-E", "node.portsfile=true")
         String collectedSystemProperties = config.systemProperties.collect { key, value -> "-D${key}=${value}" }.join(" ")
         String esJavaOpts = config.jvmArgs.isEmpty() ? collectedSystemProperties : collectedSystemProperties + " " + config.jvmArgs


### PR DESCRIPTION
We need to investigate why startup is taking so long in CI for standalone tests. This commit adds logging for bootstrap and network code that is executed before the node starts initializing in case this is the source of the trouble.

Relates #28650