### PR TITLE
Expose CommonStatsFlags directly in IndicesStatsRequest.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -55,6 +55,21 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
     }
 
     /**
+     * Returns the underlying stats flags.
+     */
+    public CommonStatsFlags flags() {
+        return flags;
+    }
+
+    /**
+     * Sets the underlying stats flags.
+     */
+    public IndicesStatsRequest flags(CommonStatsFlags flags) {
+        this.flags = flags;
+        return this;
+    }
+
+    /**
      * Document types to return stats for. Mainly affects {@link #indexing(boolean)} when
      * enabled, returning specific indexing stats for those types.
      */

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -99,65 +99,8 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
             throw new ShardNotFoundException(indexShard.shardId());
         }
 
-        CommonStatsFlags flags = new CommonStatsFlags().clear();
-
-        if (request.docs()) {
-            flags.set(CommonStatsFlags.Flag.Docs);
-        }
-        if (request.store()) {
-            flags.set(CommonStatsFlags.Flag.Store);
-        }
-        if (request.indexing()) {
-            flags.set(CommonStatsFlags.Flag.Indexing);
-            flags.types(request.types());
-        }
-        if (request.get()) {
-            flags.set(CommonStatsFlags.Flag.Get);
-        }
-        if (request.search()) {
-            flags.set(CommonStatsFlags.Flag.Search);
-            flags.groups(request.groups());
-        }
-        if (request.merge()) {
-            flags.set(CommonStatsFlags.Flag.Merge);
-        }
-        if (request.refresh()) {
-            flags.set(CommonStatsFlags.Flag.Refresh);
-        }
-        if (request.flush()) {
-            flags.set(CommonStatsFlags.Flag.Flush);
-        }
-        if (request.warmer()) {
-            flags.set(CommonStatsFlags.Flag.Warmer);
-        }
-        if (request.queryCache()) {
-            flags.set(CommonStatsFlags.Flag.QueryCache);
-        }
-        if (request.fieldData()) {
-            flags.set(CommonStatsFlags.Flag.FieldData);
-            flags.fieldDataFields(request.fieldDataFields());
-        }
-        if (request.segments()) {
-            flags.set(CommonStatsFlags.Flag.Segments);
-            flags.includeSegmentFileSizes(request.includeSegmentFileSizes());
-        }
-        if (request.completion()) {
-            flags.set(CommonStatsFlags.Flag.Completion);
-            flags.completionDataFields(request.completionFields());
-        }
-        if (request.translog()) {
-            flags.set(CommonStatsFlags.Flag.Translog);
-        }
-        if (request.requestCache()) {
-            flags.set(CommonStatsFlags.Flag.RequestCache);
-        }
-        if (request.recovery()) {
-            flags.set(CommonStatsFlags.Flag.Recovery);
-        }
-
-        return new ShardStats(
-            indexShard.routingEntry(),
-            indexShard.shardPath(),
-            new CommonStats(indicesService.getIndicesQueryCache(), indexShard, flags), indexShard.commitStats(), indexShard.seqNoStats());
+        CommonStats commonStats = new CommonStats(indicesService.getIndicesQueryCache(), indexShard, request.flags());
+        return new ShardStats(indexShard.routingEntry(), indexShard.shardPath(), commonStats,
+            indexShard.commitStats(), indexShard.seqNoStats());
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesStatsAction.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
+import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
+import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
@@ -57,23 +59,10 @@ public class RestIndicesStatsAction extends BaseRestHandler {
     static final Map<String, Consumer<IndicesStatsRequest>> METRICS;
 
     static {
-        final Map<String, Consumer<IndicesStatsRequest>> metrics = new HashMap<>();
-        metrics.put("docs", r -> r.docs(true));
-        metrics.put("store", r -> r.store(true));
-        metrics.put("indexing", r -> r.indexing(true));
-        metrics.put("search", r -> r.search(true));
-        metrics.put("get", r -> r.get(true));
-        metrics.put("merge", r -> r.merge(true));
-        metrics.put("refresh", r -> r.refresh(true));
-        metrics.put("flush", r -> r.flush(true));
-        metrics.put("warmer", r -> r.warmer(true));
-        metrics.put("query_cache", r -> r.queryCache(true));
-        metrics.put("segments", r -> r.segments(true));
-        metrics.put("fielddata", r -> r.fieldData(true));
-        metrics.put("completion", r -> r.completion(true));
-        metrics.put("request_cache", r -> r.requestCache(true));
-        metrics.put("recovery", r -> r.recovery(true));
-        metrics.put("translog", r -> r.translog(true));
+        Map<String, Consumer<IndicesStatsRequest>> metrics = new HashMap<>();
+        for (Flag flag : CommonStatsFlags.Flag.values()) {
+            metrics.put(flag.getRestName(), m -> m.flags().set(flag, true));
+        }
         METRICS = Collections.unmodifiableMap(metrics);
     }
 


### PR DESCRIPTION
This allows us to simplify the logic in a couple places where all flags need to be accessed.

Addresses #10096.