### PR TITLE
REST api specs : remove unsupported `wait_for_merge` param

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -37,10 +37,6 @@
         "only_expunge_deletes": {
           "type" : "boolean",
           "description" : "Specify whether the operation should only expunge deleted documents"
-        },
-        "wait_for_merge": {
-          "type" : "boolean",
-          "description" : "Specify whether the request should block until the merge process is finished (default: true)"
         }
       }
     },


### PR DESCRIPTION
Force Merge API does not support `wait_for_merge`.

Relates to #27158