### PR TITLE
Fix macros in changelog

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -1,7 +1,7 @@
 // Use these for links to issue and pulls. Note issues and pulls redirect one to
 // each other on Github, so don't worry too much on using the right prefix.
-// :issue: https://github.com/elastic/elasticsearch/issues/
-// :pull: https://github.com/elastic/elasticsearch/pull/
+:issue: https://github.com/elastic/elasticsearch/issues/
+:pull: https://github.com/elastic/elasticsearch/pull/
 
 = Elasticsearch Release Notes
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -9,12 +9,12 @@
 
 === Breaking Changes
 
-write-thread-pool-fallback, Removed `thread_pool.bulk.*` settings and
-`es.thread_pool.write.use_bulk_as_display_name` system property ({pull}29609[#29609])
+<<write-thread-pool-fallback, Removed `thread_pool.bulk.*` settings and
+`es.thread_pool.write.use_bulk_as_display_name` system property>> ({pull}29609[#29609])
 
-remove-suggest-metric, Removed `suggest` metric on stats APIs ({pull}29635[#29635])
+<<remove-suggest-metric, Removed `suggest` metric on stats APIs>> ({pull}29635[#29635])
 
-remove-field-caps-body, In field capabilities APIs, removed support for providing fields in the request body ({pull}30185[#30185])
+<<remove-field-caps-body, In field capabilities APIs, removed support for providing fields in the request body>> ({pull}30185[#30185])
 
 === Breaking Java Changes
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -9,12 +9,12 @@
 
 === Breaking Changes
 
-<<write-thread-pool-fallback, Removed `thread_pool.bulk.*` settings and
-`es.thread_pool.write.use_bulk_as_display_name` system property>> ({pull}29609[#29609])
+write-thread-pool-fallback, Removed `thread_pool.bulk.*` settings and
+`es.thread_pool.write.use_bulk_as_display_name` system property ({pull}29609[#29609])
 
-<<remove-suggest-metric, Removed `suggest` metric on stats APIs>> ({pull}29635[#29635])
+remove-suggest-metric, Removed `suggest` metric on stats APIs ({pull}29635[#29635])
 
-<<remove-field-caps-body, In field capabilities APIs, removed support for providing fields in the request body>> ({pull}30185[#30185])
+remove-field-caps-body, In field capabilities APIs, removed support for providing fields in the request body ({pull}30185[#30185])
 
 === Breaking Java Changes
 


### PR DESCRIPTION
I had mistakenly commented out two helpful macros for the changelog, which caused the generated docs not to look correct. This PR fixes linking to issues and pull requests with `:link:` and `:pull:`

Steps I took to test this PR:

0. if necessary, `git clone git@github.com:elastic/docs.git` and install appropriate perl stuffs, we'll be using the `build_docs.pl` script.

1. from `elasticsearch` dir, run `perl ../docs/build_docs.pl --doc docs/CHANGELOG.asciidoc --open --lenient`. This should open up a browser linking you to [localhost](http://localhost:8000/_elasticsearch_7_0_0.html)

2. confirm pull request links show up correctly, etc.

Before:
<img width="400" alt="before" src="https://user-images.githubusercontent.com/163306/39440522-fec29ce8-4c5f-11e8-8fa3-bb4cf9cde6f3.png">

After:

<img width="400" alt="after" src="https://user-images.githubusercontent.com/163306/39440531-054c3ff6-4c60-11e8-9265-359f2cae848a.png">

