### PR TITLE
[TEST] Put options that enable assertions earlier on command line

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -167,7 +167,10 @@ class NodeInfo {
         String collectedSystemProperties = config.systemProperties.collect { key, value -> "-D${key}=${value}" }.join(" ")
         String esJavaOpts = config.jvmArgs.isEmpty() ? collectedSystemProperties : collectedSystemProperties + " " + config.jvmArgs
         if (Boolean.parseBoolean(System.getProperty('tests.asserts', 'true'))) {
-            esJavaOpts += " -ea -esa"
+            // put the enable assertions options before other options to allow
+            // flexibility to disable assertions for specific packages or classes
+            // in the cluster-specific options
+            esJavaOpts = "-ea -esa " + esJavaOpts
         }
         env.put('ES_JAVA_OPTS', esJavaOpts)
         for (Map.Entry<String, String> property : System.properties.entrySet()) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -170,7 +170,7 @@ class NodeInfo {
             // put the enable assertions options before other options to allow
             // flexibility to disable assertions for specific packages or classes
             // in the cluster-specific options
-            esJavaOpts = "-ea -esa " + esJavaOpts
+            esJavaOpts = String.join(" ", "-ea", "-esa", esJavaOpts)
         }
         env.put('ES_JAVA_OPTS', esJavaOpts)
         for (Map.Entry<String, String> property : System.properties.entrySet()) {


### PR DESCRIPTION
This change moves the -ea and -esa options that enable assertions for
test nodes before the cluster-specific JVM arguments on the Java command
line.  This opens up the possibility for the cluster-specific JVM
arguments to disable assertions for one particular package or class,
which can be useful in BWC testing where incorrect assertions cannot be
removed from released versions of the product.