### PR TITLE
Fix full cluster restart test recovery

### DIFF
--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -687,8 +687,7 @@ public class FullClusterRestartIT extends ESRestTestCase {
      * Tests recovery of an index with or without a translog and the
      * statistics we gather about that.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/29544")
-    public void testRecovery() throws IOException {
+    public void testRecovery() throws Exception {
         int count;
         boolean shouldHaveTranslog;
         if (runningAgainstOldCluster) {
@@ -701,7 +700,19 @@ public class FullClusterRestartIT extends ESRestTestCase {
             indexRandomDocuments(count, true, true, i -> jsonBuilder().startObject().field("field", "value").endObject());
 
             // make sure all recoveries are done
-            ensureNoInitializingShards();
+            if (oldClusterVersion.onOrAfter(Version.V_6_2_0)) {
+                ensureNoInitializingShards();
+            } else {
+                assertBusy(() -> {
+                    final Response response = client().performRequest("GET", "/_cat/shards/" + index);
+                    assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+                    final String[] shards = toStr(response).split("\n");
+                    for (final String shard : shards) {
+                        final String[] columns = shard.split("\\s+");
+                        assertThat(columns[3], equalTo("STARTED"));
+                    }
+                });
+            }
             // Explicitly flush so we're sure to have a bunch of documents in the Lucene index
             client().performRequest("POST", "/_flush");
             if (shouldHaveTranslog) {

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -59,6 +59,7 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -704,12 +705,12 @@ public class FullClusterRestartIT extends ESRestTestCase {
                 ensureNoInitializingShards();
             } else {
                 assertBusy(() -> {
-                    final Response response = client().performRequest("GET", "/_cat/shards/" + index);
+                    final Response response =
+                            client().performRequest("GET", "/_cat/shards/" + index, Collections.singletonMap("h", "state"));
                     assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
                     final String[] shards = toStr(response).split("\n");
                     for (final String shard : shards) {
-                        final String[] columns = shard.split("\\s+");
-                        assertThat(columns[3], equalTo("STARTED"));
+                        assertThat(shard, equalTo("STARTED"));
                     }
                 });
             }

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -700,19 +700,7 @@ public class FullClusterRestartIT extends ESRestTestCase {
             indexRandomDocuments(count, true, true, i -> jsonBuilder().startObject().field("field", "value").endObject());
 
             // make sure all recoveries are done
-            if (oldClusterVersion.onOrAfter(Version.V_6_2_0)) {
-                ensureNoInitializingShards();
-            } else {
-                assertBusy(() -> {
-                    final Response response =
-                            client().performRequest("GET", "/_cat/shards/" + index, Collections.singletonMap("h", "state"));
-                    assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
-                    final String[] shards = toStr(response).split("\n");
-                    for (final String shard : shards) {
-                        assertThat(shard, equalTo("STARTED"));
-                    }
-                });
-            }
+            ensureGreen(index);
             // Explicitly flush so we're sure to have a bunch of documents in the Lucene index
             client().performRequest("POST", "/_flush");
             if (shouldHaveTranslog) {

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -59,7 +59,6 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;


### PR DESCRIPTION
The test was using a parameter on GET /_cluster/health that older nodes do not understand. Yet, we do no even need to make this call here, we can use ensure green for the index.

Closes #29544