### PR TITLE
Test: Expect extract Exception in die_with_dignity

### DIFF
--- a/qa/die-with-dignity/src/test/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
+++ b/qa/die-with-dignity/src/test/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
@@ -20,22 +20,25 @@
 package org.elasticsearch.qa.die_with_dignity;
 
 import org.apache.http.ConnectionClosedException;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseListener;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.hamcrest.Matcher;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
@@ -48,7 +51,22 @@ public class DieWithDignityIT extends ESRestTestCase {
         assertThat(pidFileLines, hasSize(1));
         final int pid = Integer.parseInt(pidFileLines.get(0));
         Files.delete(pidFile);
-        expectThrows(ConnectionClosedException.class, () -> client().performRequest("GET", "/_die_with_dignity"));
+        IOException e = expectThrows(IOException.class, () -> client().performRequest("GET", "/_die_with_dignity"));
+        Matcher<IOException> failureMatcher = instanceOf(ConnectionClosedException.class);
+        if (Constants.WINDOWS) {
+            /*
+             * If the other side closes the connection while we're waiting to fill our buffer
+             * we can get IOException with the message below. It seems to only come up on
+             * Windows and it *feels* like it could be a ConnectionClosedException but
+             * upstream does not consider this a bug:
+             * https://issues.apache.org/jira/browse/HTTPASYNC-134
+             *
+             * So we catch it here and consider it "ok".
+            */
+            failureMatcher = either(failureMatcher)
+                    .or(hasToString(containsString("An existing connection was forcibly closed by the remote host")));
+        }
+        assertThat(e, failureMatcher);
 
         // the Elasticsearch process should die and disappear from the output of jps
         assertBusy(() -> {


### PR DESCRIPTION
I did a little digging. It looks like this is caused when the other side
closes its connection while we're waiting on our buffer to fill up. We
totally expect that in this test. It feels to me like we should throw a
`ConnectionClosedException` but upstream does not agree:
https://issues.apache.org/jira/browse/HTTPASYNC-134

While we *could* catch the exception and transform it ourselves that
seems like a bigger change than is merited at this point.

Closes #29136
