### PR TITLE
Add breakers as node stats filter

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -68,6 +68,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
         metrics.put("indices", r -> r.indices(true));
         metrics.put("process", r -> r.process(true));
         metrics.put("breaker", r -> r.breaker(true));
+        metrics.put("breakers", r -> r.breaker(true));
         metrics.put("script", r -> r.script(true));
         metrics.put("discovery", r -> r.discovery(true));
         metrics.put("ingest", r -> r.ingest(true));


### PR DESCRIPTION
Former ES support "breakers" as a node stats filter. Since, the response contains "breakers", I think this was a typo?

