### PR TITLE
Reinstate missing documentation

### DIFF
--- a/docs/reference/docs/delete.asciidoc
+++ b/docs/reference/docs/delete.asciidoc
@@ -39,11 +39,14 @@ The result of the above delete operation is:
 [[delete-versioning]]
 === Versioning
 
-Each document indexed is versioned. When deleting a document, the
-`version` can be specified to make sure the relevant document we are
-trying to delete is actually being deleted and it has not changed in the
-meantime. Every write operation executed on a document, deletes included,
-causes its version to be incremented.
+Each document indexed is versioned. When deleting a document, the `version` can
+be specified to make sure the relevant document we are trying to delete is
+actually being deleted and it has not changed in the meantime. Every write
+operation executed on a document, deletes included, causes its version to be
+incremented. The version number of a deleted document remains available for a
+short time after deletion to allow for control of concurrent operations. The
+length of time for which a deleted document's version remains available is
+determined by the `index.gc_deletes` index setting and defaults to 60 seconds.
 
 [float]
 [[delete-routing]]

--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -214,6 +214,27 @@ specific index module:
     The maximum length of regex that can be used in Regexp Query.
     Defaults to `1000`.
 
+ `index.routing.allocation.enable`::
+
+    Controls shard allocation for this index. It can be set to:
+    * `all` (default) - Allows shard allocation for all shards.
+    * `primaries` - Allows shard allocation only for primary shards.
+    * `new_primaries` - Allows shard allocation only for newly-created primary shards.
+    * `none` - No shard allocation is allowed.
+
+ `index.routing.rebalance.enable`::
+
+    Enables shard rebalancing for this index. It can be set to:
+    * `all` (default) - Allows shard rebalancing for all shards.
+    * `primaries` - Allows shard rebalancing only for primary shards.
+    * `replicas` - Allows shard rebalancing only for replica shards.
+    * `none` - No shard rebalancing is allowed.
+
+ `index.gc_deletes`::
+
+    The length of time that a <<delete-versioning,deleted document's version number>> remains available for <<index-versioning,further versioned operations>>.
+    Defaults to `60s`.
+
 [float]
 === Settings in other index modules
 


### PR DESCRIPTION
The setting `index.routing.allocation.enable` was [documented in v1.7](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/indices-update-settings.html) but lost in the refactoring in f123a53d7258349a171e47a35f4581899d8fa776 so has been undocumented since 2.0.

It might also be worth checking if any other settings were lost in the same change. I have not done so yet.

/cc @elastic/es-distributed.