### PR TITLE
[DOCS] Fixes broken links to bootstrap user

### DIFF
--- a/x-pack/docs/en/commands/setup-passwords.asciidoc
+++ b/x-pack/docs/en/commands/setup-passwords.asciidoc
@@ -20,7 +20,7 @@ bin/elasticsearch-setup-passwords auto|interactive
 
 This command is intended for use only during the initial configuration of
 {xpack}. It uses the
-{xpack-ref}/setting-up-authentication.html#bootstrap-elastic-passwords[`elastic` bootstrap password]
+{stack-ov}/built-in-users.html#bootstrap-elastic-passwords[`elastic` bootstrap password]
 to run user management API requests. After you set a password for the `elastic`
 user, the bootstrap password is no longer active and you cannot use this command.
 Instead, you can change passwords by using the *Management > Users* UI in {kib}

--- a/x-pack/docs/en/security/configuring-es.asciidoc
+++ b/x-pack/docs/en/security/configuring-es.asciidoc
@@ -47,7 +47,7 @@ information, see
 +
 --
 {security} provides
-{xpack-ref}/setting-up-authentication.html#built-in-users[built-in users] to
+{stack-ov}/built-in-users.html[built-in users] to
 help you get up and running. The +elasticsearch-setup-passwords+ command is the
 simplest method to set the built-in users' passwords for the first time.
 

--- a/x-pack/docs/en/security/securing-communications/configuring-tls-docker.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/configuring-tls-docker.asciidoc
@@ -142,7 +142,8 @@ services:
 volumes: {"esdata_01": {"driver": "local"}, "esdata_02": {"driver": "local"}}
 ----
 
-<1> Bootstrap `elastic` with the password defined in `.env`. See {xpack-ref}/setting-up-authentication.html#bootstrap-elastic-passwords[the Elastic Bootstrap Password].
+<1> Bootstrap `elastic` with the password defined in `.env`. See 
+{stack-ov}/built-in-users.html#bootstrap-elastic-passwords[the Elastic Bootstrap Password].
 <2> Disable verification of authenticity for inter-node communication. Allows
 creating self-signed certificates without having to pin specific internal IP addresses.
 endif::[]


### PR DESCRIPTION
This PR fixes broken links from the Elasticsearch Reference to the Stack Overview.

Related to elastic/elasticsearch#30280