### PR TITLE
Add support for seccomp on ppc64le

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -242,6 +242,7 @@ final class SystemCallFilter {
         Map<String,Arch> m = new HashMap<>();
         m.put("amd64", new Arch(0xC000003E, 0x3FFFFFFF, 57, 58, 59, 322, 317));
         m.put("aarch64",  new Arch(0xC00000B7, 0xFFFFFFFF, 1079, 1071, 221, 281, 277));
+        m.put("ppc64le",  new Arch(0xC0000015, 0xFFFFFFFF, 2, 189, 11, 362, 358));
         ARCHITECTURES = Collections.unmodifiableMap(m);
     }
 


### PR DESCRIPTION
A new entry for ppc64le is added to ARCHITECTURES with a new Arch
instance which get the following parameters :

- audit : comes from the AUDIT_ARCH_PPC64LE define from linux/audit.h
(I compiled a sample c program to display it)

- limit : my understanding is that we don't have to fix one on that
architecture as does amd64 for 32b syscalls.

- fork, vfork, execve, execveat, seccomp : their syscall numbers come
from upstrem libseccomp (currently based on kernel 4.15) :
https://github.com/seccomp/libseccomp/blob/master/src/arch-ppc64-syscalls.c

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
