### PR TITLE
Fix dependency checks on libs when generating Eclipse configuration.

### DIFF
--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -34,6 +34,7 @@ subprojects {
                 Project depProject = dependencyToProject(dep)
                 if (depProject != null
                         && false == depProject.path.equals(':libs:elasticsearch-core')
+                        && false == isEclipse 
                         && depProject.path.startsWith(':libs')) {
                     throw new InvalidUserDataException("projects in :libs "
                             + "may not depend on other projects libs except "


### PR DESCRIPTION
Currently this fails because the Eclipse configuration splits the main and test
folders into separate projects to avoid circular dependencies.

Relates #29336
