### PR TITLE
Update outdated java version reference

### DIFF
--- a/buildSrc/src/main/resources/plugin-descriptor.properties
+++ b/buildSrc/src/main/resources/plugin-descriptor.properties
@@ -10,9 +10,9 @@
 #
 # classname=foo.bar.BazPlugin
 # description=My cool plugin
-# version=2.0
-# elasticsearch.version=2.0
-# java.version=1.7
+# version=6.0
+# elasticsearch.version=6.0
+# java.version=1.8
 #
 ### mandatory elements for all plugins:
 #


### PR DESCRIPTION
It is only a comment, but can confuse those reading the code.

Used 5.0 as an arbitrary elasticsearch.version value since it is first version that required Java 8.