### PR TITLE
Compute declared versions in a static block

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -163,6 +163,11 @@ public class Version implements Comparable<Version> {
                 + org.apache.lucene.util.Version.LATEST + "] is still set to [" + CURRENT.luceneVersion + "]";
     }
 
+    private static final List<Version> DECLARED_VERSIONS;
+    static {
+        DECLARED_VERSIONS = getDeclaredVersions(Version.class);
+    }
+
     public static Version readVersion(StreamInput in) throws IOException {
         return fromId(in.readVInt());
     }
@@ -412,10 +417,9 @@ public class Version implements Comparable<Version> {
     public Version minimumCompatibilityVersion() {
         if (major >= 6) {
             // all major versions from 6 onwards are compatible with last minor series of the previous major
-            final List<Version> declaredVersions = getDeclaredVersions(getClass());
             Version bwcVersion = null;
-            for (int i = declaredVersions.size() - 1; i >= 0; i--) {
-                final Version candidateVersion = declaredVersions.get(i);
+            for (int i = DECLARED_VERSIONS.size() - 1; i >= 0; i--) {
+                final Version candidateVersion = DECLARED_VERSIONS.get(i);
                 if (candidateVersion.major == major - 1 && candidateVersion.isRelease() && after(candidateVersion)) {
                     if (bwcVersion != null && candidateVersion.minor < bwcVersion.minor) {
                         break;

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -163,6 +163,10 @@ public class Version implements Comparable<Version> {
                 + org.apache.lucene.util.Version.LATEST + "] is still set to [" + CURRENT.luceneVersion + "]";
     }
 
+    private static class DeclaredVersionsHolder {
+        static final List<Version> DECLARED_VERSIONS = Collections.unmodifiableList(getDeclaredVersions(Version.class));
+    }
+
     public static Version readVersion(StreamInput in) throws IOException {
         return fromId(in.readVInt());
     }
@@ -372,8 +376,6 @@ public class Version implements Comparable<Version> {
     public final byte build;
     public final org.apache.lucene.util.Version luceneVersion;
 
-    private List<Version> declaredVersionsCache;
-
     Version(int id, org.apache.lucene.util.Version luceneVersion) {
         this.id = id;
         this.major = (byte) ((id / 1000000) % 100);
@@ -414,17 +416,10 @@ public class Version implements Comparable<Version> {
     public Version minimumCompatibilityVersion() {
         if (major >= 6) {
             // all major versions from 6 onwards are compatible with last minor series of the previous major
-            List<Version> declaredVersions = declaredVersionsCache;
-
-            if (declaredVersions == null) {
-                declaredVersions = Collections.unmodifiableList(getDeclaredVersions(getClass()));
-                declaredVersionsCache = declaredVersions;
-            }
-
             Version bwcVersion = null;
 
-            for (int i = declaredVersions.size() - 1; i >= 0; i--) {
-                final Version candidateVersion = declaredVersions.get(i);
+            for (int i = DeclaredVersionsHolder.DECLARED_VERSIONS.size() - 1; i >= 0; i--) {
+                final Version candidateVersion = DeclaredVersionsHolder.DECLARED_VERSIONS.get(i);
                 if (candidateVersion.major == major - 1 && candidateVersion.isRelease() && after(candidateVersion)) {
                     if (bwcVersion != null && candidateVersion.minor < bwcVersion.minor) {
                         break;


### PR DESCRIPTION
This method is called often enough that the reflection and sort
can be seen while profiling. The impact is quite small but
it is an easy enough fix and I see no reason why this needs to be
computed every invoke.