### PR TITLE
Add documentation about the include_type_name option.

### DIFF
--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -422,7 +422,7 @@ POST _reindex
 // NOTCONSOLE
 
 [float]
-=== Use `include_type_name=false` to prepare the upgrade to 8.0
+=== Use `include_type_name=false` to prepare for upgrade to 8.0
 
 Index creation, mappings and document APIs support the `include_type_name`
 option. When set to `false`, this option enables the behavior that will become

--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -421,3 +421,108 @@ POST _reindex
 ----
 // NOTCONSOLE
 
+[float]
+=== Use `include_type_name=false` to prepare the upgrade to 8.0
+
+Index creation, mappings and document APIs support the `include_type_name`
+option. When set to `false`, this option enables the behavior that will become
+default in 8.0 when types are removed. See some examples of interactions with
+Elasticsearch with this option turned off:
+
+[float]
+==== Index creation
+
+[source,js]
+--------------------------------------------------
+PUT index?include_type_name=false
+{
+  "mappings": {
+    "properties": { <1>
+      "foo": {
+        "type": "keyword"
+      }
+    }
+  }
+}
+--------------------------------------------------
+// CONSOLE
+<1> Mappings are included directly under the `mappings` key, without a type name.
+
+[float]
+==== PUT and GET mappings
+
+[source,js]
+--------------------------------------------------
+PUT index
+
+PUT index/_mappings?include_type_name=false
+{
+  "properties": { <1>
+    "foo": {
+      "type": "keyword"
+    }
+  }
+}
+
+GET index/_mappings?include_type_name=false
+--------------------------------------------------
+// CONSOLE
+<1> Mappings are included directly under the `mappings` key, without a type name.
+
+
+The above call returns
+
+[source,js]
+--------------------------------------------------
+{
+  "index": {
+    "mappings": {
+      "properties": { <1>
+        "foo": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+// TESTRESPONSE
+<1> Mappings are included directly under the `mappings` key, without a type name.
+
+[float]
+==== Document APIs
+
+Index APIs must be call with the `{index}/_doc` path for automatic generation of
+the `_id` and `{index}/_doc/{id}` with explicit ids.
+
+[source,js]
+--------------------------------------------------
+PUT index/_doc/1?include_type_name=false
+{
+  "foo": "bar"
+}
+--------------------------------------------------
+// CONSOLE
+
+[source,js]
+--------------------------------------------------
+{
+  "_index": "index", <1>
+  "_id": "1",
+  "_version": 1,
+  "result": "created",
+  "_shards": {
+    "total": 2,
+    "successful": 1,
+    "failed": 0
+  },
+  "_seq_no": 0,
+  "_primary_term": 1
+}
+--------------------------------------------------
+// TESTRESPONSE
+<1> The response does not include a `_type`.
+
+Likewise the <<docs-index_,GET>>, <<docs-delete,`DELETE`>>,
+<<docs-update,`_update`>> and <<search,`_search`>> APIs do not return a `_type`
+key in the response when `include_type_name` is set to `false`.


### PR DESCRIPTION
This option will be useful in 7.x to prepare the upgrade to 8.0 which won't
know about types anymore.
