### PR TITLE
Update to forbiddenapis 2.5

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -94,7 +94,7 @@ dependencies {
   compile 'com.netflix.nebula:gradle-info-plugin:3.0.3'
   compile 'org.eclipse.jgit:org.eclipse.jgit:3.2.0.201312181205-r'
   compile 'com.perforce:p4java:2012.3.551082' // THIS IS SUPPOSED TO BE OPTIONAL IN THE FUTURE....
-  compile 'de.thetaphi:forbiddenapis:2.4.1'
+  compile 'de.thetaphi:forbiddenapis:2.5'
   compile 'org.apache.rat:apache-rat:0.11'
   compile "org.elasticsearch:jna:4.5.1"
 }


### PR DESCRIPTION
This pull request updates forbiddenapis to version 2.5.

The new release supports Java 10 bytecode and also adds support for checking violations in commons-io-2.6.

While testing this I figured out one issue: You may pass `-Drepos.mavenLocal=true` to gradle, but this does not work globally. It will still complain about missing forbiddenapis (before it was on Maven Central). I was not able to fix this, because I have no idea what the if `project==rootProject` check should do. @rjernst ?

To support me in developing the Gradle Plugin of forbiddenapis, please add support for the above property. I also figured out that there are 2 sysprops: `repos.mavenLocal` and `repos.mavenlocal`, neither work: https://github.com/elastic/elasticsearch/search?utf8=%E2%9C%93&q=repos.mavenLocal