### PR TITLE
RestUpgradeAction : remove explicit http method check

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeAction.java
@@ -65,7 +65,11 @@ public class RestUpgradeAction extends BaseRestHandler {
         if (request.method().equals(RestRequest.Method.GET)) {
             return handleGet(request, client);
         } 
-        return handlePost(request, client);
+        if (request.method().equals(RestRequest.Method.POST)) {
+            return handlePost(request, client);
+        }
+        assert false;
+        return null;
     }
 
     private RestChannelConsumer handleGet(final RestRequest request, NodeClient client) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeAction.java
@@ -64,12 +64,11 @@ public class RestUpgradeAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (request.method().equals(RestRequest.Method.GET)) {
             return handleGet(request, client);
-        } 
-        if (request.method().equals(RestRequest.Method.POST)) {
+        } else if (request.method().equals(RestRequest.Method.POST)) {
             return handlePost(request, client);
+        } else {
+            throw new AssertionError("unsupported method [" + request.method() + "] for request [" + request.path() + "]");
         }
-        assert false;
-        return null;
     }
 
     private RestChannelConsumer handleGet(final RestRequest request, NodeClient client) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpgradeAction.java
@@ -64,11 +64,8 @@ public class RestUpgradeAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         if (request.method().equals(RestRequest.Method.GET)) {
             return handleGet(request, client);
-        } else if (request.method().equals(RestRequest.Method.POST)) {
-            return handlePost(request, client);
-        } else {
-            throw new IllegalArgumentException("illegal method [" + request.method() + "] for request [" + request.path() + "]");
-        }
+        } 
+        return handlePost(request, client);
     }
 
     private RestChannelConsumer handleGet(final RestRequest request, NodeClient client) {


### PR DESCRIPTION
The check if an HTTP method is supported is performed in the `RestController` ( if a method different that `GET`/`POST` is used for `_upgrade`, the `RestController` throws `"Incorrect HTTP method for uri [/_upgrade] and method [PUT], allowed: [GET, POST]"` )
This PR simply removed the unnecessary / unreachable explicit check for the `_upgrade` endpoint

Relates to #24437

CC @dakrone 