### PR TITLE
[documentation fix]: Creating a document requires a POST not a PUT

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -380,7 +380,7 @@ Let's now put something into our customer index. We'll index a simple customer d
 
 [source,js]
 --------------------------------------------------
-PUT /customer/_doc/1?pretty
+POST /customer/_doc/1?pretty
 {
   "name": "John Doe"
 }


### PR DESCRIPTION
Following the example of creating a customer I got the following error:
```
{
    "error": "Incorrect HTTP method for uri [/_doc/1?pretty] and method [PUT], allowed: [POST]",
    "status": 405
}
```