### PR TITLE
Deprecate filtering on `_type`.

### DIFF
--- a/docs/painless/painless-getting-started.asciidoc
+++ b/docs/painless/painless-getting-started.asciidoc
@@ -239,7 +239,7 @@ their last name:
 
 [source,js]
 ----------------------------------------------------------------
-POST hockey/player/_update_by_query
+POST hockey/_update_by_query
 {
   "script": {
     "lang": "painless",
@@ -260,7 +260,7 @@ names start with a consonant and end with a vowel:
 
 [source,js]
 ----------------------------------------------------------------
-POST hockey/player/_update_by_query
+POST hockey/_update_by_query
 {
   "script": {
     "lang": "painless",
@@ -281,7 +281,7 @@ remove all of the vowels in all of their last names:
 
 [source,js]
 ----------------------------------------------------------------
-POST hockey/player/_update_by_query
+POST hockey/_update_by_query
 {
   "script": {
     "lang": "painless",
@@ -297,7 +297,7 @@ method so it supports `$1` and `\1` for replacements:
 
 [source,js]
 ----------------------------------------------------------------
-POST hockey/player/_update_by_query
+POST hockey/_update_by_query
 {
   "script": {
     "lang": "painless",
@@ -319,7 +319,7 @@ This will make all of the vowels in the hockey player's last names upper case:
 
 [source,js]
 ----------------------------------------------------------------
-POST hockey/player/_update_by_query
+POST hockey/_update_by_query
 {
   "script": {
     "lang": "painless",
@@ -337,7 +337,7 @@ last names upper case:
 
 [source,js]
 ----------------------------------------------------------------
-POST hockey/player/_update_by_query
+POST hockey/_update_by_query
 {
   "script": {
     "lang": "painless",

--- a/docs/reference/aggregations/bucket/significanttext-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/significanttext-aggregation.asciidoc
@@ -38,7 +38,7 @@ Example:
 
 [source,js]
 --------------------------------------------------
-GET news/article/_search
+GET news/_search
 {
     "query" : {
         "match" : {"content" : "Bird flu"}
@@ -153,7 +153,7 @@ We can drill down into examples of these documents to see why pozmantier is conn
 
 [source,js]
 --------------------------------------------------
-GET news/article/_search
+GET news/_search
 {
   "query": {
     "simple_query_string": {
@@ -221,7 +221,7 @@ with the `filter_duplicate_text` setting turned on:
 
 [source,js]
 --------------------------------------------------
-GET news/article/_search
+GET news/_search
 {
   "query": {
     "match": {
@@ -424,7 +424,7 @@ context:
 
 [source,js]
 --------------------------------------------------
-GET news/article/_search
+GET news/_search
 {
     "query" : {
         "match" : {
@@ -463,7 +463,7 @@ will be analyzed using the `source_fields` parameter:
 
 [source,js]
 --------------------------------------------------
-GET news/article/_search
+GET news/_search
 {
     "query" : {
         "match" : {

--- a/docs/reference/aggregations/metrics/percentile-rank-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-rank-aggregation.asciidoc
@@ -217,7 +217,7 @@ had a value.
 
 [source,js]
 --------------------------------------------------
-GET latency/data/_search
+GET latency/_search
 {
     "size": 0,
     "aggs" : {

--- a/docs/reference/docs/delete-by-query.asciidoc
+++ b/docs/reference/docs/delete-by-query.asciidoc
@@ -75,7 +75,7 @@ Back to the API format, this will delete tweets from the `twitter` index:
 
 [source,js]
 --------------------------------------------------
-POST twitter/_doc/_delete_by_query?conflicts=proceed
+POST twitter/_delete_by_query?conflicts=proceed
 {
   "query": {
     "match_all": {}
@@ -85,12 +85,12 @@ POST twitter/_doc/_delete_by_query?conflicts=proceed
 // CONSOLE
 // TEST[setup:twitter]
 
-It's also possible to delete documents of multiple indexes and multiple
-types at once, just like the search API:
+It's also possible to delete documents of multiple indexes at once, just like
+the search API:
 
 [source,js]
 --------------------------------------------------
-POST twitter,blog/_docs,post/_delete_by_query
+POST twitter,blog/_delete_by_query
 {
   "query": {
     "match_all": {}

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -67,7 +67,7 @@ Back to the API format, this will update tweets from the `twitter` index:
 
 [source,js]
 --------------------------------------------------
-POST twitter/_doc/_update_by_query?conflicts=proceed
+POST twitter/_update_by_query?conflicts=proceed
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
@@ -145,12 +145,12 @@ This API doesn't allow you to move the documents it touches, just modify their
 source. This is intentional! We've made no provisions for removing the document
 from its original location.
 
-It's also possible to do this whole thing on multiple indexes and multiple
-types at once, just like the search API:
+It's also possible to do this whole thing on multiple indexes at once, just
+like the search API:
 
 [source,js]
 --------------------------------------------------
-POST twitter,blog/_doc,post/_update_by_query
+POST twitter,blog/_update_by_query
 --------------------------------------------------
 // CONSOLE
 // TEST[s/^/PUT twitter\nPUT blog\n/]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -22,6 +22,7 @@ GET /twitter/_search?q=user:kimchy
 // CONSOLE
 // TEST[setup:twitter]
 
+deprecated[6.3.0,Searching multiple types is deprecated, jut use `GET {index}/_search`]
 We can also search within specific types:
 
 [source,js]
@@ -29,7 +30,7 @@ We can also search within specific types:
 GET /twitter/tweet,user/_search?q=user:kimchy
 --------------------------------------------------
 // CONSOLE
-// TEST[setup:twitter]
+// TEST[setup:twitter warning:The {index}/{type}/_search endpoint is deprecated, use {index}/_search instead]
 
 We can also search all tweets with a certain tag across several indices
 (for example, when each user has his own index):

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -12,8 +12,7 @@ that match the query. The query can either be provided using a simple
 All search APIs can be applied across multiple types within an index, and
 across multiple indices with support for the
 <<multi-index,multi index syntax>>. For
-example, we can search on all documents across all types within the
-twitter index:
+example, we can search on all documents within the twitter index:
 
 [source,js]
 --------------------------------------------------
@@ -21,16 +20,6 @@ GET /twitter/_search?q=user:kimchy
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
-
-deprecated[6.3.0,Searching multiple types is deprecated, jut use `GET {index}/_search`]
-We can also search within specific types:
-
-[source,js]
---------------------------------------------------
-GET /twitter/tweet,user/_search?q=user:kimchy
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter warning:The {index}/{type}/_search endpoint is deprecated, use {index}/_search instead]
 
 We can also search all tweets with a certain tag across several indices
 (for example, when each user has his own index):

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/20_empty_bucket.yml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/20_empty_bucket.yml
@@ -35,14 +35,12 @@
   - do:
       search:
         index: empty_bucket_idx
-        type: test
 
   - match: {hits.total: 2}
 
   - do:
       search:
         index: empty_bucket_idx
-        type:  test
         body: {"aggs": {"histo": {"histogram": {"field": "val1", "interval": 1, "min_doc_count": 0}, "aggs": { "mfs" : { "matrix_stats": {"fields": ["value", "val1"]} } } } } }
 
   - match: {hits.total: 2}

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/30_single_value_field.yml
@@ -130,7 +130,6 @@ setup:
   - do:
       search:
         index: unmapped
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"]} } } }
 
   - match: {hits.total: 0}
@@ -142,7 +141,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val3"]} } } }
 
   - match: {hits.total: 15}
@@ -155,7 +153,6 @@ setup:
   - do:
       search:
         index: [test, unmapped]
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"]} } } }
 
   - match: {hits.total: 15}
@@ -169,7 +166,6 @@ setup:
   - do:
       search:
         index: [test, unmapped]
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"], "missing" : {"val2" : 10} } } } }
 
   - match: {hits.total: 15}
@@ -184,7 +180,6 @@ setup:
       catch: /parsing_exception/
       search:
         index: test
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2"], "script" : { "my_script" : {"source" : "1 + doc['val1'].value", "lang" : "js"} } } } } }
 
 ---
@@ -194,5 +189,4 @@ setup:
       catch: /parsing_exception/
       search:
         index: test
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "val3"], "script" : { "my_script" : {"source" : "my_var + doc['val1'].value", "params" : { "my_var" : 1 }, "lang" : "js" } } } } } }

--- a/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yml
+++ b/modules/aggs-matrix-stats/src/test/resources/rest-api-spec/test/stats/40_multi_value_field.yml
@@ -130,7 +130,6 @@ setup:
   - do:
       search:
         index: unmapped
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "vals"]} } } }
 
   - match: {hits.total: 0}
@@ -142,7 +141,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "vals"], "mode" : "max"} } } }
 
   - match: {hits.total: 15}
@@ -156,7 +154,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "vals"], "mode" : "min"} } } }
 
   - match: {hits.total: 15}
@@ -170,7 +167,6 @@ setup:
   - do:
       search:
         index: [test, unmapped]
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "vals"]} } } }
 
   - match: {hits.total: 15}
@@ -184,7 +180,6 @@ setup:
   - do:
       search:
         index: [test, unmapped]
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val2", "vals"], "missing" : {"val2" : 10, "vals" : 5 } } } } }
 
   - match: {hits.total: 15}
@@ -199,7 +194,6 @@ setup:
       catch: /parsing_exception/
       search:
         index: test
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["vals", "val3"], "script" : { "my_script" : {"source" : "1 + doc['val1'].value", "lang" : "js"} } } } } }
 
 ---
@@ -209,5 +203,4 @@ setup:
       catch: /parsing_exception/
       search:
         index: test
-        type:  test
         body: {"aggs": { "mfs" : { "matrix_stats": {"fields": ["val1", "val3", "vals"], "script" : { "my_script" : {"source" : "my_var + doc['val1'].value", "params" : { "my_var" : 1 }, "lang" : "js" } } } } } }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/create/60_refresh.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/create/60_refresh.yml
@@ -18,7 +18,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 1 }}
 
