### PR TITLE
Added example for _forcemerge API

### DIFF
--- a/docs/reference/indices/forcemerge.asciidoc
+++ b/docs/reference/indices/forcemerge.asciidoc
@@ -38,6 +38,12 @@ deletes. Defaults to `false`.  Note that this won't override the
 `flush`::  Should a flush be performed after the forced merge. Defaults to
 `true`.
 
+[source,js]
+--------------------------------------------------
+POST /kimchy/_forcemerge?only_expunge_deletes=false&max_num_segments=100&flush=true
+
+--------------------------------------------------
+
 [float]
 [[forcemerge-multi-index]]
 === Multi Index


### PR DESCRIPTION
Coming from https://discuss.elastic.co/t/delete-by-query-forcemerge-doesnt-free-disk-space/129352/