### PR TITLE
REST : Clear Indices Cache API remove deprecated url params

### DIFF
--- a/docs/reference/migration/migrate_7_0/indices.asciidoc
+++ b/docs/reference/migration/migrate_7_0/indices.asciidoc
@@ -46,7 +46,7 @@ shards the index has. In order to maintain the exact same distribution as a pre 
 `index.number_of_routing_shards` must be set to the `index.number_of_shards` at index creation time.
 Note: if the number of routing shards equals the number of shards `_split` operations are not supported.
 
-==== Skipped background refresh on search idle shards.
+==== Skipped background refresh on search idle shards
 
 Shards belonging to an index that does not have an explicit
 `index.refresh_interval` configured will  no longer refresh in the background
@@ -55,3 +55,12 @@ traffic for `index.search.idle.after` seconds (defaults to `30s`). Searches
 that access a search idle shard will be "parked" until the next refresh
 happens.  Indexing requests with `wait_for_refresh` will also trigger
 a background refresh.
+
+==== Remove deprecated url parameters for Clear Indices Cache API
+
+The following previously deprecated url parameter have been removed:
+
+* `filter` - use `query` instead
+* `filter_cache` - use `query` instead
+* `request_cache` - use `request` instead
+* `field_data` - use `fielddata` instead

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
@@ -12,10 +12,6 @@
         }
       },
       "params": {
-        "field_data": {
-          "type" : "boolean",
-          "description" : "Clear field data. This is deprecated. Prefer `fielddata`."
-        },
         "fielddata": {
           "type" : "boolean",
           "description" : "Clear field data"
@@ -49,10 +45,6 @@
         "recycler": {
           "type" : "boolean",
           "description" : "Clear the recycler cache"
-        },
-        "request_cache": {
-          "type" : "boolean",
-          "description" : "Clear request cache"
         },
         "request": {
           "type" : "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.clear_cache/10_basic.yml
@@ -14,32 +14,6 @@
         request: false
 
 ---
-"clear_cache with request_cache set to false":
-  - skip:
-      version: " - 5.3.99"
-      reason: request_cache was deprecated in 5.4.0
-      features: "warnings"
-
-  - do:
-      warnings:
-        - 'Deprecated field [request_cache] used, expected [request] instead'
-      indices.clear_cache:
-        request_cache: false
-
----
-"clear_cache with field_data set to true":
-  - skip:
-      version: " - 6.2.99"
-      reason: field_data was deprecated in 6.3.0
-      features: "warnings"
-
-  - do:
-      warnings:
-        - 'Deprecated field [field_data] used, expected [fielddata] instead'
-      indices.clear_cache:
-        field_data: true
-
----
 "clear_cache with fielddata set to true":
   - skip:
       version: " - 6.2.99"

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
@@ -99,9 +99,9 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
     }
 
     public static class Fields {
-        public static final ParseField QUERY = new ParseField("query", "filter", "filter_cache");
-        public static final ParseField REQUEST = new ParseField("request", "request_cache");
-        public static final ParseField FIELDDATA = new ParseField("fielddata", "field_data");
+        public static final ParseField QUERY = new ParseField("query");
+        public static final ParseField REQUEST = new ParseField("request");
+        public static final ParseField FIELDDATA = new ParseField("fielddata");
         public static final ParseField FIELDS = new ParseField("fields");
     }
 


### PR DESCRIPTION
As discussed in https://github.com/elastic/elasticsearch/pull/28943#issuecomment-372472131 and https://github.com/elastic/elasticsearch/pull/28866#discussion_r174072344, the deprecated url parameters should be removed.