### PR TITLE
Handle missing and multiple values in script

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -41,6 +41,10 @@ written to by an older Elasticsearch after writing to it with a newer Elasticsea
 
 Do not ignore request analysis/similarity settings on index resize operations when the source index already contains such settings ({pull}30216[#30216])
 
+=== Deprecations
+
+Returning 0 for missing numeric fields in script is deprecated. PR: 
+
 === Regressions
 
 === Known Issues

--- a/docs/painless/painless-getting-started.asciidoc
+++ b/docs/painless/painless-getting-started.asciidoc
@@ -68,6 +68,7 @@ GET hockey/_search
 ----------------------------------------------------------------
 // CONSOLE
 
+
 Alternatively, you could do the same thing using a script field instead of a function score:
 
 [source,js]
@@ -118,6 +119,31 @@ GET hockey/_search
 }
 ----------------------------------------------------------------
 // CONSOLE
+
+[float]
+===== Missing values
+
+Currently by default, if a document is missing a numeric field `field`,
+`doc['field'].value` returns `0` for this document. This default behaviour
+will be changed in the next major version of elasticsearch. Starting from 7.0,
+if a document is missing a field `field`, `doc['field']` for this document
+will return `null`. From 6.4 version, you can set a system property
+`export ES_JAVA_OPTS="-Des.script.null_for_missing_value=true"' on a node
+to make this node's behaviour compatible with the future major version.
+Otherwise, every time the node starts a deprecation warning will remind you
+about this forthcoming change in 7.x.
+
+
+===== Multiple values
+
+There is a number of operations designed for numeric fields,
+if a document has multiple values in such a field:
+
+- `doc['field'].min` - gets the minimum value among values
+- `doc['field'].max` - gets the maximum value among values
+- `doc['field'].sum` - gets the sum of all values
+- `doc['field'].avg` - gets the average of all values
+
 
 [float]
 ==== Updating Fields with Painless

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -25,6 +25,7 @@ esplugin {
 }
 
 integTestCluster {
+  systemProperty 'es.script.null_for_missing_value', 'true'
   module project.project(':modules:mapper-extras')
 }
 

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -73,6 +73,10 @@ class org.elasticsearch.index.fielddata.ScriptDocValues$Strings {
 class org.elasticsearch.index.fielddata.ScriptDocValues$Longs {
   Long get(int)
   long getValue()
+  long getMin()
+  long getMax()
+  long getSum()
+  double getAvg()
   List getValues()
   org.joda.time.ReadableDateTime getDate()
   List getDates()
@@ -89,6 +93,10 @@ class org.elasticsearch.index.fielddata.ScriptDocValues$Dates {
 class org.elasticsearch.index.fielddata.ScriptDocValues$Doubles {
   Double get(int)
   double getValue()
+  double getMin()
+  double getMax()
+  double getSum()
+  double getAvg()
   List getValues()
 }
 

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/20_scriptfield.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/20_scriptfield.yml
@@ -95,7 +95,7 @@ setup:
                 script_fields:
                     bar:
                         script:
-                            source: "(doc['missing'].value?.length() ?: 0) + params.x;"
+                            source: "(doc['missing']?.value?.length() ?: 0) + params.x;"
                             params:
                                 x: 5
 

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/70_missing_and_multiple_values.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/70_missing_and_multiple_values.yml
@@ -1,0 +1,117 @@
+setup:
+    - do:
+        indices.create:
+            index: test
+            body:
+                settings:
+                    number_of_shards: 1
+                mappings:
+                    _doc:
+                        properties:
+                            dval:
+                                type: double
+                            lval:
+                                type: long
+
+    - do:
+        index:
+            index:  test
+            type:   _doc
+            id:     1
+            body:   { "dval": 5.5, "lval": 5 }
+
+    - do:
+        index:
+            index:  test
+            type:   _doc
+            id:     2
+            body:   { "dval": [5.5, 3.5, 4.5] }
+
+
+    - do:
+        index:
+            index:  test
+            type:   _doc
+            id:     3
+            body:   { "lval": [5, 3, 4] }
+
+    - do:
+        indices.refresh: {}
+
+---
+"check double and long values: missing values and operations on multiple values":
+    - skip:
+        version: " - 6.3.99"
+        reason: Handling missing values and operations on multiple values were added from 6.4
+
+    - do:
+        search:
+            body:
+                script_fields:
+                    val_dval:
+                        script:
+                            source: "doc['dval']?.value ?: -1.0"
+                    min_dval:
+                        script:
+                            source: "doc['dval']?.min ?: -1.0"
+                    max_dval:
+                        script:
+                            source: "doc['dval']?.max ?: -1.0"
+                    sum_dval:
+                        script:
+                            source: "doc['dval']?.sum ?: -1.0"
+                    avg_dval:
+                        script:
+                            source: "doc['dval']?.avg ?: -1.0"
+                    val_lval:
+                        script:
+                            source: "doc['lval']?.value ?: -1"
+                    min_lval:
+                        script:
+                            source: "doc['lval']?.min ?: -1"
+                    max_lval:
+                        script:
+                            source: "doc['lval']?.max ?: -1"
+                    sum_lval:
+                        script:
+                            source: "doc['lval']?.sum ?: -1"
+                    avg_lval:
+                        script:
+                            source: "doc['lval']?.avg ?: -1"
+
+    - match: { hits.hits.0.fields.val_dval.0: 5.5}
+    - match: { hits.hits.0.fields.min_dval.0: 5.5}
+    - match: { hits.hits.0.fields.max_dval.0: 5.5}
+    - match: { hits.hits.0.fields.sum_dval.0: 5.5}
+    - match: { hits.hits.0.fields.avg_dval.0: 5.5}
+
+    - match: { hits.hits.0.fields.val_lval.0: 5}
+    - match: { hits.hits.0.fields.min_lval.0: 5}
+    - match: { hits.hits.0.fields.max_lval.0: 5}
+    - match: { hits.hits.0.fields.sum_lval.0: 5}
+    - match: { hits.hits.0.fields.avg_lval.0: 5}
+
+    - match: { hits.hits.1.fields.val_dval.0: 3.5}
+    - match: { hits.hits.1.fields.min_dval.0: 3.5}
+    - match: { hits.hits.1.fields.max_dval.0: 5.5}
+    - match: { hits.hits.1.fields.sum_dval.0: 13.5}
+    - match: { hits.hits.1.fields.avg_dval.0: 4.5}
+
+    - match: { hits.hits.1.fields.val_lval.0: -1}
+    - match: { hits.hits.1.fields.min_lval.0: -1}
+    - match: { hits.hits.1.fields.max_lval.0: -1}
+    - match: { hits.hits.1.fields.sum_lval.0: -1}
+    - match: { hits.hits.1.fields.avg_lval.0: -1}
+
+    - match: { hits.hits.2.fields.val_dval.0: -1.0}
+    - match: { hits.hits.2.fields.min_dval.0: -1.0}
+    - match: { hits.hits.2.fields.max_dval.0: -1.0}
+    - match: { hits.hits.2.fields.sum_dval.0: -1.0}
+    - match: { hits.hits.2.fields.avg_dval.0: -1.0}
+
+    - match: { hits.hits.2.fields.val_lval.0: 3}
+    - match: { hits.hits.2.fields.min_lval.0: 3}
+    - match: { hits.hits.2.fields.max_lval.0: 5}
+    - match: { hits.hits.2.fields.sum_lval.0: 12}
+    - match: { hits.hits.2.fields.avg_lval.0: 4}
+

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -58,7 +58,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
     /**
      * Set the current doc ID.
      */
-    public abstract void setNextDocId(int docId) throws IOException;
+    public abstract boolean setNextDocId(int docId) throws IOException;
 
     /**
      * Return a copy of the list of the values for the current document.
@@ -124,9 +124,10 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         @Override
-        public void setNextDocId(int docId) throws IOException {
+        public boolean setNextDocId(int docId) throws IOException {
             this.docId = docId;
-            if (in.advanceExact(docId)) {
+            boolean docHasValues = in.advanceExact(docId);
+            if (docHasValues) {
                 resize(in.docValueCount());
                 for (int i = 0; i < count; i++) {
                     values[i] = in.nextValue();
@@ -137,6 +138,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             if (dates != null) {
                 dates.setNextDocId(docId);
             }
+            return docHasValues;
         }
 
         /**
@@ -157,6 +159,37 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
                 return 0L;
             }
             return values[0];
+        }
+
+        public long getMin() {
+            if (count == 0) {
+                return 0L;
+            };
+            return values[0];
+        }
+
+        public long getMax() {
+            if (count == 0) {
+                return 0L;
+            };
+            return values[count - 1];
+        }
+
+        public long getSum() {
+            if (count == 0) {
+                return 0L;
+            };
+            long sum = 0L;
+            for (int i = 0; i < count; i++)
+                sum += values[i];
+            return sum;
+        }
+
+        public double getAvg() {
+            if (count == 0) {
+                return 0d;
+            };
+            return getSum() * 1.0/count;
         }
 
         @Deprecated
@@ -285,13 +318,15 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         @Override
-        public void setNextDocId(int docId) throws IOException {
-            if (in.advanceExact(docId)) {
+        public boolean setNextDocId(int docId) throws IOException {
+            boolean docHasValues = in.advanceExact(docId);
+            if (docHasValues) {
                 count = in.docValueCount();
             } else {
                 count = 0;
             }
             refreshArray();
+            return docHasValues;
         }
 
         /**
@@ -355,8 +390,9 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         @Override
-        public void setNextDocId(int docId) throws IOException {
-            if (in.advanceExact(docId)) {
+        public boolean setNextDocId(int docId) throws IOException {
+            boolean docHasValues = in.advanceExact(docId);
+            if (docHasValues) {
                 resize(in.docValueCount());
                 for (int i = 0; i < count; i++) {
                     values[i] = in.nextValue();
@@ -364,6 +400,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             } else {
                 resize(0);
             }
+            return docHasValues;
         }
 
         /**
@@ -385,6 +422,38 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             }
             return values[0];
         }
+
+        public double getMin() {
+            if (count == 0) {
+                return 0d;
+            };
+            return values[0];
+        }
+
+        public double getMax() {
+            if (count == 0) {
+                return 0d;
+            };
+            return values[count - 1];
+        }
+
+        public double getSum() {
+            if (count == 0) {
+                return 0d;
+            };
+            double sum = 0d;
+            for (int i = 0; i < count; i++)
+                sum += values[i];
+            return sum;
+        }
+
+        public double getAvg() {
+            if (count == 0) {
+                return 0d;
+            };
+            return getSum() / count;
+        }
+
 
         @Override
         public Double get(int index) {
@@ -408,8 +477,9 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         @Override
-        public void setNextDocId(int docId) throws IOException {
-            if (in.advanceExact(docId)) {
+        public boolean setNextDocId(int docId) throws IOException {
+            boolean docHasValues = in.advanceExact(docId);
+            if (docHasValues) {
                 resize(in.docValueCount());
                 for (int i = 0; i < count; i++) {
                     GeoPoint point = in.nextValue();
@@ -418,6 +488,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             } else {
                 resize(0);
             }
+            return docHasValues;
         }
 
         /**
@@ -528,8 +599,9 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         @Override
-        public void setNextDocId(int docId) throws IOException {
-            if (in.advanceExact(docId)) {
+        public boolean setNextDocId(int docId) throws IOException {
+            boolean docHasValues = in.advanceExact(docId);
+            if (docHasValues) {
                 resize(in.docValueCount());
                 for (int i = 0; i < count; i++) {
                     values[i] = in.nextValue() == 1;
@@ -537,6 +609,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             } else {
                 resize(0);
             }
+            return docHasValues;
         }
 
         /**
@@ -584,8 +657,9 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         @Override
-        public void setNextDocId(int docId) throws IOException {
-            if (in.advanceExact(docId)) {
+        public boolean setNextDocId(int docId) throws IOException {
+            boolean docHasValues = in.advanceExact(docId);
+            if (docHasValues) {
                 resize(in.docValueCount());
                 for (int i = 0; i < count; i++) {
                     // We need to make a copy here, because BytesBinaryDVAtomicFieldData's SortedBinaryDocValues
@@ -596,6 +670,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             } else {
                 resize(0);
             }
+            return docHasValues;
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -251,14 +251,16 @@ public class IpFieldMapper extends FieldMapper {
             }
 
             @Override
-            public void setNextDocId(int docId) throws IOException {
+            public boolean setNextDocId(int docId) throws IOException {
                 count = 0;
-                if (in.advanceExact(docId)) {
+                boolean docHasValues = in.advanceExact(docId);
+                if (docHasValues) {
                     for (long ord = in.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = in.nextOrd()) {
                         ords = ArrayUtil.grow(ords, count + 1);
                         ords[count++] = ord;
                     }
                 }
+                return docHasValues;
             }
 
             public String getValue() {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -719,6 +719,10 @@ public class Node implements Closeable {
             writePortsFile("transport", transport.boundAddress());
         }
 
+        if (!ScriptModule.NULL_FOR_MISSING_VALUE)
+            logger.warn("Script: returning 0 for missing numeric values is deprecated. " +
+            "Set system property '-Des.script.null_for_missing_value=true' to make behaviour compatible with future major versions.");
+
         logger.info("started");
 
         pluginsService.filterPlugins(ClusterPlugin.class).forEach(ClusterPlugin::onNodeStarted);

--- a/server/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.common.Booleans;
 
 /**
  * Manages building {@link ScriptService}.
@@ -51,6 +52,8 @@ public class ScriptModule {
             TemplateScript.CONTEXT
         ).collect(Collectors.toMap(c -> c.name, Function.identity()));
     }
+    public static final boolean NULL_FOR_MISSING_VALUE =
+        Booleans.parseBoolean(System.getProperty("es.script.null_for_missing_value", "false"));
 
     private final ScriptService scriptService;
 

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.script.ScriptModule;
 
 import java.io.IOException;
 import java.security.AccessController;
@@ -91,7 +92,11 @@ public class LeafDocLookup implements Map<String, ScriptDocValues<?>> {
             localCacheFieldData.put(fieldName, scriptValues);
         }
         try {
-            scriptValues.setNextDocId(docId);
+            boolean docHasValues = scriptValues.setNextDocId(docId);
+            if (!docHasValues) return null;
+            if (ScriptModule.NULL_FOR_MISSING_VALUE) {
+                if (!docHasValues) return null;
+            }
         } catch (IOException e) {
             throw ExceptionsHelper.convertToElastic(e);
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
@@ -85,19 +85,19 @@ public class MinDocCountIT extends AbstractTermsTestCase {
             scripts.put("doc['d'].values", vars -> {
                 Map<?, ?> doc = (Map) vars.get("doc");
                 ScriptDocValues.Doubles value = (ScriptDocValues.Doubles) doc.get("d");
-                return value.getValues();
+                if (value != null) { return value.getValues(); } else return null;
             });
 
             scripts.put("doc['l'].values", vars -> {
                 Map<?, ?> doc = (Map) vars.get("doc");
                 ScriptDocValues.Longs value = (ScriptDocValues.Longs) doc.get("l");
-                return value.getValues();
+                if (value != null) { return value.getValues(); } else return null;
             });
 
             scripts.put("doc['s'].values", vars -> {
                 Map<?, ?> doc = (Map) vars.get("doc");
                 ScriptDocValues.Strings value = (ScriptDocValues.Strings) doc.get("s");
-                return value.getValues();
+                if (value != null) { return value.getValues(); } else return null;
             });
 
             return scripts;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityIT.java
@@ -76,7 +76,7 @@ public class CardinalityIT extends ESIntegTestCase {
             scripts.put("doc['str_values'].values", vars -> {
                 Map<?, ?> doc = (Map) vars.get("doc");
                 ScriptDocValues.Strings strValue = (ScriptDocValues.Strings) doc.get("str_values");
-                return strValue.getValues();
+                if (strValue != null) { return strValue.getValues(); } else return null;
             });
 
             scripts.put("doc[' + singleNumericField() + '].value", vars -> {
@@ -86,7 +86,8 @@ public class CardinalityIT extends ESIntegTestCase {
 
             scripts.put("doc[' + multiNumericField(false) + '].values", vars -> {
                 Map<?, ?> doc = (Map) vars.get("doc");
-                return ((ScriptDocValues<?>) doc.get(multiNumericField(false))).getValues();
+                ScriptDocValues numValue = (ScriptDocValues<?>) doc.get(multiNumericField(false));
+                if (numValue != null) { return numValue.getValues(); } else return null;
             });
 
             return scripts;
@@ -129,7 +130,7 @@ public class CardinalityIT extends ESIntegTestCase {
                     .endObject()
                     .endObject().endObject().endObject()).execute().actionGet();
 
-        numDocs = randomIntBetween(2, 100);
+        numDocs = randomIntBetween(2, 3);
         precisionThreshold = randomIntBetween(0, 1 << randomInt(20));
         IndexRequestBuilder[] builders = new IndexRequestBuilder[(int) numDocs];
         for (int i = 0; i < numDocs; ++i) {

--- a/server/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
+++ b/server/src/test/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
@@ -83,7 +83,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
             scripts.put("doc['random_score']", vars -> {
                 Map<?, ?> doc = (Map) vars.get("doc");
                 ScriptDocValues.Doubles randomScore = (ScriptDocValues.Doubles) doc.get("random_score");
-                return randomScore.getValue();
+                if (randomScore != null) {return randomScore.getValue();} else return 0;
             });
             return scripts;
         }


### PR DESCRIPTION
Previously in script for numeric fields, there was no way to check if
a document is missing a value. Also certain operations on multiple-
values fields were missing.

This PR adds the following:

- add the following functions for multiple-valued numeric fields:
    doc['field'].min returns the minumum amoung values
    doc['field'].max returns the maximum amoung values
    doc['field'].sum returns the sum of amoung values
    doc['field'].avg returns the average of values

- return null for doc['field'] if a document is missing a 'field1':
    Now we can do this:
    if (doc['field'] == null) {return -1;} return doc['field'].value;  or
    doc['field']?.value ?: -1
    This new behaviour will only work if the following system property is set:
    `export ES_JAVA_OPTS="-Des.script.null_for_missing_value=true"'

Closes #29286
