### PR TITLE
Update context-suggest.asciidoc

### DIFF
--- a/docs/reference/search/suggesters/context-suggest.asciidoc
+++ b/docs/reference/search/suggesters/context-suggest.asciidoc
@@ -28,8 +28,7 @@ PUT place
                     "contexts": [
                         { <1>
                             "name": "place_type",
-                            "type": "category",
-                            "path": "cat"
+                            "type": "category"
                         },
                         { <2>
                             "name": "location",


### PR DESCRIPTION
it seems here is a bug in example
it is fixed for new versions but not for 5.3
Because 
"<1> Defines a `category` context named 'place_type' where the categories must be
    sent with the suggestions. "
but here is "path"...

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
