### PR TITLE
Java versions for ci 5.6

### DIFF
--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -1,0 +1,8 @@
+# This file is used with all of the non-matrix tests in Jenkins.
+
+# This .properties file defines the versions of Java with which to
+# build and test Elasticsearch for this branch. Valid Java versions
+# are 'java' or 'openjdk' followed by the major release number.
+
+ES_BUILD_JAVA=java8
+ES_RUNTIME_JAVA=java8

--- a/.ci/matrix-build-javas.yml
+++ b/.ci/matrix-build-javas.yml
@@ -1,0 +1,9 @@
+# This file is used as part of a matrix build in Jenkins where the
+# values below are included as an axis of the matrix.
+
+# This axis of the build matrix represents the versions of Java with
+# which Elasticsearch will be built.  Valid Java versions are 'java'
+# or 'openjdk' followed by the major release number.
+
+ES_BUILD_JAVA:
+  - java8

--- a/.ci/matrix-java-exclusions.yml
+++ b/.ci/matrix-java-exclusions.yml
@@ -1,0 +1,14 @@
+# This file is used as part of a matrix build in Jenkins where the
+# values below are excluded from the test matrix.
+
+# The yaml mapping below represents a single intersection on the build
+# matrix where a test *should not* be run.  The value of the exclude
+# key is a list of maps.
+
+# In this example all of the combinations defined in the matrix will
+# run except for the test that builds with java10 and runs with java8.
+# exclude:
+#   - ES_BUILD_JAVA: java10
+#     ES_RUNTIME_JAVA: java8
+
+exclude:

--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -1,0 +1,9 @@
+# This file is used as part of a matrix build in Jenkins where the
+# values below are included as an axis of the matrix.
+
+# This axis of the build matrix represents the versions of Java on
+# which Elasticsearch will be tested.  Valid Java versions are 'java'
+# or 'openjdk' followed by the major release number.
+
+ES_RUNTIME_JAVA:
+  - java8


### PR DESCRIPTION
These files will be used by Jenkins to set JAVA_HOME, RUNTIME_JAVA_HOME, and org.gradle.java.home for the tests. The intent is to decommission the script in Jenkins that tries to determine these variables based on the branch name and instead rely on the branch itself to provide that information.