### PR TITLE
Add indices options support to _rank_eval

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
@@ -544,8 +544,10 @@ public final class Request {
 
     static Request rankEval(RankEvalRequest rankEvalRequest) throws IOException {
         String endpoint = endpoint(rankEvalRequest.indices(), Strings.EMPTY_ARRAY, "_rank_eval");
+        Params params = Params.builder();
+        params.withIndicesOptions(rankEvalRequest.indicesOptions());
         HttpEntity entity = createEntity(rankEvalRequest.getRankEvalSpec(), REQUEST_BODY_CONTENT_TYPE);
-        return new Request(HttpGet.METHOD_NAME, endpoint, Collections.emptyMap(), entity);
+        return new Request(HttpGet.METHOD_NAME, endpoint, params.getParams(), entity);
     }
 
     static Request split(ResizeRequest resizeRequest) throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RankEvalIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RankEvalIT.java
@@ -21,6 +21,8 @@ package org.elasticsearch.client;
 
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.rankeval.EvalQueryQuality;
 import org.elasticsearch.index.rankeval.PrecisionAtK;
@@ -37,8 +39,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.index.rankeval.EvaluationMetric.filterUnknownDocuments;
 
@@ -55,6 +58,10 @@ public class RankEvalIT extends ESRestHighLevelClientTestCase {
         client().performRequest("PUT", "/index/doc/5", Collections.emptyMap(), doc);
         client().performRequest("PUT", "/index/doc/6", Collections.emptyMap(), doc);
         client().performRequest("POST", "/index/_refresh");
+
+        // add another index to test basic multi index support
+        client().performRequest("PUT", "/index2/doc/7", Collections.emptyMap(), doc);
+        client().performRequest("POST", "/index2/_refresh");
     }
 
     /**
@@ -64,7 +71,9 @@ public class RankEvalIT extends ESRestHighLevelClientTestCase {
     public void testRankEvalRequest() throws IOException {
         SearchSourceBuilder testQuery = new SearchSourceBuilder();
         testQuery.query(new MatchAllQueryBuilder());
-        RatedRequest amsterdamRequest = new RatedRequest("amsterdam_query", createRelevant("index" , "2", "3", "4", "5"), testQuery);
+        List<RatedDocument> amsterdamRatedDocs = createRelevant("index" , "2", "3", "4", "5");
+        amsterdamRatedDocs.addAll(createRelevant("index2", "7"));
+        RatedRequest amsterdamRequest = new RatedRequest("amsterdam_query", amsterdamRatedDocs, testQuery);
         RatedRequest berlinRequest = new RatedRequest("berlin_query", createRelevant("index", "1"), testQuery);
         List<RatedRequest> specifications = new ArrayList<>();
         specifications.add(amsterdamRequest);
@@ -72,49 +81,46 @@ public class RankEvalIT extends ESRestHighLevelClientTestCase {
         PrecisionAtK metric = new PrecisionAtK(1, false, 10);
         RankEvalSpec spec = new RankEvalSpec(specifications, metric);
 
-        RankEvalResponse response = execute(new RankEvalRequest(spec, new String[] { "index" }), highLevelClient()::rankEval,
+        RankEvalRequest rankEvalRequest = new RankEvalRequest(spec, new String[] { "index", "index2" });
+        RankEvalResponse response = execute(rankEvalRequest, highLevelClient()::rankEval,
                 highLevelClient()::rankEvalAsync);
-        // the expected Prec@ for the first query is 4/6 and the expected Prec@ for the second is 1/6, divided by 2 to get the average
-        double expectedPrecision = (1.0 / 6.0 + 4.0 / 6.0) / 2.0;
+        // the expected Prec@ for the first query is 5/7 and the expected Prec@ for the second is 1/7, divided by 2 to get the average
+        double expectedPrecision = (1.0 / 7.0 + 5.0 / 7.0) / 2.0;
         assertEquals(expectedPrecision, response.getEvaluationResult(), Double.MIN_VALUE);
-        Set<Entry<String, EvalQueryQuality>> entrySet = response.getPartialResults().entrySet();
-        assertEquals(2, entrySet.size());
-        for (Entry<String, EvalQueryQuality> entry : entrySet) {
-            EvalQueryQuality quality = entry.getValue();
-            if (entry.getKey() == "amsterdam_query") {
-                assertEquals(2, filterUnknownDocuments(quality.getHitsAndRatings()).size());
-                List<RatedSearchHit> hitsAndRatings = quality.getHitsAndRatings();
-                assertEquals(6, hitsAndRatings.size());
-                for (RatedSearchHit hit : hitsAndRatings) {
-                    String id = hit.getSearchHit().getId();
-                    if (id.equals("1") || id.equals("6")) {
-                        assertFalse(hit.getRating().isPresent());
-                    } else {
-                        assertEquals(1, hit.getRating().get().intValue());
-                    }
-                }
-            }
-            if (entry.getKey() == "berlin_query") {
-                assertEquals(5, filterUnknownDocuments(quality.getHitsAndRatings()).size());
-                List<RatedSearchHit> hitsAndRatings = quality.getHitsAndRatings();
-                assertEquals(6, hitsAndRatings.size());
-                for (RatedSearchHit hit : hitsAndRatings) {
-                    String id = hit.getSearchHit().getId();
-                    if (id.equals("1")) {
-                        assertEquals(1, hit.getRating().get().intValue());
-                    } else {
-                        assertFalse(hit.getRating().isPresent());
-                    }
-                }
+        Map<String, EvalQueryQuality> partialResults = response.getPartialResults();
+        assertEquals(2, partialResults.size());
+        EvalQueryQuality amsterdamQueryQuality = partialResults.get("amsterdam_query");
+        assertEquals(2, filterUnknownDocuments(amsterdamQueryQuality.getHitsAndRatings()).size());
+        List<RatedSearchHit> hitsAndRatings = amsterdamQueryQuality.getHitsAndRatings();
+        assertEquals(7, hitsAndRatings.size());
+        for (RatedSearchHit hit : hitsAndRatings) {
+            String id = hit.getSearchHit().getId();
+            if (id.equals("1") || id.equals("6")) {
+                assertFalse(hit.getRating().isPresent());
+            } else {
+                assertEquals(1, hit.getRating().get().intValue());
             }
         }
+        EvalQueryQuality berlinQueryQuality = partialResults.get("berlin_query");
+        assertEquals(6, filterUnknownDocuments(berlinQueryQuality.getHitsAndRatings()).size());
+        hitsAndRatings = berlinQueryQuality.getHitsAndRatings();
+        assertEquals(7, hitsAndRatings.size());
+        for (RatedSearchHit hit : hitsAndRatings) {
+            String id = hit.getSearchHit().getId();
+            if (id.equals("1")) {
+                assertEquals(1, hit.getRating().get().intValue());
+            } else {
+                assertFalse(hit.getRating().isPresent());
+            }
+        }
+
+        // now try this when test2 is closed
+        client().performRequest("POST", "index2/_close", Collections.emptyMap());
+        rankEvalRequest.indicesOptions(IndicesOptions.fromParameters(null, "true", null, SearchRequest.DEFAULT_INDICES_OPTIONS));
+        response = execute(rankEvalRequest, highLevelClient()::rankEval, highLevelClient()::rankEvalAsync);
     }
 
     private static List<RatedDocument> createRelevant(String indexName, String... docs) {
-        List<RatedDocument> relevant = new ArrayList<>();
-        for (String doc : docs) {
-            relevant.add(new RatedDocument(indexName, doc, 1));
-        }
-        return relevant;
+        return Stream.of(docs).map(s -> new RatedDocument(indexName, s, 1)).collect(Collectors.toList());
     }
 }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -1247,11 +1247,8 @@ public class RequestTests extends ESTestCase {
                 new PrecisionAtK());
         String[] indices = randomIndicesNames(0, 5);
         RankEvalRequest rankEvalRequest = new RankEvalRequest(spec, indices);
-        String wildCardOption = randomFrom("none", "open", "closed", "all");
-        String ignoreUnavailableOption = randomFrom("true", "false");
-        String allowNoIndicesOption = randomFrom("true", "false");
-        rankEvalRequest.indicesOptions(IndicesOptions.fromParameters(wildCardOption,
-                ignoreUnavailableOption, allowNoIndicesOption, SearchRequest.DEFAULT_INDICES_OPTIONS));
+        Map<String, String> expectedParams = new HashMap<>();
+        setRandomIndicesOptions(rankEvalRequest::indicesOptions, rankEvalRequest::indicesOptions, expectedParams);
 
         Request request = Request.rankEval(rankEvalRequest);
         StringJoiner endpoint = new StringJoiner("/", "/", "");
@@ -1262,9 +1259,7 @@ public class RequestTests extends ESTestCase {
         endpoint.add(RestRankEvalAction.ENDPOINT);
         assertEquals(endpoint.toString(), request.getEndpoint());
         assertEquals(3, request.getParameters().size());
-        assertEquals(allowNoIndicesOption, request.getParameters().get("allow_no_indices"));
-        assertEquals(wildCardOption.equals("all") ? "open,closed" : wildCardOption, request.getParameters().get("expand_wildcards"));
-        assertEquals(ignoreUnavailableOption, request.getParameters().get("ignore_unavailable"));
+        assertEquals(expectedParams, request.getParameters());
         assertToXContentBody(spec, request.getEntity());
 
     }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -1247,6 +1247,11 @@ public class RequestTests extends ESTestCase {
                 new PrecisionAtK());
         String[] indices = randomIndicesNames(0, 5);
         RankEvalRequest rankEvalRequest = new RankEvalRequest(spec, indices);
+        String wildCardOption = randomFrom("none", "open", "closed", "all");
+        String ignoreUnavailableOption = randomFrom("true", "false");
+        String allowNoIndicesOption = randomFrom("true", "false");
+        rankEvalRequest.indicesOptions(IndicesOptions.fromParameters(wildCardOption,
+                ignoreUnavailableOption, allowNoIndicesOption, SearchRequest.DEFAULT_INDICES_OPTIONS));
 
         Request request = Request.rankEval(rankEvalRequest);
         StringJoiner endpoint = new StringJoiner("/", "/", "");
@@ -1256,8 +1261,12 @@ public class RequestTests extends ESTestCase {
         }
         endpoint.add(RestRankEvalAction.ENDPOINT);
         assertEquals(endpoint.toString(), request.getEndpoint());
-        assertEquals(Collections.emptyMap(), request.getParameters());
+        assertEquals(3, request.getParameters().size());
+        assertEquals(allowNoIndicesOption, request.getParameters().get("allow_no_indices"));
+        assertEquals(wildCardOption.equals("all") ? "open,closed" : wildCardOption, request.getParameters().get("expand_wildcards"));
+        assertEquals(ignoreUnavailableOption, request.getParameters().get("ignore_unavailable"));
         assertToXContentBody(spec, request.getEntity());
+
     }
 
     public void testSplit() throws IOException {

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RestRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RestRankEvalAction.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.index.rankeval;
 
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -109,6 +110,7 @@ public class RestRankEvalAction extends BaseRestHandler {
 
     private static void parseRankEvalRequest(RankEvalRequest rankEvalRequest, RestRequest request, XContentParser parser) {
         rankEvalRequest.indices(Strings.splitStringByCommaToArray(request.param("index")));
+        rankEvalRequest.indicesOptions(IndicesOptions.fromRequest(request, rankEvalRequest.indicesOptions()));
         RankEvalSpec spec = RankEvalSpec.parse(parser);
         rankEvalRequest.setRankEvalSpec(spec);
     }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/TransportRankEvalAction.java
@@ -126,7 +126,9 @@ public class TransportRankEvalAction extends HandledTransportAction<RankEvalRequ
             } else {
                 ratedSearchSource.fetchSource(summaryFields.toArray(new String[summaryFields.size()]), new String[0]);
             }
-            msearchRequest.add(new SearchRequest(request.indices(), ratedSearchSource));
+            SearchRequest searchRequest = new SearchRequest(request.indices(), ratedSearchSource);
+            searchRequest.indicesOptions(request.indicesOptions());
+            msearchRequest.add(searchRequest);
         }
         assert ratedRequestsInSearch.size() == msearchRequest.requests().size();
         client.multiSearch(msearchRequest, new RankEvalActionListener(listener, metric,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
@@ -1,26 +1,36 @@
-{ 
-  "rank_eval": { 
-    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html", 
-    "methods": ["POST"], 
-    "url": { 
-      "path": "/_rank_eval", 
-      "paths": ["/_rank_eval", "/{index}/_rank_eval", "/{index}/{type}/_rank_eval"], 
+{
+  "rank_eval": {
+    "documentation": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html",
+    "methods": ["GET", "POST"],
+    "url": {
+      "path": "/_rank_eval",
+      "paths": ["/_rank_eval", "/{index}/_rank_eval"],
       "parts": {
         "index": {
          "type": "list",
          "description" : "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"
-        }, 
-        "type": {
-          "type" : "list",
-          "description" : "A comma-separated list of document types to search; leave empty to perform the operation on all types"
         }
      },
-     "params": {}
+     "params": {
+        "ignore_unavailable": {
+            "type" : "boolean",
+            "description" : "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+        },
+        "allow_no_indices": {
+            "type" : "boolean",
+            "description" : "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+        },
+        "expand_wildcards": {
+            "type" : "enum",
+            "options" : ["open","closed","none","all"],
+            "default" : "open",
+            "description" : "Whether to expand wildcard expression to concrete indices that are open, closed or both."
+        }
+     }
     }, 
-    "body": { 
-      "description": "The search definition using the Query DSL and the prototype for the eval request.", 
-      "required": true 
-    } 
-  } 
+    "body": {
+      "description": "The ranking evaluation search definition, including search requests, document ratings and ranking metric definition.",
+      "required": true
+    }
+  }
 }
-


### PR DESCRIPTION
Currently the ranking evaluation API doesn't support many of the
standard parameters of the search API. Some of these make sense, like
adding support for the common indices options parameters, which this
change adds.