### PR TITLE
Fix percolator query analysis for function_score query

### DIFF
--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/QueryAnalyzer.java
@@ -465,12 +465,17 @@ final class QueryAnalyzer {
         return (query, version) -> {
             FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) query;
             Result result = analyze(functionScoreQuery.getSubQuery(), version);
+
             // If min_score is specified we can't guarantee upfront that this percolator query matches,
             // so in that case we set verified to false.
             // (if it matches with the percolator document matches with the extracted terms.
             // Min score filters out docs, which is different than the functions, which just influences the score.)
-            boolean verified = functionScoreQuery.getMinScore() == null;
-            return new Result(verified, result.extractions, result.minimumShouldMatch);
+            boolean verified = result.verified && functionScoreQuery.getMinScore() == null;
+            if (result.matchAllDocs) {
+                return new Result(result.matchAllDocs, verified);
+            } else {
+                return new Result(verified, result.extractions, result.minimumShouldMatch);
+            }
         };
     }
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryAnalyzerTests.java
@@ -811,6 +811,24 @@ public class QueryAnalyzerTests extends ESTestCase {
         assertTermsEqual(result.extractions, new Term("_field", "_value"));
     }
 
+    public void testFunctionScoreQuery_withMatchAll() {
+        MatchAllDocsQuery innerQuery = new MatchAllDocsQuery();
+        FunctionScoreQuery functionScoreQuery1 = new FunctionScoreQuery(innerQuery, new RandomScoreFunction(0, 0, null));
+        Result result = analyze(functionScoreQuery1, Version.CURRENT);
+        assertThat(result.verified, is(true));
+        assertThat(result.minimumShouldMatch, equalTo(0));
+        assertThat(result.matchAllDocs, is(true));
+        assertThat(result.extractions.isEmpty(), is(true));
+
+        FunctionScoreQuery functionScoreQuery2 =
+            new FunctionScoreQuery(innerQuery, new RandomScoreFunction(0, 0, null), CombineFunction.MULTIPLY, 1f, 10f);
+        result = analyze(functionScoreQuery2, Version.CURRENT);
+        assertThat(result.verified, is(false));
+        assertThat(result.minimumShouldMatch, equalTo(0));
+        assertThat(result.matchAllDocs, is(true));
+        assertThat(result.extractions.isEmpty(), is(true));
+    }
+
     public void testSelectBestExtraction() {
         Set<QueryExtraction> queryTerms1 = terms(new int[0], "12", "1234", "12345");
         Set<QueryAnalyzer.QueryExtraction> queryTerms2 = terms(new int[0], "123", "1234", "12345");


### PR DESCRIPTION
* The `verified` flag of the sub result was ignored.
* The `matchAllDocs` flag of the sub result was also ignored. 

Both issues could cause incorrect results.