### PR TITLE
Scripting: Scriptengine can tell if compilation is needed

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/ScriptEngine.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptEngine.java
@@ -45,4 +45,15 @@ public interface ScriptEngine extends Closeable {
 
     @Override
     default void close() throws IOException {}
+
+    /**
+     * Usually scripts require compilation. However there can be special cases where scripts do not require any compilation to happen.
+     * For example, when the input is equal to the output when rendering a string based template without parameters.
+     *
+     * @param scriptSource the script
+     * @return             true if it makes sense to put the executed script in the cache, false otherwise
+     */
+    default boolean requiresCompilation(String scriptSource) {
+        return true;
+    }
 }


### PR DESCRIPTION
A script engine can now tell the ScriptService if compilation of a
certain script is needed. For most of the cases this will always be the
case, but the mustache templating engine can check, if a compilation is
needed, and if not just return the original template.

This also has the side effect that if no compilation is required,
caching is not required either, as it makes no sense to put the original
string into a cache.

The goal of this is to prevent hitting the compilation limit, if
a user is using a lot of templated fields (for example in a watch), but
is not putting any template in there that requires compilation.

**Note**: This is still missing some tests in the ScriptService, but as the code changes are so far small, we can take this as a first discussion and then go further from here, if the general approach makes sense.
