### PR TITLE
Speed up some of our slowest unit tests.

### DIFF
--- a/server/src/test/java/org/apache/lucene/queries/BaseRandomBinaryDocValuesRangeQueryTestCase.java
+++ b/server/src/test/java/org/apache/lucene/queries/BaseRandomBinaryDocValuesRangeQueryTestCase.java
@@ -42,12 +42,6 @@ public abstract class BaseRandomBinaryDocValuesRangeQueryTestCase extends BaseRa
     }
 
     @Override
-    public void testRandomBig() throws Exception {
-        // Test regardless whether -Dtests.nightly=true has been specified:
-        super.testRandomBig();
-    }
-
-    @Override
     protected final Field newRangeField(Range box) {
         AbstractRange<?> testRange = (AbstractRange<?>) box;
         RangeFieldMapper.Range range = new RangeFieldMapper.Range(rangeType(), testRange.getMin(), testRange.getMax(), true , true);

--- a/server/src/test/java/org/elasticsearch/common/UUIDTests.java
+++ b/server/src/test/java/org/elasticsearch/common/UUIDTests.java
@@ -120,9 +120,9 @@ public class UUIDTests extends ESTestCase {
         Logger logger = Loggers.getLogger(UUIDTests.class);
         // Low number so that the test runs quickly, but the results are more interesting with larger numbers
         // of indexed documents
-        assertThat(testCompression(500000, 10000, 3, logger), Matchers.lessThan(12d)); // ~10.8 in practice
-        assertThat(testCompression(500000, 1000, 3, logger), Matchers.lessThan(14d)); // ~11.5 in practice
-        assertThat(testCompression(500000, 100, 3, logger), Matchers.lessThan(21d)); // ~19.5 in practice
+        assertThat(testCompression(100000, 10000, 3, logger), Matchers.lessThan(14d)); // ~12 in practice
+        assertThat(testCompression(100000, 1000, 3, logger), Matchers.lessThan(15d)); // ~13 in practice
+        assertThat(testCompression(100000, 100, 3, logger), Matchers.lessThan(21d)); // ~20 in practice
     }
 
     private static double testCompression(int numDocs, int numDocsPerSecond, int numNodes, Logger logger) throws Exception {


### PR DESCRIPTION
`BaseRandomBinaryDocValuesRangeQueryTestCase.testRandomBig` should only run with
nightly tests. It doesn't make sense to make it part of every test run.

`UUIDTests` had a slow test for compression, which I made a bit faster by
decreasing the number of indexed docs.
