### PR TITLE
Enable license header exclusions

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/LicenseHeadersTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/LicenseHeadersTask.groovy
@@ -55,7 +55,7 @@ public class LicenseHeadersTask extends AntTask {
      * possibility of inadvertently using the license on our own source files).
      */
     @Input
-    List<String> excludedJavaFiles = []
+    List<String> excludes = []
 
     /**
      * Additional license families that may be found. The key is the license category name (5 characters),
@@ -103,7 +103,7 @@ public class LicenseHeadersTask extends AntTask {
                for (File dir: dirSet.srcDirs) {
                    // sometimes these dirs don't exist, e.g. site-plugin has no actual java src/main...
                    if (dir.exists()) {
-                       ant.fileset(dir: dir, excludes: excludedJavaFiles.join(' '))
+                       ant.fileset(dir: dir, excludes: excludes.join(' '))
                    }
                }
             }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/LicenseHeadersTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/precommit/LicenseHeadersTask.groovy
@@ -50,6 +50,14 @@ public class LicenseHeadersTask extends AntTask {
     List<String> approvedLicenses = ['Apache', 'Generated']
 
     /**
+     * Files that should be excluded from the license header check. Use with extreme care, only in situations where the license on the
+     * source file is compatible with the codebase but we do not want to add the license to the list of approved headers (to avoid the
+     * possibility of inadvertently using the license on our own source files).
+     */
+    @Input
+    List<String> excludedJavaFiles = []
+
+    /**
      * Additional license families that may be found. The key is the license category name (5 characters),
      * followed by the family name and the value list of patterns to search for.
      */
@@ -95,7 +103,7 @@ public class LicenseHeadersTask extends AntTask {
                for (File dir: dirSet.srcDirs) {
                    // sometimes these dirs don't exist, e.g. site-plugin has no actual java src/main...
                    if (dir.exists()) {
-                       ant.fileset(dir: dir)
+                       ant.fileset(dir: dir, excludes: excludedJavaFiles.join(' '))
                    }
                }
             }


### PR DESCRIPTION
There are some scenarios where the license on a source file is one that is compatible with our projects yet we do not want to add the license to the list of approved license headers (to keep the number of files with that compatible license contained). This commit adds the ability to exclude a file from the license check.
