### PR TITLE
Bump changelog version to 6.4

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -31,7 +31,7 @@ written to by an older Elasticsearch after writing to it with a newer Elasticsea
 
 === Known Issues
 
-== Elasticsearch version 6.3.0
+== Elasticsearch version 6.4.0
 
 === New Features
 


### PR DESCRIPTION
This commit bumps the changelog version to 6.4 as now that 6.3 is feature frozen there would be no additional entries in the changelog for 6.3.0.

Relates #29684