### PR TITLE
Disable SSL on testing old BWC nodes

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -163,7 +163,7 @@ subprojects {
       setting 'logger.level', 'DEBUG'
 
       setting 'xpack.security.enabled', 'true'
-      setting 'xpack.security.transport.ssl.enabled', version.onOrAfter("5.2.1").toString()
+      setting 'xpack.security.transport.ssl.enabled', version.onOrAfter("5.2.0").toString()
       setting 'xpack.ssl.keystore.path', 'testnode.jks'
       setting 'xpack.ssl.keystore.password', 'testnode'
       if (version.onOrAfter('6.3.0')) {

--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -163,7 +163,7 @@ subprojects {
       setting 'logger.level', 'DEBUG'
 
       setting 'xpack.security.enabled', 'true'
-      setting 'xpack.security.transport.ssl.enabled', 'true'
+      setting 'xpack.security.transport.ssl.enabled', version.onOrAfter("5.2.1").toString()
       setting 'xpack.ssl.keystore.path', 'testnode.jks'
       setting 'xpack.ssl.keystore.password', 'testnode'
       if (version.onOrAfter('6.3.0')) {


### PR DESCRIPTION
Old versions of Elasticsearch with SSL have a problem due to a bug in Netty where an illegal reference count exception can cause the cluster to fall apart. This issue impacted Netty 4.1.5.Final and 4.1.6.Final. With:

```
$ for tag in $(git tag | grep -E 'v5\.[0-9]\.[0-9]$')
> do
>   echo -n "$tag " \
>     && git show $tag:modules/transport-netty4/build.gradle \
>     | grep netty-buffer \
>     | cut -d: -f3 \
>     | perl -p -e 's/"$//g'
> done
v5.0.0 4.1.5.Final
v5.0.1 4.1.5.Final
v5.0.2 4.1.5.Final
v5.1.1 4.1.6.Final
v5.1.2 4.1.6.Final
v5.2.0 4.1.7.Final
v5.2.1 4.1.7.Final
v5.2.2 4.1.7.Final
v5.3.0 4.1.7.Final
v5.3.1 4.1.7.Final
v5.3.2 4.1.7.Final
v5.3.3 4.1.7.Final
v5.4.0 4.1.9.Final
v5.4.1 4.1.11.Final
v5.4.2 4.1.11.Final
v5.4.3 4.1.11.Final
v5.5.0 4.1.11.Final
v5.5.1 4.1.11.Final
v5.5.2 4.1.11.Final
v5.5.3 4.1.11.Final
v5.6.0 4.1.13.Final
v5.6.1 4.1.13.Final
v5.6.2 4.1.13.Final
v5.6.3 4.1.13.Final
v5.6.4 4.1.13.Final
v5.6.5 4.1.13.Final
v5.6.6 4.1.13.Final
v5.6.7 4.1.13.Final
v5.6.8 4.1.13.Final
v5.6.9 4.1.13.Final
```

We see that this means we need to not use SSL when testing nodes before 5.2.0. That is what this commit does.

Closes #30288