### PR TITLE
 Fix threading issue on listener notification

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketSelector.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketSelector.java
@@ -108,7 +108,7 @@ public class SocketSelector extends ESSelector {
         if (isOpen() == false) {
             boolean wasRemoved = queuedWrites.remove(writeOperation);
             if (wasRemoved) {
-                executeFailedListener(writeOperation.getListener(), new ClosedSelectorException());
+                writeOperation.getListener().accept(null, new ClosedSelectorException());
             }
         } else {
             wakeup();

--- a/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketSelector.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/nio/SocketSelector.java
@@ -108,7 +108,7 @@ public class SocketSelector extends ESSelector {
         if (isOpen() == false) {
             boolean wasRemoved = queuedWrites.remove(writeOperation);
             if (wasRemoved) {
-                writeOperation.getListener().accept(null, new ClosedSelectorException());
+                writeOperation.getListener().onFailure(new ClosedSelectorException());
             }
         } else {
             wakeup();


### PR DESCRIPTION
This is a fix for #28729. Currently if a write operation is not properly
queued with a selector we notify the listener. However, we are doing
this by calling a method that is only meant for the selector thread to
call. This commit fixes that issue.