### PR TITLE
[document] s/logarithm/common logarithm/

### DIFF
--- a/docs/reference/query-dsl/function-score-query.asciidoc
+++ b/docs/reference/query-dsl/function-score-query.asciidoc
@@ -302,9 +302,9 @@ There are a number of options for the `field_value_factor` function:
 | Modifier | Meaning
 
 | `none` | Do not apply any multiplier to the field value
-| `log` | Take the https://en.wikipedia.org/wiki/Logarithm[logarithm] of the field value
-| `log1p` | Add 1 to the field value and take the logarithm
-| `log2p` | Add 2 to the field value and take the logarithm
+| `log` | Take the https://en.wikipedia.org/wiki/Common_logarithm[common logarithm] of the field value
+| `log1p` | Add 1 to the field value and take the common logarithm
+| `log2p` | Add 2 to the field value and take the common logarithm
 | `ln` | Take the https://en.wikipedia.org/wiki/Natural_logarithm[natural logarithm] of the field value
 | `ln1p` | Add 1 to the field value and take the natural logarithm
 | `ln2p` | Add 2 to the field value and take the natural logarithm


### PR DESCRIPTION
This PR changes only documentation.

The logarithm which base is 10 is called "common logarithm". Otherwise, the base of "log" modifier is not clear.

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html