### PR TITLE
Tests - fix incorrect agg test assumption that zero-doc buckets will be returned

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -82,8 +82,10 @@ public class InternalAdjacencyMatrixTests extends InternalMultiBucketAggregation
         final Map<String, Long> expectedCounts = new TreeMap<>();
         for (InternalAdjacencyMatrix input : inputs) {
             for (InternalAdjacencyMatrix.InternalBucket bucket : input.getBuckets()) {
-                expectedCounts.compute(bucket.getKeyAsString(),
+                if (bucket.getDocCount() > 0) {
+                    expectedCounts.compute(bucket.getKeyAsString(),
                         (key, oldValue) -> (oldValue == null ? 0 : oldValue) + bucket.getDocCount());
+                }
             }
         }
         final Map<String, Long> actualCounts = new TreeMap<>();


### PR DESCRIPTION
The adjacency matrix aggregation does not return buckets with zero doc counts as it can be a very sparse result set. Changed construction of test's expected results.

Closes #29159 