### PR TITLE
Rest api specs : remove unsupported parameter `parent_node`

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -24,10 +24,6 @@
           "type": "boolean",
           "description": "Return detailed task information (default: false)"
         },
-        "parent_node": {
-          "type": "string",
-          "description": "Return tasks with specified parent node."
-        },
         "parent_task": {
           "type" : "number",
           "description" : "Return tasks with specified parent task id. Set to -1 to return all."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -20,10 +20,6 @@
           "type": "list",
           "description": "A comma-separated list of actions that should be cancelled. Leave empty to cancel all."
         },
-        "parent_node": {
-          "type": "string",
-          "description": "Cancel tasks with specified parent node."
-        },
         "parent_task_id": {
           "type" : "string",
           "description" : "Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -19,10 +19,6 @@
           "type": "boolean",
           "description": "Return detailed task information (default: false)"
         },
-        "parent_node": {
-          "type": "string",
-          "description": "Return tasks with specified parent node."
-        },
         "parent_task_id": {
           "type" : "string",
           "description" : "Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all."


### PR DESCRIPTION
The `parent_node` param is no longer supported by the tasks REST endpoints.

For more details : 
700b64f89cffef76c9189f0e32b40fc45d405fd5 combines node name and task id into a single string task id `nodeid:id`, 
removing `parent_node` param from [RestCancelTasksAction.java](https://github.com/elastic/elasticsearch/commit/700b64f89cffef76c9189f0e32b40fc45d405fd5#diff-1edc426e21b3789a3db742df2079935cL52) and [RestListTasksAction.java](https://github.com/elastic/elasticsearch/commit/700b64f89cffef76c9189f0e32b40fc45d405fd5#diff-187185980c1fe60a09e8b057a610cbd9L52)

81c59cae18c623fdaecf20866ef6d96c3facac1e `_cat/tasks` does not supported `parent_node` ( specified in the [cat.tasks.json](https://github.com/elastic/elasticsearch/commit/81c59cae18c623fdaecf20866ef6d96c3facac1e#diff-4060a4b8cfbce39b40c95ca616fb7c6cR27) but not in the [`RestTasksAction.java`](https://github.com/elastic/elasticsearch/commit/81c59cae18c623fdaecf20866ef6d96c3facac1e#diff-5d575d2c4031fc11c2d1da71584771b6) ) 