### PR TITLE
Propagate mapping.single_type setting on shrinked index

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -430,6 +430,17 @@ public class FullClusterRestartIT extends ESRestTestCase {
         if (runningAgainstOldCluster) {
             XContentBuilder mappingsAndSettings = jsonBuilder();
             mappingsAndSettings.startObject();
+            if (oldClusterVersion.major == 5 && randomBoolean()) {
+                {
+                    // test that mapping.single_type is correctly propagated on the shrinked index,
+                    // if not, search will fail.
+                    mappingsAndSettings.startObject("settings");
+                    mappingsAndSettings.startObject("mapping");
+                    mappingsAndSettings.field("single_type", true);
+                    mappingsAndSettings.endObject();
+                    mappingsAndSettings.endObject();
+                }
+            }
             {
                 mappingsAndSettings.startObject("mappings");
                 mappingsAndSettings.startObject("doc");

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -695,9 +695,9 @@ public class MetaDataCreateIndexService extends AbstractComponent {
         }
 
         final Predicate<String> sourceSettingsPredicate = (s) -> s.startsWith("index.similarity.")
-            || s.startsWith("index.analysis.") || s.startsWith("index.sort.");
+            || s.startsWith("index.analysis.") || s.startsWith("index.sort.") || s.equals("index.mapping.single_type");
         indexSettingsBuilder
-            // now copy all similarity / analysis / sort settings - this overrides all settings from the user unless they
+            // now copy all similarity / analysis / sort / single_type settings - this overrides all settings from the user unless they
             // wanna add extra settings
             .put(IndexMetaData.SETTING_VERSION_CREATED, sourceMetaData.getCreationVersion())
             .put(IndexMetaData.SETTING_VERSION_UPGRADED, sourceMetaData.getUpgradedVersion())


### PR DESCRIPTION
The index.mapping.single_type setting is not propagated when shrinking an index created in 5.x.
This breaks search/get on the shrinked index because this setting is used to choose
whether `_uid` or `_id` field should be used as the primary key.
This commit fixes this bug by copying the setting in the shrinked index.