### PR TITLE
[DOCS] Add X-Pack machine learning upgrade details

### DIFF
--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -26,6 +26,9 @@ recovery.
 include::synced-flush.asciidoc[]
 --
 
+. *Stop any machine learning jobs that are running.* See
+{xpack-ref}/stopping-ml.html[Stopping Machine Learning].
+
 . *Shutdown all nodes.*
 +
 --
@@ -124,3 +127,5 @@ GET _cat/recovery
 --------------------------------------------------
 // CONSOLE
 --
+
+. *Restart machine learning jobs.* 

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -32,6 +32,9 @@ include::synced-flush.asciidoc[]
 
 --
 
+. *Stop any machine learning jobs that are running.* See
+{xpack-ref}/stopping-ml.html[Stopping Machine Learning].
+
 . [[upgrade-node]] *Shut down a single node*.
 +
 --
@@ -146,6 +149,8 @@ When  the node has recovered and the cluster is stable, repeat these steps
 for each node that needs to be updated.
 
 --
+
+. *Restart machine learning jobs.* 
 
 [IMPORTANT]
 ====================================================


### PR DESCRIPTION
This PR updates the "Upgrade Elasticsearch" topics to include the step of stopping machine learning jobs and then restarting them after the upgrade. That information was originally found in https://www.elastic.co/guide/en/x-pack/master/xpack-upgrading.html