### PR TITLE
Send REST response for incorrectly encoded url params

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequestHandler.java
@@ -77,7 +77,11 @@ class Netty4HttpRequestHandler extends SimpleChannelInboundHandler<Object> {
                 new Netty4HttpChannel(serverTransport, httpRequest, pipelinedRequest, detailedErrorsEnabled, threadContext);
 
         if (request.decoderResult().isSuccess()) {
-            serverTransport.dispatchRequest(httpRequest, channel);
+            if (httpRequest.getException() != null) {
+                serverTransport.dispatchBadRequest(httpRequest, channel, httpRequest.getException());
+            } else {
+                serverTransport.dispatchRequest(httpRequest, channel);
+            }
         } else {
             assert request.decoderResult().isFailure();
             serverTransport.dispatchBadRequest(httpRequest, channel, request.decoderResult().cause());

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -63,6 +63,8 @@ public abstract class RestRequest implements ToXContent.Params {
     private final Set<String> consumedParams = new HashSet<>();
     private final SetOnce<XContentType> xContentType = new SetOnce<>();
 
+    private Exception exception;
+
     /**
      * Creates a new RestRequest
      * @param xContentRegistry the xContentRegistry to use when parsing XContent
@@ -78,7 +80,11 @@ public abstract class RestRequest implements ToXContent.Params {
             this.rawPath = uri;
         } else {
             this.rawPath = uri.substring(0, pathEndPos);
-            RestUtils.decodeQueryString(uri, pathEndPos + 1, params);
+            try {
+                RestUtils.decodeQueryString(uri, pathEndPos + 1, params);
+            } catch (Exception e) {
+                this.exception = e;
+            }
         }
         this.params = params;
         this.headers = Collections.unmodifiableMap(headers);
@@ -204,6 +210,10 @@ public abstract class RestRequest implements ToXContent.Params {
     @Nullable
     public SocketAddress getLocalAddress() {
         return null;
+    }
+
+    public Exception getException() {
+        return exception;
     }
 
     public final boolean hasParam(String key) {


### PR DESCRIPTION
Previously if the `path` contained incorrectly encoded sequence, an error was returned : 
```
curl -XGET http://localhost:9200/index%?pretty
```
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "unterminated escape sequence at end of string: index%"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "unterminated escape sequence at end of string: index%"
  },
  "status" : 400
}
```
But if the incorrect sequence was part of the `parameters`, **no** response was returned.
```
curl -XGET http://localhost:9200/index?pretty%
```
```
curl: (52) Empty reply from server
```
This PR analyze the `parameters` and returns an error when there is a wrong encoding sequence in the url params ( The errors are consistent with the ones returned for incorrect `path` )
```
curl -XGET http://localhost:9200/index?pretty%
```
```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "unterminated escape sequence at end of string: pretty%"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "unterminated escape sequence at end of string: pretty%"
  },
  "status": 400
}
``` 
Fixes : #21974