### PR TITLE
Consistent encoder names

### DIFF
--- a/docs/plugins/analysis-phonetic.asciidoc
+++ b/docs/plugins/analysis-phonetic.asciidoc
@@ -25,7 +25,7 @@ The `phonetic` token filter takes the following settings:
 
     Whether or not the original token should be replaced by the phonetic
     token. Accepts `true` (default) and `false`.  Not supported by
-    `beidermorse` encoding.
+    `beider_morse` encoding.
 
 [source,js]
 --------------------------------------------------

--- a/docs/plugins/analysis-phonetic.asciidoc
+++ b/docs/plugins/analysis-phonetic.asciidoc
@@ -17,9 +17,9 @@ The `phonetic` token filter takes the following settings:
 `encoder`::
 
     Which phonetic encoder to use.  Accepts `metaphone` (default),
-    `doublemetaphone`, `soundex`, `refinedsoundex`, `caverphone1`,
+    `double_metaphone`, `soundex`, `refined_soundex`, `caverphone1`,
     `caverphone2`, `cologne`, `nysiis`, `koelnerphonetik`, `haasephonetik`,
-    `beidermorse`, `daitch_mokotoff`.
+    `beider_morse`, `daitch_mokotoff`.
 
 `replace`::
 

--- a/plugins/analysis-phonetic/src/test/java/org/elasticsearch/index/analysis/AnalysisPhoneticFactoryTests.java
+++ b/plugins/analysis-phonetic/src/test/java/org/elasticsearch/index/analysis/AnalysisPhoneticFactoryTests.java
@@ -33,8 +33,8 @@ public class AnalysisPhoneticFactoryTests extends AnalysisFactoryTestCase {
     @Override
     protected Map<String, Class<?>> getTokenFilters() {
         Map<String, Class<?>> filters = new HashMap<>(super.getTokenFilters());
-        filters.put("beidermorse", PhoneticTokenFilterFactory.class);
-        filters.put("doublemetaphone", PhoneticTokenFilterFactory.class);
+        filters.put("beider_morse", PhoneticTokenFilterFactory.class);
+        filters.put("double_metaphone", PhoneticTokenFilterFactory.class);
         filters.put("phonetic", PhoneticTokenFilterFactory.class);
         return filters;
     }

--- a/plugins/analysis-phonetic/src/test/java/org/elasticsearch/index/analysis/AnalysisPhoneticFactoryTests.java
+++ b/plugins/analysis-phonetic/src/test/java/org/elasticsearch/index/analysis/AnalysisPhoneticFactoryTests.java
@@ -33,8 +33,8 @@ public class AnalysisPhoneticFactoryTests extends AnalysisFactoryTestCase {
     @Override
     protected Map<String, Class<?>> getTokenFilters() {
         Map<String, Class<?>> filters = new HashMap<>(super.getTokenFilters());
-        filters.put("beider_morse", PhoneticTokenFilterFactory.class);
-        filters.put("double_metaphone", PhoneticTokenFilterFactory.class);
+        filters.put("beidermorse", PhoneticTokenFilterFactory.class);
+        filters.put("doublemetaphone", PhoneticTokenFilterFactory.class);
         filters.put("phonetic", PhoneticTokenFilterFactory.class);
         return filters;
     }

--- a/plugins/analysis-phonetic/src/test/resources/org/elasticsearch/index/analysis/phonetic-1.yml
+++ b/plugins/analysis-phonetic/src/test/resources/org/elasticsearch/index/analysis/phonetic-1.yml
@@ -3,7 +3,7 @@ index:
     filter:
       doublemetaphonefilter:
         type: phonetic
-        encoder: doublemetaphone
+        encoder: double_metaphone
       metaphonefilter:
         type: phonetic
         encoder: metaphone
@@ -12,16 +12,16 @@ index:
         encoder: soundex
       refinedsoundexfilter:
         type: phonetic
-        encoder: refinedsoundex
+        encoder: refined_soundex
       caverphonefilter:
         type: phonetic
         encoder: caverphone
       beidermorsefilter:
         type: phonetic
-        encoder: beidermorse
+        encoder: beider_morse
       beidermorsefilterfrench:
         type: phonetic
-        encoder: beidermorse
+        encoder: beider_morse
         languageset : [ "french" ]
       koelnerphonetikfilter:
         type: phonetic


### PR DESCRIPTION
This commit updates encoder names to be consistent within documentation
and align with snake casing convention.