### PR TITLE
[ML] Changes to flush job responses

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFlushJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportFlushJobAction.java
@@ -61,7 +61,7 @@ public class TransportFlushJobAction extends TransportJobTaskAction<FlushJobActi
         paramsBuilder.forTimeRange(timeRangeBuilder.build());
         processManager.flushJob(task, paramsBuilder.build(), ActionListener.wrap(
                 flushAcknowledgement -> {
-                    listener.onResponse(new FlushJobAction.Response(true,
+                    listener.onResponse(new FlushJobAction.Response(flushAcknowledgement != null,
                             flushAcknowledgement == null ? null : flushAcknowledgement.getLastFinalizedBucketEnd()));
                 }, listener::onFailure
         ));

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/post_data.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/post_data.yml
@@ -107,7 +107,7 @@ setup:
       xpack.ml.flush_job:
         job_id: post-data-job
   - match: { flushed: true }
-  - match: { last_finalized_bucket_end: 0 }
+  - is_false: last_finalized_bucket_end
 
   - do:
       xpack.ml.close_job:


### PR DESCRIPTION
This is required to support control messages in the categorize
program, but also fixes a bug that I noticed while making the
change.  It also changes the response in an edge case.

* The categorize program doesn't use buckets so we now expect
  last finalized bucket end time 0 to be more common than previously
* A last finalized bucket end time of 0 is no longer included in the
  JSON representation of the flush response
* This changes the response slightly in the case of flushing an
  anomaly_detector job that has never been sent any data
* There was also a bug where serialising a flush response for a failed
  flush across the network would cause an NPE - this has been solved
  without changing the wire format by replacing nulls with Date(0)