### PR TITLE
Fix source field mapping wildcard deletes empty fields #29622

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
@@ -28,14 +28,22 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.junit.Assert;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.convertToMap;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
@@ -48,10 +56,235 @@ import static org.hamcrest.core.IsEqual.equalTo;
 
 public class XContentMapValuesTests extends AbstractFilteringTestCase {
 
+    private static final String NO_INCLUDE = null;
+    private static final String NO_EXCLUDE = null;
+    private static final Map<String, Object> EMPTY = Collections.emptyMap();
+
+    public void testFieldWithEmptyObject() {
+        Map<String, Object> root = map("abc", new HashMap<>());
+
+        filterAndCheck(root, NO_INCLUDE, NO_EXCLUDE, root);
+    }
+
+    public void testEmptyObjectInclude() {
+        Map<String, Object> root = new HashMap<>();
+
+        filterAndCheck(root, "qqq", NO_EXCLUDE, root);
+    }
+
+    public void testEmptyObjectExclude() {
+        Map<String, Object> root = new HashMap<>();
+
+        filterAndCheck(root, NO_INCLUDE, "qqq", root);
+    }
+
+    public void testFieldIncludeExact() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            "abc",
+            NO_EXCLUDE,
+            map("abc", 1));
+    }
+
+    public void testFieldIncludeExactIgnoresPartialPrefix() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            "a",
+            NO_EXCLUDE,
+            EMPTY);
+    }
+
+    public void testFieldIncludeExactUnmatched() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            "qqq",
+            NO_EXCLUDE,
+            EMPTY);
+    }
+
+    public void testFieldIncludePrefixWildcard() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            "a*",
+            NO_EXCLUDE,
+            map("abc", 1));
+    }
+
+    public void testFieldIncludeSuffixWildcard() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            "*c",
+            NO_EXCLUDE,
+            map("abc", 1));
+    }
+
+    public void testFieldIncludeWildcardUnmatched() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            "zz*",
+            NO_EXCLUDE,
+            EMPTY);
+    }
+
+    public void testFieldExcludeExact() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            NO_INCLUDE,
+            "xyz",
+            map("abc", 1));
+    }
+
+    public void testFieldExcludeExactIgnoresPartialPrefix() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            NO_INCLUDE,
+            "a");
+    }
+
+    public void testFieldExcludeExactUmmatched() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            NO_INCLUDE,
+            "qqq");
+    }
+
+    public void testFieldExcludeSuffixWildcard() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            NO_INCLUDE,
+            "*z",
+            map("abc", 1));
+    }
+
+    public void testFieldExcludePrefixWildcard() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            NO_INCLUDE,
+            "x*",
+            map("abc", 1));
+    }
+
+    public void testFieldExcludeWildcardUnmatched() {
+        filterAndCheck(map("abc", 1, "xyz", 2),
+            NO_INCLUDE,
+            "*zzz");
+    }
+
+    public void testIncludeNestedExact() {
+        filterAndCheck( map("root", map("leaf", "value")),
+            "root.leaf",
+            NO_EXCLUDE);
+    }
+
+    public void testIncludeNestedExact2() {
+        filterAndCheck(map("root", map("leaf", "value"), "lost", 123),
+            "root.leaf",
+            NO_EXCLUDE,
+            map("root", map("leaf", "value")));
+    }
+
+    public void testIncludeNestedExactWildcard() {
+        filterAndCheck(map("root", map("leaf", "value"), "lost", 123),
+            "root.*",
+            NO_EXCLUDE,
+            map("root", map("leaf", "value")));
+    }
+
+    public void testNestedExcludeExact() {
+        filterAndCheck(map("root", map("leaf", "value")),
+            NO_INCLUDE,
+            "root.leaf",
+            EMPTY);
+    }
+
+    public void testNestedExcludeExact2() {
+        filterAndCheck(map("root", map("leaf", "value", "kept", 123)),
+            NO_INCLUDE,
+            "root.leaf",
+            map("root", map("kept", 123)));
+    }
+
+    public void testNestedExcludeWildcard() {
+       filterAndCheck(map("root", map("leaf", "value")),
+            NO_INCLUDE,
+            "root.*",
+            EMPTY);
+    }
+
+    public void testNestedExcludeWildcard2() {
+        filterAndCheck(map("root", map("leaf", "value"), "kept", 123),
+            NO_INCLUDE,
+            "root.*",
+            map("kept", 123));
+    }
+
+    public void testArrayIncludeExact() {
+        filterAndCheck(map("root", list("leaf")), "root", NO_EXCLUDE);
+    }
+
+    public void testArrayIncludeExact2() {
+        filterAndCheck(map("root", list("leaf"), "lost", 123),
+            "root",
+            NO_EXCLUDE,
+            map("root", list("leaf")));
+    }
+
+    public void testArrayNestedIncludeExact() {
+        filterAndCheck(map("root", list(map("leaf", "value"))),
+            "root.leaf",
+            NO_EXCLUDE);
+    }
+
+    public void testArrayNestedIncludeExact2() {
+        filterAndCheck(map("root", list(map("leaf", "value")), "lost", 123),
+            "root.leaf",
+            NO_EXCLUDE,
+            map("root", list(map("leaf", "value"))));
+    }
+
+    public void testArrayIncludeExactWildcard() {
+        filterAndCheck(map("root", list("leaf", "2leaf2"),
+            "lost", 123),
+            "root*",
+            NO_EXCLUDE,
+            map("root", list("leaf", "2leaf2")));
+    }
+
+    public void testArrayExcludeExact() {
+        filterAndCheck(map("root", list("leaf")),
+            NO_INCLUDE,
+            "root",
+            EMPTY);
+    }
+
+    public void testArrayExcludeExact2() {
+        filterAndCheck(map("root", list("leaf"),
+            "lost", 123),
+            NO_INCLUDE,
+            "root",
+            map("lost", 123));
+    }
+
+    public void testArrayExcludeExact3() {
+        filterAndCheck(map("root", list("leaf", "leaf2"),
+            "lost", 123),
+            NO_INCLUDE,
+            "root",
+            map("lost", 123));
+    }
+
+    public void testArrayExcludeWildcard() {
+        filterAndCheck(map("root", list("leaf")),
+            NO_INCLUDE,
+            "root.*");
+    }
+
+    public void testArrayExcludeWildcard2() {
+        filterAndCheck(map("root", list("leaf"), "lost", 123),
+            NO_INCLUDE,
+            "ro*",
+            map("lost", 123));
+    }
+
+    public void testArrayExcludeWildcard3() {
+        filterAndCheck(map("root", list("leaf", "2leaf2"),
+            "lost", 123),
+            NO_INCLUDE,
+            "root.*");
+    }
+
     @Override
     protected void testFilter(Builder expected, Builder actual, Set<String> includes, Set<String> excludes) throws IOException {
         final XContentType xContentType = randomFrom(XContentType.values());
-        final boolean humanReadable = randomBoolean();
 
         String[] sourceIncludes;
         if (includes == null) {
@@ -65,10 +298,10 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         } else {
             sourceExcludes = excludes.toArray(new String[excludes.size()]);
         }
-
-        assertEquals("Filtered map must be equal to the expected map",
-                toMap(expected, xContentType, humanReadable),
-                XContentMapValues.filter(toMap(actual, xContentType, humanReadable), sourceIncludes, sourceExcludes));
+        filterAndCheck(toMap(actual, xContentType, true),
+            sourceIncludes,
+            sourceExcludes,
+            toMap(expected, xContentType, true));
     }
 
     @SuppressWarnings({"unchecked"})
