### PR TITLE
Enable skipping fetching latest for BWC builds

### DIFF
--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -502,7 +502,7 @@ will contain your change.
 
 For some BWC testing scenarios, you want to use the local clone of the
 repository without fetching latest. For these use cases, you can set the system
-property `tests.bwc.git.fetch.latest` to `false` and the BWC builds will skip
+property `tests.bwc.git_fetch_latest` to `false` and the BWC builds will skip
 fetching the latest from the remote.
 
 == Test coverage analysis

--- a/TESTING.asciidoc
+++ b/TESTING.asciidoc
@@ -498,6 +498,13 @@ will contain your change.
 . Push both branches to your remote repository.
 . Run the tests with `./gradlew check -Dtests.bwc.remote=${remote} -Dtests.bwc.refspec.5.x=index_req_bwc_5.x`.
 
+== Skip fetching latest
+
+For some BWC testing scenarios, you want to use the local clone of the
+repository without fetching latest. For these use cases, you can set the system
+property `tests.bwc.git.fetch.latest` to `false` and the BWC builds will skip
+fetching the latest from the remote.
+
 == Test coverage analysis
 
 Generating test coverage reports for Elasticsearch is currently not possible through Gradle.

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -54,6 +54,16 @@ subprojects {
 
   final String remote = System.getProperty("tests.bwc.remote", "elastic")
 
+  final boolean gitFetchLatest
+  final String gitFetchLatestProperty = System.getProperty("tests.bwc.git.fetch.latest", "true")
+  if ("true".equals(gitFetchLatestProperty)) {
+    gitFetchLatest = true
+  } else if ("false".equals(gitFetchLatestProperty)) {
+    gitFetchLatest = false
+  } else {
+    throw new GradleException("tests.bwc.git.fetch.latest must be [true] or [false] but was [" + gitFetchLatestProperty + "]")
+  }
+
   task createClone(type: LoggedExec) {
     onlyIf { checkoutDir.exists() == false }
     commandLine = ['git', 'clone', rootDir, checkoutDir]
@@ -83,7 +93,7 @@ subprojects {
   }
 
   task fetchLatest(type: LoggedExec) {
-    onlyIf { project.gradle.startParameter.isOffline() == false }
+    onlyIf { project.gradle.startParameter.isOffline() == false && gitFetchLatest }
     dependsOn addRemote
     workingDir = checkoutDir
     commandLine = ['git', 'fetch', '--all']

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -55,13 +55,13 @@ subprojects {
   final String remote = System.getProperty("tests.bwc.remote", "elastic")
 
   final boolean gitFetchLatest
-  final String gitFetchLatestProperty = System.getProperty("tests.bwc.git.fetch.latest", "true")
+  final String gitFetchLatestProperty = System.getProperty("tests.bwc.git_fetch_latest", "true")
   if ("true".equals(gitFetchLatestProperty)) {
     gitFetchLatest = true
   } else if ("false".equals(gitFetchLatestProperty)) {
     gitFetchLatest = false
   } else {
-    throw new GradleException("tests.bwc.git.fetch.latest must be [true] or [false] but was [" + gitFetchLatestProperty + "]")
+    throw new GradleException("tests.bwc.git_fetch_latest must be [true] or [false] but was [" + gitFetchLatestProperty + "]")
   }
 
   task createClone(type: LoggedExec) {


### PR DESCRIPTION
The BWC builds always fetch the latest from the elastic/elasticsearch repository for the BWC branches. Yet, there are use-cases for using the local checkout without fetching the latest. This commit enables these use-cases by adding a tests.bwc.git.fetch.latest property to skip the fetches.

