### PR TITLE
Exit batch files explictly using ERRORLEVEL

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.bat]
+indent_size = 2

--- a/distribution/src/bin/elasticsearch-cli.bat
+++ b/distribution/src/bin/elasticsearch-cli.bat
@@ -21,3 +21,5 @@ if defined ES_ADDITIONAL_CLASSPATH_DIRECTORIES (
   -cp "%ES_CLASSPATH%" ^
   "%ES_MAIN_CLASS%" ^
   %*
+  
+exit /b %ERRORLEVEL%

--- a/distribution/src/bin/elasticsearch-keystore.bat
+++ b/distribution/src/bin/elasticsearch-keystore.bat
@@ -4,9 +4,9 @@ setlocal enabledelayedexpansion
 setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.common.settings.KeyStoreCli
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/distribution/src/bin/elasticsearch-keystore.bat
+++ b/distribution/src/bin/elasticsearch-keystore.bat
@@ -5,8 +5,8 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.common.settings.KeyStoreCli
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal

--- a/distribution/src/bin/elasticsearch-keystore.bat
+++ b/distribution/src/bin/elasticsearch-keystore.bat
@@ -4,7 +4,9 @@ setlocal enabledelayedexpansion
 setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.common.settings.KeyStoreCli
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/distribution/src/bin/elasticsearch-node.bat
+++ b/distribution/src/bin/elasticsearch-node.bat
@@ -6,7 +6,9 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.cluster.coordination.NodeToolCli
 call "%~dp0elasticsearch-cli.bat" ^
   %%* ^
-  || exit /b 1
+  || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/distribution/src/bin/elasticsearch-plugin.bat
+++ b/distribution/src/bin/elasticsearch-plugin.bat
@@ -5,9 +5,10 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.plugins.PluginCli
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/plugin-cli
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+  
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/distribution/src/bin/elasticsearch-plugin.bat
+++ b/distribution/src/bin/elasticsearch-plugin.bat
@@ -5,7 +5,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.plugins.PluginCli
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/plugin-cli
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
   
 
 endlocal

--- a/distribution/src/bin/elasticsearch-plugin.bat
+++ b/distribution/src/bin/elasticsearch-plugin.bat
@@ -6,8 +6,8 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.plugins.PluginCli
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/plugin-cli
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
   
 
 endlocal

--- a/distribution/src/bin/elasticsearch-service.bat
+++ b/distribution/src/bin/elasticsearch-service.bat
@@ -258,3 +258,5 @@ goto:eof
 
 endlocal
 endlocal
+
+exit /b %ERRORLEVEL%

--- a/distribution/src/bin/elasticsearch-shard.bat
+++ b/distribution/src/bin/elasticsearch-shard.bat
@@ -4,9 +4,9 @@ setlocal enabledelayedexpansion
 setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.index.shard.ShardToolCli
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/distribution/src/bin/elasticsearch-shard.bat
+++ b/distribution/src/bin/elasticsearch-shard.bat
@@ -4,7 +4,9 @@ setlocal enabledelayedexpansion
 setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.index.shard.ShardToolCli
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/distribution/src/bin/elasticsearch-shard.bat
+++ b/distribution/src/bin/elasticsearch-shard.bat
@@ -5,8 +5,8 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.index.shard.ShardToolCli
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal

--- a/distribution/src/bin/elasticsearch.bat
+++ b/distribution/src/bin/elasticsearch.bat
@@ -55,3 +55,4 @@ cd /d "%ES_HOME%"
 
 endlocal
 endlocal
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
@@ -10,9 +10,9 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.cli.CertificateGenerateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/security-cli
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
@@ -11,8 +11,8 @@ set ES_MAIN_CLASS=org.elasticsearch.xpack.security.cli.CertificateGenerateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/security-cli
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
@@ -10,7 +10,9 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.cli.CertificateGenerateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/security-cli
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
@@ -11,8 +11,8 @@ set ES_MAIN_CLASS=org.elasticsearch.xpack.security.cli.CertificateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/security-cli
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
@@ -10,7 +10,9 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.cli.CertificateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/security-cli
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
@@ -10,9 +10,9 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.cli.CertificateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/security-cli
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
@@ -9,9 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.ESNativeRealmMigrateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
@@ -10,8 +10,8 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.ESNativeRealmMigrateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
@@ -9,7 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.ESNativeRealmMigrateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
@@ -9,9 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
@@ -9,7 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
@@ -10,8 +10,8 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
@@ -9,7 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.tool.SetupPasswordTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
@@ -9,9 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.tool.SetupPasswordTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
@@ -10,8 +10,8 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.tool.SetupPasswordTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
@@ -9,7 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.crypto.tool.SystemKeyTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
@@ -10,8 +10,8 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.crypto.tool.SystemKeyTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
@@ -9,9 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.crypto.tool.SystemKeyTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
@@ -10,8 +10,8 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.file.tool.UsersTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
@@ -9,7 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.file.tool.UsersTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
@@ -9,9 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.file.tool.UsersTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli.bat
+++ b/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli.bat
@@ -22,3 +22,4 @@ set CLI_JAR=%ES_HOME%/bin/*
 
 endlocal
 endlocal
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
+++ b/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
@@ -9,7 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.watcher.trigger.schedule.tool.CronEvalTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-watcher-env
-call "%~dp0elasticsearch-cli.bat" %%* || goto exit
+call "%~dp0elasticsearch-cli.bat" ^
+    %%* ^
+    || goto exit
 
 endlocal
 endlocal

--- a/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
+++ b/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
@@ -9,9 +9,9 @@ setlocal enableextensions
 
 set ES_MAIN_CLASS=org.elasticsearch.xpack.watcher.trigger.schedule.tool.CronEvalTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-watcher-env
-call "%~dp0elasticsearch-cli.bat" ^
-  %%* ^
-  || exit /b 1
+call "%~dp0elasticsearch-cli.bat" %%* || goto exit
 
 endlocal
 endlocal
+:exit
+exit /b %ERRORLEVEL%

--- a/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
+++ b/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
@@ -10,8 +10,8 @@ setlocal enableextensions
 set ES_MAIN_CLASS=org.elasticsearch.xpack.watcher.trigger.schedule.tool.CronEvalTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-watcher-env
 call "%~dp0elasticsearch-cli.bat" ^
-    %%* ^
-    || goto exit
+  %%* ^
+  || goto exit
 
 endlocal
 endlocal


### PR DESCRIPTION
This makes sure the exit code is preserved when calling the batch
files from different contexts other than DOS

Fixes #29582
