### PR TITLE
Add new `is_write_index` flag to Alias MetaData

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
@@ -48,6 +48,7 @@ public class Alias implements Streamable, ToXContentObject {
     private static final ParseField ROUTING = new ParseField("routing");
     private static final ParseField INDEX_ROUTING = new ParseField("index_routing", "indexRouting", "index-routing");
     private static final ParseField SEARCH_ROUTING = new ParseField("search_routing", "searchRouting", "search-routing");
+    private static final ParseField IS_WRITE_INDEX = new ParseField("is_write_index");
 
     private String name;
 
@@ -59,6 +60,9 @@ public class Alias implements Streamable, ToXContentObject {
 
     @Nullable
     private String searchRouting;
+
+    @Nullable
+    private boolean writeIndex;
 
     private Alias() {
 
@@ -166,6 +170,18 @@ public class Alias implements Streamable, ToXContentObject {
         return this;
     }
 
+    public boolean isWriteIndex() {
+        return writeIndex;
+    }
+
+    /**
+     * Associates a write-only alias boolean flag to the alias
+     */
+    public Alias writeIndex(boolean writeIndex) {
+        this.writeIndex = writeIndex;
+        return this;
+    }
+
     /**
      * Allows to read an alias from the provided input stream
      */
@@ -181,6 +197,7 @@ public class Alias implements Streamable, ToXContentObject {
         filter = in.readOptionalString();
         indexRouting = in.readOptionalString();
         searchRouting = in.readOptionalString();
+        writeIndex = in.readBoolean();
     }
 
     @Override
@@ -189,6 +206,7 @@ public class Alias implements Streamable, ToXContentObject {
         out.writeOptionalString(filter);
         out.writeOptionalString(indexRouting);
         out.writeOptionalString(searchRouting);
+        out.writeBoolean(writeIndex);
     }
 
     /**
@@ -218,6 +236,10 @@ public class Alias implements Streamable, ToXContentObject {
                 } else if (SEARCH_ROUTING.match(currentFieldName, parser.getDeprecationHandler())) {
                     alias.searchRouting(parser.text());
                 }
+            } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
+                if (IS_WRITE_INDEX.match(currentFieldName, parser.getDeprecationHandler())) {
+                    alias.writeIndex(parser.booleanValue());
+                }
             }
         }
         return alias;
@@ -243,6 +265,8 @@ public class Alias implements Streamable, ToXContentObject {
                 builder.field(SEARCH_ROUTING.getPreferredName(), searchRouting);
             }
         }
+
+        builder.field(IS_WRITE_INDEX.getPreferredName(), writeIndex);
 
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -84,6 +84,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         private static final ParseField ROUTING = new ParseField("routing");
         private static final ParseField INDEX_ROUTING = new ParseField("index_routing", "indexRouting", "index-routing");
         private static final ParseField SEARCH_ROUTING = new ParseField("search_routing", "searchRouting", "search-routing");
+        private static final ParseField IS_WRITE_INDEX = new ParseField("is_write_index");
 
         private static final ParseField ADD = new ParseField("add");
         private static final ParseField REMOVE = new ParseField("remove");
@@ -179,6 +180,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             ADD_PARSER.declareField(AliasActions::routing, XContentParser::text, ROUTING, ValueType.INT);
             ADD_PARSER.declareField(AliasActions::indexRouting, XContentParser::text, INDEX_ROUTING, ValueType.INT);
             ADD_PARSER.declareField(AliasActions::searchRouting, XContentParser::text, SEARCH_ROUTING, ValueType.INT);
+            ADD_PARSER.declareField(AliasActions::writeIndex, XContentParser::booleanValue, IS_WRITE_INDEX, ValueType.BOOLEAN);
         }
         private static final ObjectParser<AliasActions, Void> REMOVE_PARSER = parser(REMOVE.getPreferredName(), AliasActions::remove);
         private static final ObjectParser<AliasActions, Void> REMOVE_INDEX_PARSER = parser(REMOVE_INDEX.getPreferredName(),
@@ -215,6 +217,7 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
         private String routing;
         private String indexRouting;
         private String searchRouting;
+        private boolean writeIndex;
 
         public AliasActions(AliasActions.Type type) {
             this.type = type;
@@ -399,6 +402,18 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
             } catch (IOException e) {
                 throw new ElasticsearchGenerationException("Failed to build json for alias request", e);
             }
+        }
+
+        public AliasActions writeIndex(boolean writeIndex) {
+            if (type != AliasActions.Type.ADD) {
+                throw new IllegalArgumentException("[is_write_index] is unsupported for [" + type + "]");
+            }
+            this.writeIndex = writeIndex;
+            return this;
+        }
+
+        public boolean isWriteIndex() {
+            return writeIndex;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -100,7 +100,8 @@ public class TransportIndicesAliasesAction extends TransportMasterNodeAction<Ind
                 switch (action.actionType()) {
                 case ADD:
                     for (String alias : concreteAliases(action, state.metaData(), index)) {
-                        finalActions.add(new AliasAction.Add(index, alias, action.filter(), action.indexRouting(), action.searchRouting()));
+                        finalActions.add(new AliasAction.Add(index, alias, action.filter(), action.indexRouting(),
+                            action.searchRouting(), action.isWriteIndex()));
                     }
                     break;
                 case REMOVE:

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasAction.java
@@ -51,7 +51,7 @@ public abstract class AliasAction {
 
     /**
      * Apply the action.
-     * 
+     *
      * @param aliasValidator call to validate a new alias before adding it to the builder
      * @param metadata metadata builder for the changes made by all actions as part of this request
      * @param index metadata for the index being changed
@@ -64,7 +64,7 @@ public abstract class AliasAction {
      */
     @FunctionalInterface
     public interface NewAliasValidator {
-        void validate(String alias, @Nullable String indexRouting, @Nullable String filter);
+        void validate(String alias, @Nullable String indexRouting, @Nullable String filter, boolean writeIndex);
     }
 
     /**
@@ -82,10 +82,14 @@ public abstract class AliasAction {
         @Nullable
         private final String searchRouting;
 
+        @Nullable
+        private final Boolean writeIndex;
+
         /**
          * Build the operation.
          */
-        public Add(String index, String alias, @Nullable String filter, @Nullable String indexRouting, @Nullable String searchRouting) {
+        public Add(String index, String alias, @Nullable String filter, @Nullable String indexRouting,
+                   @Nullable String searchRouting, @Nullable Boolean writeIndex) {
             super(index);
             if (false == Strings.hasText(alias)) {
                 throw new IllegalArgumentException("[alias] is required");
@@ -94,6 +98,7 @@ public abstract class AliasAction {
             this.filter = filter;
             this.indexRouting = indexRouting;
             this.searchRouting = searchRouting;
+            this.writeIndex = writeIndex;
         }
 
         /**
@@ -110,9 +115,18 @@ public abstract class AliasAction {
 
         @Override
         boolean apply(NewAliasValidator aliasValidator, MetaData.Builder metadata, IndexMetaData index) {
-            aliasValidator.validate(alias, indexRouting, filter);
+            boolean modifiedWriteIndex = Boolean.TRUE.equals(writeIndex);
+
+            // If alias for index is not set as write_index:true, we can safely try and set it so
+            // TODO(talevy): do we want the same behavior here as in index creation?
+            if (writeIndex == null && AliasValidator.validAliasWriteOnly(alias, true, metadata.indices())) {
+                modifiedWriteIndex = true;
+            }
+
+            aliasValidator.validate(alias, indexRouting, filter, modifiedWriteIndex);
+
             AliasMetaData newAliasMd = AliasMetaData.newAliasMetaDataBuilder(alias).filter(filter).indexRouting(indexRouting)
-                    .searchRouting(searchRouting).build();
+                    .searchRouting(searchRouting).writeIndex(modifiedWriteIndex).build();
             // Check if this alias already exists
             AliasMetaData currentAliasMd = index.getAliases().get(alias);
             if (currentAliasMd != null && currentAliasMd.equals(newAliasMd)) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasMetaData.java
@@ -54,7 +54,9 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
 
     private final Set<String> searchRoutingValues;
 
-    private AliasMetaData(String alias, CompressedXContent filter, String indexRouting, String searchRouting) {
+    private final Boolean writeIndex;
+
+    private AliasMetaData(String alias, CompressedXContent filter, String indexRouting, String searchRouting, Boolean writeIndex) {
         this.alias = alias;
         this.filter = filter;
         this.indexRouting = indexRouting;
@@ -64,10 +66,11 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
         } else {
             searchRoutingValues = emptySet();
         }
+        this.writeIndex = writeIndex;
     }
 
     private AliasMetaData(AliasMetaData aliasMetaData, String alias) {
-        this(alias, aliasMetaData.filter(), aliasMetaData.indexRouting(), aliasMetaData.searchRouting());
+        this(alias, aliasMetaData.filter(), aliasMetaData.indexRouting(), aliasMetaData.searchRouting(), aliasMetaData.isWriteIndex());
     }
 
     public String alias() {
@@ -110,6 +113,10 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
         return searchRoutingValues;
     }
 
+    public Boolean isWriteIndex() {
+        return writeIndex;
+    }
+
     public static Builder builder(String alias) {
         return new Builder(alias);
     }
@@ -137,6 +144,8 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
         if (indexRouting != null ? !indexRouting.equals(that.indexRouting) : that.indexRouting != null) return false;
         if (searchRouting != null ? !searchRouting.equals(that.searchRouting) : that.searchRouting != null)
             return false;
+        if (writeIndex != that.writeIndex)
+            return false;
 
         return true;
     }
@@ -147,6 +156,7 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
         result = 31 * result + (filter != null ? filter.hashCode() : 0);
         result = 31 * result + (indexRouting != null ? indexRouting.hashCode() : 0);
         result = 31 * result + (searchRouting != null ? searchRouting.hashCode() : 0);
+        result = 31 * result + Boolean.hashCode(writeIndex);
         return result;
     }
 
@@ -171,7 +181,7 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
         } else {
             out.writeBoolean(false);
         }
-
+        out.writeBoolean(isWriteIndex());
     }
 
     public AliasMetaData(StreamInput in) throws IOException {
@@ -193,6 +203,7 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
             searchRouting = null;
             searchRoutingValues = emptySet();
         }
+        writeIndex = in.readBoolean();
     }
 
     public static Diff<AliasMetaData> readDiffFrom(StreamInput in) throws IOException {
@@ -209,6 +220,8 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
 
         private String searchRouting;
 
+        private boolean writeIndex;
+
 
         public Builder(String alias) {
             this.alias = alias;
@@ -219,6 +232,7 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
             filter = aliasMetaData.filter();
             indexRouting = aliasMetaData.indexRouting();
             searchRouting = aliasMetaData.searchRouting();
+            writeIndex = aliasMetaData.isWriteIndex();
         }
 
         public String alias() {
@@ -272,8 +286,13 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
             return this;
         }
 
+        public Builder writeIndex(boolean writeIndex) {
+            this.writeIndex = writeIndex;
+            return this;
+        }
+
         public AliasMetaData build() {
-            return new AliasMetaData(alias, filter, indexRouting, searchRouting);
+            return new AliasMetaData(alias, filter, indexRouting, searchRouting, writeIndex);
         }
 
         public static void toXContent(AliasMetaData aliasMetaData, XContentBuilder builder, ToXContent.Params params) throws IOException {
@@ -294,6 +313,8 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
             if (aliasMetaData.searchRouting() != null) {
                 builder.field("search_routing", aliasMetaData.searchRouting());
             }
+
+            builder.field("is_write_index", Boolean.TRUE.equals(aliasMetaData.isWriteIndex()));
 
             builder.endObject();
         }
@@ -326,6 +347,10 @@ public class AliasMetaData extends AbstractDiffable<AliasMetaData> {
                         builder.indexRouting(parser.text());
                     } else if ("search_routing".equals(currentFieldName) || "searchRouting".equals(currentFieldName)) {
                         builder.searchRouting(parser.text());
+                    }
+                } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
+                    if ("is_write_index".equals(currentFieldName)) {
+                        builder.writeIndex(parser.booleanValue());
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Encapsulates the  {@link IndexMetaData} instances of a concrete index or indices an alias is pointing to.
@@ -93,6 +94,12 @@ public interface AliasOrIndex {
         @Override
         public List<IndexMetaData> getIndices() {
             return referenceIndexMetaDatas;
+        }
+
+
+        public List<IndexMetaData> getWriteIndices() {
+            return referenceIndexMetaDatas.stream()
+                .filter(i -> i.getAliases().get(aliasName).isWriteIndex()).collect(Collectors.toList());
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -85,9 +85,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS;
@@ -490,14 +492,29 @@ public class MetaDataCreateIndexService extends AbstractComponent {
                     indexMetaDataBuilder.putMapping(mappingMd);
                 }
 
+                Map<String, AliasMetaData> aliases = new HashMap<>();
                 for (AliasMetaData aliasMetaData : templatesAliases.values()) {
-                    indexMetaDataBuilder.putAlias(aliasMetaData);
+                    // modify to be write_index when appropriate?
+                    aliases.put(aliasMetaData.getAlias(), aliasMetaData);
                 }
                 for (Alias alias : request.aliases()) {
                     AliasMetaData aliasMetaData = AliasMetaData.builder(alias.name()).filter(alias.filter())
-                        .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting()).build();
-                    indexMetaDataBuilder.putAlias(aliasMetaData);
+                        .indexRouting(alias.indexRouting()).searchRouting(alias.searchRouting())
+                        .writeIndex(alias.isWriteIndex()).build();
+                    aliases.put(aliasMetaData.getAlias(), aliasMetaData);
                 }
+
+                // TODO(talevy): modify alias to write_index when appropriate
+                aliases.forEach((aliasName, aliasMetaData) -> {
+                    if (aliasMetaData.isWriteIndex() == false
+                        && AliasValidator.validAliasWriteOnly(aliasName, true, currentState.metaData().indices())) {
+                        indexMetaDataBuilder.putAlias(AliasMetaData.builder(aliasName).filter(aliasMetaData.getFilter())
+                            .indexRouting(aliasMetaData.getIndexRouting()).searchRouting(aliasMetaData.searchRouting()).writeIndex(true));
+                    } else {
+                        aliasValidator.validateAliasWriteOnly(aliasMetaData.alias(), aliasMetaData.isWriteIndex(), currentState.metaData());
+                        indexMetaDataBuilder.putAlias(aliasMetaData);
+                    }
+                });
 
                 for (Map.Entry<String, Custom> customEntry : customs.entrySet()) {
                     indexMetaDataBuilder.putCustom(customEntry.getKey(), customEntry.getValue());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesService.java
@@ -127,11 +127,12 @@ public class MetaDataIndexAliasesService extends AbstractComponent {
                 if (index == null) {
                     throw new IndexNotFoundException(action.getIndex());
                 }
-                NewAliasValidator newAliasValidator = (alias, indexRouting, filter) -> {
+                NewAliasValidator newAliasValidator = (alias, indexRouting, filter, writeIndex) -> {
                     /* It is important that we look up the index using the metadata builder we are modifying so we can remove an
                      * index and replace it with an alias. */
                     Function<String, IndexMetaData> indexLookup = name -> metadata.get(name);
                     aliasValidator.validateAlias(alias, action.getIndex(), indexRouting, indexLookup);
+                    aliasValidator.validateAliasWriteOnly(alias, action.getIndex(), writeIndex, metadata.indices());
                     if (Strings.hasLength(filter)) {
                         IndexService indexService = indices.get(index.getIndex().getName());
                         if (indexService == null) {

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -351,7 +351,7 @@ public final class ImmutableOpenMap<KType, VType> implements Iterable<ObjectObje
 
         @Override
         public ObjectContainer<VType> values() {
-            return map.values();
+            return (map == null) ? EMPTY.values() : map.values();
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
in response to #30061.

This PR rebuilds aliasAndIndexLookup every time it wants to use it for alias validation. Depends on outcome of #29575 for using a pre-built data-structure.

This PR introduces a concept in aliases called `is_write_index`. When `true` on a specific
alias definition associated with an `index`, index requests using the associated alias name will 
resolve to this `index` for indexing.

Write now, if one attempts to index a document using an alias that points to multiple indices, there is no way to resolve which one, so an exception is thrown. With this flag, you can have an alias that points to a specific index in a set of indices as the one to write to.

It is possible to set an index as an alias' write-index during index creation:

```
PUT foo1
{
  "aliases": {
    "bar": { "is_write_index": true }
  }
}
```

Now, index requests like `PUT bar/_doc/_id` will route to index `foo1`. Another index, `foo2`, is 
free to also have an alias named "bar" pointing to it. This alias needs to be configured with `is_write_index` set to `false`. `is_write_index` is defaulted to `false` if not specified, or it can be explicitly set to `false`.

```
PUT foo2
{
  "aliases": {
    "bar": {}
  }
}
```

Now, searches against `bar` will point to both indices, but index requests will be routed to `foo1`.

These settings can be updated in the `_aliases` API like so:

```
POST _aliases
{
  "actions": [
    {
      "add": {
        "index": "foo1",
        "alias": "bar",
        "is_write_index": false
      }
    }
  ]
}
```

How does this relate to Rollover? Rollover depended on rollover-aliases that only point to 
one index since multiple would break indexing. Now that the same alias can point to multiple indices, the only requirement we have is that there is only one write index.

Here is an example scenario that didn't work before, but works with these changes:

```
PUT _template/my_template
{
  "index_patterns": ["foo-*"],
  "settings": {
    "number_of_shards": 1,
    "number_of_replicas": 1
  },
  "aliases": {
    "logs": {}
  },
  "mappings": {
    "_doc": {
      "_source": {
        "enabled": false
      }
    }
  }
}

PUT foo-000001
{
  "aliases": {
    "logs": { "is_write_index": true }
  }
}

PUT logs/_doc/_id
{
  "hello": "world"
}

POST /logs/_rollover/
{
  "conditions": {
    "max_docs":  1
  }
}

GET foo-000001 # now this is `is_write_index: false`
GET foo-000002 # now this is `is_write_index: true`
```