### PR TITLE
Configure error file for archive packages

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -268,7 +268,7 @@ subprojects {
       'error.file': [
         'deb': "-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log",
         'rpm': "-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log",
-        'def': "#-XX:ErrorFile=/error/file/path"
+        'def': "-XX:ErrorFile=logs/hs_err_pid%p.log"
       ],
 
       'stopping.timeout': [

--- a/docs/reference/setup/important-settings/error-file.asciidoc
+++ b/docs/reference/setup/important-settings/error-file.asciidoc
@@ -5,8 +5,8 @@ By default, Elasticsearch configures the JVM to write fatal error logs
 to the default logging directory (this is `/var/lib/elasticsearch` for
 the <<rpm,RPM>> and <<deb,Debian>> package distributions, and the `logs`
 directory under the root of the Elasticsearch installation for the
-<<zip-targz,tar and zip>> archive distributions. These are logs produced
-by the JVM when it encounters a fatal error (e.g., a segmentation
-fault). If this path is not suitable for receiving logs, you should
-modify the entry `-XX:ErrorFile=/var/lib/elasticsearch/hs_err_pid%p.log`
-in <<jvm-options,`jvm.options`>> to an alternate path.
+<<zip-targz,tar and zip>> archive distributions). These are logs
+produced by the JVM when it encounters a fatal error (e.g., a
+segmentation fault). If this path is not suitable for receiving logs,
+you should modify the entry `-XX:ErrorFile=...` in
+<<jvm-options,`jvm.options`>> to an alternate path.

--- a/docs/reference/setup/important-settings/error-file.asciidoc
+++ b/docs/reference/setup/important-settings/error-file.asciidoc
@@ -2,7 +2,7 @@
 === JVM fatal error logs
 
 By default, Elasticsearch configures the JVM to write fatal error logs
-to the default logging directory (this is `/var/lib/elasticsearch` for
+to the default logging directory (this is `/var/log/elasticsearch` for
 the <<rpm,RPM>> and <<deb,Debian>> package distributions, and the `logs`
 directory under the root of the Elasticsearch installation for the
 <<zip-targz,tar and zip>> archive distributions). These are logs

--- a/docs/reference/setup/important-settings/error-file.asciidoc
+++ b/docs/reference/setup/important-settings/error-file.asciidoc
@@ -1,16 +1,12 @@
 [[error-file-path]]
 === JVM fatal error logs
 
-The <<rpm,RPM>> and <<deb,Debian>> package distributions default to configuring
-the JVM to write fatal error logs to `/var/lib/elasticsearch`; these are logs
-produced by the JVM when it encounters a fatal error (e.g., a segmentation
-fault). If this path is not suitable for receiving logs, you should modify the
-entry `-XX:ErrorFile=/var/lib/elasticsearch/hs_err_pid%p.log` in
-<<jvm-options,`jvm.options`>> to an alternate path.
-
-Note that the archive distributions do not configure the error file path by
-default. Instead, the JVM will default to writing to the working directory for
-the Elasticsearch process. If you wish to configure an error file path, you
-should modify the entry `#-XX:ErrorFile=/error/file/path` in
-<<jvm-options,`jvm.options`>> to remove the comment marker `#` and to specify an
-actual path.
+By default, Elasticsearch configures the JVM to write fatal error logs
+to the default logging directory (this is `/var/lib/elasticsearch` for
+the <<rpm,RPM>> and <<deb,Debian>> package distributions, and the `logs`
+directory under the root of the Elasticsearch installation for the
+<<zip-targz,tar and zip>> archive distributions. These are logs produced
+by the JVM when it encounters a fatal error (e.g., a segmentation
+fault). If this path is not suitable for receiving logs, you should
+modify the entry `-XX:ErrorFile=/var/lib/elasticsearch/hs_err_pid%p.log`
+in <<jvm-options,`jvm.options`>> to an alternate path.


### PR DESCRIPTION
This is a follow up to a previous change which set the error file path for the package distributions. The observation here is that we always set the working directory of Elasticsearch to the root of the installation (i.e., Elasticsearch home). Therefore, we can specify the error file path relative to this directory and default it to the logs directory, similar to the package distributions.

Relates #29028, relates #29032
