### PR TITLE
Create default ES_TMPDIR on Windows

### DIFF
--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -58,4 +58,7 @@ set ES_DISTRIBUTION_TYPE=${es.distribution.type}
 
 if not defined ES_TMPDIR (
   set ES_TMPDIR=!TMP!\elasticsearch
+  if not exist "!ES_TMPDIR!" (
+    mkdir "!ES_TMPDIR!"
+  )
 )


### PR DESCRIPTION
If the elasticsearch-env bash script chooses $ES_TMPDIR
then it also creates the directory.  This change makes
elasticsearch-env.bat do the same thing: if %ES_TMPDIR%
is chosen by the script then the script will ensure it
exists, but if %ES_TMPDIR% is already set then the user
is responsible for creating it.

Relates #27609
Relates #28217