### PR TITLE
Move ObjectParser into the x-content lib

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/AbstractObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/AbstractObjectParser.java
@@ -21,10 +21,8 @@ package org.elasticsearch.common.xcontent;
 
 import org.elasticsearch.common.CheckedFunction;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ObjectParser.NamedObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -212,17 +210,6 @@ public abstract class AbstractObjectParser<Value, Context>
     public <T> void declareFieldArray(BiConsumer<Value, List<T>> consumer, ContextParser<Context, T> itemParser,
                                       ParseField field, ValueType type) {
         declareField(consumer, (p, c) -> parseArray(p, () -> itemParser.parse(p, c)), field, type);
-    }
-
-    public void declareRawObject(BiConsumer<Value, BytesReference> consumer, ParseField field) {
-        CheckedFunction<XContentParser, BytesReference, IOException> bytesParser = p -> {
-            try (XContentBuilder builder = JsonXContent.contentBuilder()) {
-                builder.prettyPrint();
-                builder.copyCurrentStructure(p);
-                return BytesReference.bytes(builder);
-            }
-        };
-        declareField(consumer, bytesParser, field, ValueType.OBJECT);
     }
 
     private interface IOSupplier<T> {

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ConstructingObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/ConstructingObjectParser.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.common.xcontent;
 
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.ObjectParser.NamedObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 
@@ -161,7 +160,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
         try {
             return parse(parser, context);
         } catch (IOException e) {
-            throw new ParsingException(parser.getTokenLocation(), "[" + objectParser.getName()  + "] failed to parse object", e);
+            throw new XContentParseException(parser.getTokenLocation(), "[" + objectParser.getName()  + "] failed to parse object", e);
         }
     }
 
@@ -335,7 +334,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
                 try {
                     consumer.accept(targetObject, v);
                 } catch (Exception e) {
-                    throw new ParsingException(location,
+                    throw new XContentParseException(location,
                             "[" + objectParser.getName() + "] failed to parse field [" + parseField.getPreferredName() + "]", e);
                 }
             });
@@ -413,7 +412,7 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
         private void queue(Consumer<Value> queueMe) {
             assert targetObject == null: "Don't queue after the targetObject has been built! Just apply the consumer directly.";
             if (queuedFields == null) {
-                @SuppressWarnings("unchecked")
+                @SuppressWarnings({"unchecked", "rawtypes"})
                 Consumer<Value>[] queuedFields = new Consumer[numberOfFields];
                 this.queuedFields = queuedFields;
             }
@@ -471,11 +470,12 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
                     queuedFieldsCount -= 1;
                     queuedFields[queuedFieldsCount].accept(targetObject);
                 }
-            } catch (ParsingException e) {
-                throw new ParsingException(e.getLineNumber(), e.getColumnNumber(),
-                        "failed to build [" + objectParser.getName() + "] after last required field arrived", e);
+            } catch (XContentParseException e) {
+                throw new XContentParseException(e.getLocation(),
+                    "failed to build [" + objectParser.getName() + "] after last required field arrived", e);
             } catch (Exception e) {
-                throw new ParsingException(null, "Failed to build [" + objectParser.getName() + "] after last required field arrived", e);
+                throw new XContentParseException(null,
+                        "Failed to build [" + objectParser.getName() + "] after last required field arrived", e);
             }
         }
     }

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParseException.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParseException.java
@@ -62,23 +62,4 @@ public class XContentParseException extends IllegalArgumentException {
         return location.map(l -> "[" + l.toString() + "] ").orElse("") + super.getMessage();
     }
 
-    /**
-     * Return the detail message, including the message from the nested exception
-     * if there is one.
-     */
-    public String getDetailedMessage() {
-        if (getCause() != null) {
-            StringBuilder sb = new StringBuilder();
-            sb.append(toString()).append("; ");
-            if (getCause() instanceof XContentParseException) {
-                sb.append(((XContentParseException) getCause()).getDetailedMessage());
-            } else {
-                sb.append(getCause());
-            }
-            return sb.toString();
-        } else {
-            return super.toString();
-        }
-    }
-
 }

--- a/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParseException.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/common/xcontent/XContentParseException.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.common.xcontent;
 
