### PR TITLE
Do not log warn shard not-available exception in replication

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -384,7 +384,9 @@ public abstract class TransportWriteAction<
         @Override
         public void failShardIfNeeded(ShardRouting replica, String message, Exception exception,
                                       Runnable onSuccess, Consumer<Exception> onPrimaryDemoted, Consumer<Exception> onIgnoredFailure) {
-            logger.warn(new ParameterizedMessage("[{}] {}", replica.shardId(), message), exception);
+            if (TransportActions.isShardNotAvailableException(exception) == false) {
+                logger.warn(new ParameterizedMessage("[{}] {}", replica.shardId(), message), exception);
+            }
             shardStateAction.remoteShardFailed(replica.shardId(), replica.allocationId().getId(), primaryTerm, true, message, exception,
                 createShardActionListener(onSuccess, onPrimaryDemoted, onIgnoredFailure));
         }


### PR DESCRIPTION
Since #28049, only fully initialized shards are received write requests.
This enhancement allows us to handle all exceptions. In #28571, we
started strictly handling shard-not-available exceptions and tried to
keep the way we report replication errors to users by only reporting if
the error is not shard-not-available exceptions. However, since then we
unintentionally always log warn for all exception. This change restores
to the previous behavior which logs warn only if an exception is not a 
shard-not-available exception.

Relates #28049
Relates #28571