@@ -200,151 +433,169 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         assertThat(XContentMapValues.extractRawValues("path1.xxx.path2.yyy.test", map).get(0).toString(), equalTo("value"));
     }
 
-    public void testPrefixedNamesFilteringTest() {
+    public void testPrefixedNames() {
         Map<String, Object> map = new HashMap<>();
         map.put("obj", "value");
         map.put("obj_name", "value_name");
-        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[]{"obj_name"}, Strings.EMPTY_ARRAY);
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat((String) filteredMap.get("obj_name"), equalTo("value_name"));
+        filterAndCheck(map, "obj_name", NO_EXCLUDE, map("obj_name", "value_name"));
     }
 
-
-    @SuppressWarnings("unchecked")
-    public void testNestedFiltering() {
+    public void testIncludeNested1() {
         Map<String, Object> map = new HashMap<>();
         map.put("field", "value");
         map.put("array",
-                Arrays.asList(
-                        1,
-                        new HashMap<String, Object>() {{
-                            put("nested", 2);
-                            put("nested_2", 3);
-                        }}));
-        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[]{"array.nested"}, Strings.EMPTY_ARRAY);
-        assertThat(filteredMap.size(), equalTo(1));
-
-        assertThat(((List<?>) filteredMap.get("array")), hasSize(1));
-        assertThat(((Map<String, Object>) ((List) filteredMap.get("array")).get(0)).size(), equalTo(1));
-        assertThat((Integer) ((Map<String, Object>) ((List) filteredMap.get("array")).get(0)).get("nested"), equalTo(2));
-
-        filteredMap = XContentMapValues.filter(map, new String[]{"array.*"}, Strings.EMPTY_ARRAY);
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat(((List<?>) filteredMap.get("array")), hasSize(1));
-        assertThat(((Map<String, Object>) ((List) filteredMap.get("array")).get(0)).size(), equalTo(2));
-
-        map.clear();
-        map.put("field", "value");
-        map.put("obj",
+            Arrays.asList(
+                1,
                 new HashMap<String, Object>() {{
-                    put("field", "value");
-                    put("field2", "value2");
-                }});
-        filteredMap = XContentMapValues.filter(map, new String[]{"obj.field"}, Strings.EMPTY_ARRAY);
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(1));
-        assertThat((String) ((Map<String, Object>) filteredMap.get("obj")).get("field"), equalTo("value"));
-
-        filteredMap = XContentMapValues.filter(map, new String[]{"obj.*"}, Strings.EMPTY_ARRAY);
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(2));
-        assertThat((String) ((Map<String, Object>) filteredMap.get("obj")).get("field"), equalTo("value"));
-        assertThat((String) ((Map<String, Object>) filteredMap.get("obj")).get("field2"), equalTo("value2"));
-
+                    put("nested", 2);
+                    put("nested_2", 3);
+                }}));
+        filterAndCheck(map,
+            "array.nested",
+            NO_EXCLUDE,
+            map("array", list(map("nested", 2))));
     }
 
