### PR TITLE
Deprecate the suggest metrics

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -344,7 +344,6 @@ Supported metrics are:
 * `search`
 * `segments`
 * `store`
-* `suggest`
 * `translog`
 * `warmer`
 

--- a/docs/reference/migration/migrate_6_3.asciidoc
+++ b/docs/reference/migration/migrate_6_3.asciidoc
@@ -60,3 +60,14 @@ place) you can start Elasticsearch with the JVM option
 `-Des.thread_pool.write.use_bulk_as_display_name=true` to have Elasticsearch
 continue to display the name of this thread pool as `bulk`. Elasticsearch will
 stop observing this system property in 7.0.0.
+
+==== Suggest stats metrics deprecated
+
+The suggest stats were previously folded into the search on the indices stats
+API. As such, the `suggest` metric on the indices stats API has been a synonym
+for the `search` metric. In 6.3.0, the `suggest` metric is deprecated in favor
+of using `search`.
+
+Similarly, the `suggest` index metric on the `indices` metric on the nodes stats
+API has provided a response containing only an empty object since 5.0.0. In
+6.3.0 this metric has been deprecated.

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -148,7 +148,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
                         if (handler != null) {
                             if ("suggest".equals(indexMetric)) {
                                 deprecationLogger.deprecated(
-                                        "the suggest flag is deprecated on the nodes stats API [" + request.uri() + "]");
+                                        "the suggest index metric is deprecated on the nodes stats API [" + request.uri() + "]");
                             }
                             handler.accept(flags);
                         } else {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -146,6 +146,10 @@ public class RestNodesStatsAction extends BaseRestHandler {
                     for (final String indexMetric : indexMetrics) {
                         final Consumer<CommonStatsFlags> handler = FLAGS.get(indexMetric);
                         if (handler != null) {
+                            if ("suggest".equals(indexMetric)) {
+                                deprecationLogger.deprecated(
+                                        "the suggest flag is deprecated on the nodes stats API [" + request.uri() + "]");
+                            }
                             handler.accept(flags);
                         } else {
                             invalidIndexMetrics.add(indexMetric);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -103,7 +103,7 @@ public class RestIndicesStatsAction extends BaseRestHandler {
                 final Consumer<IndicesStatsRequest> consumer = METRICS.get(metric);
                 if (consumer != null) {
                     if ("suggest".equals(metric)) {
-                        deprecationLogger.deprecated("the suggest flag is deprecated on the indices stats API [" + request.uri() + "]");
+                        deprecationLogger.deprecated("the suggest metric is deprecated on the indices stats API [" + request.uri() + "]");
                     }
                     consumer.accept(indicesStatsRequest);
                 } else {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -102,6 +102,9 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             for (final String metric : metrics) {
                 final Consumer<IndicesStatsRequest> consumer = METRICS.get(metric);
                 if (consumer != null) {
+                    if ("suggest".equals(metric)) {
+                        deprecationLogger.deprecated("the suggest flag is deprecated on the indices stats API [" + request.uri() + "]");
+                    }
                     consumer.accept(indicesStatsRequest);
                 } else {
                     invalidMetrics.add(metric);

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
@@ -155,7 +155,7 @@ public class RestNodesStatsActionTests extends ESTestCase {
         final RestRequest request =
                 new FakeRestRequest.Builder(xContentRegistry()).withPath("/_nodes/stats").withParams(params).build();
         action.prepareRequest(request, mock(NodeClient.class));
-        assertWarnings("the suggest flag is deprecated on the nodes stats API [/_nodes/stats]" );
+        assertWarnings("the suggest index metric is deprecated on the nodes stats API [/_nodes/stats]" );
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.rest.action.admin.cluster;
 
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -31,7 +32,10 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.object.HasToString.hasToString;
@@ -142,6 +146,16 @@ public class RestNodesStatsActionTests extends ESTestCase {
             e,
             hasToString(
                 containsString("request [/_nodes/stats] contains index metrics [" + indexMetric + "] but all stats requested")));
+    }
+
+    public void testSuggestIsDeprecated() throws IOException {
+        final Map<String, String> params =
+                Stream.of(Tuple.tuple("metric", "indices"), Tuple.tuple("index_metric", "suggest"))
+                        .collect(Collectors.toMap(Tuple::v1, Tuple::v2));
+        final RestRequest request =
+                new FakeRestRequest.Builder(xContentRegistry()).withPath("/_nodes/stats").withParams(params).build();
+        action.prepareRequest(request, mock(NodeClient.class));
+        assertWarnings("the suggest flag is deprecated on the nodes stats API [/_nodes/stats]" );
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
@@ -86,7 +86,7 @@ public class RestIndicesStatsActionTests extends ESTestCase {
 
     public void testSuggestIsDeprecated() throws IOException {
         final Map<String, String> params = Collections.singletonMap("metric", "suggest");
-        final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_stats/suggest").withParams(params).build();
+        final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_stats").withParams(params).build();
         action.prepareRequest(request, mock(NodeClient.class));
         assertWarnings("the suggest metric is deprecated on the indices stats API [/_stats]");
     }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
@@ -88,7 +88,7 @@ public class RestIndicesStatsActionTests extends ESTestCase {
         final Map<String, String> params = Collections.singletonMap("metric", "suggest");
         final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_stats/suggest").withParams(params).build();
         action.prepareRequest(request, mock(NodeClient.class));
-        assertWarnings("the suggest flag is deprecated on the indices stats API [/_stats]");
+        assertWarnings("the suggest metric is deprecated on the indices stats API [/_stats]");
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.usage.UsageService;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.object.HasToString.hasToString;
@@ -81,6 +82,13 @@ public class RestIndicesStatsActionTests extends ESTestCase {
             IllegalArgumentException.class,
             () -> action.prepareRequest(request, mock(NodeClient.class)));
         assertThat(e, hasToString(containsString("request [/_stats] contains _all and individual metrics [_all," + metric + "]")));
+    }
+
+    public void testSuggestIsDeprecated() throws IOException {
+        final Map<String, String> params = Collections.singletonMap("metric", "suggest");
+        final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_stats/suggest").withParams(params).build();
+        action.prepareRequest(request, mock(NodeClient.class));
+        assertWarnings("the suggest flag is deprecated on the indices stats API [/_stats]");
     }
 
 }


### PR DESCRIPTION
The suggest stats were folded into the search stats as part of the indices stats API in 5.0.0. However, the suggest metric remained as a synonym for the search metric for BWC reasons. This commit deprecates usage of the suggest metric on the indices stats API.

Similarly, due to the changes to fold the suggest stats into the search stats, requesting the suggest index metric on the indices metric on the nodes stats API has produced an empty object as the response since 5.0.0. This commit deprecates this index metric on the indices metric on the nodes stats API.

Relates #29589