### PR TITLE
update RolloverAction to utilize an index-setting for rollover_alias

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverStep.java
@@ -9,23 +9,23 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
 
+import java.util.Locale;
 import java.util.Objects;
 
 public class RolloverStep extends AsyncActionStep {
     public static final String NAME = "attempt_rollover";
 
-    private String alias;
     private ByteSizeValue maxSize;
     private TimeValue maxAge;
     private Long maxDocs;
 
-    public RolloverStep(StepKey key, StepKey nextStepKey, Client client, String alias, ByteSizeValue maxSize, TimeValue maxAge,
+    public RolloverStep(StepKey key, StepKey nextStepKey, Client client, ByteSizeValue maxSize, TimeValue maxAge,
             Long maxDocs) {
         super(key, nextStepKey, client);
-        this.alias = alias;
         this.maxSize = maxSize;
         this.maxAge = maxAge;
         this.maxDocs = maxDocs;
@@ -33,8 +33,15 @@ public class RolloverStep extends AsyncActionStep {
 
     @Override
     public void performAction(IndexMetaData indexMetaData, Listener listener) {
-        // TODO(talevy): shouldn't we double-check that this alias is managed by us/this-index?
-        RolloverRequest rolloverRequest = new RolloverRequest(alias, null);
+        String rolloverAlias = RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING.get(indexMetaData.getSettings());
+
+        if (Strings.isNullOrEmpty(rolloverAlias)) {
+            listener.onFailure(new IllegalArgumentException(String.format(Locale.ROOT, "setting [%s] for index [%s] is empty or not defined",
+                RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, indexMetaData.getIndex().getName())));
+            return;
+        }
+
+        RolloverRequest rolloverRequest = new RolloverRequest(rolloverAlias, null);
         if (maxAge != null) {
             rolloverRequest.addMaxIndexAgeCondition(maxAge);
         }
@@ -46,10 +53,6 @@ public class RolloverStep extends AsyncActionStep {
         }
         getClient().admin().indices().rolloverIndex(rolloverRequest,
                 ActionListener.wrap(response -> listener.onResponse(response.isRolledOver()), listener::onFailure));
-    }
-    
-    String getAlias() {
-        return alias;
     }
     
     ByteSizeValue getMaxSize() {
@@ -66,7 +69,7 @@ public class RolloverStep extends AsyncActionStep {
     
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), alias, maxSize, maxAge, maxDocs);
+        return Objects.hash(super.hashCode(), maxSize, maxAge, maxDocs);
     }
     
     @Override
@@ -79,7 +82,6 @@ public class RolloverStep extends AsyncActionStep {
         }
         RolloverStep other = (RolloverStep) obj;
         return super.equals(obj) &&
-                Objects.equals(alias, other.alias) &&
                 Objects.equals(maxSize, other.maxSize) &&
                 Objects.equals(maxAge, other.maxAge) &&
                 Objects.equals(maxDocs, other.maxDocs);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/RolloverStepTests.java
@@ -30,7 +30,10 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
 
@@ -52,19 +55,18 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
         TimeValue maxAge = (maxDocs == null && maxSize == null || randomBoolean())
                 ? TimeValue.parseTimeValue(randomPositiveTimeValue(), "rollover_action_test")
                 : null;
-        return new RolloverStep(stepKey, nextStepKey, client, alias, maxSize, maxAge, maxDocs);
+        return new RolloverStep(stepKey, nextStepKey, client, maxSize, maxAge, maxDocs);
     }
 
     @Override
     public RolloverStep mutateInstance(RolloverStep instance) {
         StepKey key = instance.getKey();
         StepKey nextKey = instance.getNextStepKey();
-        String alias = instance.getAlias();
         ByteSizeValue maxSize = instance.getMaxSize();
         TimeValue maxAge = instance.getMaxAge();
         Long maxDocs = instance.getMaxDocs();
 
-        switch (between(0, 5)) {
+        switch (between(0, 4)) {
         case 0:
             key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
             break;
@@ -72,35 +74,34 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
             nextKey = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
             break;
         case 2:
-            alias = alias + randomAlphaOfLengthBetween(1, 5);
-            break;
-        case 3:
             maxSize = randomValueOtherThan(maxSize, () -> {
                 ByteSizeUnit maxSizeUnit = randomFrom(ByteSizeUnit.values());
                 return new ByteSizeValue(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);
             });
             break;
-        case 4:
+        case 3:
             maxAge = TimeValue.parseTimeValue(randomPositiveTimeValue(), "rollover_action_test");
             break;
-        case 5:
+        case 4:
             maxDocs = randomNonNegativeLong();
             break;
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
 
-        return new RolloverStep(key, nextKey, instance.getClient(), alias, maxSize, maxAge, maxDocs);
+        return new RolloverStep(key, nextKey, instance.getClient(), maxSize, maxAge, maxDocs);
     }
 
     @Override
     public RolloverStep copyInstance(RolloverStep instance) {
         return new RolloverStep(instance.getKey(), instance.getNextStepKey(), instance.getClient(),
-            instance.getAlias(), instance.getMaxSize(), instance.getMaxAge(), instance.getMaxDocs());
+            instance.getMaxSize(), instance.getMaxAge(), instance.getMaxDocs());
     }
 
     public void testPerformAction() throws Exception {
-        IndexMetaData indexMetaData = IndexMetaData.builder(randomAlphaOfLength(10)).settings(settings(Version.CURRENT))
+        String alias = randomAlphaOfLength(5);
+        IndexMetaData indexMetaData = IndexMetaData.builder(randomAlphaOfLength(10))
+            .settings(settings(Version.CURRENT).put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias))
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
 
         RolloverStep step = createRandomInstance();
@@ -127,7 +128,7 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
                 if (step.getMaxDocs() != null) {
                     expectedConditions.add(new MaxDocsCondition(step.getMaxDocs()));
                 }
-                RolloverIndexTestHelper.assertRolloverIndexRequest(request, step.getAlias(), expectedConditions);
+                RolloverIndexTestHelper.assertRolloverIndexRequest(request, alias, expectedConditions);
                 listener.onResponse(RolloverIndexTestHelper.createMockResponse(request, true));
                 return null;
             }
@@ -156,7 +157,9 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
     }
 
     public void testPerformActionNotComplete() throws Exception {
-        IndexMetaData indexMetaData = IndexMetaData.builder(randomAlphaOfLength(10)).settings(settings(Version.CURRENT))
+        String alias = randomAlphaOfLength(5);
+        IndexMetaData indexMetaData = IndexMetaData.builder(randomAlphaOfLength(10))
+            .settings(settings(Version.CURRENT).put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias))
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
         RolloverStep step = createRandomInstance();
 
@@ -182,7 +185,7 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
                 if (step.getMaxDocs() != null) {
                     expectedConditions.add(new MaxDocsCondition(step.getMaxDocs()));
                 }
-                RolloverIndexTestHelper.assertRolloverIndexRequest(request, step.getAlias(), expectedConditions);
+                RolloverIndexTestHelper.assertRolloverIndexRequest(request, alias, expectedConditions);
                 listener.onResponse(RolloverIndexTestHelper.createMockResponse(request, false));
                 return null;
             }
