### PR TITLE
Add continuation_indent_size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,6 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+continuation_indent_size = 8
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
I spent several hours figuring out why Intellij IDEA uses Continuation Indent 4 spaces even if I change size directly in the project settings. Turned out that I had EditorConfig plugin enabled which picks up `.editorconfig` and override all the project settings. But the problem is that it sets Continuation Indent the same as `indent_size`, which is completely wrong. To fix it Plugin's authors [added custom property](https://youtrack.jetbrains.com/issue/IDEA-145069) `continuation_indent_size`. This property is supported only by IDEA but should not bring any harm for other IDEs.
