### PR TITLE
Update api.asciidoc

### DIFF
--- a/docs/reference/migration/migrate_7_0/api.asciidoc
+++ b/docs/reference/migration/migrate_7_0/api.asciidoc
@@ -1,5 +1,5 @@
 [[breaking_70_api_changes]]
-=== Breaking changes in 7.0
+=== Breaking API changes in 7.0
 
 ==== Camel case and underscore parameters deprecated in 6.x have been removed
 A  number of duplicate parameters deprecated in 6.x have been removed from


### PR DESCRIPTION
The parent page has the same title, and the URL path indicates this is about API changes, so include "API" in the title.