### PR TITLE
Fail snapshot operations early on repository corruption

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -24,7 +24,7 @@
 
 === Bug Fixes
 
-Fix NullPointerException when creating or deleting a snapshot on a repository that has been
+Fail snapshot operations early when creating or deleting a snapshot on a repository that has been
 written to by an older Elasticsearch after writing to it with a newer Elasticsearch version. ({pull}30140[#30140])
 
 === Regressions

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -24,7 +24,8 @@
 
 === Bug Fixes
 
-Fix NullPointerException when creating or deleting a snapshot ({pull}30140[#30140])
+Fix NullPointerException when creating or deleting a snapshot on a repository that has been
+written to by an older Elasticsearch after writing to it with a newer Elasticsearch version. ({pull}30140[#30140])
 
 === Regressions
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -24,6 +24,8 @@
 
 === Bug Fixes
 
+Fix NullPointerException when creating or deleting a snapshot ({pull}TODO[#TODO])
+
 === Regressions
 
 === Known Issues

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -24,7 +24,7 @@
 
 === Bug Fixes
 
-Fix NullPointerException when creating or deleting a snapshot ({pull}TODO[#TODO])
+Fix NullPointerException when creating or deleting a snapshot ({pull}30140[#30140])
 
 === Regressions
 

--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -44,9 +44,9 @@ If you register same snapshot repository with multiple clusters, only
 one cluster should have write access to the repository. All other clusters
 connected to that repository should set the repository to `readonly` mode.
 
-NOTE: The snapshot format can change across major versions, so if you have
+IMPORTANT: The snapshot format can change across major versions, so if you have
 clusters on different major versions trying to write the same repository,
-new snapshots written by one version will not be visible to the other. While
+snapshots written by one version may not be visible to the other. While
 setting the repository to `readonly` on all but one of the clusters should work
 with multiple clusters differing by one major version, it is not a supported
 configuration.

--- a/docs/reference/modules/snapshots.asciidoc
+++ b/docs/reference/modules/snapshots.asciidoc
@@ -45,11 +45,11 @@ one cluster should have write access to the repository. All other clusters
 connected to that repository should set the repository to `readonly` mode.
 
 IMPORTANT: The snapshot format can change across major versions, so if you have
-clusters on different major versions trying to write the same repository,
-snapshots written by one version may not be visible to the other. While
-setting the repository to `readonly` on all but one of the clusters should work
-with multiple clusters differing by one major version, it is not a supported
-configuration.
+clusters on different versions trying to write the same repository, snapshots
+written by one version may not be visible to the other and the repository could
+be corrupted. While setting the repository to `readonly` on all but one of the
+clusters should work with multiple clusters differing by one major version, it
+is not a supported configuration.
 
 [source,js]
 -----------------------------------

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -230,9 +230,9 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
                 SnapshotInfo snapshotInfo = snapshotsService.snapshot(repositoryName, snapshotId);
                 List<SnapshotIndexShardStatus> shardStatusBuilder = new ArrayList<>();
                 if (snapshotInfo.state().completed()) {
-                    Map<ShardId, IndexShardSnapshotStatus> shardStatues =
-                        snapshotsService.snapshotShards(request.repository(), snapshotInfo);
-                    for (Map.Entry<ShardId, IndexShardSnapshotStatus> shardStatus : shardStatues.entrySet()) {
+                    Map<ShardId, IndexShardSnapshotStatus> shardStatuses =
+                        snapshotsService.snapshotShards(repositoryName, repositoryData, snapshotInfo);
+                    for (Map.Entry<ShardId, IndexShardSnapshotStatus> shardStatus : shardStatuses.entrySet()) {
                         IndexShardSnapshotStatus.Copy lastSnapshotStatus = shardStatus.getValue().asCopy();
                         shardStatusBuilder.add(new SnapshotIndexShardStatus(shardStatus.getKey(), lastSnapshotStatus));
                     }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -230,13 +230,6 @@ public final class RepositoryData {
         return snapshotIds;
     }
 
-    /**
-     * Initializes the indices in the repository metadata; returns a new instance.
-     */
-    public RepositoryData initIndices(final Map<IndexId, Set<SnapshotId>> indexSnapshots) {
-        return new RepositoryData(genId, snapshotIds, snapshotStates, indexSnapshots, incompatibleSnapshotIds);
-    }
-
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -352,9 +345,10 @@ public final class RepositoryData {
      * Reads an instance of {@link RepositoryData} from x-content, loading the snapshots and indices metadata.
      */
     public static RepositoryData snapshotsFromXContent(final XContentParser parser, long genId) throws IOException {
-        Map<String, SnapshotId> snapshots = new HashMap<>();
-        Map<String, SnapshotState> snapshotStates = new HashMap<>();
-        Map<IndexId, Set<SnapshotId>> indexSnapshots = new HashMap<>();
+        final Map<String, SnapshotId> snapshots = new HashMap<>();
+        final Map<String, SnapshotState> snapshotStates = new HashMap<>();
+        final Map<IndexId, Set<SnapshotId>> indexSnapshots = new HashMap<>();
+
         if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
             while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
                 String field = parser.currentName();
@@ -397,17 +391,18 @@ public final class RepositoryData {
                         throw new ElasticsearchParseException("start object expected [indices]");
                     }
                     while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-                        String indexName = parser.currentName();
-                        String indexId = null;
-                        Set<SnapshotId> snapshotIds = new LinkedHashSet<>();
+                        final String indexName = parser.currentName();
+                        final Set<SnapshotId> snapshotIds = new LinkedHashSet<>();
+
+                        IndexId indexId = null;
                         if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
                             throw new ElasticsearchParseException("start object expected index[" + indexName + "]");
                         }
                         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-                            String indexMetaFieldName = parser.currentName();
+                            final String indexMetaFieldName = parser.currentName();
                             parser.nextToken();
                             if (INDEX_ID.equals(indexMetaFieldName)) {
-                                indexId = parser.text();
+                                indexId = new IndexId(indexName, parser.text());
                             } else if (SNAPSHOTS.equals(indexMetaFieldName)) {
                                 if (parser.currentToken() != XContentParser.Token.START_ARRAY) {
                                     throw new ElasticsearchParseException("start array expected [snapshots]");
@@ -428,12 +423,23 @@ public final class RepositoryData {
                                         // since we already have the name/uuid combo in the snapshots array
                                         uuid = parser.text();
                                     }
-                                    snapshotIds.add(snapshots.get(uuid));
+                                    if (uuid != null) {
+                                        SnapshotId snapshotId = snapshots.get(uuid);
+                                        if (snapshotId != null) {
+                                            snapshotIds.add(snapshotId);
+                                        } else {
+                                            // A snapshotted index references a snapshot which does not exist in
+                                            // the list of snapshots. This can happen when multiple clusters in
+                                            // different versions create or delete snapshot in the same repository.
+                                            throw new ElasticsearchParseException("Unknown snapshot uuid [" + uuid
+                                                + "] for index " + indexId);
+                                        }
+                                    }
                                 }
                             }
                         }
                         assert indexId != null;
-                        indexSnapshots.put(new IndexId(indexName, indexId), snapshotIds);
+                        indexSnapshots.put(indexId, snapshotIds);
                     }
                 } else {
                     throw new ElasticsearchParseException("unknown field name  [" + field + "]");

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -423,17 +423,16 @@ public final class RepositoryData {
                                         // since we already have the name/uuid combo in the snapshots array
                                         uuid = parser.text();
                                     }
-                                    if (uuid != null) {
-                                        SnapshotId snapshotId = snapshots.get(uuid);
-                                        if (snapshotId != null) {
-                                            snapshotIds.add(snapshotId);
-                                        } else {
-                                            // A snapshotted index references a snapshot which does not exist in
-                                            // the list of snapshots. This can happen when multiple clusters in
-                                            // different versions create or delete snapshot in the same repository.
-                                            throw new ElasticsearchParseException("Unknown snapshot uuid [" + uuid
-                                                + "] for index " + indexId);
-                                        }
+
+                                    SnapshotId snapshotId = snapshots.get(uuid);
+                                    if (snapshotId != null) {
+                                        snapshotIds.add(snapshotId);
+                                    } else {
+                                        // A snapshotted index references a snapshot which does not exist in
+                                        // the list of snapshots. This can happen when multiple clusters in
+                                        // different versions create or delete snapshot in the same repository.
+                                        throw new ElasticsearchParseException("Detected a corrupted repository, index " + indexId
+                                            + " references an unknown snapshot uuid [" + uuid + "]");
                                     }
                                 }
                             }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -592,10 +592,9 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
      * @return map of shard id to snapshot status
      */
     public Map<ShardId, IndexShardSnapshotStatus> snapshotShards(final String repositoryName,
+                                                                 final RepositoryData repositoryData,
                                                                  final SnapshotInfo snapshotInfo) throws IOException {
         final Repository repository = repositoriesService.repository(repositoryName);
-        final RepositoryData repositoryData = repository.getRepositoryData();
-
         final Map<ShardId, IndexShardSnapshotStatus> shardStatus = new HashMap<>();
         for (String index : snapshotInfo.indices()) {
             IndexId indexId = repositoryData.resolveIndexId(index);

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -19,11 +19,14 @@
 
 package org.elasticsearch.repositories;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotState;
@@ -40,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.repositories.RepositoryData.EMPTY_REPO_GEN;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 /**
@@ -101,15 +105,18 @@ public class RepositoryDataTests extends ESTestCase {
     public void testInitIndices() {
         final int numSnapshots = randomIntBetween(1, 30);
         final Map<String, SnapshotId> snapshotIds = new HashMap<>(numSnapshots);
+        final Map<String, SnapshotState> snapshotStates = new HashMap<>(numSnapshots);
         for (int i = 0; i < numSnapshots; i++) {
             final SnapshotId snapshotId = new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
             snapshotIds.put(snapshotId.getUUID(), snapshotId);
+            snapshotStates.put(snapshotId.getUUID(), randomFrom(SnapshotState.values()));
         }
         RepositoryData repositoryData = new RepositoryData(EMPTY_REPO_GEN, snapshotIds,
             Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
         // test that initializing indices works
         Map<IndexId, Set<SnapshotId>> indices = randomIndices(snapshotIds);
-        RepositoryData newRepoData = repositoryData.initIndices(indices);
+        RepositoryData newRepoData =  new RepositoryData(repositoryData.getGenId(), snapshotIds, snapshotStates, indices,
+            new ArrayList<>(repositoryData.getIncompatibleSnapshotIds()));
         List<SnapshotId> expected = new ArrayList<>(repositoryData.getSnapshotIds());
         Collections.sort(expected);
         List<SnapshotId> actual = new ArrayList<>(newRepoData.getSnapshotIds());
@@ -151,6 +158,46 @@ public class RepositoryDataTests extends ESTestCase {
         final RepositoryData repositoryData = RepositoryData.EMPTY.addSnapshot(snapshotId, state, Collections.emptyList());
         assertEquals(state, repositoryData.getSnapshotState(snapshotId));
         assertNull(repositoryData.getSnapshotState(new SnapshotId(randomAlphaOfLength(8), UUIDs.randomBase64UUID())));
+    }
+
+    public void testUnknownSnapshot() throws IOException {
+        final XContent xContent = randomFrom(XContentType.values()).xContent();
+        final RepositoryData repositoryData = generateRandomRepoData();
+
+        XContentBuilder builder = XContentBuilder.builder(xContent);
+        repositoryData.snapshotsToXContent(builder, ToXContent.EMPTY_PARAMS);
+        RepositoryData parsedRepositoryData = RepositoryData.snapshotsFromXContent(createParser(builder), repositoryData.getGenId());
+        assertEquals(repositoryData, parsedRepositoryData);
+
+        Map<String, SnapshotId> snapshotIds = new HashMap<>();
+        Map<String, SnapshotState> snapshotStates = new HashMap<>();
+        for (SnapshotId snapshotId : parsedRepositoryData.getSnapshotIds()) {
+            snapshotIds.put(snapshotId.getUUID(), snapshotId);
+            snapshotStates.put(snapshotId.getUUID(), parsedRepositoryData.getSnapshotState(snapshotId));
+        }
+
+        final IndexId corruptedIndexId = randomFrom(parsedRepositoryData.getIndices().values());
+
+        Map<IndexId, Set<SnapshotId>> indexSnapshots = new HashMap<>();
+        for (Map.Entry<String, IndexId> snapshottedIndex : parsedRepositoryData.getIndices().entrySet()) {
+            IndexId indexId = snapshottedIndex.getValue();
+            Set<SnapshotId> snapshotsIds = new LinkedHashSet<>(parsedRepositoryData.getSnapshots(indexId));
+            if (corruptedIndexId.equals(indexId)) {
+                snapshotsIds.add(new SnapshotId("_uuid", "_does_not_exist"));
+            }
+            indexSnapshots.put(indexId, snapshotsIds);
+        }
+        assertNotNull(corruptedIndexId);
+
+        RepositoryData corruptedRepositoryData = new RepositoryData(parsedRepositoryData.getGenId(), snapshotIds, snapshotStates,
+            indexSnapshots, new ArrayList<>(parsedRepositoryData.getIncompatibleSnapshotIds()));
+
+        final XContentBuilder corruptedBuilder = XContentBuilder.builder(xContent);
+        corruptedRepositoryData.snapshotsToXContent(corruptedBuilder, ToXContent.EMPTY_PARAMS);
+
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () ->
+            RepositoryData.snapshotsFromXContent(createParser(corruptedBuilder), corruptedRepositoryData.getGenId()));
+        assertThat(e.getMessage(), equalTo("Unknown snapshot uuid [_does_not_exist] for index " + corruptedIndexId));
     }
 
     public static RepositoryData generateRandomRepoData() {


### PR DESCRIPTION
Some users have reported a bug (#24477, #29649)  where a NullPointerException is thrown when trying to create or to delete a snapshot in a repository:

The `NullPointerException` is thrown when writing a new version of the snapshots index file:

```
failed to finalize snapshot java.lang.NullPointerException: null
at org.elasticsearch.repositories.RepositoryData.snapshotsToXContent(RepositoryData.java:341) ~[elasticsearch-6.2.4-SNAPSHOT.jar:6.2.4-SNAPSHOT]
at org.elasticsearch.repositories.blobstore.BlobStoreRepository.writeIndexGen(BlobStoreRepository.java:674) ~[elasticsearch-6.2.4-SNAPSHOT.jar:6.2.4-SNAPSHOT]
at org.elasticsearch.repositories.blobstore.BlobStoreRepository.finalizeSnapshot(BlobStoreRepository.java:470) ~[elasticsearch-6.2.4-SNAPSHOT.jar:6.2.4-SNAPSHOT]
```

It happens in the `RepositoryData.snapshotsToXContent()` method, when it writes the list of snapshots that an index belongs to:
```
for (final SnapshotId snapshotId : snapshotIds) {
    builder.value(snapshotId.getUUID());
}
```
And in this case `snapshotId` is null.

It took me some time to reproduce it and I finally found a scenario where this NPE can happen. Both issues where reported when moving data from a cluster in version 5.2/5.3/5.4 to a more recent version (after 5.5.0). The snapshots index file format changed in #24477 and **if the repository is misused** the NPE is thrown.

Let's say that the repository was created on 5.3.1 with two snapshots. The index-1 file looks like:
```
{
    "indices": {
        "docs": {
            "snapshots": [
                {
                    "uuid": "Asib-5XpRPqBGZNJhVV1Tw",
                    "name": "snap-1"
                },
                {
                    "uuid": "kIIR10OrQsyqWsMdRRu8Bg",
                    "name": "snap-2"
                }
            ],
            "id": "fjfzV59tS2q-H2mtb8pdDA"
        }
    },
    "snapshots": [
        {
            "uuid": "Asib-5XpRPqBGZNJhVV1Tw",
            "name": "snap-1"
        },
        {
            "uuid": "kIIR10OrQsyqWsMdRRu8Bg",
            "name": "snap-2"
        }
    ]
}
```

As written in the docs, this repository must only be used by a unique cluster in 5.3.1 version for creating or deleting snapshots. Other clusters can potentially access to this repository but they must register the repository in read-only mode.

If it's not the case, a cluster in a different recent version will write a new snapshots index file in a format that is unknown from the 5.3.1 cluster.

For example, a cluster in 5.6.9 register the same repository and creates a new snapshot. The snapshots index file is now `index-2` and contains:

```
{
    "indices": {
        "docs": {
            "snapshots": [
                "Asib-5XpRPqBGZNJhVV1Tw",
                "kIIR10OrQsyqWsMdRRu8Bg",
                "I4SHGNFGRzqgu-iIaJMgzg"
            ],
            "id": "fjfzV59tS2q-H2mtb8pdDA"
        }
    },
    "snapshots": [
        {
            "state": 1,
            "uuid": "I4SHGNFGRzqgu-iIaJMgzg",
            "name": "snap-3"
        },
        {
            "uuid": "Asib-5XpRPqBGZNJhVV1Tw",
            "name": "snap-1"
        },
        {
            "uuid": "kIIR10OrQsyqWsMdRRu8Bg",
            "name": "snap-2"
        }
    ]
}
```

The pull request #24477 changed the way each index references the snapshots it belongs to in the file. It now only contains the snapshot UUID (and not the full name/UUID).

Now, if a snapshot is deleted (or a new one is created) using the 5.3.1 cluster the index file is broken:

```
{
    "indices": {
        "docs": {
            "snapshots": [
                {
                    "uuid": "Asib-5XpRPqBGZNJhVV1Tw",
                    "name": "Asib-5XpRPqBGZNJhVV1Tw"
                },
                {
                    "uuid": "kIIR10OrQsyqWsMdRRu8Bg",
                    "name": "kIIR10OrQsyqWsMdRRu8Bg"
                },
                {
                    "uuid": "I4SHGNFGRzqgu-iIaJMgzg",
                    "name": "I4SHGNFGRzqgu-iIaJMgzg"
                }
            ],
            "id": "fjfzV59tS2q-H2mtb8pdDA"
        }
    },
    "snapshots": [
        {
            "uuid": "I4SHGNFGRzqgu-iIaJMgzg",
            "name": "snap-3"
        },
        {
            "uuid": "kIIR10OrQsyqWsMdRRu8Bg",
            "name": "snap-2"
        }
    ]
}
```

Here is what happened on the 5.3.1 cluster when the snap-1 has been deleted:

When parsing the index file generated by 5.6.9, the 5.3.1 cluster parsed each item of the `docs.snapshots` array using the [SnapshotId.fromXContent()](https://github.com/elastic/elasticsearch/blob/v5.3.1/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java#L364) method. 

This method considers that when the array item [is not an object it is a snapshot name](https://github.com/elastic/elasticsearch/blob/v5.3.1/core/src/main/java/org/elasticsearch/snapshots/SnapshotId.java#L144-L146). In 5.3.1, the list of snapshots associated to the `docs` index became in memory 3 snapshots, and each snapshot has been initialized with a name equal to the UUID.

Then the repository data are modified in memory to remove the snapshot. The snapshot to delete is correctly removed from the list of snapshots (ie, the `snapshots` array at root level) but it is not removed from the snapshots array at the index level (ie, the `docs.snapshots` array) because [the snapshot is not found](https://github.com/elastic/elasticsearch/blob/v5.3.1/core/src/main/java/org/elasticsearch/repositories/RepositoryData.java#L177): `snapshot snap-1/Asib-5XpRPqBGZNJhVV1Tw` is not equal to `Asib-5XpRPqBGZNJhVV1Tw/Asib-5XpRPqBGZNJhVV1Tw`. Then the snapshots index file `index-3` is uploaded to the repository.

This `index-3` file will not thrown any error when the 5.6.9 cluster reads it. When parsing the file, it correctly associates the  index`docs` with the snapshots `snap-2` and `snap3` (because the UUID are present in the list of snapshots) but it also adds a `null` reference because the UUID `Asib-5XpRPqBGZNJhVV1Tw` is unknown. 

Now, everytime a snapshot is created or deleted using the 5.6.9 cluster it will fail at the end of the process, when writing back the snapshots index file. This `null` reference causes a `NullPointerException`.

This pull request changes the parsing code of the index file so that it now throws an exception if an index references an unknown snapshot. This way it is not possible to create or delete a snapshot when the index file is broken. It also adds a test that would have failed before the change.

closes #24477