### PR TITLE
Fix Parsing Bug with Update By Query for Stored Scripts

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/RestUpdateByQueryAction.java
@@ -86,7 +86,7 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
             Map<String,Object> configMap = (Map<String, Object>) config;
             String script = null;
             ScriptType type = null;
-            String lang = DEFAULT_SCRIPT_LANG;
+            String lang = null;
             Map<String, Object> params = Collections.emptyMap();
             for (Iterator<Map.Entry<String, Object>> itr = configMap.entrySet().iterator(); itr.hasNext();) {
                 Map.Entry<String, Object> entry = itr.next();
@@ -126,7 +126,15 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
             }
             assert type != null : "if script is not null, type should definitely not be null";
 
-            return new Script(type, lang, script, params);
+            if (type == ScriptType.STORED) {
+                if (lang != null) {
+                    throw new IllegalArgumentException("lang cannot be specified for stored scripts");
+                }
+
+                return new Script(type, null, script, null, params);
+            } else {
+                return new Script(type, lang == null ? DEFAULT_SCRIPT_LANG : lang, script, params);
+            }
         } else {
             throw new IllegalArgumentException("Script value should be a String or a Map");
         }

--- a/qa/smoke-test-reindex-with-all-modules/src/test/resources/rest-api-spec/test/update_by_query/10_script.yml
+++ b/qa/smoke-test-reindex-with-all-modules/src/test/resources/rest-api-spec/test/update_by_query/10_script.yml
@@ -340,3 +340,84 @@
             source: if (ctx._source.user == "kimchy") {ctx.op = "index"} else {ctx.op = "junk"}
 
   - match: { error.reason: 'Operation type [junk] not allowed, only [noop, index, delete] are allowed' }
+
+---
+"Update all docs with one deletion and one noop using a stored script":
+  - do:
+      index:
+        index:  twitter
+        type:   tweet
+        id:     1
+        body:   { "level": 9, "last_updated": "2016-01-01T12:10:30Z" }
+  - do:
+      index:
+        index:  twitter
+        type:   tweet
+        id:     2
+        body:   { "level": 10, "last_updated": "2016-01-01T12:10:30Z" }
+  - do:
+      index:
+        index:  twitter
+        type:   tweet
+        id:     3
+        body:   { "level": 11, "last_updated": "2016-01-01T12:10:30Z" }
+  - do:
+      index:
+        index:  twitter
+        type:   tweet
+        id:     4
+        body:   { "level": 12, "last_updated": "2016-01-01T12:10:30Z" }
+  - do:
+      indices.refresh: {}
+  - do:
+      put_script:
+        id: "my_update_script"
+        body: { "script": {"lang": "painless",
+                "source": "int choice = ctx._source.level % 3;
+                               if (choice == 0) {
+                                   ctx._source.last_updated = '2016-01-02T00:00:00Z';
+                               } else if (choice == 1) {
+                                   ctx.op = 'noop';
+                               } else {
+                                   ctx.op = 'delete';
+                               }" } }
+  - match: { acknowledged: true }
+
+  - do:
+      update_by_query:
+        refresh: true
+        index:   twitter
+        body:
+          script:
+             id: "my_update_script"
+
+  - match: {updated: 2}
+  - match: {deleted: 1}
+  - match: {noops: 1}
+
+  - do:
+      search:
+        index: twitter
+        body:
+          query:
+            match:
+              last_updated: "2016-01-02T00:00:00Z"
+  - match: { hits.total: 2 }
+
+  - do:
+      search:
+        index: twitter
+        body:
+          query:
+            match:
+              last_updated: "2016-01-01T12:10:30Z"
+  - match: { hits.total: 1 }
+
+  - do:
+      search:
+        index: twitter
+        body:
+          query:
+            term:
+              level: 11
+  - match: { hits.total: 0 }


### PR DESCRIPTION
This changes the parsing logic for stored scripts in update by query to match the parsing logic for scripts in general Elasticsearch.  Ultimately, this should be changed to use Script.parseScript, but for now this is a much simpler fix to get our users up and going again.

Closes #28002
