### PR TITLE
Never leave stale delete tombstones in version map

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -312,6 +312,10 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
         if (maps.isSafeAccessMode()) {
             putIndexUnderLock(uid, version);
         } else {
+            // The existing delete tombstone is no longer the latest version (.i.e stale)
+            // when a newer version is processed regardless of the safe mode of the version map.
+            // Therefore, it's better to always prune that tombstone to avoid accidental accesses.
+            removeTombstoneUnderLock(uid);
             maps.current.markAsUnsafe();
             assert putAssertionMap(uid, version);
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -312,9 +312,9 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
         if (maps.isSafeAccessMode()) {
             putIndexUnderLock(uid, version);
         } else {
-            // The existing delete tombstone is no longer the latest version (.i.e stale)
-            // when a newer version is processed regardless of the safe mode of the version map.
-            // Therefore, it's better to always prune that tombstone to avoid accidental accesses.
+            // Even though we don't store a record of the indexing operation (and mark as unsafe),
+            // we should still remove any previous delete for this uuid (avoid accidental accesses).
+            // Not this should not hurt performance because the tombstone is small (or empty) when unsafe is relevant.
             removeTombstoneUnderLock(uid);
             maps.current.markAsUnsafe();
             assert putAssertionMap(uid, version);

--- a/server/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/LiveVersionMapTests.java
@@ -403,7 +403,7 @@ public class LiveVersionMapTests extends ESTestCase {
         final BytesRef uid = uid("1");
         final long versions = between(10, 1000);
         VersionValue latestVersion = null;
-        for (long i = 0; i <= versions; i++) {
+        for (long i = 0; i < versions; i++) {
             if (randomBoolean()) {
                 versionMap.beforeRefresh();
                 versionMap.afterRefresh(randomBoolean());


### PR DESCRIPTION
Today the VersionMap does not clean up a stale delete tombstone if it
does not require safe access. However, in a very rare situation due to
concurrent refreshes, the safe-access flag may be flipped over then an
engine accidentally consult that stale delete tombstone.

This commit ensures to never leave stale delete tombstones in a version
map by always pruning delete tombstones when putting a new index entry
regardless of the value of the safe-access flag.