### PR TITLE
Add useful message when no input from terminal

### DIFF
--- a/server/cli/src/main/java/org/elasticsearch/cli/Terminal.java
+++ b/server/cli/src/main/java/org/elasticsearch/cli/Terminal.java
@@ -165,7 +165,7 @@ public abstract class Terminal {
             try {
                 final String line = reader.readLine();
                 if (line == null) {
-                    throw new IllegalStateException("standard input is closed or there is no tty attached");
+                    throw new IllegalStateException("unable to read from standard input; is standard input open and a tty attached?");
                 }
                 return line;
             } catch (IOException ioe) {

--- a/server/cli/src/main/java/org/elasticsearch/cli/Terminal.java
+++ b/server/cli/src/main/java/org/elasticsearch/cli/Terminal.java
@@ -163,7 +163,11 @@ public abstract class Terminal {
             getWriter().print(text);
             BufferedReader reader = new BufferedReader(new InputStreamReader(System.in, Charset.defaultCharset()));
             try {
-                return reader.readLine();
+                final String line = reader.readLine();
+                if (line == null) {
+                    throw new IllegalStateException("standard input is closed or there is no tty attached");
+                }
+                return line;
             } catch (IOException ioe) {
                 throw new RuntimeException(ioe);
             }


### PR DESCRIPTION
Today when a user runs a CLI tool with standard input closed and no tty attached, the result from reading is null and this usually leads to a null pointer exception when we try to parse this input. This arises for example when the user runs the plugin installer through a Docker container without leaving standard input open and attaching a tty (docker exec <container ID> bin/elasticsearch-plugin install). When we try to read that the user accepts the plugin requiring additional security permissions we will get back null. This commit addresses this for all cases by throwing an illegal state exception. The solution for the user is leave standard input open and attach a tty (or, for some tools, use batch mode).

Relates #29359, relates #29365