### PR TITLE
Build: Fix test logger NPE when no tests are run

### DIFF
--- a/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestProgressLogger.groovy
+++ b/buildSrc/src/main/groovy/com/carrotsearch/gradle/junit4/TestProgressLogger.groovy
@@ -100,12 +100,15 @@ class TestProgressLogger implements AggregatedEventListener {
 
     @Subscribe
     void onQuit(AggregatedQuitEvent e) throws IOException {
-        suiteLogger.completed()
-        testLogger.completed()
-        for (ProgressLogger slaveLogger : slaveLoggers) {
-            slaveLogger.completed()
+        // if onStart was never called (eg no matching tests), suiteLogger and all the other loggers will be null
+        if (suiteLogger != null) {
+            suiteLogger.completed()
+            testLogger.completed()
+            for (ProgressLogger slaveLogger : slaveLoggers) {
+                slaveLogger.completed()
+            }
+            parentProgressLogger.completed()
         }
-        parentProgressLogger.completed()
     }
 
     @Subscribe


### PR DESCRIPTION
This commit fixes the test progress logging to not produce an NPE when
there are no tests run. The onQuit method is always called, but onStart
would not be called if no tests match the test patterns.
