### PR TITLE
Correct class to name string conversion

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -565,7 +565,7 @@ public final class Definition {
             if (component == def.class) {
                 StringBuilder builder = new StringBuilder(def.class.getSimpleName());
 
-                for (int dimension = 0; dimension < dimensions; dimensions++) {
+                for (int dimension = 0; dimension < dimensions; dimension++) {
                     builder.append("[]");
                 }
 


### PR DESCRIPTION
A typo of 'dimensions' rather than 'dimension' caused an infinite
loop.

See https://lgtm.com/projects/g/elastic/elasticsearch/snapshot/8499111b17a64ab7cf6201a2a318190fbdf5d358/files/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java?sort=name&dir=ASC&mode=heatmap&showExcluded=false#V568
