### PR TITLE
[DOCS] Updated installation pages with X-Pack indices

### DIFF
--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -128,6 +128,15 @@ sudo dpkg -i elasticsearch-{version}.deb
 
 endif::[]
 
+ifdef::include-xpack[]
+[[deb-enable-indices]]
+==== Enable automatic creation of {xpack} indices
+
+{xpack} will try to automatically create a number of indices within Elasticsearch.
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
+
+endif::include-xpack[]
+
 include::init-systemd.asciidoc[]
 
 [[deb-running-init]]

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -115,6 +115,15 @@ endif::[]
 
 include::skip-set-kernel-parameters.asciidoc[]
 
+ifdef::include-xpack[]
+[[rpm-enable-indices]]
+==== Enable automatic creation of {xpack} indices
+
+{xpack} will try to automatically create a number of indices within {es}.
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
+
+endif::include-xpack[]
+
 include::init-systemd.asciidoc[]
 
 [[rpm-running-init]]

--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -37,7 +37,7 @@ endif::[]
 [[install-msi-gui]]
 ==== Install using the graphical user interface (GUI)
 
-Double-click the downloaded `.msi` package to launch a GUI wizard that will guide you through the 
+Double-click the downloaded `.msi` package to launch a GUI wizard that will guide you through the
 installation process. You can view help on any step by clicking the `?` button, which reveals an
 aside panel with additional information for each input:
 
@@ -52,7 +52,7 @@ image::images/msi_installer/msi_installer_locations.png[]
 
 Then select whether to install as a service or start Elasticsearch manually as needed. When
 installing as a service, you can also decide which account to run the service under as well
-as whether the service should be started after installation and when Windows is started or 
+as whether the service should be started after installation and when Windows is started or
 restarted:
 
 [[msi-installer-service]]
@@ -73,14 +73,14 @@ part of the installation, with the option to configure a HTTPS proxy through whi
 [[msi-installer-selected-plugins]]
 image::images/msi_installer/msi_installer_selected_plugins.png[]
 
-Upon choosing to install X-Pack plugin, an additional step allows a choice of the type of X-Pack 
+Upon choosing to install X-Pack plugin, an additional step allows a choice of the type of X-Pack
 license to install, in addition to X-Pack Security configuration and built-in user configuration:
 
 [[msi-installer-xpack]]
 image::images/msi_installer/msi_installer_xpack.png[]
 
-NOTE: X-Pack includes a choice of a Trial or Basic license for 30 days. After that, you can obtain one of the 
-https://www.elastic.co/subscriptions[available subscriptions] or {ref}/security-settings.html[disable Security]. 
+NOTE: X-Pack includes a choice of a Trial or Basic license for 30 days. After that, you can obtain one of the
+https://www.elastic.co/subscriptions[available subscriptions] or {ref}/security-settings.html[disable Security].
 The Basic license is free and includes the https://www.elastic.co/products/x-pack/monitoring[Monitoring] extension.
 
 After clicking the install button, the installer will begin installation:
@@ -105,7 +105,7 @@ then running:
 msiexec.exe /i elasticsearch-{version}.msi /qn
 --------------------------------------------
 
-By default, msiexec does not wait for the installation process to complete, since it runs in the 
+By default, msiexec does not wait for the installation process to complete, since it runs in the
 Windows subsystem. To wait on the process to finish and ensure that `%ERRORLEVEL%` is set
 accordingly, it is recommended to use `start /wait` to create a process and wait for it to exit
 
@@ -114,8 +114,8 @@ accordingly, it is recommended to use `start /wait` to create a process and wait
 start /wait msiexec.exe /i elasticsearch-{version}.msi /qn
 --------------------------------------------
 
-As with any MSI installation package, a log file for the installation process can be found 
-within the `%TEMP%` directory, with a randomly generated name adhering to the format 
+As with any MSI installation package, a log file for the installation process can be found
+within the `%TEMP%` directory, with a randomly generated name adhering to the format
 `MSI<random>.LOG`. The path to a log file can be supplied using the `/l` command line argument
 
 ["source","sh",subs="attributes,callouts"]
@@ -139,126 +139,126 @@ All settings exposed within the GUI are also available as command line arguments
 as _properties_ within Windows Installer documentation) that can be passed to msiexec:
 
 [horizontal]
-`INSTALLDIR`:: 
+`INSTALLDIR`::
 
