### PR TITLE
Remove licenses missed by the migration

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ExpressionRoleMappingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ExpressionRoleMappingTests.java
@@ -3,23 +3,6 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-/*
-* ELASTICSEARCH CONFIDENTIAL
-* __________________
-*
-*  [2017] Elasticsearch Incorporated. All Rights Reserved.
-*
-* NOTICE:  All information contained herein is, and remains
-* the property of Elasticsearch Incorporated and its suppliers,
-* if any.  The intellectual and technical concepts contained
-* herein are proprietary to Elasticsearch Incorporated
-* and its suppliers and may be covered by U.S. and Foreign Patents,
-* patents in process, and are protected by trade secret or copyright law.
-* Dissemination of this information or reproduction of this material
-* is strictly forbidden unless prior written permission is obtained
-* from Elasticsearch Incorporated.
-*/
-
 package org.elasticsearch.xpack.security.authc.support.mapper;
 
 import org.elasticsearch.common.ParsingException;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/UnresolvedAttributeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/UnresolvedAttributeTests.java
@@ -3,23 +3,6 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-/*
-* ELASTICSEARCH CONFIDENTIAL
-* __________________
-*
-*  [2017] Elasticsearch Incorporated. All Rights Reserved.
-*
-* NOTICE:  All information contained herein is, and remains
-* the property of Elasticsearch Incorporated and its suppliers,
-* if any.  The intellectual and technical concepts contained
-* herein are proprietary to Elasticsearch Incorporated
-* and its suppliers and may be covered by U.S. and Foreign Patents,
-* patents in process, and are protected by trade secret or copyright law.
-* Dissemination of this information or reproduction of this material
-* is strictly forbidden unless prior written permission is obtained
-* from Elasticsearch Incorporated.
-*/
-
 package org.elasticsearch.xpack.sql.expression;
 
 import org.elasticsearch.xpack.sql.tree.AbstractNodeTestCase;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/UnresolvedFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/UnresolvedFunctionTests.java
@@ -3,23 +3,6 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-/*
-* ELASTICSEARCH CONFIDENTIAL
-* __________________
-*
-*  [2017] Elasticsearch Incorporated. All Rights Reserved.
-*
-* NOTICE:  All information contained herein is, and remains
-* the property of Elasticsearch Incorporated and its suppliers,
-* if any.  The intellectual and technical concepts contained
-* herein are proprietary to Elasticsearch Incorporated
-* and its suppliers and may be covered by U.S. and Foreign Patents,
-* patents in process, and are protected by trade secret or copyright law.
-* Dissemination of this information or reproduction of this material
-* is strictly forbidden unless prior written permission is obtained
-* from Elasticsearch Incorporated.
-*/
-
 package org.elasticsearch.xpack.sql.expression.function;
 
 import org.elasticsearch.xpack.sql.expression.Expression;


### PR DESCRIPTION
A few of the old style license got kept around because their comment
string did not start with a space. This caused the license check to not
see it as a license and skip it. This commit cleans it up.