### PR TITLE
Implement Iterator#remove for Cache values iter

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/cache/Cache.java
+++ b/server/src/main/java/org/elasticsearch/common/cache/Cache.java
@@ -580,7 +580,8 @@ public class Cache<K, V> {
 
     /**
      * An LRU sequencing of the values in the cache. This sequence is not protected from mutations
-     * to the cache. The result of iteration under mutation is undefined.
+     * to the cache (except for {@link Iterator#remove()}. The result of iteration under any other mutation is
+     * undefined.
      *
      * @return an LRU-ordered {@link Iterable} over the values in the cache
      */
@@ -596,6 +597,11 @@ public class Cache<K, V> {
             @Override
             public V next() {
                 return iterator.next().value;
+            }
+
+            @Override
+            public void remove() {
+                iterator.remove();
             }
         };
     }


### PR DESCRIPTION
This commit implements the ability to remove values from a Cache using
the values iterator. This brings the values iterator in line with the
keys iterator and adds support for removing items in the cache that are
not easily found by the key used for the cache.