### PR TITLE
Search: Validate script query is run with a single script

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/ScriptQueryBuilder.java
@@ -111,6 +111,12 @@ public class ScriptQueryBuilder extends AbstractQueryBuilder<ScriptQueryBuilder>
                 } else {
                     throw new ParsingException(parser.getTokenLocation(), "[script] query does not support [" + currentFieldName + "]");
                 }
+            } else {
+                if (token != XContentParser.Token.START_ARRAY) {
+                    throw new AssertionError("Impossible token received: " + token.name());
+                }
+                throw new ParsingException(parser.getTokenLocation(),
+                    "[script] query does not support an array of scripts. Use a bool query with a clause per script instead.");
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/ScriptQueryBuilderTests.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.index.query;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.query.ScriptQueryBuilder.ScriptQuery;
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBuilder> {
@@ -87,6 +88,25 @@ public class ScriptQueryBuilderTests extends AbstractQueryTestCase<ScriptQueryBu
 
         ScriptQueryBuilder parsed = (ScriptQueryBuilder) parseQuery(json);
         assertEquals(json, "5", parsed.script().getIdOrCode());
+    }
+
+    public void testArrayOfScriptsException() {
+        String json =
+            "{\n" +
+                "  \"script\" : {\n" +
+                "    \"script\" : [ {\n" +
+                "      \"source\" : \"5\",\n" +
+                "      \"lang\" : \"mockscript\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"source\" : \"6\",\n" +
+                "      \"lang\" : \"mockscript\"\n" +
+                "    }\n ]" +
+                "  }\n" +
+                "}";
+
+        ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
+        assertThat(e.getMessage(), containsString("does not support an array of scripts"));
     }
 
     @Override


### PR DESCRIPTION
The parsing code for script query currently silently skips by any tokens
it does not know about within its parsing loop. The only token it does
not catch is an array, which means passing multiple scripts in via an
array will cause the last script to be parsed, silently dropping
the others. This commit adds validation that arrays are not seen while
parsing.
