### PR TITLE
Ensure that azure stream has socket privileges

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
@@ -62,4 +62,23 @@ public interface AzureStorageService {
 
     void writeBlob(String account, LocationMode mode, String container, String blobName, InputStream inputStream, long blobSize) throws
         URISyntaxException, StorageException;
+
+    static InputStream giveSocketPermissionsToStream(InputStream stream) {
+        return new InputStream() {
+            @Override
+            public int read() throws IOException {
+                return SocketAccess.doPrivilegedIOException(stream::read);
+            }
+
+            @Override
+            public int read(byte[] b) throws IOException {
+                return SocketAccess.doPrivilegedIOException(() -> stream.read(b));
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                return SocketAccess.doPrivilegedIOException(() -> stream.read(b, off, len));
+            }
+        };
+    }
 }

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageServiceImpl.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageServiceImpl.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.RepositoryException;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -258,22 +257,7 @@ public class AzureStorageServiceImpl extends AbstractComponent implements AzureS
         CloudBlockBlob blockBlobReference = client.getContainerReference(container).getBlockBlobReference(blob);
         BlobInputStream is = SocketAccess.doPrivilegedException(() ->
             blockBlobReference.openInputStream(null, null, generateOperationContext(account)));
-        return new InputStream() {
-            @Override
-            public int read() throws IOException {
-                return SocketAccess.doPrivilegedIOException(is::read);
-            }
-
-            @Override
-            public int read(byte[] b) throws IOException {
-                return SocketAccess.doPrivilegedIOException(() -> is.read(b));
-            }
-
-            @Override
-            public int read(byte[] b, int off, int len) throws IOException {
-                return SocketAccess.doPrivilegedIOException(() -> is.read(b, off, len));
-            }
-        };
+        return AzureStorageService.giveSocketPermissionsToStream(is);
     }
 
     @Override

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/SocketAccess.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/SocketAccess.java
@@ -39,6 +39,15 @@ public final class SocketAccess {
 
     private SocketAccess() {}
 
+    public static <T> T doPrivilegedIOException(PrivilegedExceptionAction<T> operation) throws IOException {
+        SpecialPermission.check();
+        try {
+            return AccessController.doPrivileged(operation);
+        } catch (PrivilegedActionException e) {
+            throw (IOException) e.getCause();
+        }
+    }
+
     public static <T> T doPrivilegedException(PrivilegedExceptionAction<T> operation) throws StorageException, URISyntaxException {
         SpecialPermission.check();
         try {


### PR DESCRIPTION
This is related to #28662. It wraps the azure repository inputstream in
an inputstream that ensures `read` calls have socket permissions. This
is because the azure inputstream internally makes service calls.