### PR TITLE
Check consistency of sizes of collections in StreamOutput

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -459,13 +459,19 @@ public abstract class StreamOutput extends OutputStream {
         }
         assert false == (map instanceof LinkedHashMap);
         this.writeByte((byte) 10);
-        this.writeVInt(map.size());
+        final int size = map.size();
+        this.writeVInt(size);
         Iterator<? extends Map.Entry<String, ?>> iterator =
             map.entrySet().stream().sorted((a, b) -> a.getKey().compareTo(b.getKey())).iterator();
+        int count = 0;
         while (iterator.hasNext()) {
             Map.Entry<String, ?> next = iterator.next();
             this.writeString(next.getKey());
             this.writeGenericValue(next.getValue());
+            count++;
+        }
+        if (size != count) {
+            throw new IllegalStateException("Serialized size header does not match number of objects written.");
         }
     }
 
@@ -482,9 +488,15 @@ public abstract class StreamOutput extends OutputStream {
     public final <K, V> void writeMapOfLists(final Map<K, List<V>> map, final Writer<K> keyWriter, final Writer<V> valueWriter)
             throws IOException {
         writeMap(map, keyWriter, (stream, list) -> {
-            writeVInt(list.size());
+            final int size = list.size();
+            writeVInt(size);
+            int count = 0;
             for (final V value : list) {
                 valueWriter.write(this, value);
+                count++;
+            }
+            if (size != count) {
+                throw new IllegalStateException("Serialized size header does not match number of objects written.");
             }
         });
     }
@@ -501,10 +513,16 @@ public abstract class StreamOutput extends OutputStream {
      */
     public final <K, V> void writeMap(final Map<K, V> map, final Writer<K> keyWriter, final Writer<V> valueWriter)
         throws IOException {
-        writeVInt(map.size());
+        final int size = map.size();
+        writeVInt(size);
+        int count = 0;
         for (final Map.Entry<K, V> entry : map.entrySet()) {
             keyWriter.write(this, entry.getKey());
             valueWriter.write(this, entry.getValue());
+            count++;
+        }
+        if (size != count) {
+            throw new IllegalStateException("Serialized size header does not match number of objects written.");
         }
     }
 
@@ -545,9 +563,15 @@ public abstract class StreamOutput extends OutputStream {
         writers.put(List.class, (o, v) -> {
             o.writeByte((byte) 7);
             final List list = (List) v;
-            o.writeVInt(list.size());
+            final int size = list.size();
+            o.writeVInt(size);
+            int count = 0;
             for (Object item : list) {
                 o.writeGenericValue(item);
+                count++;
+            }
+            if (size != count) {
+                throw new IllegalStateException("Serialized size header does not match number of objects written.");
             }
         });
         writers.put(Object[].class, (o, v) -> {
@@ -566,10 +590,16 @@ public abstract class StreamOutput extends OutputStream {
             }
             @SuppressWarnings("unchecked")
             final Map<String, Object> map = (Map<String, Object>) v;
-            o.writeVInt(map.size());
+            final int size = map.size();
+            o.writeVInt(size);
+            int count = 0;
             for (Map.Entry<String, Object> entry : map.entrySet()) {
                 o.writeString(entry.getKey());
                 o.writeGenericValue(entry.getValue());
+                count++;
+            }
+            if (size != count) {
+                throw new IllegalStateException("Serialized size header does not match number of objects written.");
             }
         });
         writers.put(Byte.class, (o, v) -> {
@@ -926,9 +956,15 @@ public abstract class StreamOutput extends OutputStream {
      * Writes a list of {@link Streamable} objects
      */
     public void writeStreamableList(List<? extends Streamable> list) throws IOException {
-        writeVInt(list.size());
+        final int size = list.size();
+        writeVInt(size);
+        int count = 0;
         for (Streamable obj: list) {
             obj.writeTo(this);
+            count++;
+        }
+        if (size != count) {
+            throw new IllegalStateException("Serialized size header does not match number of objects written.");
         }
     }
 
@@ -936,9 +972,15 @@ public abstract class StreamOutput extends OutputStream {
      * Writes a list of {@link Writeable} objects
      */
     public void writeList(List<? extends Writeable> list) throws IOException {
-        writeVInt(list.size());
+        final int size = list.size();
+        writeVInt(size);
+        int count = 0;
         for (Writeable obj: list) {
             obj.writeTo(this);
+            count++;
+        }
+        if (size != count) {
+            throw new IllegalStateException("Serialized size header does not match number of objects written.");
         }
     }
 
@@ -946,9 +988,15 @@ public abstract class StreamOutput extends OutputStream {
      * Writes a list of strings
      */
     public void writeStringList(List<String> list) throws IOException {
-        writeVInt(list.size());
+        final int size = list.size();
+        writeVInt(size);
+        int count = 0;
         for (String string: list) {
             this.writeString(string);
+            count++;
+        }
+        if (size != count) {
+            throw new IllegalStateException("Serialized size header does not match number of objects written.");
         }
     }
 
@@ -956,9 +1004,15 @@ public abstract class StreamOutput extends OutputStream {
      * Writes a list of {@link NamedWriteable} objects.
      */
     public void writeNamedWriteableList(List<? extends NamedWriteable> list) throws IOException {
-        writeVInt(list.size());
+        final int size = list.size();
+        writeVInt(size);
+        int count = 0;
         for (NamedWriteable obj: list) {
             writeNamedWriteable(obj);
+            count++;
+        }
+        if (size != count) {
+            throw new IllegalStateException("Serialized size header does not match number of objects written.");
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.io.stream;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -33,7 +32,6 @@ import org.joda.time.DateTimeZone;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -811,5 +809,143 @@ public class BytesStreamsTests extends ESTestCase {
             assertEquals("Unknown TestEnum ordinal [" + randomNumber + "]", ex.getMessage());
         }
         assertEquals(0, input.available());
+    }
+
+    public void testWriteMapWithConsistentOrderSizeCheck() {
+        try (BytesStreamOutput output = new BytesStreamOutput(1)) {
+            Map<String,String> liesAboutItsSize = new HashMap<String,String>(){
+                @Override
+                public int size() {
+                    return 1;
+                }
+            };
+
+            final IllegalStateException illegalStateException
+                = expectThrows(IllegalStateException.class,
+                () -> output.writeMapWithConsistentOrder(liesAboutItsSize));
+            assertThat(illegalStateException.getMessage(), is("Serialized size header does not match number of objects written."));
+        }
+    }
+
+    public void testWriteMapOfListsSizeCheck() {
+        try (BytesStreamOutput output = new BytesStreamOutput(1)) {
+            Map<String,List<String>> liesAboutItsSize = new HashMap<String,List<String>>(){
+                @Override
+                public int size() {
+                    return 1;
+                }
+            };
+
+            final IllegalStateException illegalStateException
+                = expectThrows(IllegalStateException.class,
+                () -> output.writeMapOfLists(liesAboutItsSize, StreamOutput::writeString, StreamOutput::writeString));
+            assertThat(illegalStateException.getMessage(), is("Serialized size header does not match number of objects written."));
+        }
+    }
+
+    public void testWriteMapSizeCheck() {
+        try (BytesStreamOutput output = new BytesStreamOutput(1)) {
+            Map<String,String> liesAboutItsSize = new HashMap<String,String>(){
+                @Override
+                public int size() {
+                    return 1;
+                }
+            };
+
+            final IllegalStateException illegalStateException
+                = expectThrows(IllegalStateException.class,
+                () -> output.writeMap(liesAboutItsSize, StreamOutput::writeString, StreamOutput::writeString));
+            assertThat(illegalStateException.getMessage(), is("Serialized size header does not match number of objects written."));
+        }
+    }
+
+    public void testWriteGenericValueListSizeCheck() {
+        try (BytesStreamOutput output = new BytesStreamOutput(1)) {
+            List<String> liesAboutItsSize = new ArrayList<String>() {
+                @Override
+                public int size() {
+                    return 1;
+                }
+            };
+
+            final IllegalStateException illegalStateException
+                = expectThrows(IllegalStateException.class, () -> output.writeGenericValue(liesAboutItsSize));
+            assertThat(illegalStateException.getMessage(), is("Serialized size header does not match number of objects written."));
+        }
+    }
+
+    public void testWriteGenericValueMapSizeCheck() {
+        try (BytesStreamOutput output = new BytesStreamOutput(1)) {
+            Map<String,String> liesAboutItsSize = new HashMap<String,String>(){
+                @Override
+                public int size() {
+                    return 1;
+                }
+            };
+
+            final IllegalStateException illegalStateException
+                = expectThrows(IllegalStateException.class, () -> output.writeGenericValue(liesAboutItsSize));
+            assertThat(illegalStateException.getMessage(), is("Serialized size header does not match number of objects written."));
+        }
+    }
+
+    public void testWriteStreamableListSizeCheck() {
+        try (BytesStreamOutput output = new BytesStreamOutput(1)) {
+            List<Streamable> liesAboutItsSize = new ArrayList<Streamable>() {
+                @Override
+                public int size() {
+                    return 1;
+                }
+            };
+
+            final IllegalStateException illegalStateException
+                = expectThrows(IllegalStateException.class, () -> output.writeStreamableList(liesAboutItsSize));
+            assertThat(illegalStateException.getMessage(), is("Serialized size header does not match number of objects written."));
+        }
+    }
+
+    public void testWriteListSizeCheck() {
+        try (BytesStreamOutput output = new BytesStreamOutput(1)) {
+            List<Writeable> liesAboutItsSize = new ArrayList<Writeable>() {
+                @Override
+                public int size() {
+                    return 1;
+                }
+            };
+
+            final IllegalStateException illegalStateException
+                = expectThrows(IllegalStateException.class, () -> output.writeList(liesAboutItsSize));
+            assertThat(illegalStateException.getMessage(), is("Serialized size header does not match number of objects written."));
+        }
+    }
+
+    public void testWriteStringListSizeCheck() {
+        try (BytesStreamOutput output = new BytesStreamOutput(1)) {
+            List<String> liesAboutItsSize = new ArrayList<String>() {
+                @Override
+                public int size() {
+                    return 1;
+                }
+            };
+
+            final IllegalStateException illegalStateException
+                = expectThrows(IllegalStateException.class, () -> output.writeStringList(liesAboutItsSize));
+            assertThat(illegalStateException.getMessage(), is("Serialized size header does not match number of objects written."));
+        }
+    }
+
+    public void testWriteNamedWriteableListSizeCheck() {
+        try (BytesStreamOutput output = new BytesStreamOutput(1)) {
+            List<NamedWriteable> liesAboutItsSize = new ArrayList<NamedWriteable>() {
+                @Override
+                public int size() {
+                    return 1;
+                }
+            };
+
+            final IllegalStateException illegalStateException
+                = expectThrows(IllegalStateException.class, () -> output.writeNamedWriteableList(liesAboutItsSize));
+            assertThat(illegalStateException.getMessage(), is("Serialized size header does not match number of objects written."));
+        }
     }
 }


### PR DESCRIPTION
Today, we serialize collections prefixed by their lengths. If the serialized
length is inconsistent with the number of objects in the collection then the
serialization succeeds but any subsequent deserialization will (almost
certainly) fail, reporting something unexpected at some later point in the
stream. This can happen, for instance, because of a concurrent modification
(e.g. #28718) to the collection in between getting its length and iterating through
its objects.

This is a royal pain to debug, because the failure is reported a long way from
where it actually occurs. See also e.g. #25323.

This change adds checks to StreamOutput to verify that it wrote as many objects
as it said it would, in order to catch any similar problems in future closer to
their sources.
