### PR TITLE
Build: Log a warning if disabling reindex-from-old

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -83,9 +83,11 @@ dependencies {
   es090 'org.elasticsearch:elasticsearch:0.90.13@zip'
 }
 
-if (Os.isFamily(Os.FAMILY_WINDOWS) || rootProject.rootDir.toString().contains(" ")) {
-  // We can't get the pid files in windows and old versions of Elasticsearch doesn't set up the CLASSPATH correctly if there are spaces
-  // in the path. In either case, we skip reindex-from-old.
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+  logger.warn("Disabling reindex-from-old tests because we can't get the pid file on windows")
+  integTestRunner.systemProperty "tests.fromOld", "false"
+} else if (rootProject.rootDir.toString().contains(" ")) {
+  logger.warn("Disabling reindex-from-old tests because Elasticsearch 1.7 won't start with spaces in the path")
   integTestRunner.systemProperty "tests.fromOld", "false"
 } else {
   integTestRunner.systemProperty "tests.fromOld", "true"


### PR DESCRIPTION
We disable the reindex-from-old tests if we're running on windows or in
a directory that contains a space. This adds a warning to the logs when
we do that so that you can tell that it happened. This will be nice to
have when looking at CI and will be a hint to anyone developing locally.
