### PR TITLE
[Docs] Use correct formatting for links

### DIFF
--- a/docs/reference/how-to/recipes.asciidoc
+++ b/docs/reference/how-to/recipes.asciidoc
@@ -3,8 +3,8 @@
 
 This section includes a few recipes to help with common problems:
 
-* mixing-exact-search-with-stemming
-* consistent-scoring
+* <<mixing-exact-search-with-stemming>>
+* <<consistent-scoring>>
 
 include::recipes/stemming.asciidoc[]
 include::recipes/scoring.asciidoc[]


### PR DESCRIPTION
Looks like someone forgot to format these as links. 