### PR TITLE
Remove HTTP max content length leniency

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -39,7 +39,7 @@ from the outside. Defaults to the actual port assigned via `http.port`.
 |`http.host` |Used to set the `http.bind_host` and the `http.publish_host` Defaults to `http.host` or `network.host`.
 
 |`http.max_content_length` |The max content of an HTTP request. Defaults to
-`100mb`. If set to greater than `Integer.MAX_VALUE`, it will be reset to 100mb.
+`100mb`.
 
 |`http.max_initial_line_length` |The max length of an HTTP URL. Defaults
 to `4kb`

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -233,11 +233,6 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
         this.pipeliningMaxEvents = SETTING_PIPELINING_MAX_EVENTS.get(settings);
         this.corsConfig = buildCorsConfig(settings);
 
-        // validate max content length
-        if (maxContentLength.getBytes() > Integer.MAX_VALUE) {
-            logger.warn("maxContentLength[{}] set to high value, resetting it to [100mb]", maxContentLength);
-            maxContentLength = new ByteSizeValue(100, ByteSizeUnit.MB);
-        }
         this.maxContentLength = maxContentLength;
 
         logger.debug("using max_chunk_size[{}], max_header_size[{}], max_initial_line_length[{}], max_content_length[{}], " +

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -83,7 +83,12 @@ public final class HttpTransportSettings {
             return true;
         }, Property.NodeScope, Property.Deprecated);
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_CONTENT_LENGTH =
-        Setting.byteSizeSetting("http.max_content_length", new ByteSizeValue(100, ByteSizeUnit.MB), Property.NodeScope);
+        Setting.byteSizeSetting(
+                "http.max_content_length",
+                new ByteSizeValue(100, ByteSizeUnit.MB),
+                new ByteSizeValue(0, ByteSizeUnit.BYTES),
+                new ByteSizeValue(Integer.MAX_VALUE, ByteSizeUnit.BYTES),
+                Property.NodeScope);
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_CHUNK_SIZE =
         Setting.byteSizeSetting("http.max_chunk_size", new ByteSizeValue(8, ByteSizeUnit.KB), Property.NodeScope);
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_HEADER_SIZE =


### PR DESCRIPTION
I am not sure why we have this leniency for HTTP max content length, it has been there since the beginning (5ac51ee93feab6c75fcbe979b9bb338962622c2e) with no explanation of its source. That said, our philosophy today is different than the philosophy of the past where Elasticsearch would be quite lenient in its handling of settings and today we aim for predictability for both users and us. This commit removes leniency in the parsing of http.max_content_length.

