### PR TITLE
Do not renew sync-id if all shards are sealed

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -77,6 +77,13 @@ public final class CommitStats implements Streamable, ToXContentFragment {
     }
 
     /**
+     * The synced-flush id of the commit if existed.
+     */
+    public String syncId() {
+        return userData.get(InternalEngine.SYNC_COMMIT_ID);
+    }
+
+    /**
      * Returns the number of documents in the in this commit
      */
     public int getNumDocs() {

--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -34,6 +34,8 @@ import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -65,6 +67,7 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
@@ -216,9 +219,16 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
                             if (inflight != 0) {
                                 actionListener.onResponse(new ShardsSyncedFlushResult(shardId, totalShards, "[" + inflight + "] ongoing operations on primary"));
                             } else {
-                                // 3. now send the sync request to all the shards
-                                String syncId = UUIDs.randomBase64UUID();
-                                sendSyncRequests(syncId, activeShards, state, presyncResponses, shardId, totalShards, actionListener);
+                                // 3. now send the sync request to all the shards;
+                                final String sharedSyncId = sharedExistingSyncId(presyncResponses);
+                                if (sharedSyncId != null) {
+                                    assert presyncResponses.values().stream().allMatch(r -> r.existingSyncId.equals(sharedSyncId)) :
+                                        "Not all shards have the same existing sync id [" + sharedSyncId + "], responses [" + presyncResponses + "]";
+                                    reportSuccessWithExistingSyncId(shardId, sharedSyncId, activeShards, totalShards, presyncResponses, actionListener);
+                                }else {
+                                    String syncId = UUIDs.randomBase64UUID();
+                                    sendSyncRequests(syncId, activeShards, state, presyncResponses, shardId, totalShards, actionListener);
+                                }
                             }
                         }
 
@@ -242,6 +252,33 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
         } catch (Exception e) {
             actionListener.onFailure(e);
         }
+    }
+
+    private String sharedExistingSyncId(Map<String, PreSyncedFlushResponse> preSyncedFlushResponses) {
+        String existingSyncId = null;
+        for (PreSyncedFlushResponse resp : preSyncedFlushResponses.values()) {
+            if (Strings.isNullOrEmpty(resp.existingSyncId)) {
+                return null;
+            }
+            if (existingSyncId == null) {
+                existingSyncId = resp.existingSyncId;
+            }
+            if (existingSyncId.equals(resp.existingSyncId) == false) {
+                return null;
+            }
+        }
+        return existingSyncId;
+    }
+
+    private void reportSuccessWithExistingSyncId(ShardId shardId, String existingSyncId, List<ShardRouting> shards, int totalShards,
+                                                 Map<String, PreSyncedFlushResponse> preSyncResponses, ActionListener<ShardsSyncedFlushResult> listener) {
+        final Map<ShardRouting, ShardSyncedFlushResponse> results = new HashMap<>();
+        for (final ShardRouting shard : shards) {
+            if (preSyncResponses.containsKey(shard.currentNodeId())) {
+                results.put(shard, new ShardSyncedFlushResponse());
+            }
+        }
+        listener.onResponse(new ShardsSyncedFlushResult(shardId, existingSyncId, totalShards, results));
     }
 
     final IndexShardRoutingTable getShardRoutingTable(ShardId shardId, ClusterState state) {
@@ -438,7 +475,7 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
         final CommitStats commitStats = indexShard.commitStats();
         final Engine.CommitId commitId = commitStats.getRawCommitId();
         logger.trace("{} pre sync flush done. commit id {}, num docs {}", request.shardId(), commitId, commitStats.getNumDocs());
-        return new PreSyncedFlushResponse(commitId, commitStats.getNumDocs());
+        return new PreSyncedFlushResponse(commitId, commitStats.getNumDocs(), commitStats.syncId());
     }
 
     private ShardSyncedFlushResponse performSyncedFlush(ShardSyncedFlushRequest request) {
@@ -512,21 +549,15 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
 
         Engine.CommitId commitId;
         int numDocs;
+        @Nullable String existingSyncId = null;
 
         PreSyncedFlushResponse() {
         }
 
-        PreSyncedFlushResponse(Engine.CommitId commitId, int numDocs) {
+        PreSyncedFlushResponse(Engine.CommitId commitId, int numDocs, String existingSyncId) {
             this.commitId = commitId;
             this.numDocs = numDocs;
-        }
-
-        Engine.CommitId commitId() {
-            return commitId;
-        }
-
-        int numDocs() {
-            return numDocs;
+            this.existingSyncId = existingSyncId;
         }
 
         boolean includeNumDocs(Version version) {
@@ -535,6 +566,10 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
             } else {
                 return version.onOrAfter(Version.V_6_2_2);
             }
+        }
+
+        boolean includeExistingSyncId(Version version) {
+            return version.onOrAfter(Version.V_7_0_0_alpha1);
         }
 
         @Override
@@ -546,6 +581,9 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
             } else {
                 numDocs = UNKNOWN_NUM_DOCS;
             }
+            if (includeExistingSyncId(in.getVersion())) {
+                existingSyncId = in.readOptionalString();
+            }
         }
 
         @Override
@@ -554,6 +592,9 @@ public class SyncedFlushService extends AbstractComponent implements IndexEventL
             commitId.writeTo(out);
             if (includeNumDocs(out.getVersion())) {
                 out.writeInt(numDocs);
+            }
+            if (includeExistingSyncId(out.getVersion())) {
+                out.writeOptionalString(existingSyncId);
             }
         }
     }


### PR DESCRIPTION
Today the synced-flush always issues a new sync-id even though all
shards haven't been changed since the last seal. This causes active
shards to have different a sync-id from offline shards even though all
were sealed and no writes since then.

This commit adjusts not to renew sync-id if all active shards are sealed
with the same sync-id.

Closes #27838
