### PR TITLE
Do not return all indices if a specific alias is requested via get aliases api.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/AliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/AliasesRequest.java
@@ -33,9 +33,9 @@ public interface AliasesRequest extends IndicesRequest.Replaceable {
     String[] aliases();
 
     /**
-     * Replaces the aliases that the action relates to
+     * Replaces current aliases with the provided aliases.
      *
-     * This is an internal method.
+     * Sometimes aliases expressions need to be resolved to concrete aliases prior to executing the transport action.
      */
     void replaceAliases(String... aliases);
 

--- a/server/src/main/java/org/elasticsearch/action/AliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/AliasesRequest.java
@@ -33,9 +33,11 @@ public interface AliasesRequest extends IndicesRequest.Replaceable {
     String[] aliases();
 
     /**
-     * Sets the array of aliases that the action relates to
+     * Replaces the aliases that the action relates to
+     *
+     * This is an internal method.
      */
-    AliasesRequest aliases(String... aliases);
+    void replaceAliases(String... aliases);
 
     /**
      * Returns true if wildcards expressions among aliases should be resolved, false otherwise

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -302,7 +302,6 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         /**
          * Aliases to use with this action.
          */
-        @Override
         public AliasActions aliases(String... aliases) {
             if (type == AliasActions.Type.REMOVE_INDEX) {
                 throw new IllegalArgumentException("[aliases] is unsupported for [" + type + "]");
@@ -426,6 +425,11 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         @Override
         public String[] aliases() {
             return aliases;
+        }
+
+        @Override
+        public void replaceAliases(String... aliases) {
+            this.aliases = aliases;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -34,7 +34,7 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpand();
-    private String[] originalAliases;
+    private String[] originalAliases = Strings.EMPTY_ARRAY;
 
     public GetAliasesRequest(String... aliases) {
         this.aliases = aliases;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -98,9 +98,9 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     }
 
     /**
-     * Returns aliases originally specified by the user
+     * Returns the aliases as was originally specified by the user
      */
-    String[] getOriginalAliases() {
+    public String[] getOriginalAliases() {
         return originalAliases;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -28,18 +28,17 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
-import java.util.Objects;
 
 public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> implements AliasesRequest {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.strictExpand();
-    private boolean aliasesProvided = false;
+    private String[] originalAliases;
 
     public GetAliasesRequest(String... aliases) {
-        this.aliases = Objects.requireNonNull(aliases);
-        this.aliasesProvided = aliases.length != 0;
+        this.aliases = aliases;
+        this.originalAliases = aliases;
     }
 
     public GetAliasesRequest() {
@@ -51,7 +50,7 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
         aliases = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
-            aliasesProvided = in.readBoolean();
+            originalAliases = in.readStringArray();
         }
     }
 
@@ -62,7 +61,7 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
         out.writeStringArray(aliases);
         indicesOptions.writeIndicesOptions(out);
         if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
-            out.writeBoolean(aliasesProvided);
+            out.writeStringArray(originalAliases);
         }
     }
 
@@ -73,8 +72,8 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     }
 
     public GetAliasesRequest aliases(String... aliases) {
-        this.aliases = Objects.requireNonNull(aliases);
-        this.aliasesProvided = aliases.length != 0;
+        this.aliases = aliases;
+        this.originalAliases = aliases;
         return this;
     }
 
@@ -99,11 +98,10 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     }
 
     /**
-     * @return Whether aliases that where originally provided by the user via {@link #aliases(String...)} or
-     *         {@link #GetAliasesRequest(String...)}. If this is not the case and there are aliases then
+     * Returns aliases originally specified by the user
      */
-    boolean isAliasesProvided() {
-        return aliasesProvided;
+    String[] getOriginalAliases() {
+        return originalAliases;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.action.admin.indices.alias.get;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.AliasesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -27,20 +28,18 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> implements AliasesRequest {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private String[] aliases = Strings.EMPTY_ARRAY;
-
     private IndicesOptions indicesOptions = IndicesOptions.strictExpand();
+    private boolean aliasesProvided = false;
 
-    public GetAliasesRequest(String[] aliases) {
-        this.aliases = aliases;
-    }
-
-    public GetAliasesRequest(String alias) {
-        this.aliases = new String[]{alias};
+    public GetAliasesRequest(String... aliases) {
+        this.aliases = Objects.requireNonNull(aliases);
+        this.aliasesProvided = aliases.length != 0;
     }
 
     public GetAliasesRequest() {
@@ -51,6 +50,9 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
         indices = in.readStringArray();
         aliases = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
+        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+            aliasesProvided = in.readBoolean();
+        }
     }
 
     @Override
@@ -59,6 +61,9 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
         out.writeStringArray(indices);
         out.writeStringArray(aliases);
         indicesOptions.writeIndicesOptions(out);
+        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+            out.writeBoolean(aliasesProvided);
+        }
     }
 
     @Override
@@ -67,9 +72,9 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
         return this;
     }
 
-    @Override
     public GetAliasesRequest aliases(String... aliases) {
-        this.aliases = aliases;
+        this.aliases = Objects.requireNonNull(aliases);
+        this.aliasesProvided = aliases.length != 0;
         return this;
     }
 
@@ -86,6 +91,19 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     @Override
     public String[] aliases() {
         return aliases;
+    }
+
+    @Override
+    public void replaceAliases(String... aliases) {
+        this.aliases = aliases;
+    }
+
+    /**
+     * @return Whether aliases that where originally provided by the user via {@link #aliases(String...)} or
+     *         {@link #GetAliasesRequest(String...)}. If this is not the case and there are aliases then
+     */
+    boolean isAliasesProvided() {
+        return aliasesProvided;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -18,7 +18,6 @@
  */
 package org.elasticsearch.action.admin.indices.alias.get;
 
-import com.carrotsearch.hppc.ObjectHashSet;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
@@ -29,7 +28,6 @@ import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.HppcMaps;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -71,8 +69,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         // in case all aliases are requested then it is desired to return the concrete index with no aliases (#25114):
         boolean aliasesProvided = Strings.isAllOrWildcard(request.getOriginalAliases());
         ImmutableOpenMap.Builder<String, List<AliasMetaData>> mapBuilder = ImmutableOpenMap.builder(result);
-        Iterable<String> intersection = HppcMaps.intersection(ObjectHashSet.from(concreteIndices), state.metaData().indices().keys());
-        for (String index : intersection) {
+        for (String index : concreteIndices) {
             if (result.get(index) == null && aliasesProvided) {
                 mapBuilder.put(index, Collections.emptyList());
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.HppcMaps;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
@@ -68,10 +69,11 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         ImmutableOpenMap<String, List<AliasMetaData>> result = state.metaData().findAliases(request.aliases(), concreteIndices);
 
         // in case all aliases are requested then it is desired to return the concrete index with no aliases (#25114):
+        boolean aliasesProvided = Strings.isAllOrWildcard(request.getOriginalAliases());
         ImmutableOpenMap.Builder<String, List<AliasMetaData>> mapBuilder = ImmutableOpenMap.builder(result);
         Iterable<String> intersection = HppcMaps.intersection(ObjectHashSet.from(concreteIndices), state.metaData().indices().keys());
         for (String index : intersection) {
-            if (result.get(index) == null && request.isAliasesProvided() == false) {
+            if (result.get(index) == null && aliasesProvided) {
                 mapBuilder.put(index, Collections.emptyList());
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -265,8 +265,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
 
         boolean matchAllAliases = Strings.isAllOrWildcard(aliases);
         ImmutableOpenMap.Builder<String, List<AliasMetaData>> mapBuilder = ImmutableOpenMap.builder();
-        Iterable<String> intersection = HppcMaps.intersection(ObjectHashSet.from(concreteIndices), indices.keys());
-        for (String index : intersection) {
+        for (String index : concreteIndices) {
             IndexMetaData indexMetaData = indices.get(index);
             List<AliasMetaData> filteredValues = new ArrayList<>();
             for (ObjectCursor<AliasMetaData> cursor : indexMetaData.getAliases().values()) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -263,7 +263,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
             return ImmutableOpenMap.of();
         }
 
-        boolean matchAllAliases = matchAllAliases(aliases);
+        boolean matchAllAliases = Strings.isAllOrWildcard(aliases);
         ImmutableOpenMap.Builder<String, List<AliasMetaData>> mapBuilder = ImmutableOpenMap.builder();
         Iterable<String> intersection = HppcMaps.intersection(ObjectHashSet.from(concreteIndices), indices.keys());
         for (String index : intersection) {
@@ -276,22 +276,13 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
                 }
             }
 
-            if (!filteredValues.isEmpty()) {
+            if (filteredValues.isEmpty() == false) {
                 // Make the list order deterministic
                 CollectionUtil.timSort(filteredValues, Comparator.comparing(AliasMetaData::alias));
+                mapBuilder.put(index, Collections.unmodifiableList(filteredValues));
             }
-            mapBuilder.put(index, Collections.unmodifiableList(filteredValues));
         }
         return mapBuilder.build();
-    }
-
-    private static boolean matchAllAliases(final String[] aliases) {
-        for (String alias : aliases) {
-            if (alias.equals(ALL)) {
-                return true;
-            }
-        }
-        return aliases.length == 0;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java
@@ -263,7 +263,7 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
             return ImmutableOpenMap.of();
         }
 
-        boolean matchAllAliases = Strings.isAllOrWildcard(aliases);
+        boolean matchAllAliases = matchAllAliases(aliases);
         ImmutableOpenMap.Builder<String, List<AliasMetaData>> mapBuilder = ImmutableOpenMap.builder();
         for (String index : concreteIndices) {
             IndexMetaData indexMetaData = indices.get(index);
@@ -282,6 +282,15 @@ public class MetaData implements Iterable<IndexMetaData>, Diffable<MetaData>, To
             }
         }
         return mapBuilder.build();
+    }
+
+    private static boolean matchAllAliases(final String[] aliases) {
+        for (String alias : aliases) {
+            if (alias.equals(ALL)) {
+                return true;
+            }
+        }
+        return aliases.length == 0;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -77,6 +77,10 @@ public class RestGetAliasesAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        // The TransportGetAliasesAction was improved do the same post processing as is happening here.
+        // We can't remove this logic yet to support mixed clusters. We should be able to remove this logic here
+        // in when 8.0 becomes the new version in the master branch.
+
         final boolean namesProvided = request.hasParam("name");
         final String[] aliases = request.paramAsStringArrayOrEmptyIfAll("name");
         final GetAliasesRequest getAliasesRequest = new GetAliasesRequest(aliases);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.action.admin.indices.alias.get;
+
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TransportGetAliasesActionTests extends ESTestCase {
+
+    public void testPostProcess() {
+        GetAliasesRequest request = new GetAliasesRequest();
+        ImmutableOpenMap<String, List<AliasMetaData>> aliases = ImmutableOpenMap.<String, List<AliasMetaData>>builder()
+            .fPut("b", Collections.singletonList(new AliasMetaData.Builder("y").build()))
+            .build();
+        ImmutableOpenMap<String, List<AliasMetaData>> result =
+            TransportGetAliasesAction.postProcess(request, new String[]{"a", "b", "c"}, aliases);
+        assertThat(result.size(), equalTo(3));
+        assertThat(result.get("a").size(), equalTo(0));
+        assertThat(result.get("b").size(), equalTo(1));
+        assertThat(result.get("c").size(), equalTo(0));
+
+        request = new GetAliasesRequest();
+        request.replaceAliases("y", "z");
+        aliases = ImmutableOpenMap.<String, List<AliasMetaData>>builder()
+            .fPut("b", Collections.singletonList(new AliasMetaData.Builder("y").build()))
+            .build();
+        result = TransportGetAliasesAction.postProcess(request, new String[]{"a", "b", "c"}, aliases);
+        assertThat(result.size(), equalTo(3));
+        assertThat(result.get("a").size(), equalTo(0));
+        assertThat(result.get("b").size(), equalTo(1));
+        assertThat(result.get("c").size(), equalTo(0));
+
+        request = new GetAliasesRequest("y", "z");
+        aliases = ImmutableOpenMap.<String, List<AliasMetaData>>builder()
+            .fPut("b", Collections.singletonList(new AliasMetaData.Builder("y").build()))
+            .build();
+        result = TransportGetAliasesAction.postProcess(request, new String[]{"a", "b", "c"}, aliases);
+        assertThat(result.size(), equalTo(1));
+        assertThat(result.get("b").size(), equalTo(1));
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -570,24 +570,20 @@ public class IndexAliasesIT extends ESIntegTestCase {
         logger.info("--> getting alias1");
         GetAliasesResponse getResponse = admin().indices().prepareGetAliases("alias1").get();
         assertThat(getResponse, notNullValue());
-        assertThat(getResponse.getAliases().size(), equalTo(5));
+        assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").get(0), notNullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).alias(), equalTo("alias1"));
         assertThat(getResponse.getAliases().get("foobar").get(0).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getSearchRouting(), nullValue());
-        assertTrue(getResponse.getAliases().get("test").isEmpty());
-        assertTrue(getResponse.getAliases().get("test123").isEmpty());
-        assertTrue(getResponse.getAliases().get("foobarbaz").isEmpty());
-        assertTrue(getResponse.getAliases().get("bazbar").isEmpty());
         AliasesExistResponse existsResponse = admin().indices().prepareAliasesExist("alias1").get();
         assertThat(existsResponse.exists(), equalTo(true));
 
         logger.info("--> getting all aliases that start with alias*");
         getResponse = admin().indices().prepareGetAliases("alias*").get();
         assertThat(getResponse, notNullValue());
-        assertThat(getResponse.getAliases().size(), equalTo(5));
+        assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").size(), equalTo(2));
         assertThat(getResponse.getAliases().get("foobar").get(0), notNullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).alias(), equalTo("alias1"));
@@ -599,10 +595,6 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(getResponse.getAliases().get("foobar").get(1).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(1).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(1).getSearchRouting(), nullValue());
-        assertTrue(getResponse.getAliases().get("test").isEmpty());
-        assertTrue(getResponse.getAliases().get("test123").isEmpty());
-        assertTrue(getResponse.getAliases().get("foobarbaz").isEmpty());
-        assertTrue(getResponse.getAliases().get("bazbar").isEmpty());
         existsResponse = admin().indices().prepareAliasesExist("alias*").get();
         assertThat(existsResponse.exists(), equalTo(true));
 
@@ -687,13 +679,12 @@ public class IndexAliasesIT extends ESIntegTestCase {
         logger.info("--> getting f* for index *bar");
         getResponse = admin().indices().prepareGetAliases("f*").addIndices("*bar").get();
         assertThat(getResponse, notNullValue());
-        assertThat(getResponse.getAliases().size(), equalTo(2));
+        assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").get(0), notNullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).alias(), equalTo("foo"));
         assertThat(getResponse.getAliases().get("foobar").get(0).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getSearchRouting(), nullValue());
-        assertTrue(getResponse.getAliases().get("bazbar").isEmpty());
         existsResponse = admin().indices().prepareAliasesExist("f*")
                 .addIndices("*bar").get();
         assertThat(existsResponse.exists(), equalTo(true));
@@ -702,14 +693,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
         logger.info("--> getting f* for index *bac");
         getResponse = admin().indices().prepareGetAliases("foo").addIndices("*bac").get();
         assertThat(getResponse, notNullValue());
-        assertThat(getResponse.getAliases().size(), equalTo(2));
+        assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").get(0), notNullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).alias(), equalTo("foo"));
         assertThat(getResponse.getAliases().get("foobar").get(0).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getSearchRouting(), nullValue());
-        assertTrue(getResponse.getAliases().get("bazbar").isEmpty());
         existsResponse = admin().indices().prepareAliasesExist("foo")
                 .addIndices("*bac").get();
         assertThat(existsResponse.exists(), equalTo(true));
@@ -726,6 +716,19 @@ public class IndexAliasesIT extends ESIntegTestCase {
         existsResponse = admin().indices().prepareAliasesExist("foo")
                 .addIndices("foobar").get();
         assertThat(existsResponse.exists(), equalTo(true));
+
+        for (String aliasName : new String[]{null, "_all", "*"}) {
+            logger.info("--> getting {} alias for index foobar", aliasName);
+            getResponse = aliasName != null ? admin().indices().prepareGetAliases(aliasName).addIndices("foobar").get() :
+                admin().indices().prepareGetAliases().addIndices("foobar").get();
+            assertThat(getResponse, notNullValue());
+            assertThat(getResponse.getAliases().size(), equalTo(1));
+            assertThat(getResponse.getAliases().get("foobar").size(), equalTo(4));
+            assertThat(getResponse.getAliases().get("foobar").get(0).alias(), equalTo("alias1"));
+            assertThat(getResponse.getAliases().get("foobar").get(1).alias(), equalTo("alias2"));
+            assertThat(getResponse.getAliases().get("foobar").get(2).alias(), equalTo("bac"));
+            assertThat(getResponse.getAliases().get("foobar").get(3).alias(), equalTo("foo"));
+        }
 
         // alias at work again
         logger.info("--> getting * for index *bac");

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolver.java
@@ -200,7 +200,7 @@ class IndicesAndAliasesResolver {
             if (aliasesRequest.expandAliasesWildcards()) {
                 List<String> aliases = replaceWildcardsWithAuthorizedAliases(aliasesRequest.aliases(),
                         loadAuthorizedAliases(authorizedIndices.get(), metaData));
-                aliasesRequest.aliases(aliases.toArray(new String[aliases.size()]));
+                aliasesRequest.replaceAliases(aliases.toArray(new String[aliases.size()]));
             }
             if (indicesReplacedWithNoIndices) {
                 if (indicesRequest instanceof GetAliasesRequest == false) {


### PR DESCRIPTION
If a get alias api call requests a specific alias pattern then
indices not having any matching aliases should not be included in the response.

This is a second attempt to fix this (first attempt was #28294).
The reason that the first attempt was reverted is because when xpack
security is enabled then index expression (like * or _all) are resolved
prior to when a request is processed in the get aliases transport action,
then `MetaData#findAliases` can't know whether requested all where
requested since it was already expanded in concrete alias names. This
change now adds an additional field to the request calss that keeps track
whether all aliases where requested.

Closes #27763