### PR TITLE
Call addBytesSent with correct number of bytes

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4MessageChannelHandler.java
@@ -51,7 +51,8 @@ final class Netty4MessageChannelHandler extends ChannelDuplexHandler {
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (msg instanceof ByteBuf && transportServiceAdapter != null) {
             // record the number of bytes send on the channel
-            promise.addListener(f -> transportServiceAdapter.addBytesSent(((ByteBuf) msg).readableBytes()));
+            final int bytesSent = ((ByteBuf) msg).readableBytes();
+            promise.addListener(f -> transportServiceAdapter.addBytesSent(bytesSent));
         }
         ctx.write(msg, promise);
     }


### PR DESCRIPTION
This is related to #27258. Currently we call the transport service
adaptor with the number of readable bytes once a message has been sent.
However, the number of readable bytes should be zero as the bytebuf has
been consumed. This commit fixes that issue by recording the number of
bytes.