### PR TITLE
[Test] Fix docs check for DEB package in packaging tests

### DIFF
--- a/qa/vagrant/src/test/resources/packaging/tests/30_deb_package.bats
+++ b/qa/vagrant/src/test/resources/packaging/tests/30_deb_package.bats
@@ -191,8 +191,8 @@ setup() {
 
     assert_file_not_exist "/usr/share/elasticsearch"
 
-    assert_file_not_exist "/usr/share/doc/elasticsearch"
-    assert_file_not_exist "/usr/share/doc/elasticsearch/copyright"
+    assert_file_not_exist "/usr/share/doc/elasticsearch-oss"
+    assert_file_not_exist "/usr/share/doc/elasticsearch-oss/copyright"
 }
 
 @test "[DEB] package has been completly removed" {

--- a/qa/vagrant/src/test/resources/packaging/utils/packages.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/packages.bash
@@ -117,8 +117,9 @@ verify_package_installation() {
         assert_file "/etc/default/elasticsearch" f root elasticsearch 660
 
         # Doc files
-        assert_file "/usr/share/doc/elasticsearch" d root root 755
-        assert_file "/usr/share/doc/elasticsearch/copyright" f root root 644
+        local docs=$(readlink -f /usr/share/doc/elasticsearch*)
+        assert_file $docs d root root 755
+        assert_file "$docs/copyright" f root root 644
     fi
 
     if is_rpm; then

--- a/qa/vagrant/src/test/resources/packaging/utils/packages.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/packages.bash
@@ -116,10 +116,10 @@ verify_package_installation() {
         # Env file
         assert_file "/etc/default/elasticsearch" f root elasticsearch 660
 
-        # Doc files
-        local docs=$(readlink -f /usr/share/doc/elasticsearch*)
-        assert_file $docs d root root 755
-        assert_file "$docs/copyright" f root root 644
+        # Machine-readable debian/copyright file
+        local copyrightDir=$(readlink -f /usr/share/doc/$PACKAGE_NAME)
+        assert_file $copyrightDir d root root 755
+        assert_file "$copyrightDir/copyright" f root root 644
     fi
 
     if is_rpm; then

--- a/qa/vagrant/src/test/resources/packaging/utils/utils.bash
+++ b/qa/vagrant/src/test/resources/packaging/utils/utils.bash
@@ -254,6 +254,7 @@ clean_before_test() {
                             "/etc/sysconfig/elasticsearch"  \
                             "/var/run/elasticsearch"  \
                             "/usr/share/doc/elasticsearch" \
+                            "/usr/share/doc/elasticsearch-oss" \
                             "/tmp/elasticsearch" \
                             "/usr/lib/systemd/system/elasticsearch.conf" \
                             "/usr/lib/tmpfiles.d/elasticsearch.conf" \


### PR DESCRIPTION
The packaging tests for Debian based distro is loooking for docs in /usr/share/elasticsearch, but it should be
/usr/share/elasticsearch-oss for the oss package.
