### PR TITLE
Docs: Support triple quotes

### DIFF
--- a/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
+++ b/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
@@ -33,18 +33,18 @@ class RestTestFromSnippetsTaskTest extends GroovyTestCase {
 
     void testSimpleBlockQuote() {
         assertEquals("\"foo\": \"bort baz\"",
-            replaceBlockQuote("\"foo\": \"\"\"bort baz\"\"\""))
+            replaceBlockQuote("\"foo\": \"\"\"bort baz\"\"\""));
     }
 
     void testMultipleBlockQuotes() {
         assertEquals("\"foo\": \"bort baz\", \"bar\": \"other\"",
-            replaceBlockQuote("\"foo\": \"\"\"bort baz\"\"\", \"bar\": \"\"\"other\"\"\""))
+            replaceBlockQuote("\"foo\": \"\"\"bort baz\"\"\", \"bar\": \"\"\"other\"\"\""));
     }
 
     void testEscapingInBlockQuote() {
         assertEquals("\"foo\": \"bort\\\" baz\"",
-            replaceBlockQuote("\"foo\": \"\"\"bort\" baz\"\"\""))
+            replaceBlockQuote("\"foo\": \"\"\"bort\" baz\"\"\""));
         assertEquals("\"foo\": \"bort\\n baz\"",
-            replaceBlockQuote("\"foo\": \"\"\"bort\n baz\"\"\""))
+            replaceBlockQuote("\"foo\": \"\"\"bort\n baz\"\"\""));
     }
 }

--- a/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
+++ b/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.gradle.doc
+
+import org.elasticsearch.gradle.doc.SnippetsTask.Snippet
+import org.gradle.api.InvalidUserDataException
+
+import static org.elasticsearch.gradle.doc.RestTestsFromSnippetsTask.replaceBlockQuote
+
+class RestTestFromSnippetsTaskTest extends GroovyTestCase {
+    void testInvalidBlockQuote() {
+        String input = "\"foo\": \"\"\"bar\"";
+        String message = shouldFail({ replaceBlockQuote(input) });
+        assertEquals("Invalid block quote starting at 7 in:\n$input", message);
+    }
+
+    void testSimpleBlockQuote() {
+        assertEquals("\"foo\": \"bort baz\"",
+            replaceBlockQuote("\"foo\": \"\"\"bort baz\"\"\""))
+    }
+
+    void testMultipleBlockQuotes() {
+        assertEquals("\"foo\": \"bort baz\", \"bar\": \"other\"",
+            replaceBlockQuote("\"foo\": \"\"\"bort baz\"\"\", \"bar\": \"\"\"other\"\"\""))
+    }
+
+    void testEscapingInBlockQuote() {
+        assertEquals("\"foo\": \"bort\\\" baz\"",
+            replaceBlockQuote("\"foo\": \"\"\"bort\" baz\"\"\""))
+        assertEquals("\"foo\": \"bort\\n baz\"",
+            replaceBlockQuote("\"foo\": \"\"\"bort\n baz\"\"\""))
+    }
+}

--- a/docs/painless/painless-getting-started.asciidoc
+++ b/docs/painless/painless-getting-started.asciidoc
@@ -53,7 +53,13 @@ GET hockey/_search
       "script_score": {
         "script": {
           "lang": "painless",
-          "source": "int total = 0; for (int i = 0; i < doc['goals'].length; ++i) { total += doc['goals'][i]; } return total;"
+          "source": """
+            int total = 0;
+            for (int i = 0; i < doc['goals'].length; ++i) {
+              total += doc['goals'][i];
+            }
+            return total;
+          """
         }
       }
     }
@@ -75,7 +81,13 @@ GET hockey/_search
     "total_goals": {
       "script": {
         "lang": "painless",
-        "source": "int total = 0; for (int i = 0; i < doc['goals'].length; ++i) { total += doc['goals'][i]; } return total;"
+        "source": """
+          int total = 0;
+          for (int i = 0; i < doc['goals'].length; ++i) {
+            total += doc['goals'][i];
+          }
+          return total;
+        """
       }
     }
   }
@@ -157,7 +169,10 @@ POST hockey/player/1/_update
 {
   "script": {
     "lang": "painless",
-    "source": "ctx._source.last = params.last; ctx._source.nick = params.nick",
+    "source": """
+      ctx._source.last = params.last;
+      ctx._source.nick = params.nick
+    """,
     "params": {
       "last": "gaudreau",
       "nick": "hockey"
@@ -228,7 +243,13 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "if (ctx._source.last =~ /b/) {ctx._source.last += \"matched\"} else {ctx.op = 'noop'}"
+    "source": """
+      if (ctx._source.last =~ /b/) {
+        ctx._source.last += "matched";
+      } else {
+        ctx.op = "noop";
+      }
+    """
   }
 }
 ----------------------------------------------------------------
@@ -243,7 +264,13 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "if (ctx._source.last ==~ /[^aeiou].*[aeiou]/) {ctx._source.last += \"matched\"} else {ctx.op = 'noop'}"
+    "source": """
+      if (ctx._source.last ==~ /[^aeiou].*[aeiou]/) {
+        ctx._source.last += "matched";
+      } else {
+        ctx.op = "noop";
+      }
+    """
   }
 }
 ----------------------------------------------------------------
@@ -296,7 +323,10 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "ctx._source.last = ctx._source.last.replaceAll(/[aeiou]/, m -> m.group().toUpperCase(Locale.ROOT))"
+    "source": """
+      ctx._source.last = ctx._source.last.replaceAll(/[aeiou]/, m ->
+        m.group().toUpperCase(Locale.ROOT))
+    """
   }
 }
 ----------------------------------------------------------------
@@ -311,7 +341,10 @@ POST hockey/player/_update_by_query
 {
   "script": {
     "lang": "painless",
-    "source": "ctx._source.last = ctx._source.last.replaceFirst(/[aeiou]/, m -> m.group().toUpperCase(Locale.ROOT))"
+    "source": """
+      ctx._source.last = ctx._source.last.replaceFirst(/[aeiou]/, m ->
+        m.group().toUpperCase(Locale.ROOT))
+    """
   }
 }
 ----------------------------------------------------------------

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -563,7 +563,7 @@ to set the index that the document will be indexed into:
 --------------------------------------------------
 // NOTCONSOLE
 
-Dynamic field names are also supported. This example sets the field named after the 
+Dynamic field names are also supported. This example sets the field named after the
 value of `service` to the value of the field `code`:
 
 [source,js]
@@ -1829,7 +1829,10 @@ PUT _ingest/pipeline/my_index
     "processors": [
       {
         "script": {
-          "source": " ctx._index = 'my_index'; ctx._type = '_doc' "
+          "source": """
+            ctx._index = 'my_index';
+            ctx._type = '_doc';
+          """
         }
       }
     ]


### PR DESCRIPTION
Adds support for triple quoted strings to the documentation test
generator. Kibana's CONSOLE tool has supported them for a year but we
were unable to use them in Elasticsearch's docs because the process that
converts example snippets into tests couldn't handle this. This change
adds code to convert them into standard JSON so we can pass them to
Elasticsearch.
