### PR TITLE
Skip GeoIpProcessorFactoryTests on Windows

### DIFF
--- a/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/plugins/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.ingest.geoip;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.maxmind.db.NoCache;
 import com.maxmind.db.NodeCache;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.test.ESTestCase;
@@ -51,6 +52,13 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
 
     @BeforeClass
     public static void loadDatabaseReaders() throws IOException {
+        // Skip setup because Windows cannot cleanup these files properly. The reason is that they are using
+        // a MappedByteBuffer which will keep the file mappings active until it is garbage-collected. As a consequence,
+        // the corresponding file appears to be still in use and Windows cannot delete it.
+        if (Constants.WINDOWS) {
+            return;
+        }
+
         Path configDir = createTempDir();
         Path geoIpConfigDir = configDir.resolve("ingest-geoip");
         Files.createDirectories(geoIpConfigDir);
@@ -67,6 +75,13 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
 
     @AfterClass
     public static void closeDatabaseReaders() throws IOException {
+        // Skip setup because Windows cannot cleanup these files properly. The reason is that they are using
+        // a MappedByteBuffer which will keep the file mappings active until it is garbage-collected. As a consequence,
+        // the corresponding file appears to be still in use and Windows cannot delete it.
+        if (Constants.WINDOWS) {
+            return;
+        }
+
         for (DatabaseReaderLazyLoader reader : databaseReaders.values()) {
             reader.close();
         }
@@ -74,6 +89,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildDefaults() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
 
         Map<String, Object> config = new HashMap<>();
@@ -90,6 +108,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testSetIgnoreMissing() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
 
         Map<String, Object> config = new HashMap<>();
@@ -107,6 +128,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testCountryBuildDefaults() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
 
         Map<String, Object> config = new HashMap<>();
@@ -125,6 +149,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testAsnBuildDefaults() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
 
         Map<String, Object> config = new HashMap<>();
@@ -143,6 +170,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildTargetField() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -154,6 +184,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildDbFile() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -167,6 +200,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildWithCountryDbAndAsnFields() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -181,6 +217,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildWithAsnDbAndCityFields() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
@@ -195,6 +234,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildNonExistingDbFile() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
 
         Map<String, Object> config = new HashMap<>();
@@ -205,6 +247,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildFields() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
 
         Set<GeoIpProcessor.Property> properties = EnumSet.noneOf(GeoIpProcessor.Property.class);
@@ -229,6 +274,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testBuildIllegalFieldOption() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseReaders);
 
         Map<String, Object> config1 = new HashMap<>();
@@ -246,6 +294,9 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     }
 
     public void testLazyLoading() throws Exception {
+        // This test uses a MappedByteBuffer which will keep the file mappings active until it is garbage-collected.
+        // As a consequence, the corresponding file appears to be still in use and Windows cannot delete it.
+        assumeFalse("windows deletion behavior is asinine", Constants.WINDOWS);
         Path configDir = createTempDir();
         Path geoIpConfigDir = configDir.resolve("ingest-geoip");
         Files.createDirectories(geoIpConfigDir);


### PR DESCRIPTION
With this commit we skip all GeoIpProcessorFactoryTests on Windows.
These tests use a MappedByteBuffer which will keep its file mappings
until it is garbage-collected. As a consequence, the corresponding
file appears to be still in use, Windows cannot delete it and the test
will fail in teardown.

Closes #29001