### PR TITLE
Uses MergingDigest instead of AVLDigest in percentiles agg

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestState.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestState.java
@@ -18,8 +18,9 @@
  */
 package org.elasticsearch.search.aggregations.metrics;
 
-import com.tdunning.math.stats.AVLTreeDigest;
 import com.tdunning.math.stats.Centroid;
+import com.tdunning.math.stats.MergingDigest;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -29,7 +30,7 @@ import java.util.Iterator;
 /**
  * Extension of {@link com.tdunning.math.stats.TDigest} with custom serialization.
  */
-public class TDigestState extends AVLTreeDigest {
+public class TDigestState extends MergingDigest {
 
     private final double compression;
 
@@ -44,6 +45,8 @@ public class TDigestState extends AVLTreeDigest {
     }
 
     public static void write(TDigestState state, StreamOutput out) throws IOException {
+        state.compress(); // This will flush any values in the buffer to the data structure. 
+                          // If there are no values in the buffer this is cheap
         out.writeDouble(state.compression);
         out.writeVInt(state.centroidCount());
         for (Centroid centroid : state.centroids()) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
@@ -42,7 +42,7 @@ public class InternalTDigestPercentilesRanksTests extends InternalPercentilesRan
         final TDigestState state = new TDigestState(100);
         Arrays.stream(values).forEach(state::add);
 
-        assertEquals(state.centroidCount(), values.length);
+        assertEquals(state.size(), values.length);
         return new InternalTDigestPercentileRanks(name, percents, state, keyed, format, aggregators, metadata);
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
@@ -43,7 +43,7 @@ public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase
         final TDigestState state = new TDigestState(100);
         Arrays.stream(values).forEach(state::add);
 
-        assertEquals(state.centroidCount(), values.length);
+        assertEquals(state.size(), values.length);
         return new InternalTDigestPercentiles(name, percents, state, keyed, format, pipelineAggregators, metaData);
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregatorTests.java
@@ -75,13 +75,13 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new SortedNumericDocValuesField("number", 0)));
         }, tdigest -> {
             assertEquals(7L, tdigest.state.size());
-            assertEquals(7L, tdigest.state.centroidCount());
             assertEquals(4.5d, tdigest.percentile(75), 0.0d);
             assertEquals("4.5", tdigest.percentileAsString(75));
             assertEquals(2.0d, tdigest.percentile(50), 0.0d);
             assertEquals("2.0", tdigest.percentileAsString(50));
             assertEquals(1.0d, tdigest.percentile(22), 0.0d);
             assertEquals("1.0", tdigest.percentileAsString(22));
+            assertEquals(7L, tdigest.state.centroidCount());
         });
     }
 
@@ -96,7 +96,6 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new NumericDocValuesField("number", 0)));
         }, tdigest -> {
             assertEquals(tdigest.state.size(), 7L);
-            assertEquals(tdigest.state.centroidCount(), 7L);
             assertEquals(8.0d, tdigest.percentile(100), 0.0d);
             assertEquals("8.0", tdigest.percentileAsString(100));
             assertEquals(6.98d, tdigest.percentile(88), 0.0d);
@@ -107,6 +106,7 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
             assertEquals("1.0", tdigest.percentileAsString(25));
             assertEquals(0.0d, tdigest.percentile(1), 0.0d);
             assertEquals("0.0", tdigest.percentileAsString(1));
+            assertEquals(tdigest.state.centroidCount(), 7L);
         });
     }
 
@@ -123,10 +123,10 @@ public class TDigestPercentilesAggregatorTests extends AggregatorTestCase {
 
         testCase(LongPoint.newRangeQuery("row", 1, 4), docs, tdigest -> {
             assertEquals(4L, tdigest.state.size());
-            assertEquals(4L, tdigest.state.centroidCount());
             assertEquals(2.0d, tdigest.percentile(100), 0.0d);
             assertEquals(1.0d, tdigest.percentile(50), 0.0d);
             assertEquals(0.5d, tdigest.percentile(25), 0.0d);
+            assertEquals(4L, tdigest.state.centroidCount());
         });
 
         testCase(LongPoint.newRangeQuery("row", 100, 110), docs, tdigest -> {


### PR DESCRIPTION
This change modifies TDigestState to use MergingDigest instead of AVLTreeDigest. Benchmarks comparing the insertion performance of the two implementations show that MergingDigest is between 2 and 250 times faster than AVLTreeDigest in the tested scenarios. Details of the benchmark are below.

The change is straight forward but one thing which is still outstanding is to add a test which tests the assumption that the serialisation is compatible between older versions using AVLTreeDigest and new versions after this change using MergingDigest. This should be covered by bwc tests in theory but I would like to add an explicit unit test to check this as well.

The benchmark was performed on the Raw classes outside of Elasticsearch. Three scenarios were tested but in each case the test was warmed up by inserting 10,000 values into each implementation over 10 warm up runs and then measurements were taken inserting 1,000,000 values over 100 test runs for each implementation. For each test run the same values were used on both implementations. The compression was 100.0 in all tests. Measurements were taken by calling `System.nanoTime()` before and after inserting the 1,000,000 values. Measurements were combined into a mean average for the final results.

### Scenarios:

1. Random Value Doubles - Test values were doubles taken from `java.util.Random.nextDouble()`. For each test run the Random instance was seeded with the same seed for both implementations but the seed was changed for each test run.
2. Sequential Integer Values As Doubles - Test values were taken from an incrementing long variable and then converted to a double using `Double.valueOf(long)`. The long variable was reset for every test run and between testing each implementation.
3. Repeated Same Value Doubles - Test values were taken from `java.util.Random.nextDouble()` at the beginning of a test run and this same value was repeatedly inserted into the implementation under test. The value was kept the same between the two implementations but a new value was obtained between test runs.


### Results

#### Random Value Doubles

Average AVLTreeDigest (ns): 2.4393659506E8
Average AVLTreeDigest (ms): 243.93659506
Average MergingDigest (ns): 1.1975786487E8
Average MergingDigest (ms): 119.75786487
Average MergingDigest / Average AVLTreeDigest (%): 49.09384950648495
Average AVLTreeDigest / Average MergingDigest (raw value): 2.036915031215686


#### Sequential Integer Values As Doubles

Average AVLTreeDigest (ns): 9.4348391258E8
Average AVLTreeDigest (ms): 943.48391258
Average MergingDigest (ns): 1.0778998414E8
Average MergingDigest (ms): 107.78998414
Average MergingDigest / Average AVLTreeDigest (%): 11.424676425615287
Average AVLTreeDigest / Average MergingDigest (raw value): 8.752983128326491


#### Repeated Same Value Doubles

Average AVLTreeDigest (ns): 7.421614153E9
Average AVLTreeDigest (ms): 7421.614153
Average MergingDigest (ns): 2.755736346E7
Average MergingDigest (ms): 27.55736346
Average MergingDigest / Average AVLTreeDigest (%): 0.3713122629645282
Average AVLTreeDigest / Average MergingDigest (raw value): 269.315102069637521

Closes #19528