### PR TITLE
Add QueryBuilders.matchNoneQuery(), #28679

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/QueryDSLDocumentationTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/QueryDSLDocumentationTests.java
@@ -54,6 +54,7 @@ import static org.elasticsearch.index.query.QueryBuilders.geoPolygonQuery;
 import static org.elasticsearch.index.query.QueryBuilders.geoShapeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.idsQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchNoneQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.moreLikeThisQuery;
 import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
@@ -247,6 +248,12 @@ public class QueryDSLDocumentationTests extends ESTestCase {
         // tag::match_all
         matchAllQuery();
         // end::match_all
+    }
+
+    public void testMatchNone() {
+        // tag::match_none
+        matchNoneQuery();
+        // end::match_none
     }
 
     public void testMatch() {

--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -50,6 +50,13 @@ public final class QueryBuilders {
     }
 
     /**
+     * A query that matches no documents.
+     */
+    public static MatchNoneQueryBuilder matchNoneQuery() {
+        return new MatchNoneQueryBuilder();
+    }
+
+    /**
      * Creates a match query with type "BOOLEAN" for the provided field name and text.
      *
      * @param name The field name.


### PR DESCRIPTION
Small code change suggestion.
Someone with insights into ES documentation generation and QueryBuilders unit tests should review and make relevant further amendments. Thx.