### PR TITLE
Merge thread count is per shard. Closes #28518

### DIFF
--- a/docs/reference/index-modules/merge.asciidoc
+++ b/docs/reference/index-modules/merge.asciidoc
@@ -23,7 +23,8 @@ The merge scheduler supports the following _dynamic_ setting:
 
 `index.merge.scheduler.max_thread_count`::
 
-    The maximum number of threads that may be merging at once. Defaults to
+    The maximum number of threads on a single shard that may be merging at once.
+	Defaults to
     `Math.max(1, Math.min(4, Runtime.getRuntime().availableProcessors() / 2))`
     which works well for a good solid-state-disk (SSD).  If your index is on
     spinning platter drives instead, decrease this to 1.


### PR DESCRIPTION
[DOCS] Added "on a single shard" to description of index.merge.scheduler.max_thread_count. Closes 28518