### PR TITLE
Add a usage example of the JLH score

### DIFF
--- a/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/significantterms-aggregation.asciidoc
@@ -327,6 +327,15 @@ However, the `size` and `shard size` settings covered in the next section provid
 ==== Parameters
 
 ===== JLH score
+The JLH score can be used as a significance score by adding the parameter
+
+[source,js]
+--------------------------------------------------
+
+	 "jlh": {
+	 }
+--------------------------------------------------
+// NOTCONSOLE
 
 The scores are derived from the doc frequencies in _foreground_ and _background_ sets. The _absolute_ change in popularity (foregroundPercent - backgroundPercent) would favor common terms whereas the _relative_ change in popularity (foregroundPercent/ backgroundPercent) would favor rare terms. Rare vs common is essentially a precision vs recall balance and so the absolute and relative changes are multiplied to provide a sweet spot between precision and recall.
 


### PR DESCRIPTION
Closes #28513

Adds a usage example of the JLH score used in significant terms aggregation.
All other methods to calculate significance score have such an example, but JLH did not. For consistency, this scoring method should have an example as well



