### PR TITLE
Fix incorrect datemath example

### DIFF
--- a/docs/reference/api-conventions.asciidoc
+++ b/docs/reference/api-conventions.asciidoc
@@ -220,7 +220,7 @@ Assuming `now` is `2001-01-01 12:00:00`, some examples are:
 `now+1h`:: `now` in milliseconds plus one hour. Resolves to: `2001-01-01 13:00:00`
 `now-1h`:: `now` in milliseconds minus one hour. Resolves to: `2001-01-01 11:00:00`
 `now-1h/d`:: `now` in milliseconds minus one hour, rounded down to UTC 00:00. Resolves to: `2001-01-01 00:00:00``
- `2001-01-01\|\|+1M/d`:: `now` in milliseconds plus one month. Resolves to: `2001-02-01 00:00:00`
+ `2001.02.01\|\|+1M/d`:: `2001-02-01` in milliseconds plus one month. Resolves to: `2001-03-01 00:00:00`
 
 [float]
 [[common-options-response-filtering]]


### PR DESCRIPTION
The original example resulted in a 400 error due to the example being `-` separated instead of the default `.` separation.
```
failed to parse date field [2001-01-01] with format [YYYY.MM.dd]
```
This could also be corrected by changing the original to have a format string of `{YYYY-MM-dd}`:
```
`'2001-01-01\|\|+1M/d{YYYY-MM-dd}'`:: `2001-01-01` in milliseconds plus one month. Resolves to: `2001-02-01 00:00:00`
```

Can change the PR to work either way.
