### PR TITLE
Stop sourcing scripts during installation/removal

### DIFF
--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -8,14 +8,6 @@
 #       $1=0         : indicates a removal
 #       $1=1         : indicates an upgrade
 
-
-
-# Source the default env file
-ES_ENV_FILE="${path.env}"
-if [ -f "$ES_ENV_FILE" ]; then
-    . "$ES_ENV_FILE"
-fi
-
 IS_UPGRADE=false
 
 case "$1" in

--- a/distribution/packages/src/common/scripts/postrm
+++ b/distribution/packages/src/common/scripts/postrm
@@ -45,30 +45,30 @@ if [ "$REMOVE_DIRS" = "true" ]; then
 
     if [ -d /var/log/elasticsearch ]; then
         echo -n "Deleting log directory..."
-        rm -rf "$LOG_DIR"
+        rm -rf /var/log/elasticsearch
         echo " OK"
     fi
 
     if [ -d /usr/share/elasticsearch/plugins ]; then
         echo -n "Deleting plugins directory..."
-        rm -rf "$PLUGINS_DIR"
+        rm -rf /usr/share/elasticsearch/plugins
         echo " OK"
     fi
 
     if [ -d /var/run/elasticsearch ]; then
         echo -n "Deleting PID directory..."
-        rm -rf "$PID_DIR"
+        rm -rf /var/run/elasticsearch
         echo " OK"
     fi
 
     # Delete the data directory if and only if empty
     if [ -d /var/lib/elasticsearch ]; then
-        rmdir --ignore-fail-on-non-empty "$DATA_DIR"
+        rmdir --ignore-fail-on-non-empty /var/lib/elasticsearch
     fi
 
     # delete the conf directory if and only if empty
     if [ -d /etc/elasticsearch ]; then
-        rmdir --ignore-fail-on-non-empty "$ES_PATH_CONF"
+        rmdir --ignore-fail-on-non-empty /etc/elasticsearch
     fi
 
 fi

--- a/distribution/packages/src/common/scripts/postrm
+++ b/distribution/packages/src/common/scripts/postrm
@@ -9,9 +9,6 @@
 #       $1=0         : indicates a removal
 #       $1=1         : indicates an upgrade
 
-
-
-SOURCE_ENV_FILE=true
 REMOVE_DIRS=false
 REMOVE_USER_AND_GROUP=false
 
@@ -24,7 +21,6 @@ case "$1" in
 
     purge)
         REMOVE_USER_AND_GROUP=true
-        SOURCE_ENV_FILE=false
     ;;
     failed-upgrade|abort-install|abort-upgrade|disappear|upgrade|disappear)
     ;;
@@ -45,48 +41,33 @@ case "$1" in
     ;;
 esac
 
-# Sets the default values for elasticsearch variables used in this script
-LOG_DIR="/var/log/elasticsearch"
-PLUGINS_DIR="/usr/share/elasticsearch/plugins"
-PID_DIR="/var/run/elasticsearch"
-DATA_DIR="/var/lib/elasticsearch"
-ES_PATH_CONF="/etc/elasticsearch"
-
-# Source the default env file
-if [ "$SOURCE_ENV_FILE" = "true" ]; then
-    ES_ENV_FILE="${path.env}"
-    if [ -f "$ES_ENV_FILE" ]; then
-        . "$ES_ENV_FILE"
-    fi
-fi
-
 if [ "$REMOVE_DIRS" = "true" ]; then
 
-    if [ -d "$LOG_DIR" ]; then
+    if [ -d /var/log/elasticsearch ]; then
         echo -n "Deleting log directory..."
         rm -rf "$LOG_DIR"
         echo " OK"
     fi
 
-    if [ -d "$PLUGINS_DIR" ]; then
+    if [ -d /usr/share/elasticsearch/plugins ]; then
         echo -n "Deleting plugins directory..."
         rm -rf "$PLUGINS_DIR"
         echo " OK"
     fi
 
-    if [ -d "$PID_DIR" ]; then
+    if [ -d /var/run/elasticsearch ]; then
         echo -n "Deleting PID directory..."
         rm -rf "$PID_DIR"
         echo " OK"
     fi
 
     # Delete the data directory if and only if empty
-    if [ -d "$DATA_DIR" ]; then
+    if [ -d /var/lib/elasticsearch ]; then
         rmdir --ignore-fail-on-non-empty "$DATA_DIR"
     fi
 
     # delete the conf directory if and only if empty
-    if [ -d "$ES_PATH_CONF" ]; then
+    if [ -d /etc/elasticsearch ]; then
         rmdir --ignore-fail-on-non-empty "$ES_PATH_CONF"
     fi
 

--- a/distribution/packages/src/common/scripts/preinst
+++ b/distribution/packages/src/common/scripts/preinst
@@ -9,14 +9,6 @@
 #       $1=1       : indicates an new install
 #       $1=2       : indicates an upgrade
 
-
-
-# Source the default env file
-ES_ENV_FILE="${path.env}"
-if [ -f "$ES_ENV_FILE" ]; then
-    . "$ES_ENV_FILE"
-fi
-
 case "$1" in
 
     # Debian ####################################################

--- a/distribution/packages/src/common/scripts/prerm
+++ b/distribution/packages/src/common/scripts/prerm
@@ -9,8 +9,6 @@
 #       $1=0         : indicates a removal
 #       $1=1         : indicates an upgrade
 
-
-
 STOP_REQUIRED=false
 REMOVE_SERVICE=false
 
@@ -80,6 +78,5 @@ if [ "$REMOVE_SERVICE" = "true" ]; then
         update-rc.d elasticsearch remove >/dev/null || true
     fi
 fi
-
 
 ${scripts.footer}


### PR DESCRIPTION
Previously we allowed a lot of customization of Elasticsearch during package installation (e.g., the username and group). This customization was achieved by sourcing the env script (e.g., /etc/sysconfig/elasticsearch) during installation. Since we no longer allow such flexibility, we do not need to source these env scripts during package installation and removal.

Relates #14630
