### PR TITLE
Remove leftover tests.rest.spec property from docs

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -296,7 +296,6 @@ e.g. -Dtests.rest.suite=index,get,create/10_with_id
 * `tests.rest.blacklist`: comma separated globs that identify tests that are
 blacklisted and need to be skipped
 e.g. -Dtests.rest.blacklist=index/*/Index document,get/10_basic/*
-* `tests.rest.spec`: REST spec path (default /rest-api-spec/api)
 
 Note that the REST tests, like all the integration tests, can be run against an external
 cluster by specifying the `tests.cluster` property, which if present needs to contain a


### PR DESCRIPTION
We previously had a property to specify the location of the REST test spec files but this was removed in a previous refactoring yet left behind in the docs. This commit removes the last remaining vestige of this parameter.

Relates #21392