-    @SuppressWarnings("unchecked")
-    public void testCompleteObjectFiltering() {
+    public void testIncludeNested2() {
         Map<String, Object> map = new HashMap<>();
         map.put("field", "value");
-        map.put("obj",
-                new HashMap<String, Object>() {{
-                    put("field", "value");
-                    put("field2", "value2");
-                }});
         map.put("array",
-                Arrays.asList(
-                        1,
-                        new HashMap<String, Object>() {{
-                            put("field", "value");
-                            put("field2", "value2");
-                        }}));
+            Arrays.asList(
+                1,
+                new HashMap<String, Object>() {{
+                    put("nested", 2);
+                    put("nested_2", 3);
+                }}));
+        filterAndCheck(map,
+            "array.*",
+            NO_EXCLUDE,
+            map("array", list(map("nested", 2, "nested_2", 3))));
+    }
 
-        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[]{"obj"}, Strings.EMPTY_ARRAY);
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(2));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")).get("field").toString(), equalTo("value"));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")).get("field2").toString(), equalTo("value2"));
+    public void testIncludeNested3() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("field", "value");
+        map.put("obj", map("field", "value", "field2", "value2"));
 
+        filterAndCheck(map,
+            "obj.field",
+            NO_EXCLUDE,
+            map("obj", map("field", "value")));
+    }
 
-        filteredMap = XContentMapValues.filter(map, new String[]{"obj"}, new String[]{"*.field2"});
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(1));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")).get("field").toString(), equalTo("value"));
+    public void testIncludeNested4() {
+        filterAndCheck(map("field", "value",
+            "obj", map("field", "value", "field2", "value2")),
+            "obj.*",
+            NO_EXCLUDE,
+            map("obj", map("field", "value", "field2", "value2")));
+    }
 
+    public void testIncludeAndExclude() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("field", "value");
+        map.put("obj", map("field", "value", "field2", "value2"));
+        map.put("array",
+            list(1,
+                map("field", "value", "field2", "value2")));
 
-        filteredMap = XContentMapValues.filter(map, new String[]{"array"}, new String[]{});
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat(((List) filteredMap.get("array")).size(), equalTo(2));
-        assertThat((Integer) ((List) filteredMap.get("array")).get(0), equalTo(1));
-        assertThat(((Map<String, Object>) ((List) filteredMap.get("array")).get(1)).size(), equalTo(2));
+        filterAndCheck(map,
+            "obj",
+            NO_EXCLUDE,
+            map("obj", map("field", "value", "field2", "value2")));
+    }
 
