### PR TITLE
Align logic in VersionUtils to VersionCollection

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -20,25 +20,19 @@
 package org.elasticsearch.test;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.collect.Tuple;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Random;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 
 /** Utilities for selecting versions in tests */
@@ -53,6 +47,7 @@ public class VersionUtils {
      * this which it does in {@code :core:verifyVersions}. So long as the
      * rules here match up with the rules in gradle then this should
      * produce sensible results.
+     *
      * @return a tuple containing versions with backwards compatibility
      * guarantees in v1 and versions without the guranteees in v2
      */
@@ -63,22 +58,9 @@ public class VersionUtils {
         assert releasedVersions.last().equals(current) : "The highest version must be the current one "
             + "but was [" + releasedVersions.last() + "] and current was [" + current + "]";
 
-        List<Version> temporarilyRemovedReleases = new ArrayList<>();
+        List<Version> releaseCandidates = getReleaseCandidates(current, releasedVersions);
 
-        for (Version version: releasedVersions) {
-            if (version.isRelease() == false && isMajorReleased(version, releasedVersions)) {
-                // remove the Alpha/Beta/RC temporarily for already released versions
-                temporarilyRemovedReleases.add(version);
-            } else if (version.isRelease() == false
-                && version.major == current.major
-                && version.minor == current.minor
-                && version.revision == current.revision
-                && version.build != current.build) {
-                // remove the Alpha/Beta/RC temporarily for the current version
-                temporarilyRemovedReleases.add(version);
-            }
-        }
-        releasedVersions.removeAll(temporarilyRemovedReleases);
+        releasedVersions.removeAll(releaseCandidates);
         releasedVersions.remove(current);
 
         if (isReleasableBranch) {
@@ -89,71 +71,14 @@ public class VersionUtils {
                 releasedVersions.remove(highestMinor);
                 unreleasedVersions.add(highestMinor);
             } else {
-                // if our currentVersion is a X.0.0, we need to check X-1 minors to see if they are released
-                if (current.minor == 0) {
-                    boolean hasFoundNextMinor = false;
-                    boolean hasFoundStagedMinor = false;
-                    for (Version version: getMinorTips(current.major - 1, releasedVersions)) {
-                        if (isReleased(version) == false) {
-                            // This should only ever contain 2 non released branches in flight. An example is 6.x is frozen,
-                            // and 6.2 is cut but not yet released there is some simple logic to make sure that in the case of more than 2,
-                            // it will bail. The order is that the minor snapshot is fufilled first, and then the staged minor snapshot
-                            if (hasFoundNextMinor == false) {
-                                hasFoundNextMinor = true;
-                                releasedVersions.remove(version);
-                                unreleasedVersions.add(version);
-                            } else if (hasFoundStagedMinor == false) {
-                                hasFoundStagedMinor = true;
-                                releasedVersions.remove(version);
-                                unreleasedVersions.add(version);
-                            } else {
-                                throw new IllegalArgumentException(
-                                    "More than 2 snapshot version existed for the next minor and staged (frozen) minors.");
-                            }
-                        } else {
-                            // this is the last minor snap for this major, so replace the highest (last) one of these and break
-                            releasedVersions.remove(version);
-                            unreleasedVersions.add(version);
-                            // we only care about the largest minor here, so in the case of 6.1 and 6.0, it will only get 6.1
-                            break;
-                        }
-                    }
-                    // now dip back 2 versions to get the last supported snapshot version of the line
-                    Version highestMinor = getHighestPreviousMinor(current.major - 1, releasedVersions);
-                    releasedVersions.remove(highestMinor);
-                    unreleasedVersions.add(highestMinor);
-                } else {
-                    // version is not a X.0.0, so we are somewhere on a X.Y line only check till minor == 0 of the major
-                    boolean hasFoundStagedMinor = false;
-                    for (Version version: getMinorTips(current.major, releasedVersions)) {
-                        if (isReleased(version) == false) {
-                            // This should only ever contain 0 or 1 branch in flight. An example is 6.x is frozen, and 6.2 is cut
-                            // but not yet released there is some simple logic to make sure that in the case of more than 1, it will bail
-                            if (hasFoundStagedMinor == false) {
-                                hasFoundStagedMinor = true;
-                                releasedVersions.remove(version);
-                                unreleasedVersions.add(version);
-                            } else {
-                                throw new IllegalArgumentException("More than 1 snapshot version existed for the staged (frozen) minors.");
-                            }
-                        } else {
-                            // this is the last minor snap for this major, so replace the highest (last) one of these and break
-                            releasedVersions.remove(version);
-                            unreleasedVersions.add(version);
-                            // we only care about the largest minor here, so in the case of 6.1 and 6.0, it will only get 6.1
-                            break;
-                        }
-                    }
-                    // now dip back 1 version to get the last supported snapshot version of the line
-                    Version highestMinor = getHighestPreviousMinor(current.major, releasedVersions);
-                    releasedVersions.remove(highestMinor);
-                    unreleasedVersions.add(highestMinor);
-                }
+                List<Version> unreleased = getUnreleasedVersions(current, releasedVersions);
+                releasedVersions.removeAll(unreleased);
+                unreleasedVersions.addAll(unreleased);
             }
         }
 
         // re-add the Alpha/Beta/RC
-        releasedVersions.addAll(temporarilyRemovedReleases);
+        releasedVersions.addAll(releaseCandidates);
         unreleasedVersions.add(current);
 
         Collections.sort(unreleasedVersions);
@@ -232,23 +157,31 @@ public class VersionUtils {
         throw new IllegalArgumentException("couldn't find any released versions of the minor before [" + Version.CURRENT + "]");
     }
 
-    /** Returns the oldest released {@link Version} */
+    /**
+     * Returns the oldest released {@link Version}
+     */
     public static Version getFirstVersion() {
         return RELEASED_VERSIONS.get(0);
     }
 
-    /** Returns a random {@link Version} from all available versions. */
+    /**
+     * Returns a random {@link Version} from all available versions.
+     */
     public static Version randomVersion(Random random) {
         return ALL_VERSIONS.get(random.nextInt(ALL_VERSIONS.size()));
     }
 
-    /** Returns a random {@link Version} from all available versions, that is compatible with the given version. */
+    /**
+     * Returns a random {@link Version} from all available versions, that is compatible with the given version.
+     */
     public static Version randomCompatibleVersion(Random random, Version version) {
         final List<Version> compatible = ALL_VERSIONS.stream().filter(version::isCompatible).collect(Collectors.toList());
         return compatible.get(random.nextInt(compatible.size()));
     }
 
-    /** Returns a random {@link Version} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
+    /**
+     * Returns a random {@link Version} between <code>minVersion</code> and <code>maxVersion</code> (inclusive).
+     */
     public static Version randomVersionBetween(Random random, @Nullable Version minVersion, @Nullable Version maxVersion) {
         int minVersionIndex = 0;
         if (minVersion != null) {
@@ -271,14 +204,18 @@ public class VersionUtils {
         }
     }
 
-    /** returns the first future incompatible version */
+    /**
+     * returns the first future incompatible version
+     */
     public static Version incompatibleFutureVersion(Version version) {
         final Optional<Version> opt = ALL_VERSIONS.stream().filter(version::before).filter(v -> v.isCompatible(version) == false).findAny();
         assert opt.isPresent() : "no future incompatible version for " + version;
         return opt.get();
     }
 
-    /** Returns the maximum {@link Version} that is compatible with the given version. */
+    /**
+     * Returns the maximum {@link Version} that is compatible with the given version.
+     */
     public static Version maxCompatibleVersion(Version version) {
         final List<Version> compatible = ALL_VERSIONS.stream().filter(version::isCompatible).filter(version::onOrBefore)
             .collect(Collectors.toList());
@@ -286,7 +223,7 @@ public class VersionUtils {
         return compatible.get(compatible.size() - 1);
     }
 
-    private static Version generateVersion(int major, int minor, int revision) {
+    static Version generateVersion(int major, int minor, int revision) {
         return Version.fromString(String.format(Locale.ROOT, "%s.%s.%s", major, minor, revision));
     }
 
@@ -301,7 +238,7 @@ public class VersionUtils {
      * Validates that the count of non suffixed (alpha/beta/rc) versions in a given major to major+1 is greater than 1.
      * This means that there is more than just a major.0.0 or major.0.0-alpha in a branch to signify it has been prevously released.
      */
-    private static boolean isMajorReleased(Version version, TreeSet<Version> items) {
+    static boolean isMajorReleased(Version version, TreeSet<Version> items) {
         return getMajorSet(version.major, items)
             .stream()
             .map(v -> v.isRelease())
@@ -312,14 +249,14 @@ public class VersionUtils {
      * Gets the largest version previous major version based on the nextMajorVersion passed in.
      * If you have a list [5.0.2, 5.1.2, 6.0.1, 6.1.1] and pass in 6 for the nextMajorVersion, it will return you 5.1.2
      */
-    private static Version getHighestPreviousMinor(int majorVersion, TreeSet<Version> items){
+    static Version getHighestPreviousMinor(int majorVersion, TreeSet<Version> items) {
         return items.headSet(generateVersion(majorVersion, 0, 0)).last();
     }
 
     /**
      * Gets the entire set of major.minor.* given those parameters.
      */
-    private static SortedSet<Version> getMinorSetForMajor(int major, int minor, TreeSet<Version> items) {
+    static SortedSet<Version> getMinorSetForMajor(int major, int minor, TreeSet<Version> items) {
         return items
             .tailSet(generateVersion(major, minor, 0))
             .headSet(generateVersion(major, minor + 1, 0));
@@ -328,7 +265,7 @@ public class VersionUtils {
     /**
      * Gets the entire set of major.* to the currentVersion
      */
-    private static SortedSet<Version> getMajorSet(int major, TreeSet<Version> items) {
+    static SortedSet<Version> getMajorSet(int major, TreeSet<Version> items) {
         return items
             .tailSet(generateVersion(major, 0, 0))
             .headSet(generateVersion(major + 1, 0, 0));
@@ -336,12 +273,12 @@ public class VersionUtils {
 
     /**
      * Gets the tip of each minor set and puts it in a list.
-     *
+     * <p>
      * examples:
-     *  [1.0.0, 1.1.0, 1.1.1, 1.2.0, 1.3.1] will return [1.0.0, 1.1.1, 1.2.0, 1.3.1]
-     *  [1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4] will return [1.0.4]
+     * [1.0.0, 1.1.0, 1.1.1, 1.2.0, 1.3.1] will return [1.0.0, 1.1.1, 1.2.0, 1.3.1]
+     * [1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4] will return [1.0.4]
      */
-    private static List<Version> getMinorTips(int major, TreeSet<Version> items) {
+    static List<Version> getMinorTips(int major, TreeSet<Version> items) {
         SortedSet<Version> majorSet = getMajorSet(major, items);
         List<Version> minorList = new ArrayList<>();
         for (int minor = majorSet.last().minor; minor >= 0; minor--) {
@@ -351,6 +288,56 @@ public class VersionUtils {
             }
         }
         return minorList;
+    }
+
+    static List<Version> getReleaseCandidates(Version current, TreeSet<Version> versions) {
+        List<Version> releaseCandidates = new ArrayList<>();
+        for (Version version : versions) {
+            if (version.isRelease() == false && isMajorReleased(version, versions)) {
+                // remove the Alpha/Beta/RC temporarily for already released versions
+                releaseCandidates.add(version);
+            } else if (version.isRelease() == false
+                && version.major == current.major
+                && version.minor == current.minor
+                && version.revision == current.revision
+                && version.build != current.build) {
+                // remove the Alpha/Beta/RC temporarily for the current version
+                releaseCandidates.add(version);
+            }
+        }
+        return releaseCandidates;
+    }
+
+    static List<Version> getUnreleasedVersions(Version current, TreeSet<Version> versions) {
+        List<Version> unreleasedVersions = new ArrayList<>();
+        int calculateTipMajor;
+        int numUnreleased;
+        // a current with a minor equal to zero means it is on a nonreleased major version
+        if (current.minor == 0) {
+            calculateTipMajor = current.major - 1;
+            numUnreleased = 2;
+        } else {
+            calculateTipMajor = current.major;
+            numUnreleased = 1;
+        }
+
+        for (Version version: getMinorTips(calculateTipMajor, versions)) {
+            if (isReleased(version)) {
+                // found a released version, this is the last possible version we care about in the major
+                unreleasedVersions.add(version);
+                break;
+            }
+            if (unreleasedVersions.size() < numUnreleased) {
+                unreleasedVersions.add(version);
+            } else {
+                throw new IllegalArgumentException(
+                    "more than " + numUnreleased + " snapshot versions existed in the major set of " + calculateTipMajor);
+            }
+        }
+
+        unreleasedVersions.add(getHighestPreviousMinor(calculateTipMajor, versions));
+
+        return unreleasedVersions;
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -335,7 +335,9 @@ public class VersionUtils {
             }
         }
 
-        unreleasedVersions.add(getHighestPreviousMinor(calculateTipMajor, versions));
+        if (current.minor != 0) {
+            unreleasedVersions.add(getHighestPreviousMinor(calculateTipMajor, versions));
+        }
 
         return unreleasedVersions;
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -186,8 +186,6 @@ public class VersionUtilsTests extends ESTestCase {
     }
 
     public static class TestUnstableBranch {
-        public static final Version V_4_0_0 = Version.fromString("4.0.0");
-        public static final Version V_4_0_1 = Version.fromString("4.0.1");
         public static final Version V_5_3_0 = Version.fromString("5.3.0");
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
@@ -205,13 +203,11 @@ public class VersionUtilsTests extends ESTestCase {
         List<Version> unreleased = t.v2();
 
         assertThat(released, equalTo(Arrays.asList(
-            TestUnstableBranch.V_4_0_0,
             TestUnstableBranch.V_5_3_0,
             TestUnstableBranch.V_5_3_1,
             TestUnstableBranch.V_6_0_0_alpha1,
             TestUnstableBranch.V_6_0_0_alpha2)));
         assertThat(unreleased, equalTo(Arrays.asList(
-            TestUnstableBranch.V_4_0_1,
             TestUnstableBranch.V_5_3_2,
             TestUnstableBranch.V_5_4_0,
             TestUnstableBranch.V_6_0_0_beta1)));

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -107,11 +107,13 @@ public class VersionUtilsTests extends ESTestCase {
     }
 
     public static class TestReleaseBranch {
-        public static final Version V_5_3_0 = Version.fromString("5.3.0");
-        public static final Version V_5_3_1 = Version.fromString("5.3.1");
-        public static final Version V_5_3_2 = Version.fromString("5.3.2");
-        public static final Version V_5_4_0 = Version.fromString("5.4.0");
-        public static final Version V_5_4_1 = Version.fromString("5.4.1");
+        public static final Version V_4_0_0 = Version.fromString("4.0.0");
+        public static final Version V_4_0_1 = Version.fromString("4.0.1");
+        public static final Version V_5_3_0 = Version.fromString("5.0.0");
+        public static final Version V_5_3_1 = Version.fromString("5.0.1");
+        public static final Version V_5_3_2 = Version.fromString("5.0.2");
+        public static final Version V_5_4_0 = Version.fromString("5.1.0");
+        public static final Version V_5_4_1 = Version.fromString("5.1.1");
         public static final Version CURRENT = V_5_4_1;
     }
     public void testResolveReleasedVersionsForReleaseBranch() {
@@ -120,19 +122,24 @@ public class VersionUtilsTests extends ESTestCase {
         List<Version> unreleased = t.v2();
 
         assertThat(released, equalTo(Arrays.asList(
+            TestReleaseBranch.V_4_0_0,
             TestReleaseBranch.V_5_3_0,
             TestReleaseBranch.V_5_3_1,
             TestReleaseBranch.V_5_3_2,
             TestReleaseBranch.V_5_4_0)));
-        assertThat(unreleased, equalTo(Collections.singletonList(TestReleaseBranch.V_5_4_1)));
+        assertThat(unreleased, equalTo(Arrays.asList(
+            TestReleaseBranch.V_4_0_1,
+            TestReleaseBranch.V_5_4_1)));
     }
 
     public static class TestStableBranch {
-        public static final Version V_5_3_0 = Version.fromString("5.3.0");
-        public static final Version V_5_3_1 = Version.fromString("5.3.1");
-        public static final Version V_5_3_2 = Version.fromString("5.3.2");
-        public static final Version V_5_4_0 = Version.fromString("5.4.0");
-        public static final Version CURRENT = V_5_4_0;
+        public static final Version V_4_0_0 = Version.fromString("4.0.0");
+        public static final Version V_4_0_1 = Version.fromString("4.0.1");
+        public static final Version V_5_0_0 = Version.fromString("5.0.0");
+        public static final Version V_5_0_1 = Version.fromString("5.0.1");
+        public static final Version V_5_0_2 = Version.fromString("5.0.2");
+        public static final Version V_5_1_0 = Version.fromString("5.1.0");
+        public static final Version CURRENT = V_5_1_0;
     }
     public void testResolveReleasedVersionsForUnreleasedStableBranch() {
         Tuple<List<Version>, List<Version>> t = VersionUtils.resolveReleasedVersions(TestStableBranch.CURRENT,
@@ -141,14 +148,18 @@ public class VersionUtilsTests extends ESTestCase {
         List<Version> unreleased = t.v2();
 
         assertThat(released, equalTo(Arrays.asList(
-            TestStableBranch.V_5_3_0,
-            TestStableBranch.V_5_3_1)));
+            TestStableBranch.V_4_0_0,
+            TestStableBranch.V_5_0_0,
+            TestStableBranch.V_5_0_1)));
         assertThat(unreleased, equalTo(Arrays.asList(
-            TestStableBranch.V_5_3_2,
-            TestStableBranch.V_5_4_0)));
+            TestStableBranch.V_4_0_1,
+            TestStableBranch.V_5_0_2,
+            TestStableBranch.V_5_1_0)));
     }
 
     public static class TestStableBranchBehindStableBranch {
+        public static final Version V_4_0_0 = Version.fromString("4.0.0");
+        public static final Version V_4_0_1 = Version.fromString("4.0.1");
         public static final Version V_5_3_0 = Version.fromString("5.3.0");
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
@@ -163,15 +174,19 @@ public class VersionUtilsTests extends ESTestCase {
         List<Version> unreleased = t.v2();
 
         assertThat(released, equalTo(Arrays.asList(
+            TestStableBranchBehindStableBranch.V_4_0_0,
             TestStableBranchBehindStableBranch.V_5_3_0,
             TestStableBranchBehindStableBranch.V_5_3_1)));
         assertThat(unreleased, equalTo(Arrays.asList(
+            TestStableBranchBehindStableBranch.V_4_0_1,
             TestStableBranchBehindStableBranch.V_5_3_2,
             TestStableBranchBehindStableBranch.V_5_4_0,
             TestStableBranchBehindStableBranch.V_5_5_0)));
     }
 
     public static class TestUnstableBranch {
+        public static final Version V_4_0_0 = Version.fromString("4.0.0");
+        public static final Version V_4_0_1 = Version.fromString("4.0.1");
         public static final Version V_5_3_0 = Version.fromString("5.3.0");
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_3_2 = Version.fromString("5.3.2");
@@ -189,11 +204,13 @@ public class VersionUtilsTests extends ESTestCase {
         List<Version> unreleased = t.v2();
 
         assertThat(released, equalTo(Arrays.asList(
+            TestUnstableBranch.V_4_0_0,
             TestUnstableBranch.V_5_3_0,
             TestUnstableBranch.V_5_3_1,
             TestUnstableBranch.V_6_0_0_alpha1,
             TestUnstableBranch.V_6_0_0_alpha2)));
         assertThat(unreleased, equalTo(Arrays.asList(
+            TestUnstableBranch.V_4_0_1,
             TestUnstableBranch.V_5_3_2,
             TestUnstableBranch.V_5_4_0,
             TestUnstableBranch.V_6_0_0_beta1)));
@@ -221,13 +238,13 @@ public class VersionUtilsTests extends ESTestCase {
         assertThat(released, equalTo(Arrays.asList(
             TestNewMajorRelease.V_5_6_0,
             TestNewMajorRelease.V_5_6_1,
-            TestNewMajorRelease.V_5_6_2,
             TestNewMajorRelease.V_6_0_0_alpha1,
             TestNewMajorRelease.V_6_0_0_alpha2,
             TestNewMajorRelease.V_6_0_0_beta1,
             TestNewMajorRelease.V_6_0_0_beta2,
             TestNewMajorRelease.V_6_0_0)));
         assertThat(unreleased, equalTo(Arrays.asList(
+            TestNewMajorRelease.V_5_6_2,
             TestNewMajorRelease.V_6_0_1)));
     }
 
@@ -306,6 +323,8 @@ public class VersionUtilsTests extends ESTestCase {
     }
 
     public static class TestIncorrectCurrentVersion {
+        public static final Version V_4_0_0 = Version.fromString("4.0.0");
+        public static final Version V_4_0_1 = Version.fromString("4.0.1");
         public static final Version V_5_3_0 = Version.fromString("5.3.0");
         public static final Version V_5_3_1 = Version.fromString("5.3.1");
         public static final Version V_5_4_0 = Version.fromString("5.4.0");


### PR DESCRIPTION
The BCW generation code in VersionCollection.groovy was updated a while
ago to accurately grab released and unreleased versions from
Version.java. The logic for VersionUtils, which is the java equivalent
of VersionCollection, was never updated to fix the bugs present in
VersionCollection. This commit uses the same logic present in
VersionCollection in VersionUtils. While the best solution is not to
duplicate logic, this commit will first fix the test, and de duping the
logic is out of scope for this.

Relates #30133