### PR TITLE
Fix building Javadoc JARs on JDK for client JARs

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/plugin/PluginBuildPlugin.groovy
@@ -168,12 +168,10 @@ public class PluginBuildPlugin extends BuildPlugin {
             Files.copy(jarFile.resolveSibling(sourcesFileName), jarFile.resolveSibling(clientSourcesFileName),
                     StandardCopyOption.REPLACE_EXISTING)
 
-            if (project.compilerJavaVersion < JavaVersion.VERSION_1_10) {
-                String javadocFileName = jarFile.fileName.toString().replace('.jar', '-javadoc.jar')
-                String clientJavadocFileName = clientFileName.replace('.jar', '-javadoc.jar')
-                Files.copy(jarFile.resolveSibling(javadocFileName), jarFile.resolveSibling(clientJavadocFileName),
-                        StandardCopyOption.REPLACE_EXISTING)
-            }
+            String javadocFileName = jarFile.fileName.toString().replace('.jar', '-javadoc.jar')
+            String clientJavadocFileName = clientFileName.replace('.jar', '-javadoc.jar')
+            Files.copy(jarFile.resolveSibling(javadocFileName), jarFile.resolveSibling(clientJavadocFileName),
+                    StandardCopyOption.REPLACE_EXISTING)
         }
         project.assemble.dependsOn(clientJar)
     }


### PR DESCRIPTION
When a module or plugin register that it has a client JAR, we copy artifacts like the Javadoc and sources JARs as the JARs for the client as well (with -client added to the name). I previously had to disable the Javadoc task on JDK 10 due to a bug in bin/javadoc. After JDK 10 went GA without a fix for this bug, I added workaround to fix the Javadoc task on JDK 10. However, I made a mistake reverting the previously skipped Javadocs tasks and missed that one that copies the Javadoc JAR for client JARs. This commit fixes that issue.