-  The installation directory. The final directory in the path **must** 
+  The installation directory. The final directory in the path **must**
   be the version of Elasticsearch.
   Defaults to ++%ProgramW6432%\Elastic\Elasticsearch{backslash}{version}++.
 
-`DATADIRECTORY`:: 
+`DATADIRECTORY`::
 
-  The directory in which to store your data. 
+  The directory in which to store your data.
   Defaults to `%ALLUSERSPROFILE%\Elastic\Elasticsearch\data`
 
-`CONFIGDIRECTORY`:: 
+`CONFIGDIRECTORY`::
 
-  The directory in which to store your configuration. 
+  The directory in which to store your configuration.
   Defaults to `%ALLUSERSPROFILE%\Elastic\Elasticsearch\config`
 
-`LOGSDIRECTORY`:: 
+`LOGSDIRECTORY`::
 
-  The directory in which to store your logs. 
+  The directory in which to store your logs.
   Defaults to `%ALLUSERSPROFILE%\Elastic\Elasticsearch\logs`
 
-`PLACEWRITABLELOCATIONSINSAMEPATH`:: 
+`PLACEWRITABLELOCATIONSINSAMEPATH`::
 
   Whether the data, configuration and logs directories
   should be created under the installation directory. Defaults to `false`
 
-`INSTALLASSERVICE`:: 
+`INSTALLASSERVICE`::
 
-  Whether Elasticsearch is installed and configured as a Windows Service. 
+  Whether Elasticsearch is installed and configured as a Windows Service.
   Defaults to `true`
 
-`STARTAFTERINSTALL`:: 
+`STARTAFTERINSTALL`::
 
-  Whether the Windows Service is started after installation finishes. 
+  Whether the Windows Service is started after installation finishes.
   Defaults to `true`
 
-`STARTWHENWINDOWSSTARTS`:: 
+`STARTWHENWINDOWSSTARTS`::
 
-  Whether the Windows Service is started when Windows is started. 
+  Whether the Windows Service is started when Windows is started.
   Defaults to `true`
 
-`USELOCALSYSTEM`:: 
+`USELOCALSYSTEM`::
 
-  Whether the Windows service runs under the LocalSystem Account. 
+  Whether the Windows service runs under the LocalSystem Account.
   Defaults to `true`
 
-`USENETWORKSERVICE`:: 
+`USENETWORKSERVICE`::
 
   Whether the Windows service runs under the NetworkService Account. Defaults
   to `false`
 
-`USEEXISTINGUSER`:: 
+`USEEXISTINGUSER`::
 
   Whether the Windows service runs under a specified existing account. Defaults
   to `false`
 
-`USER`:: 
+`USER`::
 
   The username for the account under which the Windows service runs. Defaults to `""`
 
-`PASSWORD`:: 
+`PASSWORD`::
 
   The password for the account under which the Windows service runs. Defaults to `""`
 
-`CLUSTERNAME`:: 
+`CLUSTERNAME`::
 
   The name of the cluster. Defaults to `elasticsearch`
 
-`NODENAME`:: 
+`NODENAME`::
 
   The name of the node. Defaults to `%COMPUTERNAME%`
 
-`MASTERNODE`:: 
+`MASTERNODE`::
 
   Whether Elasticsearch is configured as a master node. Defaults to `true`
 
-`DATANODE`:: 
+`DATANODE`::
 
   Whether Elasticsearch is configured as a data node. Defaults to `true`
 
-`INGESTNODE`:: 
+`INGESTNODE`::
 
   Whether Elasticsearch is configured as an ingest node. Defaults to `true`
 
-`SELECTEDMEMORY`:: 
+`SELECTEDMEMORY`::
 
-  The amount of memory to allocate to the JVM heap for Elasticsearch. 
-  Defaults to `2048` unless the target machine has less than 4GB in total, in which case 
+  The amount of memory to allocate to the JVM heap for Elasticsearch.
+  Defaults to `2048` unless the target machine has less than 4GB in total, in which case
   it defaults to 50% of total memory.
 
-`LOCKMEMORY`:: 
+`LOCKMEMORY`::
 
   Whether `bootstrap.memory_lock` should be used to try to lock the process
   address space into RAM. Defaults to `false`
 
-`UNICASTNODES`:: 
+`UNICASTNODES`::
 
   A comma separated list of hosts in the form `host:port` or `host` to be used for
   unicast discovery. Defaults to `""`
 
