### PR TITLE
OSGI support for elasticsearch-rest-client

### DIFF
--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -23,6 +23,7 @@ apply plugin: 'elasticsearch.build'
 apply plugin: 'ru.vyarus.animalsniffer'
 apply plugin: 'nebula.maven-base-publish'
 apply plugin: 'nebula.maven-scm'
+apply plugin: 'osgi'
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7


### PR DESCRIPTION
Adding OSGI support to elasticsearch-rest-client jar file (issue #28707).

It's using the defaults, which is fine.  Might want to consider modifying `Bundle-SymbolicName` in `MANIFEST.MF` to match whatever Java module name you end up using for this.