### PR TITLE
Use String.join() to describe a list of tasks

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.Nullable;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public interface ClusterStateTaskExecutor<T> {
     /**
@@ -55,15 +56,7 @@ public interface ClusterStateTaskExecutor<T> {
      * This allows groupd task description but the submitting source.
      */
     default String describeTasks(List<T> tasks) {
-        return tasks.stream().map(T::toString).reduce((s1,s2) -> {
-            if (s1.isEmpty()) {
-                return s2;
-            } else if (s2.isEmpty()) {
-                return s1;
-            } else {
-                return s1 + ", " + s2;
-            }
-        }).orElse("");
+        return String.join(", ", tasks.stream().map(t -> (CharSequence)t.toString()).filter(t -> t.length() == 0)::iterator);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataMappingService.java
@@ -352,7 +352,7 @@ public class MetaDataMappingService extends AbstractComponent {
 
         @Override
         public String describeTasks(List<PutMappingClusterStateUpdateRequest> tasks) {
-            return tasks.stream().map(PutMappingClusterStateUpdateRequest::type).reduce((s1, s2) -> s1 + ", " + s2).orElse("");
+            return String.join(", ", tasks.stream().map(t -> (CharSequence)t.type())::iterator);
         }
     }
 


### PR DESCRIPTION
This change replaces the use of string concatenation with a call to
String.join(). String concatenation might be quadratic, unless the compiler can
optimise it away, whereas String.join() is more reliably linear. There can
sometimes be a large number of pending ClusterState update tasks and #28920
includes a report that this operation sometimes takes a long time.
