### PR TITLE
Do not ignore request analysis/similarity on resize

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,7 +39,7 @@ written to by an older Elasticsearch after writing to it with a newer Elasticsea
 
 === Bug Fixes
 
-Do not ignore request analysis/similarity settings on resize ({pull}30216[#30216])
+Do not ignore request analysis/similarity settings on resize when the source index already contains such settings ({pull}30216[#30216])
 
 === Regressions
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,7 +39,7 @@ written to by an older Elasticsearch after writing to it with a newer Elasticsea
 
 === Bug Fixes
 
-Do not ignore request analysis/similarity settings on resize when the source index already contains such settings ({pull}30216[#30216])
+Do not ignore request analysis/similarity settings on index resize operations when the source index already contains such settings ({pull}30216[#30216])
 
 === Regressions
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -39,6 +39,8 @@ written to by an older Elasticsearch after writing to it with a newer Elasticsea
 
 === Bug Fixes
 
+Do not ignore request analysis/similarity settings on resize ({pull}30216[#30216])
+
 === Regressions
 
 === Known Issues

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -119,9 +119,7 @@ POST my_source_index/_shrink/my_target_index
     segment.
 
 
-NOTE: Mappings may not be specified in the `_shrink` request, and all
-`index.analysis.*` and `index.similarity.*` settings will be overwritten with
-the settings from the source index.
+NOTE: Mappings may not be specified in the `_shrink` request.
 
 [float]
 === Monitoring the shrink process

--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -121,6 +121,9 @@ POST my_source_index/_shrink/my_target_index
 
 NOTE: Mappings may not be specified in the `_shrink` request.
 
+NOTE: By default, with the exception of `index.analysis`, `index.similarity`, and `index.sort` settings, index settings on the source
+index are not copied during a shrink operation.
+
 [float]
 === Monitoring the shrink process
 

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -175,9 +175,10 @@ POST my_source_index/_split/my_target_index
     number of shards in the source index.
 
 
-NOTE: Mappings may not be specified in the `_split` request, and all
-`index.analysis.*` and `index.similarity.*` settings will be overwritten with
-the settings from the source index.
+NOTE: Mappings may not be specified in the `_split` request.
+
+NOTE: By default, with the exception of `index.analysis`, `index.similarity`, and `index.sort` settings, index settings on the source
+index are not copied during a shrink operation.
 
 [float]
 === Monitoring the split process

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -56,6 +56,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -694,8 +695,9 @@ public class MetaDataCreateIndexService extends AbstractComponent {
             throw new IllegalStateException("unknown resize type is " + type);
         }
 
-        final Predicate<String> sourceSettingsPredicate = (s) -> s.startsWith("index.similarity.")
-            || s.startsWith("index.analysis.") || s.startsWith("index.sort.");
+        final Predicate<String> sourceSettingsPredicate =
+                (s) -> (s.startsWith("index.similarity.") || s.startsWith("index.analysis.") || s.startsWith("index.sort."))
+                        && indexSettingsBuilder.keys().contains(s) == false;
         indexSettingsBuilder
             // now copy all similarity / analysis / sort settings - this overrides all settings from the user unless they
             // wanna add extra settings


### PR DESCRIPTION
Today when a resize operation is performed, we copy the analysis, similarity, and sort settings from the source index. It is possible for the resize request to include additional index settings including analysis, similarity, and sort settings. We reject sort settings when validating the request. However, we silently ignore analysis and similarity settings on the request that are already set on the source index. Since it is possible to change the analysis and similarity settings on an existing index, this should be considered a bug and the sort of leniency that we abhor. This commit addresses this bug by allowing the request analysis/similarity settings to override the existing analysis/similarity settings on the target.

