### PR TITLE
[DOCS] Use transient setting to reenabled allocation. Closes #27677

### DIFF
--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -94,12 +94,18 @@ reenable allocation.
 ------------------------------------------------------
 PUT _cluster/settings
 {
-  "persistent": {
+  "transient": {
     "cluster.routing.allocation.enable": "all"
   }
 }
 ------------------------------------------------------
 // CONSOLE
+
+NOTE: Because <<cluster-update-settings.html#_precedence_of_settings, transient
+settings take precedence over persistent settings>>, this overrides the
+persistent setting used to disable shard allocation in the first step. If you
+don't explicitly reenable shard allocation after a full cluster restart, the
+persistent setting is used and shard allocation remains disabled.
 
 Once allocation is reenabled, the cluster starts allocating replica shards to
 the data nodes. At this point it is safe to resume indexing and searching,

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -69,6 +69,12 @@ GET _cat/nodes
 +
 --
 
+NOTE: Because <<cluster-update-settings.html#_precedence_of_settings, transient
+settings take precedence over persistent settings>>, this overrides the
+persistent setting used to disable shard allocation in the first step. If you
+don't explicitly reenable shard allocation after a full cluster restart, the
+persistent setting is used and shard allocation remains disabled.
+
 Once the node has joined the cluster, reenable shard allocation to start using
 the node:
 


### PR DESCRIPTION
Modified the FCR reenable step to use transient per @pickypg and added a reminder about precedence and the need to explicitly reenable allocation after a FCR. 