### PR TITLE
Remove usage of transient settings to enable allocations in full restart upgrade docs

### DIFF
--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -88,24 +88,19 @@ already have local shard copies.
 +
 --
 When all nodes have joined the cluster and recovered their primary shards,
-reenable allocation.
+reenable allocation by restoring `cluster.routing.allocation.enable` to it's 
+default:
 
 [source,js]
 ------------------------------------------------------
 PUT _cluster/settings
 {
-  "transient": {
-    "cluster.routing.allocation.enable": "all"
+  "persistent": {
+    "cluster.routing.allocation.enable": null
   }
 }
 ------------------------------------------------------
 // CONSOLE
-
-NOTE: Because <<_precedence_of_settings, transient
-settings take precedence over persistent settings>>, this overrides the
-persistent setting used to disable shard allocation in the first step. If you
-don't explicitly reenable shard allocation after a full cluster restart, the
-persistent setting is used and shard allocation remains disabled.
 
 Once allocation is reenabled, the cluster starts allocating replica shards to
 the data nodes. At this point it is safe to resume indexing and searching,

--- a/docs/reference/upgrade/cluster_restart.asciidoc
+++ b/docs/reference/upgrade/cluster_restart.asciidoc
@@ -88,7 +88,7 @@ already have local shard copies.
 +
 --
 When all nodes have joined the cluster and recovered their primary shards,
-reenable allocation by restoring `cluster.routing.allocation.enable` to it's 
+reenable allocation by restoring `cluster.routing.allocation.enable` to its 
 default:
 
 [source,js]


### PR DESCRIPTION

Since we disable allocation using persistent settings, we should be consistent and remove
the setting from the persistent storage. Otherwise an accidental restart will leed for shards
not being allocated.

Relates to https://github.com/elastic/elasticsearch/pull/28757
