### PR TITLE
Convert FieldCapabilitiesResponse to a ToXContentObject.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
-import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 /**
  * Response for {@link FieldCapabilitiesRequest} requests.
  */
-public class FieldCapabilitiesResponse extends ActionResponse implements ToXContentFragment {
+public class FieldCapabilitiesResponse extends ActionResponse implements ToXContentObject {
     private static final ParseField FIELDS_FIELD = new ParseField("fields");
 
     private Map<String, Map<String, FieldCapabilities>> responseMap;
@@ -123,8 +123,9 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(FIELDS_FIELD.getPreferredName(), responseMap);
-        return builder;
+        return builder.startObject()
+            .field(FIELDS_FIELD.getPreferredName(), responseMap)
+            .endObject();
     }
 
     public static FieldCapabilitiesResponse fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/rest/action/RestFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestFieldCapabilitiesAction.java
@@ -81,17 +81,6 @@ public class RestFieldCapabilitiesAction extends BaseRestHandler {
         fieldRequest.indicesOptions(
             IndicesOptions.fromRequest(request, fieldRequest.indicesOptions())
         );
-        return channel -> client.fieldCaps(fieldRequest,
-            new RestBuilderListener<FieldCapabilitiesResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(FieldCapabilitiesResponse response,
-                                              XContentBuilder builder) throws Exception {
-                RestStatus status = OK;
-                builder.startObject();
-                response.toXContent(builder, request);
-                builder.endObject();
-                return new BytesRestResponse(status, builder);
-            }
-        });
+        return channel -> client.fieldCaps(fieldRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -110,10 +110,8 @@ public class FieldCapabilitiesResponseTests extends AbstractStreamableXContentTe
     public void testToXContent() throws IOException {
         FieldCapabilitiesResponse response = createSimpleResponse();
 
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)
-            .startObject();
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        builder.endObject();
 
         String generatedResponse = BytesReference.bytes(builder).utf8ToString();
         assertEquals((


### PR DESCRIPTION
Follow-up from https://github.com/elastic/elasticsearch/pull/29664.