-        filteredMap = XContentMapValues.filter(map, new String[]{"array"}, new String[]{"*.field2"});
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat(((List<?>) filteredMap.get("array")), hasSize(2));
-        assertThat((Integer) ((List) filteredMap.get("array")).get(0), equalTo(1));
-        assertThat(((Map<String, Object>) ((List) filteredMap.get("array")).get(1)).size(), equalTo(1));
-        assertThat(((Map<String, Object>) ((List) filteredMap.get("array")).get(1)).get("field").toString(), equalTo("value"));
+     public void testIncludeAndExclude2() {
+         Map<String, Object> map = new HashMap<>();
+         map.put("field", "value");
+         map.put("obj", map("field", "value", "field2", "value2"));
+         map.put("array",
+             list(1,
+                 map("field", "value", "field2", "value2")));
+
+         filterAndCheck(map,
+             "obj",
+             "*.field2",
+             map("obj", map("field", "value")));
+     }
+
+    public void testIncludeAndExclude3() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("field", "value");
+        map.put("obj", map("field", "value", "field2", "value2"));
+        map.put("array",
+            list(1,
+                map("field", "value", "field2", "value2")));
+
+        filterAndCheck(map,
+            "array",
+            NO_EXCLUDE,
+            map("array",
+                list(1,
+                    map("field", "value", "field2", "value2"))));
+    }
+
+    public void testIncludeAndExclude4() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("field", "value");
+        map.put("obj", map("field", "value", "field2", "value2"));
+        map.put("array",
+            list(1,
+                map("field", "value", "field2", "value2")));
+
+        filterAndCheck(map,
+            "array",
+            "*.field2",
+            map("array", list(1, map("field", "value"))));
     }
 
     @SuppressWarnings("unchecked")
     public void testFilterIncludesUsingStarPrefix() {
         Map<String, Object> map = new HashMap<>();
         map.put("field", "value");
-        map.put("obj",
-                new HashMap<String, Object>() {{
-                    put("field", "value");
-                    put("field2", "value2");
-                }});
-        map.put("n_obj",
-                new HashMap<String, Object>() {{
-                    put("n_field", "value");
-                    put("n_field2", "value2");
-                }});
+        map.put("obj", map("field", "value", "field2", "value2"));
+        map.put("n_obj", map("n_field", "value", "n_field2", "value2"));
 
-        Map<String, Object> filteredMap = XContentMapValues.filter(map, new String[]{"*.field2"}, Strings.EMPTY_ARRAY);
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat(filteredMap, hasKey("obj"));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(1));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")), hasKey("field2"));
-
-        // only objects
-        filteredMap = XContentMapValues.filter(map, new String[]{"*.*"}, Strings.EMPTY_ARRAY);
-        assertThat(filteredMap.size(), equalTo(2));
-        assertThat(filteredMap, hasKey("obj"));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")).size(), equalTo(2));
-        assertThat(filteredMap, hasKey("n_obj"));
-        assertThat(((Map<String, Object>) filteredMap.get("n_obj")).size(), equalTo(2));
-
-
-        filteredMap = XContentMapValues.filter(map, new String[]{"*"}, new String[]{"*.*2"});
-        assertThat(filteredMap.size(), equalTo(3));
-        assertThat(filteredMap, hasKey("field"));
-        assertThat(filteredMap, hasKey("obj"));
-        assertThat(((Map) filteredMap.get("obj")).size(), equalTo(1));
-        assertThat(((Map<String, Object>) filteredMap.get("obj")), hasKey("field"));
-        assertThat(filteredMap, hasKey("n_obj"));
-        assertThat(((Map<String, Object>) filteredMap.get("n_obj")).size(), equalTo(1));
-        assertThat(((Map<String, Object>) filteredMap.get("n_obj")), hasKey("n_field"));
-
+        filterAndCheck(map, "*.field2", NO_EXCLUDE, map("obj", map("field2", "value2")));
     }
 
