### PR TITLE
Make RepositoriesMetaData contents unmodifiable

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetaData.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -51,7 +52,7 @@ public class RepositoriesMetaData extends AbstractNamedDiffable<Custom> implemen
      * @param repositories list of repositories
      */
     public RepositoriesMetaData(List<RepositoryMetaData> repositories) {
-        this.repositories = repositories;
+        this.repositories = Collections.unmodifiableList(repositories);
     }
 
     /**
@@ -107,7 +108,7 @@ public class RepositoriesMetaData extends AbstractNamedDiffable<Custom> implemen
         for (int i = 0; i < repository.length; i++) {
             repository[i] = new RepositoryMetaData(in);
         }
-        this.repositories = Arrays.asList(repository);
+        this.repositories = Collections.unmodifiableList(Arrays.asList(repository));
     }
 
     public static NamedDiff<Custom> readDiffFrom(StreamInput in) throws  IOException {

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoriesMetaDataSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoriesMetaDataSerializationTests.java
@@ -112,7 +112,7 @@ public class RepositoriesMetaDataSerializationTests extends AbstractDiffableSeri
         assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
         RepositoriesMetaData repositoriesMetaData = RepositoriesMetaData.fromXContent(parser);
         assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
-        List<RepositoryMetaData> repos = repositoriesMetaData.repositories();
+        List<RepositoryMetaData> repos = new ArrayList<>(repositoriesMetaData.repositories());
         repos.sort(Comparator.comparing(RepositoryMetaData::name));
         return new RepositoriesMetaData(repos);
     }


### PR DESCRIPTION
This commit makes the RepositoriesMetaData backing list no longer
modifiable.

Ref #30333