### PR TITLE
Makes request headers lowercase in English locale.

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -434,10 +434,10 @@ public class RestClient implements Closeable {
         for (Header requestHeader : requestHeaders) {
             Objects.requireNonNull(requestHeader, "request header must not be null");
             httpRequest.addHeader(requestHeader);
-            requestNames.add(requestHeader.getName());
+            requestNames.add(requestHeader.getName().toLowerCase(Locale.ENGLISH));
         }
         for (Header defaultHeader : defaultHeaders) {
-            if (requestNames.contains(defaultHeader.getName()) == false) {
+            if (!requestNames.contains(defaultHeader.getName().toLowerCase(Locale.ENGLISH))) {
                 httpRequest.addHeader(defaultHeader);
             }
         }

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -437,7 +437,7 @@ public class RestClient implements Closeable {
             requestNames.add(requestHeader.getName().toLowerCase(Locale.ENGLISH));
         }
         for (Header defaultHeader : defaultHeaders) {
-            if (!requestNames.contains(defaultHeader.getName().toLowerCase(Locale.ENGLISH))) {
+            if (requestNames.contains(defaultHeader.getName().toLowerCase(Locale.ENGLISH)) == false) {
                 httpRequest.addHeader(defaultHeader);
             }
         }


### PR DESCRIPTION
Converts requestHeader names to lowercase in the English Locale. Makes overriding default headers in RestClient possible. Converted the `requestNames.contains... == false` statement to `!requestNames.contains...`. Closes #22623