### PR TITLE
[DOCS] Adds native realm configuration details

### DIFF
--- a/x-pack/docs/en/security/authentication/configuring-native-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-native-realm.asciidoc
@@ -3,12 +3,11 @@
 === Configuring a Native Realm
 
 The easiest way to manage and authenticate users is with the internal `native`
-realm. You don't need to explicitly configure a native realm; it is added to the 
-realm chain by default. 
+realm. 
 
-IMPORTANT: When you configure realms in `elasticsearch.yml`, only the
-realms you specify are used for authentication. To use the
-`native` realm as a fallback, you must include it in the realm chain.
+The native realm is available by default when no other realms are 
+configured. If other realm settings have been configured in `elasticsearch.yml`, 
+you must add the native realm to the realm chain.
 
 You can configure options for the `native` realm in the 
 `xpack.security.authc.realms` namespace in `elasticsearch.yml`. Explicitly

--- a/x-pack/docs/en/security/authentication/configuring-native-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-native-realm.asciidoc
@@ -1,0 +1,44 @@
+[role="xpack"]
+[[configuring-native-realm]]
+=== Configuring a Native Realm
+
+The easiest way to manage and authenticate users is with the internal `native`
+realm. You don't need to explicitly configure a native realm; it is added to the 
+realm chain by default. 
+
+IMPORTANT: When you configure realms in `elasticsearch.yml`, only the
+realms you specify are used for authentication. To use the
+`native` realm as a fallback, you must include it in the realm chain.
+
+You can configure options for the `native` realm in the 
+`xpack.security.authc.realms` namespace in `elasticsearch.yml`. Explicitly
+configuring a native realm enables you to set the order in which it appears in
+the realm chain, temporarily disable the realm, and control its cache options.
+
+. Add a realm configuration of type `native` to `elasticsearch.yml` under the
+`xpack.security.authc.realms` namespace. At a minimum, you must set the realm
+`type` to `native`. If you are configuring multiple realms, you should also
+explicitly set the `order` attribute. 
++
+--
+//See <<ref-native-settings>> for all of the options you can set for the `native` realm.
+For example, the following snippet shows a `native` realm configuration that
+sets the `order` to zero so the realm is checked first:
+
+[source, yaml]
+------------------------------------------------------------
+xpack:
+  security:
+    authc:
+      realms:
+        native1:
+          type: native
+          order: 0
+------------------------------------------------------------
+--
+
+. Restart {es}.
+
+. Manage your users in {kib} on the *Management / Security / Users* page. 
+Alternatively, use the <<security-api-users,User Management APIs>>.
+

--- a/x-pack/docs/en/security/authentication/configuring-native-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-native-realm.asciidoc
@@ -21,7 +21,7 @@ the realm chain, temporarily disable the realm, and control its cache options.
 explicitly set the `order` attribute. 
 +
 --
-//See <<ref-native-settings>> for all of the options you can set for the `native` realm.
+See <<ref-native-settings>> for all of the options you can set for the `native` realm.
 For example, the following snippet shows a `native` realm configuration that
 sets the `order` to zero so the realm is checked first:
 

--- a/x-pack/docs/en/security/authentication/native-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/native-realm.asciidoc
@@ -9,12 +9,12 @@ manage user passwords.
 [float]
 ==== Configuring a native realm
 
-See {ref}/[Configuring a Native Realm]. 
+See {ref}/[Configuring a native realm]. 
 
 [[native-settings]]
 ==== Native realm settings
 
-See {ref}/security-settings.html#ref-native-settings[Native Realm Settings]. 
+See {ref}/security-settings.html#ref-native-settings[Native realm settings]. 
 
 [[managing-native-users]]
 ==== Managing native users
@@ -23,7 +23,7 @@ See {ref}/security-settings.html#ref-native-settings[Native Realm Settings].
 *Management / Security / Users* page. 
 
 Alternatively, you can manage users through the `user` API. For more 
-information and examples, see {ref}/security-api-users.html[User Management APIs].
+information and examples, see {ref}/security-api-users.html[User management APIs].
 
 [[migrating-from-file]]
 NOTE: To migrate file-based users to the `native` realm, use the

--- a/x-pack/docs/en/security/authentication/native-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/native-realm.asciidoc
@@ -9,42 +9,7 @@ manage user passwords.
 [float]
 ==== Configuring a native realm
 
-The native realm is added to the realm chain by default. You don't need to
-explicitly configure a native realm to manage users through the REST APIs.
-
-
-IMPORTANT: When you configure realms in `elasticsearch.yml`, only the
-realms you specify are used for authentication. To use the
-`native` realm as a fallback, you must include it in the realm chain.
-
-You can, however, configure options for the `native` realm in the
-`xpack.security.authc.realms` namespace in `elasticsearch.yml`. Explicitly
-configuring a native realm enables you to set the order in which it appears in
-the realm chain, temporary disable the realm, and control its cache options.
-
-To configure a native realm:
-
-. Add a realm configuration of type `native` to `elasticsearch.yml` under the
-`xpack.security.authc.realms` namespace. At a minimum, you must set the realm
-`type` to `native`. If you are configuring multiple realms, you should also
-explicitly set the `order` attribute. See <<native-settings, Native Realm Settings>>
-for all of the options you can set for the `native` realm.
-+
-For example, the following snippet shows a `native` realm configuration that
-sets the `order` to zero so the realm is checked first:
-+
-[source, yaml]
-------------------------------------------------------------
-xpack:
-  security:
-    authc:
-      realms:
-        native1:
-          type: native
-          order: 0
-------------------------------------------------------------
-
-. Restart Elasticsearch.
+See {ref}/[Configuring a Native Realm]. 
 
 [[native-settings]]
 ==== Native realm settings

--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -73,6 +73,7 @@ user API.
 . Choose which types of realms you want to use to authenticate users. 
 ** <<configuring-ad-realm,Configure an Active Directory realm>>.
 ** <<configuring-file-realm,Configure a file realm>>.
+** <<configuring-native-realm,Configure a native realm>>.
 ** <<configuring-pki-realm,Configure a PKI realm>>.
 
 . Set up roles and users to control access to {es}.
@@ -135,6 +136,7 @@ include::securing-communications/enabling-cipher-suites.asciidoc[]
 include::securing-communications/separating-node-client-traffic.asciidoc[]
 include::authentication/configuring-active-directory-realm.asciidoc[]
 include::authentication/configuring-file-realm.asciidoc[]
+include::authentication/configuring-native-realm.asciidoc[]
 include::authentication/configuring-pki-realm.asciidoc[]
 include::{xes-repo-dir}/settings/security-settings.asciidoc[]
 include::{xes-repo-dir}/settings/audit-settings.asciidoc[]


### PR DESCRIPTION
This PR creates a task list of steps related to configuring native realms in the "Configuring Security" section of the Elasticsearch Reference.

The redundant information is then removed from the X-Pack Reference's "Native User Authentication" page and replaced with links.

Related to https://github.com/elastic/elasticsearch/pull/30186