### PR TITLE
Fix bwc in GeoDistanceQuery serialization

### DIFF
--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -43,6 +43,7 @@ for (Version version : bwcVersions.wireCompatible) {
     numNodes = 2
     clusterName = 'rolling-upgrade'
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
+    setting 'node.attr.gen', 'old'
     if (version.onOrAfter('5.3.0')) {
       setting 'http.content_type.required', 'true'
     }
@@ -64,6 +65,7 @@ for (Version version : bwcVersions.wireCompatible) {
      * just stopped's data directory. */
     dataDir = { nodeNumber -> oldClusterTest.nodes[1].dataDir }
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
+    setting 'node.attr.gen', 'new'
   }
 
   Task mixedClusterTestRunner = tasks.getByName("${baseName}#mixedClusterTestRunner")
@@ -83,6 +85,7 @@ for (Version version : bwcVersions.wireCompatible) {
      * just stopped's data directory. */
     dataDir = { nodeNumber -> oldClusterTest.nodes[0].dataDir}
     setting 'repositories.url.allowed_urls', 'http://snapshot.test*'
+    setting 'node.attr.gen', 'new'
   }
 
   Task upgradedClusterTestRunner = tasks.getByName("${baseName}#upgradedClusterTestRunner")

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -278,11 +278,6 @@ public class RecoveryIT extends ESRestTestCase {
                 // before timing out
                 .put(INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), "100ms");
             createIndex(index, settings.build(), "\"doc\": {\"properties\": {\"location\": {\"type\": \"geo_point\"}}}");
-            assertOK(client().performRequest("PUT", index + "/doc/1", emptyMap(),
-                new StringEntity("{\"location\": { \"lat\": 42.358056, \"lon\": -71.063611 }, \"foo\": \"bar\"}", ContentType.APPLICATION_JSON)));
-            assertOK(client().performRequest("PUT", index + "/doc/2", emptyMap(),
-                new StringEntity("{\"location\": { \"lat\": 37.783333, \"lon\": -122.416667 }, \"foo\": \"bar\"}", ContentType.APPLICATION_JSON)));
-            assertOK(client().performRequest("POST", index + "/_refresh"));
             ensureGreen(index);
         } else if (clusterType == CLUSTER_TYPE.MIXED) {
             ensureGreen(index);

--- a/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -24,6 +24,7 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
@@ -97,6 +98,10 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
         distance = in.readDouble();
         validationMethod = GeoValidationMethod.readFromStream(in);
         center = in.readGeoPoint();
+        if (in.getVersion().before(Version.V_6_0_0_alpha1)) {
+            // optimize bounding box was removed in 6.0
+            in.readOptionalString();
+        }
         geoDistance = GeoDistance.readFromStream(in);
         ignoreUnmapped = in.readBoolean();
     }
@@ -107,6 +112,10 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
         out.writeDouble(distance);
         validationMethod.writeTo(out);
         out.writeGeoPoint(center);
+        if (out.getVersion().before(Version.V_6_0_0_alpha1)) {
+            // optimize bounding box was removed in 6.0
+            out.writeOptionalString(null);
+        }
         geoDistance.writeTo(out);
         out.writeBoolean(ignoreUnmapped);
     }


### PR DESCRIPTION
Restores backward compatibility in GeoDistanceQueryBuilder serialization
between 6.x and 5.6 after removal of optimize_bbox parameter.

Closes #29301

This will only go to 6.x branch since optimize_bbox was removed in 6.x (#22876) and shouldn't affect 7.x -> 6.last communication. 