### PR TITLE
Clarify deprecation warning for auto_generate_phrase_query

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -80,7 +80,8 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     private static final ParseField QUOTE_ANALYZER_FIELD = new ParseField("quote_analyzer");
     private static final ParseField ALLOW_LEADING_WILDCARD_FIELD = new ParseField("allow_leading_wildcard");
     private static final ParseField AUTO_GENERATE_PHRASE_QUERIES_FIELD = new ParseField("auto_generate_phrase_queries")
-            .withAllDeprecated("This setting is ignored, use [type=phrase] instead");
+            .withAllDeprecated("This setting is ignored, use [type=phrase] instead to make phrase queries out of all text that " +
+                "is within query operators, or use explicitly quoted strings if you need finer-grained control");
     private static final ParseField MAX_DETERMINIZED_STATES_FIELD = new ParseField("max_determinized_states");
     private static final ParseField LOWERCASE_EXPANDED_TERMS_FIELD = new ParseField("lowercase_expanded_terms")
             .withAllDeprecated("Decision is now made by the analyzer");


### PR DESCRIPTION
This commit clarifies the deprecation warning emitted with the
`auto_generate_phrase_query` on `query_string` by explaining
how the old behavior can be achieved without the option.