### PR TITLE
Fix byte size value equals/hash code test

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -223,25 +223,36 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     }
 
     @Override
-    protected ByteSizeValue mutateInstance(ByteSizeValue instance) throws IOException {
-        long size = instance.getSize();
-        ByteSizeUnit unit = instance.getUnit();
+    protected ByteSizeValue mutateInstance(final ByteSizeValue instance) {
+        final long instanceSize = instance.getSize();
+        final ByteSizeUnit instanceUnit = instance.getUnit();
+        final long mutateSize;
+        final ByteSizeUnit mutateUnit;
         switch (between(0, 1)) {
         case 0:
-            long unitBytes = unit.toBytes(1);
-            size = randomValueOtherThan(size, () -> randomNonNegativeLong() / unitBytes);
+            final long unitBytes = instanceUnit.toBytes(1);
+            mutateSize = randomValueOtherThan(instanceSize, () -> randomNonNegativeLong() / unitBytes);
+            mutateUnit = instanceUnit;
             break;
         case 1:
-            unit = randomValueOtherThan(unit, () -> randomFrom(ByteSizeUnit.values()));
-            long newUnitBytes = unit.toBytes(1);
-            if (size >= Long.MAX_VALUE / newUnitBytes) {
-                size = randomValueOtherThan(size, () -> randomNonNegativeLong() / newUnitBytes);
+            mutateUnit = randomValueOtherThan(instanceUnit, () -> randomFrom(ByteSizeUnit.values()));
+            final long newUnitBytes = mutateUnit.toBytes(1);
+            /*
+             * If size is zero we can not reuse zero because 0 with any unit will be equal to 0 with any other unit so in this case we need
+             * to randomize a new size. Additionally, if the size unit pair is such that the representation would be such that the number of
+             * represented bytes would exceed Long.Max_VALUE, we have to randomize a new size too.
+             */
+            if (instanceSize == 0 || instanceSize >= Long.MAX_VALUE / newUnitBytes) {
+                mutateSize = randomValueOtherThanMany(
+                        v -> v == instanceSize && v >= Long.MAX_VALUE / newUnitBytes, () -> randomNonNegativeLong() / newUnitBytes);
+            } else {
+                mutateSize = instanceSize;
             }
             break;
         default:
             throw new AssertionError("Invalid randomisation branch");
         }
-        return new ByteSizeValue(size, unit);
+        return new ByteSizeValue(mutateSize, mutateUnit);
     }
 
     public void testParse() {

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -238,9 +238,9 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
             mutateUnit = randomValueOtherThan(instanceUnit, () -> randomFrom(ByteSizeUnit.values()));
             final long newUnitBytes = mutateUnit.toBytes(1);
             /*
-             * If size is zero we can not reuse zero because 0 with any unit will be equal to 0 with any other unit so in this case we need
-             * to randomize a new size. Additionally, if the size unit pair is such that the representation would be such that the number of
-             * represented bytes would exceed Long.Max_VALUE, we have to randomize a new size too.
+             * If size is zero we can not reuse zero because zero with any unit will be equal to zero with any other unit so in this case we
+             * need to randomize a new size. Additionally, if the size unit pair is such that the representation would be such that the
+             * number of represented bytes would exceed Long.Max_VALUE, we have to randomize a new size too.
              */
             if (instanceSize == 0 || instanceSize >= Long.MAX_VALUE / newUnitBytes) {
                 mutateSize = randomValueOtherThanMany(


### PR DESCRIPTION
This commit fixes two issues with the byte size value equals/hash code test.

The first problem is due to a test failure when the original instance is zero bytes and we pick the mutation branch where we preserve the size but change the unit. The mutation should result in a different byte size value but changing the unit on zero bytes still leaves us with zero bytes.

During the course of fixing this test I discovered another problem. When we need to randomize size, we could randomly select a size that would lead to an overflow of Long.MAX_VALUE.

This commit fixes both of these issues.
