### PR TITLE
Fix delete vs update by query typo, make consistent (docs)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -53,7 +53,7 @@
             "type" : "enum",
             "options": ["abort", "proceed"],
             "default": "abort",
-            "description" : "What to do when the delete-by-query hits version conflicts?"
+            "description" : "What to do when the delete by query hits version conflicts?"
         },
         "expand_wildcards": {
             "type" : "enum",
@@ -142,12 +142,12 @@
         "scroll_size": {
           "type": "number",
           "defaut_value": 100,
-          "description": "Size on the scroll request powering the update_by_query"
+          "description": "Size on the scroll request powering the delete by query"
         },
         "wait_for_completion": {
            "type" : "boolean",
            "default": true,
-           "description" : "Should the request should block until the delete-by-query is complete."
+           "description" : "Should the request should block until the delete by query is complete."
         },
         "requests_per_second": {
           "type": "number",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -150,7 +150,7 @@
         "scroll_size": {
           "type": "number",
           "defaut_value": 100,
-          "description": "Size on the scroll request powering the update_by_query"
+          "description": "Size on the scroll request powering the update by query"
         },
         "wait_for_completion": {
            "type" : "boolean",


### PR DESCRIPTION
- Fixed "update by query" typo that should be "delete by query"
- Attempted to make a little more consistent with `_` vs `-` vs ` `