### PR TITLE
Build: Add ability to override data dir for run task

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -25,6 +25,25 @@ run it using Gradle:
 ./gradlew run
 -------------------------------------
 
+You can also attach a debugger to the running instance. The following
+command will print the port the debugger should listen to
+and wait for a connection:
+
+-------------------------------------
+./gradlew run --debug-jvm
+...
+[elasticsearch] Listening for transport dt_socket at address: 8000
+...
+-------------------------------------
+
+Addtionally, you can specify a custom data directory to use. This
+allows running repeated tests after making changes to code
+without having to reindex data on every run:
+
+-------------------------------------
+./gradlew run --data-dir=/path/to/data/dir
+-------------------------------------
+
 === Test case filtering.
 
 - `tests.class` is a class-filtering shell-like glob pattern,

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ import org.elasticsearch.gradle.BuildPlugin
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionCollection
 import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.test.RunTask
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
 import org.gradle.api.tasks.wrapper.Wrapper
@@ -402,24 +403,11 @@ allprojects {
   tasks.eclipse.dependsOn(cleanEclipse, copyEclipseSettings)
 }
 
-// we need to add the same --debug-jvm option as
-// the real RunTask has, so we can pass it through
-class Run extends DefaultTask {
-  boolean debug = false
-
-  @org.gradle.api.internal.tasks.options.Option(
-        option = "debug-jvm",
-        description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch."
-  )
-  public void setDebug(boolean enabled) {
-    project.project(':distribution').run.clusterConfig.debug = enabled
+gradle.projectsEvaluated {
+  StartParameter start = gradle.startParameter
+  if (start.currentDir == project.rootDir && start.taskNames.contains('run')) {
+    start.taskNames = start.taskNames.collect { taskName -> taskName == 'run' ? ':distribution:run' : taskName }
   }
-}
-task run(type: Run) {
-  dependsOn ':distribution:run'
-  description = 'Runs elasticsearch in the foreground'
-  group = 'Verification'
-  impliesSubProjects = true
 }
 
 task wrapper(type: Wrapper)

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -63,9 +63,6 @@ class NodeInfo {
     /** config directory */
     File pathConf
 
-    /** data directory (as an Object, to allow lazy evaluation) */
-    Object dataDir
-
     /** THE config file */
     File configFile
 
@@ -117,11 +114,6 @@ class NodeInfo {
         this.nodeVersion = nodeVersion
         homeDir = homeDir(baseDir, config.distribution, nodeVersion)
         pathConf = pathConf(baseDir, config.distribution, nodeVersion)
-        if (config.dataDir != null) {
-            dataDir = "${config.dataDir(nodeNum)}"
-        } else {
-            dataDir = new File(homeDir, "data")
-        }
         configFile = new File(pathConf, 'elasticsearch.yml')
         // even for rpm/deb, the logs are under home because we dont start with real services
         File logsDir = new File(homeDir, 'logs')
@@ -194,9 +186,9 @@ class NodeInfo {
                  * creating its data directory on startup but we simply can not do that here because getting the short path name requires
                  * the directory to already exist. Therefore, we create this directory immediately before getting the short name.
                  */
-                args.addAll("-E", "path.data=${-> Files.createDirectories(Paths.get(dataDir.toString())); getShortPathName(dataDir.toString())}")
+                args.addAll("-E", "path.data=${-> Files.createDirectories(Paths.get(dataDir)); getShortPathName(dataDir)}")
             } else {
-                args.addAll("-E", "path.data=${-> dataDir.toString()}")
+                args.addAll("-E", "path.data=${-> dataDir}")
             }
         }
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
@@ -273,11 +265,11 @@ class NodeInfo {
     }
 
     /** Returns the data directory for this node */
-    File getDataDir() {
-        if (!(dataDir instanceof File)) {
-            return new File(dataDir)
+    String getDataDir() {
+        if (config.dataDir == null) {
+            return new File(homeDir, 'data')
         }
-        return dataDir
+        return config.dataDir(nodeNum)
     }
 
     /** Returns the directory elasticsearch home is contained in for the given distribution */

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/RunTask.groovy
@@ -30,6 +30,15 @@ public class RunTask extends DefaultTask {
         clusterConfig.debug = enabled;
     }
 
+    @Option(
+            option = "data-dir",
+            description = "Set the data directory used with elasticsearch"
+    )
+    public void setDataDir(String dataDir) {
+        println "Setting custom datadir"
+        clusterConfig.dataDir = { nodeNum -> dataDir }
+    }
+
     /** Configure the cluster that will be run. */
     @Override
     public Task configure(Closure closure) {


### PR DESCRIPTION
This commit adds a `--data-dir` option to the `run` task, allowing one
to override the default data dir in the exploded distribution zip.

closes #19474