### PR TITLE
Fix overflow error in parsing of long geohashes

### DIFF
--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -92,6 +92,16 @@ format was changed early on to conform to the format used by GeoJSON.
 
 ==================================================
 
+[NOTE]
+A point can be expressed as a http://en.wikipedia.org/wiki/Geohash[geohash].
+Geohashes are https://en.wikipedia.org/wiki/Base32[base32] encoded strings of
+the bits of the latitude and longitude interleaved. Each character in a geohash
+adds additional 5 bits to the precision. So the longer the hash, the more
+precise it is. For the indexing purposed geohashs are translated into
+latitude-longitude pairs. During this process only first 12 characters are
+used, so specifying more than 12 characters in a geohash doesn't increase the
+precision. The 12 characters provide 60 bits, which should reduce a possible
+error to less than 2cm.
 
 [[geo-point-params]]
 ==== Parameters for `geo_point` fields

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoHashTests.java
@@ -82,4 +82,20 @@ public class GeoHashTests extends ESTestCase {
         assertEquals("xbpbpbpbpbpb", GeoHashUtils.stringEncode(180, 0));
         assertEquals("zzzzzzzzzzzz", GeoHashUtils.stringEncode(180, 90));
     }
+
+    public void testLongGeohashes() {
+        for (int i = 0; i < 100000; i++) {
+            String geohash = randomGeohash(12, 12);
+            GeoPoint expected = GeoPoint.fromGeohash(geohash);
+            // Adding some random geohash characters at the end
+            String extendedGeohash = geohash + randomGeohash(1, 10);
+            GeoPoint actual = GeoPoint.fromGeohash(extendedGeohash);
+            assertEquals("Additional data points above 12 should be ignored [" + extendedGeohash + "]" , expected, actual);
+
+            Rectangle expectedBbox = GeoHashUtils.bbox(geohash);
+            Rectangle actualBbox = GeoHashUtils.bbox(extendedGeohash);
+            assertEquals("Additional data points above 12 should be ignored [" + extendedGeohash + "]" , expectedBbox, actualBbox);
+
+        }
+    }
 }


### PR DESCRIPTION
Fixes a possible overflow error that geohashes longer than 12 characters
can cause during parsing.

Fixes #24616 