-    public void testFilterWithEmptyIncludesExcludes() {
+    public void testFilterIncludesUsingStarPrefix2() {
         Map<String, Object> map = new HashMap<>();
         map.put("field", "value");
-        Map<String, Object> filteredMap = XContentMapValues.filter(map, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
-        assertThat(filteredMap.size(), equalTo(1));
-        assertThat(filteredMap.get("field").toString(), equalTo("value"));
+        map.put("obj", map("field", "value", "field2", "value2"));
+        map.put("n_obj", map("n_field", "value", "n_field2", "value2"));
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("obj", map("field", "value", "field2", "value2"));
+        expected.put("n_obj", map("n_field", "value", "n_field2", "value2"));
+
+        filterAndCheck(map, "*.*", NO_EXCLUDE, expected);
+    }
+
+    public void testFilterIncludesUsingStarPrefix3() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("field", "value");
+        map.put("obj", map("field", "value", "field2", "value2"));
+        map.put("n_obj", map("n_field", "value", "n_field2", "value2"));
+
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("field", "value");
+        expected.put("obj", map("field", "value"));
+        expected.put("n_obj", map("n_field", "value"));
+
+        filterAndCheck(map, "*", "*.*2", expected);
+    }
+
+    public void testFilterWithEmptyIncludesEmptyExcludes() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("field", "value");
+        filterAndCheck(map, NO_INCLUDE, NO_EXCLUDE, map);
+    }
+
+    public void testFilterWithEmptyIncludesEmptyExcludes_EmptyString() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("field", "");
+        filterAndCheck(map, NO_INCLUDE, NO_EXCLUDE, map);
     }
 
     public void testThatFilterIncludesEmptyObjectWhenUsingIncludes() throws Exception {
@@ -353,10 +604,7 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
                 .endObject()
                 .endObject();
 
-        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"obj"}, Strings.EMPTY_ARRAY);
-
-        assertThat(mapTuple.v2(), equalTo(filteredSource));
+        filterAndCheck(builder, "obj", NO_EXCLUDE);
     }
 
     public void testThatFilterIncludesEmptyObjectWhenUsingExcludes() throws Exception {
@@ -364,26 +612,7 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
                 .startObject("obj")
                 .endObject()
                 .endObject();
-
-        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[]{"nonExistingField"});
-
-        assertThat(mapTuple.v2(), equalTo(filteredSource));
-    }
-
-    public void testNotOmittingObjectsWithExcludedProperties() throws Exception {
-        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
-                .startObject("obj")
-                .field("f1", "v1")
-                .endObject()
-                .endObject();
-
-        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[]{"obj.f1"});
-
-        assertThat(filteredSource.size(), equalTo(1));
-        assertThat(filteredSource, hasKey("obj"));
-        assertThat(((Map) filteredSource.get("obj")).size(), equalTo(0));
+        filterAndCheck(builder, NO_INCLUDE, "nonExistingField");
     }
 
     @SuppressWarnings({"unchecked"})
@@ -398,25 +627,7 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
                 .endObject();
 
         // implicit include
-        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), Strings.EMPTY_ARRAY, new String[]{"*.obj2"});
-
-        assertThat(filteredSource.size(), equalTo(1));
-        assertThat(filteredSource, hasKey("obj1"));
-        assertThat(((Map) filteredSource.get("obj1")).size(), equalTo(0));
-
-        // explicit include
-        filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"obj1"}, new String[]{"*.obj2"});
-        assertThat(filteredSource.size(), equalTo(1));
-        assertThat(filteredSource, hasKey("obj1"));
-        assertThat(((Map) filteredSource.get("obj1")).size(), equalTo(0));
-
-        // wild card include
-        filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"*.obj2"}, new String[]{"*.obj3"});
-        assertThat(filteredSource.size(), equalTo(1));
-        assertThat(filteredSource, hasKey("obj1"));
-        assertThat(((Map<String, Object>) filteredSource.get("obj1")), hasKey("obj2"));
-        assertThat(((Map) ((Map) filteredSource.get("obj1")).get("obj2")).size(), equalTo(0));
+        filterAndCheck(builder, NO_INCLUDE, "*.obj2", EMPTY);
     }
 
     @SuppressWarnings({"unchecked"})
@@ -428,16 +639,8 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
                 .endObject()
                 .endObject();
 
