### PR TITLE
Log template creation and deletion

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexTemplateService.java
@@ -117,6 +117,7 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
                 }
                 MetaData.Builder metaData = MetaData.builder(currentState.metaData());
                 for (String templateName : templateNames) {
+                    logger.info("removing template [{}]", templateName);
                     metaData.removeTemplate(templateName);
                 }
                 return ClusterState.builder(currentState).metaData(metaData).build();
@@ -185,6 +186,7 @@ public class MetaDataIndexTemplateService extends AbstractComponent {
 
                 MetaData.Builder builder = MetaData.builder(currentState.metaData()).put(template);
 
+                logger.info("adding template [{}] for index patterns {}", request.name, request.indexPatterns);
                 return ClusterState.builder(currentState).metaData(builder).build();
             }
 


### PR DESCRIPTION
These can be seen at the debug level via cluster state update logging but really they should be more visible like index creation and deletion. This commit adds info-level logging for template puts and deletes.

Closes #10795