-`MINIMUMMASTERNODES`:: 
+`MINIMUMMASTERNODES`::
 
-  The minimum number of master-eligible nodes that must be visible 
+  The minimum number of master-eligible nodes that must be visible
   in order to form a cluster. Defaults to `""`
 
-`NETWORKHOST`:: 
+`NETWORKHOST`::
 
-  The hostname or IP address to bind the node to and _publish_ (advertise) this 
+  The hostname or IP address to bind the node to and _publish_ (advertise) this
   host to other nodes in the cluster. Defaults to `""`
 
-`HTTPPORT`:: 
+`HTTPPORT`::
 
   The port to use for exposing Elasticsearch APIs over HTTP. Defaults to `9200`
 
-`TRANSPORTPORT`:: 
+`TRANSPORTPORT`::
 
-  The port to use for internal communication between nodes within the cluster. 
+  The port to use for internal communication between nodes within the cluster.
   Defaults to `9300`
 
-`PLUGINS`:: 
+`PLUGINS`::
 
   A comma separated list of the plugins to download and install as part of the installation. Defaults to `""`
 
@@ -294,7 +294,7 @@ as _properties_ within Windows Installer documentation) that can be passed to ms
   used to bootstrap the cluster and persisted as the `bootstrap.password` setting in the keystore.
   Defaults to a randomized value.
 
-`SKIPSETTINGPASSWORDS`:: 
+`SKIPSETTINGPASSWORDS`::
 
   When installing X-Pack plugin with a `Trial` license and X-Pack Security enabled, whether the
   installation should skip setting up the built-in users `elastic`, `kibana` and `logstash_system`.
@@ -313,7 +313,7 @@ as _properties_ within Windows Installer documentation) that can be passed to ms
 `LOGSTASHSYSTEMUSERPASSWORD`::
 
   When installing X-Pack plugin with a `Trial` license and X-Pack Security enabled, the password
-  to use for the built-in user `logstash_system`. Defaults to `""`  
+  to use for the built-in user `logstash_system`. Defaults to `""`
 
 To pass a value, simply append the property name and value using the format `<PROPERTYNAME>="<VALUE>"` to
 the installation command. For example, to use a different installation directory to the default one and to install https://www.elastic.co/products/x-pack[X-Pack]:
@@ -324,7 +324,16 @@ start /wait msiexec.exe /i elasticsearch-{version}.msi /qn INSTALLDIR="C:\Custom
 --------------------------------------------
 
 Consult the https://msdn.microsoft.com/en-us/library/windows/desktop/aa367988(v=vs.85).aspx[Windows Installer SDK Command-Line Options]
-for additional rules related to values containing quotation marks. 
+for additional rules related to values containing quotation marks.
+
+ifdef::include-xpack[]
+[[msi-installer-enable-indices]]
+==== Enable automatic creation of {xpack} indices
+
+{xpack} will try to automatically create a number of indices within {es}.
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
+
+endif::include-xpack[]
 
 [[msi-installer-command-line-running]]
 ==== Running Elasticsearch from the command line
@@ -374,10 +383,10 @@ include::check-running.asciidoc[]
 Elasticsearch can be installed as a service to run in the background or start
 automatically at boot time without any user interaction. This can be achieved upon installation
 using the following command line options
- 
-* `INSTALLASSERVICE=true` 
-* `STARTAFTERINSTALL=true` 
-* `STARTWHENWINDOWSSTARTS=true` 
+
+* `INSTALLASSERVICE=true`
+* `STARTAFTERINSTALL=true`
+* `STARTWHENWINDOWSSTARTS=true`
 
 Once installed, Elasticsearch will appear within the Services control panel:
 
@@ -401,18 +410,18 @@ with PowerShell:
 Get-Service Elasticsearch | Stop-Service | Start-Service
 --------------------------------------------
 
-Changes can be made to jvm.options and elasticsearch.yml configuration files to configure the 
-service after installation. Most changes (like JVM settings) will require a restart of the 
+Changes can be made to jvm.options and elasticsearch.yml configuration files to configure the
+service after installation. Most changes (like JVM settings) will require a restart of the
 service in order to take effect.
 
 [[upgrade-msi-gui]]
 ==== Upgrade using the graphical user interface (GUI)
 
