### PR TITLE
ctx.op = 'none' must be 'noop'?

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -102,7 +102,7 @@ the doc if the `tags` field contain `green`, otherwise it does nothing
 POST test/_doc/1/_update
 {
     "script" : {
-        "source": "if (ctx._source.tags.contains(params.tag)) { ctx.op = 'delete' } else { ctx.op = 'none' }",
+        "source": "if (ctx._source.tags.contains(params.tag)) { ctx.op = 'delete' } else { ctx.op = 'noop' }",
         "lang": "painless",
         "params" : {
             "tag" : "green"


### PR DESCRIPTION
Using the script from the documentation with ctx.op = 'none' created this error:

```
{
   "error":{
      "root_cause":[
         {
            "type":"illegal_argument_exception",
            "reason":"Operation type [none] not allowed, only [noop, index, delete] are allowed"
         }
      ],
      "type":"illegal_argument_exception",
      "reason":"Operation type [none] not allowed, only [noop, index, delete] are allowed"
   },
   "status":400
}
```

I think the value here must be 'noop' right? I am using elasticsearch version 5.5.
