### PR TITLE
Fix a confusing log message at org.elasticsearch.bootstrap.Natives

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
@@ -70,7 +70,7 @@ final class Natives {
 
     static void tryVirtualLock() {
         if (!JNA_AVAILABLE) {
-            logger.warn("cannot mlockall because JNA is not available");
+            logger.warn("cannot virtual lock because JNA is not available");
             return;
         }
         JNANatives.tryVirtualLock();


### PR DESCRIPTION
At org.elasticsearch.bootstrap.Natives, there are two methods which have the same log message:

static void tryMlockall() {
if (!JNA_AVAILABLE) {
logger.warn("cannot mlockall because JNA is not available");
return;
}
JNANatives.tryMlockall();
}

static void tryVirtualLock() {
if (!JNA_AVAILABLE) {
logger.warn("cannot mlockall because JNA is not available");
return;
}
JNANatives.tryVirtualLock();
}

Seems like that the log message in tryVirtualLock() doesn't match with the method name.
Maybe just simply change the message to "cannot virtual lock because JNA is not available",


Closes #28828