### PR TITLE
Versions: Add 5.6.9 version to Version.java

### DIFF
--- a/core/src/main/java/org/elasticsearch/Version.java
+++ b/core/src/main/java/org/elasticsearch/Version.java
@@ -113,6 +113,8 @@ public class Version implements Comparable<Version> {
     public static final Version V_5_6_7 = new Version(V_5_6_7_ID, org.apache.lucene.util.Version.LUCENE_6_6_1);
     public static final int V_5_6_8_ID = 5060899;
     public static final Version V_5_6_8 = new Version(V_5_6_8_ID, org.apache.lucene.util.Version.LUCENE_6_6_1);
+    public static final int V_5_6_9_ID = 5060999;
+    public static final Version V_5_6_9 = new Version(V_5_6_9_ID, org.apache.lucene.util.Version.LUCENE_6_6_1);
     public static final int V_6_0_0_alpha1_ID = 6000001;
     public static final Version V_6_0_0_alpha1 = new Version(V_6_0_0_alpha1_ID, org.apache.lucene.util.Version.LUCENE_7_0_0);
     public static final int V_6_0_0_alpha2_ID = 6000002;
@@ -187,6 +189,8 @@ public class Version implements Comparable<Version> {
                 return V_6_0_0_alpha2;
             case V_6_0_0_alpha1_ID:
                 return V_6_0_0_alpha1;
+            case V_5_6_9_ID:
+                return V_5_6_9;
             case V_5_6_8_ID:
                 return V_5_6_8;
             case V_5_6_7_ID:


### PR DESCRIPTION
`gradle verifyVersions` was failing due to a missing version.

See https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+6.1+branch-consistency/2/console

