### PR TITLE
Add search slowlog level to docs

### DIFF
--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -22,6 +22,8 @@ index.search.slowlog.threshold.fetch.warn: 1s
 index.search.slowlog.threshold.fetch.info: 800ms
 index.search.slowlog.threshold.fetch.debug: 500ms
 index.search.slowlog.threshold.fetch.trace: 200ms
+
+index.search.slowlog.level: info
 --------------------------------------------------
 
 All of the above settings are _dynamic_ and are set per-index.


### PR DESCRIPTION
This commit adds an indication how to set the search slowlog level to the docs.

Closes #7461