### PR TITLE
Painless: Remove extraneous INLINE constant

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Location.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Location.java
@@ -27,9 +27,9 @@ import java.util.Objects;
 public final class Location {
     private final String sourceName;
     private final int offset;
-    
+
     /**
-     * Create a new Location 
+     * Create a new Location
      * @param sourceName script's name
      * @param offset character offset of script element
      */
@@ -37,7 +37,7 @@ public final class Location {
         this.sourceName = Objects.requireNonNull(sourceName);
         this.offset = offset;
     }
-    
+
     /**
      * Return the script's name
      */
@@ -68,43 +68,31 @@ public final class Location {
 
     // This maximum length is theoretically 65535 bytes, but as it's CESU-8 encoded we don't know how large it is in bytes, so be safe
     private static final int MAX_NAME_LENGTH = 256;
-    
+
     /** Computes the file name (mostly important for stacktraces) */
-    public static String computeSourceName(String scriptName, String source) {
+    public static String computeSourceName(String scriptName) {
         StringBuilder fileName = new StringBuilder();
-        if (scriptName.equals(PainlessScriptEngine.INLINE_NAME)) {
-            // its an anonymous script, include at least a portion of the source to help identify which one it is
-            // but don't create stacktraces with filenames that contain newlines or huge names.
+        // its an anonymous script, include at least a portion of the source to help identify which one it is
+        // but don't create stacktraces with filenames that contain newlines or huge names.
 
-            // truncate to the first newline
-            int limit = source.indexOf('\n');
-            if (limit >= 0) {
-                int limit2 = source.indexOf('\r');
-                if (limit2 >= 0) {
-                    limit = Math.min(limit, limit2);
-                }
-            } else {
-                limit = source.length();
+        // truncate to the first newline
+        int limit = scriptName.indexOf('\n');
+        if (limit >= 0) {
+            int limit2 = scriptName.indexOf('\r');
+            if (limit2 >= 0) {
+                limit = Math.min(limit, limit2);
             }
-
-            // truncate to our limit
-            limit = Math.min(limit, MAX_NAME_LENGTH);
-            fileName.append(source, 0, limit);
-
-            // if we truncated, make it obvious
-            if (limit != source.length()) {
-                fileName.append(" ...");
-            }
-            fileName.append(" @ <inline script>");
         } else {
-            // its a named script, just use the name
-            // but don't trust this has a reasonable length!
-            if (scriptName.length() > MAX_NAME_LENGTH) {
-                fileName.append(scriptName, 0, MAX_NAME_LENGTH);
-                fileName.append(" ...");
-            } else {
-                fileName.append(scriptName);
-            }
+            limit = scriptName.length();
+        }
+
+        // truncate to our limit
+        limit = Math.min(limit, MAX_NAME_LENGTH);
+        fileName.append(scriptName, 0, limit);
+
+        // if we truncated, make it obvious
+        if (limit != scriptName.length()) {
+            fileName.append(" ...");
         }
         return fileName.toString();
     }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScript.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScript.java
@@ -91,14 +91,7 @@ public interface PainlessScript {
                 scriptStack.add(element.toString());
             }
         }
-        // build a name for the script:
-        final String name;
-        if (PainlessScriptEngine.INLINE_NAME.equals(getName())) {
-            name = getSource();
-        } else {
-            name = getName();
-        }
-        ScriptException scriptException = new ScriptException("runtime error", t, scriptStack, name, PainlessScriptEngine.NAME);
+        ScriptException scriptException = new ScriptException("runtime error", t, scriptStack, getName(), PainlessScriptEngine.NAME);
         for (Map.Entry<String, List<String>> entry : extraMetadata.entrySet()) {
             scriptException.addMetadata(entry.getKey(), entry.getValue());
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -119,11 +119,6 @@ public final class PainlessScriptEngine extends AbstractComponent implements Scr
         return NAME;
     }
 
-    /**
-     * When a script is anonymous (inline), we give it this name.
-     */
-    static final String INLINE_NAME = "<inline>";
-
     @Override
     public <T> T compile(String scriptName, String scriptSource, ScriptContext<T> context, Map<String, String> params) {
         Compiler compiler = contextsToCompilers.get(context);
@@ -425,7 +420,7 @@ public final class PainlessScriptEngine extends AbstractComponent implements Scr
             return AccessController.doPrivileged(new PrivilegedAction<Object>() {
                 @Override
                 public Object run() {
-                    String name = scriptName == null ? INLINE_NAME : scriptName;
+                    String name = scriptName == null ? source : scriptName;
                     Constructor<?> constructor = compiler.compile(loader, new MainMethodReserved(), name, source, compilerSettings);
 
                     try {
@@ -488,7 +483,7 @@ public final class PainlessScriptEngine extends AbstractComponent implements Scr
             AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 @Override
                 public Void run() {
-                    String name = scriptName == null ? INLINE_NAME : scriptName;
+                    String name = scriptName == null ? source : scriptName;
                     compiler.compile(loader, reserved, name, source, compilerSettings);
 
                     return null;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/antlr/Walker.java
@@ -198,7 +198,7 @@ public final class Walker extends PainlessParserBaseVisitor<ANode> {
         this.reserved.push(reserved);
         this.debugStream = debugStream;
         this.settings = settings;
-        this.sourceName = Location.computeSourceName(sourceName, sourceText);
+        this.sourceName = Location.computeSourceName(sourceName);
         this.sourceText = sourceText;
         this.globals = new Globals(new BitSet(sourceText.length()));
         this.definition = definition;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
@@ -249,7 +249,7 @@ public final class SSource extends AStatement {
         }
         visitor.visit(WriterConstants.CLASS_VERSION, classAccess, className, null,
             Type.getType(scriptClassInfo.getBaseClass()).getInternalName(), classInterfaces);
-        visitor.visitSource(Location.computeSourceName(name, source), null);
+        visitor.visitSource(Location.computeSourceName(name), null);
 
         // Write the a method to bootstrap def calls
         MethodWriter bootstrapDef = new MethodWriter(Opcodes.ACC_STATIC | Opcodes.ACC_VARARGS, DEF_BOOTSTRAP_METHOD, visitor,


### PR DESCRIPTION
We build the script name from source for inline scripts anyway, so there is no reason to not just name the script after source if it's inline.  This removes the need for the INLINE constant in PainlessScriptEngine.