### PR TITLE
Lazy configure build tasks that require older JDKs

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -221,7 +221,17 @@ class BuildPlugin implements Plugin<Project> {
         return System.getenv('JAVA' + version + '_HOME')
     }
 
-    public static getJavaHome(final Project project, final int version, final String message) {
+    /**
+     * Get Java home for the project for the specified version. If the specified version is not configured, an exception with the specified
+     * message is thrown.
+     *
+     * @param project the project
+     * @param version the version of Java home to obtain
+     * @param message the exception message if Java home for the specified version is not configured
+     * @return Java home for the specified version
+     * @throws GradleException if Java home for the specified version is not configured
+     */
+    static String getJavaHome(final Project project, final int version, final String message) {
         if (project.javaVersions.get(version) == null) {
             throw new GradleException(message)
         }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -221,6 +221,13 @@ class BuildPlugin implements Plugin<Project> {
         return System.getenv('JAVA' + version + '_HOME')
     }
 
+    public static getJavaHome(final Project project, final int version, final String message) {
+        if (project.javaVersions.get(version) == null) {
+            throw new GradleException(message)
+        }
+        return project.javaVersions.get(version)
+    }
+
     private static String findRuntimeJavaHome(final String compilerJavaHome) {
         assert compilerJavaHome != null
         return System.getenv('RUNTIME_JAVA_HOME') ?: compilerJavaHome

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -171,7 +171,7 @@ class NodeInfo {
         } else if (nodeVersion.onOrAfter("6.2.0") && nodeVersion.before("6.3.0")) {
             env = ['JAVA_HOME':"${-> getJavaHome(project, 9, "JAVA9_HOME must be set to run BWC tests against [" + nodeVersion + "]")}"]
         } else {
-            env = ['JAVA_HOME':project.compilerJavaHome]
+            env = ['JAVA_HOME':project.runtimeJavaHome]
         }
 
         args.addAll("-E", "node.portsfile=true")

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/test/NodeInfo.groovy
@@ -16,20 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.gradle.test
 
 import com.sun.jna.Native
 import com.sun.jna.WString
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.Version
-import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+
+import static org.elasticsearch.gradle.BuildPlugin.getJavaHome
 
 /**
  * A container for the files and configuration associated with a single node in a test cluster.
@@ -165,24 +166,14 @@ class NodeInfo {
         }
 
         final String javaHome
-        final Map<Integer, JavaVersion> javaVersions = project.javaVersions
         if (nodeVersion.before("6.2.0")) {
-            final String java8Home = javaVersions.get(8)
-            if (java8Home == null) {
-                throw new GradleException("JAVA8_HOME must be set to run BWC tests against [" + nodeVersion + "]")
-            }
-            javaHome = java8Home
+            env = ['JAVA_HOME':"${-> getJavaHome(project, 8, "JAVA8_HOME must be set to run BWC tests against [" + nodeVersion + "]")}"]
         } else if (nodeVersion.onOrAfter("6.2.0") && nodeVersion.before("6.3.0")) {
-            final String java9Home = javaVersions.get(9)
-            if (java9Home == null) {
-                throw new GradleException("JAVA9_HOME must be set to run BWC tests against [" + nodeVersion + "]")
-            }
-            javaHome = java9Home
+            env = ['JAVA_HOME':"${-> getJavaHome(project, 9, "JAVA9_HOME must be set to run BWC tests against [" + nodeVersion + "]")}"]
         } else {
-            javaHome = project.compilerJavaHome
+            env = ['JAVA_HOME':project.compilerJavaHome]
         }
 
-        env = ['JAVA_HOME':javaHome]
         args.addAll("-E", "node.portsfile=true")
         String collectedSystemProperties = config.systemProperties.collect { key, value -> "-D${key}=${value}" }.join(" ")
         String esJavaOpts = config.jvmArgs.isEmpty() ? collectedSystemProperties : collectedSystemProperties + " " + config.jvmArgs

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -17,11 +17,12 @@
  * under the License.
  */
 
+
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.LoggedExec
 import org.elasticsearch.gradle.Version
 
-import java.util.regex.Matcher
+import static org.elasticsearch.gradle.BuildPlugin.getJavaHome
 
 /**
  * This is a dummy project which does a local checkout of the previous
@@ -146,15 +147,9 @@ subprojects {
     workingDir = checkoutDir
     if (["5.6", "6.0", "6.1"].contains(bwcBranch)) {
       // we are building branches that are officially built with JDK 8, push JAVA8_HOME to JAVA_HOME for these builds
-      if (project.javaVersions.get(8) == null) {
-        throw new GradleException("JAVA8_HOME is required to build BWC versions for BWC branch [" + bwcBranch + "]")
-      }
-      environment('JAVA_HOME', project.javaVersions.get(8))
+      environment('JAVA_HOME', "${-> getJavaHome(project, 8, "JAVA8_HOME is required to build BWC versions for BWC branch [" + bwcBranch + "]")}")
     } else if ("6.2".equals(bwcBranch)) {
-      if (project.javaVersions.get(9) == null) {
-        throw new GradleException("JAVA9_HOME is required to build BWC versions for BWC branch [" + bwcBranch + "]")
-      }
-      environment('JAVA_HOME', project.javaVersions.get(9))
+      environment('JAVA_HOME', "${-> getJavaHome(project, 9, "JAVA9_HOME is required to build BWC versions for BWC branch [" + bwcBranch + "]")}")
     } else {
       environment('JAVA_HOME', project.compilerJavaHome)
     }

--- a/qa/reindex-from-old/build.gradle
+++ b/qa/reindex-from-old/build.gradle
@@ -24,7 +24,10 @@ should be able to use the standard launching mechanism which
 is more flexible and reliable.
 """
 
+
 import org.apache.tools.ant.taskdefs.condition.Os
+
+import static org.elasticsearch.gradle.BuildPlugin.getJavaHome
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-test'
@@ -55,9 +58,6 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   // we can't get the pid files in windows so we skip that
   integTest.enabled = false
 } else {
-  if (project.javaVersions.get(7) == null) {
-    throw new GradleException("JAVA7_HOME must be set to run reindex-from-old")
-  }
   /* Set up tasks to unzip and run the old versions of ES before running the
    * integration tests. */
   for (String version : ['2', '1', '090']) {
@@ -77,7 +77,7 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
       dependsOn unzip
       executable = new File(project.runtimeJavaHome, 'bin/java')
       env 'CLASSPATH', "${ -> project.configurations.oldesFixture.asPath }"
-      env 'JAVA_HOME', project.javaVersions.get(7)
+      env 'JAVA_HOME', "${-> getJavaHome(project, 7, "JAVA7_HOME must be set to run reindex-from-old")}"
       args 'oldes.OldElasticsearch',
            baseDir,
            unzip.temporaryDir,


### PR DESCRIPTION
Some build tasks require older JDKs. For example, the BWC build tasks for older versions of Elasticsearch require older JDKs. It is onerous to require these be configured when merely compiling Elasticsearch, the requirement that they be strictly set to appropriate values should only be enforced if these tasks are going to be executed. To address this, we lazy configure these tasks.

Relates #29493
