### PR TITLE
Deprecate the index thread pool

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -170,7 +170,7 @@ public class ThreadPool extends AbstractComponent implements Scheduler, Closeabl
         final int halfProcMaxAt10 = halfNumberOfProcessorsMaxTen(availableProcessors);
         final int genericThreadPoolMax = boundedBy(4 * availableProcessors, 128, 512);
         builders.put(Names.GENERIC, new ScalingExecutorBuilder(Names.GENERIC, 4, genericThreadPoolMax, TimeValue.timeValueSeconds(30)));
-        builders.put(Names.INDEX, new FixedExecutorBuilder(settings, Names.INDEX, availableProcessors, 200));
+        builders.put(Names.INDEX, new FixedExecutorBuilder(settings, Names.INDEX, availableProcessors, 200, true));
         builders.put(Names.BULK, new FixedExecutorBuilder(settings, Names.BULK, availableProcessors, 200)); // now that we reuse bulk for index/delete ops
         builders.put(Names.GET, new FixedExecutorBuilder(settings, Names.GET, availableProcessors, 1000));
         builders.put(Names.SEARCH, new AutoQueueAdjustingExecutorBuilder(settings,

--- a/server/src/test/java/org/elasticsearch/threadpool/FixedThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/FixedThreadPoolTests.java
@@ -85,6 +85,10 @@ public class FixedThreadPoolTests extends ESThreadPoolTestCase {
 
             assertThat(counter, equalTo(rejections));
             assertThat(stats(threadPool, threadPoolName).getRejected(), equalTo(rejections));
+
+            if (threadPoolName.equals(ThreadPool.Names.INDEX)) {
+                assertSettingDeprecationsAndWarnings(new String[]{"thread_pool.index.queue_size", "thread_pool.index.size"});
+            }
         } finally {
             terminateThreadPoolIfNeeded(threadPool);
         }

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolSerializationTests.java
@@ -87,9 +87,9 @@ public class ThreadPoolSerializationTests extends ESTestCase {
     }
 
     public void testThatNegativeSettingAllowsToStart() throws InterruptedException {
-        Settings settings = Settings.builder().put("node.name", "index").put("thread_pool.index.queue_size", "-1").build();
+        Settings settings = Settings.builder().put("node.name", "bulk").put("thread_pool.bulk.queue_size", "-1").build();
         ThreadPool threadPool = new ThreadPool(settings);
-        assertThat(threadPool.info("index").getQueueSize(), is(nullValue()));
+        assertThat(threadPool.info("bulk").getQueueSize(), is(nullValue()));
         terminate(threadPool);
     }
 

--- a/server/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
@@ -85,6 +85,10 @@ public class UpdateThreadPoolSettingsTests extends ESThreadPoolTestCase {
             initial,
             hasToString(containsString(
                 "Failed to parse value [" + tooBig + "] for setting [thread_pool." + name + ".size] must be ")));
+
+        if (name.equals(Names.INDEX)) {
+            assertSettingDeprecationsAndWarnings(new String[] { "thread_pool.index.size" });
+        }
     }
 
     private static int getExpectedThreadPoolSize(Settings settings, String name, int size) {
@@ -116,6 +120,10 @@ public class UpdateThreadPoolSettingsTests extends ESThreadPoolTestCase {
             assertThat(info(threadPool, threadPoolName).getMax(), equalTo(expectedSize));
             // keep alive does not apply to fixed thread pools
             assertThat(((EsThreadPoolExecutor) threadPool.executor(threadPoolName)).getKeepAliveTime(TimeUnit.MINUTES), equalTo(0L));
+
+            if (threadPoolName.equals(Names.INDEX)) {
+                assertSettingDeprecationsAndWarnings(new String[] { "thread_pool.index.size" });
+            }
         } finally {
             terminateThreadPoolIfNeeded(threadPool);
         }
@@ -171,6 +179,10 @@ public class UpdateThreadPoolSettingsTests extends ESThreadPoolTestCase {
             latch.await(3, TimeUnit.SECONDS); // if this throws then ThreadPool#shutdownNow did not interrupt
             assertThat(oldExecutor.isShutdown(), equalTo(true));
             assertThat(oldExecutor.isTerminating() || oldExecutor.isTerminated(), equalTo(true));
+
+            if (threadPoolName.equals(Names.INDEX)) {
+                assertSettingDeprecationsAndWarnings(new String[] { "thread_pool.index.queue_size" });
+            }
         } finally {
             terminateThreadPoolIfNeeded(threadPool);
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -335,11 +335,14 @@ public abstract class ESTestCase extends LuceneTestCase {
      * @param warnings other expected general deprecation warnings
      */
     protected final void assertSettingDeprecationsAndWarnings(final Setting<?>[] settings, final String... warnings) {
+        assertSettingDeprecationsAndWarnings(Arrays.stream(settings).map(Setting::getKey).toArray(String[]::new), warnings);
+    }
+
+    protected final void assertSettingDeprecationsAndWarnings(final String[] settings, final String... warnings) {
         assertWarnings(
                 Stream.concat(
                         Arrays
                                 .stream(settings)
-                                .map(Setting::getKey)
                                 .map(k -> "[" + k + "] setting was deprecated in Elasticsearch and will be removed in a future release! " +
                                         "See the breaking changes documentation for the next major version."),
                         Arrays.stream(warnings))


### PR DESCRIPTION
The index thread pool is no longer needed as its primary use-case for single-document indexing requests has been relieved now that single-document indexing requests are converted to bulk indexing requests (with a single document payload).

