### PR TITLE
[discovery-gce] Align code examples and documentation

### DIFF
--- a/docs/plugins/discovery-gce.asciidoc
+++ b/docs/plugins/discovery-gce.asciidoc
@@ -227,7 +227,7 @@ cloud:
       project_id: es-cloud
       zone: europe-west1-a
 discovery:
-      type: gce
+      zen.hosts_provider: gce
 --------------------------------------------------
 
 
@@ -341,7 +341,7 @@ cloud:
       project_id: <your-google-project-id>
       zone: ["<your-zone1>", "<your-zone2>"]
 discovery:
-      type: gce
+      zen.hosts_provider: gce
 --------------------------------------------------
 
 
@@ -377,7 +377,7 @@ cloud:
       project_id: es-cloud
       zone: europe-west1-a
 discovery:
-      type: gce
+      zen.hosts_provider: gce
       gce:
             tags: elasticsearch, dev
 --------------------------------------------------
@@ -492,7 +492,7 @@ cloud:
       project_id: es-cloud
       zone: europe-west1-a
 discovery:
-      type: gce
+      zen.hosts_provider: gce
 --------------------------------------------------
 
 Replaces `project_id` and `zone` with your settings.

--- a/docs/plugins/discovery-gce.asciidoc
+++ b/docs/plugins/discovery-gce.asciidoc
@@ -83,10 +83,10 @@ Examples:
 --------------------------------------------------
 # get the IP address from network interface 1
 network.host: _gce:privateIp:1_
-# shortcut for _gce:privateIp:0_
-network.host: _gce_
-# Using GCE internal hostname (recommended)
+# Using GCE internal hostname
 network.host: _gce:hostname_
+# shortcut for _gce:privateIp:0_ (recommended)
+network.host: _gce_
 --------------------------------------------------
 
 [[discovery-gce-usage-short]]


### PR DESCRIPTION
The docs state that `_gce_` is recommended but the code sample states
that `_gce:hostname_` is recommended. This aligns the code sample with
the documentation.

Documentation: https://www.elastic.co/guide/en/elasticsearch/plugins/6.2/discovery-gce-network-host.html
Introduced in: #13612

I also replaced the use of `discovery.type` in the code samples since this was removed in #25080.
