### PR TITLE
Configure heap dump path for archive packages

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -262,7 +262,7 @@ subprojects {
       'heap.dump.path': [
         'deb': "-XX:HeapDumpPath=/var/lib/elasticsearch",
         'rpm': "-XX:HeapDumpPath=/var/lib/elasticsearch",
-        'def': "#-XX:HeapDumpPath=/heap/dump/path"
+        'def': "-XX:HeapDumpPath=data"
       ],
 
       'error.file': [

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -77,8 +77,8 @@
 # heap dumps are created in the working directory of the JVM
 -XX:+HeapDumpOnOutOfMemoryError
 
-# specify an alternative path for heap dumps
-# ensure the directory exists and has sufficient space
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
 ${heap.dump.path}
 
 # specify an alternative path for JVM fatal error logs

--- a/docs/reference/setup/important-settings/heap-dump-path.asciidoc
+++ b/docs/reference/setup/important-settings/heap-dump-path.asciidoc
@@ -1,19 +1,15 @@
 [[heap-dump-path]]
 === JVM heap dump path
 
-The <<rpm,RPM>> and <<deb,Debian>> package distributions default to configuring
-the JVM to dump the heap on out of memory exceptions to
-`/var/lib/elasticsearch`. If this path is not suitable for storing heap dumps,
-you should modify the entry `-XX:HeapDumpPath=/var/lib/elasticsearch` in
-<<jvm-options,`jvm.options`>> to an alternate path.  If you specify a filename
-instead of a directory, the JVM will repeatedly use the same file; this is one
-mechanism for preventing heap dumps from accumulating in the heap dump path.
-Alternatively, you can configure a scheduled task via your OS to remove heap
-dumps that are older than a configured age.
-
-Note that the archive distributions do not configure the heap dump path by
-default. Instead, the JVM will default to dumping to the working directory for
-the Elasticsearch process. If you wish to configure a heap dump path, you should
-modify the entry `#-XX:HeapDumpPath=/heap/dump/path` in
-<<jvm-options,`jvm.options`>> to remove the comment marker `#` and to specify an
-actual path.
+By default, Elasticsearch configures the JVM to dump the heap on out of
+memory exceptions to the default data directory (this is
+`/var/lib/elasticsearch` for the <<rpm,RPM>> and <<deb,Debian>> package
+distributions, and the `data` directory under the root of the
+Elasticsearch installation for the <<zip-targz,tar and zip>> archive
+distributions). If this path is not suitable for receiving heap dumps,
+you should modify the entry `-XX:HeapDumpPath=...` in
+<<jvm-options,`jvm.options`>>. If you specify a fixed filename instead
+of a directory, the JVM will repeatedly use the same file; this is one
+mechanism for preventing heap dumps from accumulating in the heap dump
+path. Alternatively, you can configure a scheduled task via your OS to
+remove heap dumps that are older than a configured age.


### PR DESCRIPTION
This is a follow up to a previous change which set the heap dump path for the package distributions. The observation here is that we always set the working directory of Elasticsearch to to the root of installation (i.e., Elasticsearch home). Therefore, we can specify the heap dump path relative to this directory and default it to the data directory, similar to the package distributions.

Relates #26755