### PR TITLE
Update index_.asciidoc

### DIFF
--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -249,7 +249,7 @@ on a per-operation basis using the `routing` parameter. For example:
 
 [source,js]
 --------------------------------------------------
-POST twitter/tweet?routing=kimchy
+POST twitter/_doc?routing=kimchy
 {
     "user" : "kimchy",
     "post_date" : "2009-11-15T14:12:12",


### PR DESCRIPTION
Routing example : typo in the type's name (twitter instead of _doc type)
