### PR TITLE
Protect against NPE in RestNodesAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -238,7 +238,7 @@ public class RestNodesAction extends AbstractCatAction {
         return table;
     }
 
-    private Table buildTable(boolean fullId, RestRequest req, ClusterStateResponse state, NodesInfoResponse nodesInfo,
+    Table buildTable(boolean fullId, RestRequest req, ClusterStateResponse state, NodesInfoResponse nodesInfo,
                              NodesStatsResponse nodesStats) {
 
         DiscoveryNodes nodes = state.getState().nodes();
@@ -273,14 +273,24 @@ public class RestNodesAction extends AbstractCatAction {
             table.addCell(node.getVersion().toString());
             table.addCell(info == null ? null : info.getBuild().shortHash());
             table.addCell(jvmInfo == null ? null : jvmInfo.version());
-            
-            long diskTotal = fsInfo.getTotal().getTotal().getBytes();
-            long diskUsed = diskTotal - fsInfo.getTotal().getAvailable().getBytes();
-            double diskUsedRatio = diskTotal == 0 ? 1.0 : (double) diskUsed / diskTotal;
-            table.addCell(fsInfo == null ? null : fsInfo.getTotal().getTotal());
-            table.addCell(fsInfo == null ? null : new ByteSizeValue(diskUsed));
-            table.addCell(fsInfo == null ? null : fsInfo.getTotal().getAvailable());
-            table.addCell(fsInfo == null ? null : String.format(Locale.ROOT, "%.2f", 100.0 * diskUsedRatio));
+
+
+            ByteSizeValue diskTotal = null;
+            ByteSizeValue diskUsed = null;
+            ByteSizeValue diskAvailable = null;
+            String diskUsedPercent = null;
+            if (fsInfo != null) {
+                diskTotal = fsInfo.getTotal().getTotal();
+                diskAvailable = fsInfo.getTotal().getAvailable();
+                diskUsed = new ByteSizeValue(diskTotal.getBytes() - diskAvailable.getBytes());
+
+                double diskUsedRatio = diskTotal.getBytes() == 0 ? 1.0 : (double) diskUsed.getBytes() / diskTotal.getBytes();
+                diskUsedPercent = String.format(Locale.ROOT, "%.2f", 100.0 * diskUsedRatio);
+            }
+            table.addCell(diskTotal);
+            table.addCell(diskUsed);
+            table.addCell(diskAvailable);
+            table.addCell(diskUsedPercent);
             
             table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsed());
             table.addCell(jvmStats == null ? null : jvmStats.getMem().getHeapUsedPercent());

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestNodesActionTests.java
@@ -1,17 +1,22 @@
 /*
- * ELASTICSEARCH CONFIDENTIAL
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Copyright (c) 2018 Elasticsearch BV. All Rights Reserved.
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Notice: this software, and all information contained
- * therein, is the exclusive property of Elasticsearch BV
- * and its licensors, if any, and is protected under applicable
- * domestic and foreign law, and international treaties.
- *
- * Reproduction, republication or distribution without the
- * express written consent of Elasticsearch BV is
- * strictly prohibited.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.elasticsearch.rest.action.cat;
 
 import org.elasticsearch.Version;

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestNodesActionTests.java
@@ -1,0 +1,64 @@
+/*
+ * ELASTICSEARCH CONFIDENTIAL
+ *
+ * Copyright (c) 2018 Elasticsearch BV. All Rights Reserved.
+ *
+ * Notice: this software, and all information contained
+ * therein, is the exclusive property of Elasticsearch BV
+ * and its licensors, if any, and is protected under applicable
+ * domestic and foreign law, and international treaties.
+ *
+ * Reproduction, republication or distribution without the
+ * express written consent of Elasticsearch BV is
+ * strictly prohibited.
+ */
+package org.elasticsearch.rest.action.cat;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.usage.UsageService;
+import org.junit.Before;
+
+import java.util.Collections;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RestNodesActionTests extends ESTestCase {
+
+    private RestNodesAction action;
+
+    @Before
+    public void setUpAction() {
+        UsageService usageService = new UsageService(Settings.EMPTY);
+        action = new RestNodesAction(Settings.EMPTY,
+                new RestController(Settings.EMPTY, Collections.emptySet(), null, null, null, usageService));
+    }
+
+    public void testBuildTableDoesNotThrowGivenNullNodeInfoAndStats() {
+        ClusterName clusterName = new ClusterName("cluster-1");
+        DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
+        builder.add(new DiscoveryNode("node-1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT));
+        DiscoveryNodes discoveryNodes = builder.build();
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterState.nodes()).thenReturn(discoveryNodes);
+
+        ClusterStateResponse clusterStateResponse = new ClusterStateResponse(clusterName, clusterState, randomNonNegativeLong());
+        NodesInfoResponse nodesInfoResponse = new NodesInfoResponse(clusterName, Collections.emptyList(), Collections.emptyList());
+        NodesStatsResponse nodesStatsResponse = new NodesStatsResponse(clusterName, Collections.emptyList(), Collections.emptyList());
+
+        action.buildTable(false, new FakeRestRequest(), clusterStateResponse, nodesInfoResponse, nodesStatsResponse);
+    }
+}


### PR DESCRIPTION
`fsInfo` may be null but not all the the code that accesses it is guarded by a null check.
