### PR TITLE
Enable selecting adaptive selection stats

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -396,8 +396,8 @@ The `adaptive_selection` flag can be set to retrieve statistics that concern
 keyed by node. For each node:
 
 `adaptive_selection.outgoing_searches`::
-  The number of outstanding search requests from the node these starts are for
-  to the keyed node.
+  The number of outstanding search requests from the node these stats are for to
+  the keyed node.
 
 `avg_queue_size`::
   The exponentially weighted moving average queue size of search requests on the

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -66,7 +66,7 @@ of `indices`, `os`, `process`, `jvm`, `transport`, `http`,
 
 `adaptive_selection`::
   Statistics about <<search-adaptive-replica,adaptive replica selection>>. See
-  <<adaptive-selection-stats adaptive selection statistis>>.
+  <<adaptive-selection-stats,adaptive selection statistics>>.
 
 [source,js]
 --------------------------------------------------

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -65,7 +65,8 @@ of `indices`, `os`, `process`, `jvm`, `transport`, `http`,
   Statistics about ingest preprocessing
 
 `adaptive_selection`::
-  Statistics about <<search-adaptive-replica,adaptive replica selection>>
+  Statistics about <<search-adaptive-replica,adaptive replica selection>>. See
+  <<adaptive-selection-stats adaptive selection statistis>>.
 
 [source,js]
 --------------------------------------------------
@@ -373,15 +374,43 @@ GET /_nodes/stats/indices?groups=foo,bar
 The `ingest` flag can be set to retrieve statistics that concern ingest:
 
 `ingest.total.count`::
-    The total number of document ingested during the lifetime of this node
+  The total number of document ingested during the lifetime of this node
 
 `ingest.total.time_in_millis`::
-    The total time spent on ingest preprocessing documents during the lifetime of this node
+  The total time spent on ingest preprocessing documents during the lifetime of this node
 
 `ingest.total.current`::
-    The total number of documents currently being ingested.
+  The total number of documents currently being ingested.
 
 `ingest.total.failed`::
-    The total number ingest preprocessing operations failed during the lifetime of this node
+  The total number ingest preprocessing operations failed during the lifetime of this node
 
 On top of these overall ingest statistics, these statistics are also provided on a per pipeline basis.
+
+[float]
+[[adaptive-selection-stats]]
+=== Adaptive selection statistics
+
+The `adaptive_selection` flag can be set to retrieve statistics that concern
+<<search-adaptive-replica,adaptive replica selection>>. These statistics are
+keyed by node. For each node:
+
+`adaptive_selection.outgoing_searches`::
+  The number of outstanding search requests from the node these starts are for
+  to the keyed node.
+
+`avg_queue_size`::
+  The exponentially weighted moving average queue size of search requests on the
+  keyed node.
+
+`avg_service_time_ns`::
+  The exponentially weighted moving average service time of search requests on
+  the keyed node.
+
+`avg_response_time_ns`::
+  The exponentially weighted moving average response time of search requests on
+  the keyed node.
+
+`rank`::
+  The rank of this node; used for shard selection when routing search requests.
+

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -62,7 +62,10 @@ of `indices`, `os`, `process`, `jvm`, `transport`, `http`,
   Statistics about the discovery
 
 `ingest`::
-    Statistics about ingest preprocessing
+  Statistics about ingest preprocessing
+
+`adaptive_selection`::
+  Statistics about <<search-adaptive-replica,adaptive replica selection>>
 
 [source,js]
 --------------------------------------------------

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
@@ -138,8 +138,14 @@ public class NodesStatsRequestBuilder extends NodesOperationRequestBuilder<Nodes
     /**
      * Should ingest statistics be returned.
      */
-    public NodesStatsRequestBuilder ingest(boolean ingest) {
+    public NodesStatsRequestBuilder setIngest(boolean ingest) {
         request.ingest(ingest);
         return this;
     }
+
+    public NodesStatsRequestBuilder setAdaptiveSelection(boolean adaptiveSelection) {
+        request.adaptiveSelection(adaptiveSelection);
+        return this;
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -71,6 +71,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
         metrics.put("script", r -> r.script(true));
         metrics.put("discovery", r -> r.discovery(true));
         metrics.put("ingest", r -> r.ingest(true));
+        metrics.put("adaptive_selection", r -> r.adaptiveSelection(true));
         METRICS = Collections.unmodifiableMap(metrics);
     }
 


### PR DESCRIPTION
The node stats API enables filtlering the top-level stats for only desired top-level stats. Yet, this was never enabled for adaptive replica selection stats. This commit enables this. We also add setting these stats on the request builder, and fix an inconsistent name in a setter.

