### PR TITLE
Add note to low-level client docs for DNS caching

### DIFF
--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -86,3 +86,16 @@ will be used.
 
 For any other required configuration needed, the Apache HttpAsyncClient docs
 should be consulted: https://hc.apache.org/httpcomponents-asyncclient-4.1.x/ .
+
+NOTE: If your application runs under the security manager you might be subject
+to the JVM default policy of caching positive hostname resolutions indefinitely,
+and caching negative hostname resolutions for ten seconds.  If the resolved
+addresses of the hosts to which you are connecting the client to vary with time
+then you might want to modify the default JVM behavior. These can be modified by
+adding
+http://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html[`networkaddress.cache.ttl=<timeout>`]
+and
+http://docs.oracle.com/javase/8/docs/technotes/guides/net/properties.html[`networkaddress.cache.negative.ttl=<timeout>`]
+to your
+http://docs.oracle.com/javase/8/docs/technotes/guides/security/PolicyFiles.html[Java
+security policy].

--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -88,8 +88,8 @@ For any other required configuration needed, the Apache HttpAsyncClient docs
 should be consulted: https://hc.apache.org/httpcomponents-asyncclient-4.1.x/ .
 
 NOTE: If your application runs under the security manager you might be subject
-to the JVM default policy of caching positive hostname resolutions indefinitely,
-and caching negative hostname resolutions for ten seconds.  If the resolved
+to the JVM default policies of caching positive hostname resolutions
+indefinitely and negative hostname resolutions for ten seconds.  If the resolved
 addresses of the hosts to which you are connecting the client to vary with time
 then you might want to modify the default JVM behavior. These can be modified by
 adding


### PR DESCRIPTION
This commit adds a note to the low-level REST client docs regarding the possibility of being impacted by the JVM DNS cache policy under a default security manager policy.

Closes #24850
