### PR TITLE
Always destroy Vagrant boxes before tests

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -332,6 +332,7 @@ class VagrantTestPlugin implements Plugin<Project> {
                 commandLine "bash", "-c", "vagrant status ${box} | grep -q \"${box}\\s\\+not created\" || vagrant destroy ${box} --force"
             }
             destroy.onlyIf { vagrantDestroy }
+            update.mustRunAfter(destroy)
 
             Task up = project.tasks.create("vagrant${boxTask}#up", VagrantCommandTask) {
                 command 'up'

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -317,7 +317,7 @@ class VagrantTestPlugin implements Plugin<Project> {
              */
             final String vagrantDestroy = project.getProperties().get('vagrant.destroy', 'true')
             if ("true".equals(vagrantDestroy) == false && "false".equals(vagrantDestroy) == false) {
-                throw new GradleException("vagrant.destroy must be [true] or [false] but was [" + vagrantDestroy + "]")
+                throw new GradleException("[vagrant.destroy] must be [true] or [false] but was [" + vagrantDestroy + "]")
             }
             /*
              * Some versions of Vagrant will fail destroy if the box does not exist. Therefore, check if the box exists before destroying

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -326,7 +326,7 @@ class VagrantTestPlugin implements Plugin<Project> {
             }
             /*
              * Some versions of Vagrant will fail destroy if the box does not exist. Therefore we check if the box exists before attempting
-             * to destroy the box
+             * to destroy the box.
              */
             final Task destroy = project.tasks.create("vagrant${boxTask}#destroy", LoggedExec) {
                 commandLine "bash", "-c", "vagrant status ${box} | grep -q \"${box}\\s\\+not created\" || vagrant destroy ${box} --force"

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/vagrant/VagrantTestPlugin.groovy
@@ -329,9 +329,7 @@ class VagrantTestPlugin implements Plugin<Project> {
              * to destroy the box
              */
             final Task destroy = project.tasks.create("vagrant${boxTask}#destroy", LoggedExec) {
-                commandLine "bash",
-                        "-c",
-                        "vagrant status ${box} | grep -q \"${box}\\s\\+not created\" || vagrant destroy ${box} --force"
+                commandLine "bash", "-c", "vagrant status ${box} | grep -q \"${box}\\s\\+not created\" || vagrant destroy ${box} --force"
             }
             destroy.onlyIf { vagrantDestroy }
 


### PR DESCRIPTION
Today we do not destroy Vagrant boxes before tests. This is because constantly reprovisioning these boxes is time-consuming. Yet, not destroying these boxes can lead to state being left around that impacts subsequent test runs. To address this, we now always destroy these boxes before tests and provide a flag to set if this is not desired while iterating locally.

