### PR TITLE
Test: Remove specifying zip distribution in qa tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -66,6 +66,7 @@ public class PluginBuildPlugin extends BuildPlugin {
             }
 
             project.integTestCluster.dependsOn(project.bundlePlugin)
+            project.integTestCluster.distribution = 'integ-test-zip'
             project.tasks.run.dependsOn(project.bundlePlugin)
             if (isModule) {
                 project.integTestCluster.module(project)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -66,7 +66,6 @@ public class PluginBuildPlugin extends BuildPlugin {
             }
 
             project.integTestCluster.dependsOn(project.bundlePlugin)
-            project.integTestCluster.distribution = 'integ-test-zip'
             project.tasks.run.dependsOn(project.bundlePlugin)
             if (isModule) {
                 project.integTestCluster.module(project)
@@ -107,6 +106,7 @@ public class PluginBuildPlugin extends BuildPlugin {
     private static void createIntegTestTask(Project project) {
         RestIntegTestTask integTest = project.tasks.create('integTest', RestIntegTestTask.class)
         integTest.mustRunAfter(project.precommit, project.test)
+        project.integTestCluster.distribution = 'integ-test-zip'
         project.check.dependsOn(integTest)
     }
 

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/ClusterConfiguration.groovy
@@ -28,7 +28,7 @@ class ClusterConfiguration {
     private final Project project
 
     @Input
-    String distribution = 'integ-test-zip'
+    String distribution = 'zip'
 
     @Input
     int numNodes = 1

--- a/qa/full-cluster-restart/build.gradle
+++ b/qa/full-cluster-restart/build.gradle
@@ -45,7 +45,6 @@ for (Version version : bwcVersions.indexCompatible) {
 
   Object extension = extensions.findByName("${baseName}#oldClusterTestCluster")
   configure(extensions.findByName("${baseName}#oldClusterTestCluster")) {
-    distribution = 'zip'
     bwcVersion = version
     numBwcNodes = 2
     numNodes = 2
@@ -71,7 +70,6 @@ for (Version version : bwcVersions.indexCompatible) {
     dependsOn oldClusterTest,
         "${baseName}#oldClusterTestCluster#node0.stop",
         "${baseName}#oldClusterTestCluster#node1.stop"
-    distribution = 'zip'
     clusterName = 'full-cluster-restart'
 
     // some tests rely on the translog not being flushed

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -41,7 +41,6 @@ for (Version version : bwcVersions.wireCompatible) {
      the nodes has a different minor.  */
   Object extension = extensions.findByName("${baseName}#mixedClusterTestCluster")
   configure(extension) {
-    distribution = 'zip'
     numNodes = 4
     numBwcNodes = 2
     bwcVersion = version

--- a/qa/multi-cluster-search/build.gradle
+++ b/qa/multi-cluster-search/build.gradle
@@ -26,7 +26,6 @@ task remoteClusterTest(type: RestIntegTestTask) {
 }
 
 remoteClusterTestCluster {
-  distribution = 'zip'
   numNodes = 2
   clusterName = 'remote-cluster'
   setting 'search.remote.connect', false
@@ -40,7 +39,6 @@ task mixedClusterTest(type: RestIntegTestTask) {}
 
 mixedClusterTestCluster {
   dependsOn remoteClusterTestRunner
-  distribution = 'zip'
   setting 'search.remote.my_remote_cluster.seeds', "\"${-> remoteClusterTest.nodes.get(0).transportUri()}\""
   setting 'search.remote.connections_per_cluster', 1
   setting 'search.remote.connect', true

--- a/qa/query-builder-bwc/build.gradle
+++ b/qa/query-builder-bwc/build.gradle
@@ -42,7 +42,6 @@ for (Version version : bwcVersions.indexCompatible) {
     }
 
     configure(extensions.findByName("${baseName}#oldQueryBuilderTestCluster")) {
-        distribution = 'zip'
         bwcVersion = version
         numBwcNodes = 1
         numNodes = 1
@@ -57,7 +56,6 @@ for (Version version : bwcVersions.indexCompatible) {
     configure(extensions.findByName("${baseName}#upgradedQueryBuilderTestCluster")) {
         dependsOn oldQueryBuilderTest,
                 "${baseName}#oldQueryBuilderTestCluster#stop"
-        distribution = 'zip'
         clusterName = 'query_builder_bwc'
         numNodes = 1
         dataDir = { nodeNum -> oldQueryBuilderTest.nodes[nodeNum].dataDir }

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -38,7 +38,6 @@ for (Version version : bwcVersions.wireCompatible) {
 
   Object extension = extensions.findByName("${baseName}#oldClusterTestCluster")
   configure(extensions.findByName("${baseName}#oldClusterTestCluster")) {
-    distribution = 'zip'
     bwcVersion = version
     numBwcNodes = 2
     numNodes = 2
@@ -58,7 +57,6 @@ for (Version version : bwcVersions.wireCompatible) {
 
   configure(extensions.findByName("${baseName}#mixedClusterTestCluster")) {
     dependsOn oldClusterTestRunner, "${baseName}#oldClusterTestCluster#node1.stop"
-    distribution = 'zip'
     clusterName = 'rolling-upgrade'
     unicastTransportUri = { seedNode, node, ant -> oldClusterTest.nodes.get(0).transportUri() }
     minimumMasterNodes = { 2 }
@@ -78,7 +76,6 @@ for (Version version : bwcVersions.wireCompatible) {
 
   configure(extensions.findByName("${baseName}#upgradedClusterTestCluster")) {
     dependsOn mixedClusterTestRunner, "${baseName}#oldClusterTestCluster#node0.stop"
-    distribution = 'zip'
     clusterName = 'rolling-upgrade'
     unicastTransportUri = { seedNode, node, ant -> mixedClusterTest.nodes.get(0).transportUri() }
     minimumMasterNodes = { 2 }

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -37,7 +37,6 @@ for (Version version : bwcVersions.indexCompatible) {
         mustRunAfter(precommit)
     }
     configure(extensions.findByName("${baseName}#oldClusterTestCluster")) {
-        distribution = 'zip'
         bwcVersion = version
         numBwcNodes = 1
         numNodes = 1


### PR DESCRIPTION
Applying the rest test gradle plugin already uses the zip distribution
by default, so specifying it explicitly is not necessary. These are
leftovers from before zip was the default for rest tests.