### PR TITLE
Remove stale comment from JVM stats

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -82,10 +82,8 @@ public class JvmStats implements Writeable, ToXContentFragment {
                         peakUsage.getUsed() < 0 ? 0 : peakUsage.getUsed(),
                         peakUsage.getMax() < 0 ? 0 : peakUsage.getMax()
                 ));
-            } catch (Exception ex) {
-                /* ignore some JVMs might barf here with:
-                 * java.lang.InternalError: Memory Pool not found
-                 * we just omit the pool in that case!*/
+            } catch (final Exception ignored) {
+
             }
         }
         Mem mem = new Mem(heapCommitted, heapUsed, heapMax, nonHeapCommitted, nonHeapUsed, Collections.unmodifiableList(pools));


### PR DESCRIPTION
We removed catched throwable from the code base and left behind was a comment about catching InternalError in MemoryManagementMXBean. We are not going to catch InternalError here as we expect that to be fatal. This commit removes that stale comment.

Closes #29624