### PR TITLE
Put JVM crash logs in the default log directory

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -265,6 +265,12 @@ subprojects {
         'def': "#-XX:HeapDumpPath=/heap/dump/path"
       ],
 
+      'error.file': [
+        'deb': "-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log",
+        'rpm': "-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log",
+        'def': "#-XX:ErrorFile=/error/file/path"
+      ],
+
       'stopping.timeout': [
         'rpm': 86400,
       ],

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -81,6 +81,9 @@
 # ensure the directory exists and has sufficient space
 ${heap.dump.path}
 
+# specify an alternative path for JVM fatal error logs
+${error.file}
+
 ## JDK 8 GC logging
 
 8:-XX:+PrintGCDetails


### PR DESCRIPTION
This commit adds a JVM flag to ensure that the JVM fatal error logs land in the default log directory. Users that wish to use an alternative location should change the path configured here.

Closes #13982
