### PR TITLE
Avoid side-effect in VersionMap when assertion enabled

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/DeleteVersionValue.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/DeleteVersionValue.java
@@ -23,7 +23,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 
 /** Holds a deleted version, which just adds a timestamp to {@link VersionValue} so we know when we can expire the deletion. */
 
-class DeleteVersionValue extends VersionValue {
+final class DeleteVersionValue extends VersionValue {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DeleteVersionValue.class);
 

--- a/server/src/main/java/org/elasticsearch/index/engine/IndexVersionValue.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/IndexVersionValue.java
@@ -24,13 +24,13 @@ import org.elasticsearch.index.translog.Translog;
 
 import java.util.Objects;
 
-final class TranslogVersionValue extends VersionValue {
+final class IndexVersionValue extends VersionValue {
 
-    private static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(TranslogVersionValue.class);
+    private static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexVersionValue.class);
 
     private final Translog.Location translogLocation;
 
-    TranslogVersionValue(Translog.Location translogLocation, long version, long seqNo, long term) {
+    IndexVersionValue(Translog.Location translogLocation, long version, long seqNo, long term) {
         super(version, seqNo, term);
         this.translogLocation = translogLocation;
     }
@@ -45,7 +45,7 @@ final class TranslogVersionValue extends VersionValue {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
-        TranslogVersionValue that = (TranslogVersionValue) o;
+        IndexVersionValue that = (IndexVersionValue) o;
         return Objects.equals(translogLocation, that.translogLocation);
     }
 
@@ -56,7 +56,7 @@ final class TranslogVersionValue extends VersionValue {
 
     @Override
     public String toString() {
-        return "TranslogVersionValue{" +
+        return "IndexVersionValue{" +
             "version=" + version +
             ", seqNo=" + seqNo +
             ", term=" + term +

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -785,8 +785,9 @@ public class InternalEngine extends Engine {
                     indexResult.setTranslogLocation(location);
                 }
                 if (plan.indexIntoLucene && indexResult.hasFailure() == false) {
+                    final Translog.Location translogLocation = trackTranslogLocation.get() ? indexResult.getTranslogLocation() : null;
                     versionMap.maybePutIndexUnderLock(index.uid().bytes(),
-                        getVersionValue(plan.versionForIndexing, plan.seqNoForIndexing, index.primaryTerm(), indexResult.getTranslogLocation()));
+                        new IndexVersionValue(translogLocation, plan.versionForIndexing, plan.seqNoForIndexing, index.primaryTerm()));
                 }
                 if (indexResult.getSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO) {
                     localCheckpointTracker.markSeqNoAsCompleted(indexResult.getSeqNo());
@@ -935,10 +936,6 @@ public class InternalEngine extends Engine {
                 throw ex;
             }
         }
-    }
-
-    private IndexVersionValue getVersionValue(long version, long seqNo, long term, Translog.Location location) {
-        return new IndexVersionValue(trackTranslogLocation.get() ? location : null, version, seqNo, term);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -317,14 +317,17 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
         }
     }
 
-    // For testing
     void putIndexUnderLock(BytesRef uid, IndexVersionValue version) {
         assert assertKeyedLockHeldByCurrentThread(uid);
-        putIndexUnderLock(uid, version, maps);
+        assert uid.bytes.length == uid.length : "Oversized _uid! UID length: " + uid.length + ", bytes length: " + uid.bytes.length;
+        maps.put(uid, version);
+        removeTombstoneUnderLock(uid);
     }
 
     private boolean putAssertionMap(BytesRef uid, IndexVersionValue version) {
-        putIndexUnderLock(uid, version, unsafeKeysMap);
+        assert assertKeyedLockHeldByCurrentThread(uid);
+        assert uid.bytes.length == uid.length : "Oversized _uid! UID length: " + uid.length + ", bytes length: " + uid.bytes.length;
+        unsafeKeysMap.put(uid, version);
         return true;
     }
 
@@ -333,13 +336,6 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
         assert uid.bytes.length == uid.length : "Oversized _uid! UID length: " + uid.length + ", bytes length: " + uid.bytes.length;
         putTombstone(uid, version);
         maps.remove(uid, version);
-    }
-
-    private void putIndexUnderLock(BytesRef uid, IndexVersionValue version, Maps maps) {
-        assert assertKeyedLockHeldByCurrentThread(uid);
-        assert uid.bytes.length == uid.length : "Oversized _uid! UID length: " + uid.length + ", bytes length: " + uid.bytes.length;
-        maps.put(uid, version);
-        removeTombstoneUnderLock(uid);
     }
 
     private void putTombstone(BytesRef uid, DeleteVersionValue version) {

--- a/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -344,8 +344,8 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
             putUnderLock(uid, version, maps);
         } else {
             maps.current.markAsUnsafe();
-            assert putAssertionMap(uid, version);
         }
+        assert putAssertionMap(uid, version);
     }
 
     private boolean putAssertionMap(BytesRef uid, VersionValue version) {

--- a/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -268,7 +268,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
     }
 
     private VersionValue getUnderLock(final BytesRef uid, Maps currentMaps) {
-        assert keyedLock.isHeldByCurrentThread(uid);
+        assert assertKeyedLockHeldByCurrentThread(uid);
         // First try to get the "live" value:
         VersionValue value = currentMaps.current.get(uid);
         if (value != null) {
@@ -306,44 +306,40 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
     /**
      * Adds this uid/version to the pending adds map iff the map needs safe access.
      */
-    void maybePutUnderLock(BytesRef uid, VersionValue version) {
-        assert keyedLock.isHeldByCurrentThread(uid);
+    void maybePutIndexUnderLock(BytesRef uid, IndexVersionValue version) {
+        assert assertKeyedLockHeldByCurrentThread(uid);
         Maps maps = this.maps;
         if (maps.isSafeAccessMode()) {
-            putUnderLock(uid, version, maps);
+            putIndexUnderLock(uid, version);
         } else {
             maps.current.markAsUnsafe();
             assert putAssertionMap(uid, version);
         }
     }
 
-    private boolean putAssertionMap(BytesRef uid, VersionValue version) {
-        putUnderLock(uid, version, unsafeKeysMap);
+    // For testing
+    void putIndexUnderLock(BytesRef uid, IndexVersionValue version) {
+        assert assertKeyedLockHeldByCurrentThread(uid);
+        putIndexUnderLock(uid, version, maps);
+    }
+
+    private boolean putAssertionMap(BytesRef uid, IndexVersionValue version) {
+        putIndexUnderLock(uid, version, unsafeKeysMap);
         return true;
     }
 
-    /**
-     * Adds this uid/version to the pending adds map.
-     */
-    void putUnderLock(BytesRef uid, VersionValue version) {
-        Maps maps = this.maps;
-        putUnderLock(uid, version, maps);
+    void putDeleteUnderLock(BytesRef uid, DeleteVersionValue version) {
+        assert assertKeyedLockHeldByCurrentThread(uid);
+        assert uid.bytes.length == uid.length : "Oversized _uid! UID length: " + uid.length + ", bytes length: " + uid.bytes.length;
+        putTombstone(uid, version);
+        maps.remove(uid, version);
     }
 
-    /**
-     * Adds this uid/version to the pending adds map.
-     */
-    private void putUnderLock(BytesRef uid, VersionValue version, Maps maps) {
-        assert keyedLock.isHeldByCurrentThread(uid);
+    private void putIndexUnderLock(BytesRef uid, IndexVersionValue version, Maps maps) {
+        assert assertKeyedLockHeldByCurrentThread(uid);
         assert uid.bytes.length == uid.length : "Oversized _uid! UID length: " + uid.length + ", bytes length: " + uid.bytes.length;
-        if (version.isDelete() == false) {
-            maps.put(uid, version);
-            removeTombstoneUnderLock(uid);
-        } else {
-            DeleteVersionValue versionValue = (DeleteVersionValue) version;
-            putTombstone(uid, versionValue);
-            maps.remove(uid, versionValue);
-        }
+        maps.put(uid, version);
+        removeTombstoneUnderLock(uid);
     }
 
     private void putTombstone(BytesRef uid, DeleteVersionValue version) {
@@ -365,7 +361,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
      * Removes this uid from the pending deletes map.
      */
     void removeTombstoneUnderLock(BytesRef uid) {
-        assert keyedLock.isHeldByCurrentThread(uid);
+        assert assertKeyedLockHeldByCurrentThread(uid);
         long uidRAMBytesUsed = BASE_BYTES_PER_BYTESREF + uid.bytes.length;
         final VersionValue prev = tombstones.remove(uid);
         if (prev != null) {
@@ -464,5 +460,10 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
      */
     Releasable acquireLock(BytesRef uid) {
         return keyedLock.acquire(uid);
+    }
+
+    private boolean assertKeyedLockHeldByCurrentThread(BytesRef uid) {
+        assert keyedLock.isHeldByCurrentThread(uid) : "Thread [" + Thread.currentThread().getName() + "], uid [" + uid.utf8ToString() + "]";
+        return true;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -344,8 +344,8 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
             putUnderLock(uid, version, maps);
         } else {
             maps.current.markAsUnsafe();
+            assert putAssertionMap(uid, version);
         }
-        assert putAssertionMap(uid, version);
     }
 
     private boolean putAssertionMap(BytesRef uid, VersionValue version) {

--- a/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -102,40 +102,6 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
 
     }
 
-    private static final class Tombstones {
-        final Map<BytesRef, DeleteVersionValue> tombstones = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
-        final AtomicLong ramBytesUsedTombstones = new AtomicLong();
-
-        void putTombstone(BytesRef uid, DeleteVersionValue version) {
-            long uidRAMBytesUsed = BASE_BYTES_PER_BYTESREF + uid.bytes.length;
-            // Also enroll the delete into tombstones, and account for its RAM too:
-            final VersionValue prevTombstone = tombstones.put(uid, version);
-            long accountRam = (BASE_BYTES_PER_CHM_ENTRY + version.ramBytesUsed() + uidRAMBytesUsed);
-            // Deduct tombstones bytes used for the version we just removed or replaced:
-            if (prevTombstone != null) {
-                accountRam -= (BASE_BYTES_PER_CHM_ENTRY + prevTombstone.ramBytesUsed() + uidRAMBytesUsed);
-            }
-            if (accountRam != 0) {
-                long v = ramBytesUsedTombstones.addAndGet(accountRam);
-                assert v >= 0 : "bytes=" + v;
-            }
-        }
-
-        void removeTombstone(BytesRef uid) {
-            long uidRAMBytesUsed = BASE_BYTES_PER_BYTESREF + uid.bytes.length;
-            final VersionValue prev = tombstones.remove(uid);
-            if (prev != null) {
-                assert prev.isDelete();
-                long v = ramBytesUsedTombstones.addAndGet(-(BASE_BYTES_PER_CHM_ENTRY + prev.ramBytesUsed() + uidRAMBytesUsed));
-                assert v >= 0 : "bytes=" + v;
-            }
-        }
-
-        DeleteVersionValue getTombstone(BytesRef uid) {
-            return tombstones.get(uid);
-        }
-    }
-
     private static final class Maps {
 
         // All writes (adds and deletes) go into here:
@@ -149,19 +115,15 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
         boolean needsSafeAccess;
         final boolean previousMapsNeededSafeAccess;
 
-        // All deletes also go here, and delete "tombstones" are retained after refresh:
-        private final Tombstones tombstones;
 
-        Maps(VersionLookup current, VersionLookup old, boolean previousMapsNeededSafeAccess, Tombstones tombstones) {
+        Maps(VersionLookup current, VersionLookup old, boolean previousMapsNeededSafeAccess) {
             this.current = current;
             this.old = old;
             this.previousMapsNeededSafeAccess = previousMapsNeededSafeAccess;
-            this.tombstones = tombstones; // transfer the tombstone
         }
 
         Maps() {
-            this(new VersionLookup(ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency()), VersionLookup.EMPTY, false,
-                new Tombstones());
+            this(new VersionLookup(ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency()), VersionLookup.EMPTY, false);
         }
 
         boolean isSafeAccessMode() {
@@ -180,14 +142,14 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
          */
         Maps buildTransitionMap() {
             return new Maps(new VersionLookup(ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency(current.size())), current,
-                shouldInheritSafeAccess(), tombstones);
+                shouldInheritSafeAccess());
         }
 
         /**
          * builds a new map that invalidates the old map but maintains the current. This should be called in afterRefresh()
          */
         Maps invalidateOldMap() {
-            return new Maps(current, VersionLookup.EMPTY, previousMapsNeededSafeAccess, tombstones);
+            return new Maps(current, VersionLookup.EMPTY, previousMapsNeededSafeAccess);
         }
 
         void put(BytesRef uid, VersionValue version) {
@@ -224,6 +186,8 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
         }
     }
 
+    // All deletes also go here, and delete "tombstones" are retained after refresh:
+    private final Map<BytesRef, DeleteVersionValue> tombstones = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 
     private volatile Maps maps = new Maps();
     // we maintain a second map that only receives the updates that we skip on the actual map (unsafe ops)
@@ -264,6 +228,11 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
         // not be fully loaded
         BASE_BYTES_PER_CHM_ENTRY = chmEntryShallowSize + 2 * RamUsageEstimator.NUM_BYTES_OBJECT_REF;
     }
+
+    /**
+     * Tracks bytes used by tombstones (deletes)
+     */
+    final AtomicLong ramBytesUsedTombstones = new AtomicLong();
 
     @Override
     public void beforeRefresh() throws IOException {
@@ -311,7 +280,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
             return value;
         }
 
-        return maps.tombstones.getTombstone(uid);
+        return tombstones.get(uid);
     }
 
     VersionValue getVersionForAssert(final BytesRef uid) {
@@ -369,18 +338,41 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
         assert uid.bytes.length == uid.length : "Oversized _uid! UID length: " + uid.length + ", bytes length: " + uid.bytes.length;
         if (version.isDelete() == false) {
             maps.put(uid, version);
-            maps.tombstones.removeTombstone(uid);
+            removeTombstoneUnderLock(uid);
         } else {
             DeleteVersionValue versionValue = (DeleteVersionValue) version;
-            maps.tombstones.putTombstone(uid, versionValue);
+            putTombstone(uid, versionValue);
             maps.remove(uid, versionValue);
         }
     }
 
-    // For testing
+    private void putTombstone(BytesRef uid, DeleteVersionValue version) {
+        long uidRAMBytesUsed = BASE_BYTES_PER_BYTESREF + uid.bytes.length;
+        // Also enroll the delete into tombstones, and account for its RAM too:
+        final VersionValue prevTombstone = tombstones.put(uid, version);
+        long accountRam = (BASE_BYTES_PER_CHM_ENTRY + version.ramBytesUsed() + uidRAMBytesUsed);
+        // Deduct tombstones bytes used for the version we just removed or replaced:
+        if (prevTombstone != null) {
+            accountRam -= (BASE_BYTES_PER_CHM_ENTRY + prevTombstone.ramBytesUsed() + uidRAMBytesUsed);
+        }
+        if (accountRam != 0) {
+            long v = ramBytesUsedTombstones.addAndGet(accountRam);
+            assert v >= 0: "bytes=" + v;
+        }
+    }
+
+    /**
+     * Removes this uid from the pending deletes map.
+     */
     void removeTombstoneUnderLock(BytesRef uid) {
-        assert keyedLock.isHeldByCurrentThread(uid) : Thread.currentThread().getName();
-        maps.tombstones.removeTombstone(uid);
+        assert keyedLock.isHeldByCurrentThread(uid);
+        long uidRAMBytesUsed = BASE_BYTES_PER_BYTESREF + uid.bytes.length;
+        final VersionValue prev = tombstones.remove(uid);
+        if (prev != null) {
+            assert prev.isDelete();
+            long v = ramBytesUsedTombstones.addAndGet(-(BASE_BYTES_PER_CHM_ENTRY + prev.ramBytesUsed() + uidRAMBytesUsed));
+            assert v >= 0 : "bytes=" + v;
+        }
     }
 
     private boolean canRemoveTombstone(long maxTimestampToPrune, long maxSeqNoToPrune, DeleteVersionValue versionValue) {
@@ -397,8 +389,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
      * Try to prune tombstones whose timestamp is less than maxTimestampToPrune and seqno at most the maxSeqNoToPrune.
      */
     void pruneTombstones(long maxTimestampToPrune, long maxSeqNoToPrune) {
-        final Tombstones tombstones = maps.tombstones;
-        for (Map.Entry<BytesRef, DeleteVersionValue> entry : tombstones.tombstones.entrySet()) {
+        for (Map.Entry<BytesRef, DeleteVersionValue> entry : tombstones.entrySet()) {
             // we do check before we actually lock the key - this way we don't need to acquire the lock for tombstones that are not
             // prune-able. If the tombstone changes concurrently we will re-read and step out below since if we can't collect it now w
             // we won't collect the tombstone below since it must be newer than this one.
@@ -410,10 +401,10 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
                     // if we do use a blocking acquire. see #28714
                     if (lock != null) { // did we get the lock?
                         // Must re-get it here, vs using entry.getValue(), in case the uid was indexed/deleted since we pulled the iterator:
-                        final DeleteVersionValue versionValue = tombstones.getTombstone(uid);
+                        final DeleteVersionValue versionValue = tombstones.get(uid);
                         if (versionValue != null) {
                             if (canRemoveTombstone(maxTimestampToPrune, maxSeqNoToPrune, versionValue)) {
-                                tombstones.removeTombstone(uid);
+                                removeTombstoneUnderLock(uid);
                             }
                         }
                     }
@@ -427,6 +418,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
      */
     synchronized void clear() {
         maps = new Maps();
+        tombstones.clear();
         // NOTE: we can't zero this here, because a refresh thread could be calling InternalEngine.pruneDeletedTombstones at the same time,
         // and this will lead to an assert trip.  Presumably it's fine if our ramBytesUsedTombstones is non-zero after clear since the index
         // is being closed:
@@ -435,7 +427,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
 
     @Override
     public long ramBytesUsed() {
-        return maps.current.ramBytesUsed.get() + maps.tombstones.ramBytesUsedTombstones.get();
+        return maps.current.ramBytesUsed.get() + ramBytesUsedTombstones.get();
     }
 
     /**
@@ -461,7 +453,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
 
     /** Iterates over all deleted versions, including new ones (not yet exposed via reader) and old ones (exposed via reader but not yet GC'd). */
     Map<BytesRef, DeleteVersionValue> getAllTombstones() {
-        return maps.tombstones.tombstones;
+        return tombstones;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/engine/VersionValue.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/VersionValue.java
@@ -27,7 +27,7 @@ import org.elasticsearch.index.translog.Translog;
 import java.util.Collection;
 import java.util.Collections;
 
-class VersionValue implements Accountable {
+abstract class VersionValue implements Accountable {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(VersionValue.class);
 

--- a/server/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTests.java
@@ -25,6 +25,7 @@ import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.RamUsageTester;
 import org.apache.lucene.util.TestUtil;
 import org.elasticsearch.common.lease.Releasable;
+import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -47,9 +48,8 @@ public class LiveVersionMapTests extends ESTestCase {
         for (int i = 0; i < 100000; ++i) {
             BytesRefBuilder uid = new BytesRefBuilder();
             uid.copyChars(TestUtil.randomSimpleString(random(), 10, 20));
-            VersionValue version = new VersionValue(randomLong(), randomLong(), randomLong());
             try (Releasable r = map.acquireLock(uid.toBytesRef())) {
-                map.putUnderLock(uid.toBytesRef(), version);
+                map.putIndexUnderLock(uid.toBytesRef(), randomIndexVersionValue());
             }
         }
         long actualRamBytesUsed = RamUsageTester.sizeOf(map);
@@ -64,9 +64,8 @@ public class LiveVersionMapTests extends ESTestCase {
         for (int i = 0; i < 100000; ++i) {
             BytesRefBuilder uid = new BytesRefBuilder();
             uid.copyChars(TestUtil.randomSimpleString(random(), 10, 20));
-            VersionValue version = new VersionValue(randomLong(), randomLong(), randomLong());
             try (Releasable r = map.acquireLock(uid.toBytesRef())) {
-                map.putUnderLock(uid.toBytesRef(), version);
+                map.putIndexUnderLock(uid.toBytesRef(), randomIndexVersionValue());
             }
         }
         actualRamBytesUsed = RamUsageTester.sizeOf(map);
@@ -100,14 +99,15 @@ public class LiveVersionMapTests extends ESTestCase {
     public void testBasics() throws IOException {
         LiveVersionMap map = new LiveVersionMap();
         try (Releasable r = map.acquireLock(uid("test"))) {
-            map.putUnderLock(uid("test"), new VersionValue(1,1,1));
-            assertEquals(new VersionValue(1,1,1), map.getUnderLock(uid("test")));
+            Translog.Location tlogLoc = randomTranslogLocation();
+            map.putIndexUnderLock(uid("test"), new IndexVersionValue(tlogLoc, 1, 1, 1));
+            assertEquals(new IndexVersionValue(tlogLoc, 1, 1, 1), map.getUnderLock(uid("test")));
             map.beforeRefresh();
-            assertEquals(new VersionValue(1,1,1), map.getUnderLock(uid("test")));
+            assertEquals(new IndexVersionValue(tlogLoc, 1, 1, 1), map.getUnderLock(uid("test")));
             map.afterRefresh(randomBoolean());
             assertNull(map.getUnderLock(uid("test")));
 
-            map.putUnderLock(uid("test"), new DeleteVersionValue(1,1,1,1));
+            map.putDeleteUnderLock(uid("test"), new DeleteVersionValue(1,1,1,1));
             assertEquals(new DeleteVersionValue(1,1,1,1), map.getUnderLock(uid("test")));
             map.beforeRefresh();
             assertEquals(new DeleteVersionValue(1,1,1,1), map.getUnderLock(uid("test")));
@@ -154,7 +154,8 @@ public class LiveVersionMapTests extends ESTestCase {
                         BytesRef bytesRef = randomFrom(random(), keyList);
                         try (Releasable r = map.acquireLock(bytesRef)) {
                             VersionValue versionValue = values.computeIfAbsent(bytesRef,
-                                v -> new VersionValue(randomLong(), maxSeqNo.incrementAndGet(), randomLong()));
+                                v -> new IndexVersionValue(
+                                    randomTranslogLocation(), randomLong(), maxSeqNo.incrementAndGet(), randomLong()));
                             boolean isDelete = versionValue instanceof DeleteVersionValue;
                             if (isDelete) {
                                 map.removeTombstoneUnderLock(bytesRef);
@@ -165,10 +166,11 @@ public class LiveVersionMapTests extends ESTestCase {
                                     versionValue.term, clock.getAndIncrement());
                                 deletes.put(bytesRef, (DeleteVersionValue) versionValue);
                             } else {
-                                versionValue = new VersionValue(versionValue.version + 1, maxSeqNo.incrementAndGet(), versionValue.term);
+                                versionValue = new IndexVersionValue(randomTranslogLocation(), versionValue.version + 1,
+                                    maxSeqNo.incrementAndGet(), versionValue.term);
                             }
                             values.put(bytesRef, versionValue);
-                            map.putUnderLock(bytesRef, versionValue);
+                            putUnderLock(map, bytesRef, versionValue);
                         }
                         if (rarely()) {
                             final long pruneSeqNo = randomLongBetween(0, maxSeqNo.get());
@@ -268,7 +270,7 @@ public class LiveVersionMapTests extends ESTestCase {
         }
 
         try (Releasable r = map.acquireLock(uid(""))) {
-            map.maybePutUnderLock(new BytesRef(""), new VersionValue(randomLong(), randomLong(), randomLong()));
+            map.maybePutIndexUnderLock(new BytesRef(""), randomIndexVersionValue());
         }
         assertFalse(map.isUnsafe());
         assertEquals(1, map.getAllCurrent().size());
@@ -278,7 +280,7 @@ public class LiveVersionMapTests extends ESTestCase {
         assertFalse(map.isUnsafe());
         assertFalse(map.isSafeAccessRequired());
         try (Releasable r = map.acquireLock(uid(""))) {
-            map.maybePutUnderLock(new BytesRef(""), new VersionValue(randomLong(), randomLong(), randomLong()));
+            map.maybePutIndexUnderLock(new BytesRef(""), randomIndexVersionValue());
         }
         assertTrue(map.isUnsafe());
         assertFalse(map.isSafeAccessRequired());
@@ -288,7 +290,7 @@ public class LiveVersionMapTests extends ESTestCase {
     public void testRefreshTransition() throws IOException {
         LiveVersionMap map = new LiveVersionMap();
         try (Releasable r = map.acquireLock(uid("1"))) {
-            map.maybePutUnderLock(uid("1"), new VersionValue(randomLong(), randomLong(), randomLong()));
+            map.maybePutIndexUnderLock(uid("1"), randomIndexVersionValue());
             assertTrue(map.isUnsafe());
             assertNull(map.getUnderLock(uid("1")));
             map.beforeRefresh();
@@ -299,7 +301,7 @@ public class LiveVersionMapTests extends ESTestCase {
             assertFalse(map.isUnsafe());
 
             map.enforceSafeAccess();
-            map.maybePutUnderLock(uid("1"), new VersionValue(randomLong(), randomLong(), randomLong()));
+            map.maybePutIndexUnderLock(uid("1"), randomIndexVersionValue());
             assertFalse(map.isUnsafe());
             assertNotNull(map.getUnderLock(uid("1")));
             map.beforeRefresh();
@@ -320,9 +322,9 @@ public class LiveVersionMapTests extends ESTestCase {
         AtomicLong version = new AtomicLong();
         CountDownLatch start = new CountDownLatch(2);
         BytesRef uid = uid("1");
-        VersionValue initialVersion = new VersionValue(version.incrementAndGet(), 1, 1);
+        VersionValue initialVersion = new IndexVersionValue(randomTranslogLocation(), version.incrementAndGet(), 1, 1);
         try (Releasable ignore = map.acquireLock(uid)) {
-            map.putUnderLock(uid, initialVersion);
+            putUnderLock(map, uid, initialVersion);
         }
         Thread t = new Thread(() -> {
             start.countDown();
@@ -338,13 +340,13 @@ public class LiveVersionMapTests extends ESTestCase {
                             underLock = nextVersionValue;
                         }
                         if (underLock.isDelete()) {
-                            nextVersionValue = new VersionValue(version.incrementAndGet(), 1, 1);
+                            nextVersionValue = new IndexVersionValue(randomTranslogLocation(), version.incrementAndGet(), 1, 1);
                         } else if (randomBoolean()) {
-                            nextVersionValue = new VersionValue(version.incrementAndGet(), 1, 1);
+                            nextVersionValue = new IndexVersionValue(randomTranslogLocation(), version.incrementAndGet(), 1, 1);
                         } else {
                             nextVersionValue = new DeleteVersionValue(version.incrementAndGet(), 1, 1, 0);
                         }
-                        map.putUnderLock(uid, nextVersionValue);
+                        putUnderLock(map, uid, nextVersionValue);
                     }
                 }
             } catch (Exception e) {
@@ -375,7 +377,7 @@ public class LiveVersionMapTests extends ESTestCase {
         BytesRef uid = uid("1");
         ;
         try (Releasable ignore = map.acquireLock(uid)) {
-            map.putUnderLock(uid, new DeleteVersionValue(0, 0, 0, 0));
+            map.putDeleteUnderLock(uid, new DeleteVersionValue(0, 0, 0, 0));
             map.beforeRefresh(); // refresh otherwise we won't prune since it's tracked by the current map
             map.afterRefresh(false);
             Thread thread = new Thread(() -> {
@@ -391,5 +393,25 @@ public class LiveVersionMapTests extends ESTestCase {
         thread.start();
         thread.join();
         assertEquals(0, map.getAllTombstones().size());
+    }
+
+    void putUnderLock(LiveVersionMap maps, BytesRef uid, VersionValue version) {
+        if (version instanceof IndexVersionValue) {
+            maps.putIndexUnderLock(uid, (IndexVersionValue) version);
+        } else {
+            maps.putDeleteUnderLock(uid, (DeleteVersionValue) version);
+        }
+    }
+
+    IndexVersionValue randomIndexVersionValue() {
+        return new IndexVersionValue(randomTranslogLocation(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());
+    }
+
+    Translog.Location randomTranslogLocation() {
+        if (randomBoolean()) {
+            return null;
+        } else {
+            return new Translog.Location(randomNonNegativeLong(), randomNonNegativeLong(), randomInt());
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/VersionValueTests.java
@@ -20,12 +20,17 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.lucene.util.RamUsageTester;
+import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.test.ESTestCase;
 
 public class VersionValueTests extends ESTestCase {
 
-    public void testRamBytesUsed() {
-        VersionValue versionValue = new VersionValue(randomLong(), randomLong(), randomLong());
+    public void testIndexRamBytesUsed() {
+        Translog.Location translogLoc = null;
+        if (randomBoolean()) {
+            translogLoc = new Translog.Location(randomNonNegativeLong(), randomNonNegativeLong(), randomInt());
+        }
+        IndexVersionValue versionValue = new IndexVersionValue(translogLoc, randomLong(), randomLong(), randomLong());
         assertEquals(RamUsageTester.sizeOf(versionValue), versionValue.ramBytesUsed());
     }
 


### PR DESCRIPTION
Today when a version map does not require safe access, we will skip that document. However, if the assertion is enabled, we remove the delete tombstone of that document if existed. This side-effect may accidentally  hide bugs in which stale delete tombstones can be accessed.

This change makes sure that putAssertionMap does not modify the tombstone maps.