### PR TITLE
Validate regular expressions in dynamic templates.

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
@@ -62,7 +62,7 @@ public class DynamicTemplateTests extends ESTestCase {
     }
 
     public void testParseInvalidRegex() {
-        for (String param : new String[] { "path_match", "match", "path_unmatch", "unmatch" }) {System.out.println(param);
+        for (String param : new String[] { "path_match", "match", "path_unmatch", "unmatch" }) {
             Map<String, Object> templateDef = new HashMap<>();
             templateDef.put("match", "foo");
             templateDef.put(param, "*a");

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateTests.java
@@ -61,6 +61,19 @@ public class DynamicTemplateTests extends ESTestCase {
                 e.getMessage());
     }
 
+    public void testParseInvalidRegex() {
+        for (String param : new String[] { "path_match", "match", "path_unmatch", "unmatch" }) {System.out.println(param);
+            Map<String, Object> templateDef = new HashMap<>();
+            templateDef.put("match", "foo");
+            templateDef.put(param, "*a");
+            templateDef.put("match_pattern", "regex");
+            templateDef.put("mapping", Collections.singletonMap("store", true));
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                    () -> DynamicTemplate.parse("my_template", templateDef, Version.V_6_3_0));
+            assertEquals("Pattern [*a] of type [regex] is invalid. Cannot create dynamic template [my_template].", e.getMessage());
+        }
+    }
+
     public void testMatchAllTemplate() {
         Map<String, Object> templateDef = new HashMap<>();
         templateDef.put("match_mapping_type", "*");


### PR DESCRIPTION
Today you would only get these errors at index time.

Relates #24749