### PR TITLE
Fix AdaptiveSelectionStats serialization bug

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -95,11 +95,6 @@ public class SearchTransportService extends AbstractComponent {
         this.responseWrapper = responseWrapper;
     }
 
-    public Map<String, Long> getClientConnections() {
-        // create a (weakly consistent) snapshot of the map so that it does not get modified when serializing it for stats reporting
-        return Collections.unmodifiableMap(new HashMap<>(clientConnections));
-    }
-
     public void sendFreeContext(Transport.Connection connection, final long contextId, OriginalIndices originalIndices) {
         transportService.sendRequest(connection, FREE_CONTEXT_ACTION_NAME, new SearchFreeContextRequest(originalIndices, contextId),
             TransportRequestOptions.EMPTY, new ActionListenerResponseHandler<>(new ActionListener<SearchFreeContextResponse>() {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -96,7 +96,8 @@ public class SearchTransportService extends AbstractComponent {
     }
 
     public Map<String, Long> getClientConnections() {
-        return Collections.unmodifiableMap(clientConnections);
+        // create a (weakly consistent) snapshot of the map so that it does not get modified when serializing it for stats reporting
+        return Collections.unmodifiableMap(new HashMap<>(clientConnections));
     }
 
     public void sendFreeContext(Transport.Connection connection, final long contextId, OriginalIndices originalIndices) {

--- a/server/src/main/java/org/elasticsearch/node/NodeService.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeService.java
@@ -121,7 +121,7 @@ public class NodeService extends AbstractComponent implements Closeable {
                 script ? scriptService.stats() : null,
                 discoveryStats ? discovery.stats() : null,
                 ingest ? ingestService.getPipelineExecutionService().stats() : null,
-                adaptiveSelection ? responseCollectorService.getAdaptiveStats(searchTransportService.getClientConnections()) : null
+                adaptiveSelection ? responseCollectorService.getAdaptiveStats(searchTransportService.getPendingSearchRequests()) : null
         );
     }
 


### PR DESCRIPTION
The `AdaptiveSelectionStats` object serializes the `clientOutgoingConnections` map that's concurrently updated in `SearchTransportService`. Serializing the map consists of first writing the size of the map and then serializing the entries. If the number of entries changes while the map is being serialized, the size and number of entries go out of sync. The deserialization routine expects those to be in sync though.

Closes #28713