### PR TITLE
Decouple more classes from XContentBuilder and make builder strict

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -25,6 +25,8 @@ import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 
 import java.io.IOException;
@@ -34,7 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class Version implements Comparable<Version> {
+public class Version implements Comparable<Version>, ToXContentFragment {
     /*
      * The logic for ID is: XXYYZZAA, where XX is major version, YY is minor version, ZZ is revision, and AA is alpha/beta/rc indicator AA
      * values below 25 are for alpha builder (since 5.0), and above 25 and below 50 are beta builds, and below 99 are RC builds, with 99
@@ -420,6 +422,11 @@ public class Version implements Comparable<Version> {
     @Override
     public int compareTo(Version other) {
         return Integer.compare(this.id, other.id);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.value(toString());
     }
 
     /*

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReference.java
@@ -23,6 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.ByteArrayOutputStream;
@@ -37,7 +38,7 @@ import java.util.function.ToIntBiFunction;
 /**
  * A reference to bytes.
  */
-public abstract class BytesReference implements Accountable, Comparable<BytesReference> {
+public abstract class BytesReference implements Accountable, Comparable<BytesReference>, ToXContentFragment {
 
     private Integer hash = null; // we cache the hash of this reference since it can be quite costly to re-calculated it
 
@@ -333,5 +334,11 @@ public abstract class BytesReference implements Accountable, Comparable<BytesRef
         public long skip(long n) throws IOException {
             return input.skip(n);
         }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        BytesRef bytes = toBytesRef();
+        return builder.value(bytes.bytes, bytes.offset, bytes.length);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
+++ b/server/src/main/java/org/elasticsearch/common/document/DocumentField.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.document;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -127,11 +128,7 @@ public class DocumentField implements Streamable, ToXContentFragment, Iterable<O
             // Stored fields values are converted using MappedFieldType#valueForDisplay.
             // As a result they can either be Strings, Numbers, or Booleans, that's
             // all.
-            if (value instanceof BytesReference) {
-                builder.binaryValue(((BytesReference) value).toBytesRef());
-            } else {
-                builder.value(value);
-            }
+            builder.value(value);
         }
         builder.endArray();
         return builder;

--- a/server/src/main/java/org/elasticsearch/common/text/Text.java
+++ b/server/src/main/java/org/elasticsearch/common/text/Text.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.common.text;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -125,7 +126,8 @@ public final class Text implements Comparable<Text>, ToXContentFragment {
         } else {
             // TODO: TextBytesOptimization we can use a buffer here to convert it? maybe add a
             // request to jackson to support InputStream as well?
-            return builder.utf8Value(this.bytes().toBytesRef());
+            BytesRef br = this.bytes().toBytesRef();
+            return builder.utf8Value(br.bytes, br.offset, br.length);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
+++ b/server/src/main/java/org/elasticsearch/common/transport/TransportAddress.java
@@ -23,6 +23,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.network.NetworkAddress;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -32,7 +35,7 @@ import java.net.UnknownHostException;
 /**
  * A transport address used for IP socket address (wraps {@link java.net.InetSocketAddress}).
  */
-public final class TransportAddress implements Writeable {
+public final class TransportAddress implements Writeable, ToXContentFragment {
 
     /**
      * A <a href="https://en.wikipedia.org/wiki/0.0.0.0">non-routeable v4 meta transport address</a> that can be used for
@@ -127,5 +130,10 @@ public final class TransportAddress implements Writeable {
     @Override
     public String toString() {
         return NetworkAddress.format(address);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.value(toString());
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -27,12 +27,15 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Objects;
 
-public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue> {
+public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXContentFragment {
     private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(ByteSizeValue.class));
 
     private final long size;
@@ -268,5 +271,10 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue> {
         long thisValue = size * unit.toBytes(1);
         long otherValue = other.size * other.unit.toBytes(1);
         return Long.compare(thisValue, otherValue);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.value(toString());
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -24,6 +24,9 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.joda.time.Period;
 import org.joda.time.PeriodType;
 import org.joda.time.format.PeriodFormat;
@@ -40,7 +43,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-public class TimeValue implements Writeable, Comparable<TimeValue> {
+public class TimeValue implements Writeable, Comparable<TimeValue>, ToXContentFragment {
 
     /** How many nano-seconds in one milli-second */
     public static final long NSEC_PER_MSEC = TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS);
@@ -397,5 +400,10 @@ public class TimeValue implements Writeable, Comparable<TimeValue> {
         double thisValue = ((double) duration) * timeUnit.toNanos(1);
         double otherValue = ((double) timeValue.duration) * timeValue.timeUnit.toNanos(1);
         return Double.compare(thisValue, otherValue);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.value(toString());
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentElasticsearchExtension.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentElasticsearchExtension.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.joda.time.DateTimeZone;
+import org.joda.time.tz.CachedDateTimeZone;
+import org.joda.time.tz.FixedDateTimeZone;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * SPI extensions for Elasticsearch-specific classes (like the Lucene or Joda
+ * dependency classes) that need to be encoded by {@link XContentBuilder} in a
+ * specific way.
+ */
+public class XContentElasticsearchExtension implements XContentBuilderExtension {
+
+    @Override
+    public Map<Class<?>, XContentBuilder.Writer> getXContentWriters() {
+        Map<Class<?>, XContentBuilder.Writer> writers = new HashMap<>();
+
+        // Fully-qualified here to reduce ambiguity around our (ES') Version class
+        writers.put(org.apache.lucene.util.Version.class, (b, v) -> b.value(Objects.toString(v)));
+        writers.put(DateTimeZone.class, (b, v) -> b.value(Objects.toString(v)));
+        writers.put(CachedDateTimeZone.class, (b, v) -> b.value(Objects.toString(v)));
+        writers.put(FixedDateTimeZone.class, (b, v) -> b.value(Objects.toString(v)));
+
+        writers.put(BytesReference.class, (b, v) -> {
+            if (v == null) {
+                b.nullValue();
+            } else {
+                BytesRef bytes = ((BytesReference) v).toBytesRef();
+                b.value(bytes.bytes, bytes.offset, bytes.length);
+            }
+        });
+
+        writers.put(BytesRef.class, (b, v) -> {
+            if (v == null) {
+                b.nullValue();
+            } else {
+                BytesRef bytes = (BytesRef) v;
+                b.value(bytes.bytes, bytes.offset, bytes.length);
+            }
+        });
+        return writers;
+    }
+
+    @Override
+    public Map<Class<?>, XContentBuilder.HumanReadableTransformer> getXContentHumanReadableTransformers() {
+        Map<Class<?>, XContentBuilder.HumanReadableTransformer> transformers = new HashMap<>();
+        transformers.put(TimeValue.class, v -> ((TimeValue) v).millis());
+        transformers.put(ByteSizeValue.class, v -> ((ByteSizeValue) v).getBytes());
+        return transformers;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentParser.java
@@ -228,7 +228,6 @@ public interface XContentParser extends Closeable {
      * Reads a plain binary value that was written via one of the following methods:
      *
      * <ul>
-     *     <li>{@link XContentBuilder#field(String, org.apache.lucene.util.BytesRef)}</li>
      *     <li>{@link XContentBuilder#field(String, byte[], int, int)}}</li>
      *     <li>{@link XContentBuilder#field(String, byte[])}}</li>
      * </ul>
@@ -236,8 +235,7 @@ public interface XContentParser extends Closeable {
      * as well as via their <code>String</code> variants of the separated value methods.
      * Note: Do not use this method to read values written with:
      * <ul>
-     *     <li>{@link XContentBuilder#utf8Field(String, org.apache.lucene.util.BytesRef)}</li>
-     *     <li>{@link XContentBuilder#utf8Field(String, org.apache.lucene.util.BytesRef)}</li>
+     *     <li>{@link XContentBuilder#utf8Field(String, byte[], int, int)}</li>
      * </ul>
      *
      * these methods write UTF-8 encoded strings and must be read through:

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardId.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardId.java
@@ -23,6 +23,9 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
 
 import java.io.IOException;
@@ -30,7 +33,7 @@ import java.io.IOException;
 /**
  * Allows for shard level components to be injected with the shard id.
  */
-public class ShardId implements Streamable, Comparable<ShardId> {
+public class ShardId implements Streamable, Comparable<ShardId>, ToXContentFragment {
 
     private Index index;
 
@@ -136,5 +139,10 @@ public class ShardId implements Streamable, Comparable<ShardId> {
             return index.getUUID().compareTo(o.getIndex().getUUID());
         }
         return Integer.compare(shardId, o.getId());
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.value(toString());
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -266,7 +266,8 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
             }
 
             if (file.metadata.hash() != null && file.metadata().hash().length > 0) {
-                builder.field(META_HASH, file.metadata.hash());
+                BytesRef br = file.metadata.hash();
+                builder.field(META_HASH, br.bytes, br.offset, br.length);
             }
             builder.endObject();
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/DateHistogramValuesSourceBuilder.java
@@ -120,7 +120,7 @@ public class DateHistogramValuesSourceBuilder extends CompositeValuesSourceBuild
             builder.field(Histogram.INTERVAL_FIELD.getPreferredName(), dateHistogramInterval.toString());
         }
         if (timeZone != null) {
-            builder.field("time_zone", timeZone);
+            builder.field("time_zone", timeZone.toString());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramInterval.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramInterval.java
@@ -22,6 +22,9 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -29,7 +32,7 @@ import java.util.Objects;
 /**
  * The interval the date histogram is based on.
  */
-public class DateHistogramInterval implements Writeable {
+public class DateHistogramInterval implements Writeable, ToXContentFragment {
 
     public static final DateHistogramInterval SECOND = new DateHistogramInterval("1s");
     public static final DateHistogramInterval MINUTE = new DateHistogramInterval("1m");
@@ -99,5 +102,10 @@ public class DateHistogramInterval implements Writeable {
         }
         DateHistogramInterval other = (DateHistogramInterval) obj;
         return Objects.equals(expression, other.expression);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.value(toString());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceAggregationBuilder.java
@@ -338,7 +338,7 @@ public abstract class ValuesSourceAggregationBuilder<VS extends ValuesSource, AB
             builder.field("format", format);
         }
         if (timeZone != null) {
-            builder.field("time_zone", timeZone);
+            builder.field("time_zone", timeZone.toString());
         }
         if (valueType != null) {
             builder.field("value_type", valueType.getPreferredName());

--- a/server/src/main/resources/META-INF/services/org.elasticsearch.common.xcontent.XContentBuilderExtension
+++ b/server/src/main/resources/META-INF/services/org.elasticsearch.common.xcontent.XContentBuilderExtension
@@ -1,0 +1,1 @@
+org.elasticsearch.common.xcontent.XContentElasticsearchExtension

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -326,14 +326,14 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     }
 
     public void testBinaryUTF8() throws Exception {
-        assertResult("{'utf8':null}", () -> builder().startObject().utf8Field("utf8", null).endObject());
+        assertResult("{'utf8':null}", () -> builder().startObject().nullField("utf8").endObject());
 
         final BytesRef randomBytesRef = new BytesRef(randomBytes());
         XContentBuilder builder = builder().startObject();
         if (randomBoolean()) {
-            builder.utf8Field("utf8", randomBytesRef);
+            builder.utf8Field("utf8", randomBytesRef.bytes, randomBytesRef.offset, randomBytesRef.length);
         } else {
-            builder.field("utf8").utf8Value(randomBytesRef);
+            builder.field("utf8").utf8Value(randomBytesRef.bytes, randomBytesRef.offset, randomBytesRef.length);
         }
         builder.endObject();
 

--- a/server/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
@@ -68,7 +68,7 @@ public class BinaryDVFieldDataTests extends AbstractFieldDataTestCase {
         writer.addDocument(d.rootDoc());
 
         BytesRef bytes1 = randomBytes();
-        doc = XContentFactory.jsonBuilder().startObject().field("field", bytes1).endObject();
+        doc = XContentFactory.jsonBuilder().startObject().field("field", bytes1.bytes, bytes1.offset, bytes1.length).endObject();
         d = mapper.parse(SourceToParse.source("test", "test", "2", BytesReference.bytes(doc), XContentType.JSON));
         writer.addDocument(d.rootDoc());
 


### PR DESCRIPTION
This commit decouples `BytesRef`, `Releaseable`, and `TimeValue` from
XContentBuilder, and paves the way for doupling `ByteSizeValue` as well. It
moves much of the Lucene and Joda encoding into a new SPI extension that is
loaded by XContentBuilder to know how to encode these values.

Part of doing this also allows us to make JSON encoding strict, as we no longer
allow just any old object to be passed (in the past it was possible to get json
that was `"field": "java.lang.Object@d8355a8"` if no one was careful about what
was passed in).

Relates to #28504
