### PR TITLE
[DOCS] Add monitoring upgrade details

### DIFF
--- a/docs/reference/upgrade/upgrade-node.asciidoc
+++ b/docs/reference/upgrade/upgrade-node.asciidoc
@@ -16,7 +16,14 @@ To upgrade using a zip or compressed tarball:
 
 .. Set `path.data` in `config/elasticsearch.yml` to point to your external
    data directory. If you are not using an external `data` directory, copy
-   your old data directory over to the new installation.
+   your old data directory over to the new installation. +
++
+--
+IMPORTANT: If you use {monitoring}, re-use the data directory when you upgrade
+{es}. Monitoring identifies unique {es} nodes by using the persistent UUID, which
+is stored in the data directory.
+
+--
 
 .. Set `path.logs` in `config/elasticsearch.yml` to point to the location
    where you want to store your logs. If you do not specify this setting,


### PR DESCRIPTION
This PR updates the "Upgrade Elasticsearch" topics to include an X-Pack monitoring tip. That information was originally found in https://www.elastic.co/guide/en/x-pack/master/xpack-upgrading.html