### PR TITLE
Fix creating keystore when upgrading

### DIFF
--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -96,6 +96,9 @@ Closure commonPackageConfig(String type) {
     postInstall file("${scripts}/postinst")
     preUninstall file("${scripts}/prerm")
     postUninstall file("${scripts}/postrm")
+    if (type == 'rpm') {
+      postTrans file("${scripts}/posttrans")
+    }
 
     // top level "into" directive is not inherited from ospackage for some reason, so we must
     // specify it again explicitly for copying common files

--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -19,18 +19,22 @@ case "$1" in
         if [ -n $2 ]; then
             IS_UPGRADE=true
         fi
+        PACKAGE=deb
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
+        PACKAGE=deb
     ;;
 
     # RedHat ####################################################
     1)
         # If $1=1 this is an install
         IS_UPGRADE=false
+        PACKAGE=rpm
     ;;
     2)
         # If $1=1 this is an upgrade
         IS_UPGRADE=true
+        PACKAGE=rpm
     ;;
 
     *)
@@ -99,7 +103,8 @@ if [ -f ${path.env} ]; then
     chown root:elasticsearch ${path.env}
 fi
 
-if [ ! -f /etc/elasticsearch/elasticsearch.keystore ]; then
+# the equivalent code for rpm is in posttrans
+if [ "$PACKAGE" = "deb" -a ! -f /etc/elasticsearch/elasticsearch.keystore ]; then
     /usr/share/elasticsearch/bin/elasticsearch-keystore create
     chown root:elasticsearch /etc/elasticsearch/elasticsearch.keystore
     chmod 660 /etc/elasticsearch/elasticsearch.keystore

--- a/distribution/packages/src/common/scripts/posttrans
+++ b/distribution/packages/src/common/scripts/posttrans
@@ -1,0 +1,8 @@
+if [ ! -f /etc/elasticsearch/elasticsearch.keystore ]; then
+    /usr/share/elasticsearch/bin/elasticsearch-keystore create
+    chown root:elasticsearch /etc/elasticsearch/elasticsearch.keystore
+    chmod 660 /etc/elasticsearch/elasticsearch.keystore
+    md5sum /etc/elasticsearch/elasticsearch.keystore > /etc/elasticsearch/.elasticsearch.keystore.initial_md5sum
+fi
+
+${scripts.footer}


### PR DESCRIPTION
When upgrading via the RPM package, we can run into a problem where the keystore fails to be created. This arises because the %post script on RPM runs after the new package files are installed but before the removal of the old package files. This means that the contents of the lib folder can contain files from the old package and the new package and thus running the create keystore tool can encounter JAR hell issues and fail. To solve this, we move creating the keystore to the %posttrans script which runs after the old package files are removed. We only need to do this on the RPM package, so we add a switch in the shared post-install script.

Relates #28928

