### PR TITLE
[DOCS] Add X-Pack security steps to installation

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -99,6 +99,8 @@ Duplicate sources.list entry https://artifacts.elastic.co/packages/{major-versio
 Examine +/etc/apt/sources.list.d/elasticsearch-{major-version}.list+ for the duplicate entry or locate the duplicate entry amongst the files in `/etc/apt/sources.list.d/` and the `/etc/apt/sources.list` file.
 ==================================================
 
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
+
 endif::[]
 
 include::skip-set-kernel-parameters.asciidoc[]
@@ -125,6 +127,8 @@ sudo dpkg -i elasticsearch-{version}.deb
 --------------------------------------------
 <1> Compares the SHA of the downloaded Debian package and the published checksum, which should output
     `elasticsearch-{version}.deb: OK`.
+
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]    
 
 endif::[]
 

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -13,6 +13,14 @@ NOTE: Elasticsearch requires Java 8 or later. Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official Oracle distribution]
 or an open-source distribution such as http://openjdk.java.net[OpenJDK].
 
+. <<deb-key,Import the {es} PGP key>>.
+. Download and install {es} <<install-deb,from our website>> or
+<<deb-repo,from our APT repository>>.
+include::{xes-repo-dir}/setup/xpack-tls.asciidoc[]
+. <<deb-running,Start {es}>>.
+. <<deb-check-running,Check that {es} is running>>.
+include::{xes-repo-dir}/setup/xpack-passwords.asciidoc[]
+
 [[deb-key]]
 ==== Import the Elasticsearch PGP Key
 
@@ -99,8 +107,6 @@ Duplicate sources.list entry https://artifacts.elastic.co/packages/{major-versio
 Examine +/etc/apt/sources.list.d/elasticsearch-{major-version}.list+ for the duplicate entry or locate the duplicate entry amongst the files in `/etc/apt/sources.list.d/` and the `/etc/apt/sources.list` file.
 ==================================================
 
-include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
-
 endif::[]
 
 include::skip-set-kernel-parameters.asciidoc[]
@@ -128,10 +134,9 @@ sudo dpkg -i elasticsearch-{version}.deb
 <1> Compares the SHA of the downloaded Debian package and the published checksum, which should output
     `elasticsearch-{version}.deb: OK`.
 
-include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]    
-
 endif::[]
 
+[[deb-running]]
 include::init-systemd.asciidoc[]
 
 [[deb-running-init]]

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -86,6 +86,8 @@ sudo zypper install elasticsearch <3>
 <2> Use `dnf` on Fedora and other newer Red Hat distributions.
 <3> Use `zypper` on OpenSUSE based distributions
 
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
+
 endif::[]
 
 [[install-rpm]]
@@ -114,6 +116,8 @@ sudo rpm --install elasticsearch-{version}.rpm
 endif::[]
 
 include::skip-set-kernel-parameters.asciidoc[]
+
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
 
 include::init-systemd.asciidoc[]
 

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -17,6 +17,14 @@ NOTE: Elasticsearch requires Java 8 or later. Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official Oracle distribution]
 or an open-source distribution such as http://openjdk.java.net[OpenJDK].
 
+. <<rpm-key,Import the {es} PGP key>>.
+. Download and install {es} <<rpm-repo,from our RPM repository>> or
+<<install-rpm,from our website>>.
+include::{xes-repo-dir}/setup/xpack-tls.asciidoc[]
+. <<rpm-running,Start {es}.>>
+. <<rpm-check-running,Check that {es} is running>>.
+include::{xes-repo-dir}/setup/xpack-passwords.asciidoc[]
+
 [[rpm-key]]
 ==== Import the Elasticsearch PGP Key
 
@@ -86,8 +94,6 @@ sudo zypper install elasticsearch <3>
 <2> Use `dnf` on Fedora and other newer Red Hat distributions.
 <3> Use `zypper` on OpenSUSE based distributions
 
-include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
-
 endif::[]
 
 [[install-rpm]]
@@ -117,8 +123,7 @@ endif::[]
 
 include::skip-set-kernel-parameters.asciidoc[]
 
-include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
-
+[[rpm-running]]
 include::init-systemd.asciidoc[]
 
 [[rpm-running-init]]

--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -19,6 +19,15 @@ NOTE: Elasticsearch requires Java 8 or later. Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official Oracle distribution]
 or an open-source distribution such as http://openjdk.java.net[OpenJDK].
 
