### PR TITLE
[DOCS] security policy file name change for xpack custom extension

### DIFF
--- a/docs/plugins/authors.asciidoc
+++ b/docs/plugins/authors.asciidoc
@@ -91,7 +91,7 @@ Read more in {ref}/integration-tests.html#changing-node-configuration[Changing N
 === Java Security permissions
 
 Some plugins may need additional security permissions. A plugin can include
-the optional `plugin-security.policy` file containing `grant` statements for
+the optional `x-pack-extension-security.policy` file containing `grant` statements for
 additional permissions. Any additional permissions will be displayed to the user
 with a large warning, and they will have to confirm them when installing the
 plugin interactively. So if possible, it is best to avoid requesting any


### PR DESCRIPTION
Based on this forum discussion..
https://discuss.elastic.co/t/how-to-customize-plugin-security-policy-for-custom-realm/71570

it seems that correct name is x-pack-extension-sercurity.policy.
i tested it and it works only with new filename.. not sure on which x-pack verison this change happened but this is how it is working with 6.2.3

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
