### PR TITLE
Main response should not have status 503 when okay

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
@@ -37,11 +37,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.main.MainRequest;
 import org.elasticsearch.action.main.MainResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseListener;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -162,7 +157,7 @@ public class CustomRestHighLevelClientTests extends ESTestCase {
         ProtocolVersion protocol = new ProtocolVersion("HTTP", 1, 1);
         when(mockResponse.getStatusLine()).thenReturn(new BasicStatusLine(protocol, 200, "OK"));
 
-        MainResponse response = new MainResponse(httpHeader.getValue(), Version.CURRENT, ClusterName.DEFAULT, "_na", Build.CURRENT, true);
+        MainResponse response = new MainResponse(httpHeader.getValue(), Version.CURRENT, ClusterName.DEFAULT, "_na", Build.CURRENT);
         BytesRef bytesRef = XContentHelper.toXContent(response, XContentType.JSON, false).toBytesRef();
         when(mockResponse.getEntity()).thenReturn(new ByteArrayEntity(bytesRef.bytes, ContentType.APPLICATION_JSON));
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RestHighLevelClientTests.java
@@ -163,7 +163,7 @@ public class RestHighLevelClientTests extends ESTestCase {
     public void testInfo() throws IOException {
         Header[] headers = randomHeaders(random(), "Header");
         MainResponse testInfo = new MainResponse("nodeName", Version.CURRENT, new ClusterName("clusterName"), "clusterUuid",
-                Build.CURRENT, true);
+                Build.CURRENT);
         mockResponse(testInfo);
         MainResponse receivedInfo = restHighLevelClient.info(headers);
         assertEquals(testInfo, receivedInfo);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MainDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/MainDocumentationIT.java
@@ -52,7 +52,6 @@ public class MainDocumentationIT extends ESRestHighLevelClientTestCase {
             //tag::main-execute
             MainResponse response = client.info();
             //end::main-execute
-            assertTrue(response.isAvailable());
             //tag::main-response
             ClusterName clusterName = response.getClusterName(); // <1>
             String clusterUuid = response.getClusterUuid(); // <2>

--- a/server/src/main/java/org/elasticsearch/action/main/TransportMainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/main/TransportMainAction.java
@@ -53,6 +53,6 @@ public class TransportMainAction extends HandledTransportAction<MainRequest, Mai
         final boolean available = clusterState.getBlocks().hasGlobalBlock(RestStatus.SERVICE_UNAVAILABLE) == false;
         listener.onResponse(
             new MainResponse(Node.NODE_NAME_SETTING.get(settings), Version.CURRENT, clusterState.getClusterName(),
-                    clusterState.metaData().clusterUUID(), Build.CURRENT, available));
+                    clusterState.metaData().clusterUUID(), Build.CURRENT));
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/RestMainAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestMainAction.java
@@ -60,13 +60,11 @@ public class RestMainAction extends BaseRestHandler {
     }
 
     static BytesRestResponse convertMainResponse(MainResponse response, RestRequest request, XContentBuilder builder) throws IOException {
-        RestStatus status = response.isAvailable() ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
-
         // Default to pretty printing, but allow ?pretty=false to disable
         if (request.hasParam("pretty") == false) {
             builder.prettyPrint().lfAtEnd();
         }
         response.toXContent(builder, request);
-        return new BytesRestResponse(status, builder);
+        return new BytesRestResponse(RestStatus.OK, builder);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/main/MainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/main/MainActionTests.java
@@ -48,9 +48,8 @@ public class MainActionTests extends ESTestCase {
         final ClusterService clusterService = mock(ClusterService.class);
         final ClusterName clusterName = new ClusterName("elasticsearch");
         final Settings settings = Settings.builder().put("node.name", "my-node").build();
-        final boolean available = randomBoolean();
         ClusterBlocks blocks;
-        if (available) {
+        if (randomBoolean()) {
             if (randomBoolean()) {
                 blocks = ClusterBlocks.EMPTY_CLUSTER_BLOCK;
             } else {
@@ -86,7 +85,6 @@ public class MainActionTests extends ESTestCase {
         });
 
         assertNotNull(responseRef.get());
-        assertEquals(available, responseRef.get().isAvailable());
         verify(clusterService, times(1)).state();
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -41,7 +41,7 @@ public class MainResponseTests extends AbstractStreamableXContentTestCase<MainRe
         String nodeName = randomAlphaOfLength(10);
         Build build = new Build(randomAlphaOfLength(8), new Date(randomNonNegativeLong()).toString(), randomBoolean());
         Version version = VersionUtils.randomVersion(random());
-        return new MainResponse(nodeName, version, clusterName, clusterUuid , build, true);
+        return new MainResponse(nodeName, version, clusterName, clusterUuid , build);
     }
 
     @Override
@@ -58,7 +58,7 @@ public class MainResponseTests extends AbstractStreamableXContentTestCase<MainRe
         String clusterUUID = randomAlphaOfLengthBetween(10, 20);
         Build build = new Build(Build.CURRENT.shortHash(), Build.CURRENT.date(), Build.CURRENT.isSnapshot());
         Version version = Version.CURRENT;
-        MainResponse response = new MainResponse("nodeName", version, new ClusterName("clusterName"), clusterUUID, build, true);
+        MainResponse response = new MainResponse("nodeName", version, new ClusterName("clusterName"), clusterUUID, build);
         XContentBuilder builder = XContentFactory.jsonBuilder();
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         assertEquals("{"
@@ -80,12 +80,11 @@ public class MainResponseTests extends AbstractStreamableXContentTestCase<MainRe
     @Override
     protected MainResponse mutateInstance(MainResponse mutateInstance) {
         String clusterUuid = mutateInstance.getClusterUuid();
-        boolean available = mutateInstance.isAvailable();
         Build build = mutateInstance.getBuild();
         Version version = mutateInstance.getVersion();
         String nodeName = mutateInstance.getNodeName();
         ClusterName clusterName = mutateInstance.getClusterName();
-        switch (randomIntBetween(0, 5)) {
+        switch (randomIntBetween(0, 4)) {
             case 0:
                 clusterUuid = clusterUuid + randomAlphaOfLength(5);
                 break;
@@ -93,19 +92,16 @@ public class MainResponseTests extends AbstractStreamableXContentTestCase<MainRe
                 nodeName = nodeName + randomAlphaOfLength(5);
                 break;
             case 2:
-                available = !available;
-                break;
-            case 3:
                 // toggle the snapshot flag of the original Build parameter
                 build = new Build(build.shortHash(), build.date(), !build.isSnapshot());
                 break;
-            case 4:
+            case 3:
                 version = randomValueOtherThan(version, () -> VersionUtils.randomVersion(random()));
                 break;
-            case 5:
+            case 4:
                 clusterName = new ClusterName(clusterName + randomAlphaOfLength(5));
                 break;
         }
-        return new MainResponse(nodeName, version, clusterName, clusterUuid, build, available);
+        return new MainResponse(nodeName, version, clusterName, clusterUuid, build);
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/RestMainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/RestMainActionTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class RestMainActionTests extends ESTestCase {
@@ -44,8 +45,6 @@ public class RestMainActionTests extends ESTestCase {
         final String nodeName = "node1";
         final ClusterName clusterName = new ClusterName("cluster1");
         final String clusterUUID = randomAlphaOfLengthBetween(10, 20);
-        final boolean available = randomBoolean();
-        final RestStatus expectedStatus = available ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
         final Version version = Version.CURRENT;
         final Build build = Build.CURRENT;
 
@@ -60,7 +59,7 @@ public class RestMainActionTests extends ESTestCase {
 
         BytesRestResponse response = RestMainAction.convertMainResponse(mainResponse, restRequest, builder);
         assertNotNull(response);
-        assertEquals(expectedStatus, response.status());
+        assertThat(response.status(), equalTo(RestStatus.OK));
 
         // the empty responses are handled in the HTTP layer so we do
         // not assert on them here
@@ -70,8 +69,6 @@ public class RestMainActionTests extends ESTestCase {
         final String nodeName = "node1";
         final ClusterName clusterName = new ClusterName("cluster1");
         final String clusterUUID = randomAlphaOfLengthBetween(10, 20);
-        final boolean available = randomBoolean();
-        final RestStatus expectedStatus = available ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
         final Version version = Version.CURRENT;
         final Build build = Build.CURRENT;
         final boolean prettyPrint = randomBoolean();
@@ -87,7 +84,7 @@ public class RestMainActionTests extends ESTestCase {
 
         BytesRestResponse response = RestMainAction.convertMainResponse(mainResponse, restRequest, builder);
         assertNotNull(response);
-        assertEquals(expectedStatus, response.status());
+        assertThat(response.status(), equalTo(RestStatus.OK));
         assertThat(response.content().length(), greaterThan(0));
 
         XContentBuilder responseBuilder = JsonXContent.contentBuilder();

--- a/server/src/test/java/org/elasticsearch/rest/action/RestMainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/RestMainActionTests.java
@@ -49,7 +49,7 @@ public class RestMainActionTests extends ESTestCase {
         final Version version = Version.CURRENT;
         final Build build = Build.CURRENT;
 
-        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, clusterUUID, build, available);
+        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, clusterUUID, build);
         XContentBuilder builder = JsonXContent.contentBuilder();
         RestRequest restRequest = new FakeRestRequest() {
             @Override
@@ -76,7 +76,7 @@ public class RestMainActionTests extends ESTestCase {
         final Build build = Build.CURRENT;
         final boolean prettyPrint = randomBoolean();
 
-        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, clusterUUID, build, available);
+        final MainResponse mainResponse = new MainResponse(nodeName, version, clusterName, clusterUUID, build);
         XContentBuilder builder = JsonXContent.contentBuilder();
 
         Map<String, String> params = new HashMap<>();


### PR DESCRIPTION
The REST status 503 means "I can not handle the request that you sent me." However today we respond to a main request with a 503 when there are certain cluster blocks despite still responding with an actual main response. This is broken, we should respond with a 200 status. This commit removes this silliness.

Closes #8902