### PR TITLE
Fix NPE in InternalGeoCentroidTests#testReduceRandom

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/geocentroid/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/geocentroid/InternalGeoCentroidTests.java
@@ -68,8 +68,10 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
             }
             totalCount += input.count();
         }
-        assertEquals(latSum/totalCount, reduced.centroid().getLat(), 1E-5D);
-        assertEquals(lonSum/totalCount, reduced.centroid().getLon(), 1E-5D);
+        if (totalCount > 0) {
+            assertEquals(latSum/totalCount, reduced.centroid().getLat(), 1E-5D);
+            assertEquals(lonSum/totalCount, reduced.centroid().getLon(), 1E-5D);
+        }
         assertEquals(totalCount, reduced.count());
     }
 


### PR DESCRIPTION
In some rare cases all inputs might have 0 count and resulting in
zero totalCount, and null in centroid causing NPE.

Closes #29480 