### PR TITLE
Remove 5x bwc in LocaleUtils#parse

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/LocaleUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LocaleUtils.java
@@ -75,16 +75,6 @@ public class LocaleUtils {
         return locale;
     }
 
-    /**
-     * Parse the string describing a locale into a {@link Locale} object
-     * for 5.x indices.
-     */
-    @Deprecated
-    public static Locale parse5x(String localeStr) {
-        final String[] parts = localeStr.split("_", -1);
-        return parseParts(parts);
-    }
-
     private static Locale parseParts(String[] parts) {
         switch (parts.length) {
         case 3:

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -33,7 +33,6 @@ import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.geo.ShapeRelation;
@@ -159,13 +158,7 @@ public class DateFieldMapper extends FieldMapper {
                     builder.ignoreMalformed(TypeParsers.nodeBooleanValue(name, "ignore_malformed", propNode, parserContext));
                     iterator.remove();
                 } else if (propName.equals("locale")) {
-                    Locale locale;
-                    if (parserContext.indexVersionCreated().onOrAfter(Version.V_6_0_0_beta2)) {
-                        locale = LocaleUtils.parse(propNode.toString());
-                    } else {
-                        locale = LocaleUtils.parse5x(propNode.toString());
-                    }
-                    builder.locale(locale);
+                    builder.locale(LocaleUtils.parse(propNode.toString()));
                     iterator.remove();
                 } else if (propName.equals("format")) {
                     builder.dateTimeFormatter(parseDateTimeFormatter(propNode));

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -186,13 +186,7 @@ public class RangeFieldMapper extends FieldMapper {
                     builder.coerce(TypeParsers.nodeBooleanValue(name, "coerce", propNode, parserContext));
                     iterator.remove();
                 } else if (propName.equals("locale")) {
-                    Locale locale;
-                    if (parserContext.indexVersionCreated().onOrAfter(Version.V_6_0_0_beta2)) {
-                        locale = LocaleUtils.parse(propNode.toString());
-                    } else {
-                        locale = LocaleUtils.parse5x(propNode.toString());
-                    }
-                    builder.locale(locale);
+                    builder.locale(LocaleUtils.parse(propNode.toString()));
                     iterator.remove();
                 } else if (propName.equals("format")) {
                     builder.dateTimeFormatter(parseDateTimeFormatter(propNode));


### PR DESCRIPTION
Remove the special treatment of parsing the locale property for old 5.x
indices since in 7.0 we only need to support reading from 6.x indices.
