### PR TITLE
Add support for bootstrap.memory_lock on ppc64el

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/JNACLibrary.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/JNACLibrary.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.logging.Loggers;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * java mapping to some libc functions
@@ -36,12 +37,24 @@ final class JNACLibrary {
 
     private static final Logger logger = Loggers.getLogger(JNACLibrary.class);
 
-    public static final int MCL_CURRENT = 1;
+    public static final int MCL_CURRENT = getMCL_CURRENT();
     public static final int ENOMEM = 12;
     public static final int RLIMIT_MEMLOCK = Constants.MAC_OS_X ? 6 : 8;
     public static final int RLIMIT_AS = Constants.MAC_OS_X ? 5 : 9;
     public static final int RLIMIT_FSIZE = Constants.MAC_OS_X ? 1 : 1;
     public static final long RLIM_INFINITY = Constants.MAC_OS_X ? 9223372036854775807L : -1L;
+
+    private static int getMCL_CURRENT() {
+        /* MCL_CURRENT varies depending on the OS/arch */
+        if (Constants.OS_ARCH.toLowerCase(Locale.ROOT).contains("ppc"))
+        {
+            if (Constants.OS_NAME.toLowerCase(Locale.ROOT).contains("linux"))
+            {
+               return 0x2000;
+            }
+        }
+        return 1;
+    }
 
     static {
         try {

--- a/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -242,6 +242,7 @@ final class SystemCallFilter {
         Map<String,Arch> m = new HashMap<>();
         m.put("amd64", new Arch(0xC000003E, 0x3FFFFFFF, 57, 58, 59, 322, 317));
         m.put("aarch64",  new Arch(0xC00000B7, 0xFFFFFFFF, 1079, 1071, 221, 281, 277));
+        m.put("ppc64le",  new Arch(0xC0000015, 0xFFFFFFFF, 2, 189, 11, 362, 358));
         ARCHITECTURES = Collections.unmodifiableMap(m);
     }
 


### PR DESCRIPTION
Two modifications needed to be done:
1. A new entry for ppc64le is added to ARCHITECTURES for seccomp
support, with a new Arch instance which get the following parameters :

- audit : comes from the AUDIT_ARCH_PPC64LE define from linux/audit.h
(I compiled a sample c program to display it)

- limit : my understanding is that we don't have to set a specific one on that
architecture as does amd64 for 32b syscalls.

- fork, vfork, execve, execveat, seccomp : their syscall numbers come
from upstream libseccomp (currently based on kernel 4.15) :
https://github.com/seccomp/libseccomp/blob/master/src/arch-ppc64-syscalls.c

2. Call to mlockall on POWER provides an invalid argument because
MCL_CURRENT has a different value on POWER : change to the correct value

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
Yes.

- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
Yes

- If submitting code, have you built your formula locally prior to submission with `gradle check`?
Yes. Got an error related : 
ERROR   0.01s J0 | EvilJNANativesTests.testSetMaxFileSize <<< FAILURES!
   > Throwable #1: java.lang.NoClassDefFoundError: Could not initialize class com.sun.jna.Native

But I don't think it's related to the changes.

- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
Yes

- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
Yes, this is for linux.

- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
No
