### PR TITLE
Template name check in PUT operations, matching index/alias naming ch…

### DIFF
--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -1008,6 +1008,10 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 org.elasticsearch.common.xcontent.UnknownNamedObjectException::new, 148, Version.V_5_2_0),
         TOO_MANY_BUCKETS_EXCEPTION(MultiBucketConsumerService.TooManyBucketsException.class,
                                    MultiBucketConsumerService.TooManyBucketsException::new, 149,
+            Version.V_7_0_0_alpha1),
+        INVALID_TEMPLATE_NAME_EXCEPTION(org.elasticsearch.indices.InvalidTemplateNameException.class,
+            org.elasticsearch.indices.InvalidTemplateNameException::new,
+            150,
             Version.V_7_0_0_alpha1);
 
         final Class<? extends ElasticsearchException> exceptionClass;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasValidator.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.indices.InvalidAliasNameException;
+import org.elasticsearch.indices.Naming;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -107,7 +108,7 @@ public class AliasValidator extends AbstractComponent {
         if (!Strings.hasText(alias)) {
             throw new IllegalArgumentException("alias name is required");
         }
-        MetaDataCreateIndexService.validateIndexOrAliasName(alias, InvalidAliasNameException::new);
+        Naming.ALIAS.validate(alias);
         if (indexRouting != null && indexRouting.indexOf(',') != -1) {
             throw new IllegalArgumentException("alias [" + alias + "] has several index routing values associated with it");
         }

--- a/server/src/main/java/org/elasticsearch/indices/InvalidAliasNameException.java
+++ b/server/src/main/java/org/elasticsearch/indices/InvalidAliasNameException.java
@@ -19,14 +19,12 @@
 
 package org.elasticsearch.indices;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
-public class InvalidAliasNameException extends ElasticsearchException {
+public class InvalidAliasNameException extends InvalidNameException {
 
     public InvalidAliasNameException(Index index, String name, String desc) {
         super("Invalid alias name [{}], {}", name, desc);
@@ -39,10 +37,5 @@ public class InvalidAliasNameException extends ElasticsearchException {
 
     public InvalidAliasNameException(StreamInput in) throws IOException{
         super(in);
-    }
-
-    @Override
-    public RestStatus status() {
-        return RestStatus.BAD_REQUEST;
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/InvalidNameException.java
+++ b/server/src/main/java/org/elasticsearch/indices/InvalidNameException.java
@@ -19,23 +19,29 @@
 
 package org.elasticsearch.indices;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
-public class InvalidIndexNameException extends InvalidNameException {
+public abstract class InvalidNameException extends ElasticsearchException {
 
-    public InvalidIndexNameException(String name, String desc) {
-        super("Invalid index name [" + name + "], " + desc);
-        setIndex(name);
-    }
-    public InvalidIndexNameException(Index index, String name, String desc) {
-        super("Invalid index name [" + name + "], " + desc);
-        setIndex(index);
+    InvalidNameException(String msg, Object... args) {
+        super(msg, args);
     }
 
-    public InvalidIndexNameException(StreamInput in) throws IOException{
+    InvalidNameException(String name, String description) {
+        super(name, description);
+    }
+
+    InvalidNameException(StreamInput in) throws IOException{
         super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/InvalidTemplateNameException.java
+++ b/server/src/main/java/org/elasticsearch/indices/InvalidTemplateNameException.java
@@ -21,21 +21,27 @@ package org.elasticsearch.indices;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
-public class InvalidIndexNameException extends InvalidNameException {
+public class InvalidTemplateNameException extends InvalidNameException {
 
-    public InvalidIndexNameException(String name, String desc) {
-        super("Invalid index name [" + name + "], " + desc);
+    public InvalidTemplateNameException(String name, String desc) {
+        super("Invalid template name [" + name + "], " + desc);
         setIndex(name);
     }
-    public InvalidIndexNameException(Index index, String name, String desc) {
-        super("Invalid index name [" + name + "], " + desc);
+    public InvalidTemplateNameException(Index index, String name, String desc) {
+        super("Invalid template name [" + name + "], " + desc);
         setIndex(index);
     }
 
-    public InvalidIndexNameException(StreamInput in) throws IOException{
+    public InvalidTemplateNameException(StreamInput in) throws IOException{
         super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/Naming.java
+++ b/server/src/main/java/org/elasticsearch/indices/Naming.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.indices;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.Strings;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Locale;
+
+/**
+ * Used to validate numerous index and related artifact names.
+ */
+public enum Naming {
+
+    INDEX("index") {
+        void validate0(final String index) throws InvalidIndexNameException {
+            if (!index.toLowerCase(Locale.ROOT).equals(index)) {
+                this.report(index, "must be lowercase");
+            }
+        }
+
+        void report(final String name, final String message) throws InvalidIndexNameException {
+            throw new InvalidIndexNameException(name, message);
+        }
+    },
+    ALIAS("alias"){
+        void validate0(final String index) throws InvalidIndexNameException {
+            // nop
+        }
+
+        void report(final String name, final String message) throws InvalidAliasNameException {
+            throw new InvalidAliasNameException(name, message);
+        }
+    },
+    TEMPLATE("template"){
+        void validate0(final String index) throws InvalidIndexNameException {
+            // nop
+        }
+
+        void report(final String name, final String message) throws InvalidTemplateNameException {
+            throw new InvalidTemplateNameException(name, message);
+        }
+    };
+
+    /**
+     * This name will be used in messages, that mention the artifacts name explicitly.
+     */
+    private String prettyName;
+
+    Naming(final String prettyName) {
+        this.prettyName = prettyName;
+    }
+
+    public static final int MAX_NAME_LENGTH_BYTES = 255;
+
+    /**
+     * Validate the name for an index or alias against some static rules.
+     */
+    public final void validate(String name) {
+        if (!Strings.validFileName(name)) {
+            report(name, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
+        }
+        if (name.contains("#")) {
+            report(name, "must not contain '#'");
+        }
+        if (name.contains(":")) {
+            report(name, "must not contain ':'");
+        }
+        final char first = name.charAt(0);
+        if (first == '_' || first == '-' || first == '+') {
+            report(name, "must not start with '_', '-', or '+'");
+        }
+        int byteCount = 0;
+        try {
+            byteCount = name.getBytes("UTF-8").length;
+        } catch (UnsupportedEncodingException e) {
+            // UTF-8 should always be supported, but rethrow this if it is not for some reason
+            throw new ElasticsearchException("Unable to determine length of " + this.prettyName + " name", e);
+        }
+        if (byteCount > MAX_NAME_LENGTH_BYTES) {
+            report(name, this.prettyName + " name is too long, (" + byteCount + " > " + MAX_NAME_LENGTH_BYTES + ")");
+        }
+        if (name.equals(".") || name.equals("..")) {
+            report(name, "must not be '.' or '..'");
+        }
+        this.validate0(name);
+    }
+
+    abstract void validate0(String name);
+
+    abstract void report(String name, String message) throws InvalidNameException;
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.Naming;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -51,7 +52,10 @@ public class RestPutIndexTemplateAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest(request.param("name"));
+        final String name = request.param("name");
+        Naming.TEMPLATE.validate(name);
+
+        PutIndexTemplateRequest putRequest = new PutIndexTemplateRequest(name);
         if (request.hasParam("template")) {
             DEPRECATION_LOGGER.deprecated("Deprecated parameter[template] used, replaced by [index_patterns]");
             putRequest.patterns(Collections.singletonList(request.param("template")));

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -85,6 +85,7 @@ import org.elasticsearch.transport.ActionNotFoundTransportException;
 import org.elasticsearch.transport.ActionTransportException;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.TcpTransport;
+import org.junit.Assert;
 
 import java.io.EOFException;
 import java.io.FileNotFoundException;
@@ -810,11 +811,15 @@ public class ExceptionSerializationTests extends ESTestCase {
         ids.put(147, org.elasticsearch.env.ShardLockObtainFailedException.class);
         ids.put(148, UnknownNamedObjectException.class);
         ids.put(149, MultiBucketConsumerService.TooManyBucketsException.class);
+        ids.put(150, org.elasticsearch.indices.InvalidTemplateNameException.class);
 
         Map<Class<? extends ElasticsearchException>, Integer> reverse = new HashMap<>();
         for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {
-            if (entry.getValue() != null) {
-                reverse.put(entry.getValue(), entry.getKey());
+            final Class<? extends ElasticsearchException> value = entry.getValue();
+            if (value != null) {
+                final Integer key = entry.getKey();
+                Assert.assertNotNull(value.getName(), key);
+                reverse.put(value, key);
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/NamingTests.java
+++ b/server/src/test/java/org/elasticsearch/NamingTests.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.indices.InvalidAliasNameException;
+import org.elasticsearch.indices.InvalidIndexNameException;
+import org.elasticsearch.indices.InvalidNameException;
+import org.elasticsearch.indices.Naming;
+
+import static org.hamcrest.Matchers.endsWith;
+
+public class NamingTests extends LuceneTestCase {
+
+    public void testInvalidCharsFails() {
+        validateIndexName("index?name", "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
+    }
+
+    public void testContainsHashFails() {
+        validateIndexName("index#name", "must not contain '#'");
+    }
+
+    public void testStartUnderscoreFails() {
+        validateIndexName("_indexname", "must not start with '_', '-', or '+'");
+    }
+
+    public void testStartMinusFails() {
+        validateIndexName("-indexname", "must not start with '_', '-', or '+'");
+    }
+
+    public void testStartPlusFails() {
+        validateIndexName("+indexname", "must not start with '_', '-', or '+'");
+    }
+
+    public void testUppercaseFails() {
+        validateIndexName("INDEXNAME", "must be lowercase");
+    }
+
+    public void testDoubleDotFails() {
+        validateIndexName("..", "must not be '.' or '..'");
+    }
+
+    public void testDotFails() {
+        validateIndexName(".", "must not be '.' or '..'");
+    }
+
+    public void testContainsColonFails() {
+        validateIndexName("foo:bar", "must not contain ':'");
+    }
+
+    public void testAliasNameInvalidCharsFails() {
+        validate(Naming.ALIAS,
+            "alias?name",
+            "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS,
+            InvalidAliasNameException.class);
+    }
+
+    private void validateIndexName(String indexName, String errorMessage) {
+        validate(Naming.INDEX, indexName, errorMessage, InvalidIndexNameException.class);
+    }
+
+    private <T extends InvalidNameException> void validate(Naming naming, String indexName, String errorMessage, final Class<T> thrown) {
+        T e = expectThrows(thrown, () -> naming.validate(indexName));
+        assertThat(e.getMessage(), endsWith(errorMessage));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/server/src/test/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.indices.InvalidIndexNameException;
+import org.elasticsearch.indices.Naming;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -192,8 +193,8 @@ public class IndexActionIT extends ESIntegTestCase {
     }
 
     public void testCreateIndexWithLongName() {
-        int min = MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES + 1;
-        int max = MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES * 2;
+        int min = Naming.MAX_NAME_LENGTH_BYTES + 1;
+        int max = Naming.MAX_NAME_LENGTH_BYTES * 2;
         try {
             createIndex(randomAlphaOfLengthBetween(min, max).toLowerCase(Locale.ROOT));
             fail("exception should have been thrown on too-long index name");
@@ -212,7 +213,7 @@ public class IndexActionIT extends ESIntegTestCase {
 
         try {
             // Catch chars that are more than a single byte
-            client().prepareIndex(randomAlphaOfLength(MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES - 1).toLowerCase(Locale.ROOT) +
+            client().prepareIndex(randomAlphaOfLength(Naming.MAX_NAME_LENGTH_BYTES - 1).toLowerCase(Locale.ROOT) +
                             "Ϟ".toLowerCase(Locale.ROOT),
                     "mytype").setSource("foo", "bar").get();
             fail("exception should have been thrown on too-long index name");
@@ -222,7 +223,7 @@ public class IndexActionIT extends ESIntegTestCase {
         }
 
         // we can create an index of max length
-        createIndex(randomAlphaOfLength(MetaDataCreateIndexService.MAX_INDEX_NAME_BYTES).toLowerCase(Locale.ROOT));
+        createIndex(randomAlphaOfLength(Naming.MAX_NAME_LENGTH_BYTES).toLowerCase(Locale.ROOT));
     }
 
     public void testInvalidIndexName() {

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.rest.action.admin.indices;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.indices.InvalidTemplateNameException;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.document.RestIndexAction;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+
+public class RestPutIndexTemplateActionTests extends ESTestCase {
+
+    public void testInvalidTemplateNameFails() {
+        Settings settings = settings(Version.CURRENT).build();
+        RestPutIndexTemplateAction action = new RestPutIndexTemplateAction(settings, mock(RestController.class));
+
+        final RestRequest request = new RestRequest(NamedXContentRegistry.EMPTY,
+            Collections.singletonMap("name", "*"),
+            "_template/*",
+            Collections.emptyMap()) {
+
+            @Override
+            public RestRequest.Method method() {
+                return RestRequest.Method.GET;
+            }
+
+            @Override
+            public String uri() {
+                return null;
+            }
+
+            @Override
+            public boolean hasContent() {
+                return true;
+            }
+
+            @Override
+            public BytesReference content() {
+                return null;
+            }
+        };
+
+        InvalidTemplateNameException e = expectThrows(InvalidTemplateNameException.class,
+            () -> action.prepareRequest(request, mock(NodeClient.class)));
+        assertThat(e.getMessage(),
+            equalTo("Invalid template name [*], must not contain the following characters [ , \", *, \\, <, |, ,, >, /, ?]"));
+    }
+}


### PR DESCRIPTION
…ecks,

- only check in PUTs, allows other ops to continue until the user is ready to change
 template names via DELETE all and PUT again.
- introduced InvalidTemplateNameException, registered as a new sub class of
  ElasticsearchException.
- introduced base class for InvalidTemplateNameException, InvalidIndexNameException,
  InvalidAliasNameException
- #25645

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
YES

- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
YES

- If submitting code, have you built your formula locally prior to submission with `gradle check`?
YES - Passed

- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
just rebased against master 201805011753(au EST)

- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
OSX shouldnt matter

- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.

NA