### PR TITLE
Restrict Document list access in ParseContext

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -76,7 +76,7 @@ final class DocumentParser {
             throw new IllegalStateException("found leftover path elements: " + remainingPath);
         }
 
-        reverseOrder(context);
+        context.postParse();
 
         return parsedDocument(source, context, createDynamicUpdate(mapping, docMapper, context.getDynamicMappers()));
     }
@@ -141,12 +141,6 @@ final class DocumentParser {
         return false;
     }
 
-    private static void reverseOrder(ParseContext.InternalParseContext context) {
-        // reverse the order of docs for nested docs support, parent should be last
-        if (context.docs().size() > 1) {
-            Collections.reverse(context.docs());
-        }
-    }
 
     private static ParsedDocument parsedDocument(SourceToParse source, ParseContext.InternalParseContext context, Mapping update) {
         return new ParsedDocument(

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -263,7 +263,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         if (fieldType().isEnabled() == false) {
             return;
         }
-        for (ParseContext.Document document : context.docs()) {
+        for (ParseContext.Document document : context) {
             final List<String> paths = new ArrayList<>(document.getFields().size());
             String previousPath = ""; // used as a sentinel - field names can't be empty
             for (IndexableField field : document.getFields()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -268,9 +268,6 @@ public class IdFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    public void postParse(ParseContext context) throws IOException {}
-
-    @Override
     protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
         if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
             BytesRef id = Uid.encodeId(context.sourceToParse().id());

--- a/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IndexFieldMapper.java
@@ -173,9 +173,6 @@ public class IndexFieldMapper extends MetadataFieldMapper {
     public void preParse(ParseContext context) throws IOException {}
 
     @Override
-    public void postParse(ParseContext context) throws IOException {}
-
-    @Override
     protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {}
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -64,7 +64,9 @@ public abstract class MetadataFieldMapper extends FieldMapper {
     /**
      * Called after {@link FieldMapper#parse(ParseContext)} on the {@link RootObjectMapper}.
      */
-    public abstract void postParse(ParseContext context) throws IOException;
+    public void postParse(ParseContext context) throws IOException {
+        // do nothing
+    }
 
     @Override
     public MetadataFieldMapper merge(Mapper mergeWith) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParseContext.java
@@ -26,7 +26,6 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.util.ArrayList;
@@ -174,8 +173,8 @@ public abstract class ParseContext implements Iterable<ParseContext.Document>{
         }
 
         @Override
-        public Iterable<Document> nonRootIterator() {
-            return in.nonRootIterator();
+        public Iterable<Document> nonRootDocuments() {
+            return in.nonRootDocuments();
         }
 
         @Override
@@ -435,7 +434,7 @@ public abstract class ParseContext implements Iterable<ParseContext.Document>{
         }
 
         @Override
-        public Iterable<Document> nonRootIterator() {
+        public Iterable<Document> nonRootDocuments() {
             if (docsReversed) {
                 throw new IllegalStateException("documents are already reversed");
             }
@@ -456,7 +455,11 @@ public abstract class ParseContext implements Iterable<ParseContext.Document>{
         }
     }
 
-    public abstract Iterable<Document> nonRootIterator();
+    /**
+     * Returns an Iterable over all non-root documents. If there are no non-root documents
+     * the iterable will return an empty iterator.
+     */
+    public abstract Iterable<Document> nonRootDocuments();
 
     public abstract DocumentMapperParser docMapperParser();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingFieldMapper.java
@@ -158,10 +158,6 @@ public class RoutingFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    public void postParse(ParseContext context) throws IOException {
-    }
-
-    @Override
     public Mapper parse(ParseContext context) throws IOException {
         // no need ot parse here, we either get the routing in the sourceToParse
         // or we don't have routing, if we get it in sourceToParse, we process it in preParse

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -253,11 +253,9 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         // we share the parent docs fields to ensure good compression
         SequenceIDFields seqID = context.seqID();
         assert seqID != null;
-        int numDocs = context.docs().size();
         final Version versionCreated = context.mapperService().getIndexSettings().getIndexVersionCreated();
         final boolean includePrimaryTerm = versionCreated.before(Version.V_6_1_0);
-        for (int i = 1; i < numDocs; i++) {
-            final Document doc = context.docs().get(i);
+        for (Document doc : context.nonRootIterator()) {
             doc.add(seqID.seqNo);
             doc.add(seqID.seqNoDocValue);
             if (includePrimaryTerm) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SeqNoFieldMapper.java
@@ -255,7 +255,7 @@ public class SeqNoFieldMapper extends MetadataFieldMapper {
         assert seqID != null;
         final Version versionCreated = context.mapperService().getIndexSettings().getIndexVersionCreated();
         final boolean includePrimaryTerm = versionCreated.before(Version.V_6_1_0);
-        for (Document doc : context.nonRootIterator()) {
+        for (Document doc : context.nonRootDocuments()) {
             doc.add(seqID.seqNo);
             doc.add(seqID.seqNoDocValue);
             if (includePrimaryTerm) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -217,10 +217,6 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    public void postParse(ParseContext context) throws IOException {
-    }
-
-    @Override
     public Mapper parse(ParseContext context) throws IOException {
         // nothing to do here, we will call it in pre parse
         return null;
@@ -228,32 +224,25 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     @Override
     protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
-        if (!enabled) {
-            return;
-        }
-        if (!fieldType().stored()) {
-            return;
-        }
+        boolean needsOriginalSource = false;
         BytesReference source = context.sourceToParse().source();
-        // Percolate and tv APIs may not set the source and that is ok, because these APIs will not index any data
-        if (source == null) {
-            return;
+        if (enabled && fieldType().stored() && source != null) {
+            // Percolate and tv APIs may not set the source and that is ok, because these APIs will not index any data
+            if (filter != null) {
+                // we don't update the context source if we filter, we want to keep it as is...
+                Tuple<XContentType, Map<String, Object>> mapTuple =
+                    XContentHelper.convertToMap(source, true, context.sourceToParse().getXContentType());
+                Map<String, Object> filteredSource = filter.apply(mapTuple.v2());
+                BytesStreamOutput bStream = new BytesStreamOutput();
+                XContentType contentType = mapTuple.v1();
+                XContentBuilder builder = XContentFactory.contentBuilder(contentType, bStream).map(filteredSource);
+                builder.close();
+                needsOriginalSource = true;
+                source = bStream.bytes();
+            }
+            BytesRef ref = source.toBytesRef();
+            fields.add(new StoredField(fieldType().name(), ref.bytes, ref.offset, ref.length));
         }
-
-        if (filter != null) {
-            // we don't update the context source if we filter, we want to keep it as is...
-            Tuple<XContentType, Map<String, Object>> mapTuple =
-                XContentHelper.convertToMap(source, true, context.sourceToParse().getXContentType());
-            Map<String, Object> filteredSource = filter.apply(mapTuple.v2());
-            BytesStreamOutput bStream = new BytesStreamOutput();
-            XContentType contentType = mapTuple.v1();
-            XContentBuilder builder = XContentFactory.contentBuilder(contentType, bStream).map(filteredSource);
-            builder.close();
-
-            source = bStream.bytes();
-        }
-        BytesRef ref = source.toBytesRef();
-        fields.add(new StoredField(fieldType().name(), ref.bytes, ref.offset, ref.length));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -224,7 +224,6 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     @Override
     protected void parseCreateField(ParseContext context, List<IndexableField> fields) throws IOException {
-        boolean needsOriginalSource = false;
         BytesReference source = context.sourceToParse().source();
         if (enabled && fieldType().stored() && source != null) {
             // Percolate and tv APIs may not set the source and that is ok, because these APIs will not index any data
@@ -237,7 +236,6 @@ public class SourceFieldMapper extends MetadataFieldMapper {
                 XContentType contentType = mapTuple.v1();
                 XContentBuilder builder = XContentFactory.contentBuilder(contentType, bStream).map(filteredSource);
                 builder.close();
-                needsOriginalSource = true;
                 source = bStream.bytes();
             }
             BytesRef ref = source.toBytesRef();

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeFieldMapper.java
@@ -270,10 +270,6 @@ public class TypeFieldMapper extends MetadataFieldMapper {
     }
 
     @Override
-    public void postParse(ParseContext context) throws IOException {
-    }
-
-    @Override
     public Mapper parse(ParseContext context) throws IOException {
         // we parse in pre parse
         return null;

--- a/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
@@ -128,8 +128,7 @@ public class VersionFieldMapper extends MetadataFieldMapper {
         // that don't have the field. This is consistent with the default value for efficiency.
         Field version = context.version();
         assert version != null;
-        for (int i = 1; i < context.docs().size(); i++) {
-            final Document doc = context.docs().get(i);
+        for (Document doc : context.nonRootIterator()) {
             doc.add(version);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/VersionFieldMapper.java
@@ -128,7 +128,7 @@ public class VersionFieldMapper extends MetadataFieldMapper {
         // that don't have the field. This is consistent with the default value for efficiency.
         Field version = context.version();
         assert version != null;
-        for (Document doc : context.nonRootIterator()) {
+        for (Document doc : context.nonRootDocuments()) {
             doc.add(version);
         }
     }


### PR DESCRIPTION
Today we expose a mutable list of documents in ParseContext via
ParseContext#docs(). This, on the one hand places knowledge how
to access nested documnts in multiple places and on the other
allows for potential illegal access to nested only docs after
the docs are reversed. This change restricts the access and
streamlines nested / non-root doc access.