+. <<download-msi,Download the `.msi` package.>>
+. Install {es} using either the <<<<install-msi-gui,graphical user interface>>
+or the <<install-msi-command-line,command line>>.
+include::{xes-repo-dir}/setup/xpack-tls.asciidoc[]
+. <<msi-installer-command-line-running,Start {es}>>. You can optionally
+<<msi-installer-windows-service, run it as a service>>.
+. <<msi-installer-check-running,Check that {es} is running>>.
+include::{xes-repo-dir}/setup/xpack-passwords.asciidoc[]
+
 [[download-msi]]
 ==== Download the `.msi` package
 
@@ -37,7 +46,7 @@ endif::[]
 [[install-msi-gui]]
 ==== Install using the graphical user interface (GUI)
 
-Double-click the downloaded `.msi` package to launch a GUI wizard that will guide you through the 
+Double-click the downloaded `.msi` package to launch a GUI wizard that will guide you through the
 installation process. You can view help on any step by clicking the `?` button, which reveals an
 aside panel with additional information for each input:
 
@@ -52,7 +61,7 @@ image::images/msi_installer/msi_installer_locations.png[]
 
 Then select whether to install as a service or start Elasticsearch manually as needed. When
 installing as a service, you can also decide which account to run the service under as well
-as whether the service should be started after installation and when Windows is started or 
+as whether the service should be started after installation and when Windows is started or
 restarted:
 
 [[msi-installer-service]]
@@ -73,14 +82,14 @@ part of the installation, with the option to configure a HTTPS proxy through whi
 [[msi-installer-selected-plugins]]
 image::images/msi_installer/msi_installer_selected_plugins.png[]
 
-Upon choosing to install X-Pack plugin, an additional step allows a choice of the type of X-Pack 
+Upon choosing to install X-Pack plugin, an additional step allows a choice of the type of X-Pack
 license to install, in addition to X-Pack Security configuration and built-in user configuration:
 
 [[msi-installer-xpack]]
 image::images/msi_installer/msi_installer_xpack.png[]
 
-NOTE: X-Pack includes a choice of a Trial or Basic license for 30 days. After that, you can obtain one of the 
-https://www.elastic.co/subscriptions[available subscriptions] or {ref}/security-settings.html[disable Security]. 
+NOTE: X-Pack includes a choice of a Trial or Basic license for 30 days. After that, you can obtain one of the
+https://www.elastic.co/subscriptions[available subscriptions] or {ref}/security-settings.html[disable Security].
 The Basic license is free and includes the https://www.elastic.co/products/x-pack/monitoring[Monitoring] extension.
 
 After clicking the install button, the installer will begin installation:
@@ -105,7 +114,7 @@ then running:
 msiexec.exe /i elasticsearch-{version}.msi /qn
 --------------------------------------------
 
-By default, msiexec does not wait for the installation process to complete, since it runs in the 
+By default, msiexec does not wait for the installation process to complete, since it runs in the
 Windows subsystem. To wait on the process to finish and ensure that `%ERRORLEVEL%` is set
 accordingly, it is recommended to use `start /wait` to create a process and wait for it to exit
 
@@ -114,8 +123,8 @@ accordingly, it is recommended to use `start /wait` to create a process and wait
 start /wait msiexec.exe /i elasticsearch-{version}.msi /qn
 --------------------------------------------
 
-As with any MSI installation package, a log file for the installation process can be found 
-within the `%TEMP%` directory, with a randomly generated name adhering to the format 
+As with any MSI installation package, a log file for the installation process can be found
+within the `%TEMP%` directory, with a randomly generated name adhering to the format
 `MSI<random>.LOG`. The path to a log file can be supplied using the `/l` command line argument
 
 ["source","sh",subs="attributes,callouts"]
@@ -139,126 +148,126 @@ All settings exposed within the GUI are also available as command line arguments
 as _properties_ within Windows Installer documentation) that can be passed to msiexec:
 
 [horizontal]
-`INSTALLDIR`:: 
+`INSTALLDIR`::
 
-  The installation directory. The final directory in the path **must** 
+  The installation directory. The final directory in the path **must**
   be the version of Elasticsearch.
   Defaults to ++%ProgramW6432%\Elastic\Elasticsearch{backslash}{version}++.
 
-`DATADIRECTORY`:: 
+`DATADIRECTORY`::
 
