### PR TITLE
[docs] Add a note to the cat API for the `help` option

### DIFF
--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -55,7 +55,7 @@ GET /_cat/master?help
 --------------------------------------------------
 // CONSOLE
 
-Might respond respond with:
+Might respond with:
 
 [source,txt]
 --------------------------------------------------
@@ -65,6 +65,11 @@ ip   |   | ip address
 node | n | node name
 --------------------------------------------------
 // TESTRESPONSE[s/[|]/[|]/ _cat]
+
+NOTE: `help` is not supported if any optional url parameter is used.
+For example `GET _cat/shards/twitter?help` or `GET _cat/indices/twi*?help`
+results in an error. Use `GET _cat/shards?help` or `GET _cat/indices?help`
+instead.
 
 [float]
 [[headers]]


### PR DESCRIPTION
Add a note to the docs that using the `help` option with cat API, which provide an optional url param, results in an error

Removed a duplicate word

Relates to #27424