@@ -36,7 +35,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 2 }}
 
@@ -56,7 +54,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 1 }}
 
@@ -76,7 +73,6 @@
  - do:
       search:
           index:   create_60_refresh_1
-          type:    test
           body:
             query:   { term: { _id: create_60_refresh_id1 }}
  - match: { hits.total: 1 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/delete/50_refresh.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/delete/50_refresh.yml
@@ -37,7 +37,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { terms: { _id: [1,3] }}
 
@@ -52,7 +51,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { terms: { _id: [1,3] }}
 
@@ -72,7 +70,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { terms: { _id: [1,3] }}
 
@@ -92,7 +89,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 1 }}
  - match: { hits.total: 1 }
@@ -107,7 +103,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 1 }}
  - match: { hits.total: 0 }
@@ -126,7 +121,6 @@
  - do:
       search:
           index:   delete_50_refresh_1
-          type:    test
           body:
             query:   { term: { _id: delete_50_refresh_id1 }}
  - match: { hits.total: 1 }
@@ -142,7 +136,6 @@
  - do:
       search:
           index:   delete_50_refresh_1
-          type:    test
           body:
             query:   { term: { _id: delete_50_refresh_id1 }}
  - match: { hits.total: 0 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/index/60_refresh.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/index/60_refresh.yml
@@ -19,7 +19,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 1 }}
 
