### PR TITLE
Tests: Use buildDir as base for generated-resources

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -114,7 +114,7 @@ subprojects {
     approvedLicenses << 'Apache'
   }
 
-  String outputDir = "generated-resources/${project.name}"
+  String outputDir = "${buildDir}/generated-resources/${project.name}"
 
   // This is a top level task which we will add dependencies to below.
   // It is a single task that can be used to backcompat tests against all versions.
@@ -123,7 +123,7 @@ subprojects {
     group = 'verification'
   }
 
-  String output = "generated-resources/${project.name}"
+  String output = "${buildDir}/generated-resources/${project.name}"
   task copyTestNodeKeystore(type: Copy) {
     from project(xpackModule('core'))
             .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')

--- a/x-pack/qa/rolling-upgrade-basic/build.gradle
+++ b/x-pack/qa/rolling-upgrade-basic/build.gradle
@@ -71,7 +71,7 @@ task bwcTest {
     group = 'verification'
 }
 
-String outputDir = "generated-resources/${project.name}"
+String outputDir = "${buildDir}/generated-resources/${project.name}"
 
 for (Version version : bwcVersions.wireCompatible) {
     String baseName = "v${version}"

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -96,7 +96,7 @@ subprojects {
     }
   }
 
-  String outputDir = "generated-resources/${project.name}"
+  String outputDir = "${buildDir}/generated-resources/${project.name}"
 
   // This is a top level task which we will add dependencies to below.
   // It is a single task that can be used to backcompat tests against all versions.
@@ -105,7 +105,7 @@ subprojects {
     group = 'verification'
   }
 
-  String output = "generated-resources/${project.name}"
+  String output = "${buildDir}/generated-resources/${project.name}"
   task copyTestNodeKeystore(type: Copy) {
     from project(xpackModule('core'))
             .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')

--- a/x-pack/qa/security-client-tests/build.gradle
+++ b/x-pack/qa/security-client-tests/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   testCompile project(path: xpackProject('transport-client').path, configuration: 'runtime')
 }
 
-String outputDir = "generated-resources/${project.name}"
+String outputDir = "${buildDir}/generated-resources/${project.name}"
 task copyXPackPluginProps(type: Copy) {
   from project(xpackModule('core')).file('src/main/plugin-metadata')
   from project(xpackModule('core')).tasks.pluginProperties

--- a/x-pack/qa/smoke-test-plugins-ssl/build.gradle
+++ b/x-pack/qa/smoke-test-plugins-ssl/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'runtime')
 }
 
-String outputDir = "generated-resources/${project.name}"
+String outputDir = "${buildDir}/generated-resources/${project.name}"
 task copyXPackPluginProps(type: Copy) {
   from project(xpackModule('core')).file('src/main/plugin-metadata')
   from project(xpackModule('core')).tasks.pluginProperties


### PR DESCRIPTION
This commit moves the generated-resources directory created by many qa
projects into the build directory, so it is not seen as unknown files to
git.