### PR TITLE
Remove leftover doc comment on client JVM check

### DIFF
--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -166,8 +166,7 @@ the two VMs can be substantial. The client JVM check ensures that
 Elasticsearch is not running inside the client JVM. To pass the client
 JVM check, you must start Elasticsearch with the server VM. On modern
 systems and operating systems, the server VM is the
-default. Additionally, Elasticsearch is configured by default to force
-the server VM.
+default.
 
 === Use serial collector check
 


### PR DESCRIPTION
We previously specified the -server flag to force the JVM to use the server JVM. This is the default on all the systems that we support when using a 64-bit JVM (and we no longer support 32-bit JVMs). There was some trouble with this flag for the Windows service since procrun did not understand what to do with it; as such, we had to filter this flag out in the service. When we migrated to parsing JVM options in Java (via the JVM options parser) we simplified this situation and removed specifying the -server flag. This commit removes a leftover statement that we are forcing the server JVM.

Relates #18155, #27675

FYI @elastic/es-core-infra.