### PR TITLE
Fix incorrect geohash for lat 90, lon 180

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
@@ -57,11 +57,7 @@ public class GeoHashUtils {
      * 31 bit encoding utils *
      *************************/
     public static long encodeLatLon(final double lat, final double lon) {
-      long result = MortonEncoder.encode(lat, lon);
-      if (result == 0xFFFFFFFFFFFFFFFFL) {
-        return result & 0xC000000000000000L;
-      }
-      return result >>> 2;
+      return MortonEncoder.encode(lat, lon) >>> 2;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoHashTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.test.ESTestCase;
  * Tests for {@link org.elasticsearch.common.geo.GeoHashUtils}
  */
 public class GeoHashTests extends ESTestCase {
-    public void testGeohashAsLongRoutines()  {
+    public void testGeohashAsLongRoutines() {
         final GeoPoint expected = new GeoPoint();
         final GeoPoint actual = new GeoPoint();
         //Ensure that for all points at all supported levels of precision
@@ -69,5 +69,17 @@ public class GeoHashTests extends ESTestCase {
         assertEquals(expectedLonDiff, bbox.maxLon - bbox.minLon, 0.00001);
         assertEquals(expectedLatDiff, bbox.maxLat - bbox.minLat, 0.00001);
         assertEquals(hash, GeoHashUtils.stringEncode(bbox.minLon, bbox.minLat, level));
+    }
+
+    public void testGeohashExtremes() {
+        assertEquals("000000000000", GeoHashUtils.stringEncode(-180, -90));
+        assertEquals("800000000000", GeoHashUtils.stringEncode(-180, 0));
+        assertEquals("bpbpbpbpbpbp", GeoHashUtils.stringEncode(-180, 90));
+        assertEquals("h00000000000", GeoHashUtils.stringEncode(0, -90));
+        assertEquals("s00000000000", GeoHashUtils.stringEncode(0, 0));
+        assertEquals("upbpbpbpbpbp", GeoHashUtils.stringEncode(0, 90));
+        assertEquals("pbpbpbpbpbpb", GeoHashUtils.stringEncode(180, -90));
+        assertEquals("xbpbpbpbpbpb", GeoHashUtils.stringEncode(180, 0));
+        assertEquals("zzzzzzzzzzzz", GeoHashUtils.stringEncode(180, 90));
     }
 }


### PR DESCRIPTION
Due to special treatment for the 0xFFFFFF... value in GeoHashUtils'
encodeLatLon method, the hashcode for lat 90, lon 180 is incorrectly
encoded as `"000000000000"` instead of "zzzzzzzzzzzz". This commit
removes the special treatment and fixes the issue.

Closes #22163

Not sure if any special provisions for BWC are required here, considering a somewhat limit impact. 