### PR TITLE
Remove leftover mention of file-based scripts

### DIFF
--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -258,11 +258,6 @@ directory so that you do not delete important data later on.
  d| Not configured
   | path.repo
 
-| script
-  | Location of script files.
-  | %ES_HOME%\scripts
-  | path.scripts
-
 |=======================================================================
 
 include::next-steps.asciidoc[]


### PR DESCRIPTION
This commit removes a leftover mention of file-based scripts from the Windows docs.

Relates #24627
