### PR TITLE
[DOCS] Adds changelog to Elasticsearch Reference

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -10,26 +10,16 @@
 
 This section summarizes the changes in each release.
 
-* <<release-notes-7.0.0>>
-* <<release-notes-6.4.0>>
-
+* <<release-notes-6.3.0>>
 
 --
 
-== Elasticsearch version 6.3.0
-[[release-notes-7.0.0]]
-== {es} 7.0.0
+[[release-notes-6.3.0]]
+== {es} version 6.3.0
 
-[float]
-[[breaking-7.0.0]]
-=== Breaking Changes
-
-<<write-thread-pool-fallback, Removed `thread_pool.bulk.*` settings and
-`es.thread_pool.write.use_bulk_as_display_name` system property>> ({pull}29609[#29609])
-
-<<remove-suggest-metric, Removed `suggest` metric on stats APIs>> ({pull}29635[#29635])
-
-<<remove-field-caps-body, In field capabilities APIs, removed support for providing fields in the request body>> ({pull}30185[#30185])
+//[float]
+//[[breaking-6.3.0]]
+//=== Breaking Changes
 
 //[float]
 //=== Breaking Java Changes
@@ -43,39 +33,8 @@ This section summarizes the changes in each release.
 //[float]
 //=== Enhancements
 
-[float]
-=== Bug Fixes
-
-Fail snapshot operations early when creating or deleting a snapshot on a repository that has been
-written to by an older Elasticsearch after writing to it with a newer Elasticsearch version. ({pull}30140[#30140])
-
 //[float]
-//=== Regressions
-
-//[float]
-//=== Known Issues
-
-[[release-notes-6.4.0]]
-== {es} 6.4.0
-
-//[float]
-//=== New Features
-
-[float]
-=== Enhancements
-
-=== Bug Fixes
-
-=== Regressions
-
-=== Known Issues
-
-<<copy-source-settings-on-resize, Allow copying source settings on index resize operations>> ({pull}30255[#30255])
-
-[float]
-=== Bug Fixes
-
-Do not ignore request analysis/similarity settings on index resize operations when the source index already contains such settings ({pull}30216[#30216])
+//=== Bug Fixes
 
 //[float]
 //=== Regressions

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -1,14 +1,67 @@
+[[es-release-notes]]
+= {es} Release Notes
+
+[partintro]
+--
 // Use these for links to issue and pulls. Note issues and pulls redirect one to
 // each other on Github, so don't worry too much on using the right prefix.
 // :issue: https://github.com/elastic/elasticsearch/issues/
 // :pull: https://github.com/elastic/elasticsearch/pull/
 
-= Elasticsearch Release Notes
+This section summarizes the changes in each release.
+
+* <<release-notes-7.0.0>>
+* <<release-notes-6.4.0>>
+
+
+--
 
 == Elasticsearch version 6.3.0
+[[release-notes-7.0.0]]
+== {es} 7.0.0
 
-=== New Features
+[float]
+[[breaking-7.0.0]]
+=== Breaking Changes
 
+<<write-thread-pool-fallback, Removed `thread_pool.bulk.*` settings and
+`es.thread_pool.write.use_bulk_as_display_name` system property>> ({pull}29609[#29609])
+
+<<remove-suggest-metric, Removed `suggest` metric on stats APIs>> ({pull}29635[#29635])
+
+<<remove-field-caps-body, In field capabilities APIs, removed support for providing fields in the request body>> ({pull}30185[#30185])
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+//[float]
+//=== Enhancements
+
+[float]
+=== Bug Fixes
+
+Fail snapshot operations early when creating or deleting a snapshot on a repository that has been
+written to by an older Elasticsearch after writing to it with a newer Elasticsearch version. ({pull}30140[#30140])
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[[release-notes-6.4.0]]
+== {es} 6.4.0
+
+//[float]
+//=== New Features
+
+[float]
 === Enhancements
 
 === Bug Fixes
@@ -17,4 +70,15 @@
 
 === Known Issues
 
+<<copy-source-settings-on-resize, Allow copying source settings on index resize operations>> ({pull}30255[#30255])
 
+[float]
+=== Bug Fixes
+
+Do not ignore request analysis/similarity settings on index resize operations when the source index already contains such settings ({pull}30216[#30216])
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues

--- a/docs/reference/index-shared4.asciidoc
+++ b/docs/reference/index-shared4.asciidoc
@@ -5,4 +5,4 @@ include::testing.asciidoc[]
 
 include::glossary.asciidoc[]
 
-include::release-notes.asciidoc[]
+include::{docdir}/../CHANGELOG.asciidoc[]

--- a/x-pack/docs/en/release-notes/6.0.0-alpha1.asciidoc
+++ b/x-pack/docs/en/release-notes/6.0.0-alpha1.asciidoc
@@ -34,6 +34,5 @@ Watcher::
 
 See also:
 
-* <<release-notes-6.0.0-alpha1,{es} 6.0.0-alpha1 Release Notes>>
 * {kibana-ref}/release-notes-xkb.html[{kib} {xpack} Release Notes]
 * {logstash-ref}/release-notes-xls.html[Logstash {xpack} Release Notes]

--- a/x-pack/docs/en/release-notes/6.0.0-alpha2.asciidoc
+++ b/x-pack/docs/en/release-notes/6.0.0-alpha2.asciidoc
@@ -39,6 +39,5 @@ Metadata fails, the update is now retried.
 
 See also:
 
-* <<release-notes-6.0.0-alpha2,{es} 6.0.0-alpha2 Release Notes>>
 * {kibana-ref}/release-notes-xkb.html[{kib} {xpack} Release Notes]
 * {logstash-ref}/release-notes-xls.html[Logstash {xpack} Release Notes]

--- a/x-pack/docs/en/release-notes/6.0.0-beta1.asciidoc
+++ b/x-pack/docs/en/release-notes/6.0.0-beta1.asciidoc
@@ -29,6 +29,5 @@ to `false` in your `elasticsearch.yml`. See
 
 See also:
 
-* <<release-notes-6.0.0-beta1,{es} 6.0.0-beta1 Release Notes>>
 * {kibana-ref}/release-notes-xkb.html[{kib} {xpack} Release Notes]
 * {logstash-ref}/release-notes-xls.html[Logstash {xpack} Release Notes]

--- a/x-pack/docs/en/release-notes/6.0.0-beta2.asciidoc
+++ b/x-pack/docs/en/release-notes/6.0.0-beta2.asciidoc
@@ -79,6 +79,5 @@ Watcher::
 
 See also:
 
-* <<release-notes-6.0.0-beta2,{es} 6.0.0-beta2 Release Notes>>
 * {kibana-ref}/release-notes-xkb.html[{kib} {xpack} Release Notes]
 * {logstash-ref}/release-notes-xls.html[Logstash {xpack} Release Notes]

--- a/x-pack/docs/en/release-notes/6.0.0-rc1.asciidoc
+++ b/x-pack/docs/en/release-notes/6.0.0-rc1.asciidoc
@@ -72,6 +72,5 @@ Watcher::
 
 See also:
 
-* <<release-notes-6.0.0-rc1,{es} 6.0.0-rc1 Release Notes>>
 * {kibana-ref}/release-notes-xkb.html[{kib} {xpack} Release Notes]
 * {logstash-ref}/release-notes-xls.html[Logstash {xpack} Release Notes]

--- a/x-pack/docs/en/release-notes/6.0.0-rc2.asciidoc
+++ b/x-pack/docs/en/release-notes/6.0.0-rc2.asciidoc
@@ -69,6 +69,5 @@ to require multiple binds when authenticating in user search mode.
 
 See also:
 
-* <<release-notes-6.0.0-rc2,{es} 6.0.0-rc2 Release Notes>>
 * {kibana-ref}/release-notes-xkb.html[{kib} {xpack} Release Notes]
 * {logstash-ref}/release-notes-xls.html[Logstash {xpack} Release Notes]


### PR DESCRIPTION
This PR backports #30271

It also removes links to the old release notes.
