### PR TITLE
Add Profile API to search speed tuning howto

### DIFF
--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -385,3 +385,9 @@ and reduce latency for search-heavy applications.
 You can also analyse how expensive each component of your queries and aggregations are using the {ref}[Profile API].
 This might allow you to tune your queries to be less expensive, resulting in a positive performance result and reduced load.
 Also note that Profile API payloads can be easily visualised for better readability in the {ref-searchprofiler}[Search Profiler], which is a Kibana dev tools UI available in all X-Pack licenses, including the free X-Pack Basic license.
+
+Some caveats to the Profile API are that:
+
+ - the Profile API as a debugging tool adds significant overhead to search execution and can also have a very verbose output
+ - given the added overhead, the resulting took times are not reliable indicators of actual took time, but can be used comparatively between clauses for relative timing differences
+ - the Profile API is best for exploring possible reasons behind the most costly clauses of a query but isn't intended for accurately measuring absolute timings of each clause 

--- a/docs/reference/how-to/search-speed.asciidoc
+++ b/docs/reference/how-to/search-speed.asciidoc
@@ -377,3 +377,11 @@ criteria called <<search-adaptive-replica,adaptive replica selection>> to select
 the best copy of the data based on response time, service time, and queue size
 of the node containing each copy of the shard. This can improve query throughput
 and reduce latency for search-heavy applications.
+
+=== Tune your queries with the Profile API
+:ref:  https://www.elastic.co/guide/en/elasticsearch/reference/current/search-profile.html
+:ref-searchprofiler:  https://www.elastic.co/guide/en/kibana/current/xpack-profiler.html
+
+You can also analyse how expensive each component of your queries and aggregations are using the {ref}[Profile API].
+This might allow you to tune your queries to be less expensive, resulting in a positive performance result and reduced load.
+Also note that Profile API payloads can be easily visualised for better readability in the {ref-searchprofiler}[Search Profiler], which is a Kibana dev tools UI available in all X-Pack licenses, including the free X-Pack Basic license.


### PR DESCRIPTION
Seemed useful to mention the Profile API in the context of tuning for search speed.
