### PR TITLE
Backport PR 26985, upgrading indices with a custom similarity plugin

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexUpgradeService.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.similarity.SimilarityService;
+import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.plugins.Plugin;
 
@@ -42,6 +43,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
 /**
@@ -137,19 +139,42 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
      */
     private void checkMappingsCompatibility(IndexMetaData indexMetaData) {
         try {
-            // We cannot instantiate real analysis server at this point because the node might not have
-            // been started yet. However, we don't really need real analyzers at this stage - so we can fake it
+
+            // We cannot instantiate real analysis server or similiarity service at this point because the node
+            // might not have been started yet. However, we don't really need real analyzers or similarities at
+            // this stage - so we can fake it using constant maps accepting every key.
+            // This is ok because all used similarities and analyzers for this index were known before the upgrade.
+            // Missing analyzers and similarities plugin will still trigger the apropriate error during the
+            // actual upgrade.
+
             IndexSettings indexSettings = new IndexSettings(indexMetaData, this.settings);
-            SimilarityService similarityService = new SimilarityService(indexSettings, Collections.emptyMap());
+            final Map<String, BiFunction<String, Settings, SimilarityProvider>> similarityMap = new AbstractMap<String, BiFunction<String, Settings, SimilarityProvider>>() {
+                @Override
+                public boolean containsKey(Object key) {
+                    return true;
+                }
+
+                @Override
+                public BiFunction<String, Settings, SimilarityProvider> get(Object key) {
+                    assert key instanceof String : "key must be a string but was: " + key.getClass();
+                    return SimilarityService.BUILT_IN.get(SimilarityService.DEFAULT_SIMILARITY);
+                }
+
+                // this entrySet impl isn't fully correct but necessary as SimilarityService will iterate
+                // over all similarities
+                @Override
+                public Set<Entry<String, BiFunction<String, Settings, SimilarityProvider>>> entrySet() {
+                    return Collections.emptySet();
+                }
+            };
+            SimilarityService similarityService = new SimilarityService(indexSettings, similarityMap);
             final NamedAnalyzer fakeDefault = new NamedAnalyzer("fake_default", AnalyzerScope.INDEX, new Analyzer() {
                 @Override
                 protected TokenStreamComponents createComponents(String fieldName) {
                     throw new UnsupportedOperationException("shouldn't be here");
                 }
             });
-            // this is just a fake map that always returns the same value for any possible string key
-            // also the entrySet impl isn't fully correct but we implement it since internally
-            // IndexAnalyzers will iterate over all analyzers to close them.
+
             final Map<String, NamedAnalyzer> analyzerMap = new AbstractMap<String, NamedAnalyzer>() {
                 @Override
                 public NamedAnalyzer get(Object key) {
@@ -157,6 +182,8 @@ public class MetaDataIndexUpgradeService extends AbstractComponent {
                     return new NamedAnalyzer((String)key, AnalyzerScope.INDEX, fakeDefault.analyzer());
                 }
 
+                // this entrySet impl isn't fully correct but necessary as IndexAnalyzers will iterate
+                // over all analyzers to close them
                 @Override
                 public Set<Entry<String, NamedAnalyzer>> entrySet() {
                     return Collections.emptySet();


### PR DESCRIPTION
This is a straightforward port of #26985 to the 5.6 branch. Quoting the original:

> Fix upgrading indices which use a custom similarity plugin.
> Use a fake similarity map that always returns a value in MetaDataIndexUpgradeService.checkMappingsCompatibility instead of an empty map.
