### PR TITLE
Improve exception handling on TransportMasterNodeAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -145,69 +145,79 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
         }
 
         protected void doStart(ClusterState clusterState) {
-            final Predicate<ClusterState> masterChangePredicate = MasterNodeChangePredicate.build(clusterState);
-            final DiscoveryNodes nodes = clusterState.nodes();
-            if (nodes.isLocalNodeElectedMaster() || localExecute(request)) {
-                // check for block, if blocked, retry, else, execute locally
-                final ClusterBlockException blockException = checkBlock(request, clusterState);
-                if (blockException != null) {
-                    if (!blockException.retryable()) {
-                        listener.onFailure(blockException);
+            try {
+                final Predicate<ClusterState> masterChangePredicate = MasterNodeChangePredicate.build(clusterState);
+                final DiscoveryNodes nodes = clusterState.nodes();
+                if (nodes.isLocalNodeElectedMaster() || localExecute(request)) {
+                    // check for block, if blocked, retry, else, execute locally
+                    final ClusterBlockException blockException = checkBlock(request, clusterState);
+                    if (blockException != null) {
+                        if (!blockException.retryable()) {
+                            listener.onFailure(blockException);
+                        } else {
+                            logger.trace("can't execute due to a cluster block, retrying", blockException);
+                            retry(blockException, newState -> {
+                                try {
+                                    ClusterBlockException newException = checkBlock(request, newState);
+                                    return (newException == null || !newException.retryable());
+                                } catch (Exception e) {
+                                    // accept state as block will be rechecked by doStart() and listener.onFailure() then called
+                                    logger.trace("exception occurred during cluster block checking, accepting state", e);
+                                    return true;
+                                }
+                            });
+                        }
                     } else {
-                        logger.trace("can't execute due to a cluster block, retrying", blockException);
-                        retry(blockException, newState -> {
-                            ClusterBlockException newException = checkBlock(request, newState);
-                            return (newException == null || !newException.retryable());
+                        ActionListener<Response> delegate = new ActionListener<Response>() {
+                            @Override
+                            public void onResponse(Response response) {
+                                listener.onResponse(response);
+                            }
+
+                            @Override
+                            public void onFailure(Exception t) {
+                                if (t instanceof Discovery.FailedToCommitClusterStateException
+                                    || (t instanceof NotMasterException)) {
+                                    logger.debug(() -> new ParameterizedMessage("master could not publish cluster state or stepped down before publishing action [{}], scheduling a retry", actionName), t);
+                                    retry(t, masterChangePredicate);
+                                } else {
+                                    listener.onFailure(t);
+                                }
+                            }
+                        };
+                        threadPool.executor(executor).execute(new ActionRunnable(delegate) {
+                            @Override
+                            protected void doRun() throws Exception {
+                                masterOperation(task, request, clusterState, delegate);
+                            }
                         });
                     }
                 } else {
-                    ActionListener<Response> delegate = new ActionListener<Response>() {
-                        @Override
-                        public void onResponse(Response response) {
-                            listener.onResponse(response);
-                        }
-
-                        @Override
-                        public void onFailure(Exception t) {
-                            if (t instanceof Discovery.FailedToCommitClusterStateException
-                                    || (t instanceof NotMasterException)) {
-                                logger.debug(() -> new ParameterizedMessage("master could not publish cluster state or stepped down before publishing action [{}], scheduling a retry", actionName), t);
-                                retry(t, masterChangePredicate);
-                            } else {
-                                listener.onFailure(t);
-                            }
-                        }
-                    };
-                    threadPool.executor(executor).execute(new ActionRunnable(delegate) {
-                        @Override
-                        protected void doRun() throws Exception {
-                            masterOperation(task, request, clusterState, delegate);
-                        }
-                    });
-                }
-            } else {
-                if (nodes.getMasterNode() == null) {
-                    logger.debug("no known master node, scheduling a retry");
-                    retry(null, masterChangePredicate);
-                } else {
-                    DiscoveryNode masterNode = nodes.getMasterNode();
-                    final String actionName = getMasterActionName(masterNode);
-                    transportService.sendRequest(masterNode, actionName, request, new ActionListenerResponseHandler<Response>(listener,
-                        TransportMasterNodeAction.this::newResponse) {
-                        @Override
-                        public void handleException(final TransportException exp) {
-                            Throwable cause = exp.unwrapCause();
-                            if (cause instanceof ConnectTransportException) {
-                                // we want to retry here a bit to see if a new master is elected
-                                logger.debug("connection exception while trying to forward request with action name [{}] to master node [{}], scheduling a retry. Error: [{}]",
+                    if (nodes.getMasterNode() == null) {
+                        logger.debug("no known master node, scheduling a retry");
+                        retry(null, masterChangePredicate);
+                    } else {
+                        DiscoveryNode masterNode = nodes.getMasterNode();
+                        final String actionName = getMasterActionName(masterNode);
+                        transportService.sendRequest(masterNode, actionName, request, new ActionListenerResponseHandler<Response>(listener,
+                            TransportMasterNodeAction.this::newResponse) {
+                            @Override
+                            public void handleException(final TransportException exp) {
+                                Throwable cause = exp.unwrapCause();
+                                if (cause instanceof ConnectTransportException) {
+                                    // we want to retry here a bit to see if a new master is elected
+                                    logger.debug("connection exception while trying to forward request with action name [{}] to master node [{}], scheduling a retry. Error: [{}]",
                                         actionName, nodes.getMasterNode(), exp.getDetailedMessage());
-                                retry(cause, masterChangePredicate);
-                            } else {
-                                listener.onFailure(exp);
+                                    retry(cause, masterChangePredicate);
+                                } else {
+                                    listener.onFailure(exp);
+                                }
                             }
-                        }
-                    });
+                        });
+                    }
                 }
+            } catch (Exception e) {
+                listener.onFailure(e);
             }
         }
 


### PR DESCRIPTION
We have seen exceptions of the following kind bubbling up to the uncaught exception handler:

```
[WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [XYZ] uncaught exception in thread [elasticsearch[XYZ][clusterService#updateTask][T#1]]
org.elasticsearch.index.IndexNotFoundException: no such index
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.infe(IndexNameExpressionResolver.java:676) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.innerResolve(IndexNameExpressionResolver.java:630) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.resolve(IndexNameExpressionResolver.java:578) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndices(IndexNameExpressionResolver.java:168) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndexNames(IndexNameExpressionResolver.java:144) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndexNames(IndexNameExpressionResolver.java:77) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.action.admin.indices.get.TransportGetIndexAction.checkBlock(TransportGetIndexAction.java:63) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.action.admin.indices.get.TransportGetIndexAction.checkBlock(TransportGetIndexAction.java:47) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.action.support.master.TransportMasterNodeAction$AsyncSingleAction.doStart(TransportMasterNodeAction.java:134) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.action.support.master.TransportMasterNodeAction$AsyncSingleAction$4.onNewClusterState(TransportMasterNodeAction.java:198) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.cluster.ClusterStateObserver$ContextPreservingListener.onNewClusterState(ClusterStateObserver.java:297) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.cluster.ClusterStateObserver$ObserverClusterStateListener.postAdded(ClusterStateObserver.java:208) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.cluster.service.ClusterService$1.run(ClusterService.java:401) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:569) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:247) ~[elasticsearch-5.6.5.jar:5.6.5]
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:210) ~[elasticsearch-5.6.5.jar:5.6.5]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_144]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_144]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_144]
```

Checking the blocks can lead for example to `IndexNotFoundException` when the indices are resolved. In order to make `TransportMasterNodeAction` more resilient against such expected exceptions, this code change wraps the execution of doStart() into a try catch and informs the listener in case of failures.