### PR TITLE
clarify 'Fuzzy Like this Query' redirect doc

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -240,7 +240,7 @@ as a query in ``query context'' and as a filter in ``filter context'' (see
 [role="exclude",id="query-dsl-flt-query"]
 === Fuzzy Like This Query
 
-The `fuzzy_like_this` or `flt` query has been removed.  Instead use
+The `fuzzy_like_this`, alternatively known as `flt`, query has been removed.  Instead use either
 the <<query-dsl-match-query-fuzziness,`fuzziness`>> parameter with the
 <<query-dsl-match-query,`match` query>> or the <<query-dsl-mlt-query>>.
 


### PR DESCRIPTION
This documentation is unclear. "The fuzzy_like_this_field or flt_field query has been removed." is confusing since it leads the reader to think one or the other was removed, not necessarily both. I've changed it to specify both have been removed. 

Secondly, "Instead use the fuzziness parameter with the match query or the More Like This Query." implies that both the fuzziness parameter and the mlt parameter can be used together. It doesn't seem like they can, so I've changed it to either...or to show it is an exclusive or. 

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