@@ -211,7 +214,9 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
     }
 
     public void testPerformActionFailure() throws Exception {
-        IndexMetaData indexMetaData = IndexMetaData.builder(randomAlphaOfLength(10)).settings(settings(Version.CURRENT))
+        String alias = randomAlphaOfLength(5);
+        IndexMetaData indexMetaData = IndexMetaData.builder(randomAlphaOfLength(10))
+            .settings(settings(Version.CURRENT).put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias))
             .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
         Exception exception = new RuntimeException();
         RolloverStep step = createRandomInstance();
@@ -238,7 +243,7 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
                 if (step.getMaxDocs() != null) {
                     expectedConditions.add(new MaxDocsCondition(step.getMaxDocs()));
                 }
-                RolloverIndexTestHelper.assertRolloverIndexRequest(request, step.getAlias(), expectedConditions);
+                RolloverIndexTestHelper.assertRolloverIndexRequest(request, alias, expectedConditions);
                 listener.onFailure(exception);
                 return null;
             }
@@ -265,6 +270,31 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
         Mockito.verify(client, Mockito.only()).admin();
         Mockito.verify(adminClient, Mockito.only()).indices();
         Mockito.verify(indicesClient, Mockito.only()).rolloverIndex(Mockito.any(), Mockito.any());
