### PR TITLE
[docs] Replace `tweet` type with `_doc` to reflect the code snippets

### DIFF
--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -72,7 +72,7 @@ If you'd like to count version conflicts rather than cause them to abort then
 set `conflicts=proceed` on the url or `"conflicts": "proceed"` in the request body.
 
 Back to the API format, you can limit `_delete_by_query` to a single type. This
-will only delete `tweet` documents from the `twitter` index:
+will only delete `_doc` documents from the `twitter` index:
 
 [source,js]
 --------------------------------------------------
@@ -91,7 +91,7 @@ types at once, just like the search API:
 
 [source,js]
 --------------------------------------------------
-POST twitter,blog/tweet,post/_delete_by_query
+POST twitter,blog/_docs,post/_delete_by_query
 {
   "query": {
     "match_all": {}

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -71,8 +71,7 @@ these documents. In case a search or bulk request got rejected, `_delete_by_quer
 If you'd like to count version conflicts rather than cause them to abort then
 set `conflicts=proceed` on the url or `"conflicts": "proceed"` in the request body.
 
-Back to the API format, you can limit `_delete_by_query` to a single type. This
-will only delete `_doc` documents from the `twitter` index:
+Back to the API format, this will delete tweets from the `twitter` index:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -74,7 +74,7 @@ DELETE /twitter/_doc/1?routing=kimchy
 // CONSOLE
 // TEST[continued]
 
-The above will delete a `_doc` with id `1`, but will be routed based on the
+The above will delete a tweet with id `1`, but will be routed based on the
 user. Note, issuing a delete without the correct routing, will cause the
 document to not be deleted.
 

--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -3,8 +3,7 @@
 
 The delete API allows to delete a typed JSON document from a specific
 index based on its id. The following example deletes the JSON document
-from an index called twitter, under a type called tweet, with id valued
-1:
+from an index called `twitter`, under a type called `_doc`, with id `1`:
 
 [source,js]
 --------------------------------------------------
@@ -75,7 +74,7 @@ DELETE /twitter/_doc/1?routing=kimchy
 // CONSOLE
 // TEST[continued]
 
-The above will delete a tweet with id 1, but will be routed based on the
+The above will delete a `_doc` with id `1`, but will be routed based on the
 user. Note, issuing a delete without the correct routing, will cause the
 document to not be deleted.
 

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -261,7 +261,7 @@ GET twitter/_doc/2?routing=user1
 // CONSOLE
 // TEST[continued]
 
-The above will get a `_doc` with id `2`, but will be routed based on the
+The above will get a tweet with id `2`, but will be routed based on the
 user. Note, issuing a get without the correct routing, will cause the
 document not to be fetched.
 

--- a/docs/reference/docs/get.asciidoc
+++ b/docs/reference/docs/get.asciidoc
@@ -261,7 +261,7 @@ GET twitter/_doc/2?routing=user1
 // CONSOLE
 // TEST[continued]
 
-The above will get a tweet with id 2, but will be routed based on the
+The above will get a `_doc` with id `2`, but will be routed based on the
 user. Note, issuing a get without the correct routing, will cause the
 document not to be fetched.
 

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -160,9 +160,9 @@ POST _reindex
 // TEST[setup:twitter]
 
 `index` and `type` in `source` can both be lists, allowing you to copy from
-lots of sources in one request. This will copy documents from the `tweet` and
+lots of sources in one request. This will copy documents from the `_doc` and
 `post` types in the `twitter` and `blog` index. It'd include the `post` type in
-the `twitter` index and the `tweet` type in the `blog` index. If you want to be
+the `twitter` index and the `_doc` type in the `blog` index. If you want to be
 more specific you'll need to use the `query`. It also makes no effort to handle
 ID collisions. The target index will remain valid but it's not easy to predict
 which document will survive because the iteration order isn't well defined.

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -64,7 +64,7 @@ and the time when it attempted to update the document. This is fine because
 that update will have picked up the online mapping update.
 
 Back to the API format, you can limit `_update_by_query` to a single type. This
-will only update `tweet` documents from the `twitter` index:
+will only update `_doc` documents from the `twitter` index:
 
 [source,js]
 --------------------------------------------------
@@ -99,7 +99,7 @@ So far we've only been updating documents without changing their source. That
 is genuinely useful for things like
 <<picking-up-a-new-property,picking up new properties>> but it's only half the
 fun. `_update_by_query` <<modules-scripting-using,supports scripts>> to update
-the document. This will increment the `likes` field on all of kimchy's tweets:
+the document. This will increment the `likes` field on all of kimchy's _docs:
 
 [source,js]
 --------------------------------------------------
@@ -151,7 +151,7 @@ types at once, just like the search API:
 
 [source,js]
 --------------------------------------------------
-POST twitter,blog/tweet,post/_update_by_query
+POST twitter,blog/_doc,post/_update_by_query
 --------------------------------------------------
 // CONSOLE
 // TEST[s/^/PUT twitter\nPUT blog\n/]

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -63,8 +63,7 @@ conflicting document was updated between the start of the `_update_by_query`
 and the time when it attempted to update the document. This is fine because
 that update will have picked up the online mapping update.
 
-Back to the API format, you can limit `_update_by_query` to a single type. This
-will only update `_doc` documents from the `twitter` index:
+Back to the API format, this will update tweets from the `twitter` index:
 
 [source,js]
 --------------------------------------------------
@@ -99,7 +98,7 @@ So far we've only been updating documents without changing their source. That
 is genuinely useful for things like
 <<picking-up-a-new-property,picking up new properties>> but it's only half the
 fun. `_update_by_query` <<modules-scripting-using,supports scripts>> to update
-the document. This will increment the `likes` field on all of kimchy's _docs:
+the document. This will increment the `likes` field on all of kimchy's tweets:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/search/count.asciidoc
+++ b/docs/reference/search/count.asciidoc
@@ -30,7 +30,7 @@ NOTE: The query being sent in the body must be nested in a `query` key, same as
 the <<search-search,search api>> works
 
 Both examples above do the same thing, which is count the number of
-tweets from the twitter index for a certain user. The result is:
+_docs from the twitter index for a certain user. The result is:
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/search/count.asciidoc
+++ b/docs/reference/search/count.asciidoc
@@ -30,7 +30,7 @@ NOTE: The query being sent in the body must be nested in a `query` key, same as
 the <<search-search,search api>> works
 
 Both examples above do the same thing, which is count the number of
-_docs from the twitter index for a certain user. The result is:
+tweets from the `twitter` index for a certain user. The result is:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Relates to #27751

Indices support only a single type and as per #27816 the docs should use `_doc` as type.
