### PR TITLE
Remove the suggest metric from stats APIs

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -12,6 +12,8 @@
 <<write-thread-pool-fallback, Removed `thread_pool.bulk.*` settings and
 `es.thread_pool.write.use_bulk_as_display_name` system property>> ({pull}29609[#29609])
 
+<<remove-suggest-metric, Removed `suggest` metric on stats APIs>> ({pull}29635[#29635])
+
 === Breaking Java Changes
 
 === Deprecations

--- a/docs/reference/migration/migrate_7_0/api.asciidoc
+++ b/docs/reference/migration/migrate_7_0/api.asciidoc
@@ -22,7 +22,14 @@ The following parameters starting with underscore have been removed:
 Instead of these removed parameters, use their non camel case equivalents without
 starting underscore, e.g. use `version_type` instead of `_version_type` or `versionType`.
 
-
 ==== The parameter `fields` deprecated in 6.x has been removed from Bulk request 
 and Update request. The Update API returns `400 - Bad request` if request contains 
 unknown parameters (instead of ignored in the previous version).
+
+[[remove-suggest-metric]]
+==== Remove support for `suggest` metric/index metric in indices stats and nodes stats APIs
+
+Previously, `suggest` stats were folded into `search` stats. Support for the
+`suggest` metric on the indices stats and nodes stats APIs remained for
+backwards compatibility. Backwards support for the `suggest` metric was
+deprecated in 6.3.0 and now removed in 7.0.0.

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -152,9 +152,6 @@ public class CommonStats implements Writeable, ToXContentFragment {
                 case Translog:
                     translog = new TranslogStats();
                     break;
-                case Suggest:
-                    // skip
-                    break;
                 case RequestCache:
                     requestCache = new RequestCacheStats();
                     break;
@@ -212,9 +209,6 @@ public class CommonStats implements Writeable, ToXContentFragment {
                     break;
                 case Translog:
                     translog = indexShard.translogStats();
-                    break;
-                case Suggest:
-                    // skip
                     break;
                 case RequestCache:
                     requestCache = indexShard.requestCache().stats();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -221,7 +221,7 @@ public class CommonStatsFlags implements Writeable, Cloneable {
         Completion("completion", 11),
         Segments("segments", 12),
         Translog("translog", 13),
-        Suggest("suggest", 14), // unused
+        // 14 was previously used for Suggest
         RequestCache("request_cache", 15),
         Recovery("recovery", 16);
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -229,15 +229,6 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
         return flags.isSet(Flag.Translog);
     }
 
-    public IndicesStatsRequest suggest(boolean suggest) {
-        flags.set(Flag.Suggest, suggest);
-        return this;
-    }
-
-    public boolean suggest() {
-        return flags.isSet(Flag.Suggest);
-    }
-
     public IndicesStatsRequest requestCache(boolean requestCache) {
         flags.set(Flag.RequestCache, requestCache);
         return this;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -148,9 +148,6 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
         if (request.translog()) {
             flags.set(CommonStatsFlags.Flag.Translog);
         }
-        if (request.suggest()) {
-            flags.set(CommonStatsFlags.Flag.Suggest);
-        }
         if (request.requestCache()) {
             flags.set(CommonStatsFlags.Flag.RequestCache);
         }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -146,10 +146,6 @@ public class RestNodesStatsAction extends BaseRestHandler {
                     for (final String indexMetric : indexMetrics) {
                         final Consumer<CommonStatsFlags> handler = FLAGS.get(indexMetric);
                         if (handler != null) {
-                            if ("suggest".equals(indexMetric)) {
-                                deprecationLogger.deprecated(
-                                        "the suggest index metric is deprecated on the nodes stats API [" + request.uri() + "]");
-                            }
                             handler.accept(flags);
                         } else {
                             invalidIndexMetrics.add(indexMetric);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -62,7 +62,6 @@ public class RestIndicesStatsAction extends BaseRestHandler {
         metrics.put("store", r -> r.store(true));
         metrics.put("indexing", r -> r.indexing(true));
         metrics.put("search", r -> r.search(true));
-        metrics.put("suggest", r -> r.search(true));
         metrics.put("get", r -> r.get(true));
         metrics.put("merge", r -> r.merge(true));
         metrics.put("refresh", r -> r.refresh(true));
@@ -102,9 +101,6 @@ public class RestIndicesStatsAction extends BaseRestHandler {
             for (final String metric : metrics) {
                 final Consumer<IndicesStatsRequest> consumer = METRICS.get(metric);
                 if (consumer != null) {
-                    if ("suggest".equals(metric)) {
-                        deprecationLogger.deprecated("the suggest metric is deprecated on the indices stats API [" + request.uri() + "]");
-                    }
                     consumer.accept(indicesStatsRequest);
                 } else {
                     invalidMetrics.add(metric);

--- a/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -589,10 +589,6 @@ public class IndexStatsIT extends ESIntegTestCase {
 
         IndicesStatsResponse stats = builder.execute().actionGet();
         for (Flag flag : values) {
-            if (flag == Flag.Suggest) {
-                // suggest flag is unused
-                continue;
-            }
             assertThat(isSet(flag, stats.getPrimaries()), equalTo(false));
             assertThat(isSet(flag, stats.getTotal()), equalTo(false));
         }
@@ -628,10 +624,6 @@ public class IndexStatsIT extends ESIntegTestCase {
         }
 
         for (Flag flag : EnumSet.complementOf(flags)) { // check the complement
-            if (flag == Flag.Suggest) {
-                // suggest flag is unused
-                continue;
-            }
             assertThat(isSet(flag, stats.getPrimaries()), equalTo(false));
             assertThat(isSet(flag, stats.getTotal()), equalTo(false));
         }
@@ -684,7 +676,7 @@ public class IndexStatsIT extends ESIntegTestCase {
     public void testFlagOrdinalOrder() {
         Flag[] flags = new Flag[]{Flag.Store, Flag.Indexing, Flag.Get, Flag.Search, Flag.Merge, Flag.Flush, Flag.Refresh,
                 Flag.QueryCache, Flag.FieldData, Flag.Docs, Flag.Warmer, Flag.Completion, Flag.Segments,
-                Flag.Translog, Flag.Suggest, Flag.RequestCache, Flag.Recovery};
+                Flag.Translog, Flag.RequestCache, Flag.Recovery};
 
         assertThat(flags.length, equalTo(Flag.values().length));
         for (int i = 0; i < flags.length; i++) {
@@ -935,8 +927,6 @@ public class IndexStatsIT extends ESIntegTestCase {
             case Translog:
                 builder.setTranslog(set);
                 break;
-            case Suggest: // unused
-                break;
             case RequestCache:
                 builder.setRequestCache(set);
                 break;
@@ -979,8 +969,6 @@ public class IndexStatsIT extends ESIntegTestCase {
                 return response.getSegments() != null;
             case Translog:
                 return response.getTranslog() != null;
-            case Suggest: // unused
-                return true;
             case RequestCache:
                 return response.getRequestCache() != null;
             case Recovery:

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsActionTests.java
@@ -148,14 +148,4 @@ public class RestNodesStatsActionTests extends ESTestCase {
                 containsString("request [/_nodes/stats] contains index metrics [" + indexMetric + "] but all stats requested")));
     }
 
-    public void testSuggestIsDeprecated() throws IOException {
-        final Map<String, String> params =
-                Stream.of(Tuple.tuple("metric", "indices"), Tuple.tuple("index_metric", "suggest"))
-                        .collect(Collectors.toMap(Tuple::v1, Tuple::v2));
-        final RestRequest request =
-                new FakeRestRequest.Builder(xContentRegistry()).withPath("/_nodes/stats").withParams(params).build();
-        action.prepareRequest(request, mock(NodeClient.class));
-        assertWarnings("the suggest index metric is deprecated on the nodes stats API [/_nodes/stats]" );
-    }
-
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsActionTests.java
@@ -84,11 +84,4 @@ public class RestIndicesStatsActionTests extends ESTestCase {
         assertThat(e, hasToString(containsString("request [/_stats] contains _all and individual metrics [_all," + metric + "]")));
     }
 
-    public void testSuggestIsDeprecated() throws IOException {
-        final Map<String, String> params = Collections.singletonMap("metric", "suggest");
-        final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_stats").withParams(params).build();
-        action.prepareRequest(request, mock(NodeClient.class));
-        assertWarnings("the suggest metric is deprecated on the indices stats API [/_stats]");
-    }
-
 }


### PR DESCRIPTION
This metric previously existed for backwards compatibility reasons although the suggest stats were folded into search stats. This metric was deprecated in 6.3.0 and this commit removes them for 7.0.0.

Closes #29589 