### PR TITLE
Fix missing node id prefix in startup logs

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -277,7 +277,7 @@ public class Node implements Closeable {
             // this must be captured after the node name is possibly added to the settings
             final String nodeName = NODE_NAME_SETTING.get(tmpSettings);
             if (hadPredefinedNodeName == false) {
-                logger.info("node name [{}] derived from node ID [{}]; set [{}] to override", nodeName, nodeId, NODE_NAME_SETTING.getKey());
+                logger.info("node name derived from node ID [{}]; set [{}] to override", nodeId, NODE_NAME_SETTING.getKey());
             } else {
                 logger.info("node name [{}], node ID [{}]", nodeName, nodeId);
             }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -258,7 +258,6 @@ public class Node implements Closeable {
             // use temp logger just to say we are starting. we can't use it later on because the node name might not be set
             Logger logger = Loggers.getLogger(Node.class, NODE_NAME_SETTING.get(environment.settings()));
             logger.info("initializing ...");
-
         }
         try {
             Settings tmpSettings = Settings.builder().put(environment.settings())
@@ -272,9 +271,9 @@ public class Node implements Closeable {
                 throw new IllegalStateException("Failed to create node environment", ex);
             }
             final boolean hadPredefinedNodeName = NODE_NAME_SETTING.exists(tmpSettings);
-            Logger logger = Loggers.getLogger(Node.class, tmpSettings);
             final String nodeId = nodeEnvironment.nodeId();
             tmpSettings = addNodeNameIfNeeded(tmpSettings, nodeId);
+            final Logger logger = Loggers.getLogger(Node.class, tmpSettings);
             // this must be captured after the node name is possibly added to the settings
             final String nodeName = NODE_NAME_SETTING.get(tmpSettings);
             if (hadPredefinedNodeName == false) {


### PR DESCRIPTION
When `node.name` is not set, some log traces at startup time does not show the node id. It does not look nice as some traces have the id and some others haven't:

```
[2018-04-16T16:02:14,812][INFO ][o.e.n.Node               ] [] initializing ...
[2018-04-16T16:02:14,847][INFO ][o.e.e.NodeEnvironment    ] [P2NUhLl] heap size [989.8mb], compressed ordinary object pointers [true]
[2018-04-16T16:02:14,848][INFO ][o.e.n.Node               ] node name [P2NUhLl] derived from node ID [P2NUhLlQTkmAHzlNM4HF2A]; set [node.name] to override
[2018-04-16T16:02:14,849][INFO ][o.e.n.Node               ] version[7.0.0-alpha1-SNAPSHOT], ... ]
[2018-04-16T16:02:14,849][INFO ][o.e.n.Node               ] JVM arguments [-Xms1g, -Xmx1g, ...]
[2018-04-16T16:02:14,849][WARN ][o.e.n.Node               ] version [7.0.0-alpha1-SNAPSHOT] is a pre-release version of Elasticsearch and is not suitable for production
...
[2018-04-16T16:02:16,373][INFO ][o.e.d.DiscoveryModule    ] [P2NUhLl] using discovery type [zen]
[2018-04-16T16:02:16,642][INFO ][o.e.n.Node               ] initialized
```

We can improve this a bit in order to make startup logs parsing easier (and to not hurt my eyes):

```
[2018-04-16T16:02:14,812][INFO ][o.e.n.Node               ] [] initializing ...
[2018-04-16T16:02:14,847][INFO ][o.e.e.NodeEnvironment    ] [P2NUhLl] heap size [989.8mb], compressed ordinary object pointers [true]
[2018-04-16T16:02:14,848][INFO ][o.e.n.Node               ] [P2NUhLl] node name [P2NUhLl] derived from node ID [P2NUhLlQTkmAHzlNM4HF2A]; set [node.name] to override
[2018-04-16T16:02:14,849][INFO ][o.e.n.Node               ] [P2NUhLl] version[7.0.0-alpha1-SNAPSHOT], ... ]
[2018-04-16T16:02:14,849][INFO ][o.e.n.Node               ] [P2NUhLl] JVM arguments [-Xms1g, -Xmx1g, ...]
[2018-04-16T16:02:14,849][WARN ][o.e.n.Node               ] [P2NUhLl] version [7.0.0-alpha1-SNAPSHOT] is a pre-release version of Elasticsearch and is not suitable for production
...
[2018-04-16T16:02:16,373][INFO ][o.e.d.DiscoveryModule    ] [P2NUhLl] using discovery type [zen]
[2018-04-16T16:02:16,642][INFO ][o.e.n.Node               ] [P2NUhLl] initialized
```