-  The directory in which to store your data. 
+  The directory in which to store your data.
   Defaults to `%ALLUSERSPROFILE%\Elastic\Elasticsearch\data`
 
-`CONFIGDIRECTORY`:: 
+`CONFIGDIRECTORY`::
 
-  The directory in which to store your configuration. 
+  The directory in which to store your configuration.
   Defaults to `%ALLUSERSPROFILE%\Elastic\Elasticsearch\config`
 
-`LOGSDIRECTORY`:: 
+`LOGSDIRECTORY`::
 
-  The directory in which to store your logs. 
+  The directory in which to store your logs.
   Defaults to `%ALLUSERSPROFILE%\Elastic\Elasticsearch\logs`
 
-`PLACEWRITABLELOCATIONSINSAMEPATH`:: 
+`PLACEWRITABLELOCATIONSINSAMEPATH`::
 
   Whether the data, configuration and logs directories
   should be created under the installation directory. Defaults to `false`
 
-`INSTALLASSERVICE`:: 
+`INSTALLASSERVICE`::
 
-  Whether Elasticsearch is installed and configured as a Windows Service. 
+  Whether Elasticsearch is installed and configured as a Windows Service.
   Defaults to `true`
 
-`STARTAFTERINSTALL`:: 
+`STARTAFTERINSTALL`::
 
-  Whether the Windows Service is started after installation finishes. 
+  Whether the Windows Service is started after installation finishes.
   Defaults to `true`
 
-`STARTWHENWINDOWSSTARTS`:: 
+`STARTWHENWINDOWSSTARTS`::
 
-  Whether the Windows Service is started when Windows is started. 
+  Whether the Windows Service is started when Windows is started.
   Defaults to `true`
 
-`USELOCALSYSTEM`:: 
+`USELOCALSYSTEM`::
 
-  Whether the Windows service runs under the LocalSystem Account. 
+  Whether the Windows service runs under the LocalSystem Account.
   Defaults to `true`
 
-`USENETWORKSERVICE`:: 
+`USENETWORKSERVICE`::
 
   Whether the Windows service runs under the NetworkService Account. Defaults
   to `false`
 
-`USEEXISTINGUSER`:: 
+`USEEXISTINGUSER`::
 
   Whether the Windows service runs under a specified existing account. Defaults
   to `false`
 
-`USER`:: 
+`USER`::
 
   The username for the account under which the Windows service runs. Defaults to `""`
 
-`PASSWORD`:: 
+`PASSWORD`::
 
   The password for the account under which the Windows service runs. Defaults to `""`
 
-`CLUSTERNAME`:: 
+`CLUSTERNAME`::
 
   The name of the cluster. Defaults to `elasticsearch`
 
-`NODENAME`:: 
+`NODENAME`::
 
   The name of the node. Defaults to `%COMPUTERNAME%`
 
-`MASTERNODE`:: 
+`MASTERNODE`::
 
   Whether Elasticsearch is configured as a master node. Defaults to `true`
 
-`DATANODE`:: 
+`DATANODE`::
 
   Whether Elasticsearch is configured as a data node. Defaults to `true`
 
-`INGESTNODE`:: 
+`INGESTNODE`::
 
   Whether Elasticsearch is configured as an ingest node. Defaults to `true`
 
-`SELECTEDMEMORY`:: 
+`SELECTEDMEMORY`::
 
-  The amount of memory to allocate to the JVM heap for Elasticsearch. 
-  Defaults to `2048` unless the target machine has less than 4GB in total, in which case 
+  The amount of memory to allocate to the JVM heap for Elasticsearch.
+  Defaults to `2048` unless the target machine has less than 4GB in total, in which case
   it defaults to 50% of total memory.
 
-`LOCKMEMORY`:: 
+`LOCKMEMORY`::
 
   Whether `bootstrap.memory_lock` should be used to try to lock the process
   address space into RAM. Defaults to `false`
 
-`UNICASTNODES`:: 
+`UNICASTNODES`::
 
   A comma separated list of hosts in the form `host:port` or `host` to be used for
   unicast discovery. Defaults to `""`
 
-`MINIMUMMASTERNODES`:: 
+`MINIMUMMASTERNODES`::
 
-  The minimum number of master-eligible nodes that must be visible 
+  The minimum number of master-eligible nodes that must be visible
   in order to form a cluster. Defaults to `""`
 
-`NETWORKHOST`:: 
+`NETWORKHOST`::
 
