### PR TITLE
[DOCS] Enables edit links for X-Pack pages

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -325,6 +325,5 @@ the <<cluster.name,`cluster.name`>>, the <<node.name,`node.name`>> and the
 <<modules-network,network settings>>.
 
 ifdef::include-xpack[]
-:edit_url!:
 include::{xes-repo-dir}/node.asciidoc[]
 endif::include-xpack[]

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -66,8 +66,5 @@ include::install/rpm.asciidoc[]
 include::install/windows.asciidoc[]
 
 ifdef::include-xpack[]
-:edit_url!:
 include::{xes-repo-dir}/setup/docker.asciidoc[]
-
-:edit_url:
 endif::include-xpack[]

--- a/x-pack/docs/en/index.asciidoc
+++ b/x-pack/docs/en/index.asciidoc
@@ -1,35 +1,24 @@
 
 include::{es-repo-dir}/index-shared1.asciidoc[]
 
-:edit_url!:
 include::setup/setup-xes.asciidoc[]
 
-:edit_url:
 include::{es-repo-dir}/index-shared2.asciidoc[]
 
-:edit_url!:
 include::release-notes/xpack-breaking.asciidoc[]
 
-:edit_url:
 include::{es-repo-dir}/index-shared3.asciidoc[]
 
-:edit_url!:
 include::sql/index.asciidoc[]
 
-:edit_url!:
 include::monitoring/index.asciidoc[]
 
-:edit_url!:
 include::rollup/index.asciidoc[]
 
-:edit_url!:
 include::rest-api/index.asciidoc[]
 
-:edit_url!:
 include::commands/index.asciidoc[]
 
-:edit_url:
 include::{es-repo-dir}/index-shared4.asciidoc[]
 
-:edit_url:
 include::{es-repo-dir}/index-shared5.asciidoc[]


### PR DESCRIPTION
This PR removes enables the "edit" link at the top of pages in the x-pack folder. 