### PR TITLE
Deprecate large max content length truncation

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -263,6 +263,9 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
         // validate max content length
         if (maxContentLength.getBytes() > Integer.MAX_VALUE) {
             logger.warn("maxContentLength[{}] set to high value, resetting it to [100mb]", maxContentLength);
+            deprecationLogger.deprecated(
+                    "out of bounds max content length value [{}] will no longer be truncated to [100mb], you must enter a valid setting",
+                    maxContentLength.getStringRep());
             maxContentLength = new ByteSizeValue(100, ByteSizeUnit.MB);
         }
         this.maxContentLength = maxContentLength;


### PR DESCRIPTION
Today if a user inputs a value for http.max_content_length that is greater than the setting can accomodate (Integer.MAX_VALUE), we truncate this to 100 MB (the default). This commit deprecates this leniency which will be removed in 7.0.0.

Relates #29337