-  The hostname or IP address to bind the node to and _publish_ (advertise) this 
+  The hostname or IP address to bind the node to and _publish_ (advertise) this
   host to other nodes in the cluster. Defaults to `""`
 
-`HTTPPORT`:: 
+`HTTPPORT`::
 
   The port to use for exposing Elasticsearch APIs over HTTP. Defaults to `9200`
 
-`TRANSPORTPORT`:: 
+`TRANSPORTPORT`::
 
-  The port to use for internal communication between nodes within the cluster. 
+  The port to use for internal communication between nodes within the cluster.
   Defaults to `9300`
 
-`PLUGINS`:: 
+`PLUGINS`::
 
   A comma separated list of the plugins to download and install as part of the installation. Defaults to `""`
 
@@ -294,7 +303,7 @@ as _properties_ within Windows Installer documentation) that can be passed to ms
   used to bootstrap the cluster and persisted as the `bootstrap.password` setting in the keystore.
   Defaults to a randomized value.
 
-`SKIPSETTINGPASSWORDS`:: 
+`SKIPSETTINGPASSWORDS`::
 
   When installing X-Pack plugin with a `Trial` license and X-Pack Security enabled, whether the
   installation should skip setting up the built-in users `elastic`, `kibana` and `logstash_system`.
@@ -313,7 +322,7 @@ as _properties_ within Windows Installer documentation) that can be passed to ms
 `LOGSTASHSYSTEMUSERPASSWORD`::
 
   When installing X-Pack plugin with a `Trial` license and X-Pack Security enabled, the password
-  to use for the built-in user `logstash_system`. Defaults to `""`  
+  to use for the built-in user `logstash_system`. Defaults to `""`
 
 To pass a value, simply append the property name and value using the format `<PROPERTYNAME>="<VALUE>"` to
 the installation command. For example, to use a different installation directory to the default one and to install https://www.elastic.co/products/x-pack[X-Pack]:
@@ -324,7 +333,7 @@ start /wait msiexec.exe /i elasticsearch-{version}.msi /qn INSTALLDIR="C:\Custom
 --------------------------------------------
 
 Consult the https://msdn.microsoft.com/en-us/library/windows/desktop/aa367988(v=vs.85).aspx[Windows Installer SDK Command-Line Options]
-for additional rules related to values containing quotation marks. 
+for additional rules related to values containing quotation marks.
 
 [[msi-installer-command-line-running]]
 ==== Running Elasticsearch from the command line
@@ -366,6 +375,7 @@ TIP: Typically, any cluster-wide settings (like `cluster.name`) should be
 added to the `elasticsearch.yml` config file, while any node-specific settings
 such as `node.name` could be specified on the command line.
 
+[[msi-installer-check-running]]
 include::check-running.asciidoc[]
 
 [[msi-installer-windows-service]]
@@ -374,10 +384,10 @@ include::check-running.asciidoc[]
 Elasticsearch can be installed as a service to run in the background or start
 automatically at boot time without any user interaction. This can be achieved upon installation
 using the following command line options
- 
-* `INSTALLASSERVICE=true` 
-* `STARTAFTERINSTALL=true` 
-* `STARTWHENWINDOWSSTARTS=true` 
+
+* `INSTALLASSERVICE=true`
+* `STARTAFTERINSTALL=true`
+* `STARTWHENWINDOWSSTARTS=true`
 
 Once installed, Elasticsearch will appear within the Services control panel:
 
@@ -401,18 +411,18 @@ with PowerShell:
 Get-Service Elasticsearch | Stop-Service | Start-Service
 --------------------------------------------
 
-Changes can be made to jvm.options and elasticsearch.yml configuration files to configure the 
-service after installation. Most changes (like JVM settings) will require a restart of the 
+Changes can be made to jvm.options and elasticsearch.yml configuration files to configure the
+service after installation. Most changes (like JVM settings) will require a restart of the
 service in order to take effect.
 
 [[upgrade-msi-gui]]
 ==== Upgrade using the graphical user interface (GUI)
 
-The `.msi` package supports upgrading an installed version of Elasticsearch to a newer 
-version of Elasticsearch. The upgrade process through the GUI handles upgrading all 
+The `.msi` package supports upgrading an installed version of Elasticsearch to a newer
+version of Elasticsearch. The upgrade process through the GUI handles upgrading all
 installed plugins as well as retaining both your data and configuration.
 