-        Tuple<XContentType, Map<String, Object>> mapTuple = convertToMap(BytesReference.bytes(builder), true, builder.contentType());
-        Map<String, Object> filteredSource = XContentMapValues.filter(mapTuple.v2(), new String[]{"*.obj2"}, Strings.EMPTY_ARRAY);
-
-        assertThat(filteredSource.size(), equalTo(1));
-        assertThat(filteredSource, hasKey("obj1"));
-        assertThat(((Map) filteredSource.get("obj1")).size(), equalTo(1));
-        assertThat(((Map<String, Object>) filteredSource.get("obj1")), hasKey("obj2"));
-        assertThat(((Map) ((Map) filteredSource.get("obj1")).get("obj2")).size(), equalTo(0));
+        filterAndCheck(builder, "*.obj2", NO_EXCLUDE);
     }
-
 
     public void testDotsInFieldNames() {
         Map<String, Object> map = new HashMap<>();
@@ -448,16 +651,14 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         map.put("quux", 5);
 
         // dots in field names in includes
-        Map<String, Object> filtered = XContentMapValues.filter(map, new String[] {"foo"}, new String[0]);
         Map<String, Object> expected = new HashMap<>(map);
         expected.remove("quux");
-        assertEquals(expected, filtered);
+        filterAndCheck(map, "foo", NO_EXCLUDE, expected);
 
         // dots in field names in excludes
-        filtered = XContentMapValues.filter(map, new String[0], new String[] {"foo"});
         expected = new HashMap<>(map);
         expected.keySet().retainAll(Collections.singleton("quux"));
-        assertEquals(expected, filtered);
+        filterAndCheck(map, NO_INCLUDE, "foo", expected);
     }
 
     public void testSupplementaryCharactersInPaths() {
@@ -465,8 +666,15 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         map.put("搜索", 2);
         map.put("指数", 3);
 
-        assertEquals(Collections.singletonMap("搜索", 2), XContentMapValues.filter(map, new String[] {"搜索"}, new String[0]));
-        assertEquals(Collections.singletonMap("指数", 3), XContentMapValues.filter(map, new String[0], new String[] {"搜索"}));
+        filterAndCheck(map, "搜索", NO_EXCLUDE, map("搜索", 2));
+    }
+
+    public void testSupplementaryCharactersInPaths2() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("搜索", 2);
+        map.put("指数", 3);
+
+        filterAndCheck(map, NO_INCLUDE, "搜索", map("指数", 3));
     }
 
     public void testSharedPrefixes() {
@@ -474,8 +682,14 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         map.put("foobar", 2);
         map.put("foobaz", 3);
 
-        assertEquals(Collections.singletonMap("foobar", 2), XContentMapValues.filter(map, new String[] {"foobar"}, new String[0]));
-        assertEquals(Collections.singletonMap("foobaz", 3), XContentMapValues.filter(map, new String[0], new String[] {"foobar"}));
+        filterAndCheck(map, "foobar", NO_EXCLUDE, map("foobar", 2));
+    }
+
+    public void testSharedPrefixes2() {
+        filterAndCheck(map("foobar", 2, "foobaz", 3),
+            NO_INCLUDE,
+            "foobar",
+            map("foobaz", 3));
     }
 
     public void testPrefix() {
@@ -483,14 +697,142 @@ public class XContentMapValuesTests extends AbstractFilteringTestCase {
         map.put("photos", Arrays.asList(new String[] {"foo", "bar"}));
         map.put("photosCount", 2);
 
-        Map<String, Object> filtered = XContentMapValues.filter(map, new String[] {"photosCount"}, new String[0]);
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("photosCount", 2);
-        assertEquals(expected, filtered);
+        filterAndCheck(map, "photosCount", NO_EXCLUDE, map("photosCount", 2));
+    }
+
+    public void testEmptyArray() throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+            .array("arrayField")
+            .endObject();
+
+        filterAndCheck(builder, NO_INCLUDE, NO_EXCLUDE);
+    }
+
+    public void testEmptyArray_UnmatchedExclude() throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+            .array("myField")
+            .endObject();
+
+        filterAndCheck(builder, NO_INCLUDE, "bar");
+    }
+
+    public void testEmptyArray_UnmatchedExcludeWildcard() throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+            .array("myField")
+            .endObject();
+
+        filterAndCheck(builder, NO_INCLUDE, "*bar");
+    }
+
+    public void testOneElementArray() throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+            .array("arrayField", "value1")
+            .endObject();
+
+        filterAndCheck(builder, NO_INCLUDE, NO_EXCLUDE);
+    }
+
+    public void testOneElementArray_UnmatchedExclude() throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+            .array("arrayField", "value1")
+            .endObject();
+
+        filterAndCheck(builder, NO_INCLUDE, "different");
+    }
+
+    public void testOneElementArray_UnmatchedExcludeWildcard() throws Exception {
+        XContentBuilder builder = XContentFactory.jsonBuilder().startObject()
+            .array("arrayField", "")
+            .endObject();
+
+        filterAndCheck(builder, NO_INCLUDE, "different*");
     }
 
     private static Map<String, Object> toMap(Builder test, XContentType xContentType, boolean humanReadable) throws IOException {
         ToXContentObject toXContent = (builder, params) -> test.apply(builder);
         return convertToMap(toXContent(toXContent, xContentType, humanReadable), true, xContentType).v2();
+    }
+
+    private Map<String, Object> toMap(final XContentBuilder builder) {
+        return convertToMap(BytesReference.bytes(builder), true, builder.contentType()).v2();
+    }
+
+    private Map<String, Object> filter(final Map<String, Object> input, final String include, final String exclude) {
+        return filter(input, array(include), array(exclude));
+    }
+
+    private Map<String, Object> filter(final XContentBuilder input, final String include, final String exclude) {
+        return filter(input, array(include), array(exclude));
+    }
+
+    private String[] array(final String...elements) {
+        return elements.length == 1 && elements[0] == null ? Strings.EMPTY_ARRAY : elements;
+    }
+
+    private Map<String, Object> filter(final Map<String, Object> input, final String[] includes, final String[] excludes) {
+        return XContentMapValues.filter(input, includes, excludes);
+    }
+
+    private void filterAndCheck(final Map<String, Object> input, final String include, final String exclude) {
+        filterAndCheck(input, array(include), array(exclude), Collections.unmodifiableMap(input));
+    }
+
+    private void filterAndCheck(final Map<String, Object> input,
+                                final String include,
+                                final String exclude,
+                                final Map<String, Object> expected) {
+        filterAndCheck(input, array(include), array(exclude), expected);
+    }
+
+    private void filterAndCheck(final Map<String, Object> input,
+                                final String[] includes,
+                                final String[] excludes,
+                                final Map<String, Object> expected) {
+        Map<String, Object> filteredSource = filter(input, includes, excludes);
+
+        final StringBuilder b = new StringBuilder();
+        if(null!=includes && includes.length > 0) {
+            b.append("includes=")
+                .append(Arrays.stream(includes).collect(Collectors.joining(", ")))
+                .append(' ');
+        }
+        if(null!=excludes && excludes.length > 0) {
+            b.append(" excludes=")
+                .append(Arrays.stream(excludes).collect(Collectors.joining(", ")))
+                .append(' ');
+        }
+        b.append("input: ").append(input);
+
+        Assert.assertEquals(b.toString(), expected, filteredSource);
+    }
+
+    private Map<String, Object> filter(final XContentBuilder input, final String[] includes, final String[] excludes) {
+        return filter(toMap(input), includes, excludes);
+    }
+
+    private void filterAndCheck(final XContentBuilder input, final String include, final String exclude) {
+        filterAndCheck(toMap(input), include, exclude);
+    }
+
+    private void filterAndCheck(final XContentBuilder input,
+                                final String include,
+                                final String exclude,
+                                final Map<String, Object> expected) {
+        filterAndCheck(toMap(input), include, exclude, expected);
+    }
+
+    private <T> List<T> list(final T...elements) {
+        return new ArrayList<>(Arrays.asList(elements));
+    }
+
+    private <K, V> Map<K, V> map(final K key, final V value) {
+        return Collections.singletonMap(key, value);
+    }
+
+    private <K, V> Map<K, V> map(final K key1, final V value1, final K key2, final V value2) {
+        final Map<K, V> map = new LinkedHashMap<>();
+        map.put(key1, value1);
+        map.put(key2, value2);
+        return map;
     }
 }


### PR DESCRIPTION
- fixed reported bug of empty lists not being index within _source, and absent
  when fetched later.
- fixed filtering so maps and lists that are made empty (not initially empty)
 are removed from their parent.
- added substantial numbers of tests for all combos of filtering maps.
- introduced helpers in XContentMapValuesTest, and cleaned up most tests.
- #29622

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
YES

- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
YES

- If submitting code, have you built your formula locally prior to submission with `gradle check`?
YES - passed

- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
rebased against master

- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
OSX - shouldnt matter

- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.

NA