### PR TITLE
Fix using relative custom config path

### DIFF
--- a/distribution/src/main/resources/bin/elasticsearch-env
+++ b/distribution/src/main/resources/bin/elasticsearch-env
@@ -74,6 +74,9 @@ if [ -z "$ES_PATH_CONF" ]; then
   exit 1
 fi
 
+# now make ES_PATH_CONF absolute
+ES_PATH_CONF=`cd "$ES_PATH_CONF"; pwd`
+
 if [ -z "$ES_TMPDIR" ]; then
   set +e
   mktemp --version 2>&1 | grep coreutils > /dev/null

--- a/distribution/src/main/resources/bin/elasticsearch-env.bat
+++ b/distribution/src/main/resources/bin/elasticsearch-env.bat
@@ -50,6 +50,9 @@ if not defined ES_PATH_CONF (
   set ES_PATH_CONF=!ES_HOME!\config
 )
 
+rem now make ES_PATH_CONF absolute
+for %%I in ("%ES_PATH_CONF%..") do set ES_PATH_CONF=%%~dpfI
+
 if not defined ES_TMPDIR (
   set ES_TMPDIR=!TMP!\elasticsearch
 )

--- a/qa/vagrant/src/test/resources/packaging/tests/20_tar_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/20_tar_package.bats
@@ -139,6 +139,23 @@ setup() {
     stop_elasticsearch_service
 }
 
+@test "[TAR] relative ES_PATH_CONF" {
+    local es_path_conf=$ES_PATH_CONF
+    local temp=`mktemp -d`
+    mkdir "$temp"/config
+    cp "$ESCONFIG"/elasticsearch.yml "$temp"/config
+    cp "$ESCONFIG"/log4j2.properties "$temp"/config
+    cp "$ESCONFIG/jvm.options" "$temp/config"
+    chown -R elasticsearch:elasticsearch "$temp"
+    echo "node.name: relative" >> "$temp"/config/elasticsearch.yml
+    cd "$temp"
+    export ES_PATH_CONF=config
+    start_elasticsearch_service
+    curl -s -XGET localhost:9200/_nodes | fgrep '"name":"relative"'
+    stop_elasticsearch_service
+    export ES_PATH_CONF=$es_path_conf
+}
+
 @test "[TAR] remove tar" {
     rm -rf "/tmp/elasticsearch"
 }


### PR DESCRIPTION
Previously a user could set a custom config path to a relative directory using `ES_PATH_CONF`. In a previous change related to enabling GC logging by default, we forced the working directory for Elasticsearch to be `ES_HOME`. This had the impact of causing all relative paths to be relative to `ES_HOME`, against the intent of the user. This commit addresses this by making `ES_PATH_CONF` absolute before we switch the working directory to `ES_HOME`.

Relates #27610