-Downloading and clicking on a newer version of the `.msi` package will launch the GUI wizard. 
+Downloading and clicking on a newer version of the `.msi` package will launch the GUI wizard.
 The first step will list the read only properties from the previous installation:
 
 [[msi-installer-upgrade-notice]]
@@ -423,7 +433,7 @@ The following configuration step allows certain configuration options to be chan
 [[msi-installer-upgrade-configuration]]
 image::images/msi_installer/msi_installer_upgrade_configuration.png[]
 
-Finally, the plugins step allows currently installed plugins to be upgraded or removed, and 
+Finally, the plugins step allows currently installed plugins to be upgraded or removed, and
 for plugins not currently installed, to be downloaded and installed:
 
 [[msi-installer-upgrade-plugins]]
@@ -432,25 +442,25 @@ image::images/msi_installer/msi_installer_upgrade_plugins.png[]
 [[upgrade-msi-command-line]]
 ==== Upgrade using the command line
 
-The `.msi` can also upgrade Elasticsearch using the command line. 
+The `.msi` can also upgrade Elasticsearch using the command line.
 
 [IMPORTANT]
 ===========================================
 A command line upgrade requires passing the **same** command line properties as
-used at first install time; the Windows Installer does not remember these properties. 
+used at first install time; the Windows Installer does not remember these properties.
 
 For example, if you originally installed with the command line options `PLUGINS="x-pack"` and
 `LOCKMEMORY="true"`, then you must pass these same values when performing an
 upgrade from the command line.
 
-The **exception** to this is `INSTALLDIR` (if originally specified), which must be a different directory to the 
-current installation. 
+The **exception** to this is `INSTALLDIR` (if originally specified), which must be a different directory to the
+current installation.
 If setting `INSTALLDIR`, the final directory in the path **must** be the version of Elasticsearch e.g.
 
 ++C:\Program Files\Elastic\Elasticsearch{backslash}{version}++
 ===========================================
 
-The simplest upgrade, assuming Elasticsearch was installed using all defaults, 
+The simplest upgrade, assuming Elasticsearch was installed using all defaults,
 is achieved by first navigating to the download directory, then running:
 
 ["source","sh",subs="attributes,callouts"]
@@ -471,7 +481,7 @@ start /wait msiexec.exe /i elasticsearch-{version}.msi /qn /l upgrade.log
 
 The `.msi` package handles uninstallation of all directories and files added as part of installation.
 
-WARNING: Uninstallation will remove **all** directories and their contents created as part of 
+WARNING: Uninstallation will remove **all** directories and their contents created as part of
 installation, **including data within the data directory**. If you wish to retain your data upon
 uninstallation, it is recommended that you make a copy of the data directory before uninstallation.
 

--- a/docs/reference/setup/install/zip-targz.asciidoc
+++ b/docs/reference/setup/install/zip-targz.asciidoc
@@ -14,6 +14,14 @@ NOTE: Elasticsearch requires Java 8 or later. Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official Oracle distribution]
 or an open-source distribution such as http://openjdk.java.net[OpenJDK].
 
+. Download and install either the <<install-zip,`.zip`>> or
+<<install-targz,`.tar.gz`>> package.
+include::{xes-repo-dir}/setup/xpack-tls.asciidoc[]
+. <<zip-targz-running,Start {es}>>. You can optionally
+<<setup-installation-daemon, run it as a daemon>>.
+. <<zip-targz-checking,Check that {es} is running>>.
+include::{xes-repo-dir}/setup/xpack-passwords.asciidoc[]
+
 [[install-zip]]
 ==== Download and install the `.zip` package
 
@@ -39,6 +47,8 @@ cd elasticsearch-{version}/ <2>
 <1> Compares the SHA of the downloaded `.zip` archive and the published checksum, which should output
     `elasticsearch-{version}.zip: OK`.
 <2> This directory is known as `$ES_HOME`.
+
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
 
 endif::[]
 
@@ -68,6 +78,8 @@ cd elasticsearch-{version}/ <2>
     `elasticsearch-{version}.tar.gz: OK`.
 <2> This directory is known as `$ES_HOME`.
 
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
+
 endif::[]
 
 [[zip-targz-running]]
@@ -88,6 +100,7 @@ that supports arrays and assume that Bash is available at `/bin/bash`.
 As such, Bash should be available at this path either directly or via a
 symbolic link.
 
+[[zip-targz-checking]]
 include::check-running.asciidoc[]
 
 Log printing to `stdout` can be disabled using the `-q` or `--quiet`

