### PR TITLE
Clarifies how the query_string splits textual part to build a query

### DIFF
--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -35,11 +35,11 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
-... will be splitted in `new york city` and `big apple` and each part is then
+... will be split into `new york city` and `big apple` and each part is then
 analyzed independently by the analyzer configured for the field.
 
-WARNING: Whitespaces are not considered as operators, this means that `new york city`
-will be pass "as is" to the analyzer configured for the field. If the field is a `keyword`
+WARNING: Whitespaces are not considered operators, this means that `new york city`
+will be passed "as is" to the analyzer configured for the field. If the field is a `keyword`
 field the analyzer will create a single term `new york city` and the query builder will
 use this term in the query. If you want to query each term separately you need to add explicit
 operators around the terms (e.g. `new AND york AND city`).

--- a/docs/reference/query-dsl/query-string-query.asciidoc
+++ b/docs/reference/query-dsl/query-string-query.asciidoc
@@ -28,14 +28,22 @@ GET /_search
     "query": {
         "query_string" : {
             "default_field" : "content",
-            "query" : "field:new york AND city"
+            "query" : "(new york city) OR (big apple)"
         }
     }
 }
 --------------------------------------------------
 // CONSOLE
 
-... will be splitted in `new`, `york` and `city` and each part is analyzed independently.
+... will be splitted in `new york city` and `big apple` and each part is then
+analyzed independently by the analyzer configured for the field.
+
+WARNING: Whitespaces are not considered as operators, this means that `new york city`
+will be pass "as is" to the analyzer configured for the field. If the field is a `keyword`
+field the analyzer will create a single term `new york city` and the query builder will
+use this term in the query. If you want to query each term separately you need to add explicit
+operators around the terms (e.g. `new AND york AND city`).
+
 When multiple fields are provided it is also possible to modify how the different
 field queries are combined inside each textual part using the `type` parameter.
 The possible modes are described <<multi-match-types, here>> and the default is `best_fields`.


### PR DESCRIPTION
Whitespaces are not considered as operators anymore in 6x but the documentation is not clear about it.
This commit changes the example in the documentation and adds a note regarding whitespaces and operators.

Closes #28719