### PR TITLE
Remove remaining tribe node references

### DIFF
--- a/docs/reference/modules/cross-cluster-search.asciidoc
+++ b/docs/reference/modules/cross-cluster-search.asciidoc
@@ -222,8 +222,7 @@ GET /cluster_one:twitter/_search
 // TESTRESPONSE[s/"_score": 1/"_score": "$body.hits.hits.0._score"/]
 
 
-In contrast to the `tribe` feature cross cluster search can also search indices with the same name on different
-clusters:
+Indices can also be searched with the same name on different clusters:
 
 [source,js]
 --------------------------------------------------

--- a/qa/evil-tests/src/test/resources/org/elasticsearch/tribe/elasticsearch.yml
+++ b/qa/evil-tests/src/test/resources/org/elasticsearch/tribe/elasticsearch.yml
@@ -1,5 +1,0 @@
-cluster.name: tribe_node_cluster
-tribe.t1.cluster.name: tribe1
-tribe.t2.cluster.name: tribe2
-tribe.t1.node.id.seed: 1
-tribe.t2.node.id.seed: 2

--- a/server/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -328,7 +328,6 @@ final class Security {
     private static void addBindPermissions(Permissions policy, Settings settings) {
         addSocketPermissionForHttp(policy, settings);
         addSocketPermissionForTransportProfiles(policy, settings);
-        addSocketPermissionForTribeNodes(policy, settings);
     }
 
     /**
@@ -372,16 +371,6 @@ final class Security {
     private static void addSocketPermissionForTransport(final Permissions policy, final Settings settings) {
         final String transportRange = TcpTransport.PORT.get(settings);
         addSocketPermissionForPortRange(policy, transportRange);
-    }
-
-    private static void addSocketPermissionForTribeNodes(final Permissions policy, final Settings settings) {
-        for (final Settings tribeNodeSettings : settings.getGroups("tribe", true).values()) {
-            // tribe nodes have HTTP disabled by default, so we check if HTTP is enabled before granting
-            if (NetworkModule.HTTP_ENABLED.exists(tribeNodeSettings) && NetworkModule.HTTP_ENABLED.get(tribeNodeSettings)) {
-                addSocketPermissionForHttp(policy, tribeNodeSettings);
-            }
-            addSocketPermissionForTransport(policy, tribeNodeSettings);
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -777,7 +777,7 @@ public class Node implements Closeable {
         logger.info("closing ...");
         List<Closeable> toClose = new ArrayList<>();
         StopWatch stopWatch = new StopWatch("node_close");
-        toClose.add(() -> stopWatch.stop().start("node_service"));
+        toClose.add(() -> stopWatch.start("node_service"));
         toClose.add(nodeService);
         toClose.add(() -> stopWatch.stop().start("http"));
         if (NetworkModule.HTTP_ENABLED.get(settings)) {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -777,7 +777,6 @@ public class Node implements Closeable {
         logger.info("closing ...");
         List<Closeable> toClose = new ArrayList<>();
         StopWatch stopWatch = new StopWatch("node_close");
-        toClose.add(() -> stopWatch.start("tribe"));
         toClose.add(() -> stopWatch.stop().start("node_service"));
         toClose.add(nodeService);
         toClose.add(() -> stopWatch.stop().start("http"));


### PR DESCRIPTION
While tribe node was removed in
https://github.com/elastic/elasticsearch/pull/28443, there remained a
couple lingering references to it in docs and code. This commit removes
those remaining references.