--- a/docs/reference/setup/install/zip-targz.asciidoc
+++ b/docs/reference/setup/install/zip-targz.asciidoc
@@ -19,7 +19,7 @@ or an open-source distribution such as http://openjdk.java.net[OpenJDK].
 include::{xes-repo-dir}/setup/xpack-tls.asciidoc[]
 . <<zip-targz-running,Start {es}>>. You can optionally
 <<setup-installation-daemon, run it as a daemon>>.
-. <<zip-targz-checking,Check that {es} is running>>.
+. <<zip-targz-check-running,Check that {es} is running>>.
 include::{xes-repo-dir}/setup/xpack-passwords.asciidoc[]
 
 [[install-zip]]
@@ -47,8 +47,6 @@ cd elasticsearch-{version}/ <2>
 <1> Compares the SHA of the downloaded `.zip` archive and the published checksum, which should output
     `elasticsearch-{version}.zip: OK`.
 <2> This directory is known as `$ES_HOME`.
-
-include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
 
 endif::[]
 
@@ -78,8 +76,6 @@ cd elasticsearch-{version}/ <2>
     `elasticsearch-{version}.tar.gz: OK`.
 <2> This directory is known as `$ES_HOME`.
 
-include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
-
 endif::[]
 
 [[zip-targz-running]]
@@ -100,7 +96,7 @@ that supports arrays and assume that Bash is available at `/bin/bash`.
 As such, Bash should be available at this path either directly or via a
 symbolic link.
 
-[[zip-targz-checking]]
+[[zip-targz-check-running]]
 include::check-running.asciidoc[]
 
 Log printing to `stdout` can be disabled using the `-q` or `--quiet`

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -22,7 +22,7 @@ or an open-source distribution such as http://openjdk.java.net[OpenJDK].
 include::{xes-repo-dir}/setup/xpack-tls.asciidoc[]
 . <<windows-running,Start {es}>>. You can optionally
 <<windows-service, run it as a service>>.
-. <<windows-checking,Check that {es} is running>>.
+. <<windows-check-running,Check that {es} is running>>.
 include::{xes-repo-dir}/setup/xpack-passwords.asciidoc[]
 
 [[install-windows]]
@@ -46,8 +46,6 @@ window, `cd` to the `%ES_HOME%` directory, for instance:
 ----------------------------
 cd c:\elasticsearch-{version}
 ----------------------------
-
-include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
 
 endif::[]
 
@@ -85,7 +83,7 @@ TIP: Typically, any cluster-wide settings (like `cluster.name`) should be
 added to the `elasticsearch.yml` config file, while any node-specific settings
 such as `node.name` could be specified on the command line.
 
-[[windows-checking]]
+[[windows-check-running]]
 include::check-running.asciidoc[]
 
 [[windows-service]]

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -18,6 +18,13 @@ NOTE: Elasticsearch requires Java 8 or later. Use the
 http://www.oracle.com/technetwork/java/javase/downloads/index.html[official Oracle distribution]
 or an open-source distribution such as http://openjdk.java.net[OpenJDK].
 
+. <<install-windows,Download and install the `.zip` package.>>
+include::{xes-repo-dir}/setup/xpack-tls.asciidoc[]
+. <<windows-running,Start {es}>>. You can optionally
+<<windows-service, run it as a service>>.
+. <<windows-checking,Check that {es} is running>>.
+include::{xes-repo-dir}/setup/xpack-passwords.asciidoc[]
+
 [[install-windows]]
 ==== Download and install the `.zip` package
 
@@ -39,6 +46,8 @@ window, `cd` to the `%ES_HOME%` directory, for instance:
 ----------------------------
 cd c:\elasticsearch-{version}
 ----------------------------
+
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
 
 endif::[]
 
@@ -76,6 +85,7 @@ TIP: Typically, any cluster-wide settings (like `cluster.name`) should be
 added to the `elasticsearch.yml` config file, while any node-specific settings
 such as `node.name` could be specified on the command line.
 
+[[windows-checking]]
 include::check-running.asciidoc[]
 
 [[windows-service]]


### PR DESCRIPTION
This PR adds an ordered list to the top of each of the Elasticsearch installation pages. It also integrates two steps in each list: configuring TLS and setting up the passwords for built-in users.  

Those two added steps originally appeared in https://www.elastic.co/guide/en/elasticsearch/reference/master/installing-xpack-es.html
