### PR TITLE
REST : deprecate `field_data` for Clear Indices Cache API

### DIFF
--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -55,3 +55,8 @@ traffic for `index.search.idle.after` seconds (defaults to `30s`). Searches
 that access a search idle shard will be "parked" until the next refresh
 happens.  Indexing requests with `wait_for_refresh` will also trigger
 a background refresh.
+
+==== `field_data` param deprecated in favor of `fielddata`.
+
+The `field_data` url parameter has been deprecated in favor of `fielddata` for
+Clear Indices Cache API.

--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -55,8 +55,3 @@ traffic for `index.search.idle.after` seconds (defaults to `30s`). Searches
 that access a search idle shard will be "parked" until the next refresh
 happens.  Indexing requests with `wait_for_refresh` will also trigger
 a background refresh.
-
-==== `field_data` param deprecated in favor of `fielddata`.
-
-The `field_data` url parameter has been deprecated in favor of `fielddata` for
-Clear Indices Cache API.

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yml
@@ -25,3 +25,26 @@
         - 'Deprecated field [request_cache] used, expected [request] instead'
       indices.clear_cache:
         request_cache: false
+
+---
+"clear_cache with field_data set to true":
+  - skip:
+      version: " - 6.2.99"
+      reason: field_data was deprecated in 6.3.0
+      features: "warnings"
+
+  - do:
+      warnings:
+        - 'Deprecated field [field_data] used, expected [fielddata] instead'
+      indices.clear_cache:
+        field_data: true
+
+---
+"clear_cache with fielddata set to true":
+  - skip:
+      version: " - 6.2.99"
+      reason: fielddata was deprecated before 6.3.0
+
+  - do:
+      indices.clear_cache:
+        fielddata: true

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
@@ -88,7 +88,7 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
                 clearIndicesCacheRequest.queryCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.queryCache()));
             } else if (Fields.REQUEST.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
                 clearIndicesCacheRequest.requestCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.requestCache()));
-            } else if (Fields.FIELD_DATA.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
+            } else if (Fields.FIELDDATA.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
                 clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.fieldDataCache()));
             } else  if (Fields.FIELDS.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
                 clearIndicesCacheRequest.fields(request.paramAsStringArray(entry.getKey(), clearIndicesCacheRequest.fields()));
@@ -101,7 +101,7 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
     public static class Fields {
         public static final ParseField QUERY = new ParseField("query", "filter", "filter_cache");
         public static final ParseField REQUEST = new ParseField("request", "request_cache");
-        public static final ParseField FIELD_DATA = new ParseField("field_data", "fielddata");
+        public static final ParseField FIELDDATA = new ParseField("fielddata", "field_data");
         public static final ParseField FIELDS = new ParseField("fields");
     }
 


### PR DESCRIPTION
Throughout the code and the documentation `fielddata` is used. Only for the Clear Indices Cache API `field_data` has been used : 
https://github.com/elastic/elasticsearch/blob/95a13ea01cfefac372e0d1b69de595b9aac0d603/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java#L104
 ( if `fielddata` is used as a url param, a deprecation warning is logged and also returned in the response headers ) 

Also the [reference docs](https://github.com/elastic/elasticsearch/blob/95a13ea01cfefac372e0d1b69de595b9aac0d603/docs/reference/indices/clearcache.asciidoc) are referring only to `fielddata`.

For consistency reasons this PR deprecates ` field_data` in favor of `fielddata`.

---
For context,  a few usages of `fielddata` :
```
GET /_cat/fielddata
```
```
GET /_nodes/stats/indices/fielddata
```
Index setting : `index.fielddata.cache`

---
The change from `fielddata` to `field_data` has been done in e2c8ff92ba1f49b4314cba35c5792a74fe4efe20 ( at this point the two names were interchangeable : no deprecation logging ) 

Since b927cfe1de6f573f443ebd58f492b759cf939093 (#17804) a http warning header is sent for the deprecated usage