### PR TITLE
Fix #29057 CWD to ES_HOME does not change drive

### DIFF
--- a/distribution/src/bin/elasticsearch.bat
+++ b/distribution/src/bin/elasticsearch.bat
@@ -50,7 +50,7 @@ if "%MAYBE_JVM_OPTIONS_PARSER_FAILED%" == "jvm_options_parser_failed" (
   exit /b 1
 )
 
-cd "%ES_HOME%"
+cd /d "%ES_HOME%"
 %JAVA% %ES_JAVA_OPTS% -Delasticsearch -Des.path.home="%ES_HOME%" -Des.path.conf="%ES_PATH_CONF%" -cp "%ES_CLASSPATH%" "org.elasticsearch.bootstrap.Elasticsearch" !newparams!
 
 endlocal


### PR DESCRIPTION
The /d switch on cd also changes the current drive in DOS.
This allows the bat file to be called while the users CWD is on a different drive.