### PR TITLE
Fix the search request default operation behavior doc

### DIFF
--- a/docs/reference/search/request/preference.asciidoc
+++ b/docs/reference/search/request/preference.asciidoc
@@ -2,7 +2,8 @@
 === Preference
 
 Controls a `preference` of which shard copies on which to execute the
-search. By default, the operation is randomized among the available shard copies.
+search. By default, the operation is randomized among the available shard 
+copies, unless allocation awareness is used.
 
 The `preference` is a query string parameter which can be set to:
 


### PR DESCRIPTION
Add a note about the search request default operation is randomized among the available shard copies unless allocation awareness is used.

Closes #29302