### PR TITLE
Rest api specs : remove a common param from nodes.usage.json

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
@@ -22,11 +22,6 @@
         }
       },
       "params": {
-        "human": {
-            "type": "boolean",
-            "description": "Whether to return time and byte values in human-readable format.",
-            "default": false
-        },
         "timeout": {
           "type" : "time",
           "description" : "Explicit operation timeout"


### PR DESCRIPTION
"human" is a common parameter defined in [_common.json](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json#L10-L14)
It should not be repeated again for the concrete api spec

Fixes : #28226