### PR TITLE
Avoid class cast exception from index writer

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1730,7 +1730,13 @@ public class InternalEngine extends Engine {
         // we need to fail the engine. it might have already been failed before
         // but we are double-checking it's failed and closed
         if (indexWriter.isOpen() == false && indexWriter.getTragicException() != null) {
-            failEngine("already closed by tragic event on the index writer", (Exception) indexWriter.getTragicException());
+            final Exception tragicException;
+            if (indexWriter.getTragicException() instanceof Exception) {
+                tragicException = (Exception) indexWriter.getTragicException();
+            } else {
+                tragicException = new RuntimeException(indexWriter.getTragicException());
+            }
+            failEngine("already closed by tragic event on the index writer", tragicException);
             engineFailed = true;
         } else if (translog.isOpen() == false && translog.getTragicException() != null) {
             failEngine("already closed by tragic event on the translog", translog.getTragicException());


### PR DESCRIPTION
When an index writer encounters a tragic exception, it could be a `Throwable` and not an `Exception`. Yet we blindly cast the tragic exception to an `Exception` which can encounter a `ClassCastException`. This commit addresses this by checking if the tragic exception is an `Exception` and otherwise wrapping the `Throwable` in a `RuntimeException` if it is not. We choose to wrap the `Throwable` instead of passing it around because passing it around leads to changing a lot of places where we handle `Exception` to handle `Throwable` instead. In general, we have tried to avoid handling `Throwable` and instead let those bubble up to the uncaught exception handler.

