### PR TITLE
[TEST] REST client request without leading '/'

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
@@ -58,6 +58,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration test to check interaction between {@link RestClient} and {@link org.apache.http.client.HttpClient}.
@@ -135,8 +136,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
         final RestClientBuilder restClientBuilder = RestClient.builder(
             new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort())).setDefaultHeaders(defaultHeaders);
         if (pathPrefix.length() > 0) {
-            // sometimes cut off the leading slash
-            restClientBuilder.setPathPrefix(randomBoolean() ? pathPrefix.substring(1) : pathPrefix);
+            restClientBuilder.setPathPrefix(pathPrefix);
         }
 
         if (useAuth) {
@@ -277,6 +277,33 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 final Response response = bodyTest(restClient, method);
 
                 assertThat(response.getHeader("Authorization"), nullValue());
+            }
+        }
+    }
+
+    public void testUrlWithoutLeadingSlash() throws Exception {
+        if (pathPrefix.length() == 0) {
+            try {
+                restClient.performRequest("GET", "200");
+                fail("request should have failed");
+            } catch(ResponseException e) {
+                assertEquals(404, e.getResponse().getStatusLine().getStatusCode());
+            }
+        } else {
+            {
+                Response response = restClient.performRequest("GET", "200");
+                //a trailing slash gets automatically added if a pathPrefix is configured
+                assertEquals(200, response.getStatusLine().getStatusCode());
+            }
+            {
+                //pathPrefix is not required to start with '/', will be added automatically
+                try (RestClient restClient = RestClient.builder(
+                        new HttpHost(httpServer.getAddress().getHostString(), httpServer.getAddress().getPort()))
+                        .setPathPrefix(pathPrefix.substring(1)).build()) {
+                    Response response = restClient.performRequest("GET", "200");
+                    //a trailing slash gets automatically added if a pathPrefix is configured
+                    assertEquals(200, response.getStatusLine().getStatusCode());
+                }
             }
         }
     }


### PR DESCRIPTION
The following is the current behaviour, tested now through a specific
test.

The low-level REST client doesn't add a leading wildcard when not
provided, unless a `pathPrefix` is configured in which case a trailing
slash will be automatically added when concatenating the prefix and the
provided uri.

Also when configuring a pathPrefix, if it doesn't start with a '/' it
will be modified by adding the missing leading '/'.