### PR TITLE
Add a helper method to get a random java.util.TimeZone

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -174,6 +174,9 @@ import static org.hamcrest.Matchers.hasItem;
 @LuceneTestCase.SuppressReproduceLine
 public abstract class ESTestCase extends LuceneTestCase {
 
+    private static final List<String> JODA_TIMEZONE_IDS;
+    private static final List<String> JAVA_TIMEZONE_IDS;
+
     private static final AtomicInteger portGenerator = new AtomicInteger();
 
     @AfterClass
@@ -192,6 +195,14 @@ public abstract class ESTestCase extends LuceneTestCase {
         }));
 
         BootstrapForTesting.ensureInitialized();
+
+        List<String> jodaTZIds = new ArrayList<>(DateTimeZone.getAvailableIDs());
+        Collections.sort(jodaTZIds);
+        JODA_TIMEZONE_IDS = Collections.unmodifiableList(jodaTZIds);
+
+        List<String> javaTZIds = Arrays.asList(TimeZone.getAvailableIDs());
+        Collections.sort(javaTZIds);
+        JAVA_TIMEZONE_IDS = Collections.unmodifiableList(javaTZIds);
     }
 
     protected final Logger logger = Loggers.getLogger(getClass());
@@ -670,18 +681,14 @@ public abstract class ESTestCase extends LuceneTestCase {
      * generate a random DateTimeZone from the ones available in joda library
      */
     public static DateTimeZone randomDateTimeZone() {
-        List<String> ids = new ArrayList<>(DateTimeZone.getAvailableIDs());
-        Collections.sort(ids);
-        return DateTimeZone.forID(randomFrom(ids));
+        return DateTimeZone.forID(randomFrom(JODA_TIMEZONE_IDS));
     }
 
     /**
      * generate a random TimeZone from the ones available in java.time
      */
     public static TimeZone randomTimeZone() {
-        List<String> ids = Arrays.asList(TimeZone.getAvailableIDs());
-        Collections.sort(ids);
-        return TimeZone.getTimeZone(randomFrom(ids));
+        return TimeZone.getTimeZone(randomFrom(JAVA_TIMEZONE_IDS));
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -135,6 +135,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -672,6 +673,15 @@ public abstract class ESTestCase extends LuceneTestCase {
         List<String> ids = new ArrayList<>(DateTimeZone.getAvailableIDs());
         Collections.sort(ids);
         return DateTimeZone.forID(randomFrom(ids));
+    }
+
+    /**
+     * generate a random TimeZone from the ones available in java.time
+     */
+    public static TimeZone randomTimeZone() {
+        List<String> ids = Arrays.asList(TimeZone.getAvailableIDs());
+        Collections.sort(ids);
+        return TimeZone.getTimeZone(randomFrom(ids));
     }
 
     /**


### PR DESCRIPTION
This adds a helper method to ESTestCase that returns a randomized
`java.util.TimeZone`. This can be used when transitioning code from Joda to the
JDK's time classes.
