### PR TITLE
Move Tuple into elasticsearch-core

### DIFF
--- a/libs/elasticsearch-core/src/main/java/org/elasticsearch/common/collect/Tuple.java
+++ b/libs/elasticsearch-core/src/main/java/org/elasticsearch/common/collect/Tuple.java
@@ -46,6 +46,7 @@ public class Tuple<V1, V2> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
+        @SuppressWarnings("rawtypes")
         Tuple tuple = (Tuple) o;
 
         if (v1 != null ? !v1.equals(tuple.v1) : tuple.v1 != null) return false;

--- a/libs/elasticsearch-core/src/main/java/org/elasticsearch/common/collect/Tuple.java
+++ b/libs/elasticsearch-core/src/main/java/org/elasticsearch/common/collect/Tuple.java
@@ -46,8 +46,7 @@ public class Tuple<V1, V2> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        @SuppressWarnings("rawtypes")
-        Tuple tuple = (Tuple) o;
+        Tuple<?, ?> tuple = (Tuple<?, ?>) o;
 
         if (v1 != null ? !v1.equals(tuple.v1) : tuple.v1 != null) return false;
         if (v2 != null ? !v2.equals(tuple.v2) : tuple.v2 != null) return false;

--- a/libs/elasticsearch-core/src/test/java/org/elasticsearch/common/collect/TupleTests.java
+++ b/libs/elasticsearch-core/src/test/java/org/elasticsearch/common/collect/TupleTests.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.collect;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class TupleTests extends ESTestCase {
+
+    public void testTuple() {
+        Tuple<Long, String> t1 = new Tuple<>(2L, "foo");
+        Tuple<Long, String> t2 = new Tuple<>(2L, "foo");
+        Tuple<Long, String> t3 = new Tuple<>(3L, "foo");
+        Tuple<Long, String> t4 = new Tuple<>(2L, "bar");
+        Tuple<Integer, String> t5 = new Tuple<>(2, "foo");
+
+        assertEquals(t1.v1(), Long.valueOf(2L));
+        assertEquals(t1.v2(), "foo");
+
+        assertEquals(t1, t2);
+        assertNotEquals(t1, t3);
+        assertNotEquals(t2, t3);
+        assertNotEquals(t2, t4);
+        assertNotEquals(t3, t4);
+        assertNotEquals(t1, t5);
+
+        assertEquals(t1.toString(), "Tuple [v1=2, v2=foo]");
+    }
+}

--- a/libs/elasticsearch-core/src/test/java/org/elasticsearch/common/collect/TupleTests.java
+++ b/libs/elasticsearch-core/src/test/java/org/elasticsearch/common/collect/TupleTests.java
@@ -21,6 +21,8 @@ package org.elasticsearch.common.collect;
 
 import org.elasticsearch.test.ESTestCase;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class TupleTests extends ESTestCase {
 
     public void testTuple() {
@@ -30,16 +32,16 @@ public class TupleTests extends ESTestCase {
         Tuple<Long, String> t4 = new Tuple<>(2L, "bar");
         Tuple<Integer, String> t5 = new Tuple<>(2, "foo");
 
-        assertEquals(t1.v1(), Long.valueOf(2L));
-        assertEquals(t1.v2(), "foo");
+        assertThat(t1.v1(), equalTo(Long.valueOf(2L)));
+        assertThat(t1.v2(), equalTo("foo"));
 
-        assertEquals(t1, t2);
+        assertThat(t1, equalTo(t2));
         assertNotEquals(t1, t3);
         assertNotEquals(t2, t3);
         assertNotEquals(t2, t4);
         assertNotEquals(t3, t4);
         assertNotEquals(t1, t5);
 
-        assertEquals(t1.toString(), "Tuple [v1=2, v2=foo]");
+        assertThat(t1.toString(), equalTo("Tuple [v1=2, v2=foo]"));
     }
 }


### PR DESCRIPTION
This allows us to use Tuple from other projects that don't want to rely on the
entire Elasticsearch jar.

I have also added very simple tests, since there were none.

Relates tangentially to #28504