### PR TITLE
Honor RUNTIME_JAVA_HOME for benchmarks

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -85,6 +85,10 @@ shadowJar {
     classifier = 'benchmarks'
 }
 
+runShadow {
+    executable = new File(project.runtimeJavaHome, 'bin/java')
+}
+
 // alias the shadowJar and runShadow tasks to abstract from the concrete plugin that we are using and provide a more consistent interface
 task jmhJar(
         dependsOn: shadowJar,


### PR DESCRIPTION
With this commit we configure our microbenchmarks project to use the
configured RUNTIME_JAVA_HOME and to fallback on JAVA_HOME when 
executing the `jmh` task so that this behavior is consistent  with the rest
of the Elasticsearch build.

Closes #28961