### PR TITLE
Fixed path decoding during rest controller dispatch

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
+++ b/server/src/main/java/org/elasticsearch/common/path/PathTrie.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.common.path;
 
+import org.elasticsearch.rest.RestUtils;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -209,7 +211,7 @@ public class PathTrie<T> {
             if (index >= path.length)
                 return null;
 
-            String token = path[index];
+            String token = RestUtils.decodePathComponent(path[index]);
             TrieNode node = children.get(token);
             boolean usedWildcard;
 

--- a/server/src/test/java/org/elasticsearch/rest/RestUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestUtilsTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.rest;
 
 import org.elasticsearch.test.ESTestCase;
+import org.junit.Assert;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -34,6 +35,50 @@ public class RestUtilsTests extends ESTestCase {
 
     static char randomDelimiter() {
         return randomBoolean() ? '&' : ';';
+    }
+
+    public void testDecodeComponentPathPlain() {
+        decodePathComponentAndCheck("abc");
+    }
+
+    public void testDecodeComponentPathSlash() {
+        // path components shouldnt have slashes but if they did let it thru
+        decodePathComponentAndCheck("/abc");
+    }
+
+    public void testDecodeComponentPathEncoded() {
+        decodePathComponentAndCheck("abc%2Bxyz", "abc+xyz");
+    }
+
+    public void testDecodeComponentPathEncoded2() {
+        decodePathComponentAndCheck("abc%31xyz", "abc1xyz");
+    }
+
+    public void testDecodeComponentPathEncoded3() {
+        decodePathComponentAndCheck("abc%41xyz", "abcAxyz");
+    }
+
+    public void testDecodeComponentPathIncompleteHex() {
+        decodePathComponentAndCheck("abc%5xyz");
+    }
+
+    public void testDecodeComponentPathInvalidHex() {
+        decodePathComponentAndCheck("abc%Qxyz");
+    }
+
+    // https://github.com/elastic/elasticsearch/issues/5341
+    public void testDecodeComponentPathPlus() {
+        decodePathComponentAndCheck("/abc+xyz");
+    }
+
+    private void decodePathComponentAndCheck(final String in) {
+        decodePathComponentAndCheck(in, in);
+    }
+
+    private void decodePathComponentAndCheck(final String in, final String expected) {
+        Assert.assertEquals("RestUtils.decodePathComponent \"" + in + "\"",
+            expected,
+            RestUtils.decodePathComponent(in));
     }
 
     public void testDecodeQueryString() {


### PR DESCRIPTION
- old code didnt decode path components before matching handlers.
- old code incorrectly did a query string decode on path components,
  now does a proper path decode.
- #5341, #24537

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
YES

- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
YES

- If submitting code, have you built your formula locally prior to submission with `gradle check`?
YES, passed

- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
master

- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?

OSX - shouldnt matter

- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.

N/A