### PR TITLE
Fix NPE when using deprecated Azure settings

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
@@ -175,9 +175,13 @@ public class AzureStorageServiceImpl extends AbstractComponent implements AzureS
         return client;
     }
 
-    private OperationContext generateOperationContext(String clientName) {
+    // Package private for testing in 6.x only: not needed anymore after
+    OperationContext generateOperationContext(String clientName) {
         OperationContext context = new OperationContext();
         AzureStorageSettings azureStorageSettings = this.storageSettings.get(clientName);
+        if (azureStorageSettings == null) {
+            azureStorageSettings = deprecatedStorageSettings.get(clientName);
+        }
 
         if (azureStorageSettings.getProxy() != null) {
             context.setProxy(azureStorageSettings.getProxy());

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTests.java
@@ -390,7 +390,7 @@ public class AzureStorageServiceTests extends ESTestCase {
     }
 
     @Deprecated
-    public void testGetSelectedClientDefault() {
+    public void testGenerateOperationContext() {
         AzureStorageServiceImpl azureStorageService = new AzureStorageServiceMock(deprecatedSettings);
         // This was producing a NPE when calling any operation with deprecated settings.
         // See https://github.com/elastic/elasticsearch/issues/28299

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTests.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTests.java
@@ -392,8 +392,9 @@ public class AzureStorageServiceTests extends ESTestCase {
     @Deprecated
     public void testGetSelectedClientDefault() {
         AzureStorageServiceImpl azureStorageService = new AzureStorageServiceMock(deprecatedSettings);
-        CloudBlobClient client = azureStorageService.getSelectedClient("default", LocationMode.PRIMARY_ONLY);
-        assertThat(client.getEndpoint(), is(URI.create("https://azure1")));
+        // This was producing a NPE when calling any operation with deprecated settings.
+        // See https://github.com/elastic/elasticsearch/issues/28299
+        azureStorageService.generateOperationContext("default");
         assertDeprecatedWarnings();
     }
 


### PR DESCRIPTION
When someone migrates from 5.6 to 6.x with deprecated settings like:

```
cloud:
    azure:
        storage:
            foo:
                account: <my_account>
                key: <my_key>
```

It produces a NPE anytime someone wants to use a repository which name is not `default`.

This has been introduced by #23518 when I backported it to 6.x branch.
In this case, when we generate an OperationContext, we only try to get azure settings from "normal" `storageSettings` with:

```java
this.storageSettings.get(clientName)
```

But in the context of deprecated settings, this returns `null` which causes the NPE just after.

This commit adds a check and if no settings are found in the "normal" `storageSettings`, we look at settings from `deprecatedStorageSettings`.
The reason I missed it in the 7.0 version (master branch) is because actually `deprecatedStorageSettings` has been removed there already.

Also I modified the `testGetSelectedClientDefault` method which was only doing exactly the same thing as `testGetDefaultClientWithPrimaryAndSecondaries`.

Closes #28299.