### PR TITLE
Update minimum-should-match.asciidoc

### DIFF
--- a/docs/reference/query-dsl/minimum-should-match.asciidoc
+++ b/docs/reference/query-dsl/minimum-should-match.asciidoc
@@ -1,13 +1,14 @@
 [[query-dsl-minimum-should-match]]
 == Minimum Should Match
 
+The property `minimum_should_match` can be used with a bool `should` that has multiple clauses. Since multiword `match` and `multi-match` queries simply wrap the generated term queries in a bool query, they can use `minimum_should_match` as well.
 The `minimum_should_match` parameter possible values:
 
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Type |Example |Description
 |Integer |`3` |Indicates a fixed value regardless of the number of
-optional clauses.
+optional clauses. Zero is allowed.
 
 |Negative integer |`-2` |Indicates that the total number of optional
 clauses, minus this number should be mandatory.


### PR DESCRIPTION
A little more verbiage for minimum_should_match might make its use more clear for developers.   Also, this update adds that the integer zero is allowed.
