### PR TITLE
Remove usage of transient settings to enable allocations in rolling upgrade docs

### DIFF
--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -69,21 +69,15 @@ GET _cat/nodes
 +
 --
 
-NOTE: Because <<_precedence_of_settings, transient
-settings take precedence over persistent settings>>, this overrides the
-persistent setting used to disable shard allocation in the first step. If you
-don't explicitly reenable shard allocation after a full cluster restart, the
-persistent setting is used and shard allocation remains disabled.
-
-Once the node has joined the cluster, reenable shard allocation to start using
-the node:
+Once the node has joined the cluster, remove the `cluster.routing.allocation.enable`
+settings to enable shard allocation and start using the node:
 
 [source,js]
 --------------------------------------------------
 PUT _cluster/settings
 {
-  "transient": {
-    "cluster.routing.allocation.enable": "all"
+  "persistent": {
+    "cluster.routing.allocation.enable": null
   }
 }
 --------------------------------------------------

--- a/docs/reference/upgrade/rolling_upgrade.asciidoc
+++ b/docs/reference/upgrade/rolling_upgrade.asciidoc
@@ -70,7 +70,7 @@ GET _cat/nodes
 --
 
 Once the node has joined the cluster, remove the `cluster.routing.allocation.enable`
-settings to enable shard allocation and start using the node:
+setting to enable shard allocation and start using the node:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
Since we disable allocation using persistent settings, we should be consistent and remove
the setting from the persistent storage. Otherwise an accidental restart will leed for shards
not being allocated.

Relates to #28757

