### PR TITLE
gitignore: Add VSCode and remove Maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,8 @@ nbactions.xml
 .gradle/
 build/
 
-# maven stuff (to be removed when trunk becomes 4.x)
-*-execution-hints.log
-target/
-dependency-reduced-pom.xml
+# vscode stuff
+.vscode/
 
 # testing stuff
 **/.local*
@@ -43,4 +41,3 @@ html_docs
 # random old stuff that we should look at the necessity of...
 /tmp/
 eclipse-build
-


### PR DESCRIPTION
Adds the `.vscode` directory to `.gitignore`. This didn't come up when
we had x-pack in a different repository than Elasticsearch because I'd
open the directory that contained both of them in VSCode. Now that they
are merged I tend to just open the Elasticsearch repository which causes
VSCode to create this directory that we don't need to commit.

Also removes leftover maven files from `.gitignore`.