-The `.msi` package supports upgrading an installed version of Elasticsearch to a newer 
-version of Elasticsearch. The upgrade process through the GUI handles upgrading all 
+The `.msi` package supports upgrading an installed version of Elasticsearch to a newer
+version of Elasticsearch. The upgrade process through the GUI handles upgrading all
 installed plugins as well as retaining both your data and configuration.
 
-Downloading and clicking on a newer version of the `.msi` package will launch the GUI wizard. 
+Downloading and clicking on a newer version of the `.msi` package will launch the GUI wizard.
 The first step will list the read only properties from the previous installation:
 
 [[msi-installer-upgrade-notice]]
@@ -423,7 +432,7 @@ The following configuration step allows certain configuration options to be chan
 [[msi-installer-upgrade-configuration]]
 image::images/msi_installer/msi_installer_upgrade_configuration.png[]
 
-Finally, the plugins step allows currently installed plugins to be upgraded or removed, and 
+Finally, the plugins step allows currently installed plugins to be upgraded or removed, and
 for plugins not currently installed, to be downloaded and installed:
 
 [[msi-installer-upgrade-plugins]]
@@ -432,25 +441,25 @@ image::images/msi_installer/msi_installer_upgrade_plugins.png[]
 [[upgrade-msi-command-line]]
 ==== Upgrade using the command line
 
-The `.msi` can also upgrade Elasticsearch using the command line. 
+The `.msi` can also upgrade Elasticsearch using the command line.
 
 [IMPORTANT]
 ===========================================
 A command line upgrade requires passing the **same** command line properties as
-used at first install time; the Windows Installer does not remember these properties. 
+used at first install time; the Windows Installer does not remember these properties.
 
 For example, if you originally installed with the command line options `PLUGINS="x-pack"` and
 `LOCKMEMORY="true"`, then you must pass these same values when performing an
 upgrade from the command line.
 
-The **exception** to this is `INSTALLDIR` (if originally specified), which must be a different directory to the 
-current installation. 
+The **exception** to this is `INSTALLDIR` (if originally specified), which must be a different directory to the
+current installation.
 If setting `INSTALLDIR`, the final directory in the path **must** be the version of Elasticsearch e.g.
 
 ++C:\Program Files\Elastic\Elasticsearch{backslash}{version}++
 ===========================================
 
-The simplest upgrade, assuming Elasticsearch was installed using all defaults, 
+The simplest upgrade, assuming Elasticsearch was installed using all defaults,
 is achieved by first navigating to the download directory, then running:
 
 ["source","sh",subs="attributes,callouts"]
@@ -471,7 +480,7 @@ start /wait msiexec.exe /i elasticsearch-{version}.msi /qn /l upgrade.log
 
 The `.msi` package handles uninstallation of all directories and files added as part of installation.
 
-WARNING: Uninstallation will remove **all** directories and their contents created as part of 
+WARNING: Uninstallation will remove **all** directories and their contents created as part of
 installation, **including data within the data directory**. If you wish to retain your data upon
 uninstallation, it is recommended that you make a copy of the data directory before uninstallation.
 

--- a/docs/reference/setup/install/zip-targz.asciidoc
+++ b/docs/reference/setup/install/zip-targz.asciidoc
@@ -70,6 +70,15 @@ cd elasticsearch-{version}/ <2>
 
 endif::[]
 
+ifdef::include-xpack[]
+[[zip-targz-enable-indices]]
+==== Enable automatic creation of {xpack} indices
+
+{xpack} will try to automatically create a number of indices within {es}.
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
+
+endif::include-xpack[]
+
 [[zip-targz-running]]
 ==== Running Elasticsearch from the command line
 

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -42,6 +42,15 @@ cd c:\elasticsearch-{version}
 
 endif::[]
 
+ifdef::include-xpack[]
+[[windows-enable-indices]]
+==== Enable automatic creation of {xpack} indices
+
+{xpack} will try to automatically create a number of indices within {es}.
+include::{xes-repo-dir}/setup/xpack-indices.asciidoc[]
+
+endif::include-xpack[]
+
 [[windows-running]]
 ==== Running Elasticsearch from the command line
 


### PR DESCRIPTION
This PR updates the Elasticsearch installation pages with information about the enabling the automatic creation of X-Pack indices.  

That information previously existed in the X-Pack installation information here: https://www.elastic.co/guide/en/elasticsearch/reference/master/installing-xpack-es.html

If you prefer that this information be added in a different section of the Elasticsearch Reference, let me know. 