### PR TITLE
Clarify that dates are always rendered as strings.

### DIFF
--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -10,6 +10,13 @@ JSON doesn't have a date datatype, so dates in Elasticsearch can either be:
 Internally, dates are converted to UTC (if the time-zone is specified) and
 stored as a long number representing milliseconds-since-the-epoch.
 
+Queries on dates are internally converted to range queries on this long
+representation, and the result of aggregations and stored fields is converted
+back to a string depending on the date format that is associated with the field.
+
+NOTE: Dates will always be rendered as strings, even if they were initially
+supplied as a long in the JSON document.
+
 Date formats can be customised, but if no `format` is specified then it uses
 the default:
 


### PR DESCRIPTION
Even in the case that the date was originally supplied as a long in the
JSON document.

Closes #26504