+import org.elasticsearch.common.Nullable;
+
 import java.util.Optional;
 
 /**
@@ -37,6 +39,11 @@ public class XContentParseException extends IllegalArgumentException {
         this.location = Optional.ofNullable(location);
     }
 
+    public XContentParseException(XContentLocation location, String message, Exception cause) {
+        super(message, cause);
+        this.location = Optional.ofNullable(location);
+    }
+
     public int getLineNumber() {
         return location.map(l -> l.lineNumber).orElse(-1);
     }
@@ -45,8 +52,33 @@ public class XContentParseException extends IllegalArgumentException {
         return location.map(l -> l.columnNumber).orElse(-1);
     }
 
+    @Nullable
+    public XContentLocation getLocation() {
+        return location.orElse(null);
+    }
+
     @Override
     public String getMessage() {
         return location.map(l -> "[" + l.toString() + "] ").orElse("") + super.getMessage();
     }
+
+    /**
+     * Return the detail message, including the message from the nested exception
+     * if there is one.
+     */
+    public String getDetailedMessage() {
+        if (getCause() != null) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(toString()).append("; ");
+            if (getCause() instanceof XContentParseException) {
+                sb.append(((XContentParseException) getCause()).getDetailedMessage());
+            } else {
+                sb.append(getCause());
+            }
+            return sb.toString();
+        } else {
+            return super.toString();
+        }
+    }
+
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorFactoryTests.java
@@ -84,7 +84,7 @@ public class ScriptProcessorFactoryTests extends ESTestCase {
 
         XContentParseException exception = expectThrows(XContentParseException.class,
             () -> factory.create(null, randomAlphaOfLength(10), configMap));
-        assertThat(exception.getDetailedMessage(), containsString("[script] failed to parse field [source]"));
+        assertThat(exception.getMessage(), containsString("[script] failed to parse field [source]"));
     }
 
     public void testFactoryValidationAtLeastOneScriptingType() throws Exception {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorFactoryTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptException;
 import org.elasticsearch.script.ScriptService;
@@ -30,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
@@ -80,9 +82,9 @@ public class ScriptProcessorFactoryTests extends ESTestCase {
         configMap.put("source", "bar");
         configMap.put("lang", "mockscript");
 
-        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
+        XContentParseException exception = expectThrows(XContentParseException.class,
             () -> factory.create(null, randomAlphaOfLength(10), configMap));
-        assertThat(exception.getMessage(), is("[script] failed to parse field [source]"));
+        assertThat(exception.getDetailedMessage(), containsString("[script] failed to parse field [source]"));
     }
 
     public void testFactoryValidationAtLeastOneScriptingType() throws Exception {

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateRequestTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateRequestTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.script.mustache;
 
-import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.script.ScriptType;
@@ -122,7 +122,7 @@ public class SearchTemplateRequestTests extends ESTestCase {
 
     public void testParseWrongTemplate() {
         // Unclosed template id
-        expectThrows(ParsingException.class, () -> RestSearchTemplateAction.parse(newParser("{'id' : 'another_temp }")));
+        expectThrows(XContentParseException.class, () -> RestSearchTemplateAction.parse(newParser("{'id' : 'another_temp }")));
     }
 
     /**

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalSpecTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalSpecTests.java
@@ -51,6 +51,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 
 public class RankEvalSpecTests extends ESTestCase {
@@ -133,7 +134,7 @@ public class RankEvalSpecTests extends ESTestCase {
         BytesReference withRandomFields = insertRandomFields(xContentType, originalBytes, null, random());
         try (XContentParser parser = createParser(xContentType.xContent(), withRandomFields)) {
             Exception exception = expectThrows(Exception.class, () -> RankEvalSpec.parse(parser));
-            assertThat(exception.getMessage(), startsWith("[rank_eval] failed to parse field"));
+            assertThat(exception.getMessage(), containsString("[rank_eval] failed to parse field"));
         }
     }
 

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.rankeval;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -138,8 +139,8 @@ public class RatedRequestsTests extends ESTestCase {
             Exception exception = expectThrows(Exception.class, () -> RatedRequest.fromXContent(parser));
             if (exception instanceof XContentParseException) {
                 XContentParseException xcpe = (XContentParseException) exception;
-                assertThat(xcpe.getDetailedMessage(), containsString("unknown field"));
-                assertThat(xcpe.getDetailedMessage(), containsString("parser not found"));
+                assertThat(ExceptionsHelper.detailedMessage(xcpe), containsString("unknown field"));
+                assertThat(ExceptionsHelper.detailedMessage(xcpe), containsString("parser not found"));
             }
             if (exception instanceof XContentParseException) {
                 assertThat(exception.getMessage(), containsString("[request] failed to parse field"));

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -135,11 +136,13 @@ public class RatedRequestsTests extends ESTestCase {
         BytesReference withRandomFields = insertRandomFields(xContentType, originalBytes, null, random());
         try (XContentParser parser = createParser(xContentType.xContent(), withRandomFields)) {
             Exception exception = expectThrows(Exception.class, () -> RatedRequest.fromXContent(parser));
-            if (exception instanceof IllegalArgumentException) {
-                assertThat(exception.getMessage(), containsString("[request] unknown field"));
+            if (exception instanceof XContentParseException) {
+                XContentParseException xcpe = (XContentParseException) exception;
+                assertThat(xcpe.getDetailedMessage(), containsString("unknown field"));
+                assertThat(xcpe.getDetailedMessage(), containsString("parser not found"));
             }
-            if (exception instanceof ParsingException) {
-                assertThat(exception.getMessage(), startsWith("[request] failed to parse field"));
+            if (exception instanceof XContentParseException) {
+                assertThat(exception.getMessage(), containsString("[request] failed to parse field"));
             }
         }
     }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -51,6 +51,7 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 
 public class RatedRequestsTests extends ESTestCase {
@@ -135,7 +136,7 @@ public class RatedRequestsTests extends ESTestCase {
         try (XContentParser parser = createParser(xContentType.xContent(), withRandomFields)) {
             Exception exception = expectThrows(Exception.class, () -> RatedRequest.fromXContent(parser));
             if (exception instanceof IllegalArgumentException) {
-                assertThat(exception.getMessage(), startsWith("[request] unknown field"));
+                assertThat(exception.getMessage(), containsString("[request] unknown field"));
             }
             if (exception instanceof ParsingException) {
                 assertThat(exception.getMessage(), startsWith("[request] failed to parse field"));

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/remote/RemoteScrollableHitSource.java
@@ -31,6 +31,7 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.index.reindex.ScrollableHitSource;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.ResponseException;
@@ -199,7 +200,7 @@ public class RemoteScrollableHitSource extends ScrollableHitSource {
                                 try (XContentParser xContentParser = xContentType.xContent().createParser(NamedXContentRegistry.EMPTY,
                                     LoggingDeprecationHandler.INSTANCE, content)) {
                                     parsedResponse = parser.apply(xContentParser, xContentType);
-                                } catch (ParsingException e) {
+                                } catch (XContentParseException e) {
                                 /* Because we're streaming the response we can't get a copy of it here. The best we can do is hint that it
                                  * is totally wrong and we're probably not talking to Elasticsearch. */
                                     throw new ElasticsearchException(

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/160_extended_stats_metric.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/160_extended_stats_metric.yml
@@ -281,7 +281,7 @@ setup:
                 sigma: -1
 
   - do:
-      catch: /parsing_exception/
+      catch: /x_content_parse_exception/
       search:
         body:
           aggs:

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ObjectParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ObjectParserHelper.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.xcontent;
+
+import org.elasticsearch.common.CheckedFunction;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.function.BiConsumer;
+
+public final class ObjectParserHelper<Value, Context> {
+
+    public void declareRawObject(final AbstractObjectParser<Value, Context> parser,
+                                 final BiConsumer<Value, BytesReference> consumer,
+                                 final ParseField field) {
+        final CheckedFunction<XContentParser, BytesReference, IOException> bytesParser = p -> {
+            try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+                builder.copyCurrentStructure(p);
+                return BytesReference.bytes(builder);
+            }
+        };
+        parser.declareField(consumer, bytesParser, field, ValueType.OBJECT);
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ObjectParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ObjectParserHelper.java
@@ -28,8 +28,15 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import java.io.IOException;
 import java.util.function.BiConsumer;
 
+/**
+ * This class provides helpers for {@link ObjectParser} that allow dealing with
+ * classes outside of the xcontent dependencies.
+ */
 public final class ObjectParserHelper<Value, Context> {
 
+    /**
+     * Helper to declare an object that will be parsed into a {@link BytesReference}
+     */
     public void declareRawObject(final AbstractObjectParser<Value, Context> parser,
                                  final BiConsumer<Value, BytesReference> consumer,
                                  final ParseField field) {

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryQueryContext.java
@@ -19,12 +19,11 @@
 
 package org.elasticsearch.search.suggest.completion.context;
 
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParseField;
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -110,14 +109,14 @@ public final class CategoryQueryContext implements ToXContentObject {
         if (token == XContentParser.Token.START_OBJECT) {
             try {
                 CATEGORY_PARSER.parse(parser, builder, null);
-            } catch(ParsingException e) {
-                throw new ElasticsearchParseException("category context must be a string, number or boolean");
+            } catch(XContentParseException e) {
+                throw new XContentParseException("category context must be a string, number or boolean");
             }
         } else if (token == XContentParser.Token.VALUE_STRING || token == XContentParser.Token.VALUE_BOOLEAN
                 || token == XContentParser.Token.VALUE_NUMBER) {
             builder.setCategory(parser.text());
         } else {
-            throw new ElasticsearchParseException("category context must be an object, string, number or boolean");
+            throw new XContentParseException("category context must be an object, string, number or boolean");
         }
         return builder.build();
     }

--- a/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParserHelper;
 import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -242,7 +243,8 @@ public final class TaskInfo implements Writeable, ToXContentFragment {
         PARSER.declareString(constructorArg(), new ParseField("type"));
         PARSER.declareString(constructorArg(), new ParseField("action"));
         PARSER.declareString(optionalConstructorArg(), new ParseField("description"));
-        PARSER.declareRawObject(optionalConstructorArg(), new ParseField("status"));
+        ObjectParserHelper<TaskInfo, Void> parserHelper = new ObjectParserHelper<>();
+        parserHelper.declareRawObject(PARSER, optionalConstructorArg(), new ParseField("status"));
         PARSER.declareLong(constructorArg(), new ParseField("start_time_in_millis"));
         PARSER.declareLong(constructorArg(), new ParseField("running_time_in_nanos"));
         PARSER.declareBoolean(constructorArg(), new ParseField("cancellable"));

--- a/server/src/main/java/org/elasticsearch/tasks/TaskResult.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskResult.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParserHelper;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -185,8 +186,9 @@ public final class TaskResult implements Writeable, ToXContentObject {
     static {
         PARSER.declareBoolean(constructorArg(), new ParseField("completed"));
         PARSER.declareObject(constructorArg(), TaskInfo.PARSER, new ParseField("task"));
-        PARSER.declareRawObject(optionalConstructorArg(), new ParseField("error"));
-        PARSER.declareRawObject(optionalConstructorArg(), new ParseField("response"));
+        ObjectParserHelper<TaskResult, Void> parserHelper = new ObjectParserHelper<>();
+        parserHelper.declareRawObject(PARSER, optionalConstructorArg(), new ParseField("error"));
+        parserHelper.declareRawObject(PARSER, optionalConstructorArg(), new ParseField("response"));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/AliasActionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/AliasActionsTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
@@ -42,6 +43,7 @@ import static org.elasticsearch.index.alias.RandomAliasActionsGenerator.randomRo
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class AliasActionsTests extends ESTestCase {
@@ -265,9 +267,9 @@ public class AliasActionsTests extends ESTestCase {
         }
         b.endObject();
         try (XContentParser parser = createParser(b)) {
-            Exception e = expectThrows(ParsingException.class, () -> AliasActions.PARSER.apply(parser, null));
+            Exception e = expectThrows(XContentParseException.class, () -> AliasActions.PARSER.apply(parser, null));
             assertThat(e.getCause().getCause(), instanceOf(IllegalArgumentException.class));
-            assertEquals("Only one of [index] and [indices] is supported", e.getCause().getCause().getMessage());
+            assertThat(e.getCause().getCause().getMessage(), containsString("Only one of [index] and [indices] is supported"));
         }
     }
 
@@ -285,9 +287,9 @@ public class AliasActionsTests extends ESTestCase {
         }
         b.endObject();
         try (XContentParser parser = createParser(b)) {
-            Exception e = expectThrows(ParsingException.class, () -> AliasActions.PARSER.apply(parser, null));
+            Exception e = expectThrows(XContentParseException.class, () -> AliasActions.PARSER.apply(parser, null));
             assertThat(e.getCause().getCause(), instanceOf(IllegalArgumentException.class));
-            assertEquals("Only one of [alias] and [aliases] is supported", e.getCause().getCause().getMessage());
+            assertThat(e.getCause().getCause().getMessage(), containsString("Only one of [alias] and [aliases] is supported"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.action.admin.indices.rollover;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestTests;
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -33,6 +32,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.RandomCreateIndexGenerator;
 import org.elasticsearch.indices.IndicesModule;
@@ -172,7 +172,7 @@ public class RolloverRequestTests extends ESTestCase {
         }
         builder.endObject();
         BytesReference mutated = XContentTestUtils.insertRandomFields(xContentType, BytesReference.bytes(builder), null, random());
-        expectThrows(ParsingException.class, () -> request.fromXContent(createParser(xContentType.xContent(), mutated)));
+        expectThrows(XContentParseException.class, () -> request.fromXContent(createParser(xContentType.xContent(), mutated)));
     }
 
     public void testSameConditionCanOnlyBeAddedOnce() {

--- a/server/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IdsQueryBuilderTests.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 
 public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder> {
 
@@ -94,7 +95,7 @@ public class IdsQueryBuilderTests extends AbstractQueryTestCase<IdsQueryBuilder>
     public void testIdsQueryWithInvalidValues() throws Exception {
         String query = "{ \"ids\": { \"values\": [[1]] } }";
         ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(query));
-        assertEquals("[ids] failed to parse field [values]", e.getMessage());
+        assertThat(e.getMessage(), containsString("[ids] failed to parse field [values]"));
     }
 
     public void testFromJson() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
@@ -78,7 +78,8 @@ public class DateRangeTests extends BaseAggregationTestCase<DateRangeAggregation
                 "]\n" +
             "}";
         XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
-        ParsingException ex = expectThrows(ParsingException.class, () -> DateRangeAggregationBuilder.parse("aggregationName", parser));
+        XContentParseException ex = expectThrows(XContentParseException.class,
+                () -> DateRangeAggregationBuilder.parse("aggregationName", parser));
         assertThat(ex.getDetailedMessage(), containsString("badField"));
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DateRangeTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -80,7 +81,7 @@ public class DateRangeTests extends BaseAggregationTestCase<DateRangeAggregation
         XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
         XContentParseException ex = expectThrows(XContentParseException.class,
                 () -> DateRangeAggregationBuilder.parse("aggregationName", parser));
-        assertThat(ex.getDetailedMessage(), containsString("badField"));
+        assertThat(ExceptionsHelper.detailedMessage(ex), containsString("badField"));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.unit.DistanceUnit;
@@ -80,7 +81,7 @@ public class GeoDistanceRangeTests extends BaseAggregationTestCase<GeoDistanceAg
         XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
         XContentParseException ex = expectThrows(XContentParseException.class,
             () -> GeoDistanceAggregationBuilder.parse("aggregationName", parser));
-        assertThat(ex.getDetailedMessage(), containsString("badField"));
+        assertThat(ExceptionsHelper.detailedMessage(ex), containsString("badField"));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceRangeTests.java
@@ -19,10 +19,10 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
@@ -78,7 +78,8 @@ public class GeoDistanceRangeTests extends BaseAggregationTestCase<GeoDistanceAg
                 "]\n" +
             "}";
         XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
-        ParsingException ex = expectThrows(ParsingException.class, () -> GeoDistanceAggregationBuilder.parse("aggregationName", parser));
+        XContentParseException ex = expectThrows(XContentParseException.class,
+            () -> GeoDistanceAggregationBuilder.parse("aggregationName", parser));
         assertThat(ex.getDetailedMessage(), containsString("badField"));
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -76,7 +77,7 @@ public class RangeTests extends BaseAggregationTestCase<RangeAggregationBuilder>
         XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
         XContentParseException ex = expectThrows(XContentParseException.class,
                 () -> RangeAggregationBuilder.parse("aggregationName", parser));
-        assertThat(ex.getDetailedMessage(), containsString("badField"));
+        assertThat(ExceptionsHelper.detailedMessage(ex), containsString("badField"));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/RangeTests.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
@@ -74,7 +74,8 @@ public class RangeTests extends BaseAggregationTestCase<RangeAggregationBuilder>
                 "]\n" +
             "}";
         XContentParser parser = createParser(JsonXContent.jsonXContent, rangeAggregation);
-        ParsingException ex = expectThrows(ParsingException.class, () -> RangeAggregationBuilder.parse("aggregationName", parser));
+        XContentParseException ex = expectThrows(XContentParseException.class,
+                () -> RangeAggregationBuilder.parse("aggregationName", parser));
         assertThat(ex.getDetailedMessage(), containsString("badField"));
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParserTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParserTests.java
@@ -18,8 +18,8 @@
  */
 package org.elasticsearch.search.aggregations.bucket.geogrid;
 
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
@@ -73,8 +73,9 @@ public class GeoHashGridParserTests extends ESTestCase {
                 "{\"field\":\"my_loc\", \"precision\": \"10kg\", \"size\": \"500\", \"shard_size\": \"550\"}");
         XContentParser.Token token = stParser.nextToken();
         assertSame(XContentParser.Token.START_OBJECT, token);
-        ParsingException ex = expectThrows(ParsingException.class, () -> GeoGridAggregationBuilder.parse("geohash_grid", stParser));
-        assertEquals("[geohash_grid] failed to parse field [precision]", ex.getMessage());
+        XContentParseException ex = expectThrows(XContentParseException.class,
+                () -> GeoGridAggregationBuilder.parse("geohash_grid", stParser));
+        assertThat(ex.getMessage(), containsString("[geohash_grid] failed to parse field [precision]"));
         assertThat(ex.getCause(), instanceOf(NumberFormatException.class));
         assertEquals("For input string: \"10kg\"", ex.getCause().getMessage());
     }
@@ -84,8 +85,9 @@ public class GeoHashGridParserTests extends ESTestCase {
                 "{\"field\":\"my_loc\", \"precision\": \"1cm\", \"size\": \"500\", \"shard_size\": \"550\"}");
         XContentParser.Token token = stParser.nextToken();
         assertSame(XContentParser.Token.START_OBJECT, token);
-        ParsingException ex = expectThrows(ParsingException.class, () -> GeoGridAggregationBuilder.parse("geohash_grid", stParser));
-        assertEquals("[geohash_grid] failed to parse field [precision]", ex.getMessage());
+        XContentParseException ex = expectThrows(XContentParseException.class,
+                () -> GeoGridAggregationBuilder.parse("geohash_grid", stParser));
+        assertThat(ex.getMessage(), containsString("[geohash_grid] failed to parse field [precision]"));
         assertThat(ex.getCause(), instanceOf(IllegalArgumentException.class));
         assertEquals("precision too high [1cm]", ex.getCause().getMessage());
     }
@@ -94,8 +96,9 @@ public class GeoHashGridParserTests extends ESTestCase {
         XContentParser stParser = createParser(JsonXContent.jsonXContent, "{\"field\":\"my_loc\", \"precision\":false}");
         XContentParser.Token token = stParser.nextToken();
         assertSame(XContentParser.Token.START_OBJECT, token);
-        Exception e = expectThrows(ParsingException.class, () -> GeoGridAggregationBuilder.parse("geohash_grid", stParser));
-        assertThat(e.getMessage(), containsString("[geohash_grid] precision doesn't support values of type: VALUE_BOOLEAN"));
+        XContentParseException e = expectThrows(XContentParseException.class,
+                () -> GeoGridAggregationBuilder.parse("geohash_grid", stParser));
+        assertThat(e.getDetailedMessage(), containsString("[geohash_grid] precision doesn't support values of type: VALUE_BOOLEAN"));
     }
 
     public void testParseErrorOnPrecisionOutOfRange() throws Exception {
@@ -105,7 +108,7 @@ public class GeoHashGridParserTests extends ESTestCase {
         try {
             GeoGridAggregationBuilder.parse("geohash_grid", stParser);
             fail();
-        } catch (ParsingException ex) {
+        } catch (XContentParseException ex) {
             assertThat(ex.getCause(), instanceOf(IllegalArgumentException.class));
             assertEquals("Invalid geohash aggregation precision of 13. Must be between 1 and 12.", ex.getCause().getMessage());
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParserTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridParserTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.search.aggregations.bucket.geogrid;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -98,7 +99,8 @@ public class GeoHashGridParserTests extends ESTestCase {
         assertSame(XContentParser.Token.START_OBJECT, token);
         XContentParseException e = expectThrows(XContentParseException.class,
                 () -> GeoGridAggregationBuilder.parse("geohash_grid", stParser));
-        assertThat(e.getDetailedMessage(), containsString("[geohash_grid] precision doesn't support values of type: VALUE_BOOLEAN"));
+        assertThat(ExceptionsHelper.detailedMessage(e),
+                containsString("[geohash_grid] precision doesn't support values of type: VALUE_BOOLEAN"));
     }
 
     public void testParseErrorOnPrecisionOutOfRange() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ParseFieldRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
@@ -270,7 +271,7 @@ public class SignificanceHeuristicTests extends ESTestCase {
             stParser.nextToken();
             SignificantTermsAggregationBuilder.getParser(significanceHeuristicParserRegistry).parse("testagg", stParser);
             fail();
-        } catch (ParsingException e) {
+        } catch (XContentParseException e) {
             assertThat(e.getCause().getMessage(), containsString(expectedError));
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -20,12 +20,15 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.search.aggregations.BaseAggregationTestCase;
 import org.elasticsearch.search.aggregations.metrics.percentiles.PercentilesAggregationBuilder;
 
 import java.io.IOException;
+
+import static org.hamcrest.Matchers.containsString;
 
 public class PercentilesTests extends BaseAggregationTestCase<PercentilesAggregationBuilder> {
 
@@ -85,12 +88,8 @@ public class PercentilesTests extends BaseAggregationTestCase<PercentilesAggrega
         XContentParser parser = createParser(JsonXContent.jsonXContent, illegalAgg);
         assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
         assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-        ParsingException e = expectThrows(ParsingException.class,
+        XContentParseException e = expectThrows(XContentParseException.class,
                 () -> PercentilesAggregationBuilder.parse("myPercentiles", parser));
-        assertEquals(
-                "ParsingException[[percentiles] failed to parse field [hdr]]; "
-                + "nested: IllegalStateException[Only one percentiles method should be declared.];; "
-                + "java.lang.IllegalStateException: Only one percentiles method should be declared.",
-                e.getDetailedMessage());
+        assertThat(e.getDetailedMessage(), containsString("[percentiles] failed to parse field [hdr]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/PercentilesTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -90,6 +91,6 @@ public class PercentilesTests extends BaseAggregationTestCase<PercentilesAggrega
         assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
         XContentParseException e = expectThrows(XContentParseException.class,
                 () -> PercentilesAggregationBuilder.parse("myPercentiles", parser));
-        assertThat(e.getDetailedMessage(), containsString("[percentiles] failed to parse field [hdr]"));
+        assertThat(ExceptionsHelper.detailedMessage(e), containsString("[percentiles] failed to parse field [hdr]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -69,6 +70,7 @@ import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class HighlightBuilderTests extends ESTestCase {
@@ -163,15 +165,15 @@ public class HighlightBuilderTests extends ESTestCase {
         }
 
         {
-            ParsingException e = expectParseThrows(ParsingException.class, "{\n" +
+            XContentParseException e = expectParseThrows(XContentParseException.class, "{\n" +
                     "  \"fields\" : {\n" +
                     "     \"body\" : {\n" +
                     "        \"bad_fieldname\" : [ \"field1\" , \"field2\" ]\n" +
                     "     }\n" +
                     "   }\n" +
                     "}\n");
-            assertEquals("[highlight] failed to parse field [fields]", e.getMessage());
-            assertEquals("[fields] failed to parse field [body]", e.getCause().getMessage());
+            assertThat(e.getMessage(), containsString("[highlight] failed to parse field [fields]"));
+            assertThat(e.getCause().getMessage(), containsString("[fields] failed to parse field [body]"));
             assertEquals("[highlight_field] unknown field [bad_fieldname], parser not found", e.getCause().getCause().getMessage());
         }
     }
@@ -193,15 +195,15 @@ public class HighlightBuilderTests extends ESTestCase {
         }
 
         {
-            ParsingException e = expectParseThrows(ParsingException.class, "{\n" +
+            XContentParseException e = expectParseThrows(XContentParseException.class, "{\n" +
                     "  \"fields\" : {\n" +
                     "     \"body\" : {\n" +
                     "        \"bad_fieldname\" : \"value\"\n" +
                     "     }\n" +
                     "   }\n" +
                     "}\n");
-            assertEquals("[highlight] failed to parse field [fields]", e.getMessage());
-            assertEquals("[fields] failed to parse field [body]", e.getCause().getMessage());
+            assertThat(e.getMessage(), containsString("[highlight] failed to parse field [fields]"));
+            assertThat(e.getCause().getMessage(), containsString("[fields] failed to parse field [body]"));
             assertEquals("[highlight_field] unknown field [bad_fieldname], parser not found", e.getCause().getCause().getMessage());
         }
     }
@@ -218,49 +220,50 @@ public class HighlightBuilderTests extends ESTestCase {
         }
 
         {
-            ParsingException e = expectParseThrows(ParsingException.class, "{\n" +
+            XContentParseException e = expectParseThrows(XContentParseException.class, "{\n" +
                     "  \"fields\" : {\n" +
                     "     \"body\" : {\n" +
                     "        \"bad_fieldname\" : { \"field\" : \"value\" }\n" +
                     "     }\n" +
                     "   }\n" +
                     "}\n");
-            assertEquals("[highlight] failed to parse field [fields]", e.getMessage());
-            assertEquals("[fields] failed to parse field [body]", e.getCause().getMessage());
+            assertThat(e.getMessage(), containsString("[highlight] failed to parse field [fields]"));
+            assertThat(e.getCause().getMessage(), containsString("[fields] failed to parse field [body]"));
             assertEquals("[highlight_field] unknown field [bad_fieldname], parser not found", e.getCause().getCause().getMessage());
         }
     }
 
     public void testStringInFieldsArray() throws IOException {
-        ParsingException e = expectParseThrows(ParsingException.class, "{\"fields\" : [ \"junk\" ]}");
-        assertEquals("[highlight] failed to parse field [fields]", e.getMessage());
-        assertEquals(
-                "[fields] can be a single object with any number of fields or an array where each entry is an object with a single field",
-                e.getCause().getMessage());
+        XContentParseException e = expectParseThrows(XContentParseException.class, "{\"fields\" : [ \"junk\" ]}");
+        assertThat(e.getMessage(), containsString("[highlight] failed to parse field [fields]"));
+        assertThat(e.getCause().getMessage(),
+                containsString("[fields] can be a single object with any number of fields " +
+                    "or an array where each entry is an object with a single field"));
     }
 
     public void testNoFieldsInObjectInFieldsArray() throws IOException {
-        ParsingException e = expectParseThrows(ParsingException.class, "{\n" +
+        XContentParseException e = expectParseThrows(XContentParseException.class, "{\n" +
                 "  \"fields\" : [ {\n" +
                 "   }] \n" +
                 "}\n");
-        assertEquals("[highlight] failed to parse field [fields]", e.getMessage());
-        assertEquals(
-                "[fields] can be a single object with any number of fields or an array where each entry is an object with a single field",
-                e.getCause().getMessage());
+        assertThat(e.getMessage(), containsString("[highlight] failed to parse field [fields]"));
+        assertThat(e.getCause().getMessage(),
+                containsString("[fields] can be a single object with any number of fields " +
+                        "or an array where each entry is an object with a single field"));
     }
 
     public void testTwoFieldsInObjectInFieldsArray() throws IOException {
-        ParsingException e = expectParseThrows(ParsingException.class, "{\n" +
+        XContentParseException e = expectParseThrows(XContentParseException.class, "{\n" +
                 "  \"fields\" : [ {\n" +
                 "     \"body\" : {},\n" +
                 "     \"nope\" : {}\n" +
                 "   }] \n" +
                 "}\n");
-        assertEquals("[highlight] failed to parse field [fields]", e.getMessage());
-        assertEquals(
-                "[fields] can be a single object with any number of fields or an array where each entry is an object with a single field",
-                e.getCause().getMessage());    }
+        assertThat(e.getMessage(), containsString("[highlight] failed to parse field [fields]"));
+        assertThat(e.getCause().getMessage(),
+                containsString("[fields] can be a single object with any number of fields " +
+                        "or an array where each entry is an object with a single field"));
+    }
 
      /**
      * test that build() outputs a {@link SearchContextHighlight} that is has similar parameters
@@ -405,10 +408,10 @@ public class HighlightBuilderTests extends ESTestCase {
         assertArrayEquals("setting tags_schema 'default' should alter post_tags", HighlightBuilder.DEFAULT_POST_TAGS,
                 highlightBuilder.postTags());
 
-        ParsingException e = expectParseThrows(ParsingException.class, "{\n" +
+        XContentParseException e = expectParseThrows(XContentParseException.class, "{\n" +
                 "    \"tags_schema\" : \"somthing_else\"\n" +
                 "}\n");
-        assertEquals("[highlight] failed to parse field [tags_schema]", e.getMessage());
+        assertThat(e.getMessage(), containsString("[highlight] failed to parse field [tags_schema]"));
         assertEquals("Unknown tag schema [somthing_else]", e.getCause().getMessage());
     }
 
@@ -436,20 +439,20 @@ public class HighlightBuilderTests extends ESTestCase {
     }
 
     public void testPreTagsWithoutPostTags() throws IOException {
-        ParsingException e = expectParseThrows(ParsingException.class, "{\n" +
+        ParsingException err = expectParseThrows(ParsingException.class, "{\n" +
                 "    \"pre_tags\" : [\"<a>\"]\n" +
                 "}\n");
-        assertEquals("pre_tags are set but post_tags are not set", e.getMessage());
+        assertEquals("pre_tags are set but post_tags are not set", err.getMessage());
 
-        e = expectParseThrows(ParsingException.class, "{\n" +
+        XContentParseException e = expectParseThrows(XContentParseException.class, "{\n" +
                 "  \"fields\" : {\n" +
                 "     \"body\" : {\n" +
                 "        \"pre_tags\" : [\"<a>\"]\n" +
                 "     }\n" +
                 "   }\n" +
                 "}\n");
-        assertEquals("[highlight] failed to parse field [fields]", e.getMessage());
-        assertEquals("[fields] failed to parse field [body]", e.getCause().getMessage());
+        assertThat(e.getMessage(), containsString("[highlight] failed to parse field [fields]"));
+        assertThat(e.getCause().getMessage(), containsString("[fields] failed to parse field [body]"));
         assertEquals("pre_tags are set but post_tags are not set", e.getCause().getCause().getMessage());
     }
 

--- a/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -55,6 +56,7 @@ import java.io.IOException;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.hamcrest.Matchers.containsString;
 
 public class QueryRescorerBuilderTests extends ESTestCase {
 
@@ -262,8 +264,8 @@ public class QueryRescorerBuilderTests extends ESTestCase {
                 "}\n";
         {
             XContentParser parser = createParser(rescoreElement);
-            Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
-            assertEquals("[query] failed to parse field [rescore_query]", e.getMessage());
+            Exception e = expectThrows(XContentParseException.class, () -> RescorerBuilder.parseFromXContent(parser));
+            assertThat(e.getMessage(), containsString("[query] failed to parse field [rescore_query]"));
         }
 
         rescoreElement = "{\n" +

--- a/server/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource;
@@ -50,6 +51,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.elasticsearch.search.sort.NestedSortBuilderTests.createRandomNestedSort;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class ScriptSortBuilderTests extends AbstractSortTestCase<ScriptSortBuilder> {
@@ -246,8 +248,8 @@ public class ScriptSortBuilderTests extends AbstractSortTestCase<ScriptSortBuild
         parser.nextToken();
         parser.nextToken();
 
-        Exception e = expectThrows(ParsingException.class, () -> ScriptSortBuilder.fromXContent(parser, null));
-        assertEquals("[_script] script doesn't support values of type: START_ARRAY", e.getMessage());
+        Exception e = expectThrows(XContentParseException.class, () -> ScriptSortBuilder.fromXContent(parser, null));
+        assertThat(e.getMessage(), containsString("[_script] script doesn't support values of type: START_ARRAY"));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -403,8 +404,8 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(parser));
-        assertEquals("category context must be an object, string, number or boolean", e.getMessage());
+        XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+        assertThat(e.getDetailedMessage(), containsString("category context must be an object, string, number or boolean"));
     }
 
     public void testQueryContextParsingArray() throws Exception {
@@ -460,8 +461,8 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(parser));
-        assertEquals("category context must be an object, string, number or boolean", e.getMessage());
+        XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+        assertThat(e.getDetailedMessage(), containsString("category context must be an object, string, number or boolean"));
     }
 
     public void testQueryContextParsingObject() throws Exception {
@@ -518,8 +519,8 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(parser));
-        assertEquals("category context must be a string, number or boolean", e.getMessage());
+        Exception e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+        assertThat(e.getMessage(), containsString("category context must be a string, number or boolean"));
     }
 
     public void testQueryContextParsingObjectArray() throws Exception {
@@ -619,8 +620,8 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(parser));
-        assertEquals("category context must be a string, number or boolean", e.getMessage());
+        XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+        assertThat(e.getDetailedMessage(), containsString("category context must be a string, number or boolean"));
     }
 
 
@@ -676,8 +677,8 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> mapping.parseQueryContext(parser));
-        assertEquals("category context must be an object, string, number or boolean", e.getMessage());
+        XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+        assertThat(e.getDetailedMessage(), containsString("category context must be an object, string, number or boolean"));
     }
 
     public void testUnknownQueryContextParsing() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -28,6 +28,7 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.suggest.document.ContextSuggestField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -405,7 +406,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
         XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
-        assertThat(e.getDetailedMessage(), containsString("category context must be an object, string, number or boolean"));
+        assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be an object, string, number or boolean"));
     }
 
     public void testQueryContextParsingArray() throws Exception {
@@ -462,7 +463,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
         XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
-        assertThat(e.getDetailedMessage(), containsString("category context must be an object, string, number or boolean"));
+        assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be an object, string, number or boolean"));
     }
 
     public void testQueryContextParsingObject() throws Exception {
@@ -621,7 +622,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
         XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
-        assertThat(e.getDetailedMessage(), containsString("category context must be a string, number or boolean"));
+        assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be a string, number or boolean"));
     }
 
 
@@ -678,7 +679,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
         CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
         XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
-        assertThat(e.getDetailedMessage(), containsString("category context must be an object, string, number or boolean"));
+        assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be an object, string, number or boolean"));
     }
 
     public void testUnknownQueryContextParsing() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
@@ -24,12 +24,12 @@ import org.apache.lucene.search.spell.JaroWinklerDistance;
 import org.apache.lucene.search.spell.LevensteinDistance;
 import org.apache.lucene.search.spell.LuceneLevenshteinDistance;
 import org.apache.lucene.search.spell.NGramDistance;
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
@@ -175,12 +176,12 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
 
         // test bad value for field (e.g. size expects an int)
         directGenerator = "{ \"size\" : \"xxl\" }";
-        assertIllegalXContent(directGenerator, ParsingException.class,
+        assertIllegalXContent(directGenerator, XContentParseException.class,
                 "[direct_generator] failed to parse field [size]");
 
         // test unexpected token
         directGenerator = "{ \"size\" : [ \"xxl\" ] }";
-        assertIllegalXContent(directGenerator, ParsingException.class,
+        assertIllegalXContent(directGenerator, XContentParseException.class,
                 "[direct_generator] size doesn't support values of type: START_ARRAY");
     }
 
@@ -188,7 +189,7 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
             throws IOException {
         XContentParser parser = createParser(JsonXContent.jsonXContent, directGenerator);
         Exception e = expectThrows(exceptionClass, () -> DirectCandidateGeneratorBuilder.PARSER.apply(parser, null));
-        assertEquals(exceptionMsg, e.getMessage());
+        assertThat(e.getMessage(), containsString(exceptionMsg));
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -60,6 +60,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentGenerator;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -338,7 +339,7 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
                 if (expectedException) {
                     fail("some parsing exception expected for query: " + testQuery);
                 }
-            } catch (ParsingException | ElasticsearchParseException e) {
+            } catch (ParsingException | ElasticsearchParseException | XContentParseException e) {
                 // different kinds of exception wordings depending on location
                 // of mutation, so no simple asserts possible here
                 if (expectedException == false) {


### PR DESCRIPTION
This moves `ObjectParser`, `AbstractObjectParser`, and
`ConstructingObjectParser` into the libs/x-content dependency. This decoupling
allows them to be used for parsing for projects that don't want to depend on the
entire Elasticsearch jar.

Relates to #28504