+    }
+
+    public void testPerformActionInvalidNullOrEmptyAlias() {
+        String alias = randomBoolean() ? "" : null;
+        IndexMetaData indexMetaData = IndexMetaData.builder(randomAlphaOfLength(10))
+            .settings(settings(Version.CURRENT).put(RolloverAction.LIFECYCLE_ROLLOVER_ALIAS, alias))
+            .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
+        RolloverStep step = createRandomInstance();
+
+        SetOnce<Exception> exceptionThrown = new SetOnce<>();
+        step.performAction(indexMetaData, new Listener() {
+            @Override
+            public void onResponse(boolean complete) {
+                throw new AssertionError("Unexpected method call");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                exceptionThrown.set(e);
+            }
+        });
+        assertThat(exceptionThrown.get().getClass(), equalTo(IllegalArgumentException.class));
+        assertThat(exceptionThrown.get().getMessage(), equalTo(String.format(Locale.ROOT,
+            "setting [%s] for index [%s] is empty or not defined", RolloverAction.LIFECYCLE_ROLLOVER_ALIAS,
+            indexMetaData.getIndex().getName())));
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/TimeseriesLifecycleTypeTests.java
@@ -33,7 +33,7 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
     private static final DeleteAction TEST_DELETE_ACTION = new DeleteAction();
     private static final ForceMergeAction TEST_FORCE_MERGE_ACTION = new ForceMergeAction(1, true);
     private static final ReplicasAction TEST_REPLICAS_ACTION = new ReplicasAction(1);
-    private static final RolloverAction TEST_ROLLOVER_ACTION = new RolloverAction("", new ByteSizeValue(1), null, null);
+    private static final RolloverAction TEST_ROLLOVER_ACTION = new RolloverAction(new ByteSizeValue(1), null, null);
     private static final ShrinkAction TEST_SHRINK_ACTION = new ShrinkAction(1);
     private static final ReadOnlyAction TEST_READ_ONLY_ACTION = new ReadOnlyAction();
 

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
@@ -33,6 +33,7 @@ import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleSettings;
+import org.elasticsearch.xpack.core.indexlifecycle.RolloverAction;
 import org.elasticsearch.xpack.core.indexlifecycle.action.DeleteLifecycleAction;
 import org.elasticsearch.xpack.core.indexlifecycle.action.GetLifecycleAction;
 import org.elasticsearch.xpack.core.indexlifecycle.action.PutLifecycleAction;
@@ -95,7 +96,8 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             LifecycleSettings.LIFECYCLE_ACTION_TIME_SETTING,
             LifecycleSettings.LIFECYCLE_ACTION_SETTING,
             LifecycleSettings.LIFECYCLE_STEP_TIME_SETTING,
-            LifecycleSettings.LIFECYCLE_STEP_SETTING);
+            LifecycleSettings.LIFECYCLE_STEP_SETTING,
+            RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING);
     }
 
     @Override


### PR DESCRIPTION
The purpose of this change is to reflect what is the future way of configuring aliases in
the Rollover action for ILM. With this change, users will be able to edit all desired rollover-related
information in the index's template, so that the index-lifecycle policy does not need to be dependent on it.