### PR TITLE
[DOCS] Added security upgrade details

### DIFF
--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -128,4 +128,15 @@ GET _cat/recovery
 // CONSOLE
 --
 
-. *Restart machine learning jobs.* 
+. If you use {security} and are upgrading directly to {version} from 5.5 or
+earlier, you must upgrade the `.security` index after you restart {es}.
++
+--
+IMPORTANT: Native realm users cannot authenticate until the index is upgraded.
+For instructions, see {stack-ref}/upgrading-elastic-stack.html#upgrade-internal-indices[Upgrading
+internal indices]. You also need to upgrade the `.security` index if
+you restore a pre-5.6 snapshot to a fresh 6.0 install.
+
+--
+
+. *Restart machine learning jobs.*


### PR DESCRIPTION
This PR adds information about upgrading security indices to the Elasticsearch upgrade instructions. 

That information originally appeared in the X-Pack documentation here: https://www.elastic.co/guide/en/x-pack/current/xpack-upgrading.html