### PR TITLE
Don't load global state when only restoring indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -20,6 +20,7 @@ package org.elasticsearch.repositories;
 
 import org.apache.lucene.index.IndexCommit;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.RepositoryMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -78,15 +79,21 @@ public interface Repository extends LifecycleComponent {
     SnapshotInfo getSnapshotInfo(SnapshotId snapshotId);
 
     /**
-     * Returns global metadata associate with the snapshot.
-     * <p>
-     * The returned meta data contains global metadata as well as metadata for all indices listed in the indices parameter.
+     * Returns global metadata associated with the snapshot.
      *
-     * @param snapshot snapshot
-     * @param indices    list of indices
-     * @return information about snapshot
+     * @param snapshotId the snapshot id to load the global metadata from
+     * @return the global metadata about the snapshot
      */
-    MetaData getSnapshotMetaData(SnapshotInfo snapshot, List<IndexId> indices) throws IOException;
+    MetaData getSnapshotGlobalMetaData(SnapshotId snapshotId);
+
+    /**
+     * Returns the index metadata associated with the snapshot.
+     *
+     * @param snapshotId the snapshot id to load the index metadata from
+     * @param index      the {@link IndexId} to load the metadata from
+     * @return the index metadata about the given index for the given snapshot
+     */
+    IndexMetaData getSnapshotIndexMetaData(SnapshotId snapshotId, IndexId index) throws IOException;
 
     /**
      * Returns a {@link RepositoryData} to describe the data in the repository, including the snapshots

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -66,6 +66,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.RepositoryData;
@@ -91,6 +92,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_CREATED;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_UPGRADED;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
+import static org.elasticsearch.snapshots.SnapshotUtils.filterIndices;
 
 /**
  * Service responsible for restoring snapshots
@@ -182,17 +184,36 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
             if (matchingSnapshotId.isPresent() == false) {
                 throw new SnapshotRestoreException(request.repositoryName, request.snapshotName, "snapshot does not exist");
             }
+
             final SnapshotId snapshotId = matchingSnapshotId.get();
             final SnapshotInfo snapshotInfo = repository.getSnapshotInfo(snapshotId);
             final Snapshot snapshot = new Snapshot(request.repositoryName, snapshotId);
-            List<String> filteredIndices = SnapshotUtils.filterIndices(snapshotInfo.indices(), request.indices(), request.indicesOptions());
-            final MetaData metaData = repository.getSnapshotMetaData(snapshotInfo, repositoryData.resolveIndices(filteredIndices));
 
             // Make sure that we can restore from this snapshot
             validateSnapshotRestorable(request.repositoryName, snapshotInfo);
 
-            // Find list of indices that we need to restore
-            final Map<String, String> renamedIndices = renamedIndices(request, filteredIndices);
+            // Resolve the indices from the snapshot that need to be restored
+            final List<String> indicesInSnapshot = filterIndices(snapshotInfo.indices(), request.indices(), request.indicesOptions());
+
+            final MetaData.Builder metaDataBuilder;
+            if (request.includeGlobalState()) {
+                metaDataBuilder = MetaData.builder(repository.getSnapshotGlobalMetaData(snapshotId));
+            } else {
+                metaDataBuilder = MetaData.builder();
+            }
+
+            final List<IndexId> indexIdsInSnapshot = repositoryData.resolveIndices(indicesInSnapshot);
+            if (indexIdsInSnapshot != null) {
+                for (IndexId indexId : indexIdsInSnapshot) {
+                    metaDataBuilder.put(repository.getSnapshotIndexMetaData(snapshotId, indexId), false);
+                }
+            }
+
+            final MetaData metaData = metaDataBuilder.build();
+
+            // Apply renaming on index names, returning a map of names where
+            // the key is the renamed index and the value is the original name
+            final Map<String, String> indices = renamedIndices(request, indicesInSnapshot);
 
             // Now we can start the actual restore process by adding shards to be recovered in the cluster state
             // and updating cluster metadata (global and index) as needed
@@ -222,12 +243,13 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                     RoutingTable.Builder rtBuilder = RoutingTable.builder(currentState.routingTable());
                     ImmutableOpenMap<ShardId, RestoreInProgress.ShardRestoreStatus> shards;
                     Set<String> aliases = new HashSet<>();
-                    if (!renamedIndices.isEmpty()) {
+
+                    if (indices.isEmpty() == false) {
                         // We have some indices to restore
                         ImmutableOpenMap.Builder<ShardId, RestoreInProgress.ShardRestoreStatus> shardsBuilder = ImmutableOpenMap.builder();
                         final Version minIndexCompatibilityVersion = currentState.getNodes().getMaxNodeVersion()
                             .minimumIndexCompatibilityVersion();
-                        for (Map.Entry<String, String> indexEntry : renamedIndices.entrySet()) {
+                        for (Map.Entry<String, String> indexEntry : indices.entrySet()) {
                             String index = indexEntry.getValue();
                             boolean partial = checkPartial(index);
                             SnapshotRecoverySource recoverySource = new SnapshotRecoverySource(snapshot, snapshotInfo.version(), index);
@@ -304,21 +326,42 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                         }
 
                         shards = shardsBuilder.build();
-                        RestoreInProgress.Entry restoreEntry = new RestoreInProgress.Entry(snapshot, overallState(RestoreInProgress.State.INIT, shards), Collections.unmodifiableList(new ArrayList<>(renamedIndices.keySet())), shards);
+                        RestoreInProgress.Entry restoreEntry = new RestoreInProgress.Entry(snapshot, overallState(RestoreInProgress.State.INIT, shards), Collections.unmodifiableList(new ArrayList<>(indices.keySet())), shards);
                         builder.putCustom(RestoreInProgress.TYPE, new RestoreInProgress(restoreEntry));
                     } else {
                         shards = ImmutableOpenMap.of();
                     }
 
-                    checkAliasNameConflicts(renamedIndices, aliases);
+                    checkAliasNameConflicts(indices, aliases);
 
                     // Restore global state if needed
-                    restoreGlobalStateIfRequested(mdBuilder);
+                    if (request.includeGlobalState()) {
+                        if (metaData.persistentSettings() != null) {
+                            Settings settings = metaData.persistentSettings();
+                            clusterSettings.validateUpdate(settings);
+                            mdBuilder.persistentSettings(settings);
+                        }
+                        if (metaData.templates() != null) {
+                            // TODO: Should all existing templates be deleted first?
+                            for (ObjectCursor<IndexTemplateMetaData> cursor : metaData.templates().values()) {
+                                mdBuilder.put(cursor.value);
+                            }
+                        }
+                        if (metaData.customs() != null) {
+                            for (ObjectObjectCursor<String, MetaData.Custom> cursor : metaData.customs()) {
+                                if (!RepositoriesMetaData.TYPE.equals(cursor.key)) {
+                                    // Don't restore repositories while we are working with them
+                                    // TODO: Should we restore them at the end?
+                                    mdBuilder.putCustom(cursor.key, cursor.value);
+                                }
+                            }
+                        }
+                    }
 
                     if (completed(shards)) {
                         // We don't have any indices to restore - we are done
                         restoreInfo = new RestoreInfo(snapshotId.getName(),
-                                                      Collections.unmodifiableList(new ArrayList<>(renamedIndices.keySet())),
+                                                      Collections.unmodifiableList(new ArrayList<>(indices.keySet())),
                                                       shards.size(),
                                                       shards.size() - failedShards(shards));
                     }
@@ -425,32 +468,6 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                         }));
                     return builder.settings(settingsBuilder).build();
                 }
-
-                private void restoreGlobalStateIfRequested(MetaData.Builder mdBuilder) {
-                    if (request.includeGlobalState()) {
-                        if (metaData.persistentSettings() != null) {
-                            Settings settings = metaData.persistentSettings();
-                            clusterSettings.validateUpdate(settings);
-                            mdBuilder.persistentSettings(settings);
-                        }
-                        if (metaData.templates() != null) {
-                            // TODO: Should all existing templates be deleted first?
-                            for (ObjectCursor<IndexTemplateMetaData> cursor : metaData.templates().values()) {
-                                mdBuilder.put(cursor.value);
-                            }
-                        }
-                        if (metaData.customs() != null) {
-                            for (ObjectObjectCursor<String, MetaData.Custom> cursor : metaData.customs()) {
-                                if (!RepositoriesMetaData.TYPE.equals(cursor.key)) {
-                                    // Don't restore repositories while we are working with them
-                                    // TODO: Should we restore them at the end?
-                                    mdBuilder.putCustom(cursor.key, cursor.value);
-                                }
-                            }
-                        }
-                    }
-                }
-
 
                 @Override
                 public void onFailure(String source, Exception e) {
@@ -757,7 +774,7 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
                         "indices [" + index + "] and [" + previousIndex + "] are renamed into the same index [" + renamedIndex + "]");
             }
         }
-        return renamedIndices;
+        return Collections.unmodifiableMap(renamedIndices);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -203,10 +203,8 @@ public class RestoreService extends AbstractComponent implements ClusterStateApp
             }
 
             final List<IndexId> indexIdsInSnapshot = repositoryData.resolveIndices(indicesInSnapshot);
-            if (indexIdsInSnapshot != null) {
-                for (IndexId indexId : indexIdsInSnapshot) {
-                    metaDataBuilder.put(repository.getSnapshotIndexMetaData(snapshotId, indexId), false);
-                }
+            for (IndexId indexId : indexIdsInSnapshot) {
+                metaDataBuilder.put(repository.getSnapshotIndexMetaData(snapshotId, indexId), false);
             }
 
             final MetaData metaData = metaDataBuilder.build();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2605,7 +2605,12 @@ public class IndexShardTests extends IndexShardTestCase {
         }
 
         @Override
-        public MetaData getSnapshotMetaData(SnapshotInfo snapshot, List<IndexId> indices) throws IOException {
+        public MetaData getSnapshotGlobalMetaData(SnapshotId snapshotId) {
+            return null;
+        }
+
+        @Override
+        public IndexMetaData getSnapshotIndexMetaData(SnapshotId snapshotId, IndexId index) throws IOException {
             return null;
         }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.metadata.RepositoryMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.snapshots.mockstore.MockRepository;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * This class tests that snapshot's global metadata and index metadata are loaded from the
+ * {@link Repository} on purpose
+*/
+public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        /// This test uses a snapshot/restore plugin implementation that
+        // counts the number of times metadata are loaded
+        return Collections.singletonList(CountingMockRepositoryPlugin.class);
+    }
+
+    public void testWhenMetadataAreLoaded() throws Exception {
+        createIndex("docs");
+        indexRandom(true,
+            client().prepareIndex("docs", "doc", "1").setSource("rank", 1),
+            client().prepareIndex("docs", "doc", "2").setSource("rank", 2),
+            client().prepareIndex("docs", "doc", "3").setSource("rank", 3),
+            client().prepareIndex("others", "other").setSource("rank", 4),
+            client().prepareIndex("others", "other").setSource("rank", 5));
+
+        assertAcked(client().admin().cluster().preparePutRepository("repository")
+                                              .setType("coutingmock")
+                                              .setSettings(Settings.builder().put("location", randomRepoPath())));
+
+        // Creating a snapshot does not load any metadata
+        CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("repository", "snap")
+                                                                                    .setIncludeGlobalState(true)
+                                                                                    .setWaitForCompletion(true)
+                                                                                    .get();
+        assertThat(createSnapshotResponse.getSnapshotInfo().failedShards(), equalTo(0));
+        assertThat(createSnapshotResponse.getSnapshotInfo().status(), equalTo(RestStatus.OK));
+        assertGlobalMetadataLoads("snap", null);
+        assertIndexMetadataLoads("snap", "docs", null);
+        assertIndexMetadataLoads("snap", "others", null);
+
+        // Getting a snapshot does not load any metadata
+        GetSnapshotsResponse getSnapshotsResponse =
+            client().admin().cluster().prepareGetSnapshots("repository").addSnapshots("snap").setVerbose(randomBoolean()).get();
+        assertThat(getSnapshotsResponse.getSnapshots(), hasSize(1));
+        assertGlobalMetadataLoads("snap", null);
+        assertIndexMetadataLoads("snap", "docs", null);
+        assertIndexMetadataLoads("snap", "others", null);
+
+        // Getting the status of a snapshot loads indices metadata but not global metadata
+        SnapshotsStatusResponse snapshotStatusResponse =
+            client().admin().cluster().prepareSnapshotStatus("repository").setSnapshots("snap").get();
+        assertThat(snapshotStatusResponse.getSnapshots(), hasSize(1));
+        assertGlobalMetadataLoads("snap", null);
+        assertIndexMetadataLoads("snap", "docs", 1);
+        assertIndexMetadataLoads("snap", "others", 1);
+
+        assertAcked(client().admin().indices().prepareDelete("docs", "others"));
+
+        // Restoring a snapshot loads indices metadata but not the global state
+        RestoreSnapshotResponse restoreSnapshotResponse = client().admin().cluster().prepareRestoreSnapshot("repository", "snap")
+                                                                                    .setWaitForCompletion(true)
+                                                                                    .get();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
+        assertThat(restoreSnapshotResponse.getRestoreInfo().status(), equalTo(RestStatus.OK));
+        assertGlobalMetadataLoads("snap", null);
+        assertIndexMetadataLoads("snap", "docs", 2);
+        assertIndexMetadataLoads("snap", "others", 2);
+
+        assertAcked(client().admin().indices().prepareDelete("docs"));
+
+        // Restoring a snapshot with selective indices loads only required index metadata
+        restoreSnapshotResponse = client().admin().cluster().prepareRestoreSnapshot("repository", "snap")
+                                                            .setIndices("docs")
+                                                            .setWaitForCompletion(true)
+                                                            .get();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
+        assertThat(restoreSnapshotResponse.getRestoreInfo().status(), equalTo(RestStatus.OK));
+        assertGlobalMetadataLoads("snap", null);
+        assertIndexMetadataLoads("snap", "docs", 3);
+        assertIndexMetadataLoads("snap", "others", 2);
+
+        assertAcked(client().admin().indices().prepareDelete("docs", "others"));
+
+        // Restoring a snapshot including the global state loads it with the index metadata
+        restoreSnapshotResponse = client().admin().cluster().prepareRestoreSnapshot("repository", "snap")
+            .setIndices("docs", "oth*")
+            .setRestoreGlobalState(true)
+            .setWaitForCompletion(true)
+            .get();
+        assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
+        assertThat(restoreSnapshotResponse.getRestoreInfo().status(), equalTo(RestStatus.OK));
+        assertGlobalMetadataLoads("snap", 1);
+        assertIndexMetadataLoads("snap", "docs", 4);
+        assertIndexMetadataLoads("snap", "others", 3);
+    }
+
+    private void assertGlobalMetadataLoads(final String snapshot, final Integer times) {
+        AtomicInteger count = getCountingMockRepository().globalMetadata.get(snapshot);
+        if (times == null) {
+            assertThat("Global metadata for " + snapshot + " must not have been loaded", count, nullValue());
+        } else {
+            assertThat("Global metadata for " + snapshot + " must have been loaded " + times + " times", count.get(), equalTo(times));
+        }
+    }
+
+    private void assertIndexMetadataLoads(final String snapshot, final String index, final Integer times) {
+        final String key = key(snapshot, index);
+        AtomicInteger count = getCountingMockRepository().indicesMetadata.get(key);
+        if (times == null) {
+            assertThat("Index metadata for " + key + " must not have been loaded", count, nullValue());
+        } else {
+            assertThat("Index metadata for " + key + " must have been loaded " + times + " times", count.get(), equalTo(times));
+        }
+    }
+
+    private CountingMockRepository getCountingMockRepository() {
+        String master = internalCluster().getMasterName();
+        RepositoriesService repositoriesService = internalCluster().getInstance(RepositoriesService.class, master);
+        Repository repository = repositoriesService.repository("repository");
+        assertThat(repository, instanceOf(CountingMockRepository.class));
+        return  (CountingMockRepository) repository;
+    }
+
+    /** Compute a map key for the given snapshot and index names **/
+    private static String key(final String snapshot, final String index) {
+        return snapshot + ":" + index;
+    }
+
+    /** A mocked repository that counts the number of times global/index metadata are accessed **/
+    public static class CountingMockRepository extends MockRepository {
+
+        final Map<String, AtomicInteger> globalMetadata = new ConcurrentHashMap<>();
+        final Map<String, AtomicInteger> indicesMetadata = new ConcurrentHashMap<>();
+
+        public CountingMockRepository(final RepositoryMetaData metadata,
+                                      final Environment environment,
+                                      final NamedXContentRegistry namedXContentRegistry) throws IOException {
+            super(metadata, environment, namedXContentRegistry);
+        }
+
+        @Override
+        public MetaData getSnapshotGlobalMetaData(SnapshotId snapshotId) {
+            globalMetadata.computeIfAbsent(snapshotId.getName(), (s) -> new AtomicInteger(0)).incrementAndGet();
+            return super.getSnapshotGlobalMetaData(snapshotId);
+        }
+
+        @Override
+        public IndexMetaData getSnapshotIndexMetaData(SnapshotId snapshotId, IndexId indexId) throws IOException {
+            indicesMetadata.computeIfAbsent(key(snapshotId.getName(), indexId.getName()), (s) -> new AtomicInteger(0)).incrementAndGet();
+            return super.getSnapshotIndexMetaData(snapshotId, indexId);
+        }
+    }
+
+    /** A plugin that uses CountingMockRepository as implementation of the Repository **/
+    public static class CountingMockRepositoryPlugin extends MockRepository.Plugin {
+        @Override
+        public Map<String, Repository.Factory> getRepositories(Environment env, NamedXContentRegistry namedXContentRegistry) {
+            return Collections.singletonMap("coutingmock", (metadata) -> new CountingMockRepository(metadata, env, namedXContentRegistry));
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -2667,13 +2667,16 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
     public void testRestoreSnapshotWithCorruptedIndexMetadata() throws Exception {
         final Client client = client();
         final Path repo = randomRepoPath();
-        final int nbIndices = randomIntBetween(2, 7);
+        final int nbIndices = randomIntBetween(2, 3);
 
         final Map<String, Integer> nbDocsPerIndex = new HashMap<>();
         for (int i = 0; i < nbIndices; i++) {
             String indexName = "test-idx-" + i;
 
-            int nbDocs = randomIntBetween(1, 50);
+            assertAcked(prepareCreate(indexName).setSettings(Settings.builder()
+                .put(SETTING_NUMBER_OF_SHARDS, Math.min(2, numberOfShards())).put(SETTING_NUMBER_OF_REPLICAS, 0)));
+
+            int nbDocs = randomIntBetween(1, 10);
             nbDocsPerIndex.put(indexName, nbDocs);
 
             IndexRequestBuilder[] documents = new IndexRequestBuilder[nbDocs];


### PR DESCRIPTION
Restoring a snapshot (or getting the status of finished snapshots) currently always load the global state metadata file from the repository even if it not required. This slows down the restore process (or listing statuses process)  and can also be an issue if the global state cannot be deserialized (because it has unknown customs for example).

This commit splits the `Repository.getSnapshotMetadata()` method into two distincts methods: `getGlobalMetadata()` and `getIndexMetadata()` that are now called on purpose. It also adds a test to control which/when metadata files are accessed. I'm not really happy of the test but I didn't come up with a better one. It also renames few variables and reorganizes the order of some instructions.

Closes #28934