### PR TITLE
[DOCS] Adds changelog to Elasticsearch Reference

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -14,9 +14,6 @@ This section summarizes the changes in each release.
 [[release-notes-7.0.0]]
 == {es} 7.0.0
 
-Test
-
-////
 // Use these for links to issue and pulls. Note issues and pulls redirect one to
 // each other on Github, so don't worry too much on using the right prefix.
 :issue: https://github.com/elastic/elasticsearch/issues/
@@ -26,6 +23,7 @@ Test
 
 == Elasticsearch 7.0.0
 
+[float]
 === Breaking Changes
 
 <<write-thread-pool-fallback, Removed `thread_pool.bulk.*` settings and
@@ -35,41 +33,38 @@ Test
 
 <<remove-field-caps-body, In field capabilities APIs, removed support for providing fields in the request body>> ({pull}30185[#30185])
 
-=== Breaking Java Changes
+//=== Breaking Java Changes
 
-=== Deprecations
+//=== Deprecations
 
-=== New Features
+//=== New Features
 
-=== Enhancements
+//=== Enhancements
 
+[float]
 === Bug Fixes
 
 Fail snapshot operations early when creating or deleting a snapshot on a repository that has been
 written to by an older Elasticsearch after writing to it with a newer Elasticsearch version. ({pull}30140[#30140])
 
-=== Regressions
+//=== Regressions
 
-=== Known Issues
-////
+//=== Known Issues
 
 [[release-notes-6.4.0]]
 == {es} 6.4.0
 
-Test
-////
-=== New Features
+//=== New Features
 
-=== Enhancements
+//=== Enhancements
 
 <<copy-source-settings-on-resize, Allow copying source settings on index resize operations>> ({pull}30255[#30255])
 
+[float]
 === Bug Fixes
 
 Do not ignore request analysis/similarity settings on index resize operations when the source index already contains such settings ({pull}30216[#30216])
 
-=== Regressions
+//=== Regressions
 
-=== Known Issues
-
-////
+//=== Known Issues

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -1,3 +1,22 @@
+[[es-release-notes]]
+= {es} Release Notes
+
+[partintro]
+--
+
+This section summarizes the changes in each release.
+
+* <<release-notes-7.0.0>>
+* <<release-notes-6.4.0>>
+
+--
+
+[[release-notes-7.0.0]]
+== {es} 7.0.0
+
+Test
+
+////
 // Use these for links to issue and pulls. Note issues and pulls redirect one to
 // each other on Github, so don't worry too much on using the right prefix.
 :issue: https://github.com/elastic/elasticsearch/issues/
@@ -32,9 +51,13 @@ written to by an older Elasticsearch after writing to it with a newer Elasticsea
 === Regressions
 
 === Known Issues
+////
 
-== Elasticsearch version 6.4.0
+[[release-notes-6.4.0]]
+== {es} 6.4.0
 
+Test
+////
 === New Features
 
 === Enhancements
@@ -49,4 +72,4 @@ Do not ignore request analysis/similarity settings on index resize operations wh
 
 === Known Issues
 
-
+////

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -20,6 +20,7 @@ This section summarizes the changes in each release.
 == {es} 7.0.0
 
 [float]
+[[breaking-7.0.0]]
 === Breaking Changes
 
 <<write-thread-pool-fallback, Removed `thread_pool.bulk.*` settings and

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -3,11 +3,16 @@
 
 [partintro]
 --
+// Use these for links to issue and pulls. Note issues and pulls redirect one to
+// each other on Github, so don't worry too much on using the right prefix.
+:issue: https://github.com/elastic/elasticsearch/issues/
+:pull: https://github.com/elastic/elasticsearch/pull/
 
 This section summarizes the changes in each release.
 
 * <<release-notes-7.0.0>>
 * <<release-notes-6.4.0>>
+
 
 --
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -19,15 +19,6 @@ This section summarizes the changes in each release.
 [[release-notes-7.0.0]]
 == {es} 7.0.0
 
-// Use these for links to issue and pulls. Note issues and pulls redirect one to
-// each other on Github, so don't worry too much on using the right prefix.
-:issue: https://github.com/elastic/elasticsearch/issues/
-:pull: https://github.com/elastic/elasticsearch/pull/
-
-= Elasticsearch Release Notes
-
-== Elasticsearch 7.0.0
-
 [float]
 === Breaking Changes
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -30,12 +30,16 @@ This section summarizes the changes in each release.
 
 <<remove-field-caps-body, In field capabilities APIs, removed support for providing fields in the request body>> ({pull}30185[#30185])
 
+//[float]
 //=== Breaking Java Changes
 
+//[float]
 //=== Deprecations
 
+//[float]
 //=== New Features
 
+//[float]
 //=== Enhancements
 
 [float]
@@ -44,13 +48,16 @@ This section summarizes the changes in each release.
 Fail snapshot operations early when creating or deleting a snapshot on a repository that has been
 written to by an older Elasticsearch after writing to it with a newer Elasticsearch version. ({pull}30140[#30140])
 
+//[float]
 //=== Regressions
 
+//[float]
 //=== Known Issues
 
 [[release-notes-6.4.0]]
 == {es} 6.4.0
 
+//[float]
 //=== New Features
 
 [float]
@@ -63,6 +70,8 @@ written to by an older Elasticsearch after writing to it with a newer Elasticsea
 
 Do not ignore request analysis/similarity settings on index resize operations when the source index already contains such settings ({pull}30216[#30216])
 
+//[float]
 //=== Regressions
 
+//[float]
 //=== Known Issues

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -53,7 +53,8 @@ written to by an older Elasticsearch after writing to it with a newer Elasticsea
 
 //=== New Features
 
-//=== Enhancements
+[float]
+=== Enhancements
 
 <<copy-source-settings-on-resize, Allow copying source settings on index resize operations>> ({pull}30255[#30255])
 

--- a/docs/reference/index-shared4.asciidoc
+++ b/docs/reference/index-shared4.asciidoc
@@ -5,4 +5,4 @@ include::testing.asciidoc[]
 
 include::glossary.asciidoc[]
 
-include::release-notes.asciidoc[]
+include::{docdir}/../CHANGELOG.asciidoc[]

--- a/x-pack/docs/en/release-notes/7.0.0-alpha1.asciidoc
+++ b/x-pack/docs/en/release-notes/7.0.0-alpha1.asciidoc
@@ -21,6 +21,5 @@ ones that the user is authorized to access in case field level security is enabl
 
 See also:
 
-* <<release-notes-7.0.0-alpha1,{es} 7.0.0-alpha1 Release Notes>>
 * {kibana-ref}/xkb-7.0.0-alpha1.html[{kib} {xpack} 7.0.0-alpha1 Release Notes]
 * {logstash-ref}/xls-7.0.0-alpha1.html[Logstash {xpack} 7.0.0-alpha1 Release Notes]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/29450

This PR replaces the use of release notes files with the use of the CHANGELOG.asciidoc file. 