@@ -37,7 +36,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 2 }}
 
@@ -57,7 +55,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 1 }}
 
@@ -77,7 +74,6 @@
  - do:
       search:
           index:   index_60_refresh_1
-          type:    test
           body:
             query:   { term: { _id: index_60_refresh_id1 }}
  - match: { hits.total: 1 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.rollover/10_basic.yml
@@ -70,7 +70,6 @@
   - do:
       search:
         index: logs_search
-        type:  test
 
   - match: { hits.total: 1 }
   - match: { hits.hits.0._index: "logs-000002"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.sort/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.sort/10_basic.yml
@@ -93,7 +93,6 @@
   - do:
       search:
         index: test
-        type: test
         body:
           sort: ["rank"]
           size: 1
@@ -105,7 +104,6 @@
   - do:
       search:
         index: test
-        type: test
         body:
           sort: ["rank"]
           query: {"range": { "rank": { "from": 0 } } }
@@ -128,7 +126,6 @@
   - do:
       search:
         index: test
-        type: test
         body:
           sort: _doc
 
@@ -146,7 +143,6 @@
   - do:
       search:
         index: test
-        type: test
         body:
           sort: ["rank"]
           query: {"range": { "rank": { "from": 0 } } }
@@ -163,7 +159,6 @@
       catch:      /disabling \[track_total_hits\] is not allowed in a scroll context/
       search:
         index: test
-        type: test
         scroll: 1m
         body:
           sort: ["rank"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mlt/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mlt/10_basic.yml
@@ -32,7 +32,6 @@
   - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:
               more_like_this:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mlt/20_docs.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mlt/20_docs.yml
@@ -37,7 +37,6 @@
   - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:
               more_like_this:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/mlt/30_unlike.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/mlt/30_unlike.yml
@@ -37,7 +37,6 @@
   - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:
               more_like_this:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/30_sig_terms.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/30_sig_terms.yml
@@ -67,14 +67,12 @@
   - do:
       search:
         index: goodbad
-        type:  doc
 
   - match: {hits.total: 7}
   
   - do:
       search:
         index: goodbad
-        type:  doc
         body: {"aggs": {"class": {"terms": {"field": "class"},"aggs": {"sig_terms": {"significant_terms": {"field": "text"}}}}}}
 
   - match: {aggregations.class.buckets.0.sig_terms.buckets.0.key: "bad"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/90_sig_text.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search.aggregation/90_sig_text.yml
@@ -72,14 +72,12 @@
   - do:
       search:
         index: goodbad
-        type:  doc
 
   - match: {hits.total: 7}
   
   - do:
       search:
         index: goodbad
-        type:  doc
         body: {"aggs": {"class": {"terms": {"field": "class"},"aggs": {"sig_text": {"significant_text": {"field": "text"}}}}}}
 
   - match: {aggregations.class.buckets.0.sig_text.buckets.0.key: "bad"}
@@ -159,14 +157,12 @@
   - do:
       search:
         index: goodbad
-        type:  doc
 
   - match: {hits.total: 7}
   
   - do:
       search:
         index: goodbad
-        type:  doc
         body: {"aggs": {"class": {"terms": {"field": "class"},"aggs": {"sig_text": {"significant_text": {"field": "text", "filter_duplicate_text": true}}}}}}
 
   - match: {aggregations.class.buckets.0.sig_text.buckets.0.key: "bad"}

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/110_field_collapsing.yml
@@ -64,7 +64,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           collapse: { field: numeric_group }
           sort: [{ sort: desc }]
@@ -100,7 +99,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           from: 2
           collapse: { field: numeric_group }
@@ -125,7 +123,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           collapse: { field: numeric_group, inner_hits: { name: sub_hits, size: 2, sort: [{ sort: asc }] } }
           sort: [{ sort: desc }]
@@ -169,7 +166,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           collapse: { field: numeric_group, max_concurrent_group_searches: 10, inner_hits: { name: sub_hits, size: 2, sort: [{ sort: asc }] } }
           sort: [{ sort: desc }]
@@ -215,7 +211,6 @@ setup:
       catch:      /cannot use \`collapse\` in a scroll context/
       search:
         index: test
-        type:  test
         scroll: 1s
         body:
           collapse: { field: numeric_group }
@@ -231,7 +226,6 @@ setup:
       catch:      /cannot use \`collapse\` in conjunction with \`search_after\`/
       search:
         index: test
-        type:  test
         body:
           collapse: { field: numeric_group }
           search_after: [6]
@@ -248,7 +242,6 @@ setup:
       catch:      /cannot use \`collapse\` in conjunction with \`rescore\`/
       search:
         index: test
-        type:  test
         body:
           collapse: { field: numeric_group }
           rescore:
@@ -269,7 +262,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           size: 0
           collapse: { field: numeric_group, inner_hits: { name: sub_hits, size: 1} }
@@ -288,7 +280,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           collapse: 
             field: numeric_group
@@ -345,7 +336,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           collapse: { field: numeric_group, inner_hits: { name: sub_hits, version: true, size: 2, sort: [{ sort: asc }] } }
           sort: [{ sort: desc }]

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/20_default_values.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/20_default_values.yml
@@ -29,7 +29,6 @@ setup:
   - do:
       search:
         index: _all
-        type:  test
         body:
           query:
             match:
@@ -40,7 +39,6 @@ setup:
   - do:
       search:
         index: test_1
-        type:  test
         body:
           query:
             match:
@@ -54,7 +52,6 @@ setup:
   - do:
       search:
         index: test_2
-        type:  test
         body:
           query:
             match:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/90_search_after.yml
@@ -36,7 +36,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           size: 1
           query:
@@ -54,7 +53,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           size: 1
           query:
@@ -73,7 +71,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           size: 1
           query:
@@ -92,7 +89,6 @@ setup:
   - do:
       search:
         index: test
-        type:  test
         body:
           size: 1
           query:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/update/60_refresh.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/update/60_refresh.yml
@@ -21,7 +21,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 1 }}
 
@@ -41,7 +40,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { _id: 2 }}
 
@@ -71,7 +69,6 @@
  - do:
       search:
           index:   test_1
-          type:    test
           body:
             query:   { term: { cat: dog }}
 
@@ -91,7 +88,6 @@
  - do:
       search:
           index:   update_60_refresh_1
-          type:    test
           body:
             query:   { term: { _id: update_60_refresh_id1 }}
  - match: { hits.total: 1 }
@@ -109,7 +105,6 @@
  - do:
       search:
           index:   update_60_refresh_1
-          type:    test
           body:
             query:   { match: { test: asdf } }
  - match: { hits.total: 1 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -224,7 +224,9 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
     /**
      * The document types to execute the search against. Defaults to be executed against
      * all types.
+     * @deprecated Types are going away, prefer filtering on a type.
      */
+    @Deprecated
     public SearchRequest types(String... types) {
         Objects.requireNonNull(types, "types must not be null");
         for (String type : types) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -61,7 +61,9 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     /**
      * The document types to execute the search against. Defaults to be executed against
      * all types.
+     * @deprecated Types are going away, prefer filtering on a field.
      */
+    @Deprecated
     public SearchRequestBuilder setTypes(String... types) {
         request.types(types);
         return this;

--- a/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryBuilders.java
@@ -571,7 +571,9 @@ public final class QueryBuilders {
 
     /**
      * A filter based on doc/mapping type.
+     * @deprecated Types are going away, prefer filtering on a field.
      */
+    @Deprecated
     public static TypeQueryBuilder typeQuery(String type) {
         return new TypeQueryBuilder(type);
     }

--- a/server/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TypeQueryBuilder.java
@@ -27,6 +27,8 @@ import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -39,6 +41,7 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
     public static final String NAME = "type";
 
     private static final ParseField VALUE_FIELD = new ParseField("value");
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(TypeQueryBuilder.class));
 
     private final String type;
 
@@ -125,6 +128,7 @@ public class TypeQueryBuilder extends AbstractQueryBuilder<TypeQueryBuilder> {
 
     @Override
     protected Query doToQuery(QueryShardContext context) throws IOException {
+        DEPRECATION_LOGGER.deprecated("The [type] query is deprecated, filter on a field instead.");
         //LUCENE 4 UPGRADE document mapper should use bytesref as well?
         DocumentMapper documentMapper = context.getMapperService().documentMapper(type);
         if (documentMapper == null) {

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -23,6 +23,8 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -55,6 +57,7 @@ public class RestSearchAction extends BaseRestHandler {
 
     public static final String TYPED_KEYS_PARAM = "typed_keys";
     private static final Set<String> RESPONSE_PARAMS = Collections.singleton(TYPED_KEYS_PARAM);
+    private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(Loggers.getLogger(RestSearchAction.class));
 
     public RestSearchAction(Settings settings, RestController controller) {
         super(settings);
@@ -147,7 +150,11 @@ public class RestSearchAction extends BaseRestHandler {
             searchRequest.scroll(new Scroll(parseTimeValue(scroll, null, "scroll")));
         }
 
-        searchRequest.types(Strings.splitStringByCommaToArray(request.param("type")));
+        String types = request.param("type");
+        if (types != null) {
+            DEPRECATION_LOGGER.deprecated("The {index}/{type}/_search endpoint is deprecated, use {index}/_search instead");
+        }
+        searchRequest.types(Strings.splitStringByCommaToArray(types));
         searchRequest.routing(request.param("routing"));
         searchRequest.preference(request.param("preference"));
         searchRequest.indicesOptions(IndicesOptions.fromRequest(request, searchRequest.indicesOptions()));

--- a/server/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TypeQueryBuilderTests.java
@@ -71,4 +71,16 @@ public class TypeQueryBuilderTests extends AbstractQueryTestCase<TypeQueryBuilde
 
         assertEquals(json, "my_type", parsed.type());
     }
+
+    @Override
+    public void testToQuery() throws IOException {
+        super.testToQuery();
+        assertWarnings("The [type] query is deprecated, filter on a field instead.");
+    }
+
+    @Override
+    public void testMustRewrite() throws IOException {
+        super.testMustRewrite();
+        assertWarnings("The [type] query is deprecated, filter on a field instead.");
+    }
 }


### PR DESCRIPTION
As indices are only allowed to have one type now, and types are going away in
the future, we should deprecate filtering by `_type`.

Relates #15613
