### PR TITLE
Restore tiebreaker for cross fields query

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -82,7 +82,7 @@ public class MultiMatchQuery extends MatchQuery {
                     queryBuilder = new QueryBuilder(tieBreaker);
                     break;
                 case CROSS_FIELDS:
-                    queryBuilder = new CrossFieldsQueryBuilder();
+                    queryBuilder = new CrossFieldsQueryBuilder(tieBreaker);
                     break;
                 default:
                     throw new IllegalStateException("No such type: " + type);
@@ -152,8 +152,8 @@ public class MultiMatchQuery extends MatchQuery {
     final class CrossFieldsQueryBuilder extends QueryBuilder {
         private FieldAndFieldType[] blendedFields;
 
-        CrossFieldsQueryBuilder() {
-            super(0.0f);
+        CrossFieldsQueryBuilder(float tiebreaker) {
+            super(tiebreaker);
         }
 
         @Override
@@ -239,7 +239,7 @@ public class MultiMatchQuery extends MatchQuery {
             /**
              * We build phrase queries for multi-word synonyms when {@link QueryBuilder#autoGenerateSynonymsPhraseQuery} is true.
              */
-            return MultiMatchQuery.blendPhrase(query, blendedFields);
+            return MultiMatchQuery.blendPhrase(query, tieBreaker, blendedFields);
         }
     }
 
@@ -307,7 +307,7 @@ public class MultiMatchQuery extends MatchQuery {
      * Expand a {@link PhraseQuery} to multiple fields that share the same analyzer.
      * Returns a {@link DisjunctionMaxQuery} with a disjunction for each expanded field.
      */
-    static Query blendPhrase(PhraseQuery query, FieldAndFieldType... fields) {
+    static Query blendPhrase(PhraseQuery query, float tiebreaker, FieldAndFieldType... fields) {
         List<Query> disjunctions = new ArrayList<>();
         for (FieldAndFieldType field : fields) {
             int[] positions = query.getPositions();
@@ -322,7 +322,7 @@ public class MultiMatchQuery extends MatchQuery {
             }
             disjunctions.add(q);
         }
-        return new DisjunctionMaxQuery(disjunctions, 0.0f);
+        return new DisjunctionMaxQuery(disjunctions, tiebreaker);
     }
 
     @Override


### PR DESCRIPTION
This commit restores the handling of tiebreaker for multi_match
cross fields query. This functionality was lost during a refactoring
of the multi_match query (#25115).

Fixes #28933