### PR TITLE
Remove 7.0.0 from 6.x changelog

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -5,27 +5,9 @@
 
 = Elasticsearch Release Notes
 
-== Elasticsearch 7.0.0
-
-=== Breaking Changes
-
-=== Breaking Java Changes
-
-=== Deprecations
-
-=== New Features 
-
-=== Enhancements
-
-=== Bug Fixes
-
-=== Regressions
-
-=== Known Issues
-
 == Elasticsearch version 6.3.0
 
-=== New Features 
+=== New Features
 
 === Enhancements
 


### PR DESCRIPTION
This commit removes 7.0.0 entires from the changelog for the 6.x branch.

