### PR TITLE
Update plan for the removal of mapping types.

### DIFF
--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -265,7 +265,7 @@ Elasticsearch 7.x::
 
 * The index creation, `GET|PUT _mapping` and document APIs support a query
   string parameter (`include_type_name`) which indicates whether requests and
-  responses should include a layer for the type name. It defaults to `true`.
+  responses should include a type name. It defaults to `true`.
   7.x indices which don't have an explicit type will use the dummy type name
   `_doc`. Not setting `include_type_name=false` will result in a deprecation
   warning.

--- a/docs/reference/mapping/removal_of_types.asciidoc
+++ b/docs/reference/mapping/removal_of_types.asciidoc
@@ -258,15 +258,17 @@ Elasticsearch 6.x::
 
 Elasticsearch 7.x::
 
-* The `type` parameter in URLs are optional.  For instance, indexing
+* The `type` parameter in URLs are deprecated.  For instance, indexing
   a document no longer requires a document `type`.  The new index APIs
   are `PUT {index}/_doc/{id}` in case of explicit ids and `POST {index}/_doc`
   for auto-generated ids.
 
-* The `GET|PUT _mapping` APIs support a query string parameter
-  (`include_type_name`) which indicates whether the body should include
-  a layer for the type name. It defaults to `true`. 7.x indices which
-  don't have an explicit type will use the dummy type name `_doc`.
+* The index creation, `GET|PUT _mapping` and document APIs support a query
+  string parameter (`include_type_name`) which indicates whether requests and
+  responses should include a layer for the type name. It defaults to `true`.
+  7.x indices which don't have an explicit type will use the dummy type name
+  `_doc`. Not setting `include_type_name=false` will result in a deprecation
+  warning.
 
 * The `_default_` mapping type is removed.
 
@@ -274,7 +276,8 @@ Elasticsearch 8.x::
 
 * The `type` parameter is no longer supported in URLs.
 
-* The `include_type_name` parameter defaults to `false`.
+* The `include_type_name` parameter is deprecated, default to `false` and fails
+  the request when set to `true`.
 
 Elasticsearch 9.x::
 


### PR DESCRIPTION
8.x will no longer allow types in APIs and 7.x will issue deprecation warnings
when `include_type_name` is not set to `false`.
