### PR TITLE
Fix typo in composite aggregation

### DIFF
--- a/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/composite-aggregation.asciidoc
@@ -352,7 +352,7 @@ and in ascending order when comparing values from the `terms` source.
 
 The `size` parameter can be set to define how many composite buckets should be returned.
 Each composite bucket is considered as a single bucket so setting a size of 10 will return the
-first 1O composite buckets created from the values source.
+first 10 composite buckets created from the values source.
 The response contains the values for each composite bucket in an array containing the values extracted
 from each value source.
 


### PR DESCRIPTION
This PR fixes some typo in the docs about composite aggregation.

The current documentation actually had a `1O` (one, large-letter-O) instead of a proper `10` in there :-)