### PR TITLE
Make index and bulk APIs work without types.

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -4,7 +4,7 @@
     "methods": ["POST", "PUT"],
     "url": {
       "path": "/{index}/{type}",
-      "paths": ["/{index}/{type}", "/{index}/{type}/{id}"],
+      "paths": ["/{index}/{type}", "/{index}/{type}/{id}", "/{index}/_doc/{id}", "/{index}/_doc"],
       "parts": {
         "id": {
           "type" : "string",
@@ -17,7 +17,6 @@
         },
         "type": {
           "type" : "string",
-          "required" : true,
           "description" : "The type of the document"
         }
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_no_types.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.put_mapping/20_no_types.yml
@@ -39,6 +39,45 @@
   - match: { index.mappings.properties.foo.type: "keyword" }
   - match: { index.mappings.properties.bar.type: "float" }
 
+# Explicit id
+  - do:
+      index:
+          index:   index
+          id:      1
+          body:    { foo: bar }
+
+# Implicit id
+  - do:
+      index:
+          index:   index
+          body:    { foo: bar }
+
+# Bulk with explicit id
+  - do:
+      bulk:
+          index:   index
+          body: |
+            { "index": { "_id": "2" } }
+            { "doc": { "foo": "baz" } }
+
+# Bulk with implicit id
+  - do:
+      bulk:
+          index:   index
+          body: |
+            { "index": { } }
+            { "doc": { "foo": "baz" } }
+
+  - do:
+      indices.refresh:
+          index:  index
+
+  - do:
+      count:
+          index: index
+
+  - match: { count: 4 }
+
 ---
 "PUT mapping with a type and include_type_name: false":
 

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -76,7 +77,7 @@ public class RestBulkAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         BulkRequest bulkRequest = Requests.bulkRequest();
         String defaultIndex = request.param("index");
-        String defaultType = request.param("type");
+        String defaultType = request.param("type", MapperService.SINGLE_MAPPING_NAME);
         String defaultRouting = request.param("routing");
         FetchSourceContext defaultFetchSourceContext = FetchSourceContext.parseFromRestRequest(request);
         String fieldsParam = request.param("fields");


### PR DESCRIPTION
Unlike the `indices.create`, `indices.get_mapping` and `indices.put_mapping`
APIs, the index APIs do not need the `include_type_name` option, they can work
work with and without types withouth knowing whether types are being used.

Internally, `_doc` is used as a type if no type is provided, like for the
`indices.put_mapping` API.
