### PR TITLE
REST : Clear Indices Cache API simplify param parsing

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterUpdateSettingsAction.java
@@ -22,7 +22,6 @@ package org.elasticsearch.rest.action.admin.cluster;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.rest.BaseRestHandler;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
@@ -42,11 +42,6 @@ import static org.elasticsearch.rest.action.RestActions.buildBroadcastShardsHead
 
 public class RestClearIndicesCacheAction extends BaseRestHandler {
 
-    private static final String QUERY = "query";
-    private static final String REQUEST = "request";
-    private static final String FIELDDATA = "fielddata";
-    private static final String FIELDS = "fields";
-
     public RestClearIndicesCacheAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(POST, "/_cache/clear", this);
@@ -85,10 +80,10 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
     }
 
     public static ClearIndicesCacheRequest fromRequest(final RestRequest request, ClearIndicesCacheRequest clearIndicesCacheRequest) {
-        clearIndicesCacheRequest.queryCache(request.paramAsBoolean(QUERY, clearIndicesCacheRequest.queryCache()));
-        clearIndicesCacheRequest.requestCache(request.paramAsBoolean(REQUEST, clearIndicesCacheRequest.requestCache()));
-        clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean(FIELDDATA, clearIndicesCacheRequest.fieldDataCache()));
-        clearIndicesCacheRequest.fields(request.paramAsStringArray(FIELDS, clearIndicesCacheRequest.fields()));
+        clearIndicesCacheRequest.queryCache(request.paramAsBoolean("query", clearIndicesCacheRequest.queryCache()));
+        clearIndicesCacheRequest.requestCache(request.paramAsBoolean("request", clearIndicesCacheRequest.requestCache()));
+        clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean("fielddata", clearIndicesCacheRequest.fieldDataCache()));
+        clearIndicesCacheRequest.fields(request.paramAsStringArray("fields", clearIndicesCacheRequest.fields()));
         return clearIndicesCacheRequest;
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
@@ -85,19 +85,10 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
     }
 
     public static ClearIndicesCacheRequest fromRequest(final RestRequest request, ClearIndicesCacheRequest clearIndicesCacheRequest) {
-
-        for (String param : request.params().keySet()) {
-            if (QUERY.equals(param)) {
-                clearIndicesCacheRequest.queryCache(request.paramAsBoolean(param, clearIndicesCacheRequest.queryCache()));
-            } else if (REQUEST.equals(param)) {
-                clearIndicesCacheRequest.requestCache(request.paramAsBoolean(param, clearIndicesCacheRequest.requestCache()));
-            } else if (FIELDDATA.equals(param)) {
-                clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean(param, clearIndicesCacheRequest.fieldDataCache()));
-            } else if (FIELDS.equals(param)) {
-                clearIndicesCacheRequest.fields(request.paramAsStringArray(param, clearIndicesCacheRequest.fields()));
-            }
-        }
-
+        clearIndicesCacheRequest.queryCache(request.paramAsBoolean(QUERY, clearIndicesCacheRequest.queryCache()));
+        clearIndicesCacheRequest.requestCache(request.paramAsBoolean(REQUEST, clearIndicesCacheRequest.requestCache()));
+        clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean(FIELDDATA, clearIndicesCacheRequest.fieldDataCache()));
+        clearIndicesCacheRequest.fields(request.paramAsStringArray(FIELDS, clearIndicesCacheRequest.fields()));
         return clearIndicesCacheRequest;
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java
@@ -23,10 +23,8 @@ import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheReque
 import org.elasticsearch.action.admin.indices.cache.clear.ClearIndicesCacheResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -36,7 +34,6 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.action.RestBuilderListener;
 
 import java.io.IOException;
-import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -44,6 +41,12 @@ import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.action.RestActions.buildBroadcastShardsHeader;
 
 public class RestClearIndicesCacheAction extends BaseRestHandler {
+
+    private static final String QUERY = "query";
+    private static final String REQUEST = "request";
+    private static final String FIELDDATA = "fielddata";
+    private static final String FIELDS = "fields";
+
     public RestClearIndicesCacheAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(POST, "/_cache/clear", this);
@@ -83,26 +86,19 @@ public class RestClearIndicesCacheAction extends BaseRestHandler {
 
     public static ClearIndicesCacheRequest fromRequest(final RestRequest request, ClearIndicesCacheRequest clearIndicesCacheRequest) {
 
-        for (Map.Entry<String, String> entry : request.params().entrySet()) {
-            if (Fields.QUERY.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
-                clearIndicesCacheRequest.queryCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.queryCache()));
-            } else if (Fields.REQUEST.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
-                clearIndicesCacheRequest.requestCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.requestCache()));
-            } else if (Fields.FIELDDATA.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
-                clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean(entry.getKey(), clearIndicesCacheRequest.fieldDataCache()));
-            } else  if (Fields.FIELDS.match(entry.getKey(), LoggingDeprecationHandler.INSTANCE)) {
-                clearIndicesCacheRequest.fields(request.paramAsStringArray(entry.getKey(), clearIndicesCacheRequest.fields()));
+        for (String param : request.params().keySet()) {
+            if (QUERY.equals(param)) {
+                clearIndicesCacheRequest.queryCache(request.paramAsBoolean(param, clearIndicesCacheRequest.queryCache()));
+            } else if (REQUEST.equals(param)) {
+                clearIndicesCacheRequest.requestCache(request.paramAsBoolean(param, clearIndicesCacheRequest.requestCache()));
+            } else if (FIELDDATA.equals(param)) {
+                clearIndicesCacheRequest.fieldDataCache(request.paramAsBoolean(param, clearIndicesCacheRequest.fieldDataCache()));
+            } else if (FIELDS.equals(param)) {
+                clearIndicesCacheRequest.fields(request.paramAsStringArray(param, clearIndicesCacheRequest.fields()));
             }
         }
 
         return clearIndicesCacheRequest;
-    }
-
-    public static class Fields {
-        public static final ParseField QUERY = new ParseField("query");
-        public static final ParseField REQUEST = new ParseField("request");
-        public static final ParseField FIELDDATA = new ParseField("fielddata");
-        public static final ParseField FIELDS = new ParseField("fields");
     }
 
 }


### PR DESCRIPTION
Simplify the parsing of the params in Clear Indices Cache API, as a follow up to the removing of the deprecated parameter names.