### PR TITLE
_cluster/state Skip Test for pre-6.4, not pre-7.0

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/10_basic.yml
@@ -22,7 +22,7 @@
 ---
 "get cluster state returns cluster_uuid at the top level":
   - skip:
-      version:  " - 6.99.99"
+      version:  " - 6.3.99"
       reason:   "cluster state including cluster_uuid at the top level is new in v6.4.0 and higher"
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/20_filtering.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/cluster.state/20_filtering.yml
@@ -160,7 +160,7 @@ setup:
 ---
 "Filtering the cluster state returns cluster_uuid at the top level regardless of metric filters":
   - skip:
-      version:  " - 6.99.99"
+      version:  " - 6.3.99"
       reason:   "cluster state including cluster_uuid at the top level is new in v6.4.0 and higher"
 
   - do:


### PR DESCRIPTION
This updates the skip section for the new `_cluster/state` responses to
include 6.4+ now that it has been backported.