### PR TITLE
Use ESBlobStoreRepositoryIntegTestCase to test the repository-s3 plugin

### DIFF
--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -151,8 +151,7 @@ class S3Repository extends BlobStoreRepository {
     /**
      * Constructs an s3 backed repository
      */
-    S3Repository(RepositoryMetaData metadata, Settings settings,
-                        NamedXContentRegistry namedXContentRegistry, AwsS3Service s3Service) throws IOException {
+    S3Repository(RepositoryMetaData metadata, Settings settings, NamedXContentRegistry namedXContentRegistry, AwsS3Service s3Service) {
         super(metadata, settings, namedXContentRegistry);
 
         String bucket = BUCKET_SETTING.get(metadata.settings());

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -88,7 +88,6 @@ class MockAmazonS3 extends AbstractAmazonS3 {
     @Override
     public PutObjectResult putObject(final PutObjectRequest request) throws AmazonClientException {
         assertThat(request.getBucketName(), equalTo(bucket));
-        assertThat(request.getBucketName(), equalTo(bucket));
         assertThat(request.getMetadata().getSSEAlgorithm(), serverSideEncryption ? equalTo("AES256") : nullValue());
         assertThat(request.getCannedAcl(), notNullValue());
         assertThat(request.getCannedAcl().toString(), cannedACL != null ? equalTo(cannedACL) : equalTo("private"));
@@ -185,7 +184,7 @@ class MockAmazonS3 extends AbstractAmazonS3 {
 
         final List<DeleteObjectsResult.DeletedObject> deletions = new ArrayList<>();
         for (DeleteObjectsRequest.KeyVersion key : request.getKeys()) {
-            if(blobs.remove(key.getKey()) == null){
+            if (blobs.remove(key.getKey()) == null) {
                 AmazonS3Exception exception = new AmazonS3Exception("[" + key + "] does not exist.");
                 exception.setStatusCode(404);
                 throw exception;

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.repositories.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.StorageClass;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.Repository;
+import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
+import org.junit.BeforeClass;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+public class S3BlobStoreRepositoryTests extends ESBlobStoreRepositoryIntegTestCase {
+
+    private static String bucket;
+    private static String client;
+    private static ByteSizeValue bufferSize;
+    private static boolean serverSideEncryption;
+    private static String cannedACL;
+    private static String storageClass;
+
+    @BeforeClass
+    public static void setUpRepositorySettings() {
+        bucket = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        client = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        bufferSize = new ByteSizeValue(randomIntBetween(5, 50), ByteSizeUnit.MB);
+        serverSideEncryption = randomBoolean();
+        if (randomBoolean()) {
+            cannedACL = randomFrom(CannedAccessControlList.values()).toString();
+        }
+        if (randomBoolean()) {
+            storageClass = randomValueOtherThan(StorageClass.Glacier, () -> randomFrom(StorageClass.values())).toString();
+        }
+    }
+
+    @Override
+    protected void createTestRepository(final String name) {
+        assertAcked(client().admin().cluster().preparePutRepository(name)
+            .setType(S3Repository.TYPE)
+            .setSettings(Settings.builder()
+                .put(S3Repository.BUCKET_SETTING.getKey(), bucket)
+                .put(InternalAwsS3Service.CLIENT_NAME.getKey(), client)
+                .put(S3Repository.BUFFER_SIZE_SETTING.getKey(), bufferSize)
+                .put(S3Repository.SERVER_SIDE_ENCRYPTION_SETTING.getKey(), serverSideEncryption)
+                .put(S3Repository.CANNED_ACL_SETTING.getKey(), cannedACL)
+                .put(S3Repository.STORAGE_CLASS_SETTING.getKey(), storageClass)));
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(TestS3RepositoryPlugin.class);
+    }
+
+    public static class TestS3RepositoryPlugin extends S3RepositoryPlugin {
+
+        public TestS3RepositoryPlugin(final Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public Map<String, Repository.Factory> getRepositories(final Environment env, final NamedXContentRegistry registry) {
+            return Collections.singletonMap(S3Repository.TYPE, (metadata) ->
+                new S3Repository(metadata, env.settings(), registry, new InternalAwsS3Service(env.settings(), emptyMap()) {
+                    @Override
+                    public synchronized AmazonS3 client(final Settings repositorySettings) {
+                        return MockAmazonS3.createClient(bucket, serverSideEncryption, cannedACL, storageClass);
+                    }
+                }));
+        }
+    }
+}

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.util.Collection;
@@ -63,6 +64,11 @@ public class S3BlobStoreRepositoryTests extends ESBlobStoreRepositoryIntegTestCa
         if (randomBoolean()) {
             storageClass = randomValueOtherThan(StorageClass.Glacier, () -> randomFrom(StorageClass.values())).toString();
         }
+    }
+
+    @AfterClass
+    public static void wipeRepository() {
+        blobs.clear();
     }
 
     @Override

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -35,12 +35,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
 public class S3BlobStoreRepositoryTests extends ESBlobStoreRepositoryIntegTestCase {
 
+    private static final ConcurrentMap<String, byte[]> blobs = new ConcurrentHashMap<>();
     private static String bucket;
     private static String client;
     private static ByteSizeValue bufferSize;
@@ -92,7 +95,7 @@ public class S3BlobStoreRepositoryTests extends ESBlobStoreRepositoryIntegTestCa
                 new S3Repository(metadata, env.settings(), registry, new InternalAwsS3Service(env.settings(), emptyMap()) {
                     @Override
                     public synchronized AmazonS3 client(final Settings repositorySettings) {
-                        return MockAmazonS3.createClient(bucket, serverSideEncryption, cannedACL, storageClass);
+                        return new MockAmazonS3(blobs, bucket, serverSideEncryption, cannedACL, storageClass);
                     }
                 }));
         }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreTests.java
@@ -19,18 +19,28 @@
 
 package org.elasticsearch.repositories.s3;
 
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.StorageClass;
+import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.blobstore.BlobStoreException;
-import org.elasticsearch.repositories.s3.S3BlobStore;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.repositories.ESBlobStoreTestCase;
 
-import java.io.IOException;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class S3BlobStoreTests extends ESTestCase {
-    public void testInitCannedACL() throws IOException {
+public class S3BlobStoreTests extends ESBlobStoreTestCase {
+
+    @Override
+    protected BlobStore newBlobStore() {
+        return randomMockS3BlobStore();
+    }
+
+    public void testInitCannedACL() {
         String[] aclList = new String[]{
                 "private", "public-read", "public-read-write", "authenticated-read",
                 "log-delivery-write", "bucket-owner-read", "bucket-owner-full-control"};
@@ -52,16 +62,12 @@ public class S3BlobStoreTests extends ESTestCase {
         }
     }
 
-    public void testInvalidCannedACL() throws IOException {
-        try {
-            S3BlobStore.initCannedACL("test_invalid");
-            fail("CannedACL should fail");
-        } catch (BlobStoreException ex) {
-            assertThat(ex.getMessage(), equalTo("cannedACL is not valid: [test_invalid]"));
-        }
+    public void testInvalidCannedACL() {
+        BlobStoreException ex = expectThrows(BlobStoreException.class, () -> S3BlobStore.initCannedACL("test_invalid"));
+        assertThat(ex.getMessage(), equalTo("cannedACL is not valid: [test_invalid]"));
     }
 
-    public void testInitStorageClass() throws IOException {
+    public void testInitStorageClass() {
         // it should default to `standard`
         assertThat(S3BlobStore.initStorageClass(null), equalTo(StorageClass.Standard));
         assertThat(S3BlobStore.initStorageClass(""), equalTo(StorageClass.Standard));
@@ -72,25 +78,44 @@ public class S3BlobStoreTests extends ESTestCase {
         assertThat(S3BlobStore.initStorageClass("reduced_redundancy"), equalTo(StorageClass.ReducedRedundancy));
     }
 
-    public void testCaseInsensitiveStorageClass() throws IOException {
+    public void testCaseInsensitiveStorageClass() {
         assertThat(S3BlobStore.initStorageClass("sTandaRd"), equalTo(StorageClass.Standard));
         assertThat(S3BlobStore.initStorageClass("sTandaRd_Ia"), equalTo(StorageClass.StandardInfrequentAccess));
         assertThat(S3BlobStore.initStorageClass("reduCED_redundancy"), equalTo(StorageClass.ReducedRedundancy));
     }
 
-    public void testInvalidStorageClass() throws IOException {
-        try {
-            S3BlobStore.initStorageClass("whatever");
-        } catch(BlobStoreException ex) {
-            assertThat(ex.getMessage(), equalTo("`whatever` is not a valid S3 Storage Class."));
-        }
+    public void testInvalidStorageClass() {
+        BlobStoreException ex = expectThrows(BlobStoreException.class, () -> S3BlobStore.initStorageClass("whatever"));
+        assertThat(ex.getMessage(), equalTo("`whatever` is not a valid S3 Storage Class."));
     }
 
-    public void testRejectGlacierStorageClass() throws IOException {
-        try {
-            S3BlobStore.initStorageClass("glacier");
-        } catch(BlobStoreException ex) {
-            assertThat(ex.getMessage(), equalTo("Glacier storage class is not supported"));
+    public void testRejectGlacierStorageClass() {
+        BlobStoreException ex = expectThrows(BlobStoreException.class, () -> S3BlobStore.initStorageClass("glacier"));
+        assertThat(ex.getMessage(), equalTo("Glacier storage class is not supported"));
+    }
+
+    /**
+     * Creates a new {@link S3BlobStore} with random settings.
+     * <p>
+     * The blobstore uses internally a mocked {@link AmazonS3} client.
+     */
+    public static S3BlobStore randomMockS3BlobStore() {
+        String bucket = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
+        ByteSizeValue bufferSize = new ByteSizeValue(randomIntBetween(5, 100), ByteSizeUnit.MB);
+        boolean serverSideEncryption = randomBoolean();
+
+        String cannedACL = null;
+        if (randomBoolean()) {
+            cannedACL = randomFrom(CannedAccessControlList.values()).toString();
         }
+
+        String storageClass = null;
+        if (randomBoolean()) {
+            storageClass = randomValueOtherThan(StorageClass.Glacier, () -> randomFrom(StorageClass.values())).toString();
+        }
+
+        AmazonS3 client = MockAmazonS3.createClient(bucket, serverSideEncryption, cannedACL, storageClass);
+
+        return new S3BlobStore(Settings.EMPTY, client, bucket, serverSideEncryption, bufferSize, cannedACL, storageClass);
     }
 }

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreTests.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.repositories.ESBlobStoreTestCase;
 
 import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -97,7 +98,7 @@ public class S3BlobStoreTests extends ESBlobStoreTestCase {
     /**
      * Creates a new {@link S3BlobStore} with random settings.
      * <p>
-     * The blobstore uses internally a mocked {@link AmazonS3} client.
+     * The blobstore uses a {@link MockAmazonS3} client.
      */
     public static S3BlobStore randomMockS3BlobStore() {
         String bucket = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
@@ -114,8 +115,7 @@ public class S3BlobStoreTests extends ESBlobStoreTestCase {
             storageClass = randomValueOtherThan(StorageClass.Glacier, () -> randomFrom(StorageClass.values())).toString();
         }
 
-        AmazonS3 client = MockAmazonS3.createClient(bucket, serverSideEncryption, cannedACL, storageClass);
-
+        AmazonS3 client = new MockAmazonS3(new ConcurrentHashMap<>(), bucket, serverSideEncryption, cannedACL, storageClass);
         return new S3BlobStore(Settings.EMPTY, client, bucket, serverSideEncryption, bufferSize, cannedACL, storageClass);
     }
 }


### PR DESCRIPTION
The test framework contains three base classes for testing blob store repository implementations, but the S3 plugin does not use all of them.

This commit adds the `S3BlobStoreRepositoryTests` and `S3BlobStoreTests` classes that extends the base testing classes for S3. It also cleans up the `S3BlobStoreTests` and `S3BlobStoreContainerTests` so that they are now based on pure mock S3 clients.

It also removes some usage of socket servers that emulate socket connections in unit tests. It was added to trigger security exceptions, but this won't be needed anymore once #29296 will be merged.

closes #16472