### PR TITLE
[DOCS]  GET API change "tweet" type to "_doc"

### DIFF
--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -3,7 +3,7 @@
 
 The get API allows to get a typed JSON document from the index based on
 its id. The following example gets a JSON document from an index called
-twitter, under a type called tweet, with id valued 0:
+twitter, under a type called _doc, with id valued 0:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Elasticsearch 6.x indices do not allow multiple types indices. Instead, they use "_doc" as default if created internally (Elasticsearch), or "doc" if sent by Logstash.

This small fix just clarify the type usage from Elasticsearch 6.x : https://www.elastic.co/guide/en/elasticsearch/reference/6.x/breaking-changes-6.0.html
There might be other cases on others pages.

Kuaaaly