### PR TITLE
Simplify Translog#closeOnTragicEvent

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -490,19 +490,11 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 return current.add(bytes, operation.seqNo());
             }
         } catch (final AlreadyClosedException | IOException ex) {
-            try {
-                closeOnTragicEvent(ex);
-            } catch (final Exception inner) {
-                ex.addSuppressed(inner);
-            }
+            closeOnTragicEvent(ex);
             throw ex;
-        } catch (final Exception e) {
-            try {
-                closeOnTragicEvent(e);
-            } catch (final Exception inner) {
-                e.addSuppressed(inner);
-            }
-            throw new TranslogException(shardId, "Failed to write operation [" + operation + "]", e);
+        } catch (final Exception ex) {
+            closeOnTragicEvent(ex);
+            throw new TranslogException(shardId, "Failed to write operation [" + operation + "]", ex);
         } finally {
             Releasables.close(out);
         }
@@ -586,13 +578,9 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 // if they are still in RAM and we are reading onto that position
                 try {
                     return current.read(location);
-                } catch (final IOException e) {
-                    try {
-                        closeOnTragicEvent(e);
-                    } catch (final Exception inner) {
-                        e.addSuppressed(inner);
-                    }
-                    throw e;
+                } catch (final Exception ex) {
+                    closeOnTragicEvent(ex);
+                    throw ex;
                 }
             } else {
                 // read backwards - it's likely we need to read on that is recent
@@ -679,12 +667,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             if (closed.get() == false) {
                 current.sync();
             }
-        } catch (Exception ex) {
-            try {
-                closeOnTragicEvent(ex);
-            } catch (Exception inner) {
-                ex.addSuppressed(inner);
-            }
+        } catch (final Exception ex) {
+            closeOnTragicEvent(ex);
             throw ex;
         }
     }
@@ -719,12 +703,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 ensureOpen();
                 return current.syncUpTo(location.translogLocation + location.size);
             }
-        } catch (Exception ex) {
-            try {
-                closeOnTragicEvent(ex);
-            } catch (Exception inner) {
-                ex.addSuppressed(inner);
-            }
+        } catch (final Exception ex) {
+            closeOnTragicEvent(ex);
             throw ex;
         }
         return false;
@@ -748,14 +728,14 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         }
     }
 
-    private void closeOnTragicEvent(Exception ex) {
+    private void closeOnTragicEvent(final Exception ex) {
         if (current.getTragicException() != null) {
             try {
                 close();
-            } catch (AlreadyClosedException inner) {
+            } catch (final AlreadyClosedException inner) {
                 // don't do anything in this case. The AlreadyClosedException comes from TranslogWriter and we should not add it as suppressed because
                 // will contain the Exception ex as cause. See also https://github.com/elastic/elasticsearch/issues/15941
-            } catch (Exception inner) {
+            } catch (final Exception inner) {
                 assert (ex != inner.getCause());
                 ex.addSuppressed(inner);
             }
@@ -1609,12 +1589,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             assert readers.isEmpty() == false || current.generation == minReferencedGen :
                 "all readers were cleaned but the minReferenceGen [" + minReferencedGen + "] is not the current writer's gen [" +
                     current.generation + "]";
-        } catch (Exception ex) {
-            try {
-                closeOnTragicEvent(ex);
-            } catch (final Exception inner) {
-                ex.addSuppressed(inner);
-            }
+        } catch (final Exception ex) {
+            closeOnTragicEvent(ex);
             throw ex;
         }
     }


### PR DESCRIPTION
This commit simplifies the invocations to Translog#closeOnTragicEvent. This method already catches all possible exceptions and suppresses the non-AlreadyClosedExceptions into the exception that triggered the invocation. Therefore, there is no need for callers to do this same logic (which would never execute).

Relates #29401