### PR TITLE
Updates documentation on generating test coverage reports

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -499,32 +499,21 @@ will contain your change.
 . Push both branches to your remote repository.
 . Run the tests with `./gradlew check -Dtests.bwc.remote=${remote} -Dtests.bwc.refspec=index_req_bwc_5.x`.
 
-== Coverage analysis
+== Test coverage analysis
 
-Tests can be run instrumented with jacoco to produce a coverage report in
-`target/site/jacoco/`.
+Generating test coverage reports for Elasticsearch is currently not possible through Gradle.
+However, it _is_ possible to gain insight in code coverage using IntelliJ's built-in coverage 
+analysis tool that can measure coverage upon executing specific tests. Eclipse may also be able
+to do the same using the EclEmma plugin.
 
-Unit test coverage:
-
----------------------------------------------------------------------------
-mvn -Dtests.coverage test jacoco:report
----------------------------------------------------------------------------
-
-Integration test coverage:
-
----------------------------------------------------------------------------
-mvn -Dtests.coverage -Dskip.unit.tests verify jacoco:report
----------------------------------------------------------------------------
-
-Combined (Unit+Integration) coverage:
-
----------------------------------------------------------------------------
-mvn -Dtests.coverage verify jacoco:report
----------------------------------------------------------------------------
+Test coverage reporting used to be possible with JaCoCo when Elasticsearch was using Maven
+as its build system. Since the switch to Gradle though, this is no longer possible, seeing as
+the code currently used to build Elasticsearch does not allow JaCoCo to recognize its tests.
+For more information on this, see the discussion in https://github.com/elastic/elasticsearch/issues/28867[issue #28867].
 
 == Launching and debugging from an IDE
 
-If you want to run elasticsearch from your IDE, the `./gradlew run` task
+If you want to run Elasticsearch from your IDE, the `./gradlew run` task
 supports a remote debugging option:
 
 ---------------------------------------------------------------------------


### PR DESCRIPTION
As stated and discussed in issue #28867 the documentation on generating test coverage reports is outdated, since it still provides Maven commands while Elasticsearch currently uses Gradle. I've updated the documentation to reflect the conclusions taken from the discussion in the issue. Additionally, I saw a small capitalization mistake in the first line of the paragraph below, so I fixed that as well.

Pinging @rjernst @hub-cap @jasontedor as reviewers.