### PR TITLE
[DOCS] Integrates 6.x items in master changelog

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -167,6 +167,22 @@ Machine Learning::
 
 * Account for gaps in data counts after job is reopened ({pull}30294[#30294])
 
+[[release-notes-6.3.1]]
+== Elasticsearch version 6.3.1
+
+coming[6.3.1]
+
+//[float]
+//=== New Features
+
+//[float]
+//=== Enhancements
+
+[float]
+=== Bug Fixes
+
+Reduce the number of object allocations made by {security} when resolving the indices and aliases for a request ({pull}30180[#30180])
+
 //[float]
 //=== Regressions
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -17,6 +17,26 @@ This section summarizes the changes in each release.
 * <<release-notes-7.0.0>>
 * <<release-notes-6.4.0>>
 * <<release-notes-6.3.1>>
+* <<release-notes-6.3.0>>
+* <<release-notes-6.2.4>>
+* <<release-notes-6.2.3>>
+* <<release-notes-6.2.2>>
+* <<release-notes-6.2.1>>
+* <<release-notes-6.2.0>>
+* <<release-notes-6.1.4>>
+* <<release-notes-6.1.3>>
+* <<release-notes-6.1.2>>
+* <<release-notes-6.1.1>>
+* <<release-notes-6.1.0>>
+* <<release-notes-6.0.1>>
+* <<release-notes-6.0.0>>
+* <<release-notes-6.0.0-rc2>>
+* <<release-notes-6.0.0-rc1>>
+* <<release-notes-6.0.0-beta2>>
+* <<release-notes-6.0.0-beta1>>
+* <<release-notes-6.0.0-alpha2>>
+* <<release-notes-6.0.0-alpha1>>
+* <<release-notes-6.0.0-alpha1-5x>>
 
 --
 
@@ -28,7 +48,7 @@ This section summarizes the changes in each release.
 // TEMPLATE:
 
 // [[release-notes-n.n.n]]
-// == {es} n.n.n
+// == {es} version n.n.n
 
 //[float]
 [[breaking-n.n.n]]
@@ -58,7 +78,7 @@ This section summarizes the changes in each release.
 ////
 
 [[release-notes-7.0.0]]
-== {es} 7.0.0
+== {es} version 7.0.0
 
 coming[7.0.0]
 
@@ -121,7 +141,7 @@ Fix NPE when CumulativeSum agg encounters null value/empty bucket ({pull}29641[#
 //=== Known Issues
 
 [[release-notes-6.4.0]]
-== {es} 6.4.0
+== {es} version 6.4.0
 
 coming[6.4.0]
 
@@ -141,6 +161,7 @@ coming[6.4.0]
 The new <<mapping-ignored-field,`_ignored`>> field allows to know which fields
 got ignored at index time because of the <<ignore-malformed,`ignore_malformed`>>
 option. ({pull}30140[#29658])
+
 
 [float]
 === Enhancements
@@ -196,6 +217,55 @@ coming[6.3.1]
 
 //[float]
 [[breaking-6.3.1]]
+[[release-notes-6.3.0]]
+== {es} version 6.3.0
+
+coming[6.3.0]
+
+[float]
+[[breaking-6.3.0]]
+=== Breaking Changes
+
+[float]
+=== Deprecations
+Monitoring::
+* By default when you install {xpack}, monitoring is enabled but data collection
+is disabled. To enable data collection, use the new
+`xpack.monitoring.collection.enabled` setting. You can update this setting by
+using the <<cluster-update-settings,Cluster Update Settings API>>. For more
+information, see <<monitoring-settings>>.
+
+Security::
+* The legacy `XPackExtension` extension mechanism has been removed and replaced
+with an SPI based extension mechanism that is installed and built as an
+elasticsearch plugin.
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+//[float]
+//=== Enhancements
+
+//[float]
+//=== Bug Fixes
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[[release-notes-6.2.4]]
+== {es} version 6.2.4
+
+//[float]
+//[[breaking-6.2.4]]
 //=== Breaking Changes
 
 //[float]
@@ -213,10 +283,5330 @@ coming[6.3.1]
 [float]
 === Bug Fixes
 
-Reduce the number of object allocations made by {security} when resolving the indices and aliases for a request ({pull}30180[#30180])
+Engine::
+* Harden periodically check to avoid endless flush loop {pull}29125[#29125] (issues: {issue}28350[#28350], {issue}29097[#29097])
+
+Ingest::
+* Don't allow referencing the pattern bank name in the pattern bank {pull}29295[#29295] (issue: {issue}29257[#29257])
+[float]
+=== Regressions
+Fail snapshot operations early when creating or deleting a snapshot on a repository that has been
+written to by an older Elasticsearch after writing to it with a newer Elasticsearch version. ({pull}30140[#30140])
+
+Java High Level REST Client::
+* Bulk processor#awaitClose to close scheduler {pull}29263[#29263]
+
+Java Low Level REST Client::
+* REST client: hosts marked dead for the first time should not be immediately retried {pull}29230[#29230]
+
+Machine Learning::
+* Prevents failed jobs from mistakenly re-opening after node loss recovery. 
+* Returns an error when an operation cannot be submitted because the process was 
+killed. 
+* Respects the datafeed frequency when it is less or equal to the 
+`query_delay` setting.  
+
+Network::
+* Cross-cluster search and default connections can get crossed [OPEN] [ISSUE] {pull}29321[#29321]
+
+Percolator::
+* Fixed bug when non percolator docs end up in the search hits {pull}29447[#29447] (issue: {issue}29429[#29429])
+* Fixed a msm accounting error that can occur during analyzing a percolator query {pull}29415[#29415] (issue: {issue}29393[#29393])
+* Fix more query extraction bugs. {pull}29388[#29388] (issues: {issue}28353[#28353], {issue}29376[#29376])
+* Fix some query extraction bugs. {pull}29283[#29283]
+
+Plugins::
+* Plugins: Fix native controller confirmation for non-meta plugin {pull}29434[#29434]
+
+Search::
+* Propagate ignore_unmapped to inner_hits {pull}29261[#29261] (issue: {issue}29071[#29071])
+
+Security/Authentication::
+* Adds missing `idp.use_single_logout` and `populate_user_metadata` SAML realm 
+settings. See <<ref-saml-settings>>. 
+
+Settings::
+* Archive unknown or invalid settings on updates {pull}28888[#28888] (issue: {issue}28609[#28609])
+
+Watcher::
+* Re-enables `smtp.*` account configuration properties in the notification 
+settings. See <<email-notification-settings>>.  
+* Ensures starting and stopping {watcher} is properly acknowledged as a master 
+node action. 
+* Refrains from appending a question mark to an HTTP request if no parameters 
+are used. 
+
+//[float]
+//=== Known Issues
+
+[[release-notes-6.2.3]]
+== {es} version 6.2.3
+
+//[float]
+//[[breaking-6.2.3]]
+//=== Breaking Changes
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+[float]
+=== Enhancements
+
+Highlighting::
+* Limit analyzed text for highlighting (improvements) {pull}28808[#28808] (issues: {issue}16764[#16764], {issue}27934[#27934])
+
+Recovery::
+* Require translogUUID when reading global checkpoint {pull}28587[#28587] (issue: {issue}28435[#28435])
+
+[float]
+=== Bug Fixes
+
+Core::
+* Remove special handling for _all in nodes info {pull}28971[#28971] (issue: {issue}28797[#28797])
+
+Engine::
+* Avoid class cast exception from index writer {pull}28989[#28989]
+* Maybe die before failing engine {pull}28973[#28973] (issues: {issue}27265[#27265], {issue}28967[#28967])
+* Never block on key in `LiveVersionMap#pruneTombstones` {pull}28736[#28736] (issue: {issue}28714[#28714])
+
+Ingest::
+* Continue registering pipelines after one pipeline parse failure. {pull}28752[#28752] (issue: {issue}28269[#28269])
+
+Java High Level REST Client::
+* REST high-level client: encode path parts {pull}28663[#28663] (issue: {issue}28625[#28625])
+
+Machine Learning::
+* Fixed the <<ml-get-datafeed-stats,get datafeed statistics API>> such that it
+returns only machine learning-specific node attributes.
+
+Monitoring::
+* Aligned reporting of index statistics that exist in the current cluster state.
+This fix avoids subtle race conditions in stats reporting.
+
+Packaging::
+* Delay path expansion on Windows {pull}28753[#28753] (issues: {issue}27675[#27675], {issue}28748[#28748])
+
+Percolator::
+* Fix percolator query analysis for function_score query {pull}28854[#28854]
+* Improved percolator's random candidate query duel test {pull}28840[#28840]
+
+Security::
+* Fixed handling of comments in XML documents [ESA-2018-07].
+* Fixed auditing such that when you use a local audit index, it maintains the
+mappings automatically. Maintenance is necessary, for example, when new fields
+are introduced or document types change.
+* Added and changed settings for the SAML NameID policy. For example, added the
+`nameid.allow_create` setting and changed the default value for
+the SPNameQualifier setting to blank. See {stack-ov}/saml-realm.html[SAML Authentication].
+* Fixed handling of an Assertion Consumer Service (ACS) URL with existing query
+parameters. See {stack-ov}/saml-realm.html[SAML Authentication].
+* Fixed the PKI realm bootstrap check such that it works with secure settings.
+For more information, see <<bootstrap-checks-xpack>>.
+
+Snapshot/Restore::
+* Fix NPE when using deprecated Azure settings {pull}28769[#28769] (issues: {issue}23518[#23518], {issue}28299[#28299])
+
+Stats::
+* Fix AdaptiveSelectionStats serialization bug {pull}28718[#28718] (issue: {issue}28713[#28713])
+
+Watcher::
+* Fixed the serialization of failed hipchat messages, such that it no longer
+tries to write the status field twice.
+* Fixed TransformInput toXContent serialization errors. For more information,
+see
+{stack-ov}/input-chain.html#_transforming_chained_input_data[Transforming Chained Input Data].
 
 //[float]
 //=== Regressions
 
 //[float]
 //=== Known Issues
+
+
+[[release-notes-6.2.2]]
+== {es} version 6.2.2
+
+//[float]
+//[[breaking-6.2.2]]
+//=== Breaking Changes
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+[float]
+=== Enhancements
+
+Recovery::
+* Synced-flush should not seal index of out of sync replicas {pull}28464[#28464] (issue: {issue}10032[#10032])
+
+[float]
+=== Bug Fixes
+
+Core::
+* Handle throws on tasks submitted to thread pools {pull}28667[#28667]
+* Fix size blocking queue to not lie about its weight {pull}28557[#28557] (issue: {issue}28547[#28547])
+
+Ingest::
+* Guard accessDeclaredMembers for Tika on JDK 10 {pull}28603[#28603] (issue: {issue}28602[#28602])
+* Fix for bug that prevents pipelines to load that use stored scripts after a restart {pull}28588[#28588]
+
+Java High Level REST Client::
+* Fix parsing of script fields {pull}28395[#28395] (issue: {issue}28380[#28380])
+* Move to POST when calling API to retrieve which support request body {pull}28342[#28342] (issue: {issue}28326[#28326])
+
+Machine Learning::
+* Fixed an exception that occurred when a categorization field contained an
+empty string.
+
+Monitoring::
+* Properly registered `xpack.monitoring.exporters.*.headers.*` settings, which
+were broken in 6.2.0 and 6.2.1. For more information, see
+<<http-exporter-settings>>.
+
+Packaging::
+* Fix using relative custom config path {pull}28700[#28700] (issue: {issue}27610[#27610])
+* Disable console logging in the Windows service {pull}28618[#28618] (issue: {issue}20422[#20422])
+
+Percolator::
+* Do not take duplicate query extractions into account for minimum_should_match attribute {pull}28353[#28353] (issue: {issue}28315[#28315])
+
+Recovery::
+* Fsync directory after cleanup {pull}28604[#28604] (issue: {issue}28435[#28435])
+
+Security::
+* Added CachingRealm to published artifacts so it can be used in custom realm
+extensions.
+* If the realm uses native role mappings and the security index health changes,
+the realm caches are cleared. For example, they are cleared when the index
+recovers from a red state, when the index is deleted, when the index becomes
+outdated, and when the index becomes up-to-date.
+* Fixed a bug that could prevent auditing to a remote index if the remote
+cluster was re-started at the same time as the audited cluster.
+* Removed AuthorityKeyIdentifier's Issuer and Serial number from certificates
+generated by `certgen` and `certutil`. This improves compatibility with
+certificate verification in {kib}.
+
+Watcher::
+* Proxies now use HTTP by default, which was the default prior to 6.0. This
+fixes issues with HTTPS requests that tried to access proxies via HTTP.
+* Fixed the HTML sanitizer settings
+(`xpack.notification.email.html.sanitization.*`), which were broken in 6.2. For
+more information, see <<notification-settings>>.
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[[release-notes-6.2.1]]
+== {es} version 6.2.1
+
+//[float]
+//[[breaking-6.2.1]]
+//=== Breaking Changes
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+//[float]
+//=== Enhancements
+The cluster state listener to decide if watcher should be
+stopped/started/paused now runs far less code in an executor but is more
+synchronous and predictable. Also the trigger engine thread is only started on
+data nodes. And the Execute Watch API can be triggered regardless is watcher is
+started or stopped. ({pull}30118[#30118])
+
+[float]
+=== Bug Fixes
+
+Plugin Lang Painless::
+* Painless: Fix For Loop NullPointerException {pull}28506[#28506] (issue: {issue}28501[#28501])
+
+Plugins::
+* Fix the ability to remove old plugin {pull}28540[#28540] (issue: {issue}28538[#28538])
+
+Security::
+* Fixed missing dependencies for x-pack-transport.
+* Fixed `saml-metadata` env file such that it sources the appropriate 
+environment file.
+
+Machine Learning::
+
+* Account for gaps in data counts after job is reopened ({pull}30294[#30294])
+
+[[release-notes-6.2.0]]
+== {es} version 6.2.0
+
+[float]
+[[breaking-6.2.0]]
+=== Breaking Changes
+
+Aggregations::
+* Add a new cluster setting to limit the total number of buckets returned by a request {pull}27581[#27581] (issues: {issue}26012[#26012], {issue}27452[#27452])
+
+Core::
+* Forbid granting the all permission in production {pull}27548[#27548]
+
+Highlighting::
+* Limit the analyzed text for highlighting {pull}27934[#27934] (issue: {issue}27517[#27517])
+
+Rollover::
+* Fail rollover if duplicated alias found in templates {pull}28110[#28110] (issue: {issue}26976[#26976])
+
+Search::
+* Introduce limit to the number of terms in Terms Query {pull}27968[#27968] (issue: {issue}18829[#18829])
+
+[float]
+=== Breaking Java Changes
+
+Java API::
+* Remove `operationThreaded` from Java API {pull}27836[#27836]
+
+Java High Level REST Client::
+* REST high-level client: remove index suffix from indices client method names {pull}28263[#28263]
+
+[float]
+=== Deprecations
+
+Analysis::
+* Backport delimited payload filter renaming {pull}27535[#27535] (issue: {issue}26625[#26625])
+
+Suggesters::
+* deprecating `jarowinkler` in favor of `jaro_winkler` {pull}27526[#27526]
+* Deprecating `levenstein` in favor of `levensHtein` {pull}27409[#27409] (issue: {issue}27325[#27325])
+
+[float]
+=== New Features
+
+Machine Learning::
+* Added the ability to identify scheduled events and prevent anomaly detection
+during these periods. For more information, see
+{stack-ov}/ml-calendars.html[Calendars and Scheduled Events].
+
+Plugin Ingest GeoIp::
+* Enable ASN support for Ingest GeoIP plugin.  {pull}27958[#27958] (issue: {issue}27849[#27849])
+
+Plugin Lang Painless::
+* Painless: Add spi jar that will be published for extending whitelists {pull}28302[#28302]
+* Painless: Add a simple cache for whitelist methods and fields. {pull}28142[#28142]
+
+Plugins::
+* Add the ability to bundle multiple plugins into a meta plugin {pull}28022[#28022] (issue: {issue}27316[#27316])
+
+Rank Evaluation::
+* Backport of ranking evaluation API (#27478) {pull}27844[#27844] (issue: {issue}27478[#27478])
+
+Recovery::
+* Backport for using lastSyncedGlobalCheckpoint in deletion policy {pull}27866[#27866] (issue: {issue}27826[#27826])
+
+Reindex API::
+* Add scroll parameter to _reindex API {pull}28041[#28041] (issue: {issue}27555[#27555])
+
+Security::
+* {security} now supports user authentication using SAML Single Sign on. For
+more information, see {stack-ov}/saml-realm.html[SAML authentication].
+
+Watcher::
+* Added a transform input for chained input. For more information, see
+{stack-ov}/input-chain.html#_transforming_chained_input_data[Transforming Chained Input Data].
+
+[float]
+=== Enhancements
+
+Allocation::
+* Fix cluster.routing.allocation.enable and cluster.routing.rebalance.enable case {pull}28037[#28037] (issue: {issue}28007[#28007])
+* Add node id to shard failure message {pull}28024[#28024] (issue: {issue}28018[#28018])
+
+Analysis::
+* Limit the analyzed text for highlighting (#27934) {pull}28176[#28176] (issue: {issue}27517[#27517])
+* Allow TrimFilter to be used in custom normalizers {pull}27758[#27758] (issue: {issue}27310[#27310])
+
+Circuit Breakers::
+* Add accounting circuit breaker and track segment memory usage {pull}27116[#27116] (issue: {issue}27044[#27044])
+
+Cluster::
+* Adds wait_for_no_initializing_shards to cluster health API {pull}27489[#27489] (issue: {issue}25623[#25623])
+
+Core::
+* Introduce elasticsearch-core jar {pull}28191[#28191] (issue: {issue}27933[#27933])
+* Rename core module to server {pull}28190[#28190] (issue: {issue}27933[#27933])
+*  Rename core module to server {pull}28180[#28180] (issue: {issue}27933[#27933])
+* Introduce elasticsearch-core jar {pull}28178[#28178] (issue: {issue}27933[#27933])
+* Add Writeable.Reader support to TransportResponseHandler {pull}28010[#28010] (issue: {issue}26315[#26315])
+* Simplify rejected execution exception {pull}27664[#27664] (issue: {issue}27663[#27663])
+* Add node name to thread pool executor name {pull}27663[#27663] (issues: {issue}26007[#26007], {issue}26835[#26835])
+
+Discovery::
+* Add information when master node left to DiscoveryNodes' shortSummary() {pull}28197[#28197] (issue: {issue}28169[#28169])
+
+Engine::
+* Move uid lock into LiveVersionMap {pull}27905[#27905]
+* Optimize version map for append-only indexing {pull}27752[#27752]
+
+Geo::
+* [GEO] Add WKT Support to GeoBoundingBoxQueryBuilder {pull}27692[#27692] (issues: {issue}27690[#27690], {issue}9120[#9120])
+* [Geo] Add Well Known Text (WKT) Parsing Support to ShapeBuilders {pull}27417[#27417] (issue: {issue}9120[#9120])
+
+Highlighting::
+* Include all sentences smaller than fragment_size in the unified highlighter {pull}28132[#28132] (issue: {issue}28089[#28089])
+
+Ingest::
+* Enable convert processor to support Long and Double {pull}27891[#27891] (issues: {issue}23085[#23085], {issue}23423[#23423])
+
+Internal::
+* Make KeyedLock reentrant {pull}27920[#27920]
+* Make AbstractQueryBuilder.declareStandardFields to be protected (#27865) {pull}27894[#27894] (issue: {issue}27865[#27865])
+* Tighten the CountedBitSet class {pull}27632[#27632]
+* Avoid doing redundant work when checking for self references. {pull}26927[#26927] (issue: {issue}26907[#26907])
+
+Java API::
+* Add missing delegate methods to NodeIndicesStats {pull}28092[#28092]
+* Java api clean-up : consistency for `shards_acknowledged` getters  {pull}27819[#27819] (issue: {issue}27784[#27784])
+
+Java High Level REST Client::
+* add toString implementation for UpdateRequest. {pull}27997[#27997] (issue: {issue}27986[#27986])
+* Add Close Index API to the high level REST client {pull}27734[#27734] (issue: {issue}27205[#27205])
+* Add Open Index API to the high level REST client {pull}27574[#27574] (issue: {issue}27205[#27205])
+* Added Create Index support to high-level REST client {pull}27351[#27351] (issue: {issue}27205[#27205])
+* Add multi get api to the high level rest client {pull}27337[#27337] (issue: {issue}27205[#27205])
+* Add msearch api to high level client {pull}27274[#27274]
+
+Machine Learning::
+* Increased tokenization flexibility for categorization. Now all {es} analyzer
+functionality is available, which opens up the possibility of sensibly
+categorizing non-English log messages. For more information, see {stack-ov}/ml-configuring-categories.html#ml-configuring-analyzer[Customizing the Categorization Analyzer].
+* Improved the sensitivity of the analysis to high variance data with lots of
+values near zero.
+* Improved the decay rate of the model memory by using a weighted moving average.
+* Machine learning indices created after upgrading to 6.2 have the
+`auto_expand_replicas: 0-1` setting rather than a fixed setting of 1 replica.
+As a result, {ml} indices created after upgrading to 6.2 can have a green
+status on single node clusters. There is no impact in multi-node clusters.
+* Changed the credentials that are used by {dfeeds}. When {security} is enabled,
+a {dfeed} stores the roles of the user who created or updated the {dfeed}
+**at that time**. This means that if those roles are updated, the {dfeed}
+subsequently runs with the new permissions that are associated with the roles.
+However, if the user's roles are adjusted after creating or updating the {dfeed}
+then the {dfeed} continues to run with the permissions that are associated with
+the original roles. For more information, see
+{stack-ov}/ml-dfeeds.html[Datafeeds].
+* Added a new `scheduled` forecast status, which indicates that the forecast
+has not started yet.
+
+Mapping::
+* Allow `_doc` as a type. {pull}27816[#27816] (issues: {issue}27750[#27750], {issue}27751[#27751])
+
+Monitoring::
+* {monitoring} indices (`.monitoring`) created after upgrading to 6.2 have the
+`auto_expand_replicas: 0-1` setting rather than a fixed setting of 1 replica.
+As a result, monitoring indices created after upgrading to 6.2 can have a green
+status on single node clusters. There is no impact in multi-node clusters.
+* Added a cluster alert that triggers whenever a node is added, removed, or
+restarted.
+
+Network::
+* Add NioGroup for use in different transports {pull}27737[#27737] (issue: {issue}27260[#27260])
+* Add read timeouts to http module {pull}27713[#27713]
+* Implement byte array reusage in `NioTransport` {pull}27696[#27696] (issue: {issue}27563[#27563])
+* Introduce resizable inbound byte buffer {pull}27551[#27551] (issue: {issue}27563[#27563])
+* Decouple nio constructs from the tcp transport {pull}27484[#27484] (issue: {issue}27260[#27260])
+
+Packaging::
+* Extend JVM options to support multiple versions {pull}27675[#27675] (issue: {issue}27646[#27646])
+* Add explicit coreutils dependency {pull}27660[#27660] (issue: {issue}27609[#27609])
+* Detect mktemp from coreutils {pull}27659[#27659] (issues: {issue}27609[#27609], {issue}27643[#27643])
+* Enable GC logs by default {pull}27610[#27610]
+* Use private directory for temporary files {pull}27609[#27609] (issues: {issue}14372[#14372], {issue}27144[#27144])
+
+Percolator::
+* also extract match_all queries when indexing percolator queries {pull}27585[#27585]
+
+Plugin Lang Painless::
+* Painless: Add whitelist extensions {pull}28161[#28161]
+* Painless: Modify Loader to Load Classes Directly from Definition {pull}28088[#28088]
+* Clean Up Painless Cast Object {pull}27794[#27794]
+* Painless: Only allow Painless type names to be the same as the equivalent Java class. {pull}27264[#27264]
+
+Plugins::
+* Add client actions to action plugin {pull}28280[#28280] (issue: {issue}27759[#27759])
+* Plugins: Add validation to plugin descriptor parsing {pull}27951[#27951]
+* Plugins: Add plugin extension capabilities {pull}27881[#27881]
+* Add support for filtering mappings fields {pull}27603[#27603]
+
+Rank Evaluation::
+* Simplify RankEvalResponse output {pull}28266[#28266]
+
+Recovery::
+* Truncate tlog cli should assign global checkpoint {pull}28192[#28192] (issue: {issue}28181[#28181])
+* Replica starts peer recovery with safe commit {pull}28181[#28181] (issue: {issue}10708[#10708])
+* Primary send safe commit in file-based recovery {pull}28038[#28038] (issue: {issue}10708[#10708])
+* Fail resync-failed shards in subsequent writes {pull}28005[#28005]
+* Introduce promoting index shard state {pull}28004[#28004] (issue: {issue}24841[#24841])
+* Non-peer recovery should set the global checkpoint {pull}27965[#27965]
+* Persist global checkpoint when finalizing a peer recovery {pull}27947[#27947] (issue: {issue}27861[#27861])
+* Rollback a primary before recovering from translog {pull}27804[#27804] (issue: {issue}10708[#10708])
+
+Search::
+* Use typeName() to check field type in GeoShapeQueryBuilder {pull}27730[#27730]
+* Optimize search_after when sorting in index sort order {pull}26401[#26401]
+
+Security::
+* Added the ability to refresh tokens that were created by the token API. The
+API provides information about a refresh token, which you can use within 24
+hours of its creation to extend the life of a token. For more information, see
+<<security-api-tokens>>.
+* Added principal and role information to `access_granted`, `access_denied`,
+`run_as_granted`, and `run_as_denied` audit events. For more information about
+these events, see {stack-ov}/auditing.html[Auditing Security Events].
+* Added audit event ignore policies, which are a way to tune the verbosity of an
+audit trail. These policies define rules for ignoring audit events that match
+specific attribute values. For more information, see
+{stack-ov}/auditing.html#audit-log-ignore-policy[Logfile Audit Events Ignore Policies].
+* Added a certificates API, which enables you to retrieve information about the
+X.509 certificates that are used to encrypt communications in your {es} cluster.
+For more information, see <<security-api-ssl>>.
+
+Sequence IDs::
+* Do not keep 5.x commits when having 6.x commits {pull}28188[#28188] (issues: {issue}27606[#27606], {issue}28038[#28038])
+* Use lastSyncedGlobalCheckpoint in deletion policy {pull}27826[#27826] (issue: {issue}27606[#27606])
+* Use CountedBitSet in LocalCheckpointTracker {pull}27793[#27793]
+* Only fsync global checkpoint if needed {pull}27652[#27652]
+* Keep commits and translog up to the global checkpoint {pull}27606[#27606]
+* Adjust CombinedDeletionPolicy for multiple commits {pull}27456[#27456] (issues: {issue}10708[#10708], {issue}27367[#27367])
+* Keeps index commits up to the current global checkpoint {pull}27367[#27367] (issue: {issue}10708[#10708])
+* Dedup translog operations by reading in reverse {pull}27268[#27268] (issue: {issue}10708[#10708])
+
+Settings::
+* Add validation of keystore setting names {pull}27626[#27626]
+
+Snapshot/Restore::
+* Use AmazonS3.doesObjectExist() method in S3BlobContainer {pull}27723[#27723]
+* Remove XContentType auto detection in BlobStoreRepository {pull}27480[#27480]
+* Include include_global_state in Snapshot status API (#22423) {pull}26853[#26853] (issue: {issue}22423[#22423])
+
+Task Manager::
+* Add ability to associate an ID with tasks  {pull}27764[#27764] (issue: {issue}23250[#23250])
+
+Translog::
+* Simplify MultiSnapshot#SeqNoset {pull}27547[#27547] (issue: {issue}27268[#27268])
+* Enclose CombinedDeletionPolicy in SnapshotDeletionPolicy {pull}27528[#27528] (issues: {issue}27367[#27367], {issue}27456[#27456])
+
+Watcher::
+* Added the ability to set the `index` and `doc_type` dynamically in an index
+action. For more information, see {stack-ov}/actions-index.html[Index Action].
+* Added a `refresh` index action attribute, which enables you to set the
+refresh policy of the write request. For more information, see
+{stack-ov}/actions-index.html[Index Action].
+* Added support for actions in slack attachments, which enables you to add
+buttons that can be clicked in slack messages. For more information, see
+{stack-ov}/actions-slack.html[Slack Action].
+* {watcher} indices (`.watch*` and `triggered_watches`) created after upgrading
+to 6.2 have the `auto_expand_replicas: 0-1` setting rather than a fixed setting
+of 1 replica. As a result, {watcher} indices created after upgrading to 6.2 can
+have a green status on single node clusters. There is no impact in multi-node
+clusters.
+
+[float]
+=== Bug Fixes
+
+Reduce the number of object allocations made by {security} when resolving the indices and aliases for a request ({pull}30180[#30180])
+Aggregations::
+* Adds metadata to rewritten aggregations {pull}28185[#28185] (issue: {issue}28170[#28170])
+* Fix NPE on composite aggregation with sub-aggregations that need scores {pull}28129[#28129]
+* StringTerms.Bucket.getKeyAsNumber detection type {pull}28118[#28118] (issue: {issue}28012[#28012])
+* Fix incorrect results for aggregations nested under a nested aggregation {pull}27946[#27946] (issue: {issue}27912[#27912])
+* Fix global aggregation that requires breadth first and scores {pull}27942[#27942] (issues: {issue}22321[#22321], {issue}27928[#27928])
+* Fix composite aggregation when after term is missing in the shard {pull}27936[#27936]
+* Fix preserving FiltersAggregationBuilder#keyed field on rewrite {pull}27900[#27900] (issue: {issue}27841[#27841])
+* Using DocValueFormat::parseBytesRef for parsing missing value parameter {pull}27855[#27855] (issue: {issue}27788[#27788])
+* Fix illegal cast of the "low cardinality" optimization of the `terms` aggregation. {pull}27543[#27543]
+* Always include the _index and _id for nested search hits. {pull}27201[#27201] (issue: {issue}27053[#27053])
+
+Allocation::
+* Do not open indices with broken settings {pull}26995[#26995]
+
+Core::
+* Fix lock accounting in releasable lock {pull}28202[#28202]
+* Fixes ByteSizeValue to serialise correctly {pull}27702[#27702] (issue: {issue}27568[#27568])
+* Do not set data paths on no local storage required {pull}27587[#27587] (issue: {issue}27572[#27572])
+* Ensure threadcontext is preserved when refresh listeners are invoked {pull}27565[#27565]
+* Ensure logging is configured for CLI commands {pull}27523[#27523] (issue: {issue}27521[#27521])
+
+Engine::
+* Replica recovery could go into an endless flushing loop {pull}28350[#28350]
+* Use `_refresh` to shrink the version map on inactivity {pull}27918[#27918] (issue: {issue}27852[#27852])
+* Allow resize version map under lock even if there are pending operations {pull}27870[#27870] (issue: {issue}27852[#27852])
+* Reset LiveVersionMap on sync commit {pull}27534[#27534] (issue: {issue}27516[#27516])
+
+Geo::
+* Correct two equality checks on incomparable types {pull}27688[#27688]
+* Handle case where the hole vertex is south of the containing polygon(s) {pull}27685[#27685] (issue: {issue}25933[#25933])
+
+Highlighting::
+* Fix highlighting on a keyword field that defines a normalizer {pull}27604[#27604]
+
+Inner Hits::
+* Add version support for inner hits in field collapsing (#27822) {pull}27833[#27833] (issue: {issue}27822[#27822])
+
+Internal::
+* Never return null from Strings.tokenizeToStringArray {pull}28224[#28224] (issue: {issue}28213[#28213])
+* Fallback to TransportMasterNodeAction for cluster health retries {pull}28195[#28195] (issue: {issue}28169[#28169])
+* Retain originalIndex info when rewriting FieldCapabilities requests {pull}27761[#27761]
+
+Java REST Client::
+* Do not use system properties when building the HttpAsyncClient {pull}27829[#27829] (issue: {issue}27827[#27827])
+
+Machine Learning::
+* Improved error reporting for crashes and resource problems on Linux.
+* Improved the detection of seasonal trends in bucket spans longer than 1 hour.
+* Updated the forecast API to wait for validation and return an error if the
+validation fails.
+* Set the actual bucket value to 0 in model plots for empty buckets for count
+and sum functions. The count and sum functions treat empty buckets as 0 rather
+than unknown for anomaly detection, so it was inconsistent not to do the same
+for model plots. This inconsistency resulted in problems plotting these buckets
+in {kib}.
+
+Mapping::
+* Ignore null value for range field (#27845) {pull}28116[#28116] (issue: {issue}27845[#27845])
+* Pass `java.locale.providers=COMPAT` to Java 9 onwards {pull}28080[#28080] (issue: {issue}10984[#10984])
+* Allow update of `eager_global_ordinals` on `_parent`. {pull}28014[#28014] (issue: {issue}24407[#24407])
+* Fix merging of _meta field {pull}27352[#27352] (issue: {issue}27323[#27323])
+
+Network::
+* Only bind loopback addresses when binding to local {pull}28029[#28029] (issue: {issue}1877[#1877])
+* Remove potential nio selector leak {pull}27825[#27825]
+* Fix issue where the incorrect buffers are written {pull}27695[#27695] (issue: {issue}27551[#27551])
+* Throw UOE from compressible bytes stream reset {pull}27564[#27564] (issue: {issue}24927[#24927])
+* Bubble exceptions when closing compressible streams {pull}27542[#27542] (issue: {issue}27540[#27540])
+
+Packaging::
+* Allow custom service names when installing on windows {pull}25255[#25255] (issue: {issue}25231[#25231])
+
+Percolator::
+* Avoid TooManyClauses exception if number of terms / ranges is exactly equal to 1024 {pull}27519[#27519] (issue: {issue}1[#1])
+
+Plugin Analysis ICU::
+* Catch InvalidPathException in IcuCollationTokenFilterFactory {pull}27202[#27202]
+
+Plugin Analysis Phonetic::
+* Fix daitch_mokotoff phonetic filter to use the dedicated Lucene filter {pull}28225[#28225] (issue: {issue}28211[#28211])
+
+Plugin Lang Painless::
+* Painless: Fix variable scoping issue in lambdas {pull}27571[#27571] (issue: {issue}26760[#26760])
+* Painless: Fix errors allowing void to be assigned to def. {pull}27460[#27460] (issue: {issue}27210[#27210])
+
+Plugin Repository HDFS::
+* Fix SecurityException when HDFS Repository used against HA Namenodes {pull}27196[#27196]
+
+Plugins::
+* Make sure that we don't detect files as maven coordinate when installing a plugin {pull}28163[#28163]
+* Fix upgrading indices which use a custom similarity plugin. {pull}26985[#26985] (issue: {issue}25350[#25350])
+
+Recovery::
+* Open engine should keep only starting commit {pull}28228[#28228] (issues: {issue}27804[#27804], {issue}28181[#28181])
+* Allow shrinking of indices from a previous major {pull}28076[#28076] (issue: {issue}28061[#28061])
+* Set global checkpoint before open engine from store {pull}27972[#27972] (issues: {issue}27965[#27965], {issue}27970[#27970])
+* Check and repair index under the store metadata lock {pull}27768[#27768] (issues: {issue}24481[#24481], {issue}24787[#24787], {issue}27731[#27731])
+* Flush old indices on primary promotion and relocation {pull}27580[#27580] (issue: {issue}27536[#27536])
+
+Rollover::
+* Make index rollover action atomic {pull}28039[#28039] (issue: {issue}26976[#26976])
+
+Scripting::
+* Ensure we protect Collections obtained from scripts from self-referencing {pull}28335[#28335]
+
+Scroll::
+* Reject scroll query if size is 0 (#22552) {pull}27842[#27842] (issue: {issue}22552[#22552])
+* Fix scroll query with a sort that is a prefix of the index sort {pull}27498[#27498]
+
+Search::
+* Fix simple_query_string on invalid input {pull}28219[#28219] (issue: {issue}28204[#28204])
+* Use the underlying connection version for CCS connections  {pull}28093[#28093]
+* Fix synonym phrase query expansion for cross_fields parsing {pull}28045[#28045]
+* Carry forward weights, etc on rescore rewrite {pull}27981[#27981] (issue: {issue}27979[#27979])
+* Fix routing with leading or trailing whitespace {pull}27712[#27712] (issue: {issue}27708[#27708])
+
+Security::
+* Updated the `setup-passwords` command to generate passwords with characters
+`A-Z`, `a-z`, and `0-9`, so that they are safe to use in shell scripts. For more
+information about this command, see <<setup-passwords>>.
+* Improved the error messages that occur if the `x-pack` directory is missing
+when you run <<users-command,`users` commands>>.
+* Fixed the ordering of realms in a realm chain, which determines the order in
+which the realms are consulted. For more information, see
+{stack-ov}/realms.html[Realms].
+
+Sequence IDs::
+* Recovery from snapshot may leave seq# gaps {pull}27850[#27850]
+* No longer unidle shard during recovery {pull}27757[#27757] (issue: {issue}26591[#26591])
+* Obey translog durability in global checkpoint sync {pull}27641[#27641]
+
+Settings::
+* Settings: Introduce settings updater for a list of settings {pull}28338[#28338] (issue: {issue}28047[#28047])
+*  Fix setting notification for complex setting (affixMap settings) that could cause transient settings to be ignored {pull}28317[#28317] (issue: {issue}28316[#28316])
+* Fix environment variable substitutions in list setting {pull}28106[#28106] (issue: {issue}27926[#27926])
+* Allow index settings to be reset by wildcards {pull}27671[#27671] (issue: {issue}27537[#27537])
+
+Snapshot/Restore::
+* Consistent updates of IndexShardSnapshotStatus {pull}28130[#28130] (issue: {issue}26480[#26480])
+* Avoid concurrent snapshot finalizations when deleting an INIT snapshot {pull}28078[#28078] (issues: {issue}27214[#27214], {issue}27931[#27931], {issue}27974[#27974])
+* Do not start snapshots that are deleted during initialization {pull}27931[#27931]
+* Do not swallow exception in ChecksumBlobStoreFormat.writeAtomic() {pull}27597[#27597]
+* Consistent update of stage and failure message in IndexShardSnapshotStatus {pull}27557[#27557] (issue: {issue}26480[#26480])
+* Fail restore when the shard allocations max retries count is reached {pull}27493[#27493] (issue: {issue}26865[#26865])
+* Delete shard store files before restoring a snapshot {pull}27476[#27476] (issues: {issue}20220[#20220], {issue}26865[#26865])
+
+Stats::
+* Fixes DocStats to properly deal with shards that report -1 index size {pull}27863[#27863]
+* Include internal refreshes in refresh stats {pull}27615[#27615]
+
+Term Vectors::
+* Fix term vectors generator with keyword and normalizer {pull}27608[#27608] (issue: {issue}27320[#27320])
+
+Watcher::
+* Replaced group settings with affix key settings where filters are needed.
+For more information, see https://github.com/elastic/elasticsearch/pull/28338.
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Core::
+* Dependencies: Update joda time to 2.9.9 {pull}28261[#28261]
+* upgrade to lucene 7.2.1 {pull}28218[#28218] (issue: {issue}28044[#28044])
+* Upgrade jna from 4.4.0-1 to 4.5.1 {pull}28183[#28183] (issue: {issue}28172[#28172])
+
+Ingest::
+* update ingest-attachment to use Tika 1.17 and newer deps {pull}27824[#27824]
+
+[[release-notes-6.1.4]]
+== {es} version 6.1.4
+
+//[float]
+//[[breaking-6.1.4]]
+//=== Breaking Changes
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+[float]
+=== Enhancements
+
+Core::
+* Fix classes that can exit {pull}27518[#27518]
+
+[float]
+=== Bug Fixes
+
+Aggregations::
+* StringTerms.Bucket.getKeyAsNumber detection type {pull}28118[#28118] (issue: {issue}28012[#28012])
+
+Core::
+* Remove special handling for _all in nodes info {pull}28971[#28971] (issue: {issue}28797[#28797])
+
+Engine::
+* Avoid class cast exception from index writer {pull}28989[#28989]
+* Maybe die before failing engine {pull}28973[#28973] (issues: {issue}27265[#27265], {issue}28967[#28967])
+
+Scripting::
+* Painless: Fix For Loop NullPointerException {pull}28506[#28506] (issue: {issue}28501[#28501])
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[[release-notes-6.1.3]]
+== {es} version 6.1.3
+
+//[float]
+//[[breaking-6.1.3]]
+//=== Breaking Changes
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+//[float]
+//=== Enhancements
+
+[float]
+=== Bug Fixes
+
+Engine::
+* Replica recovery could go into an endless flushing loop {pull}28350[#28350]
+
+Internal::
+* Never return null from Strings.tokenizeToStringArray {pull}28224[#28224] (issue: {issue}28213[#28213])
+* Fallback to TransportMasterNodeAction for cluster health retries {pull}28195[#28195] (issue: {issue}28169[#28169])
+
+Mapping::
+* Allow update of `eager_global_ordinals` on `_parent`. {pull}28014[#28014] (issue: {issue}24407[#24407])
+
+Scripting::
+* Ensure we protect Collections obtained from scripts from self-referencing {pull}28335[#28335]
+
+Security::
+* Improved cache expiry handling in the token service. Previously, if the token
+service was idle for more than 60 minutes, the key expired and the service
+failed to generate user tokens.
+
+Settings::
+*  Fix setting notification for complex setting (affixMap settings) that could cause transient settings to be ignored {pull}28317[#28317] (issue: {issue}28316[#28316])
+* Fix environment variable substitutions in list setting {pull}28106[#28106] (issue: {issue}27926[#27926])
+
+Snapshot/Restore::
+* Avoid concurrent snapshot finalizations when deleting an INIT snapshot {pull}28078[#28078] (issues: {issue}27214[#27214], {issue}27931[#27931], {issue}27974[#27974])
+* Do not start snapshots that are deleted during initialization {pull}27931[#27931]
+
+Watcher::
+* Fixed a null pointer exception in the TemplateRegistry when there is no master
+node available.
+* Ensured collections obtained from scripts are protected from self-referencing.
+See https://github.com/elastic/elasticsearch/pull/28335.
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[[release-notes-6.1.2]]
+== {es} version 6.1.2
+
+//[float]
+//[[breaking-6.1.2]]
+//=== Breaking Changes
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+[float]
+=== Enhancements
+
+Internal::
+* Make AbstractQueryBuilder.declareStandardFields to be protected (#27865) {pull}27894[#27894] (issue: {issue}27865[#27865])
+
+Added new "Request" object flavored request methods. Prefer these instead of the
+multi-argument versions. ({pull}29623[#29623])
+
+
+[float]
+=== Bug Fixes
+
+Aggregations::
+* Fix incorrect results for aggregations nested under a nested aggregation {pull}27946[#27946] (issue: {issue}27912[#27912])
+* Fix composite aggregation when after term is missing in the shard {pull}27936[#27936]
+* Fix preserving FiltersAggregationBuilder#keyed field on rewrite {pull}27900[#27900] (issue: {issue}27841[#27841])
+
+Engine::
+* Use `_refresh` to shrink the version map on inactivity {pull}27918[#27918] (issue: {issue}27852[#27852])
+* Allow resize version map under lock even if there are pending operations {pull}27870[#27870] (issue: {issue}27852[#27852])
+
+Machine Learning::
+* Fixed the removal of tokens during categorization, where the tokens were
+incorrectly deemed to be hexadecimal numbers. For more information, see
+{stack-ov}/ml-configuring-categories.html[Categorizing log messages].
+* Reduced the sensitivity of the analysis to small perturbations in the input
+data.
+* Disabled the ability to create forecasts for jobs that were created before
+6.1.0.
+
+Monitoring::
+* Added a `cluster_alerts.management.blacklist` setting for HTTP Exporters,
+which you can use to block the creation of specific cluster alerts. For more
+information, see <<monitoring-settings>>.
+
+Network::
+* Only bind loopback addresses when binding to local {pull}28029[#28029]
+
+Recovery::
+* Allow shrinking of indices from a previous major {pull}28076[#28076] (issue: {issue}28061[#28061])
+
+Search::
+* Use the underlying connection version for CCS connections  {pull}28093[#28093]
+* Carry forward weights, etc on rescore rewrite {pull}27981[#27981] (issue: {issue}27979[#27979])
+
+Security::
+* Fixed an issue in the Active Directory realm when following referrals that
+resulted in an increase in the number of connections made to Active Directory.
+* Fixed exception that occurred when using auditing and transport clients. In
+particular, the problem occurred when the number of processors on the transport
+client did not match the number of processors on the server.
+* Ensured that TLS is not required to install a license if you are using
+single-node discovery. For more information, see <<single-node-discovery>> and
+{stack-ov}/ssl-tls.html[Setting up TLS on a Cluster].
+* Fixed the <<security-api-privileges,has_privileges API>>. In particular, the
+`has_all_requested` field in the API results was not taking cluster privileges
+into consideration.
+
+Snapshot/Restore::
+* Fail restore when the shard allocations max retries count is reached {pull}27493[#27493] (issue: {issue}26865[#26865])
+
+Translog::
+* Only sync translog when global checkpoint increased {pull}27973[#27973] (issues: {issue}27837[#27837], {issue}27970[#27970])
+
+Watcher::
+* Fixed encoding of UTF-8 data in the HTTP client.
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[[release-notes-6.1.1]]
+== {es} version 6.1.1
+
+//[float]
+//[[breaking-6.1.1]]
+//=== Breaking Changes
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+[float]
+=== Enhancements
+
+Snapshot/Restore::
+* Use AmazonS3.doesObjectExist() method in S3BlobContainer {pull}27723[#27723]
+
+Watcher::
+* Ensured the watcher thread pool size is reasonably bound. In particular, the
+watcher thread pool size is now five times the number of processors until 50
+threads are reached. If more than 50 cores exist and 50 threads exist, the
+watch thread pool size grows to match the number of processors.
+
+[float]
+=== Bug Fixes
+
+Inner Hits::
+* Add version support for inner hits in field collapsing (#27822) {pull}27833[#27833] (issue: {issue}27822[#27822])
+
+Java REST Client::
+* Do not use system properties when building the HttpAsyncClient {pull}27829[#27829] (issue: {issue}27827[#27827])
+
+Monitoring::
+* Data collectors now all share the same cluster state that existed at the
+beginning of data collection. This removes the extremely rare race condition
+where the cluster state can change between some data collectors, which could
+cause temporary issues in the Monitoring UI.
+
+Search::
+* Fix routing with leading or trailing whitespace {pull}27712[#27712] (issue: {issue}27708[#27708])
+
+Sequence IDs::
+* Recovery from snapshot may leave seq# gaps {pull}27850[#27850]
+* No longer unidle shard during recovery {pull}27757[#27757] (issue: {issue}26591[#26591])
+
+Watcher::
+* Fixed the pagerduty action to send context data. For more information, see
+{stack-ov}/actions-pagerduty.html[PagerDuty Action].
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Ingest::
+* update ingest-attachment to use Tika 1.17 and newer deps {pull}27824[#27824]
+
+[[release-notes-6.1.0]]
+== {es} version 6.1.0
+
+[float]
+[[breaking-6.1.0]]
+=== Breaking Changes
+
+Network::
+* Allow only a fixed-size receive predictor {pull}26165[#26165] (issue: {issue}23185[#23185])
+
+REST::
+* Standardize underscore requirements in parameters {pull}27414[#27414] (issues: {issue}26886[#26886], {issue}27040[#27040])
+
+Scroll::
+* Fail queries with scroll that explicitely set request_cache {pull}27342[#27342]
+
+Search::
+* Add a limit to from + size in top_hits and inner hits. {pull}26492[#26492] (issue: {issue}11511[#11511])
+
+Security::
+* The `certgen` command now returns validation errors when it encounters problems
+reading from an input file (with the `-in` command option). Previously these
+errors might have been ignored or caused the command to abort with unclear
+messages. For more information, see <<certgen>>.
+
+[float]
+=== Breaking Java Changes
+
+Aggregations::
+* Moves deferring code into its own subclass {pull}26421[#26421]
+
+Core::
+* Unify Settings xcontent reading and writing {pull}26739[#26739]
+
+Settings::
+* Return List instead of an array from settings {pull}26903[#26903]
+* Remove `Settings,put(Map<String,String>)` {pull}26785[#26785]
+
+[float]
+=== Deprecations
+
+Aggregations::
+* Deprecate global_ordinals_hash and global_ordinals_low_cardinality {pull}26173[#26173] (issue: {issue}26014[#26014])
+
+Allocation::
+* Add deprecation warning for negative index.unassigned.node_left.delayed_timeout {pull}26832[#26832] (issue: {issue}26828[#26828])
+
+Analysis::
+* Add limits for ngram and shingle settings {pull}27411[#27411] (issues: {issue}25887[#25887], {issue}27211[#27211])
+
+Geo::
+* [GEO] 6x Deprecate ShapeBuilders and decouple geojson parse logic {pull}27345[#27345]
+
+Mapping::
+* Deprecate the `index_options` parameter for numeric fields {pull}26672[#26672] (issue: {issue}21475[#21475])
+
+Plugin Repository Azure::
+* Azure repository: Move to named configurations as we do for S3 repository and secure settings {pull}23405[#23405] (issues: {issue}22762[#22762], {issue}22763[#22763])
+
+Search::
+* doc: deprecate _primary and _replica shard option {pull}26792[#26792] (issue: {issue}26335[#26335])
+
+[float]
+=== New Features
+
+Aggregations::
+* Aggregations: bucket_sort pipeline aggregation {pull}27152[#27152] (issue: {issue}14928[#14928])
+* Add composite aggregator {pull}26800[#26800]
+
+Analysis::
+* Added Bengali Analyzer to Elasticsearch with respect to the lucene update {pull}26527[#26527]
+
+Ingest::
+* add URL-Decode Processor to Ingest {pull}26045[#26045] (issue: {issue}25837[#25837])
+
+Java High Level REST Client::
+* Added Delete Index support to high-level REST client {pull}27019[#27019] (issue: {issue}25847[#25847])
+
+Machine Learning::
+* Added the ability to create job forecasts. This feature enables you to use
+historical behavior to predict the future behavior of your time series. You can
+create forecasts in {kib} or by using the <<ml-forecast,forecast jobs>> API.
++
+--
+NOTE: You cannot create forecasts for jobs that were created in previous
+versions; this functionality is available only for jobs created in 6.1 or later.
+
+--
+* Added overall buckets, which summarize bucket results for multiple jobs.
+For more information, see the <<ml-get-overall-buckets,get overall buckets>> API.
+* Added job groups, which you can use to manage or retrieve information from
+multiple jobs at once. Also updated many {ml} APIs to support groups and
+wildcard expressions in the job identifier.
+
+Nested Docs::
+* Multi-level Nested Sort with Filters {pull}26395[#26395]
+
+Query DSL::
+* Add terms_set query {pull}27145[#27145] (issue: {issue}26915[#26915])
+* Introduce sorted_after query for sorted index {pull}26377[#26377]
+* Add support for auto_generate_synonyms_phrase_query in match_query, multi_match_query, query_string and simple_query_string {pull}26097[#26097]
+
+Search::
+* Expose `fuzzy_transpositions` parameter in fuzzy queries {pull}26870[#26870] (issue: {issue}18348[#18348])
+* Add upper limit for scroll expiry {pull}26448[#26448] (issues: {issue}11511[#11511], {issue}23268[#23268])
+* Implement adaptive replica selection {pull}26128[#26128] (issue: {issue}24915[#24915])
+* configure distance limit {pull}25731[#25731] (issue: {issue}25528[#25528])
+
+Similarities::
+* Add a scripted similarity. {pull}25831[#25831]
+
+Suggesters::
+* Expose duplicate removal in the completion suggester {pull}26496[#26496] (issue: {issue}23364[#23364])
+* Support must and should for context query in context suggester {pull}26407[#26407] (issues: {issue}24421[#24421], {issue}24565[#24565])
+
+[float]
+=== Enhancements
+
+Aggregations::
+* Allow aggregation sorting via nested aggregation {pull}26683[#26683] (issue: {issue}16838[#16838])
+
+Allocation::
+* Tie-break shard path decision based on total number of shards on path {pull}27039[#27039] (issue: {issue}26654[#26654])
+* Balance shards for an index more evenly across multiple data paths {pull}26654[#26654] (issue: {issue}16763[#16763])
+* Expand "NO" decision message in NodeVersionAllocationDecider {pull}26542[#26542] (issue: {issue}10403[#10403])
+* _reroute's retry_failed flag should reset failure counter {pull}25888[#25888] (issue: {issue}25291[#25291])
+
+Analysis::
+* Add configurable `max_token_length` parameter to whitespace tokenizer {pull}26749[#26749] (issue: {issue}26643[#26643])
+
+CRUD::
+* Add wait_for_active_shards parameter to index open command {pull}26682[#26682] (issue: {issue}20937[#20937])
+
+Core::
+* Fix classes that can exit {pull}27518[#27518]
+* Replace empty index block checks with global block checks in template delete/put actions {pull}27050[#27050] (issue: {issue}10530[#10530])
+* Allow Uid#decodeId to decode from a byte array slice {pull}26987[#26987] (issue: {issue}26931[#26931])
+* Use separate searchers for "search visibility" vs "move indexing buffer to disk {pull}26972[#26972] (issues: {issue}15768[#15768], {issue}26802[#26802], {issue}26912[#26912], {issue}3593[#3593])
+* Add ability to split shards {pull}26931[#26931]
+* Make circuit breaker mutations debuggable {pull}26067[#26067] (issue: {issue}25891[#25891])
+
+Dates::
+* DateProcessor Locale {pull}26186[#26186] (issue: {issue}25513[#25513])
+
+Discovery::
+* Stop responding to ping requests before master abdication {pull}27329[#27329] (issue: {issue}27328[#27328])
+
+Engine::
+* Ensure external refreshes will also refresh internal searcher to minimize segment creation {pull}27253[#27253] (issue: {issue}26972[#26972])
+* Move IndexShard#getWritingBytes() under InternalEngine {pull}27209[#27209] (issue: {issue}26972[#26972])
+* Refactor internal engine {pull}27082[#27082]
+
+Geo::
+* Add ignore_malformed to geo_shape fields {pull}24654[#24654] (issue: {issue}23747[#23747])
+
+Ingest::
+* add json-processor support for non-map json types {pull}27335[#27335] (issue: {issue}25972[#25972])
+* Introduce templating support to timezone/locale in DateProcessor {pull}27089[#27089] (issue: {issue}24024[#24024])
+* Add support for parsing inline script (#23824) {pull}26846[#26846] (issue: {issue}23824[#23824])
+* Consolidate locale parsing. {pull}26400[#26400]
+* Accept ingest simulate params as ints or strings {pull}23885[#23885] (issue: {issue}23823[#23823])
+
+Internal::
+* Avoid uid creation in ParsedDocument {pull}27241[#27241]
+* Upgrade to Lucene 7.1.0 snapshot version {pull}26864[#26864] (issue: {issue}26527[#26527])
+* Remove `_index` fielddata hack if cluster alias is present {pull}26082[#26082] (issue: {issue}25885[#25885])
+
+Java High Level REST Client::
+* Adjust RestHighLevelClient method modifiers {pull}27238[#27238]
+* Decouple BulkProcessor from ThreadPool {pull}26727[#26727] (issue: {issue}26028[#26028])
+
+Logging::
+* Add more information on _failed_to_convert_ exception (#21946) {pull}27034[#27034] (issue: {issue}21946[#21946])
+* Improve shard-failed log messages. {pull}26866[#26866]
+
+Machine Learning::
+* Improved the way {ml} jobs are allocated to nodes, such that it is primarily
+determined by the estimated memory requirement of the job. If there is insufficient
+information about the job's memory requirements, the allocation decision is based
+on job counts per node.
+* Increased the default value of the `xpack.ml.max_open_jobs` setting from `10`
+to `20`. The allocation of jobs to nodes now considers memory usage as well as
+job counts, so it's reasonable to permit more small jobs on a single node. For
+more information, see <<ml-settings>>.
+* Decreased the default `model_memory_limit` property value to 1 GB for new jobs.
+If you want to create a job that analyzes high cardinality fields, you can
+increase this property value. For more information, see <<ml-apilimits>>.
+* Improved analytics related to decay rates when predictions are very accurate.
+* Improved analytics related to detecting non-negative quantities and using this
+information to constrain analysis, predictions, and confidence intervals.
+* Improved periodic trough or spike detection.
+* Improved the speed of the aggregation of {ml} results.
+* Improved probability calculation performance.
+* Expedited bucket processing time in very large populations by determining when
+there are nearly duplicate values in a bucket and de-duplicating the samples that
+are added to the model.
+* Improved handling of periodically missing values.
+* Improved analytics related to diurnal periodicity.
+* Reduced memory usage during population analysis by releasing redundant memory
+after the bucket results are written.
+* Improved modeling of long periodic components, particularly when there is a
+long bucket span.
+
+Mapping::
+* Allow ip_range to accept CIDR notation {pull}27192[#27192] (issue: {issue}26260[#26260])
+* Deduplicate `_field_names`. {pull}26550[#26550]
+* Throw a better error message for empty field names {pull}26543[#26543] (issue: {issue}23348[#23348])
+* Stricter validation for min/max values for whole numbers {pull}26137[#26137]
+* Make FieldMapper.copyTo() always non-null. {pull}25994[#25994]
+
+Monitoring::
+* Added the new `interval_ms` field to monitoring documents. This field
+indicates the current collection interval for {es} or external monitored systems.
+
+Nested Docs::
+* Use the primary_term field to identify parent documents {pull}27469[#27469] (issue: {issue}24362[#24362])
+* Prohibit using `nested_filter`, `nested_path` and new `nested` Option at the same time in FieldSortBuilder {pull}26490[#26490] (issue: {issue}17286[#17286])
+
+Network::
+* Remove manual tracking of registered channels {pull}27445[#27445] (issue: {issue}27260[#27260])
+* Remove tcp profile from low level nio channel {pull}27441[#27441] (issue: {issue}27260[#27260])
+* Decouple `ChannelFactory` from Tcp classes {pull}27286[#27286] (issue: {issue}27260[#27260])
+
+Percolator::
+* Use Lucene's CoveringQuery to select percolate candidate matches {pull}27271[#27271] (issues: {issue}26081[#26081], {issue}26307[#26307])
+* Add support to percolate query to percolate multiple documents simultaneously {pull}26418[#26418]
+* Hint what clauses are important in a conjunction query based on fields {pull}26081[#26081]
+* Add support for selecting percolator query candidate matches containing range queries {pull}25647[#25647] (issue: {issue}21040[#21040])
+
+Plugin Discovery EC2::
+* update AWS SDK for ECS Task IAM support in discovery-ec2 {pull}26479[#26479] (issue: {issue}23039[#23039])
+
+Plugin Lang Painless::
+* Painless: Only allow Painless type names to be the same as the equivalent Java class. {pull}27264[#27264]
+* Allow for the Painless Definition to have multiple instances for white-listing {pull}27096[#27096]
+* Separate Painless Whitelist Loading from the Painless Definition {pull}26540[#26540]
+* Remove Sort enum from Painless Definition {pull}26179[#26179]
+
+Plugin Repository Azure::
+* Add azure storage endpoint suffix #26432 {pull}26568[#26568] (issue: {issue}26432[#26432])
+* Support for accessing Azure repositories through a proxy {pull}23518[#23518] (issues: {issue}23506[#23506], {issue}23517[#23517])
+
+Plugin Repository S3::
+* Remove S3 output stream {pull}27280[#27280] (issue: {issue}27278[#27278])
+* Update to AWS SDK 1.11.223 {pull}27278[#27278]
+
+Plugins::
+* Plugins: Add versionless alias to all security policy codebase properties {pull}26756[#26756] (issue: {issue}26521[#26521])
+* Allow plugins to plug rescore implementations {pull}26368[#26368] (issue: {issue}26208[#26208])
+
+Query DSL::
+* Add support for wildcard on `_index` {pull}27334[#27334] (issue: {issue}25722[#25722])
+
+Reindex API::
+* Update by Query is modified to accept short `script` parameter. {pull}26841[#26841] (issue: {issue}24898[#24898])
+* reindex: automatically choose the number of slices {pull}26030[#26030] (issues: {issue}24547[#24547], {issue}25582[#25582])
+
+Rollover::
+* Add size-based condition to the index rollover API {pull}27160[#27160] (issue: {issue}27004[#27004])
+* Add size-based condition to the index rollover API {pull}27115[#27115] (issue: {issue}27004[#27004])
+
+Scripting::
+* Script: Convert script query to a dedicated script context {pull}26003[#26003]
+
+Search::
+* Make fields optional in multi_match query and rely on index.query.default_field by default {pull}27380[#27380]
+* fix unnecessary logger creation {pull}27349[#27349]
+* `ObjectParser` : replace `IllegalStateException` with `ParsingException` {pull}27302[#27302] (issue: {issue}27147[#27147])
+* Uses norms for exists query if enabled {pull}27237[#27237]
+* Cross Cluster Search: make remote clusters optional {pull}27182[#27182] (issues: {issue}26118[#26118], {issue}27161[#27161])
+* Enhances exists queries to reduce need for `_field_names` {pull}26930[#26930] (issue: {issue}26770[#26770])
+* Change ParentFieldSubFetchPhase to create doc values iterator once per segment {pull}26815[#26815]
+* Change VersionFetchSubPhase to create doc values iterator once per segment {pull}26809[#26809]
+* Change ScriptFieldsFetchSubPhase to create search scripts once per segment {pull}26808[#26808] (issue: {issue}26775[#26775])
+* Make sure SortBuilders rewrite inner nested sorts {pull}26532[#26532]
+* Extend testing of build method in ScriptSortBuilder {pull}26520[#26520] (issues: {issue}17286[#17286], {issue}26490[#26490])
+* Accept an array of field names and boosts in the index.query.default_field setting {pull}26320[#26320] (issue: {issue}25946[#25946])
+* Reject IPv6-mapped IPv4 addresses when using the CIDR notation. {pull}26254[#26254] (issue: {issue}26078[#26078])
+* Rewrite range queries with open bounds to exists query {pull}26160[#26160] (issue: {issue}22640[#22640])
+
+Security::
+* Added the `manage_index_templates` cluster privilege to the built-in role
+`kibana_system`. For more information, see
+{stack-ov}/security-privileges.html#privileges-list-cluster[Cluster Privileges]
+and {stack-ov}/built-in-roles.html[Built-in Roles].
+* Newly created or updated watches execute with the privileges of the user that
+last modified the watch.
+* Added log messages when a PEM key is found when a PEM certificate was
+expected (or vice versa) in the `xpack.ssl.key` or `xpack.ssl.certificate` settings.
+* Added the new `certutil` command to simplify the creation of certificates for
+use with the Elastic stack. For more information, see <<certutil>>.
+* Added automatic detection of support for AES 256 bit TLS ciphers and enabled
+their use when the JVM supports them.
+
+Sequence IDs::
+* Only fsync global checkpoint if needed {pull}27652[#27652]
+* Log primary-replica resync failures {pull}27421[#27421] (issues: {issue}24841[#24841], {issue}27418[#27418])
+* Lazy initialize checkpoint tracker bit sets {pull}27179[#27179] (issue: {issue}10708[#10708])
+* Returns the current primary_term for Get/MultiGet requests {pull}27177[#27177] (issue: {issue}26493[#26493])
+
+Settings::
+* Allow affix settings to specify dependencies {pull}27161[#27161]
+* Represent lists as actual lists inside Settings {pull}26878[#26878] (issue: {issue}26723[#26723])
+* Remove Settings#getAsMap() {pull}26845[#26845]
+* Replace group map settings with affix setting {pull}26819[#26819]
+* Throw exception if setting isn't recognized {pull}26569[#26569] (issue: {issue}25607[#25607])
+* Settings: Move keystore creation to plugin installation {pull}26329[#26329] (issue: {issue}26309[#26309])
+
+Snapshot/Restore::
+* Remove XContentType auto detection in BlobStoreRepository {pull}27480[#27480]
+* Snapshot: Migrate TransportRequestHandler to TransportMasterNodeAction {pull}27165[#27165] (issue: {issue}27151[#27151])
+* Fix toString of class SnapshotStatus (#26851) {pull}26852[#26852] (issue: {issue}26851[#26851])
+
+Stats::
+* Adds average document size to DocsStats {pull}27117[#27117] (issue: {issue}27004[#27004])
+* Stats to record how often the ClusterState diff mechanism is used successfully {pull}27107[#27107] (issue: {issue}26973[#26973])
+* Expose adaptive replica selection stats in /_nodes/stats API {pull}27090[#27090]
+* Add cgroup memory usage/limit to OS stats on Linux {pull}26166[#26166]
+* Add segment attributes to the `_segments` API. {pull}26157[#26157] (issue: {issue}26130[#26130])
+
+Suggesters::
+* Improve error message for parse failures of completion fields {pull}27297[#27297]
+* Support 'AND' operation for context query in context suggester {pull}24565[#24565] (issue: {issue}24421[#24421])
+
+Watcher::
+* Improved error messages when there are no accounts configured for {watcher}.
+* Added thread pool rejection information to execution state, which makes it
+easier to debug execution failures.
+* Added execution state information to watch status details. It is stored in the
+`status.execution_state` field.
+* Enabled the account monitoring `url` field in the `xpack.notification.jira`
+setting to support customized paths. For more information about configuring Jira
+accounts for use with watches, see
+{stack-ov}/actions-jira.html[Jira Action].
+* Improved handling of exceptions in {watcher} to make it easier to debug 
+problems.
+
+[float]
+=== Bug Fixes
+
+Aggregations::
+* Disable the "low cardinality" optimization of terms aggregations. {pull}27545[#27545] (issue: {issue}27543[#27543])
+* scripted_metric _agg parameter disappears if params are provided {pull}27159[#27159] (issues: {issue}19768[#19768], {issue}19863[#19863])
+
+Cluster::
+* Properly format IndexGraveyard deletion date as date {pull}27362[#27362]
+*  Remove optimisations to reuse objects when applying a new `ClusterState` {pull}27317[#27317]
+
+Core::
+* Do not set data paths on no local storage required {pull}27587[#27587] (issue: {issue}27572[#27572])
+* Ensure threadcontext is preserved when refresh listeners are invoked {pull}27565[#27565]
+* Ensure logging is configured for CLI commands {pull}27523[#27523] (issue: {issue}27521[#27521])
+* Protect shard splitting from illegal target shards {pull}27468[#27468] (issue: {issue}26931[#26931])
+* Avoid NPE when getting build information {pull}27442[#27442]
+* Fix `ShardSplittingQuery` to respect nested documents. {pull}27398[#27398] (issue: {issue}27378[#27378])
+* When building Settings do not set SecureSettings if empty {pull}26988[#26988] (issue: {issue}316[#316])
+
+Engine::
+* Reset LiveVersionMap on sync commit {pull}27534[#27534] (issue: {issue}27516[#27516])
+* Carry over version map size to prevent excessive resizing {pull}27516[#27516] (issue: {issue}20498[#20498])
+
+Geo::
+* Correct two equality checks on incomparable types {pull}27688[#27688]
+* [GEO] fix pointsOnly bug for MULTIPOINT {pull}27415[#27415]
+
+Index Templates::
+* Prevent constructing an index template without index patterns {pull}27662[#27662]
+
+Ingest::
+* Add pipeline support for REST API bulk upsert {pull}27075[#27075] (issue: {issue}25601[#25601])
+* Fixing Grok pattern for Apache 2.4 {pull}26635[#26635]
+
+Inner Hits::
+* Return an empty _source for nested inner hit when filtering on a field that doesn't exist {pull}27531[#27531]
+
+Internal::
+* When checking if key exists in ThreadContextStruct:putHeaders() method，should put requestHeaders in map first {pull}26068[#26068]
+* Adding a refresh listener to a recovering shard should be a noop {pull}26055[#26055]
+
+Java High Level REST Client::
+* Register ip_range aggregation with the high level client {pull}26383[#26383]
+* add top hits as a parsed aggregation to the rest high level client {pull}26370[#26370]
+
+Machine Learning::
+* Improved handling of scenarios where there are insufficient values to
+interpolate trend components.
+* Improved calculation of confidence intervals.
+* Fixed degrees of freedom calculation that could lead to excessive error logging.
+* Improved trend modeling with long bucket spans.
+* Fixed timing of when model size statistics are written. Previously, if there
+were multiple partitions, there could be multiple model size stats docs written
+within the same bucket.
+* Updated the calculation of the model memory to include the memory used by
+partition, over, by, or influencer fields.
+* Fixed calculation of the `frequency` property value for {dfeeds} that use
+aggregations. The value must be a multiple of the histogram interval. For more
+information, see
+{stack-ov}/ml-configuring-aggregation.html[Aggregating Data for Faster Performance].
+* Removed unnecessary messages from logs when a job is forcefully closed.
+
+Mapping::
+* Fix dynamic mapping update generation. {pull}27467[#27467]
+* Fix merging of _meta field {pull}27352[#27352] (issue: {issue}27323[#27323])
+* Fixed rounding of bounds in scaled float comparison {pull}27207[#27207] (issue: {issue}27189[#27189])
+
+Nested Docs::
+* Ensure nested documents have consistent version and seq_ids {pull}27455[#27455]
+* Prevent duplicate fields when mixing parent and root nested includes {pull}27072[#27072] (issue: {issue}26990[#26990])
+
+Network::
+* Throw UOE from compressible bytes stream reset {pull}27564[#27564] (issue: {issue}24927[#24927])
+* Bubble exceptions when closing compressible streams {pull}27542[#27542] (issue: {issue}27540[#27540])
+* Do not set SO_LINGER on server channels {pull}26997[#26997]
+* Do not set SO_LINGER to 0 when not shutting down {pull}26871[#26871] (issue: {issue}26764[#26764])
+* Close TcpTransport on RST in some Spots to Prevent Leaking TIME_WAIT Sockets {pull}26764[#26764] (issue: {issue}26701[#26701])
+
+Packaging::
+* Removes minimum master nodes default number {pull}26803[#26803]
+* setgid on /etc/elasticearch on package install {pull}26412[#26412] (issue: {issue}26410[#26410])
+
+Percolator::
+* Avoid TooManyClauses exception if number of terms / ranges is exactly equal to 1024 {pull}27519[#27519] (issue: {issue}1[#1])
+
+Plugin Analysis ICU::
+* Catch InvalidPathException in IcuCollationTokenFilterFactory {pull}27202[#27202]
+
+Plugin Lang Painless::
+* Painless: Fix variable scoping issue in lambdas {pull}27571[#27571] (issue: {issue}26760[#26760])
+* Painless: Fix errors allowing void to be assigned to def. {pull}27460[#27460] (issue: {issue}27210[#27210])
+
+Plugin Repository GCS::
+* Create new handlers for every new request in GoogleCloudStorageService {pull}27339[#27339] (issue: {issue}27092[#27092])
+
+Recovery::
+* Flush old indices on primary promotion and relocation {pull}27580[#27580] (issue: {issue}27536[#27536])
+
+Reindex API::
+* Reindex: Fix headers in reindex action {pull}26937[#26937] (issue: {issue}22976[#22976])
+
+Scroll::
+* Fix scroll query with a sort that is a prefix of the index sort {pull}27498[#27498]
+
+Search::
+* Fix profiling naming issues {pull}27133[#27133]
+* Fix max score tracking with field collapsing {pull}27122[#27122] (issue: {issue}23840[#23840])
+* Apply missing request options to the expand phase {pull}27118[#27118] (issues: {issue}26649[#26649], {issue}27079[#27079])
+* Calculate and cache result when advanceExact is called {pull}26920[#26920] (issue: {issue}26817[#26817])
+* Filter unsupported relation for RangeQueryBuilder {pull}26620[#26620] (issue: {issue}26575[#26575])
+* Handle leniency for phrase query on a field indexed without positions {pull}26388[#26388]
+
+Security::
+* Fixed REST requests that required a body but did not validate it, resulting in
+null pointer exceptions.
+
+Sequence IDs::
+* Obey translog durability in global checkpoint sync {pull}27641[#27641]
+* Fix resync request serialization {pull}27418[#27418] (issue: {issue}24841[#24841])
+
+Settings::
+* Allow index settings to be reset by wildcards {pull}27671[#27671] (issue: {issue}27537[#27537])
+
+Snapshot/Restore::
+* Do not swallow exception in ChecksumBlobStoreFormat.writeAtomic() {pull}27597[#27597]
+* Delete shard store files before restoring a snapshot {pull}27476[#27476] (issues: {issue}20220[#20220], {issue}26865[#26865])
+* Fix snapshot getting stuck in INIT state {pull}27214[#27214] (issue: {issue}27180[#27180])
+* Fix default value of ignore_unavailable for snapshot REST API (#25359) {pull}27056[#27056] (issue: {issue}25359[#25359])
+* Do not create directory on readonly repository (#21495) {pull}26909[#26909] (issue: {issue}21495[#21495])
+
+Stats::
+* Include internal refreshes in refresh stats {pull}27615[#27615]
+* Make Segment statistics aware of segments hold by internal readers {pull}27558[#27558]
+* Ensure `doc_stats` are changing even if refresh is disabled {pull}27505[#27505]
+
+Watcher::
+* Fixed handling of watcher templates. Missing watcher templates can be added by
+any node if that node has a higher version than the master node.
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Core::
+* Upgrade to Jackson 2.8.10 {pull}27230[#27230]
+* Upgrade to Lucene 7.1 {pull}27225[#27225]
+
+Plugin Discovery EC2::
+* Upgrade AWS SDK Jackson Databind to 2.6.7.1 {pull}27361[#27361] (issues: {issue}27278[#27278], {issue}27359[#27359])
+
+Plugin Discovery GCE::
+* Update Google SDK to version 1.23.0 {pull}27381[#27381] (issue: {issue}26636[#26636])
+
+Plugin Lang Painless::
+* Upgrade Painless from ANTLR 4.5.1-1 to  ANTLR 4.5.3. {pull}27153[#27153]
+
+[[release-notes-6.0.1]]
+== {es} version 6.0.1
+
+[float]
+[[breaking-6.0.1]]
+=== Breaking Changes
+
+Scroll::
+* Fail queries with scroll that explicitely set request_cache {pull}27342[#27342]
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+[float]
+=== Enhancements
+
+Core::
+* Fix classes that can exit {pull}27518[#27518]
+
+Discovery::
+* Stop responding to ping requests before master abdication {pull}27329[#27329] (issue: {issue}27328[#27328])
+
+Plugin Repository S3::
+* Remove S3 output stream {pull}27280[#27280] (issue: {issue}27278[#27278])
+* Update to AWS SDK 1.11.223 {pull}27278[#27278]
+
+Search::
+* fix unnecessary logger creation {pull}27349[#27349]
+
+Sequence IDs::
+* Log primary-replica resync failures {pull}27421[#27421] (issues: {issue}24841[#24841], {issue}27418[#27418])
+
+Snapshot/Restore::
+* Remove XContentType auto detection in BlobStoreRepository {pull}27480[#27480]
+
+[float]
+=== Bug Fixes
+
+Cluster::
+* Properly format IndexGraveyard deletion date as date {pull}27362[#27362]
+
+Core::
+* Do not set data paths on no local storage required {pull}27587[#27587] (issue: {issue}27572[#27572])
+* Ensure threadcontext is preserved when refresh listeners are invoked {pull}27565[#27565]
+* Avoid NPE when getting build information {pull}27442[#27442]
+* When building Settings do not set SecureSettings if empty {pull}26988[#26988] (issue: {issue}316[#316])
+
+Engine::
+* Reset LiveVersionMap on sync commit {pull}27534[#27534] (issue: {issue}27516[#27516])
+* Carry over version map size to prevent excessive resizing {pull}27516[#27516] (issue: {issue}20498[#20498])
+
+Inner Hits::
+* Return an empty _source for nested inner hit when filtering on a field that doesn't exist {pull}27531[#27531]
+
+Machine Learning::
+* Fixed analytics problem where sparse data resulted in "update failed" errors
+in the logs.
+
+Mapping::
+* Fix dynamic mapping update generation. {pull}27467[#27467]
+* Fixed rounding of bounds in scaled float comparison {pull}27207[#27207] (issue: {issue}27189[#27189])
+
+Nested Docs::
+* Ensure nested documents have consistent version and seq_ids {pull}27455[#27455]
+
+Network::
+* Throw UOE from compressible bytes stream reset {pull}27564[#27564] (issue: {issue}24927[#24927])
+* Bubble exceptions when closing compressible streams {pull}27542[#27542] (issue: {issue}27540[#27540])
+
+Plugin Lang Painless::
+* Painless: Fix errors allowing void to be assigned to def. {pull}27460[#27460] (issue: {issue}27210[#27210])
+
+Plugin Repository GCS::
+* Create new handlers for every new request in GoogleCloudStorageService {pull}27339[#27339] (issue: {issue}27092[#27092])
+
+Recovery::
+* Flush old indices on primary promotion and relocation {pull}27580[#27580] (issue: {issue}27536[#27536])
+
+Reindex API::
+* Reindex: Fix headers in reindex action {pull}26937[#26937] (issue: {issue}22976[#22976])
+
+Search::
+* Fix profiling naming issues {pull}27133[#27133]
+
+Security::
+* Fixed error that occurred when attempting to audit `system_access_granted`
+events.
+* Fixed the `setup-passwords` command such that it fails appropriately when
+invalid URLs are specified in the `--url` option and when {security} is not
+enabled.
+
+Sequence IDs::
+* Fix resync request serialization {pull}27418[#27418] (issue: {issue}24841[#24841])
+
+Snapshot/Restore::
+* Do not swallow exception in ChecksumBlobStoreFormat.writeAtomic() {pull}27597[#27597]
+* Delete shard store files before restoring a snapshot {pull}27476[#27476] (issues: {issue}20220[#20220], {issue}26865[#26865])
+* Fix snapshot getting stuck in INIT state {pull}27214[#27214] (issue: {issue}27180[#27180])
+* Fix default value of ignore_unavailable for snapshot REST API (#25359) {pull}27056[#27056] (issue: {issue}25359[#25359])
+* Do not create directory on readonly repository (#21495) {pull}26909[#26909] (issue: {issue}21495[#21495])
+
+Watcher::
+* Fixed handling of Hipchat rooms. For example, room names with spaces did not
+work as expected. For more information, see
+{stack-ov}/actions-hipchat.html[HipChat Action].
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Plugin Discovery EC2::
+* Upgrade AWS SDK Jackson Databind to 2.6.7.1 {pull}27361[#27361] (issues: {issue}27278[#27278], {issue}27359[#27359])
+
+Plugin Discovery GCE::
+* Update Google SDK to version 1.23.0 {pull}27381[#27381] (issue: {issue}26636[#26636])
+
+[[release-notes-6.0.0]]
+== {es} version 6.0.0
+
+[float]
+[[breaking-6.0.0]]
+=== Breaking Changes
+
+Aggregations::
+* Change parsing of numeric `to` and `from` parameters in `date_range` aggregation {pull}25376[#25376] (issue: {issue}17920[#17920])
+
+Aliases::
+* Wrong behavior deleting alias {pull}23997[#23997] (issues: {issue}10106[#10106], {issue}23960[#23960])
+
+Allocation::
+* Remove `cluster.routing.allocation.snapshot.relocation_enabled` setting {pull}20994[#20994]
+
+Analysis::
+* Do not allow custom analyzers to have the same names as built-in analyzers {pull}22349[#22349] (issue: {issue}22263[#22263])
+* Removing query-string parameters in `_analyze` API {pull}20704[#20704] (issue: {issue}20246[#20246])
+
+CAT API::
+* Write -1 on unbounded queue in cat thread pool {pull}21342[#21342] (issue: {issue}21187[#21187])
+
+CRUD::
+* Disallow `VersionType.FORCE` for GetRequest {pull}21079[#21079] (issue: {issue}20995[#20995])
+* Disallow `VersionType.FORCE` versioning for 6.x indices {pull}20995[#20995] (issue: {issue}20377[#20377])
+* If the index does not exist, delete document will not auto create it {pull}24518[#24518] (issue: {issue}15425[#15425])
+
+Cluster::
+* Disallow : in cluster and index/alias names {pull}26247[#26247] (issue: {issue}23892[#23892])
+* No longer allow cluster name in data path {pull}20433[#20433] (issue: {issue}20391[#20391])
+
+Core::
+* Simplify file store {pull}24402[#24402] (issue: {issue}24390[#24390])
+* Make boolean conversion strict {pull}22200[#22200]
+* Remove the `default` store type. {pull}21616[#21616]
+* Remove store throttling. {pull}21573[#21573]
+
+Geo::
+* Remove deprecated geo search features {pull}22876[#22876]
+* Reduce GeoDistance Insanity {pull}19846[#19846]
+
+Highlighting::
+* Remove the postings highlighter and make unified the default highlighter choice {pull}25028[#25028]
+
+Index APIs::
+* Remove (deprecated) support for '+' in index expressions {pull}25274[#25274] (issue: {issue}24515[#24515])
+* Delete index API to work only against concrete indices {pull}25268[#25268] (issues: {issue}2318[#2318], {issue}23997[#23997])
+* Open/Close index api to allow_no_indices by default {pull}24401[#24401] (issues: {issue}24031[#24031], {issue}24341[#24341])
+* Remove support for controversial `ignore_unavailable` and `allow_no_indices` from indices exists api {pull}20712[#20712]
+
+Index Templates::
+* Allows multiple patterns to be specified for index templates {pull}21009[#21009] (issue: {issue}20690[#20690])
+
+Indexed Scripts/Templates::
+* Scripting: Remove search template actions {pull}25717[#25717]
+
+Ingest::
+* update ingest-user-agent regexes.yml {pull}25608[#25608]
+* remove ingest.new_date_format {pull}25583[#25583]
+
+Inner Hits::
+* Return the _source of inner hit nested as is without wrapping it into its full path context {pull}26982[#26982] (issues: {issue}26102[#26102], {issue}26944[#26944])
+
+Java API::
+* Enforce Content-Type requirement on the rest layer and remove deprecated methods {pull}23146[#23146] (issue: {issue}19388[#19388])
+
+Java REST Client::
+* Remove deprecated created and found from index, delete and bulk {pull}25516[#25516] (issues: {issue}19566[#19566], {issue}19630[#19630], {issue}19633[#19633])
+
+Mapping::
+* Reject out of range numbers for float, double and half_float {pull}25826[#25826] (issue: {issue}25534[#25534])
+* Enforce at most one type. {pull}24428[#24428] (issue: {issue}24317[#24317])
+* Disallow `include_in_all` for 6.0+ indices {pull}22970[#22970] (issue: {issue}22923[#22923])
+* Disable _all by default, disallow configuring _all on 6.0+ indices {pull}22144[#22144] (issues: {issue}19784[#19784], {issue}20925[#20925], {issue}21341[#21341])
+* Throw an exception on unrecognized "match_mapping_type" {pull}22090[#22090] (issue: {issue}17285[#17285])
+
+Network::
+* Remove unused Netty-related settings {pull}26161[#26161]
+* Remove blocking TCP clients and servers {pull}22639[#22639]
+* Remove `modules/transport_netty_3` in favor of `netty_4` {pull}21590[#21590]
+* Remove LocalTransport in favor of MockTcpTransport {pull}20695[#20695]
+
+Packaging::
+* Configure heap dump path out of the box {pull}26755[#26755] (issue: {issue}26665[#26665])
+* Remove support for ES_INCLUDE {pull}25804[#25804]
+* Setup: Change default heap to 1G {pull}25695[#25695]
+* Use config directory to find jvm.options {pull}25679[#25679] (issue: {issue}23004[#23004])
+* Remove implicit 32-bit support {pull}25435[#25435]
+* Remove default path settings {pull}25408[#25408] (issue: {issue}25357[#25357])
+* Remove path.conf setting {pull}25392[#25392] (issue: {issue}25357[#25357])
+* Honor masking of systemd-sysctl.service {pull}24234[#24234] (issues: {issue}21899[#21899], {issue}806[#806])
+* Rename CONF_DIR to ES_PATH_CONF {pull}26197[#26197] (issue: {issue}26154[#26154])
+* Remove customization of ES_USER and ES_GROUP {pull}23989[#23989] (issue: {issue}23848[#23848])
+
+Percolator::
+* Remove deprecated percolate and mpercolate apis {pull}22331[#22331]
+
+Plugin Analysis ICU::
+* Upgrade icu4j for the ICU analysis plugin to 59.1 {pull}25243[#25243] (issue: {issue}21425[#21425])
+* Upgrade icu4j to latest version {pull}24821[#24821]
+
+Plugin Delete By Query::
+* Require explicit query in _delete_by_query API {pull}23632[#23632] (issue: {issue}23629[#23629])
+
+Plugin Discovery Azure Classic::
+* Remove `discovery.type` BWC layer from the EC2/Azure/GCE plugins {pull}25080[#25080] (issue: {issue}24543[#24543])
+
+Plugin Discovery EC2::
+* Ec2 Discovery: Cleanup deprecated settings {pull}24150[#24150]
+* Discovery EC2: Remove region setting {pull}23991[#23991] (issue: {issue}22758[#22758])
+* AWS Plugins: Remove signer type setting {pull}23984[#23984] (issue: {issue}22599[#22599])
+
+Plugin Lang JS::
+* Remove lang-python and lang-javascript {pull}20734[#20734] (issue: {issue}20698[#20698])
+
+Plugin Mapper Attachment::
+* Remove mapper attachments plugin {pull}20416[#20416] (issue: {issue}18837[#18837])
+
+Plugin Repository Azure::
+* Remove global `repositories.azure` settings {pull}23262[#23262] (issues: {issue}22800[#22800], {issue}22856[#22856])
+* Remove auto creation of container for azure repository {pull}22858[#22858] (issue: {issue}22857[#22857])
+
+Plugin Repository GCS::
+* GCS Repository: Remove specifying credential file on disk {pull}24727[#24727]
+
+Plugin Repository S3::
+* S3 Repository: Cleanup deprecated settings {pull}24097[#24097]
+* S3 Repository: Remove region setting {pull}22853[#22853] (issue: {issue}22758[#22758])
+* S3 Repository: Remove bucket auto create {pull}22846[#22846] (issue: {issue}22761[#22761])
+* S3 Repository: Remove env var and sysprop credentials support {pull}22842[#22842]
+* Remove deprecated S3 settings {pull}24445[#24445]
+
+Plugins::
+* Make plugin loading stricter {pull}25405[#25405]
+
+Query DSL::
+* Remove deprecated `type` and `slop` field in `match` query {pull}26720[#26720]
+* Remove several parse field deprecations in query builders {pull}26711[#26711]
+* Remove deprecated parameters from `ids_query` {pull}26508[#26508]
+* Refactor QueryStringQuery for 6.0 {pull}25646[#25646] (issue: {issue}25574[#25574])
+* Change `split_on_whitespace` default to false {pull}25570[#25570] (issue: {issue}25470[#25470])
+* Remove deprecated template query {pull}24577[#24577] (issue: {issue}19390[#19390])
+* Throw exception in scroll requests using `from` {pull}26235[#26235] (issue: {issue}9373[#9373])
+* Remove deprecated `minimum_number_should_match` in BoolQueryBuilder {pull}22416[#22416]
+* Remove support for empty queries {pull}22092[#22092] (issue: {issue}17624[#17624])
+* Remove deprecated query names: in, geo_bbox, mlt, fuzzy_match and match_fuzzy {pull}21852[#21852]
+* The `terms` query should always map to a Lucene `TermsQuery`. {pull}21786[#21786]
+* Be strict when parsing values searching for booleans {pull}21555[#21555] (issue: {issue}21545[#21545])
+* Remove collect payloads parameter {pull}20385[#20385]
+
+REST::
+* IndexClosedException to return 400 rather than 403 {pull}25752[#25752]
+* Remove comma-separated feature parsing for GetIndicesAction {pull}24723[#24723] (issue: {issue}24437[#24437])
+* Improve REST error handling when endpoint does not support HTTP verb, add OPTIONS support {pull}24437[#24437] (issues: {issue}0[#0], {issue}15335[#15335], {issue}17916[#17916])
+* Remove ldjson support and document ndjson for bulk/msearch {pull}23049[#23049] (issue: {issue}23025[#23025])
+* Enable strict duplicate checks for all XContent types {pull}22225[#22225] (issues: {issue}19614[#19614], {issue}22073[#22073])
+* Enable strict duplicate checks for JSON content {pull}22073[#22073] (issue: {issue}19614[#19614])
+* Remove lenient stats parsing {pull}21417[#21417] (issues: {issue}20722[#20722], {issue}21410[#21410])
+* Remove allow unquoted JSON {pull}20388[#20388] (issues: {issue}17674[#17674], {issue}17801[#17801])
+* Remove FORCE version_type {pull}20377[#20377] (issue: {issue}19769[#19769])
+
+Scripting::
+* remove lang url parameter from stored script requests {pull}25779[#25779] (issue: {issue}22887[#22887])
+* Disallow lang to be used with Stored Scripts {pull}25610[#25610]
+* Remove Deprecated Script Settings {pull}24756[#24756] (issue: {issue}24532[#24532])
+* Scripting: Remove native scripts {pull}24726[#24726] (issue: {issue}19966[#19966])
+* Scripting: Remove file scripts {pull}24627[#24627] (issue: {issue}21798[#21798])
+* Make dates be ReadableDateTimes in scripts {pull}22948[#22948] (issue: {issue}22875[#22875])
+* Remove groovy scripting language {pull}21607[#21607]
+* Remove script access to term statistics {pull}19462[#19462] (issue: {issue}19359[#19359])
+
+Search::
+* Make `index` in TermsLookup mandatory {pull}25753[#25753] (issue: {issue}25750[#25750])
+* Removes FieldStats API {pull}25628[#25628] (issue: {issue}25577[#25577])
+* Remove deprecated fielddata_fields from search request {pull}25566[#25566] (issue: {issue}25537[#25537])
+* Removes deprecated fielddata_fields {pull}25537[#25537] (issue: {issue}19027[#19027])
+* ProfileResult and CollectorResult should print machine readable timing information {pull}22561[#22561]
+* Remove indices query {pull}21837[#21837] (issue: {issue}17710[#17710])
+* Remove ignored type parameter in search_shards api {pull}21688[#21688]
+
+Security::
+* Added new security limitations:
+** When a user's role enables document level security for an index and
+suggesters are specified, the specified suggesters are ignored. For more
+information about suggesters, see {ref}/search-suggesters.html[Suggesters].
+** When document level security is enabled, search requests cannot be profiled.
+For more information about profiling, see the
+{ref}/search-profile.html[Profile API].
+
+Sequence IDs::
+* Change certain replica failures not to fail the replica shard {pull}22874[#22874] (issue: {issue}10708[#10708])
+
+Settings::
+* Settings: Remove shared setting property {pull}24728[#24728]
+* Settings: Remove support for yaml and json config files {pull}24664[#24664] (issue: {issue}19391[#19391])
+
+Shadow Replicas::
+* Remove shadow replicas {pull}23906[#23906] (issue: {issue}22024[#22024])
+
+Similarities::
+* Similarity should accept dynamic settings when possible {pull}20339[#20339] (issue: {issue}6727[#6727])
+
+[float]
+=== Breaking Java Changes
+
+Aggregations::
+* Remove the unused SignificantTerms.compareTerm() method {pull}24714[#24714]
+* Make SignificantTerms.Bucket an interface rather than an abstract class {pull}24670[#24670] (issue: {issue}24492[#24492])
+* Fix NPE when `values` is omitted on percentile_ranks agg {pull}26046[#26046]
+* Make Terms.Bucket an interface rather than an abstract class {pull}24492[#24492]
+* Compound order for histogram aggregations  {pull}22343[#22343] (issues: {issue}14771[#14771], {issue}20003[#20003], {issue}23613[#23613])
+
+Internal::
+* Collapses package structure for some bucket aggs {pull}25579[#25579] (issue: {issue}22868[#22868])
+
+Java API::
+* Remove deprecated IdsQueryBuilder ctor {pull}25529[#25529]
+* Removing unneeded getTookInMillis method {pull}23923[#23923]
+* Java api: ActionRequestBuilder#execute to return a PlainActionFuture {pull}24415[#24415] (issues: {issue}24412[#24412], {issue}9201[#9201])
+
+Java High Level REST Client::
+* Unify the result interfaces from get and search in Java client {pull}25361[#25361] (issue: {issue}16440[#16440])
+* Allow RestHighLevelClient to use plugins {pull}25024[#25024]
+
+Java REST Client::
+* Rename client artifacts {pull}25693[#25693] (issue: {issue}20248[#20248])
+
+Network::
+* Simplify TransportAddress {pull}20798[#20798]
+
+Plugin Delete By Query::
+* Move DeleteByQuery and Reindex requests into core {pull}24578[#24578]
+
+Plugins::
+* Drop name from TokenizerFactory {pull}24869[#24869]
+
+Query DSL::
+* Remove QueryParseContext {pull}25486[#25486]
+* Remove QueryParseContext from parsing QueryBuilders {pull}25448[#25448]
+
+REST::
+* Return index name and empty map for `/{index}/_alias` with no aliases {pull}25114[#25114] (issues: {issue}24723[#24723], {issue}25090[#25090])
+
+[float]
+=== Deprecations
+
+Index APIs::
+* Deprecated use of + in index expressions {pull}24585[#24585] (issue: {issue}24515[#24515])
+
+Index Templates::
+* Restore deprecation warning for invalid match_mapping_type values {pull}22304[#22304]
+
+Indexed Scripts/Templates::
+* Scripting: Deprecate stored search template apis {pull}25437[#25437] (issue: {issue}24596[#24596])
+
+Internal::
+* Deprecate XContentType auto detection methods in XContentFactory {pull}22181[#22181] (issue: {issue}19388[#19388])
+
+Percolator::
+* Deprecate percolate query's document_type parameter. {pull}25199[#25199]
+
+Plugins::
+* Plugins: Add backcompat for sha1 checksums {pull}26748[#26748] (issue: {issue}26746[#26746])
+
+Scripting::
+* Scripting: Change keys for inline/stored scripts to source/id {pull}25127[#25127]
+* Scripting: Deprecate native scripts {pull}24692[#24692] (issue: {issue}19966[#19966])
+* Scripting: Deprecate index lookup {pull}24691[#24691] (issue: {issue}19359[#19359])
+* Deprecate Fine Grain Settings for Scripts {pull}24573[#24573] (issue: {issue}24532[#24532])
+* Scripting: Deprecate file script settings {pull}24555[#24555] (issue: {issue}21798[#21798])
+* Scripting: Deprecate file scripts {pull}24552[#24552] (issue: {issue}21798[#21798])
+
+Settings::
+* Settings: Update settings deprecation from yml to yaml {pull}24663[#24663] (issue: {issue}19391[#19391])
+* Deprecate settings in .yml and .json {pull}24059[#24059] (issue: {issue}19391[#19391])
+
+Tribe Node::
+* Deprecate tribe service {pull}24598[#24598] (issue: {issue}24581[#24581])
+
+[float]
+=== New Features
+
+Aggregations::
+* SignificantText aggregation - like significant_terms, but for text {pull}24432[#24432] (issue: {issue}23674[#23674])
+
+Analysis::
+* Expose simplepattern and simplepatternsplit tokenizers {pull}25159[#25159] (issue: {issue}23363[#23363])
+* Parse synonyms with the same analysis chain {pull}8049[#8049] (issue: {issue}7199[#7199])
+
+Core::
+* Enable index-time sorting {pull}24055[#24055] (issue: {issue}6720[#6720])
+
+Internal::
+* Automatically adjust search threadpool queue_size {pull}23884[#23884] (issue: {issue}3890[#3890])
+
+Mapping::
+* Add new ip_range field type {pull}24433[#24433]
+
+Parent/Child::
+* Move parent_id query to the parent-join module {pull}25072[#25072] (issue: {issue}20257[#20257])
+* Introduce ParentJoinFieldMapper, a field mapper that creates parent/child relation within documents of the same index {pull}24978[#24978] (issue: {issue}20257[#20257])
+
+Plugin Analysis ICU::
+* Add ICUCollationFieldMapper {pull}24126[#24126]
+
+Search::
+* Automatically early terminate search query based on index sorting {pull}24864[#24864] (issue: {issue}6720[#6720])
+
+Sequence IDs::
+* Add a scheduled translog retention check {pull}25622[#25622] (issues: {issue}10708[#10708], {issue}25294[#25294])
+* Initialize sequence numbers on a shrunken index {pull}25321[#25321] (issue: {issue}10708[#10708])
+* Initialize primary term for shrunk indices {pull}25307[#25307] (issue: {issue}10708[#10708])
+* Introduce translog size and age based retention policies {pull}25147[#25147] (issue: {issue}10708[#10708])
+
+Stats::
+* Adds nodes usage API to monitor usages of actions {pull}24169[#24169]
+
+Task Manager::
+* Task Management [ISSUE] {pull}15117[#15117]
+
+Upgrade API::
+* TemplateUpgraders should be called during rolling restart {pull}25263[#25263] (issues: {issue}24379[#24379], {issue}24680[#24680])
+
+[float]
+=== Enhancements
+
+Aggregations::
+* Add strict parsing of aggregation ranges {pull}25769[#25769]
+* Adds rewrite phase to aggregations {pull}25495[#25495] (issue: {issue}17676[#17676])
+* Tweak AggregatorBase.addRequestCircuitBreakerBytes {pull}25162[#25162] (issue: {issue}24511[#24511])
+* Add superset size to Significant Term REST response {pull}24865[#24865]
+* Add document count to Matrix Stats aggregation response {pull}24776[#24776]
+* Adds an implementation of LogLogBeta for the cardinality aggregation {pull}22323[#22323] (issue: {issue}22230[#22230])
+* Support distance units in GeoHashGrid aggregation precision {pull}26291[#26291] (issue: {issue}5042[#5042])
+* Reject multiple methods in `percentiles` aggregation {pull}26163[#26163] (issue: {issue}26095[#26095])
+* Use `global_ordinals_hash` execution mode when sorting by sub aggregations. {pull}26014[#26014] (issue: {issue}24359[#24359])
+* Add a specialized deferring collector for terms aggregator {pull}25190[#25190]
+* Agg builder accessibility fixes {pull}24323[#24323]
+* Remove support for the include/pattern syntax. {pull}23141[#23141] (issue: {issue}22933[#22933])
+* Promote longs to doubles when a terms agg mixes decimal and non-decimal numbers {pull}22449[#22449] (issue: {issue}22232[#22232])
+
+Allocation::
+* Adjust status on bad allocation explain requests {pull}25503[#25503] (issue: {issue}25458[#25458])
+* Promote replica on the highest version node {pull}25277[#25277] (issue: {issue}10708[#10708])
+
+Analysis::
+* [Analysis] Support normalizer in request param {pull}24767[#24767] (issue: {issue}23347[#23347])
+* Enforce validation for PathHierarchy tokenizer {pull}23510[#23510]
+* [analysis-icu] Allow setting unicodeSetFilter {pull}20814[#20814] (issue: {issue}20820[#20820])
+* Match- and MultiMatchQueryBuilder should only allow setting analyzer on string values {pull}23684[#23684] (issue: {issue}21665[#21665])
+
+Bulk::
+* Simplify bulk request execution  {pull}20109[#20109]
+
+CAT API::
+* expand `/_cat/nodes` to return information about hard drive {pull}21775[#21775] (issue: {issue}21679[#21679])
+
+CRUD::
+* Added validation for upsert request {pull}24282[#24282] (issue: {issue}16671[#16671])
+
+Circuit Breakers::
+* ScriptService: Replace max compilation per minute setting with max compilation rate {pull}26399[#26399]
+
+Cluster::
+* Validate a joining node's version with version of existing cluster nodes {pull}25808[#25808]
+* Switch indices read-only if a node runs out of disk space {pull}25541[#25541] (issue: {issue}24299[#24299])
+* Add a cluster block that allows to delete indices that are read-only {pull}24678[#24678]
+* Separate publishing from applying cluster states {pull}24236[#24236]
+* Adds cluster state size to /_cluster/state response {pull}23440[#23440] (issue: {issue}3415[#3415])
+
+Core::
+* Allow `InputStreamStreamInput` array size validation where applicable {pull}26692[#26692]
+* Refactor bootstrap check results and error messages {pull}26637[#26637]
+* Add BootstrapContext to expose settings and recovered state to bootstrap checks {pull}26628[#26628]
+* Unit testable index creation task on MetaDataCreateIndexService {pull}25961[#25961]
+* Ignore .DS_Store files on macOS {pull}27108[#27108] (issue: {issue}23982[#23982])
+* Add max file size bootstrap check {pull}25974[#25974]
+* Add compatibility versions to main action response {pull}25799[#25799]
+* Index ids in binary form. {pull}25352[#25352] (issues: {issue}18154[#18154], {issue}24615[#24615])
+* Explicitly reject duplicate data paths {pull}25178[#25178]
+* Use SPI in High Level Rest Client to load XContent parsers {pull}25097[#25097]
+* Upgrade to lucene-7.0.0-snapshot-a0aef2f {pull}24775[#24775]
+* Speed up PK lookups at index time. {pull}19856[#19856]
+* Use Java 9 FilePermission model {pull}26302[#26302] (issue: {issue}21534[#21534])
+* Add friendlier message on bad keystore permissions {pull}26284[#26284]
+* Epoch millis and second formats accept float implicitly {pull}26119[#26119] (issue: {issue}14641[#14641])
+* Remove connect SocketPermissions from core {pull}22797[#22797]
+* Add repository-url module and move URLRepository {pull}22752[#22752] (issue: {issue}22116[#22116])
+* Remove accept SocketPermissions from core {pull}22622[#22622] (issue: {issue}22116[#22116])
+* Move IfConfig.logIfNecessary call into bootstrap {pull}22455[#22455] (issue: {issue}22116[#22116])
+* Remove artificial default processors limit {pull}20874[#20874] (issue: {issue}20828[#20828])
+* Simplify write failure handling {pull}19105[#19105] (issue: {issue}20109[#20109])
+* Improve bootstrap checks error messages {pull}24548[#24548]
+
+Discovery::
+* Allow plugins to validate cluster-state on join {pull}26595[#26595]
+
+Engine::
+* Add refresh stats tracking for realtime get {pull}25052[#25052] (issue: {issue}24806[#24806])
+* Introducing a translog deletion policy {pull}24950[#24950]
+* Fill missing sequence IDs up to max sequence ID when recovering from store {pull}24238[#24238] (issue: {issue}10708[#10708])
+* Use sequence numbers to identify out of order delivery in replicas & recovery {pull}24060[#24060] (issue: {issue}10708[#10708])
+* Add replica ops with version conflict to translog {pull}22626[#22626]
+* Clarify global checkpoint recovery {pull}21934[#21934] (issue: {issue}21254[#21254])
+* Move the IndexDeletionPolicy to be engine internal {pull}24930[#24930] (issue: {issue}10708[#10708])
+
+Exceptions::
+* IllegalStateException: Only duplicated jar instead of classpath {pull}24953[#24953]
+
+Highlighting::
+* Picks offset source for the unified highlighter directly from the es mapping {pull}25747[#25747] (issue: {issue}25699[#25699])
+
+Index APIs::
+* Let primary own its replication group {pull}25692[#25692] (issue: {issue}25485[#25485])
+* Create index request should return the index name {pull}25139[#25139] (issue: {issue}23044[#23044])
+
+Index Templates::
+* Fix error message for a put index template request without index_patterns {pull}27102[#27102] (issue: {issue}27100[#27100])
+
+Ingest::
+* Add Ingest-Processor specific Rest Endpoints & Add Grok endpoint {pull}25059[#25059] (issue: {issue}24725[#24725])
+* Port support for commercial GeoIP2 databases from Logstash. {pull}24889[#24889]
+* add `exclude_keys` option to KeyValueProcessor {pull}24876[#24876] (issue: {issue}23856[#23856])
+* Allow removing multiple fields in ingest processor {pull}24750[#24750] (issue: {issue}24622[#24622])
+* Add target_field parameter to ingest processors {pull}24133[#24133] (issues: {issue}23228[#23228], {issue}23682[#23682])
+
+Inner Hits::
+* Reuse inner hit query weight {pull}24571[#24571] (issue: {issue}23917[#23917])
+
+Internal::
+* TemplateUpgradeService should only run on the master {pull}27294[#27294]
+* Cleanup IndexFieldData visibility {pull}25900[#25900]
+* Bump the min compat version to 5.6.0 {pull}25805[#25805]
+* "shard started" should show index and shard ID {pull}25157[#25157]
+* Break out clear scroll logic from TransportClearScrollAction {pull}25125[#25125] (issue: {issue}25094[#25094])
+* Add helper methods to TransportActionProxy to identify proxy actions and requests {pull}25124[#25124]
+* Add remote cluster infrastructure to fetch discovery nodes. {pull}25123[#25123] (issue: {issue}25094[#25094])
+* Add the ability to set eager_global_ordinals in the new parent-join field {pull}25019[#25019]
+* Disallow multiple parent-join fields per mapping {pull}25002[#25002]
+* Remove the need for _UNRELEASED suffix in versions {pull}24798[#24798] (issue: {issue}24768[#24768])
+* Optimize the order of bytes in uuids for better compression. {pull}24615[#24615] (issue: {issue}18209[#18209])
+* Prevent cluster internal `ClusterState.Custom` impls to leak to a client {pull}26232[#26232]
+* Use holder pattern for lazy deprecation loggers {pull}26218[#26218] (issue: {issue}26210[#26210])
+* Allow `ClusterState.Custom` to be created on initial cluster states {pull}26144[#26144]
+* Try to convince the JVM not to lose stacktraces {pull}24426[#24426] (issue: {issue}24376[#24376])
+* Make document write requests immutable {pull}23038[#23038]
+* Add assertions enabled helper {pull}24834[#24834]
+
+Java API::
+* Always Accumulate Transport Exceptions {pull}25017[#25017] (issue: {issue}23099[#23099])
+
+Java High Level REST Client::
+* [DOCS] restructure java clients docs pages {pull}25517[#25517]
+* Use SPI in High Level Rest Client to load XContent parsers {pull}25098[#25098] (issues: {issue}25024[#25024], {issue}25097[#25097])
+* Add support for clear scroll to high level REST client {pull}25038[#25038]
+* Add search scroll method to high level REST client {pull}24938[#24938] (issue: {issue}23331[#23331])
+* Add search method to high level REST client {pull}24796[#24796] (issues: {issue}24794[#24794], {issue}24795[#24795])
+* Make RestHighLevelClient Closeable and simplify its creation {pull}26180[#26180] (issue: {issue}26086[#26086])
+* Add info method to High Level Rest client {pull}23350[#23350]
+* Add support for named xcontent parsers to high level REST client {pull}23328[#23328]
+* Add BulkRequest support to High Level Rest client {pull}23312[#23312]
+* Add UpdateRequest support to High Level Rest client {pull}23266[#23266]
+* Add delete API to the High Level Rest Client {pull}23187[#23187]
+* Add Index API to High Level Rest Client {pull}23040[#23040]
+* Add get/exists method to RestHighLevelClient {pull}22706[#22706]
+* Add fromxcontent methods to delete response {pull}22680[#22680] (issue: {issue}22229[#22229])
+* Add REST high level client gradle submodule and first simple method {pull}22371[#22371]
+* Add doc_count to ParsedMatrixStats {pull}24952[#24952] (issue: {issue}24776[#24776])
+* Add fromXContent method to ClearScrollResponse {pull}24909[#24909]
+* ClearScrollRequest to implement ToXContentObject {pull}24907[#24907]
+* SearchScrollRequest to implement ToXContentObject {pull}24906[#24906] (issue: {issue}3889[#3889])
+* Add aggs parsers for high level REST Client {pull}24824[#24824] (issues: {issue}23965[#23965], {issue}23973[#23973], {issue}23974[#23974], {issue}24085[#24085], {issue}24160[#24160], {issue}24162[#24162], {issue}24182[#24182], {issue}24183[#24183], {issue}24208[#24208], {issue}24213[#24213], {issue}24239[#24239], {issue}24284[#24284], {issue}24312[#24312], {issue}24330[#24330], {issue}24365[#24365], {issue}24371[#24371], {issue}24442[#24442], {issue}24521[#24521], {issue}24524[#24524], {issue}24564[#24564], {issue}24583[#24583], {issue}24589[#24589], {issue}24648[#24648], {issue}24667[#24667], {issue}24675[#24675], {issue}24682[#24682], {issue}24700[#24700], {issue}24706[#24706], {issue}24717[#24717], {issue}24720[#24720], {issue}24738[#24738], {issue}24746[#24746], {issue}24789[#24789], {issue}24791[#24791], {issue}24794[#24794], {issue}24796[#24796], {issue}24822[#24822])
+
+Java REST Client::
+* Shade external dependencies in the rest client jar {pull}25780[#25780] (issue: {issue}25208[#25208])
+* RestClient uses system properties and system default SSLContext {pull}25757[#25757] (issue: {issue}23231[#23231])
+* Wrap rest httpclient with doPrivileged blocks {pull}22603[#22603] (issue: {issue}22116[#22116])
+
+Logging::
+* Prevent excessive disk consumption by log files {pull}25660[#25660]
+* Use LRU set to reduce repeat deprecation messages {pull}25474[#25474] (issue: {issue}25457[#25457])
+
+Mapping::
+* More efficient encoding of range fields. {pull}26470[#26470] (issue: {issue}26443[#26443])
+* Don't detect source's XContentType in DocumentParser.parseDocument() {pull}26880[#26880]
+* Better validation of `copy_to`. {pull}25983[#25983]
+* Optimize `terms` queries on `ip` addresses to use a `PointInSetQuery` whenever possible. {pull}25669[#25669] (issue: {issue}25667[#25667])
+* Loosen the restrictions on disabling _all in 6.x {pull}26259[#26259]
+* Date detection should not rely on a hardcoded set of characters. {pull}22171[#22171] (issue: {issue}1694[#1694])
+* Identify documents by their `_id`. {pull}24460[#24460]
+
+Network::
+* Add additional low-level logging handler {pull}26887[#26887]
+* Unwrap causes when maybe dying {pull}26884[#26884]
+* Move TransportStats accounting into TcpTransport {pull}25251[#25251]
+* Simplify connection closing and cleanups in TcpTransport {pull}25250[#25250]
+* Disable the Netty recycler in the client {pull}24793[#24793] (issues: {issue}22452[#22452], {issue}24721[#24721])
+* Remove Netty logging hack {pull}24653[#24653] (issues: {issue}24469[#24469], {issue}5624[#5624], {issue}6568[#6568], {issue}6696[#6696])
+* Isolate SocketPermissions to Netty {pull}23057[#23057]
+* Wrap netty accept/connect ops with doPrivileged {pull}22572[#22572] (issue: {issue}22116[#22116])
+* Replace Socket, ServerSocket, and HttpServer usages in tests with mocksocket versions {pull}22287[#22287] (issue: {issue}22116[#22116])
+
+Packaging::
+* Remove memlock suggestion from systemd service {pull}25979[#25979]
+* Set address space limit in systemd service file {pull}25975[#25975]
+* Version option should display if snapshot {pull}25970[#25970]
+* Ignore JVM options before checking Java version {pull}25969[#25969]
+* Also skip JAVA_TOOL_OPTIONS on Windows {pull}25968[#25968]
+* Introduce elasticsearch-env for Windows {pull}25958[#25958]
+* Introduce elasticsearch-env {pull}25815[#25815] (issue: {issue}20286[#20286])
+* Stop exporting HOSTNAME from scripts {pull}25807[#25807]
+* Set number of processes in systemd unit file {pull}24970[#24970] (issue: {issue}20874[#20874])
+
+Parent/Child::
+* Remove ParentJoinFieldSubFetchPhase {pull}25550[#25550] (issue: {issue}25363[#25363])
+* Support parent id being specified as number in the _source {pull}25547[#25547]
+
+Percolator::
+* Store the QueryBuilder's Writable representation instead of its XContent representation {pull}25456[#25456]
+* Add support for selecting percolator query candidate matches containing wildcard / prefix queries {pull}25351[#25351]
+
+Plugin Discovery EC2::
+* Read ec2 discovery address from aws instance tags {pull}22743[#22743] (issue: {issue}22566[#22566])
+
+Plugin Lang Painless::
+* Allow Custom Whitelists in Painless {pull}25557[#25557]
+* Update Painless to Allow Augmentation from Any Class {pull}25360[#25360]
+* Add Needs Methods to Painless Script Context Factories {pull}25267[#25267]
+* Support Script Context Stateful Factory in Painless {pull}25233[#25233]
+* Generate Painless Factory for Creating Script Instances {pull}25120[#25120]
+* Update Painless to Use New Script Contexts {pull}25015[#25015]
+* Optimize instance creation in LambdaBootstrap {pull}24618[#24618]
+* Make Painless Compiler Use an Instance Per Context {pull}24972[#24972]
+* Make PainlessScript An Interface {pull}24966[#24966]
+
+Plugin Repository GCS::
+* GCS Repository: Add secure storage of credentials {pull}24697[#24697]
+
+Plugin Repository HDFS::
+* Add permission checks before reading from HDFS stream {pull}26716[#26716] (issue: {issue}26714[#26714])
+* Add doPrivilege blocks for socket connect ops in repository-hdfs {pull}22793[#22793] (issue: {issue}22116[#22116])
+* Add Kerberos support for Repo HDFS plugin [ISSUE] {pull}21990[#21990]
+
+Plugin Repository S3::
+* S3 Repository: Add back repository level credentials {pull}24609[#24609]
+
+Plugins::
+* Adjust SHA-512 supported format on plugin install {pull}27093[#27093]
+* Move tribe to a module {pull}25778[#25778]
+* Plugins can register pre-configured char filters {pull}25000[#25000] (issue: {issue}23658[#23658])
+* Add purge option to remove plugin CLI {pull}24981[#24981]
+* Allow plugins to register pre-configured tokenizers {pull}24751[#24751] (issues: {issue}24223[#24223], {issue}24572[#24572])
+* Move ReindexAction class to core {pull}24684[#24684] (issue: {issue}24578[#24578])
+* Make PreConfiguredTokenFilter harder to misuse {pull}24572[#24572] (issue: {issue}23658[#23658])
+* Plugins: Remove leniency for missing plugins dir {pull}24173[#24173]
+* Add doPrivilege blocks for socket connect operations in plugins {pull}22534[#22534] (issue: {issue}22116[#22116])
+
+Query DSL::
+* Make slop optional when parsing `span_near` query {pull}25677[#25677] (issue: {issue}25642[#25642])
+* Require a field when a `seed` is provided to the `random_score` function. {pull}25594[#25594] (issue: {issue}25240[#25240])
+* Add support for auto_generate_synonyms_phrase_query in match_query, multi_match_query, query_string and simple_query_string {pull}23147[#23147]
+
+REST::
+* Cat shards bytes {pull}26952[#26952]
+* Refactor PathTrie and RestController to use a single trie for all methods {pull}25459[#25459] (issue: {issue}24437[#24437])
+* Make ObjectParser support string to boolean conversion {pull}24668[#24668] (issue: {issue}21802[#21802])
+
+Recovery::
+* Introduce a History UUID as a requirement for ops based recovery  {pull}26577[#26577] (issue: {issue}10708[#10708])
+* Goodbye, Translog Views {pull}25962[#25962]
+* Disallow multiple concurrent recovery attempts for same target shard {pull}25428[#25428]
+* Live primary-replica resync (no rollback) {pull}24841[#24841] (issue: {issue}10708[#10708])
+* Peer Recovery: remove maxUnsafeAutoIdTimestamp hand off {pull}24243[#24243] (issue: {issue}24149[#24149])
+* Introduce sequence-number-based recovery {pull}22484[#22484] (issue: {issue}10708[#10708])
+
+Scripting::
+* Scripting: Rename SearchScript.needsScores to needs_score {pull}25235[#25235]
+* Scripting: Add optional context parameter to put stored script requests {pull}25014[#25014]
+* Add New Security Script Settings {pull}24637[#24637] (issue: {issue}24532[#24532])
+* Add StatefulFactoryType as optional intermediate factory in script contexts {pull}24974[#24974] (issue: {issue}20426[#20426])
+* Make contexts available to ScriptEngine construction {pull}24896[#24896]
+* Make ScriptEngine.compile generic on the script context {pull}24873[#24873]
+* Add instance and compiled classes to script contexts {pull}24868[#24868]
+
+Search::
+* Add soft limit on allowed number of script fields in request {pull}26598[#26598] (issue: {issue}26390[#26390])
+* Add a soft limit for the number of requested doc-value fields {pull}26574[#26574] (issue: {issue}26390[#26390])
+* Rewrite search requests on the coordinating nodes {pull}25814[#25814] (issue: {issue}25791[#25791])
+* Ensure query resources are fetched asynchronously during rewrite {pull}25791[#25791]
+* Introduce a new Rewriteable interface to streamline rewriting {pull}25788[#25788]
+* Reduce the scope of `QueryRewriteContext` {pull}25787[#25787]
+* Reduce the overhead of timeouts and low-level search cancellation. {pull}25776[#25776]
+* Reduce profiling overhead. {pull}25772[#25772] (issue: {issue}24799[#24799])
+* Prevent `can_match` requests from sending to incompatible nodes {pull}25705[#25705] (issue: {issue}25704[#25704])
+* Add a shard filter search phase to pre-filter shards based on query rewriting {pull}25658[#25658]
+* Ensure we rewrite common queries to `match_none` if possible {pull}25650[#25650]
+* Limit the number of concurrent shard requests per search request {pull}25632[#25632]
+* Add cluster name validation to RemoteClusterConnection {pull}25568[#25568]
+* Speed up sorted scroll when the index sort matches the search sort {pull}25138[#25138] (issue: {issue}6720[#6720])
+* Leverage scorerSupplier when applicable. {pull}25109[#25109]
+* Add Cross Cluster Search support for scroll searches {pull}25094[#25094]
+* Track EWMA[1] of task execution time in search threadpool executor {pull}24989[#24989] (issue: {issue}24915[#24915])
+* Query range fields by doc values when they are expected to be more efficient than points {pull}24823[#24823] (issue: {issue}24314[#24314])
+* Search: Fairer balancing when routing searches by session ID {pull}24671[#24671] (issue: {issue}24642[#24642])
+*  Add parsing from xContent to Suggest {pull}22903[#22903]
+* Add parsing from xContent to ShardSearchFailure {pull}22699[#22699]
+* Eliminate array access in tight loops when profiling is enabled. {pull}24959[#24959]
+* Support Multiple Inner Hits on a Field Collapse Request {pull}24517[#24517]
+* Expand cross cluster search indices for search requests to the concrete index or to it's aliases {pull}24502[#24502]
+
+Search Templates::
+* Add max concurrent searches to multi template search {pull}24255[#24255] (issues: {issue}20912[#20912], {issue}21907[#21907])
+
+Sequence IDs::
+* Roll translog generation on primary promotion {pull}27313[#27313]
+* Restoring from snapshot should force generation of a new history uuid {pull}26694[#26694] (issues: {issue}10708[#10708], {issue}26544[#26544], {issue}26557[#26557], {issue}26577[#26577])
+* Add global checkpoint tracking on the primary {pull}26666[#26666] (issue: {issue}26591[#26591])
+* Introduce global checkpoint background sync {pull}26591[#26591] (issues: {issue}26573[#26573], {issue}26630[#26630], {issue}26666[#26666])
+* Move `UNASSIGNED_SEQ_NO` and `NO_OPS_PERFORMED` to SequenceNumbers` {pull}26494[#26494] (issue: {issue}10708[#10708])
+* Move primary term from ReplicationRequest to ConcreteShardRequest {pull}25822[#25822]
+* Add reason to global checkpoint updates on replica {pull}25612[#25612] (issue: {issue}10708[#10708])
+* Introduce primary/replica mode for GlobalCheckPointTracker {pull}25468[#25468]
+* Throw back replica local checkpoint on new primary {pull}25452[#25452] (issues: {issue}10708[#10708], {issue}25355[#25355])
+* Update global checkpoint when increasing primary term on replica {pull}25422[#25422] (issues: {issue}10708[#10708], {issue}25355[#25355])
+* Enable a long translog retention policy by default {pull}25294[#25294] (issues: {issue}10708[#10708], {issue}25147[#25147])
+* Introduce primary context {pull}25122[#25122] (issues: {issue}10708[#10708], {issue}25355[#25355])
+* Block older operations on primary term transition {pull}24779[#24779] (issue: {issue}10708[#10708])
+* Block global checkpoint advances when recovering {pull}24404[#24404] (issue: {issue}10708[#10708])
+* Add primary term to doc write response {pull}24171[#24171] (issue: {issue}10708[#10708])
+* Preserve multiple translog generations {pull}24015[#24015] (issue: {issue}10708[#10708])
+* Introduce translog generation rolling {pull}23606[#23606] (issue: {issue}10708[#10708])
+* Replicate write failures {pull}23314[#23314]
+* Introduce sequence-number-aware translog {pull}22822[#22822] (issue: {issue}10708[#10708])
+* Introduce translog no-op {pull}22291[#22291] (issue: {issue}10708[#10708])
+* Tighten sequence numbers recovery {pull}22212[#22212] (issue: {issue}10708[#10708])
+* Add BWC layer to seq no infra and enable BWC tests {pull}22185[#22185] (issue: {issue}21670[#21670])
+* Add internal _primary_term doc values field, fix _seq_no indexing {pull}21637[#21637] (issues: {issue}10708[#10708], {issue}21480[#21480])
+* Add global checkpoint to translog checkpoints {pull}21254[#21254]
+* Sequence numbers commit data for Lucene uses Iterable interface {pull}20793[#20793] (issue: {issue}10708[#10708])
+* Simplify GlobalCheckpointService and properly hook it for cluster state updates {pull}20720[#20720]
+* Fill gaps on primary promotion {pull}24945[#24945] (issue: {issue}10708[#10708])
+* Introduce clean transition on primary promotion {pull}24925[#24925] (issue: {issue}10708[#10708])
+* Guarantee that translog generations are seqNo conflict free {pull}24825[#24825] (issues: {issue}10708[#10708], {issue}24779[#24779])
+* Inline global checkpoints {pull}24513[#24513] (issue: {issue}10708[#10708])
+
+Settings::
+* Add disk threshold settings validation {pull}25600[#25600] (issue: {issue}25560[#25560])
+* Enable cross-setting validation {pull}25560[#25560] (issue: {issue}25541[#25541])
+* Validate `transport.profiles.*` settings {pull}25508[#25508]
+* Cleanup network / transport related settings {pull}25489[#25489]
+* Emit settings deprecation logging at most once {pull}25457[#25457]
+* IndexMetaData: Introduce internal format index setting {pull}25292[#25292]
+* Persist created keystore on startup unless keystore is present {pull}26253[#26253] (issue: {issue}26126[#26126])
+* Settings: Add keystore.seed auto generated secure setting {pull}26149[#26149]
+* Settings: Add keystore creation to add commands {pull}26126[#26126]
+
+Snapshot/Restore::
+* Fixed references to Multi Index Syntax {pull}27283[#27283]
+* Improves snapshot logging and snapshot deletion error handling {pull}25264[#25264]
+* Enhances get snapshots API to allow retrieving repository index only {pull}24477[#24477] (issue: {issue}24288[#24288])
+
+Stats::
+* Update `IndexShard#refreshMetric` via a `ReferenceManager.RefreshListener` {pull}25083[#25083] (issues: {issue}24806[#24806], {issue}25052[#25052])
+* Expose disk usage estimates in nodes stats {pull}22081[#22081] (issue: {issue}8686[#8686])
+
+Store::
+* Remote support for lucene versions without checksums {pull}24021[#24021]
+
+Suggesters::
+* Remove deprecated _suggest endpoint {pull}22203[#22203] (issue: {issue}20305[#20305])
+
+Task Manager::
+* Add descriptions to bulk tasks {pull}22059[#22059] (issue: {issue}21768[#21768])
+
+Translog::
+* Translog file recovery should not rely on lucene commits {pull}25005[#25005] (issue: {issue}24950[#24950])
+
+[float]
+=== Bug Fixes
+
+Aggregations::
+* Do not delegate a null scorer to LeafBucketCollectors {pull}26747[#26747] (issue: {issue}26611[#26611])
+* Create weights lazily in filter and filters aggregation {pull}26983[#26983]
+* Fix IndexOutOfBoundsException in histograms for NaN doubles (#26787) {pull}26856[#26856] (issue: {issue}26787[#26787])
+* Scripted_metric _agg parameter disappears if params are provided {pull}19863[#19863] (issue: {issue}19768[#19768])
+* Fixes array out of bounds for value count agg {pull}26038[#26038] (issue: {issue}17379[#17379])
+* Aggregations bug: Significant_text fails on arrays of text. {pull}25030[#25030] (issue: {issue}25029[#25029])
+* Check bucket metric ages point to a multi bucket agg {pull}26215[#26215] (issue: {issue}25775[#25775])
+* Terms aggregation should remap global ordinal buckets when a sub-aggregator is used to sort the terms {pull}24941[#24941] (issue: {issue}24788[#24788])
+* Correctly set doc_count when MovAvg "predicts" values on existing buckets {pull}24892[#24892] (issue: {issue}24327[#24327])
+* DateHistogram: Fix `extended_bounds` with `offset` {pull}23789[#23789] (issue: {issue}23776[#23776])
+* Fix ArrayIndexOutOfBoundsException when no ranges are specified in the query {pull}23241[#23241] (issue: {issue}22881[#22881])
+
+Aliases::
+* mget with an alias shouldn't ignore alias routing {pull}25697[#25697] (issue: {issue}25696[#25696])
+* GET aliases should 404 if aliases are missing {pull}25043[#25043] (issue: {issue}24644[#24644])
+
+Allocation::
+* Fix DiskThresholdMonitor flood warning {pull}26204[#26204] (issue: {issue}26201[#26201])
+* Allow wildcards for shard IP filtering {pull}26187[#26187] (issues: {issue}22591[#22591], {issue}26184[#26184])
+
+Analysis::
+* Pre-configured shingle filter should disable graph analysis {pull}25853[#25853] (issue: {issue}25555[#25555])
+* PatternAnalyzer should lowercase wildcard queries when `lowercase` is true. {pull}24967[#24967]
+
+CAT API::
+* Fix NPE for /_cat/indices when no primary shard {pull}26953[#26953] (issue: {issue}26942[#26942])
+
+CRUD::
+* Serialize and expose timeout of acknowledged requests in REST layer {pull}26189[#26189] (issue: {issue}26213[#26213])
+* Fix silent loss of last command to _bulk and _msearch due to missing newline {pull}25740[#25740] (issue: {issue}7601[#7601])
+
+Cache::
+* Reduce the default number of cached queries. {pull}26949[#26949] (issue: {issue}26938[#26938])
+* fix bug of weight computation {pull}24856[#24856]
+
+Circuit Breakers::
+* Checks the circuit breaker before allocating bytes for a new big array {pull}25010[#25010] (issue: {issue}24790[#24790])
+
+Cluster::
+* Register setting `cluster.indices.tombstones.size` {pull}26193[#26193] (issue: {issue}26191[#26191])
+
+Core::
+* Correctly encode warning headers {pull}27269[#27269] (issue: {issue}27244[#27244])
+* Fix cache compute if absent for expired entries {pull}26516[#26516]
+* Timed runnable should delegate to abstract runnable {pull}27095[#27095] (issue: {issue}27069[#27069])
+* Stop invoking non-existent syscall {pull}27016[#27016] (issue: {issue}20179[#20179])
+* MetaData Builder doesn't properly prevent an alias with the same name as an index {pull}26804[#26804]
+* Release operation permit on thread-pool rejection {pull}25930[#25930] (issue: {issue}25863[#25863])
+* Node should start up despite of a lingering `.es_temp_file` {pull}21210[#21210] (issue: {issue}21007[#21007])
+* Fix cache expire after access {pull}24546[#24546]
+
+Dates::
+* Fix typo in date format {pull}26503[#26503] (issue: {issue}26500[#26500])
+
+Discovery::
+* MasterNodeChangePredicate should use the node instance to detect master change {pull}25877[#25877] (issue: {issue}25471[#25471])
+
+Engine::
+* Die with dignity while merging {pull}27265[#27265] (issue: {issue}19272[#19272])
+* Engine - do not index operations with seq# lower than the local checkpoint into lucene {pull}25827[#25827] (issues: {issue}1[#1], {issue}2[#2], {issue}25592[#25592])
+
+Geo::
+* Fix typo in GeoUtils#isValidLongitude {pull}25121[#25121]
+
+Highlighting::
+* Fix percolator highlight sub fetch phase to not highlight query twice {pull}26622[#26622]
+* FastVectorHighlighter should not cache the field query globally {pull}25197[#25197] (issue: {issue}25171[#25171])
+* Higlighters: Fix MultiPhrasePrefixQuery rewriting {pull}25103[#25103] (issue: {issue}25088[#25088])
+* Fix nested query highlighting {pull}26305[#26305] (issue: {issue}26230[#26230])
+
+Index APIs::
+* Shrink API should ignore templates {pull}25380[#25380] (issue: {issue}25035[#25035])
+* Rollover max docs should only count primaries {pull}24977[#24977] (issue: {issue}24217[#24217])
+* Validates updated settings on closed indices {pull}24487[#24487] (issue: {issue}23787[#23787])
+
+Ingest::
+* date processor should not fail if timestamp is specified as json number {pull}26986[#26986] (issue: {issue}26967[#26967])
+* date_index_name processor should not fail if timestamp is specified as json number {pull}26910[#26910] (issue: {issue}26890[#26890])
+* Sort Processor does not have proper behavior with targetField {pull}25237[#25237] (issue: {issue}24133[#24133])
+* fix grok's pattern parsing to validate pattern names in expression {pull}25063[#25063] (issue: {issue}22831[#22831])
+* Remove support for Visio and potm files {pull}22079[#22079] (issue: {issue}22077[#22077])
+* Fix floating-point error when DateProcessor parses UNIX {pull}24947[#24947]
+* add option for _ingest.timestamp to use new ZonedDateTime (5.x backport) {pull}24030[#24030] (issues: {issue}23168[#23168], {issue}23174[#23174])
+
+Inner Hits::
+* Do not allow inner hits that fetch _source and have a non nested object field as parent {pull}25749[#25749] (issue: {issue}25315[#25315])
+* When fetching nested inner hits only access stored fields when needed {pull}25864[#25864] (issue: {issue}6[#6])
+* If size / offset are out of bounds just do a plain count {pull}20556[#20556] (issue: {issue}20501[#20501])
+* Fix Source filtering in new field collapsing feature {pull}24068[#24068] (issue: {issue}24063[#24063])
+
+Internal::
+* Bump version to 6.0.1 [OPEN] {pull}27386[#27386]
+* `IndexShard.routingEntry` should only be updated once all internal state is ready {pull}26776[#26776]
+* Catch exceptions and inform handler in RemoteClusterConnection#collectNodes {pull}26725[#26725] (issue: {issue}26700[#26700])
+* Internal: Add versionless alias for rest client codebase in policy files {pull}26521[#26521]
+* Upgrade Lucene to version 7.0.1 {pull}26926[#26926]
+* Fix BytesReferenceStreamInput#skip with offset {pull}25634[#25634]
+* Fix race condition in RemoteClusterConnection node supplier {pull}25432[#25432]
+* Initialise empty lists in BaseTaskResponse constructor {pull}25290[#25290]
+* Extract a common base class for scroll executions {pull}24979[#24979] (issue: {issue}16555[#16555])
+* Obey lock order if working with store to get metadata snapshots {pull}24787[#24787] (issue: {issue}24481[#24481])
+* Fix Version based BWC and set correct minCompatVersion {pull}24732[#24732]
+* Fix `_field_caps` serialization in order to support cross cluster search {pull}24722[#24722]
+* Avoid race when shutting down controller processes {pull}24579[#24579]
+* Fix handling of document failure exception in InternalEngine {pull}22718[#22718]
+* Ensure remote cluster is connected before fetching `_field_caps` {pull}24845[#24845] (issue: {issue}24763[#24763])
+
+Java API::
+* BulkProcessor flush runnable preserves the thread context from creation time {pull}26718[#26718] (issue: {issue}26596[#26596])
+
+Java High Level REST Client::
+* Make RestHighLevelClient's Request class public {pull}26627[#26627] (issue: {issue}26455[#26455])
+* Forbid direct usage of ContentType.create() methods {pull}26457[#26457] (issues: {issue}22769[#22769], {issue}26438[#26438])
+* Make ShardSearchTarget optional when parsing ShardSearchFailure {pull}27078[#27078] (issue: {issue}27055[#27055])
+
+Java REST Client::
+* Better message text for ResponseException {pull}26564[#26564]
+* rest-client-sniffer: configurable threadfactory {pull}26897[#26897]
+
+Logging::
+* Allow not configure logging without config {pull}26209[#26209] (issues: {issue}20575[#20575], {issue}24076[#24076])
+
+Machine Learning::
+* Fixed a race condition when simultaneous close requests are made for the same
+job.
+
+Mapping::
+* Allow copying from a field to another field that belongs to the same nested object. {pull}26774[#26774] (issue: {issue}26763[#26763])
+* Fixed bug that mapper_parsing_exception is thrown for numeric field with ignore_malformed=true when inserting "NaN" {pull}25967[#25967] (issue: {issue}25289[#25289])
+* Coerce decimal strings for whole number types by truncating the decimal part {pull}25835[#25835] (issue: {issue}25819[#25819])
+* Fix parsing of ip range queries. {pull}25768[#25768] (issue: {issue}25636[#25636])
+* Disable date field mapping changing {pull}25285[#25285] (issue: {issue}25271[#25271])
+* Correctly enable _all for older 5.x indices {pull}25087[#25087] (issue: {issue}25068[#25068])
+* token_count datatype should handle null value {pull}25046[#25046] (issue: {issue}24928[#24928])
+* keep _parent field while updating child type mapping {pull}24407[#24407] (issue: {issue}23381[#23381])
+* ICUCollationKeywordFieldMapper use SortedSetDocValuesField {pull}26267[#26267]
+* Fix serialization of the `_all` field. {pull}26143[#26143] (issue: {issue}26136[#26136])
+
+More Like This::
+* Pass over _routing value with more_like_this items to be retrieved {pull}24679[#24679] (issue: {issue}23699[#23699])
+
+NOT CLASSIFIED::
+* DocumentMissingException during Logstash scripted upsert [ISSUE] {pull}27148[#27148]
+* An assertion trips when master opens an index from before 5.x [ISSUE] {pull}24809[#24809]
+
+Nested Docs::
+* In case of a single type the _id field should be added to the nested document instead of _uid field {pull}25149[#25149]
+* Inner hits source filtering not working [ISSUE] {pull}23090[#23090]
+
+Network::
+* Fixed ByteBuf leaking in org.elasticsearch.http.netty4.Netty4HttpRequestHandler {pull}27222[#27222] (issues: {issue}3[#3], {issue}4[#4], {issue}5[#5], {issue}6[#6])
+* Check for closed connection while opening {pull}26932[#26932]
+* Ensure pending transport handlers are invoked for all channel failures {pull}25150[#25150]
+* Notify onConnectionClosed rather than onNodeDisconnect to prune transport handlers {pull}24639[#24639] (issues: {issue}24557[#24557], {issue}24575[#24575], {issue}24632[#24632])
+* Release pipelined http responses on close {pull}26226[#26226]
+* Fix error message if an incompatible node connects {pull}24884[#24884]
+
+Packaging::
+* Fix handling of Windows paths containing parentheses {pull}26916[#26916] (issue: {issue}26454[#26454])
+* Exit Windows scripts promptly on failure {pull}25959[#25959]
+* Pass config path as a system property {pull}25943[#25943]
+* ES_HOME needs to be made absolute before attempt at traversal {pull}25865[#25865]
+* Fix elasticsearch-keystore handling of path.conf {pull}25811[#25811]
+* Stop disabling explicit GC {pull}25759[#25759]
+* Avoid failing install if system-sysctl is masked {pull}25657[#25657] (issue: {issue}24234[#24234])
+* Get short path name for native controllers {pull}25344[#25344]
+* When stopping via systemd only kill the JVM, not its control group {pull}25195[#25195]
+* remove remaining references to scripts directory {pull}24771[#24771]
+* Handle parentheses in batch file path {pull}24731[#24731] (issue: {issue}24712[#24712])
+* Detect modified keystore on package removal {pull}26300[#26300]
+* Create keystore on RPM and Debian package install {pull}26282[#26282]
+* Add safer empty variable checking for Windows {pull}26268[#26268] (issue: {issue}26261[#26261])
+* Export HOSTNAME environment variable {pull}26262[#26262] (issues: {issue}25807[#25807], {issue}26255[#26255])
+* Fix daemonization command status test {pull}26196[#26196] (issue: {issue}26080[#26080])
+* Set RuntimeDirectory in systemd service {pull}23526[#23526]
+
+Parent/Child::
+* The default _parent field should not try to load global ordinals {pull}25851[#25851] (issue: {issue}25849[#25849])
+
+Percolator::
+* Also support query extraction for queries wrapped inside a ESToParentBlockJoinQuery {pull}26754[#26754]
+* Fix range queries with date range based on current time in percolator queries. {pull}24666[#24666] (issue: {issue}23921[#23921])
+
+Plugin Analysis Kuromoji::
+* Fix kuromoji default stoptags {pull}26600[#26600] (issue: {issue}26519[#26519])
+
+Plugin Analysis Phonetic::
+* Fix beidermorse phonetic token filter for unspecified `languageset` {pull}27112[#27112] (issue: {issue}26771[#26771])
+
+Plugin Discovery File::
+* Fix discovery-file plugin to use custom config path {pull}26662[#26662] (issue: {issue}26660[#26660])
+
+Plugin Ingest Attachment::
+* Add missing mime4j library {pull}22764[#22764] (issue: {issue}22077[#22077])
+
+Plugin Lang Painless::
+* Painless: allow doubles to be casted to longs. {pull}25936[#25936]
+
+Plugin Repository Azure::
+* Azure snapshots can not be restored anymore {pull}26778[#26778] (issues: {issue}22858[#22858], {issue}26751[#26751], {issue}26777[#26777])
+* Snapshot : azure module - accelerate the listing of files (used in delete snapshot) {pull}25710[#25710] (issue: {issue}25424[#25424])
+* Use Azure upload method instead of our own implementation {pull}26751[#26751]
+* Make calls to CloudBlobContainer#exists privileged {pull}25937[#25937] (issue: {issue}25931[#25931])
+
+Plugin Repository GCS::
+* Ensure that gcs client creation is privileged {pull}25938[#25938] (issue: {issue}25932[#25932])
+
+Plugin Repository HDFS::
+* Add Log4j to SLF4J binding for repository-hdfs {pull}26514[#26514] (issue: {issue}26512[#26512])
+* Upgrading HDFS Repository Plugin to use HDFS 2.8.1 Client {pull}25497[#25497] (issue: {issue}25450[#25450])
+
+Plugin Repository S3::
+* Avoid SecurityException in repository-S3 on DefaultS3OutputStream.flush() {pull}25254[#25254] (issue: {issue}25192[#25192])
+* Wrap getCredentials() in a doPrivileged() block {pull}23297[#23297] (issues: {issue}22534[#22534], {issue}23271[#23271])
+
+Plugins::
+* X-Pack plugin download fails on Windows desktop [ISSUE] {pull}24570[#24570]
+* Fix plugin installation permissions {pull}24527[#24527] (issue: {issue}24480[#24480])
+
+Query DSL::
+* Fixed incomplete JSON body on count request making org.elasticsearch.rest.action.RestActions#parseTopLevelQueryBuilder go into endless loop {pull}26680[#26680] (issue: {issue}26083[#26083])
+* SpanNearQueryBuilder should return the inner clause when a single clause is provided {pull}25856[#25856] (issue: {issue}25630[#25630])
+* Refactor field expansion for match, multi_match and query_string query {pull}25726[#25726] (issues: {issue}25551[#25551], {issue}25556[#25556])
+* WrapperQueryBuilder should also rewrite the parsed query {pull}25480[#25480]
+
+REST::
+* Rest test fixes {pull}27354[#27354]
+* Fix inconsistencies in the rest api specs for cat.snapshots {pull}26996[#26996] (issues: {issue}25737[#25737], {issue}26923[#26923])
+* Fix inconsistencies in the rest api specs for *_script {pull}26971[#26971] (issue: {issue}26923[#26923])
+* exists template needs a template name {pull}25988[#25988]
+* Fix handling of invalid error trace parameter {pull}25785[#25785] (issue: {issue}25774[#25774])
+* Fix handling of exceptions thrown on HEAD requests {pull}25172[#25172] (issue: {issue}21125[#21125])
+* Fixed NPEs caused by requests without content. {pull}23497[#23497] (issue: {issue}24701[#24701])
+* Fix get mappings HEAD requests {pull}23192[#23192] (issue: {issue}21125[#21125])
+
+Recovery::
+* Close translog view after primary-replica resync {pull}25862[#25862] (issue: {issue}24841[#24841])
+
+Reindex API::
+* Fix update_by_query's default size parameter {pull}26784[#26784] (issue: {issue}26761[#26761])
+* Reindex: don't duplicate _source parameter {pull}24629[#24629] (issue: {issue}24628[#24628])
+* Add qa module that tests reindex-from-remote against pre-5.0 versions of Elasticsearch {pull}24561[#24561] (issues: {issue}23828[#23828], {issue}24520[#24520])
+
+Scroll::
+* Fix single shard scroll within a cluster with nodes in version `>= 5.3` and `<= 5.3` {pull}24512[#24512]
+
+Search::
+* Fail query when a sort is provided in conjunction with rescorers {pull}26510[#26510]
+* Let search phases override max concurrent requests {pull}26484[#26484] (issue: {issue}26198[#26198])
+* Avoid stack overflow on search phases {pull}27069[#27069] (issue: {issue}27042[#27042])
+* Fix search_after with geo distance sorting {pull}26891[#26891]
+* Fix serialization errors when cross cluster search goes to a single shard {pull}26881[#26881] (issue: {issue}26833[#26833])
+* Early termination with index sorting should not set terminated_early in the response {pull}26597[#26597] (issue: {issue}26408[#26408])
+* Format doc values fields. {pull}22146[#22146]
+* Fix term(s) query for range field {pull}25918[#25918]
+* Caching a MinDocQuery can lead to wrong results. {pull}25909[#25909]
+* Fix random score generation when no seed is provided. {pull}25908[#25908]
+* Merge FunctionScoreQuery and FiltersFunctionScoreQuery {pull}25889[#25889] (issues: {issue}15709[#15709], {issue}23628[#23628])
+* Respect cluster alias in `_index` aggs and queries {pull}25885[#25885] (issue: {issue}25606[#25606])
+* First increment shard stats before notifying and potentially sending response {pull}25818[#25818]
+* Remove assertion about deviation when casting to a float. {pull}25806[#25806] (issue: {issue}25330[#25330])
+* Prevent skipping shards if a suggest builder is present {pull}25739[#25739] (issue: {issue}25658[#25658])
+* Ensure remote cluster alias is preserved in inner hits aggs {pull}25627[#25627] (issue: {issue}25606[#25606])
+* Do not search locally if remote index pattern resolves to no indices {pull}25436[#25436] (issue: {issue}25426[#25426])
+* Adds check for negative search request size {pull}25397[#25397] (issue: {issue}22530[#22530])
+* Make sure range queries are correctly profiled. {pull}25108[#25108]
+* Fix RangeFieldMapper rangeQuery to properly handle relations {pull}24808[#24808] (issue: {issue}24744[#24744])
+* Fix ExpandSearchPhase when response contains no hits {pull}24688[#24688] (issue: {issue}24672[#24672])
+* Refactor simple_query_string to handle text part like multi_match and query_string {pull}26145[#26145] (issue: {issue}25726[#25726])
+* Fix `_exists_` in query_string on empty indices. {pull}25993[#25993] (issue: {issue}25956[#25956])
+* Fix script field sort returning Double.MAX_VALUE for all documents {pull}24942[#24942] (issue: {issue}24940[#24940])
+* Compute the took time of the query after the expand phase of field collapsing {pull}24902[#24902] (issue: {issue}24900[#24900])
+
+Security::
+* Prevented 6.0 nodes from joining clusters with un-upgraded version 5
+`.security` indices. For upgrade instructions, see
+{stack-ref}/upgrading-elastic-stack.html[Upgrading the Elastic Stack].
+* Enabled read-only access to the index audit log by the `_xpack` internal user.
+For more information, see
+{stack-ov}/internal-users.html[Internal users].
+* Updated the concrete security index such that it is now always named
+`.security-6`. In 6.0 beta and RC releases, it was sometimes named `.security-v6`.
+* Fixed handling of exceptions when retrieving roles from a native roles store.
+For more information about configuring a native realm, see
+{stack-ov}/native-realm.html[Native User Authentication].
+
+Sequence IDs::
+* Fire global checkpoint sync under system context {pull}26984[#26984]
+* Fix pre-6.0 response to unknown replication actions {pull}25744[#25744] (issue: {issue}10708[#10708])
+* Track local checkpoint on primary immediately {pull}25434[#25434] (issues: {issue}10708[#10708], {issue}25355[#25355], {issue}25415[#25415])
+* Initialize max unsafe auto ID timestamp on shrink {pull}25356[#25356] (issues: {issue}10708[#10708], {issue}25355[#25355])
+* Use correct primary term for replicating NOOPs {pull}25128[#25128]
+* Handle already closed while filling gaps {pull}25021[#25021] (issue: {issue}24925[#24925])
+* TranslogWriter.assertNoSeqNumberConflict failure [ISSUE] {pull}26710[#26710]
+* Avoid losing ops in file-based recovery {pull}22945[#22945] (issue: {issue}22484[#22484])
+* Handle primary failure handling replica response {pull}24926[#24926] (issue: {issue}24935[#24935])
+
+Settings::
+* Emit settings deprecation logging on empty update {pull}27017[#27017] (issue: {issue}26419[#26419])
+* Fix filtering for ListSetting {pull}26914[#26914]
+* Fix settings serialization to not serialize secure settings or not take the total size into account {pull}25323[#25323]
+* Keystore CLI should use the AddFileKeyStoreCommand for files {pull}25298[#25298]
+* Allow resetting settings that use an IP validator {pull}24713[#24713] (issue: {issue}24709[#24709])
+* Updating an unrecognized setting should error out with that reason [ISSUE] {pull}25607[#25607]
+* Settings: Fix setting groups to include secure settings {pull}25076[#25076] (issue: {issue}25069[#25069])
+
+Similarities::
+* Add boolean similarity to built in similarity types {pull}26613[#26613]
+
+Snapshot/Restore::
+* Snapshot/Restore: better handle incorrect chunk_size settings in FS repo {pull}26844[#26844] (issue: {issue}26843[#26843])
+* Snapshot/Restore: Ensure that shard failure reasons are correctly stored in CS {pull}25941[#25941] (issue: {issue}25878[#25878])
+* Output all empty snapshot info fields if in verbose mode {pull}25455[#25455] (issue: {issue}24477[#24477])
+* Remove redundant and broken MD5 checksum from repository-s3 {pull}25270[#25270] (issue: {issue}25269[#25269])
+* Consolidates the logic for cleaning up snapshots on master election {pull}24894[#24894] (issue: {issue}24605[#24605])
+* Removes completed snapshot from cluster state on master change {pull}24605[#24605] (issue: {issue}24452[#24452])
+* Keep snapshot restore state and routing table in sync {pull}20836[#20836] (issue: {issue}19774[#19774])
+* Master failover during snapshotting could leave the snapshot incomplete [OPEN] [ISSUE] {pull}25281[#25281]
+* Fix inefficient (worst case exponential) loading of snapshot repository {pull}24510[#24510] (issue: {issue}24509[#24509])
+
+Stats::
+* Fix RestGetAction name typo {pull}27266[#27266]
+* Keep cumulative elapsed scroll time in microseconds {pull}27068[#27068] (issue: {issue}27046[#27046])
+* _nodes/stats should not fail due to concurrent AlreadyClosedException {pull}25016[#25016] (issue: {issue}23099[#23099])
+* Avoid double decrement on current query counter {pull}24922[#24922] (issues: {issue}22996[#22996], {issue}24872[#24872])
+* Adjust available and free bytes to be non-negative on huge FSes {pull}24911[#24911] (issues: {issue}23093[#23093], {issue}24453[#24453])
+
+Suggesters::
+* Fix division by zero in phrase suggester that causes assertion to fail {pull}27149[#27149]
+* Context suggester should filter doc values field {pull}25858[#25858] (issue: {issue}25404[#25404])
+* Fix context suggester to read values from keyword type field {pull}24200[#24200] (issue: {issue}24129[#24129])
+
+Templates::
+* Tests: Fix FullClusterRestartIT.testSnapshotRestore test failing in 6.x {pull}27218[#27218] (issue: {issue}27213[#27213])
+
+Translog::
+* Fix Translog.Delete serialization for sequence numbers {pull}22543[#22543]
+
+Upgrade API::
+* Upgrade API: fix excessive logging and unnecessary template updates {pull}26698[#26698] (issue: {issue}26673[#26673])
+
+[float]
+=== Regressions
+
+Bulk::
+* Only re-parse operation if a mapping update was needed {pull}23832[#23832] (issue: {issue}23665[#23665])
+
+Highlighting::
+* Fix Fast Vector Highlighter NPE on match phrase prefix {pull}25116[#25116] (issue: {issue}25088[#25088])
+
+Search::
+* Always use DisjunctionMaxQuery to build cross fields disjunction {pull}25115[#25115] (issue: {issue}23966[#23966])
+
+Sequence IDs::
+* Indexing performance degradation in 6.0.0-beta1 [ISSUE] {pull}26339[#26339]
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Core::
+* Upgrade to Lucene 7.0.0 {pull}26744[#26744]
+* Upgrade to lucene-7.0.0-snapshot-d94a5f0. {pull}26441[#26441]
+* Upgrade to lucene-7.0.0-snapshot-a128fcb. {pull}26090[#26090]
+* Upgrade to a Lucene 7 snapshot {pull}24089[#24089] (issues: {issue}23966[#23966], {issue}24086[#24086], {issue}24087[#24087], {issue}24088[#24088])
+
+Logging::
+* Upgrade to Log4j 2.9.1 {pull}26750[#26750] (issues: {issue}109[#109], {issue}26464[#26464], {issue}26467[#26467])
+* Upgrade to Log4j 2.9.0 {pull}26450[#26450] (issue: {issue}23798[#23798])
+
+Network::
+* Upgrade to Netty 4.1.13.Final {pull}25581[#25581] (issues: {issue}24729[#24729], {issue}6866[#6866])
+* Upgrade to Netty 4.1.11.Final {pull}24652[#24652]
+
+Plugin Ingest Attachment::
+* Update to Tika 1.14 {pull}21591[#21591] (issue: {issue}20390[#20390])
+
+Upgrade API::
+* Improve stability and logging of TemplateUpgradeServiceIT tests {pull}25386[#25386] (issue: {issue}25382[#25382])
+
+[[release-notes-6.0.0-rc2]]
+== {es} version 6.0.0-rc2
+
+[float]
+[[breaking-6.0.0-rc2]]
+=== Breaking Changes
+
+Inner Hits::
+* Return the _source of inner hit nested as is without wrapping it into its full path context {pull}26982[#26982] (issues: {issue}26102[#26102], {issue}26944[#26944])
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
+
+//[float]
+//=== New Features
+
+[float]
+=== Enhancements
+
+Core::
+* Ignore .DS_Store files on macOS {pull}27108[#27108] (issue: {issue}23982[#23982])
+
+Index Templates::
+* Fix error message for a put index template request without index_patterns {pull}27102[#27102] (issue: {issue}27100[#27100])
+
+Machine Learning::
+* Added the `xpack.ml.max_model_memory_limit` setting, which can be dynamically
+updated. For more information, see <<ml-settings>>.
+* Added checks and error messages for the `ml.enabled` and `ml.max_open_jobs`
+node attributes. These are reserved for internal use and their values should be
+set by using `xpack.ml.enabled` and `xpack.ml.max_open_jobs`
+<<ml-settings,{ml} settings>>.
+
+Mapping::
+* Don't detect source's XContentType in DocumentParser.parseDocument() {pull}26880[#26880]
+
+Network::
+* Add additional low-level logging handler {pull}26887[#26887]
+* Unwrap causes when maybe dying {pull}26884[#26884]
+
+Plugins::
+* Adjust SHA-512 supported format on plugin install {pull}27093[#27093]
+
+REST::
+* Cat shards bytes {pull}26952[#26952]
+
+Security::
+* Improved the error messages that are returned by the `setup-passwords` command.
+
+Watcher::
+* Added verification that the required templates exist before {watcher} starts.
+For more information, see
+{stack-ov}/how-watcher-works.html#scripts-templates[Scripts and Templates].
+* Added the `xpack.watcher.history.cleaner_service.enabled` setting. You can use
+this setting to enable or disable the cleaner service, which removes previous
+versions of {watcher} indices (for example, .watcher-history*) when it
+determines that they are old. For more information, see <<notification-settings>>.
+
+[float]
+=== Bug Fixes
+
+Aggregations::
+* Create weights lazily in filter and filters aggregation {pull}26983[#26983]
+* Fix IndexOutOfBoundsException in histograms for NaN doubles (#26787) {pull}26856[#26856] (issue: {issue}26787[#26787])
+* Scripted_metric _agg parameter disappears if params are provided {pull}19863[#19863] (issue: {issue}19768[#19768])
+
+CAT API::
+* Fix NPE for /_cat/indices when no primary shard {pull}26953[#26953] (issue: {issue}26942[#26942])
+
+Cache::
+* Reduce the default number of cached queries. {pull}26949[#26949] (issue: {issue}26938[#26938])
+
+Core::
+* Timed runnable should delegate to abstract runnable {pull}27095[#27095] (issue: {issue}27069[#27069])
+* Stop invoking non-existent syscall {pull}27016[#27016] (issue: {issue}20179[#20179])
+* MetaData Builder doesn't properly prevent an alias with the same name as an index {pull}26804[#26804]
+
+Ingest::
+* date processor should not fail if timestamp is specified as json number {pull}26986[#26986] (issue: {issue}26967[#26967])
+* date_index_name processor should not fail if timestamp is specified as json number {pull}26910[#26910] (issue: {issue}26890[#26890])
+
+Internal::
+* Upgrade Lucene to version 7.0.1 {pull}26926[#26926]
+
+Java High Level REST Client::
+* Make ShardSearchTarget optional when parsing ShardSearchFailure {pull}27078[#27078] (issue: {issue}27055[#27055])
+
+Java REST Client::
+* rest-client-sniffer: configurable threadfactory {pull}26897[#26897]
+
+Machine Learning::
+* Fixed a scenario where models were incorrectly combined. This problem occurred
+when anomaly detectors were considered to be the same despite having different
+partition field values.
+* Cleaned up the job closure process for situations where the job was still in
+the process of opening.
+
+Mapping::
+* wrong link target for datatype murmur3 {pull}27143[#27143]
+
+Network::
+* Check for closed connection while opening {pull}26932[#26932]
+
+Packaging::
+* Fix handling of Windows paths containing parentheses {pull}26916[#26916] (issue: {issue}26454[#26454])
+
+Percolator::
+* Also support query extraction for queries wrapped inside a ESToParentBlockJoinQuery {pull}26754[#26754]
+
+Plugin Analysis Phonetic::
+* Fix beidermorse phonetic token filter for unspecified `languageset` {pull}27112[#27112] (issue: {issue}26771[#26771])
+
+Plugin Repository Azure::
+* Use Azure upload method instead of our own implementation {pull}26751[#26751]
+
+REST::
+* Fix inconsistencies in the rest api specs for cat.snapshots {pull}26996[#26996] (issues: {issue}25737[#25737], {issue}26923[#26923])
+* Fix inconsistencies in the rest api specs for *_script {pull}26971[#26971] (issue: {issue}26923[#26923])
+* exists template needs a template name {pull}25988[#25988]
+
+Reindex API::
+* Fix update_by_query's default size parameter {pull}26784[#26784] (issue: {issue}26761[#26761])
+
+Search::
+* Avoid stack overflow on search phases {pull}27069[#27069] (issue: {issue}27042[#27042])
+* Fix search_after with geo distance sorting {pull}26891[#26891]
+* Fix serialization errors when cross cluster search goes to a single shard {pull}26881[#26881] (issue: {issue}26833[#26833])
+* Early termination with index sorting should not set terminated_early in the response {pull}26597[#26597] (issue: {issue}26408[#26408])
+* Format doc values fields. {pull}22146[#22146]
+
+Security::
+* Enabled PKI realms to obtain the password for the truststore from either the
+`truststore.secure_password` or the `truststore.password` setting. For more
+information, see <<ref-pki-settings>>.
+* Fixed document level security such that if your role has authority to access a
+root document, you also have access to its nested documents.
+* Fixed an issue that caused LDAP authentication requests to be slow and
+to require multiple binds when authenticating in user search mode.
+
+Sequence IDs::
+* Fire global checkpoint sync under system context {pull}26984[#26984]
+
+Settings::
+* Emit settings deprecation logging on empty update {pull}27017[#27017] (issue: {issue}26419[#26419])
+* Fix filtering for ListSetting {pull}26914[#26914]
+
+Stats::
+* Keep cumulative elapsed scroll time in microseconds {pull}27068[#27068] (issue: {issue}27046[#27046])
+
+Suggesters::
+* Fix division by zero in phrase suggester that causes assertion to fail {pull}27149[#27149]
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[[release-notes-6.0.0-rc1]]
+== {es} version 6.0.0-rc1
+
+[float]
+[[breaking-6.0.0-rc1]]
+=== Breaking Changes
+
+Packaging::
+* Configure heap dump path out of the box {pull}26755[#26755] (issue: {issue}26665[#26665])
+
+Query DSL::
+* Remove deprecated `type` and `slop` field in `match` query {pull}26720[#26720]
+* Remove several parse field deprecations in query builders {pull}26711[#26711]
+* Remove deprecated parameters from `ids_query` {pull}26508[#26508]
+
+//[float]
+//=== Breaking Java Changes
+
+[float]
+=== Deprecations
+
+Plugins::
+* Plugins: Add backcompat for sha1 checksums {pull}26748[#26748] (issue: {issue}26746[#26746])
+
+Security::
+* The `xpack.security.authc.token.passphrase` is deprecated. If this setting is
+not used, the cluster automatically generates a key, which is the recommended
+method. See <<security-settings>>.
+
+//[float]
+//=== New Features
+
+[float]
+=== Enhancements
+
+Core::
+* Allow `InputStreamStreamInput` array size validation where applicable {pull}26692[#26692]
+* Refactor bootstrap check results and error messages {pull}26637[#26637]
+* Add BootstrapContext to expose settings and recovered state to bootstrap checks {pull}26628[#26628]
+* Unit testable index creation task on MetaDataCreateIndexService {pull}25961[#25961]
+
+Discovery::
+* Allow plugins to validate cluster-state on join {pull}26595[#26595]
+
+Mapping::
+* More efficient encoding of range fields. {pull}26470[#26470] (issue: {issue}26443[#26443])
+
+Plugin Repository HDFS::
+* Add permission checks before reading from HDFS stream {pull}26716[#26716] (issue: {issue}26714[#26714])
+
+Recovery::
+* Introduce a History UUID as a requirement for ops based recovery  {pull}26577[#26577] (issue: {issue}10708[#10708])
+
+Security::
+* Added requirement for TLS/SSL when a cluster with security is running in
+production. If you try to upgrade to a production license when security is
+enabled, the upgrade is not successful until you configure TLS. For more
+information, see
+{stack-ov}/ssl-tls.html[Setting Up SSL/TLS on a Cluster].
+* Added bootstrap check that enforces the use of TLS when security is enabled
+and you are using a production license.
+
+Scripting::
+* ScriptService: Replace max compilation per minute setting with max compilation rate {pull}26399[#26399]
+
+Search::
+* Add soft limit on allowed number of script fields in request {pull}26598[#26598] (issue: {issue}26390[#26390])
+* Add a soft limit for the number of requested doc-value fields {pull}26574[#26574] (issue: {issue}26390[#26390])
+
+Sequence IDs::
+* Restoring from snapshot should force generation of a new history uuid {pull}26694[#26694] (issues: {issue}10708[#10708], {issue}26544[#26544], {issue}26557[#26557], {issue}26577[#26577])
+* Add global checkpoint tracking on the primary {pull}26666[#26666] (issue: {issue}26591[#26591])
+* Introduce global checkpoint background sync {pull}26591[#26591] (issues: {issue}26573[#26573], {issue}26630[#26630], {issue}26666[#26666])
+* Move `UNASSIGNED_SEQ_NO` and `NO_OPS_PERFORMED` to SequenceNumbers` {pull}26494[#26494] (issue: {issue}10708[#10708])
+
+[float]
+=== Bug Fixes
+
+Aggregations::
+* Do not delegate a null scorer to LeafBucketCollectors {pull}26747[#26747] (issue: {issue}26611[#26611])
+
+Core::
+* Fix cache compute if absent for expired entries {pull}26516[#26516]
+
+Dates::
+* Fix typo in date format {pull}26503[#26503] (issue: {issue}26500[#26500])
+
+Highlighting::
+* Fix percolator highlight sub fetch phase to not highlight query twice {pull}26622[#26622]
+
+Inner Hits::
+* Do not allow inner hits that fetch _source and have a non nested object field as parent {pull}25749[#25749] (issue: {issue}25315[#25315])
+
+Internal::
+* `IndexShard.routingEntry` should only be updated once all internal state is ready {pull}26776[#26776]
+* Catch exceptions and inform handler in RemoteClusterConnection#collectNodes {pull}26725[#26725] (issue: {issue}26700[#26700])
+* Internal: Add versionless alias for rest client codebase in policy files {pull}26521[#26521]
+
+Java API::
+* BulkProcessor flush runnable preserves the thread context from creation time {pull}26718[#26718] (issue: {issue}26596[#26596])
+
+Java High Level REST Client::
+* Make RestHighLevelClient's Request class public {pull}26627[#26627] (issue: {issue}26455[#26455])
+* Forbid direct usage of ContentType.create() methods {pull}26457[#26457] (issues: {issue}22769[#22769], {issue}26438[#26438])
+
+Java REST Client::
+* Better message text for ResponseException {pull}26564[#26564]
+
+Machine Learning::
+* Fixed problem with dropped or duplicated data when datafeeds used aggregations.
+* Fixed problems when model plot is enabled and there are sparse metrics.
+* Improved modeling of long-term trends.
+* Fixed a bug in calculation of mean values for seasonal components.
+* Added more accurate adherence to model memory limit.
+
+Mapping::
+* Allow copying from a field to another field that belongs to the same nested object. {pull}26774[#26774] (issue: {issue}26763[#26763])
+
+Monitoring::
+* Fixed the email message when cluster license expiration issues are resolved.
+
+Plugin Analysis Kuromoji::
+* Fix kuromoji default stoptags {pull}26600[#26600] (issue: {issue}26519[#26519])
+
+Plugin Discovery File::
+* Fix discovery-file plugin to use custom config path {pull}26662[#26662] (issue: {issue}26660[#26660])
+
+Plugin Repository Azure::
+* Azure snapshots can not be restored anymore {pull}26778[#26778] (issues: {issue}22858[#22858], {issue}26751[#26751], {issue}26777[#26777])
+* Snapshot : azure module - accelerate the listing of files (used in delete snapshot) {pull}25710[#25710] (issue: {issue}25424[#25424])
+
+Plugin Repository HDFS::
+* Add Log4j to SLF4J binding for repository-hdfs {pull}26514[#26514] (issue: {issue}26512[#26512])
+
+Query DSL::
+* Fixed incomplete JSON body on count request making org.elasticsearch.rest.action.RestActions#parseTopLevelQueryBuilder go into endless loop {pull}26680[#26680] (issue: {issue}26083[#26083])
+
+Search::
+* Fail query when a sort is provided in conjunction with rescorers {pull}26510[#26510]
+* Let search phases override max concurrent requests {pull}26484[#26484] (issue: {issue}26198[#26198])
+
+Security::
+* Added ability infer the keystore type from its pathname when the type is not specified.
+* Added usability improvements for the password bootstrap tool. For more
+information, see <<setup-passwords>>.
+
+Similarities::
+* Add boolean similarity to built in similarity types {pull}26613[#26613]
+
+Upgrade API::
+* Upgrade API: fix excessive logging and unnecessary template updates {pull}26698[#26698] (issue: {issue}26673[#26673])
+
+Watcher::
+* Fixed {watcher} such that it loads only active watches.
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Core::
+* Upgrade to Lucene 7.0.0 {pull}26744[#26744]
+* Upgrade to lucene-7.0.0-snapshot-d94a5f0. {pull}26441[#26441]
+
+Logging::
+* Upgrade to Log4j 2.9.1 {pull}26750[#26750] (issues: {issue}109[#109], {issue}26464[#26464], {issue}26467[#26467])
+* Upgrade to Log4j 2.9.0 {pull}26450[#26450] (issue: {issue}23798[#23798])
+
+[[release-notes-6.0.0-beta2]]
+== {es} version 6.0.0-beta2
+
+[float]
+[[breaking-6.0.0-beta2]]
+=== Breaking Changes
+
+Analysis::
+* Do not allow custom analyzers to have the same names as built-in analyzers {pull}22349[#22349] (issue: {issue}22263[#22263])
+
+Cluster::
+* Disallow : in cluster and index/alias names {pull}26247[#26247] (issue: {issue}23892[#23892])
+
+Inner Hits::
+* Unfiltered nested source should keep its full path {pull}26102[#26102] (issues: {issue}18567[#18567], {issue}23090[#23090])
+
+Mapping::
+* Reject out of range numbers for float, double and half_float {pull}25826[#25826] (issue: {issue}25534[#25534])
+
+Network::
+* Remove unused Netty-related settings {pull}26161[#26161]
+
+Packaging::
+* Rename CONF_DIR to ES_PATH_CONF {pull}26197[#26197] (issue: {issue}26154[#26154])
+
+Query DSL::
+* Throw exception in scroll requests using `from` {pull}26235[#26235] (issue: {issue}9373[#9373])
+
+[float]
+=== Breaking Java Changes
+
+Aggregations::
+* Fix NPE when `values` is omitted on percentile_ranks agg {pull}26046[#26046]
+
+[float]
+=== Deprecations
+
+Machine Learning::
+* The `max_running_jobs` node property is deprecated and is replaced by 
+`xpack.ml.max_open_jobs`. See <<ml-settings>>.
+
+//[float]
+//=== New Features
+
+[float]
+=== Enhancements
+
+Aggregations::
+* Support distance units in GeoHashGrid aggregation precision {pull}26291[#26291] (issue: {issue}5042[#5042])
+* Reject multiple methods in `percentiles` aggregation {pull}26163[#26163] (issue: {issue}26095[#26095])
+* Use `global_ordinals_hash` execution mode when sorting by sub aggregations. {pull}26014[#26014] (issue: {issue}24359[#24359])
+* Add a specialized deferring collector for terms aggregator {pull}25190[#25190]
+
+Core::
+* Use Java 9 FilePermission model {pull}26302[#26302] (issue: {issue}21534[#21534])
+* Add friendlier message on bad keystore permissions {pull}26284[#26284]
+* Epoch millis and second formats accept float implicitly {pull}26119[#26119] (issue: {issue}14641[#14641])
+
+Internal::
+* Prevent cluster internal `ClusterState.Custom` impls to leak to a client {pull}26232[#26232]
+* Use holder pattern for lazy deprecation loggers {pull}26218[#26218] (issue: {issue}26210[#26210])
+* Allow `ClusterState.Custom` to be created on initial cluster states {pull}26144[#26144]
+
+Java High Level REST Client::
+* Make RestHighLevelClient Closeable and simplify its creation {pull}26180[#26180] (issue: {issue}26086[#26086])
+
+Machine Learning::
+* Added `xpack.ml.max_open_jobs` as a node attribute. See <<ml-settings>>.
+
+Mapping::
+* Loosen the restrictions on disabling _all in 6.x {pull}26259[#26259]
+
+Percolator::
+* Store the QueryBuilder's Writable representation instead of its XContent representation {pull}25456[#25456]
+* Add support for selecting percolator query candidate matches containing wildcard / prefix queries {pull}25351[#25351]
+
+Security::
+* Added the `keystore.seed` setting to create a randomly generated bootstrap
+password if an actual password is not present.
+* The `bootstrap.password` secure setting is now managed locally on each node
+and no longer updates the security index.
+* The `xpack.security.authc.token.passphrase` setting is no longer mandatory
+when using the token service. The cluster automatically generates a secure key
+on startup. See {ref}/security-settings.html[Security Settings in {es}].
+* Added reserved `kibana_dashboard_only_user` role. For more information, see
+{kibana-ref}/xpack-dashboard-only-mode.html[Kibana Dashboard Only Mode].
+
+Settings::
+* Persist created keystore on startup unless keystore is present {pull}26253[#26253] (issue: {issue}26126[#26126])
+* Settings: Add keystore.seed auto generated secure setting {pull}26149[#26149]
+* Settings: Add keystore creation to add commands {pull}26126[#26126]
+
+[float]
+=== Bug Fixes
+
+Aggregations::
+* Check bucket metric ages point to a multi bucket agg {pull}26215[#26215] (issue: {issue}25775[#25775])
+
+Allocation::
+* Fix DiskThresholdMonitor flood warning {pull}26204[#26204] (issue: {issue}26201[#26201])
+* Allow wildcards for shard IP filtering {pull}26187[#26187] (issues: {issue}22591[#22591], {issue}26184[#26184])
+
+CRUD::
+* Serialize and expose timeout of acknowledged requests in REST layer {pull}26189[#26189] (issue: {issue}26213[#26213])
+* Fix silent loss of last command to _bulk and _msearch due to missing newline {pull}25740[#25740] (issue: {issue}7601[#7601])
+
+Cluster::
+* Register setting `cluster.indices.tombstones.size` {pull}26193[#26193] (issue: {issue}26191[#26191])
+
+Highlighting::
+* Fix nested query highlighting {pull}26305[#26305] (issue: {issue}26230[#26230])
+
+Logging::
+* Allow not configure logging without config {pull}26209[#26209] (issues: {issue}20575[#20575], {issue}24076[#24076])
+
+Machine Learning::
+* Fixed calculation of bucket count and empty bucket count statistics.
+
+Mapping::
+* ICUCollationKeywordFieldMapper use SortedSetDocValuesField {pull}26267[#26267]
+* Fix serialization of the `_all` field. {pull}26143[#26143] (issue: {issue}26136[#26136])
+
+Network::
+* Release pipelined http responses on close {pull}26226[#26226]
+
+Packaging::
+* Detect modified keystore on package removal {pull}26300[#26300]
+* Create keystore on RPM and Debian package install {pull}26282[#26282]
+* Add safer empty variable checking for Windows {pull}26268[#26268] (issue: {issue}26261[#26261])
+* Export HOSTNAME environment variable {pull}26262[#26262] (issues: {issue}25807[#25807], {issue}26255[#26255])
+* Fix daemonization command status test {pull}26196[#26196] (issue: {issue}26080[#26080])
+* Set RuntimeDirectory in systemd service {pull}23526[#23526]
+
+Search::
+* Refactor simple_query_string to handle text part like multi_match and query_string {pull}26145[#26145] (issue: {issue}25726[#25726])
+* Fix `_exists_` in query_string on empty indices. {pull}25993[#25993] (issue: {issue}25956[#25956])
+
+Security::
+* The `xpack.security.authc.token.enabled` setting now defaults to true when
+HTTPS is enabled. See <<token-service-settings>>.
+* Improved the safety of file updates in the `x-pack/users` tool.
+* Bootstrap checks no longer fail when checking secure settings.
+* The `setup-password` tool no longer fails when using a default
+`elasticsearch.yml` configuration file.
+* Fixed validation of the input parameters in the
+<<security-api-tokens,create token API>>.
+
+Watcher::
+* Ensured that a watch can be activated and deactivated during execution.
+* Ensured watch execution always uses the latest watch including its latest status.
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Core::
+* Upgrade to lucene-7.0.0-snapshot-a128fcb. {pull}26090[#26090]
+
+[[release-notes-6.0.0-beta1]]
+== {es} version 6.0.0-beta1
+
+[float]
+[[breaking-6.0.0-beta1]]
+=== Breaking Changes
+
+Aggregations::
+* Change parsing of numeric `to` and `from` parameters in `date_range` aggregation {pull}25376[#25376] (issue: {issue}17920[#17920])
+
+Aliases::
+* Wrong behavior deleting alias {pull}23997[#23997] (issues: {issue}10106[#10106], {issue}23960[#23960])
+
+Highlighting::
+* Remove the postings highlighter and make unified the default highlighter choice {pull}25028[#25028]
+
+Index APIs::
+* Remove (deprecated) support for '+' in index expressions {pull}25274[#25274] (issue: {issue}24515[#24515])
+* Delete index API to work only against concrete indices {pull}25268[#25268] (issues: {issue}2318[#2318], {issue}23997[#23997])
+
+Indexed Scripts/Templates::
+* Scripting: Remove search template actions {pull}25717[#25717]
+
+Ingest::
+* update ingest-user-agent regexes.yml {pull}25608[#25608]
+* remove ingest.new_date_format {pull}25583[#25583]
+
+Java REST Client::
+* Remove deprecated created and found from index, delete and bulk {pull}25516[#25516] (issues: {issue}19566[#19566], {issue}19630[#19630], {issue}19633[#19633])
+
+Packaging::
+* Remove support for ES_INCLUDE {pull}25804[#25804]
+* Setup: Change default heap to 1G {pull}25695[#25695]
+* Use config directory to find jvm.options {pull}25679[#25679] (issue: {issue}23004[#23004])
+* Remove implicit 32-bit support {pull}25435[#25435]
+* Remove default path settings {pull}25408[#25408] (issue: {issue}25357[#25357])
+* Remove path.conf setting {pull}25392[#25392] (issue: {issue}25357[#25357])
+* Honor masking of systemd-sysctl.service {pull}24234[#24234] (issues: {issue}21899[#21899], {issue}806[#806])
+
+Plugin Analysis ICU::
+* Upgrade icu4j for the ICU analysis plugin to 59.1 {pull}25243[#25243] (issue: {issue}21425[#21425])
+
+Plugin Discovery Azure Classic::
+* Remove `discovery.type` BWC layer from the EC2/Azure/GCE plugins {pull}25080[#25080] (issue: {issue}24543[#24543])
+
+Plugin Repository GCS::
+* GCS Repository: Remove specifying credential file on disk {pull}24727[#24727]
+
+Plugins::
+* Make plugin loading stricter {pull}25405[#25405]
+
+Query DSL::
+* Refactor QueryStringQuery for 6.0 {pull}25646[#25646] (issue: {issue}25574[#25574])
+* Change `split_on_whitespace` default to false {pull}25570[#25570] (issue: {issue}25470[#25470])
+* Remove deprecated template query {pull}24577[#24577] (issue: {issue}19390[#19390])
+
+REST::
+* IndexClosedException to return 400 rather than 403 {pull}25752[#25752]
+* Remove comma-separated feature parsing for GetIndicesAction {pull}24723[#24723] (issue: {issue}24437[#24437])
+* Improve REST error handling when endpoint does not support HTTP verb, add OPTIONS support {pull}24437[#24437] (issues: {issue}0[#0], {issue}15335[#15335], {issue}17916[#17916])
+
+Scripting::
+* remove lang url parameter from stored script requests {pull}25779[#25779] (issue: {issue}22887[#22887])
+* Disallow lang to be used with Stored Scripts {pull}25610[#25610]
+* Remove Deprecated Script Settings {pull}24756[#24756] (issue: {issue}24532[#24532])
+* Scripting: Remove native scripts {pull}24726[#24726] (issue: {issue}19966[#19966])
+* Scripting: Remove file scripts {pull}24627[#24627] (issue: {issue}21798[#21798])
+
+Search::
+* Make `index` in TermsLookup mandatory {pull}25753[#25753] (issue: {issue}25750[#25750])
+* Removes FieldStats API {pull}25628[#25628] (issue: {issue}25577[#25577])
+* Remove deprecated fielddata_fields from search request {pull}25566[#25566] (issue: {issue}25537[#25537])
+* Removes deprecated fielddata_fields {pull}25537[#25537] (issue: {issue}19027[#19027])
+
+Security::
+* A new bootstrap check enforces that TLS/SSL is required for inter-node
+communication when running in
+{ref}/bootstrap-checks.html#_development_vs_production_mode[production mode]. See
+{stack-ov}/encrypting-communications.html[Encrypting Communications].
+* A new bootstrap check enforces that HTTPS is used by the built-in token
+service when running in
+{ref}/bootstrap-checks.html#_development_vs_production_mode[production mode].
+To disable the token service, set `xpack.security.authc.token.enabled`
+to `false` in your `elasticsearch.yml`. See
+<<token-service-settings>>.
+
+Settings::
+* Settings: Remove shared setting property {pull}24728[#24728]
+* Settings: Remove support for yaml and json config files {pull}24664[#24664] (issue: {issue}19391[#19391])
+
+Similarities::
+* Similarity should accept dynamic settings when possible {pull}20339[#20339] (issue: {issue}6727[#6727])
+
+[float]
+=== Breaking Java Changes
+
+Aggregations::
+* Remove the unused SignificantTerms.compareTerm() method {pull}24714[#24714]
+* Make SignificantTerms.Bucket an interface rather than an abstract class {pull}24670[#24670] (issue: {issue}24492[#24492])
+
+Internal::
+* Collapses package structure for some bucket aggs {pull}25579[#25579] (issue: {issue}22868[#22868])
+
+Java API::
+* Remove deprecated IdsQueryBuilder ctor {pull}25529[#25529]
+* Removing unneeded getTookInMillis method {pull}23923[#23923]
+
+Java High Level REST Client::
+* Unify the result interfaces from get and search in Java client {pull}25361[#25361] (issue: {issue}16440[#16440])
+* Allow RestHighLevelClient to use plugins {pull}25024[#25024]
+
+Java REST Client::
+* Rename client artifacts {pull}25693[#25693] (issue: {issue}20248[#20248])
+
+Plugin Delete By Query::
+* Move DeleteByQuery and Reindex requests into core {pull}24578[#24578]
+
+Query DSL::
+* Remove QueryParseContext {pull}25486[#25486]
+* Remove QueryParseContext from parsing QueryBuilders {pull}25448[#25448]
+
+REST::
+* Return index name and empty map for /`{index}`/_alias with no aliases {pull}25114[#25114] (issues: {issue}24723[#24723], {issue}25090[#25090])
+
+[float]
+=== Deprecations
+
+Index APIs::
+* Deprecated use of + in index expressions {pull}24585[#24585] (issue: {issue}24515[#24515])
+
+Indexed Scripts/Templates::
+* Scripting: Deprecate stored search template apis {pull}25437[#25437] (issue: {issue}24596[#24596])
+
+Percolator::
+* Deprecate percolate query's document_type parameter. {pull}25199[#25199]
+
+Scripting::
+* Scripting: Change keys for inline/stored scripts to source/id {pull}25127[#25127]
+* Scripting: Deprecate native scripts {pull}24692[#24692] (issue: {issue}19966[#19966])
+* Scripting: Deprecate index lookup {pull}24691[#24691] (issue: {issue}19359[#19359])
+* Deprecate Fine Grain Settings for Scripts {pull}24573[#24573] (issue: {issue}24532[#24532])
+* Scripting: Deprecate file script settings {pull}24555[#24555] (issue: {issue}21798[#21798])
+* Scripting: Deprecate file scripts {pull}24552[#24552] (issue: {issue}21798[#21798])
+
+Settings::
+* Settings: Update settings deprecation from yml to yaml {pull}24663[#24663] (issue: {issue}19391[#19391])
+
+Tribe Node::
+* Deprecate tribe service {pull}24598[#24598] (issue: {issue}24581[#24581])
+
+[float]
+=== New Features
+
+Analysis::
+* Expose simplepattern and simplepatternsplit tokenizers {pull}25159[#25159] (issue: {issue}23363[#23363])
+* Parse synonyms with the same analysis chain {pull}8049[#8049] (issue: {issue}7199[#7199])
+
+Parent/Child::
+* Move parent_id query to the parent-join module {pull}25072[#25072] (issue: {issue}20257[#20257])
+* Introduce ParentJoinFieldMapper, a field mapper that creates parent/child relation within documents of the same index {pull}24978[#24978] (issue: {issue}20257[#20257])
+
+Search::
+* Automatically early terminate search query based on index sorting {pull}24864[#24864] (issue: {issue}6720[#6720])
+
+Sequence IDs::
+* Add a scheduled translog retention check {pull}25622[#25622] (issues: {issue}10708[#10708], {issue}25294[#25294])
+* Initialize sequence numbers on a shrunken index {pull}25321[#25321] (issue: {issue}10708[#10708])
+* Initialize primary term for shrunk indices {pull}25307[#25307] (issue: {issue}10708[#10708])
+* Introduce translog size and age based retention policies {pull}25147[#25147] (issue: {issue}10708[#10708])
+
+Stats::
+* Adds nodes usage API to monitor usages of actions {pull}24169[#24169]
+
+Task Manager::
+* Task Management {pull}15117[#15117]
+
+Upgrade API::
+* TemplateUpgraders should be called during rolling restart {pull}25263[#25263] (issues: {issue}24379[#24379], {issue}24680[#24680])
+
+[float]
+=== Enhancements
+
+Aggregations::
+* Add strict parsing of aggregation ranges {pull}25769[#25769]
+* Adds rewrite phase to aggregations {pull}25495[#25495] (issue: {issue}17676[#17676])
+* Tweak AggregatorBase.addRequestCircuitBreakerBytes {pull}25162[#25162] (issue: {issue}24511[#24511])
+* Add superset size to Significant Term REST response {pull}24865[#24865]
+* Add document count to Matrix Stats aggregation response {pull}24776[#24776]
+* Adds an implementation of LogLogBeta for the cardinality aggregation {pull}22323[#22323] (issue: {issue}22230[#22230])
+
+Allocation::
+* Adjust status on bad allocation explain requests {pull}25503[#25503] (issue: {issue}25458[#25458])
+* Promote replica on the highest version node {pull}25277[#25277] (issue: {issue}10708[#10708])
+
+Analysis::
+* [Analysis] Support normalizer in request param {pull}24767[#24767] (issue: {issue}23347[#23347])
+* Enforce validation for PathHierarchy tokenizer {pull}23510[#23510]
+* [analysis-icu] Allow setting unicodeSetFilter {pull}20814[#20814] (issue: {issue}20820[#20820])
+
+CAT API::
+* expand `/_cat/nodes` to return information about hard drive {pull}21775[#21775] (issue: {issue}21679[#21679])
+
+Cluster::
+* Validate a joining node's version with version of existing cluster nodes {pull}25808[#25808]
+* Switch indices read-only if a node runs out of disk space {pull}25541[#25541] (issue: {issue}24299[#24299])
+* Add a cluster block that allows to delete indices that are read-only {pull}24678[#24678]
+
+Core::
+* Add max file size bootstrap check {pull}25974[#25974]
+* Add compatibility versions to main action response {pull}25799[#25799]
+* Index ids in binary form. {pull}25352[#25352] (issues: {issue}18154[#18154], {issue}24615[#24615])
+* Explicitly reject duplicate data paths {pull}25178[#25178]
+* Use SPI in High Level Rest Client to load XContent parsers {pull}25097[#25097]
+* Upgrade to lucene-7.0.0-snapshot-a0aef2f {pull}24775[#24775]
+* Speed up PK lookups at index time. {pull}19856[#19856]
+
+Engine::
+* Add refresh stats tracking for realtime get {pull}25052[#25052] (issue: {issue}24806[#24806])
+* Introducing a translog deletion policy {pull}24950[#24950]
+
+Exceptions::
+* IllegalStateException: Only duplicated jar instead of classpath {pull}24953[#24953]
+
+Highlighting::
+* Picks offset source for the unified highlighter directly from the es mapping {pull}25747[#25747] (issue: {issue}25699[#25699])
+
+Index APIs::
+* Let primary own its replication group {pull}25692[#25692] (issue: {issue}25485[#25485])
+* Create index request should return the index name {pull}25139[#25139] (issue: {issue}23044[#23044])
+
+Ingest::
+* Add Ingest-Processor specific Rest Endpoints & Add Grok endpoint {pull}25059[#25059] (issue: {issue}24725[#24725])
+* Port support for commercial GeoIP2 databases from Logstash. {pull}24889[#24889]
+* add `exclude_keys` option to KeyValueProcessor {pull}24876[#24876] (issue: {issue}23856[#23856])
+* Allow removing multiple fields in ingest processor {pull}24750[#24750] (issue: {issue}24622[#24622])
+* Add target_field parameter to ingest processors {pull}24133[#24133] (issues: {issue}23228[#23228], {issue}23682[#23682])
+
+Inner Hits::
+* Reuse inner hit query weight {pull}24571[#24571] (issue: {issue}23917[#23917])
+
+Internal::
+* Cleanup IndexFieldData visibility {pull}25900[#25900]
+* Bump the min compat version to 5.6.0 {pull}25805[#25805]
+* "shard started" should show index and shard ID {pull}25157[#25157]
+* Break out clear scroll logic from TransportClearScrollAction {pull}25125[#25125] (issue: {issue}25094[#25094])
+* Add helper methods to TransportActionProxy to identify proxy actions and requests {pull}25124[#25124]
+* Add remote cluster infrastructure to fetch discovery nodes. {pull}25123[#25123] (issue: {issue}25094[#25094])
+* Add the ability to set eager_global_ordinals in the new parent-join field {pull}25019[#25019]
+* Disallow multiple parent-join fields per mapping {pull}25002[#25002]
+* Remove the need for _UNRELEASED suffix in versions {pull}24798[#24798] (issue: {issue}24768[#24768])
+* Optimize the order of bytes in uuids for better compression. {pull}24615[#24615] (issue: {issue}18209[#18209])
+
+Java API::
+* Always Accumulate Transport Exceptions {pull}25017[#25017] (issue: {issue}23099[#23099])
+
+Java High Level REST Client::
+* [DOCS] restructure java clients docs pages {pull}25517[#25517]
+* Use SPI in High Level Rest Client to load XContent parsers {pull}25098[#25098] (issues: {issue}25024[#25024], {issue}25097[#25097])
+* Add support for clear scroll to high level REST client {pull}25038[#25038]
+* Add search scroll method to high level REST client {pull}24938[#24938] (issue: {issue}23331[#23331])
+* Add search method to high level REST client {pull}24796[#24796] (issues: {issue}24794[#24794], {issue}24795[#24795])
+
+Java REST Client::
+* Shade external dependencies in the rest client jar {pull}25780[#25780] (issue: {issue}25208[#25208])
+* RestClient uses system properties and system default SSLContext {pull}25757[#25757] (issue: {issue}23231[#23231])
+
+Logging::
+* Prevent excessive disk consumption by log files {pull}25660[#25660]
+* Use LRU set to reduce repeat deprecation messages {pull}25474[#25474] (issue: {issue}25457[#25457])
+
+Mapping::
+* Better validation of `copy_to`. {pull}25983[#25983]
+* Optimize `terms` queries on `ip` addresses to use a `PointInSetQuery` whenever possible. {pull}25669[#25669] (issue: {issue}25667[#25667])
+
+Network::
+* Move TransportStats accounting into TcpTransport {pull}25251[#25251]
+* Simplify connection closing and cleanups in TcpTransport {pull}25250[#25250]
+* Disable the Netty recycler in the client {pull}24793[#24793] (issues: {issue}22452[#22452], {issue}24721[#24721])
+* Remove Netty logging hack {pull}24653[#24653] (issues: {issue}24469[#24469], {issue}5624[#5624], {issue}6568[#6568], {issue}6696[#6696])
+
+Packaging::
+* Remove memlock suggestion from systemd service {pull}25979[#25979]
+* Set address space limit in systemd service file {pull}25975[#25975]
+* Version option should display if snapshot {pull}25970[#25970]
+* Ignore JVM options before checking Java version {pull}25969[#25969]
+* Also skip JAVA_TOOL_OPTIONS on Windows {pull}25968[#25968]
+* Introduce elasticsearch-env for Windows {pull}25958[#25958]
+* Introduce elasticsearch-env {pull}25815[#25815] (issue: {issue}20286[#20286])
+* Stop exporting HOSTNAME from scripts {pull}25807[#25807]
+
+Parent/Child::
+* Remove ParentJoinFieldSubFetchPhase {pull}25550[#25550] (issue: {issue}25363[#25363])
+* Support parent id being specified as number in the _source {pull}25547[#25547]
+
+Plugin Lang Painless::
+* Allow Custom Whitelists in Painless {pull}25557[#25557]
+* Update Painless to Allow Augmentation from Any Class {pull}25360[#25360]
+* Add Needs Methods to Painless Script Context Factories {pull}25267[#25267]
+* Support Script Context Stateful Factory in Painless {pull}25233[#25233]
+* Generate Painless Factory for Creating Script Instances {pull}25120[#25120]
+* Update Painless to Use New Script Contexts {pull}25015[#25015]
+* Optimize instance creation in LambdaBootstrap {pull}24618[#24618]
+
+Plugin Repository GCS::
+* GCS Repository: Add secure storage of credentials {pull}24697[#24697]
+
+Plugin Repository S3::
+* S3 Repository: Add back repository level credentials {pull}24609[#24609]
+
+Plugins::
+* Move tribe to a module {pull}25778[#25778]
+* Plugins can register pre-configured char filters {pull}25000[#25000] (issue: {issue}23658[#23658])
+* Add purge option to remove plugin CLI {pull}24981[#24981]
+* Allow plugins to register pre-configured tokenizers {pull}24751[#24751] (issues: {issue}24223[#24223], {issue}24572[#24572])
+* Move ReindexAction class to core {pull}24684[#24684] (issue: {issue}24578[#24578])
+* Make PreConfiguredTokenFilter harder to misuse {pull}24572[#24572] (issue: {issue}23658[#23658])
+
+Query DSL::
+* Make slop optional when parsing `span_near` query {pull}25677[#25677] (issue: {issue}25642[#25642])
+* Require a field when a `seed` is provided to the `random_score` function. {pull}25594[#25594] (issue: {issue}25240[#25240])
+
+REST::
+* Refactor PathTrie and RestController to use a single trie for all methods {pull}25459[#25459] (issue: {issue}24437[#24437])
+* Make ObjectParser support string to boolean conversion {pull}24668[#24668] (issue: {issue}21802[#21802])
+
+Recovery::
+* Goodbye, Translog Views {pull}25962[#25962]
+* Disallow multiple concurrent recovery attempts for same target shard {pull}25428[#25428]
+* Live primary-replica resync (no rollback) {pull}24841[#24841] (issue: {issue}10708[#10708])
+
+Scripting::
+* Scripting: Rename SearchScript.needsScores to needs_score {pull}25235[#25235]
+* Scripting: Add optional context parameter to put stored script requests {pull}25014[#25014]
+* Add New Security Script Settings {pull}24637[#24637] (issue: {issue}24532[#24532])
+
+Search::
+* Rewrite search requests on the coordinating nodes {pull}25814[#25814] (issue: {issue}25791[#25791])
+* Ensure query resources are fetched asynchronously during rewrite {pull}25791[#25791]
+* Introduce a new Rewriteable interface to streamline rewriting {pull}25788[#25788]
+* Reduce the scope of `QueryRewriteContext` {pull}25787[#25787]
+* Reduce the overhead of timeouts and low-level search cancellation. {pull}25776[#25776]
+* Reduce profiling overhead. {pull}25772[#25772] (issue: {issue}24799[#24799])
+* Prevent `can_match` requests from sending to incompatible nodes {pull}25705[#25705] (issue: {issue}25704[#25704])
+* Add a shard filter search phase to pre-filter shards based on query rewriting {pull}25658[#25658]
+* Ensure we rewrite common queries to `match_none` if possible {pull}25650[#25650]
+* Limit the number of concurrent shard requests per search request {pull}25632[#25632]
+* Add cluster name validation to RemoteClusterConnection {pull}25568[#25568]
+* Speed up sorted scroll when the index sort matches the search sort {pull}25138[#25138] (issue: {issue}6720[#6720])
+* Leverage scorerSupplier when applicable. {pull}25109[#25109]
+* Add Cross Cluster Search support for scroll searches {pull}25094[#25094]
+* Track EWMA[1] of task execution time in search threadpool executor {pull}24989[#24989] (issue: {issue}24915[#24915])
+* Query range fields by doc values when they are expected to be more efficient than points {pull}24823[#24823] (issue: {issue}24314[#24314])
+* Search: Fairer balancing when routing searches by session ID {pull}24671[#24671] (issue: {issue}24642[#24642])
+
+Sequence IDs::
+* Move primary term from ReplicationRequest to ConcreteShardRequest {pull}25822[#25822]
+* Add reason to global checkpoint updates on replica {pull}25612[#25612] (issue: {issue}10708[#10708])
+* Introduce primary/replica mode for GlobalCheckPointTracker {pull}25468[#25468]
+* Throw back replica local checkpoint on new primary {pull}25452[#25452] (issues: {issue}10708[#10708], {issue}25355[#25355])
+* Update global checkpoint when increasing primary term on replica {pull}25422[#25422] (issues: {issue}10708[#10708], {issue}25355[#25355])
+* Enable a long translog retention policy by default {pull}25294[#25294] (issues: {issue}10708[#10708], {issue}25147[#25147])
+* Introduce primary context {pull}25122[#25122] (issues: {issue}10708[#10708], {issue}25355[#25355])
+* Block older operations on primary term transition {pull}24779[#24779] (issue: {issue}10708[#10708])
+
+Settings::
+* Add disk threshold settings validation {pull}25600[#25600] (issue: {issue}25560[#25560])
+* Enable cross-setting validation {pull}25560[#25560] (issue: {issue}25541[#25541])
+* Validate `transport.profiles.*` settings {pull}25508[#25508]
+* Cleanup network / transport related settings {pull}25489[#25489]
+* Emit settings deprecation logging at most once {pull}25457[#25457]
+* IndexMetaData: Introduce internal format index setting {pull}25292[#25292]
+
+Snapshot/Restore::
+* Improves snapshot logging and snapshot deletion error handling {pull}25264[#25264]
+
+Stats::
+* Update `IndexShard#refreshMetric` via a `ReferenceManager.RefreshListener` {pull}25083[#25083] (issues: {issue}24806[#24806], {issue}25052[#25052])
+
+Translog::
+* Translog file recovery should not rely on lucene commits {pull}25005[#25005] (issue: {issue}24950[#24950])
+
+[float]
+=== Bug Fixes
+
+Aggregations::
+* Fixes array out of bounds for value count agg {pull}26038[#26038] (issue: {issue}17379[#17379])
+* Aggregations bug: Significant_text fails on arrays of text. {pull}25030[#25030] (issue: {issue}25029[#25029])
+
+Aliases::
+* mget with an alias shouldn't ignore alias routing {pull}25697[#25697] (issue: {issue}25696[#25696])
+* GET aliases should 404 if aliases are missing {pull}25043[#25043] (issue: {issue}24644[#24644])
+
+Analysis::
+* Pre-configured shingle filter should disable graph analysis {pull}25853[#25853] (issue: {issue}25555[#25555])
+
+Circuit Breakers::
+* Checks the circuit breaker before allocating bytes for a new big array {pull}25010[#25010] (issue: {issue}24790[#24790])
+
+Core::
+* Release operation permit on thread-pool rejection {pull}25930[#25930] (issue: {issue}25863[#25863])
+* Node should start up despite of a lingering `.es_temp_file` {pull}21210[#21210] (issue: {issue}21007[#21007])
+
+Discovery::
+* MasterNodeChangePredicate should use the node instance to detect master change {pull}25877[#25877] (issue: {issue}25471[#25471])
+
+Engine::
+* Engine - do not index operations with seq# lower than the local checkpoint into lucene {pull}25827[#25827] (issues: {issue}1[#1], {issue}2[#2], {issue}25592[#25592])
+
+Geo::
+* Fix typo in GeoUtils#isValidLongitude {pull}25121[#25121]
+
+Highlighting::
+* FastVectorHighlighter should not cache the field query globally {pull}25197[#25197] (issue: {issue}25171[#25171])
+* Higlighters: Fix MultiPhrasePrefixQuery rewriting {pull}25103[#25103] (issue: {issue}25088[#25088])
+
+Index APIs::
+* Shrink API should ignore templates {pull}25380[#25380] (issue: {issue}25035[#25035])
+* Rollover max docs should only count primaries {pull}24977[#24977] (issue: {issue}24217[#24217])
+
+Ingest::
+* Sort Processor does not have proper behavior with targetField {pull}25237[#25237] (issue: {issue}24133[#24133])
+* fix grok's pattern parsing to validate pattern names in expression {pull}25063[#25063] (issue: {issue}22831[#22831])
+
+Inner Hits::
+* When fetching nested inner hits only access stored fields when needed {pull}25864[#25864] (issue: {issue}6[#6])
+
+Internal::
+* Fix BytesReferenceStreamInput#skip with offset {pull}25634[#25634]
+* Fix race condition in RemoteClusterConnection node supplier {pull}25432[#25432]
+* Initialise empty lists in BaseTaskResponse constructor {pull}25290[#25290]
+* Extract a common base class for scroll executions {pull}24979[#24979] (issue: {issue}16555[#16555])
+* Obey lock order if working with store to get metadata snapshots {pull}24787[#24787] (issue: {issue}24481[#24481])
+* Fix Version based BWC and set correct minCompatVersion {pull}24732[#24732]
+* Fix `_field_caps` serialization in order to support cross cluster search {pull}24722[#24722]
+* Avoid race when shutting down controller processes {pull}24579[#24579]
+
+Mapping::
+* Fix parsing of ip range queries. {pull}25768[#25768] (issue: {issue}25636[#25636])
+* Disable date field mapping changing {pull}25285[#25285] (issue: {issue}25271[#25271])
+* Correctly enable _all for older 5.x indices {pull}25087[#25087] (issue: {issue}25068[#25068])
+* token_count datatype should handle null value {pull}25046[#25046] (issue: {issue}24928[#24928])
+* keep _parent field while updating child type mapping {pull}24407[#24407] (issue: {issue}23381[#23381])
+
+More Like This::
+* Pass over _routing value with more_like_this items to be retrieved {pull}24679[#24679] (issue: {issue}23699[#23699])
+
+Nested Docs::
+* In case of a single type the _id field should be added to the nested document instead of _uid field {pull}25149[#25149]
+
+Network::
+* Ensure pending transport handlers are invoked for all channel failures {pull}25150[#25150]
+* Notify onConnectionClosed rather than onNodeDisconnect to prune transport handlers {pull}24639[#24639] (issues: {issue}24557[#24557], {issue}24575[#24575], {issue}24632[#24632])
+
+Packaging::
+* Exit Windows scripts promptly on failure {pull}25959[#25959]
+* Pass config path as a system property {pull}25943[#25943]
+* ES_HOME needs to be made absolute before attempt at traversal {pull}25865[#25865]
+* Fix elasticsearch-keystore handling of path.conf {pull}25811[#25811]
+* Stop disabling explicit GC {pull}25759[#25759]
+* Avoid failing install if system-sysctl is masked {pull}25657[#25657] (issue: {issue}24234[#24234])
+* Get short path name for native controllers {pull}25344[#25344]
+* When stopping via systemd only kill the JVM, not its control group {pull}25195[#25195]
+* remove remaining references to scripts directory {pull}24771[#24771]
+* Handle parentheses in batch file path {pull}24731[#24731] (issue: {issue}24712[#24712])
+
+Parent/Child::
+* The default _parent field should not try to load global ordinals {pull}25851[#25851] (issue: {issue}25849[#25849])
+
+Percolator::
+* Fix range queries with date range based on current time in percolator queries. {pull}24666[#24666] (issue: {issue}23921[#23921])
+
+Plugin Lang Painless::
+* Painless: allow doubles to be casted to longs. {pull}25936[#25936]
+
+Plugin Repository Azure::
+* Make calls to CloudBlobContainer#exists privileged {pull}25937[#25937] (issue: {issue}25931[#25931])
+
+Plugin Repository GCS::
+* Ensure that gcs client creation is privileged {pull}25938[#25938] (issue: {issue}25932[#25932])
+
+Plugin Repository HDFS::
+* Upgrading HDFS Repository Plugin to use HDFS 2.8.1 Client {pull}25497[#25497] (issue: {issue}25450[#25450])
+
+Plugin Repository S3::
+* Avoid SecurityException in repository-S3 on DefaultS3OutputStream.flush() {pull}25254[#25254] (issue: {issue}25192[#25192])
+
+Plugins::
+* X-Pack plugin download fails on Windows desktop {pull}24570[#24570]
+
+Query DSL::
+* SpanNearQueryBuilder should return the inner clause when a single clause is provided {pull}25856[#25856] (issue: {issue}25630[#25630])
+* Refactor field expansion for match, multi_match and query_string query {pull}25726[#25726] (issues: {issue}25551[#25551], {issue}25556[#25556])
+* WrapperQueryBuilder should also rewrite the parsed query {pull}25480[#25480]
+
+REST::
+* Fix handling of invalid error trace parameter {pull}25785[#25785] (issue: {issue}25774[#25774])
+* Fix handling of exceptions thrown on HEAD requests {pull}25172[#25172] (issue: {issue}21125[#21125])
+* Fixed NPEs caused by requests without content. {pull}23497[#23497] (issue: {issue}24701[#24701])
+* Fix get mappings HEAD requests {pull}23192[#23192] (issue: {issue}21125[#21125])
+
+Recovery::
+* Close translog view after primary-replica resync {pull}25862[#25862] (issue: {issue}24841[#24841])
+
+Reindex API::
+* Reindex: don't duplicate _source parameter {pull}24629[#24629] (issue: {issue}24628[#24628])
+* Add qa module that tests reindex-from-remote against pre-5.0 versions of Elasticsearch {pull}24561[#24561] (issues: {issue}23828[#23828], {issue}24520[#24520])
+
+Search::
+* Caching a MinDocQuery can lead to wrong results. {pull}25909[#25909]
+* Fix random score generation when no seed is provided. {pull}25908[#25908]
+* Merge FunctionScoreQuery and FiltersFunctionScoreQuery {pull}25889[#25889] (issues: {issue}15709[#15709], {issue}23628[#23628])
+* Respect cluster alias in `_index` aggs and queries {pull}25885[#25885] (issue: {issue}25606[#25606])
+* First increment shard stats before notifying and potentially sending response {pull}25818[#25818]
+* Remove assertion about deviation when casting to a float. {pull}25806[#25806] (issue: {issue}25330[#25330])
+* Prevent skipping shards if a suggest builder is present {pull}25739[#25739] (issue: {issue}25658[#25658])
+* Ensure remote cluster alias is preserved in inner hits aggs {pull}25627[#25627] (issue: {issue}25606[#25606])
+* Do not search locally if remote index pattern resolves to no indices {pull}25436[#25436] (issue: {issue}25426[#25426])
+* Adds check for negative search request size {pull}25397[#25397] (issue: {issue}22530[#22530])
+* Make sure range queries are correctly profiled. {pull}25108[#25108]
+* Fix RangeFieldMapper rangeQuery to properly handle relations {pull}24808[#24808] (issue: {issue}24744[#24744])
+* Fix ExpandSearchPhase when response contains no hits {pull}24688[#24688] (issue: {issue}24672[#24672])
+
+Sequence IDs::
+* Fix pre-6.0 response to unknown replication actions {pull}25744[#25744] (issue: {issue}10708[#10708])
+* Track local checkpoint on primary immediately {pull}25434[#25434] (issues: {issue}10708[#10708], {issue}25355[#25355], {issue}25415[#25415])
+* Initialize max unsafe auto ID timestamp on shrink {pull}25356[#25356] (issues: {issue}10708[#10708], {issue}25355[#25355])
+* Use correct primary term for replicating NOOPs {pull}25128[#25128]
+* Handle already closed while filling gaps {pull}25021[#25021] (issue: {issue}24925[#24925])
+
+Settings::
+* Fix settings serialization to not serialize secure settings or not take the total size into account {pull}25323[#25323]
+* Keystore CLI should use the AddFileKeyStoreCommand for files {pull}25298[#25298]
+* Allow resetting settings that use an IP validator {pull}24713[#24713] (issue: {issue}24709[#24709])
+
+Snapshot/Restore::
+* Snapshot/Restore: Ensure that shard failure reasons are correctly stored in CS {pull}25941[#25941] (issue: {issue}25878[#25878])
+* Output all empty snapshot info fields if in verbose mode {pull}25455[#25455] (issue: {issue}24477[#24477])
+* Remove redundant and broken MD5 checksum from repository-s3 {pull}25270[#25270] (issue: {issue}25269[#25269])
+* Consolidates the logic for cleaning up snapshots on master election {pull}24894[#24894] (issue: {issue}24605[#24605])
+* Removes completed snapshot from cluster state on master change {pull}24605[#24605] (issue: {issue}24452[#24452])
+
+Stats::
+* _nodes/stats should not fail due to concurrent AlreadyClosedException {pull}25016[#25016] (issue: {issue}23099[#23099])
+
+Suggesters::
+* Context suggester should filter doc values field {pull}25858[#25858] (issue: {issue}25404[#25404])
+
+[float]
+=== Regressions
+
+Highlighting::
+* Fix Fast Vector Highlighter NPE on match phrase prefix {pull}25116[#25116] (issue: {issue}25088[#25088])
+
+Search::
+* Always use DisjunctionMaxQuery to build cross fields disjunction {pull}25115[#25115] (issue: {issue}23966[#23966])
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Network::
+* Upgrade to Netty 4.1.13.Final {pull}25581[#25581] (issues: {issue}24729[#24729], {issue}6866[#6866])
+* Upgrade to Netty 4.1.11.Final {pull}24652[#24652]
+
+Upgrade API::
+* Improve stability and logging of TemplateUpgradeServiceIT tests {pull}25386[#25386] (issue: {issue}25382[#25382])
+
+[[release-notes-6.0.0-alpha2]]
+== {es} version 6.0.0-alpha2
+
+[float]
+[[breaking-6.0.0-alpha2]]
+=== Breaking Changes
+
+CRUD::
+* Deleting a document from a non-existing index creates the indexIf the index does not exist, delete document will not auto create it {pull}24518[#24518] (issue: {issue}15425[#15425])
+
+Plugin Analysis ICU::
+* Upgrade icu4j to latest version {pull}24821[#24821]
+
+Plugin Repository S3::
+* Remove deprecated S3 settings {pull}24445[#24445]
+
+Scripting::
+* Remove script access to term statistics {pull}19462[#19462] (issue: {issue}19359[#19359])
+
+Watcher::
+* The watch `_status` field has been renamed to `status`, as underscores in
+field names will not be allowed.
+
+[float]
+=== Breaking Java Changes
+
+Aggregations::
+* Make Terms.Bucket an interface rather than an abstract class {pull}24492[#24492]
+* Compound order for histogram aggregations  {pull}22343[#22343] (issues: {issue}14771[#14771], {issue}20003[#20003], {issue}23613[#23613])
+
+Plugins::
+* Drop name from TokenizerFactory {pull}24869[#24869]
+
+[float]
+=== Deprecations
+
+Settings::
+* Deprecate settings in .yml and .json {pull}24059[#24059] (issue: {issue}19391[#19391])
+
+[float]
+=== New Features
+
+Aggregations::
+* SignificantText aggregation - like significant_terms, but for text {pull}24432[#24432] (issue: {issue}23674[#23674])
+
+Internal::
+* Automatically adjust search threadpool queue_size {pull}23884[#23884] (issue: {issue}3890[#3890])
+
+Mapping::
+* Add new ip_range field type {pull}24433[#24433]
+
+Plugin Analysis ICU::
+* Add ICUCollationFieldMapper {pull}24126[#24126]
+
+[float]
+=== Enhancements
+
+Core::
+* Improve bootstrap checks error messages {pull}24548[#24548]
+
+Engine::
+* Move the IndexDeletionPolicy to be engine internal {pull}24930[#24930] (issue: {issue}10708[#10708])
+
+Internal::
+* Add assertions enabled helper {pull}24834[#24834]
+
+Java High Level REST Client::
+* Add doc_count to ParsedMatrixStats {pull}24952[#24952] (issue: {issue}24776[#24776])
+* Add fromXContent method to ClearScrollResponse {pull}24909[#24909]
+* ClearScrollRequest to implement ToXContentObject {pull}24907[#24907]
+* SearchScrollRequest to implement ToXContentObject {pull}24906[#24906] (issue: {issue}3889[#3889])
+* Add aggs parsers for high level REST Client {pull}24824[#24824] (issues: {issue}23965[#23965], {issue}23973[#23973], {issue}23974[#23974], {issue}24085[#24085], {issue}24160[#24160], {issue}24162[#24162], {issue}24182[#24182], {issue}24183[#24183], {issue}24208[#24208], {issue}24213[#24213], {issue}24239[#24239], {issue}24284[#24284], {issue}24312[#24312], {issue}24330[#24330], {issue}24365[#24365], {issue}24371[#24371], {issue}24442[#24442], {issue}24521[#24521], {issue}24524[#24524], {issue}24564[#24564], {issue}24583[#24583], {issue}24589[#24589], {issue}24648[#24648], {issue}24667[#24667], {issue}24675[#24675], {issue}24682[#24682], {issue}24700[#24700], {issue}24706[#24706], {issue}24717[#24717], {issue}24720[#24720], {issue}24738[#24738], {issue}24746[#24746], {issue}24789[#24789], {issue}24791[#24791], {issue}24794[#24794], {issue}24796[#24796], {issue}24822[#24822])
+
+Mapping::
+* Identify documents by their `_id`. {pull}24460[#24460]
+
+Packaging::
+* Set number of processes in systemd unit file {pull}24970[#24970] (issue: {issue}20874[#20874])
+
+Plugin Lang Painless::
+* Make Painless Compiler Use an Instance Per Context {pull}24972[#24972]
+* Make PainlessScript An Interface {pull}24966[#24966]
+
+Recovery::
+* Introduce primary context {pull}25031[#25031] (issue: {issue}10708[#10708])
+
+Scripting::
+* Add StatefulFactoryType as optional intermediate factory in script contexts {pull}24974[#24974] (issue: {issue}20426[#20426])
+* Make contexts available to ScriptEngine construction {pull}24896[#24896]
+* Make ScriptEngine.compile generic on the script context {pull}24873[#24873]
+* Add instance and compiled classes to script contexts {pull}24868[#24868]
+
+Search::
+* Eliminate array access in tight loops when profiling is enabled. {pull}24959[#24959]
+* Support Multiple Inner Hits on a Field Collapse Request {pull}24517[#24517]
+* Expand cross cluster search indices for search requests to the concrete index or to it's aliases {pull}24502[#24502]
+
+Search Templates::
+* Add max concurrent searches to multi template search {pull}24255[#24255] (issues: {issue}20912[#20912], {issue}21907[#21907])
+
+Security::
+* Adapted indices resolution to use new `ignoreAliases` index option.
+* Added the `logstash_admin` role, which provides access
+to `.logstash-*` indices for managing configurations.
+
+Sequence IDs::
+* Fill gaps on primary promotion {pull}24945[#24945] (issue: {issue}10708[#10708])
+* Introduce clean transition on primary promotion {pull}24925[#24925] (issue: {issue}10708[#10708])
+* Guarantee that translog generations are seqNo conflict free {pull}24825[#24825] (issues: {issue}10708[#10708], {issue}24779[#24779])
+* Inline global checkpoints {pull}24513[#24513] (issue: {issue}10708[#10708])
+
+Snapshot/Restore::
+* Enhances get snapshots API to allow retrieving repository index only {pull}24477[#24477] (issue: {issue}24288[#24288])
+
+Watcher::
+* Watcher indices no longer use multiple types.
+
+[float]
+=== Bug Fixes
+
+Aggregations::
+* Terms aggregation should remap global ordinal buckets when a sub-aggregator is used to sort the terms {pull}24941[#24941] (issue: {issue}24788[#24788])
+* Correctly set doc_count when MovAvg "predicts" values on existing buckets {pull}24892[#24892] (issue: {issue}24327[#24327])
+* DateHistogram: Fix `extended_bounds` with `offset` {pull}23789[#23789] (issue: {issue}23776[#23776])
+* Fix ArrayIndexOutOfBoundsException when no ranges are specified in the query {pull}23241[#23241] (issue: {issue}22881[#22881])
+
+Analysis::
+* PatternAnalyzer should lowercase wildcard queries when `lowercase` is true. {pull}24967[#24967]
+
+Cache::
+* fix bug of weight computation {pull}24856[#24856]
+
+Core::
+* Fix cache expire after access {pull}24546[#24546]
+
+Graph::
+* Reinstated `_xpack/graph/_explore` as the correct graph endpoint.
+`_xpack/_graph/_explore` is deprecated and will be removed in v7.0.
+
+Index APIs::
+* Validates updated settings on closed indices {pull}24487[#24487] (issue: {issue}23787[#23787])
+
+Ingest::
+* Fix floating-point error when DateProcessor parses UNIX {pull}24947[#24947]
+* add option for _ingest.timestamp to use new ZonedDateTime (5.x backport) {pull}24030[#24030] (issues: {issue}23168[#23168], {issue}23174[#23174])
+
+Inner Hits::
+* Fix Source filtering in new field collapsing feature {pull}24068[#24068] (issue: {issue}24063[#24063])
+
+Internal::
+* Ensure remote cluster is connected before fetching `_field_caps` {pull}24845[#24845] (issue: {issue}24763[#24763])
+
+Machine Learning::
+* If the initial cluster state update to install the Machine Learning
+Metadata fails, the update is now retried.
+
+Network::
+* Fix error message if an incompatible node connects {pull}24884[#24884]
+
+Plugins::
+* Fix plugin installation permissions {pull}24527[#24527] (issue: {issue}24480[#24480])
+
+Scroll::
+* Fix single shard scroll within a cluster with nodes in version `>= 5.3` and `<= 5.3` {pull}24512[#24512]
+
+Search::
+* Fix script field sort returning Double.MAX_VALUE for all documents {pull}24942[#24942] (issue: {issue}24940[#24940])
+* Compute the took time of the query after the expand phase of field collapsing {pull}24902[#24902] (issue: {issue}24900[#24900])
+
+Sequence IDs::
+* Handle primary failure handling replica response {pull}24926[#24926] (issue: {issue}24935[#24935])
+
+Snapshot/Restore::
+* Fix inefficient (worst case exponential) loading of snapshot repository {pull}24510[#24510] (issue: {issue}24509[#24509])
+
+Stats::
+* Avoid double decrement on current query counter {pull}24922[#24922] (issues: {issue}22996[#22996], {issue}24872[#24872])
+* Adjust available and free bytes to be non-negative on huge FSes {pull}24911[#24911] (issues: {issue}23093[#23093], {issue}24453[#24453])
+
+Suggesters::
+* Fix context suggester to read values from keyword type field {pull}24200[#24200] (issue: {issue}24129[#24129])
+
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
+[[release-notes-6.0.0-alpha1]]
+== {es} version 6.0.0-alpha1
+
+[float]
+[[breaking-6.0.0-alpha1]]
+=== Breaking Changes
+
+
+Allocation::
+* Remove `cluster.routing.allocation.snapshot.relocation_enabled` setting {pull}20994[#20994]
+
+Analysis::
+* Removing query-string parameters in `_analyze` API {pull}20704[#20704] (issue: {issue}20246[#20246])
+
+CAT API::
+* Write -1 on unbounded queue in cat thread pool {pull}21342[#21342] (issue: {issue}21187[#21187])
+
+CRUD::
+* Disallow `VersionType.FORCE` for GetRequest {pull}21079[#21079] (issue: {issue}20995[#20995])
+* Disallow `VersionType.FORCE` versioning for 6.x indices {pull}20995[#20995] (issue: {issue}20377[#20377])
+
+Cluster::
+* No longer allow cluster name in data path {pull}20433[#20433] (issue: {issue}20391[#20391])
+
+Core::
+* Simplify file store {pull}24402[#24402] (issue: {issue}24390[#24390])
+* Make boolean conversion strict {pull}22200[#22200]
+* Remove the `default` store type. {pull}21616[#21616]
+* Remove store throttling. {pull}21573[#21573]
+
+Geo::
+* Remove deprecated geo search features {pull}22876[#22876]
+* Reduce GeoDistance Insanity {pull}19846[#19846]
+
+Index APIs::
+* Open/Close index api to allow_no_indices by default {pull}24401[#24401] (issues: {issue}24031[#24031], {issue}24341[#24341])
+* Remove support for controversial `ignore_unavailable` and `allow_no_indices` from indices exists api {pull}20712[#20712]
+
+Index Templates::
+* Allows multiple patterns to be specified for index templates {pull}21009[#21009] (issue: {issue}20690[#20690])
+
+Java API::
+* Enforce Content-Type requirement on the rest layer and remove deprecated methods {pull}23146[#23146] (issue: {issue}19388[#19388])
+
+Mapping::
+* Enforce at most one type. {pull}24428[#24428] (issue: {issue}24317[#24317])
+* Disallow `include_in_all` for 6.0+ indices {pull}22970[#22970] (issue: {issue}22923[#22923])
+* Disable _all by default, disallow configuring _all on 6.0+ indices {pull}22144[#22144] (issues: {issue}19784[#19784], {issue}20925[#20925], {issue}21341[#21341])
+* Throw an exception on unrecognized "match_mapping_type" {pull}22090[#22090] (issue: {issue}17285[#17285])
+
+Network::
+* Remove blocking TCP clients and servers {pull}22639[#22639]
+* Remove `modules/transport_netty_3` in favor of `netty_4` {pull}21590[#21590]
+* Remove LocalTransport in favor of MockTcpTransport {pull}20695[#20695]
+
+Packaging::
+* Remove customization of ES_USER and ES_GROUP {pull}23989[#23989] (issue: {issue}23848[#23848])
+
+Percolator::
+* Remove deprecated percolate and mpercolate apis {pull}22331[#22331]
+
+Plugin Delete By Query::
+* Require explicit query in _delete_by_query API {pull}23632[#23632] (issue: {issue}23629[#23629])
+
+Plugin Discovery EC2::
+* Ec2 Discovery: Cleanup deprecated settings {pull}24150[#24150]
+* Discovery EC2: Remove region setting {pull}23991[#23991] (issue: {issue}22758[#22758])
+* AWS Plugins: Remove signer type setting {pull}23984[#23984] (issue: {issue}22599[#22599])
+
+Plugin Lang JS::
+* Remove lang-python and lang-javascript {pull}20734[#20734] (issue: {issue}20698[#20698])
+
+Plugin Mapper Attachment::
+* Remove mapper attachments plugin {pull}20416[#20416] (issue: {issue}18837[#18837])
+
+Plugin Repository Azure::
+* Remove global `repositories.azure` settings {pull}23262[#23262] (issues: {issue}22800[#22800], {issue}22856[#22856])
+* Remove auto creation of container for azure repository {pull}22858[#22858] (issue: {issue}22857[#22857])
+
+Plugin Repository S3::
+* S3 Repository: Cleanup deprecated settings {pull}24097[#24097]
+* S3 Repository: Remove region setting {pull}22853[#22853] (issue: {issue}22758[#22758])
+* S3 Repository: Remove bucket auto create {pull}22846[#22846] (issue: {issue}22761[#22761])
+* S3 Repository: Remove env var and sysprop credentials support {pull}22842[#22842]
+
+Query DSL::
+* Remove deprecated `minimum_number_should_match` in BoolQueryBuilder {pull}22416[#22416]
+* Remove support for empty queries {pull}22092[#22092] (issue: {issue}17624[#17624])
+* Remove deprecated query names: in, geo_bbox, mlt, fuzzy_match and match_fuzzy {pull}21852[#21852]
+* The `terms` query should always map to a Lucene `TermsQuery`. {pull}21786[#21786]
+* Be strict when parsing values searching for booleans {pull}21555[#21555] (issue: {issue}21545[#21545])
+* Remove collect payloads parameter {pull}20385[#20385]
+
+REST::
+* Remove ldjson support and document ndjson for bulk/msearch {pull}23049[#23049] (issue: {issue}23025[#23025])
+* Enable strict duplicate checks for all XContent types {pull}22225[#22225] (issues: {issue}19614[#19614], {issue}22073[#22073])
+* Enable strict duplicate checks for JSON content {pull}22073[#22073] (issue: {issue}19614[#19614])
+* Remove lenient stats parsing {pull}21417[#21417] (issues: {issue}20722[#20722], {issue}21410[#21410])
+* Remove allow unquoted JSON {pull}20388[#20388] (issues: {issue}17674[#17674], {issue}17801[#17801])
+* Remove FORCE version_type {pull}20377[#20377] (issue: {issue}19769[#19769])
+
+Scripting::
+* Make dates be ReadableDateTimes in scripts {pull}22948[#22948] (issue: {issue}22875[#22875])
+* Remove groovy scripting language {pull}21607[#21607]
+
+Search::
+* ProfileResult and CollectorResult should print machine readable timing information {pull}22561[#22561]
+* Remove indices query {pull}21837[#21837] (issue: {issue}17710[#17710])
+* Remove ignored type parameter in search_shards api {pull}21688[#21688]
+
+Security::
+* A new bootstrap check enforces that default passwords are disabled for the
+built-in users when running in
+{ref}/bootstrap-checks.html#_development_vs_production_mode[production mode].
+You must set `xpack.security.authc.accept_default_password` to `false` in your
+`elasticsearch.yml`. For more information, see <<security-settings>> and
+{stack-ov}/setting-up-authentication.html[User authentication].
+* A new configuration setting is available to disable support for the default
+password (_"changeme"_). For more information, see
+{stack-ov}/built-in-users.html#disabling-default-password[Disable default password functionality].
+
+Sequence IDs::
+* Change certain replica failures not to fail the replica shard {pull}22874[#22874] (issue: {issue}10708[#10708])
+
+Shadow Replicas::
+* Remove shadow replicas {pull}23906[#23906] (issue: {issue}22024[#22024])
+
+Watcher::
+* The built-in HTTP client used in webhooks, the http input and the http email attachment has been replaced.
+This results in the need to always escape all parts of an URL.
+* The new built-in HTTP client also enforces a maximum request size, which defaults to 10mb.
+
+[float]
+=== Breaking Java Changes
+
+Java API::
+* Java api: ActionRequestBuilder#execute to return a PlainActionFuture {pull}24415[#24415] (issues: {issue}24412[#24412], {issue}9201[#9201])
+
+Network::
+* Simplify TransportAddress {pull}20798[#20798]
+
+[float]
+=== Deprecations
+
+Index Templates::
+* Restore deprecation warning for invalid match_mapping_type values {pull}22304[#22304]
+
+Internal::
+* Deprecate XContentType auto detection methods in XContentFactory {pull}22181[#22181] (issue: {issue}19388[#19388])
+
+[float]
+=== New Features
+
+Core::
+* Enable index-time sorting {pull}24055[#24055] (issue: {issue}6720[#6720])
+
+[float]
+=== Enhancements
+
+Aggregations::
+* Agg builder accessibility fixes {pull}24323[#24323]
+* Remove support for the include/pattern syntax. {pull}23141[#23141] (issue: {issue}22933[#22933])
+* Promote longs to doubles when a terms agg mixes decimal and non-decimal numbers {pull}22449[#22449] (issue: {issue}22232[#22232])
+
+Analysis::
+* Match- and MultiMatchQueryBuilder should only allow setting analyzer on string values {pull}23684[#23684] (issue: {issue}21665[#21665])
+
+Bulk::
+* Simplify bulk request execution  {pull}20109[#20109]
+
+CRUD::
+* Added validation for upsert request {pull}24282[#24282] (issue: {issue}16671[#16671])
+
+Cluster::
+* Separate publishing from applying cluster states {pull}24236[#24236]
+* Adds cluster state size to /_cluster/state response {pull}23440[#23440] (issue: {issue}3415[#3415])
+
+Core::
+* Remove connect SocketPermissions from core {pull}22797[#22797]
+* Add repository-url module and move URLRepository {pull}22752[#22752] (issue: {issue}22116[#22116])
+* Remove accept SocketPermissions from core {pull}22622[#22622] (issue: {issue}22116[#22116])
+* Move IfConfig.logIfNecessary call into bootstrap {pull}22455[#22455] (issue: {issue}22116[#22116])
+* Remove artificial default processors limit {pull}20874[#20874] (issue: {issue}20828[#20828])
+* Simplify write failure handling {pull}19105[#19105] (issue: {issue}20109[#20109])
+
+Engine::
+* Fill missing sequence IDs up to max sequence ID when recovering from store {pull}24238[#24238] (issue: {issue}10708[#10708])
+* Use sequence numbers to identify out of order delivery in replicas & recovery {pull}24060[#24060] (issue: {issue}10708[#10708])
+* Add replica ops with version conflict to translog {pull}22626[#22626]
+* Clarify global checkpoint recovery {pull}21934[#21934] (issue: {issue}21254[#21254])
+
+Internal::
+* Try to convince the JVM not to lose stacktraces {pull}24426[#24426] (issue: {issue}24376[#24376])
+* Make document write requests immutable {pull}23038[#23038]
+
+Java High Level REST Client::
+* Add info method to High Level Rest client {pull}23350[#23350]
+* Add support for named xcontent parsers to high level REST client {pull}23328[#23328]
+* Add BulkRequest support to High Level Rest client {pull}23312[#23312]
+* Add UpdateRequest support to High Level Rest client {pull}23266[#23266]
+* Add delete API to the High Level Rest Client {pull}23187[#23187]
+* Add Index API to High Level Rest Client {pull}23040[#23040]
+* Add get/exists method to RestHighLevelClient {pull}22706[#22706]
+* Add fromxcontent methods to delete response {pull}22680[#22680] (issue: {issue}22229[#22229])
+* Add REST high level client gradle submodule and first simple method {pull}22371[#22371]
+
+Java REST Client::
+* Wrap rest httpclient with doPrivileged blocks {pull}22603[#22603] (issue: {issue}22116[#22116])
+
+Mapping::
+* Date detection should not rely on a hardcoded set of characters. {pull}22171[#22171] (issue: {issue}1694[#1694])
+
+Network::
+* Isolate SocketPermissions to Netty {pull}23057[#23057]
+* Wrap netty accept/connect ops with doPrivileged {pull}22572[#22572] (issue: {issue}22116[#22116])
+* Replace Socket, ServerSocket, and HttpServer usages in tests with mocksocket versions {pull}22287[#22287] (issue: {issue}22116[#22116])
+
+Plugin Discovery EC2::
+* Read ec2 discovery address from aws instance tags {pull}22743[#22743] (issue: {issue}22566[#22566])
+
+Plugin Repository HDFS::
+* Add doPrivilege blocks for socket connect ops in repository-hdfs {pull}22793[#22793] (issue: {issue}22116[#22116])
+
+Plugins::
+* Add doPrivilege blocks for socket connect operations in plugins {pull}22534[#22534] (issue: {issue}22116[#22116])
+
+Recovery::
+* Peer Recovery: remove maxUnsafeAutoIdTimestamp hand off {pull}24243[#24243] (issue: {issue}24149[#24149])
+* Introduce sequence-number-based recovery {pull}22484[#22484] (issue: {issue}10708[#10708])
+
+Search::
+*  Add parsing from xContent to Suggest {pull}22903[#22903]
+* Add parsing from xContent to ShardSearchFailure {pull}22699[#22699]
+
+Sequence IDs::
+* Block global checkpoint advances when recovering {pull}24404[#24404] (issue: {issue}10708[#10708])
+* Add primary term to doc write response {pull}24171[#24171] (issue: {issue}10708[#10708])
+* Preserve multiple translog generations {pull}24015[#24015] (issue: {issue}10708[#10708])
+* Introduce translog generation rolling {pull}23606[#23606] (issue: {issue}10708[#10708])
+* Replicate write failures {pull}23314[#23314]
+* Introduce sequence-number-aware translog {pull}22822[#22822] (issue: {issue}10708[#10708])
+* Introduce translog no-op {pull}22291[#22291] (issue: {issue}10708[#10708])
+* Tighten sequence numbers recovery {pull}22212[#22212] (issue: {issue}10708[#10708])
+* Add BWC layer to seq no infra and enable BWC tests {pull}22185[#22185] (issue: {issue}21670[#21670])
+* Add internal _primary_term doc values field, fix _seq_no indexing {pull}21637[#21637] (issues: {issue}10708[#10708], {issue}21480[#21480])
+* Add global checkpoint to translog checkpoints {pull}21254[#21254]
+* Sequence numbers commit data for Lucene uses Iterable interface {pull}20793[#20793] (issue: {issue}10708[#10708])
+* Simplify GlobalCheckpointService and properly hook it for cluster state updates {pull}20720[#20720]
+
+Stats::
+* Expose disk usage estimates in nodes stats {pull}22081[#22081] (issue: {issue}8686[#8686])
+
+Store::
+* Remote support for lucene versions without checksums {pull}24021[#24021]
+
+Suggesters::
+* Remove deprecated _suggest endpoint {pull}22203[#22203] (issue: {issue}20305[#20305])
+
+Task Manager::
+* Add descriptions to bulk tasks {pull}22059[#22059] (issue: {issue}21768[#21768])
+
+[float]
+=== Bug Fixes
+
+Ingest::
+* Remove support for Visio and potm files {pull}22079[#22079] (issue: {issue}22077[#22077])
+
+Inner Hits::
+* If size / offset are out of bounds just do a plain count {pull}20556[#20556] (issue: {issue}20501[#20501])
+
+Internal::
+* Fix handling of document failure exception in InternalEngine {pull}22718[#22718]
+
+Plugin Ingest Attachment::
+* Add missing mime4j library {pull}22764[#22764] (issue: {issue}22077[#22077])
+
+Plugin Repository S3::
+* Wrap getCredentials() in a doPrivileged() block {pull}23297[#23297] (issues: {issue}22534[#22534], {issue}23271[#23271])
+
+Sequence IDs::
+* Avoid losing ops in file-based recovery {pull}22945[#22945] (issue: {issue}22484[#22484])
+
+Snapshot/Restore::
+* Keep snapshot restore state and routing table in sync {pull}20836[#20836] (issue: {issue}19774[#19774])
+
+Translog::
+* Fix Translog.Delete serialization for sequence numbers {pull}22543[#22543]
+
+Watcher::
+* The HTTP client respects timeouts now and does not get stuck leading to stuck watches.
+
+[float]
+=== Regressions
+
+Bulk::
+* Only re-parse operation if a mapping update was needed {pull}23832[#23832] (issue: {issue}23665[#23665])
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Core::
+* Upgrade to a Lucene 7 snapshot {pull}24089[#24089] (issues: {issue}23966[#23966], {issue}24086[#24086], {issue}24087[#24087], {issue}24088[#24088])
+
+Plugin Ingest Attachment::
+* Update to Tika 1.14 {pull}21591[#21591] (issue: {issue}20390[#20390])
+
+[[release-notes-6.0.0-alpha1-5x]]
+== {es} version 6.0.0-alpha1 (Changes previously released in 5.x)
+
+The changes listed below were first released in the 5.x series. Changes
+released for the first time in Elasticsearch 6.0.0-alpha1 are listed in
+<<release-notes-6.0.0-alpha1>>.
+
+[float]
+[[breaking-6.0.0-alpha1-5x]]
+=== Breaking Changes
+
+Aliases::
+* Validate alias names the same as index names {pull}20771[#20771] (issue: {issue}20748[#20748])
+
+CRUD::
+* Fixed naming inconsistency for fields/stored_fields in the APIs {pull}20166[#20166] (issues: {issue}18943[#18943], {issue}20155[#20155])
+
+Core::
+* Add system call filter bootstrap check {pull}21940[#21940]
+* Remove ignore system bootstrap checks {pull}20511[#20511]
+
+Internal::
+* `_flush` should block by default {pull}20597[#20597] (issue: {issue}20569[#20569])
+
+Packaging::
+* Rename service.bat to elasticsearch-service.bat {pull}20496[#20496] (issue: {issue}17528[#17528])
+
+Plugin Lang Painless::
+* Remove all date 'now' methods from Painless {pull}20766[#20766] (issue: {issue}20762[#20762])
+
+Query DSL::
+* Fix name of `enabled_position_increments` {pull}22895[#22895]
+
+REST::
+* Change separator for shards preference {pull}20786[#20786] (issues: {issue}20722[#20722], {issue}20769[#20769])
+
+Search::
+* Remove DFS_QUERY_AND_FETCH as a search type {pull}22787[#22787]
+
+Settings::
+* Remove support for default settings {pull}24093[#24093] (issues: {issue}23981[#23981], {issue}24052[#24052], {issue}24074[#24074])
+
+[float]
+=== Breaking Java Changes
+
+Aggregations::
+* Move getProperty method out of MultiBucketsAggregation.Bucket interface {pull}23988[#23988]
+* Remove getProperty method from Aggregations interface and impl {pull}23972[#23972]
+* Move getProperty method out of Aggregation interface {pull}23949[#23949]
+
+Allocation::
+* Cluster Explain API uses the allocation process to explain shard allocation decisions {pull}22182[#22182] (issues: {issue}20347[#20347], {issue}20634[#20634], {issue}21103[#21103], {issue}21662[#21662], {issue}21691[#21691])
+
+Cluster::
+* Remove PROTO-based custom cluster state components {pull}22336[#22336] (issue: {issue}21868[#21868])
+
+Core::
+* Remove ability to plug-in TransportService {pull}20505[#20505]
+
+Discovery::
+* Remove pluggability of ElectMasterService {pull}21031[#21031]
+
+Exceptions::
+* Remove `IndexTemplateAlreadyExistsException` and `IndexShardAlreadyExistsException` {pull}21539[#21539] (issue: {issue}21494[#21494])
+* Replace IndexAlreadyExistsException with ResourceAlreadyExistsException {pull}21494[#21494]
+
+Ingest::
+* Change type of ingest doc meta-data field 'TIMESTAMP' to `Date` {pull}22234[#22234] (issue: {issue}22074[#22074])
+
+Internal::
+* Replace SearchExtRegistry with namedObject {pull}22492[#22492]
+* Replace Suggesters with namedObject {pull}22491[#22491]
+* Consolidate the last easy parser construction {pull}22095[#22095]
+* Introduce XContentParser#namedObject {pull}22003[#22003]
+* Pass executor name to request interceptor to support async intercept calls {pull}21089[#21089]
+* Remove TransportService#registerRequestHandler leniency {pull}20469[#20469] (issue: {issue}20468[#20468])
+
+Java API::
+* Fold InternalSearchHits and friends into their interfaces {pull}23042[#23042]
+
+Network::
+* Remove HttpServer and HttpServerAdapter in favor of a simple dispatch method {pull}22636[#22636] (issue: {issue}18482[#18482])
+* Unguice Transport and friends {pull}20526[#20526]
+
+Plugins::
+* Deguice rest handlers {pull}22575[#22575]
+* Plugins: Replace Rest filters with RestHandler wrapper {pull}21905[#21905]
+* Plugins: Remove support for onModule {pull}21416[#21416]
+* Cleanup sub fetch phase extension point {pull}20382[#20382]
+
+Query DSL::
+* Resolve index names in indices_boost {pull}21393[#21393] (issue: {issue}4756[#4756])
+
+Scripting::
+* Refactor ScriptType to be a Top-Level Class {pull}21136[#21136]
+
+Search::
+* Remove QUERY_AND_FETCH search type {pull}22996[#22996]
+* Cluster search shards improvements: expose ShardId, adjust visibility of some members {pull}21752[#21752]
+
+[float]
+=== Deprecations
+
+Java API::
+* Add BulkProcessor methods with XContentType parameter {pull}23078[#23078] (issue: {issue}22691[#22691])
+* Deprecate and remove "minimumNumberShouldMatch" in BoolQueryBuilder {pull}22403[#22403]
+
+Plugin Repository S3::
+* S3 Repository: Deprecate remaining `repositories.s3.*` settings {pull}24144[#24144] (issue: {issue}24143[#24143])
+* Deprecate specifying credentials through env vars, sys props, and remove profile files {pull}22567[#22567] (issues: {issue}21041[#21041], {issue}22479[#22479])
+
+Query DSL::
+* Add deprecation logging message for 'fuzzy' query {pull}20993[#20993] (issue: {issue}15760[#15760])
+
+REST::
+* Optionally require a valid content type for all rest requests with content {pull}22691[#22691] (issue: {issue}19388[#19388])
+
+Scripting::
+* Change Namespace for Stored Script to Only Use Id {pull}22206[#22206]
+
+Shadow Replicas::
+* Add a deprecation notice to shadow replicas  {pull}22647[#22647] (issue: {issue}22024[#22024])
+
+Stats::
+* Deprecate _field_stats endpoint {pull}23914[#23914]
+
+[float]
+=== New Features
+
+Aggregations::
+* Initial version of an adjacency matrix using the Filters aggregation {pull}22239[#22239] (issue: {issue}22169[#22169])
+
+Analysis::
+* Adds pattern keyword marker filter support {pull}23600[#23600] (issue: {issue}4877[#4877])
+* Expose WordDelimiterGraphTokenFilter {pull}23327[#23327] (issue: {issue}23104[#23104])
+* Synonym Graph Support (LUCENE-6664) {pull}21517[#21517]
+* Expose Lucenes Ukrainian analyzer {pull}21176[#21176] (issue: {issue}19433[#19433])
+
+CAT API::
+* Provides a cat api endpoint for templates. {pull}20545[#20545] (issue: {issue}20467[#20467])
+
+CRUD::
+* Allow an index to be partitioned with custom routing {pull}22274[#22274] (issue: {issue}21585[#21585])
+
+Highlighting::
+* Integrate UnifiedHighlighter {pull}21621[#21621] (issue: {issue}21376[#21376])
+
+Index APIs::
+* Add FieldCapabilities (_field_caps) API {pull}23007[#23007] (issue: {issue}22438[#22438])
+
+Ingest::
+* introduce KV Processor in Ingest Node {pull}22272[#22272] (issue: {issue}22222[#22222])
+
+Mapping::
+* Add the ability to set a normalizer on keyword fields. {pull}21919[#21919] (issue: {issue}18064[#18064])
+* Add RangeFieldMapper for numeric and date range types {pull}21002[#21002] (issue: {issue}20999[#20999])
+
+Plugin Discovery File::
+* File-based discovery plugin {pull}20394[#20394] (issue: {issue}20323[#20323])
+
+Query DSL::
+* Add "all fields" execution mode to simple_query_string query {pull}21341[#21341] (issues: {issue}19784[#19784], {issue}20925[#20925])
+* Add support for `quote_field_suffix` to `simple_query_string`. {pull}21060[#21060] (issue: {issue}18641[#18641])
+* Add "all field" execution mode to query_string query {pull}20925[#20925] (issue: {issue}19784[#19784])
+
+Reindex API::
+* Add automatic parallelization support to reindex and friends {pull}20767[#20767] (issue: {issue}20624[#20624])
+
+Search::
+* Introduce incremental reduction of TopDocs {pull}23946[#23946]
+* Add federated cross cluster search capabilities {pull}22502[#22502] (issue: {issue}21473[#21473])
+* Add field collapsing for search request {pull}22337[#22337] (issue: {issue}21833[#21833])
+
+Settings::
+* Add infrastructure for elasticsearch keystore {pull}22335[#22335]
+
+Similarities::
+* Adds boolean similarity to Elasticsearch {pull}23637[#23637] (issue: {issue}6731[#6731])
+
+[float]
+=== Enhancements
+
+Aggregations::
+* Add `count` to rest output of `geo_centroid` {pull}24387[#24387] (issue: {issue}24366[#24366])
+* Allow scripted metric agg to access `_score` {pull}24295[#24295]
+* Add BucketMetricValue interface {pull}24188[#24188]
+* Move aggs CommonFields and TYPED_KEYS_DELIMITER from InternalAggregation to Aggregation {pull}23987[#23987]
+* Use ParseField for aggs CommonFields rather than String {pull}23717[#23717]
+* Share XContent rendering code in terms aggs {pull}23680[#23680]
+* Add unit tests for ParentToChildAggregator {pull}23305[#23305] (issue: {issue}22278[#22278])
+* First step towards incremental reduction of query responses {pull}23253[#23253]
+* `value_type` is useful regardless of scripting. {pull}22160[#22160] (issue: {issue}20163[#20163])
+* Support for partitioning set of terms  {pull}21626[#21626] (issue: {issue}21487[#21487])
+* Rescorer should be applied in the TopHits aggregation {pull}20978[#20978] (issue: {issue}19317[#19317])
+
+Aliases::
+* Handle multiple aliases in _cat/aliases api {pull}23698[#23698] (issue: {issue}23661[#23661])
+
+Allocation::
+* Trigger replica recovery restarts by master when primary relocation completes {pull}23926[#23926] (issue: {issue}23904[#23904])
+* Makes the same_shard host dynamically updatable {pull}23397[#23397] (issue: {issue}22992[#22992])
+* Include stale replica shard info when explaining an unassigned primary {pull}22826[#22826]
+* Adds setting level to allocation decider explanations {pull}22268[#22268] (issue: {issue}21771[#21771])
+* Improves allocation decider decision explanation messages {pull}21771[#21771]
+* Prepares allocator decision objects for use with the allocation explain API {pull}21691[#21691]
+* Balance step in BalancedShardsAllocator for a single shard {pull}21103[#21103]
+* Process more expensive allocation deciders last {pull}20724[#20724] (issue: {issue}12815[#12815])
+* Separates decision making from decision application in BalancedShardsAllocator  {pull}20634[#20634]
+
+Analysis::
+* Support Keyword type in Analyze API {pull}23161[#23161]
+* Expose FlattenGraphTokenFilter {pull}22643[#22643]
+* Analyze API Position Length Support {pull}22574[#22574]
+* Remove AnalysisService and reduce it to a simple name to analyzer mapping {pull}20627[#20627] (issues: {issue}19827[#19827], {issue}19828[#19828])
+
+CAT API::
+* Adding built-in sorting capability to _cat apis. {pull}20658[#20658] (issue: {issue}16975[#16975])
+* Add health status parameter to cat indices API {pull}20393[#20393]
+
+CRUD::
+* Use correct block levels for TRA subclasses {pull}22224[#22224]
+* Make index and delete operation execute as a single bulk item {pull}21964[#21964]
+
+Cache::
+* Do not cache term queries. {pull}21566[#21566] (issues: {issue}16031[#16031], {issue}20116[#20116])
+* Parse alias filters on the coordinating node {pull}20916[#20916]
+
+Circuit Breakers::
+* Closing a ReleasableBytesStreamOutput closes the underlying BigArray {pull}23941[#23941]
+* Add used memory amount to CircuitBreakingException message (#22521) {pull}22693[#22693] (issue: {issue}22521[#22521])
+* Cluster Settings Updates should not trigger circuit breakers. {pull}20827[#20827]
+
+Cluster::
+* Extract a common base class to allow services to listen to remote cluster config updates {pull}24367[#24367]
+* Prevent nodes from joining if newer indices exist in the cluster {pull}23843[#23843]
+* Connect to new nodes concurrently {pull}22984[#22984] (issue: {issue}22828[#22828])
+* Keep NodeConnectionsService in sync with current nodes in the cluster state {pull}22509[#22509]
+* Add a generic way of checking version before serializing custom cluster object {pull}22376[#22376] (issue: {issue}22313[#22313])
+* Add validation for supported index version on node join, restore, upgrade & open index {pull}21830[#21830] (issue: {issue}21670[#21670])
+* Let ClusterStateObserver only hold onto state that's needed for change detection {pull}21631[#21631] (issue: {issue}21568[#21568])
+* Cache successful shard deletion checks {pull}21438[#21438]
+* Remove mutable status field from cluster state {pull}21379[#21379]
+* Skip shard management code when updating cluster state on client/tribe nodes {pull}20731[#20731]
+* Add clusterUUID to RestMainAction output {pull}20503[#20503]
+
+Core::
+* Regex upgrades {pull}24316[#24316] (issue: {issue}24226[#24226])
+* Detect remnants of path.data/default.path.data bug {pull}24099[#24099] (issues: {issue}23981[#23981], {issue}24052[#24052], {issue}24074[#24074], {issue}24093[#24093])
+* Await termination after shutting down executors {pull}23889[#23889]
+* Add early-access check {pull}23743[#23743] (issue: {issue}23668[#23668])
+* Adapter action future should restore interrupts {pull}23618[#23618] (issue: {issue}23617[#23617])
+* Disable bootstrap checks for single-node discovery {pull}23598[#23598] (issues: {issue}23585[#23585], {issue}23595[#23595])
+* Enable explicitly enforcing bootstrap checks {pull}23585[#23585] (issue: {issue}21864[#21864])
+* Add equals/hashcode method to ReplicationResponse {pull}23215[#23215]
+* Simplify ElasticsearchException rendering as a XContent {pull}22611[#22611]
+* Remove setLocalNode from ClusterService and TransportService {pull}22608[#22608]
+* Rename bootstrap.seccomp to bootstrap.system_call_filter {pull}22226[#22226] (issue: {issue}21940[#21940])
+* Cleanup random stats serialization code {pull}22223[#22223]
+* Avoid corruption when deserializing booleans {pull}22152[#22152]
+* Reduce memory pressure when sending large terms queries. {pull}21776[#21776]
+* Install a security manager on startup {pull}21716[#21716]
+* Log node ID on startup {pull}21673[#21673]
+* Ensure source filtering automatons are only compiled once {pull}20857[#20857] (issue: {issue}20839[#20839])
+* Improve scheduling fairness when batching cluster state changes with equal priority {pull}20775[#20775] (issue: {issue}20768[#20768])
+* Add production warning for pre-release builds {pull}20674[#20674]
+* Add serial collector bootstrap check {pull}20558[#20558]
+* Do not log full bootstrap checks exception {pull}19989[#19989]
+
+Dates::
+* Improve error handling for epoch format parser with time zone (#22621) {pull}23689[#23689]
+
+Discovery::
+* Introduce single-node discovery {pull}23595[#23595]
+* UnicastZenPing shouldn't ping the address of the local node {pull}23567[#23567]
+* MasterFaultDetection can start after the initial cluster state has been processed {pull}23037[#23037] (issue: {issue}22828[#22828])
+* Simplify Unicast Zen Ping {pull}22277[#22277] (issues: {issue}19370[#19370], {issue}21739[#21739], {issue}22120[#22120], {issue}22194[#22194])
+* Prefer joining node with conflicting transport address when becoming master {pull}22134[#22134] (issues: {issue}22049[#22049], {issue}22120[#22120])
+
+Engine::
+* Engine: store maxUnsafeAutoIdTimestamp in commit {pull}24149[#24149]
+* Replace EngineClosedException with AlreadyClosedExcpetion {pull}22631[#22631]
+
+Exceptions::
+* Add BWC layer for Exceptions {pull}21694[#21694] (issue: {issue}21656[#21656])
+
+Geo::
+* Optimize geo-distance sorting. {pull}20596[#20596] (issue: {issue}20450[#20450])
+
+Highlighting::
+* Add support for fragment_length in the unified highlighter {pull}23431[#23431]
+* Add BreakIteratorBoundaryScanner support {pull}23248[#23248]
+
+Index APIs::
+* Open and close index to honour allow_no_indices option {pull}24222[#24222] (issue: {issue}24031[#24031])
+* Wildcard cluster names for cross cluster search {pull}23985[#23985] (issue: {issue}23893[#23893])
+* Indexing: Add shard id to indexing operation listener {pull}22606[#22606]
+* Better error when can't auto create index  {pull}22488[#22488] (issues: {issue}21448[#21448], {issue}22435[#22435])
+* Add date-math support to `_rollover` {pull}20709[#20709]
+
+Ingest::
+* Lazy load the geoip databases {pull}23337[#23337]
+* add `ignore_missing` flag to ingest plugins {pull}22273[#22273]
+* Added ability to remove pipelines via wildcards (#22149) {pull}22191[#22191] (issue: {issue}22149[#22149])
+* Enables the ability to inject serialized json fields into root of document {pull}22179[#22179] (issue: {issue}21898[#21898])
+* compile ScriptProcessor inline scripts when creating ingest pipelines {pull}21858[#21858] (issue: {issue}21842[#21842])
+* add `ignore_missing` option to SplitProcessor {pull}20982[#20982] (issues: {issue}19995[#19995], {issue}20840[#20840])
+* add ignore_missing option to convert,trim,lowercase,uppercase,grok,rename {pull}20194[#20194] (issue: {issue}19995[#19995])
+* introduce the JSON Processor {pull}20128[#20128] (issue: {issue}20052[#20052])
+
+Internal::
+* Add cross cluster support to `_field_caps` {pull}24463[#24463] (issue: {issue}24334[#24334])
+* Log JVM arguments on startup {pull}24451[#24451]
+* Preserve cluster alias throughout search execution to lookup nodes by cluster and ID {pull}24438[#24438]
+* Move RemoteClusterService into TransportService {pull}24424[#24424]
+* Enum related performance additions. {pull}24274[#24274] (issue: {issue}24226[#24226])
+* Add a dedicated TransportRemoteInfoAction for consistency {pull}24040[#24040] (issue: {issue}23969[#23969])
+* Simplify sorted top docs merging in SearchPhaseController {pull}23881[#23881]
+* Synchronized CollapseTopFieldDocs with lucenes relatives {pull}23854[#23854]
+* Cleanup SearchPhaseController interface {pull}23844[#23844]
+* Do not create String instances in 'Strings' methods accepting StringBuilder {pull}22907[#22907]
+* Improve connection closing in `RemoteClusterConnection` {pull}22804[#22804] (issue: {issue}22803[#22803])
+* Remove some more usages of ParseFieldMatcher {pull}22437[#22437] (issues: {issue}19552[#19552], {issue}22130[#22130])
+* Remove some more usages of ParseFieldMatcher {pull}22398[#22398] (issues: {issue}19552[#19552], {issue}22130[#22130])
+* Remove some more usages of ParseFieldMatcher {pull}22395[#22395] (issues: {issue}19552[#19552], {issue}22130[#22130])
+* Remove some ParseFieldMatcher usages {pull}22389[#22389] (issues: {issue}19552[#19552], {issue}22130[#22130])
+* Introduce ToXContentObject interface {pull}22387[#22387] (issue: {issue}16347[#16347])
+* Add infrastructure to manage network connections outside of Transport/TransportService {pull}22194[#22194]
+* Replace strict parsing mode with response headers assertions {pull}22130[#22130] (issues: {issue}11859[#11859], {issue}19552[#19552], {issue}20993[#20993])
+* Start using `ObjectParser` for aggs. {pull}22048[#22048] (issue: {issue}22009[#22009])
+* Don't output null source node in RecoveryFailedException {pull}21963[#21963]
+* ClusterService should expose "applied" cluster states (i.e., remove ClusterStateStatus) {pull}21817[#21817]
+* Rename ClusterState#lookupPrototypeSafe to `lookupPrototype` and remove "unsafe" unused variant {pull}21686[#21686]
+* ShardActiveResponseHandler shouldn't hold to an entire cluster state {pull}21470[#21470] (issue: {issue}21394[#21394])
+* Remove unused ClusterService dependency from SearchPhaseController {pull}21421[#21421]
+* Remove special case in case no action filters are registered {pull}21251[#21251]
+* Use TimveValue instead of long for CacheBuilder methods {pull}20887[#20887]
+* Remove SearchContext#current and all it's threadlocals {pull}20778[#20778] (issue: {issue}19341[#19341])
+* Remove poor-mans compression in InternalSearchHit and friends {pull}20472[#20472]
+
+Java API::
+* Added types options to DeleteByQueryRequest {pull}23265[#23265] (issue: {issue}21984[#21984])
+* prevent NPE when trying to uncompress a null BytesReference {pull}22386[#22386]
+
+Java High Level REST Client::
+* Add utility method to parse named XContent objects with typed prefix {pull}24240[#24240] (issue: {issue}22965[#22965])
+* Convert suggestion response parsing to use NamedXContentRegistry {pull}23355[#23355]
+* UpdateRequest implements ToXContent {pull}23289[#23289]
+* Add javadoc for DocWriteResponse.Builders {pull}23267[#23267]
+* Expose WriteRequest.RefreshPolicy string representation {pull}23106[#23106]
+* Use `typed_keys` parameter to prefix suggester names by type in search responses {pull}23080[#23080] (issue: {issue}22965[#22965])
+* Add parsing from xContent to MainResponse {pull}22934[#22934]
+* Parse elasticsearch exception's root causes {pull}22924[#22924]
+* Add parsing method to BytesRestResponse's error {pull}22873[#22873]
+* Add parsing methods to BulkItemResponse {pull}22859[#22859]
+* Add parsing method for ElasticsearchException.generateFailureXContent() {pull}22815[#22815]
+* Add parsing method for ElasticsearchException.generateThrowableXContent() {pull}22783[#22783]
+* Add parsing methods for UpdateResponse {pull}22586[#22586]
+* Add parsing from xContent to InternalSearchHit and InternalSearchHits {pull}22429[#22429]
+* Add fromxcontent methods to index response {pull}22229[#22229]
+* Add fromXContent() methods for ReplicationResponse {pull}22196[#22196] (issue: {issue}22082[#22082])
+* Add parsing method for ElasticsearchException {pull}22143[#22143]
+* Add fromXContent method to GetResponse {pull}22082[#22082]
+
+Java REST Client::
+* move ignore parameter support from yaml test client to low level rest client {pull}22637[#22637]
+* Warn log deprecation warnings received from server {pull}21895[#21895]
+* Support Preemptive Authentication with RestClient {pull}21336[#21336]
+* Provide error message when rest request path is null {pull}21233[#21233] (issue: {issue}21232[#21232])
+
+Logging::
+* Log deleting indices at info level {pull}22627[#22627] (issue: {issue}22605[#22605])
+* Expose logs base path {pull}22625[#22625]
+* Log failure to connect to node at info instead of debug {pull}21809[#21809] (issue: {issue}6468[#6468])
+* Truncate log messages from the end {pull}21609[#21609] (issue: {issue}21602[#21602])
+* Ensure logging is initialized in CLI tools {pull}20575[#20575]
+* Give useful error message if log config is missing {pull}20493[#20493]
+* Complete Elasticsearch logger names {pull}20457[#20457] (issue: {issue}20326[#20326])
+* Logging shutdown hack {pull}20389[#20389] (issue: {issue}20304[#20304])
+* Disable console logging {pull}20387[#20387]
+* Warn on not enough masters during election {pull}20063[#20063] (issue: {issue}8362[#8362])
+
+Mapping::
+* Do not index `_type` when there is at most one type. {pull}24363[#24363]
+* Only allow one type on 6.0 indices {pull}24317[#24317] (issue: {issue}15613[#15613])
+* token_count type : add an option to count tokens (fix #23227) {pull}24175[#24175] (issue: {issue}23227[#23227])
+* Atomic mapping updates across types {pull}22220[#22220]
+* Only update DocumentMapper if field type changes {pull}22165[#22165]
+* Better error message when _parent isn't an object {pull}21987[#21987]
+* Create the QueryShardContext lazily in DocumentMapperParser. {pull}21287[#21287]
+
+Nested Docs::
+* Avoid adding unnecessary nested filters when ranges are used. {pull}23427[#23427]
+
+Network::
+* Set available processors for Netty {pull}24420[#24420] (issue: {issue}6224[#6224])
+* Adjust default Netty receive predictor size to 64k {pull}23542[#23542] (issue: {issue}23185[#23185])
+* Keep the pipeline handler queue small initially {pull}23335[#23335]
+* Set network receive predictor size to 32kb {pull}23284[#23284] (issue: {issue}23185[#23185])
+* TransportService.connectToNode should validate remote node ID {pull}22828[#22828] (issue: {issue}22194[#22194])
+* Disable the Netty recycler {pull}22452[#22452] (issues: {issue}22189[#22189], {issue}22360[#22360], {issue}22406[#22406], {issue}5904[#5904])
+* Tell Netty not to be unsafe in transport client {pull}22284[#22284]
+* Introduce a low level protocol handshake {pull}22094[#22094]
+* Detach handshake from connect to node {pull}22037[#22037]
+* Reduce number of connections per node depending on the nodes role {pull}21849[#21849]
+* Add a connect timeout to the ConnectionProfile to allow per node connect timeouts {pull}21847[#21847] (issue: {issue}19719[#19719])
+* Grant Netty permission to read system somaxconn {pull}21840[#21840]
+* Remove connectToNodeLight and replace it with a connection profile {pull}21799[#21799]
+* Lazy resolve unicast hosts {pull}21630[#21630] (issues: {issue}14441[#14441], {issue}16412[#16412])
+* Fix handler name on message not fully read {pull}21478[#21478]
+* Handle rejected pings on shutdown gracefully {pull}20842[#20842]
+* Network: Allow to listen on virtual interfaces. {pull}19568[#19568] (issues: {issue}17473[#17473], {issue}19537[#19537])
+
+Packaging::
+* Introduce Java version check {pull}23194[#23194] (issue: {issue}21102[#21102])
+* Improve the out-of-the-box experience {pull}21920[#21920] (issues: {issue}18317[#18317], {issue}21783[#21783])
+* Add empty plugins dir for archive distributions {pull}21204[#21204] (issue: {issue}20342[#20342])
+* Make explicit missing settings for Windows service {pull}21200[#21200] (issue: {issue}18317[#18317])
+* Change permissions on config files {pull}20966[#20966]
+* Add quiet option to disable console logging {pull}20422[#20422] (issues: {issue}15315[#15315], {issue}16159[#16159], {issue}17220[#17220])
+
+Percolator::
+* Allowing range queries with now ranges inside percolator queries {pull}23921[#23921] (issue: {issue}23859[#23859])
+* Add term extraction support for MultiPhraseQuery {pull}23176[#23176]
+
+Plugin Discovery EC2::
+* Settings: Migrate ec2 discovery sensitive settings to elasticsearch keystore {pull}23961[#23961] (issue: {issue}22475[#22475])
+* Add support for ca-central-1 region to EC2 and S3 plugins {pull}22458[#22458] (issue: {issue}22454[#22454])
+* Support for eu-west-2 (London) cloud-aws plugin {pull}22308[#22308] (issue: {issue}22306[#22306])
+* Add us-east-2 AWS region {pull}21961[#21961] (issue: {issue}21881[#21881])
+* Add setting to set read timeout for EC2 discovery and S3 repository plugins {pull}21956[#21956] (issue: {issue}19078[#19078])
+
+Plugin Ingest GeoIp::
+* Cache results of geoip lookups {pull}22231[#22231] (issue: {issue}22074[#22074])
+
+Plugin Lang Painless::
+* Allow painless to load stored fields {pull}24290[#24290]
+* Start on custom whitelists for Painless {pull}23563[#23563]
+* Fix Painless's implementation of interfaces returning primitives {pull}23298[#23298] (issue: {issue}22983[#22983])
+* Allow painless to implement more interfaces {pull}22983[#22983]
+* Generate reference links for painless API {pull}22775[#22775]
+* Painless: Add augmentation to String for base 64 {pull}22665[#22665] (issue: {issue}22648[#22648])
+* Improve painless's ScriptException generation {pull}21762[#21762] (issue: {issue}21733[#21733])
+* Add Debug.explain to painless {pull}21723[#21723] (issue: {issue}20263[#20263])
+* Implement the ?: operator in painless {pull}21506[#21506]
+* In painless suggest a long constant if int won't do {pull}21415[#21415] (issue: {issue}21313[#21313])
+* Support decimal constants with trailing [dD] in painless {pull}21412[#21412] (issue: {issue}21116[#21116])
+* Implement reading from null safe dereferences {pull}21239[#21239]
+* Painless negative offsets {pull}21080[#21080] (issue: {issue}20870[#20870])
+* Remove more equivalents of the now method from the Painless whitelist. {pull}21047[#21047]
+* Disable regexes by default in painless {pull}20427[#20427] (issue: {issue}20397[#20397])
+
+Plugin Repository Azure::
+* Add Backoff policy to azure repository {pull}23387[#23387] (issue: {issue}22728[#22728])
+
+Plugin Repository S3::
+* Removes the retry mechanism from the S3 blob store {pull}23952[#23952] (issue: {issue}22845[#22845])
+* S3 Repository: Eagerly load static settings {pull}23910[#23910]
+* S3 repository: Add named configurations {pull}22762[#22762] (issues: {issue}22479[#22479], {issue}22520[#22520])
+* Make the default S3 buffer size depend on the available memory. {pull}21299[#21299]
+
+Plugins::
+* Plugins: Add support for platform specific plugins {pull}24265[#24265]
+* Plugins: Remove leniency for missing plugins dir {pull}24173[#24173]
+* Modify permissions dialog for plugins {pull}23742[#23742]
+* Plugins: Add plugin cli specific exit codes {pull}23599[#23599] (issue: {issue}15295[#15295])
+* Plugins: Output better error message when existing plugin is incompatible {pull}23562[#23562] (issue: {issue}20691[#20691])
+* Add the ability to define search response listeners in search plugin {pull}22682[#22682]
+* Pass ThreadContext to transport interceptors to allow header modification {pull}22618[#22618] (issue: {issue}22585[#22585])
+* Provide helpful error message if a plugin exists {pull}22305[#22305] (issue: {issue}22084[#22084])
+* Add shutdown hook for closing CLI commands {pull}22126[#22126] (issue: {issue}22111[#22111])
+* Allow plugins to install bootstrap checks {pull}22110[#22110]
+* Clarify that plugins can be closed {pull}21669[#21669]
+* Plugins: Convert custom discovery to pull based plugin {pull}21398[#21398]
+* Removing plugin that isn't installed shouldn't trigger usage information {pull}21272[#21272] (issue: {issue}21250[#21250])
+* Remove pluggability of ZenPing {pull}21049[#21049]
+* Make UnicastHostsProvider extension pull based {pull}21036[#21036]
+* Revert "Display plugins versions" {pull}20807[#20807] (issues: {issue}18683[#18683], {issue}20668[#20668])
+* Provide error message when plugin id is missing {pull}20660[#20660]
+
+Query DSL::
+* Make it possible to validate a query on all shards instead of a single random shard {pull}23697[#23697] (issue: {issue}18254[#18254])
+* QueryString and SimpleQueryString Graph Support {pull}22541[#22541]
+* Additional Graph Support in Match Query {pull}22503[#22503] (issue: {issue}22490[#22490])
+* RangeQuery WITHIN case now normalises query {pull}22431[#22431] (issue: {issue}22412[#22412])
+* Un-deprecate fuzzy query {pull}22088[#22088] (issue: {issue}15760[#15760])
+* support numeric bounds with decimal parts for long/integer/short/byte datatypes {pull}21972[#21972] (issue: {issue}21600[#21600])
+* Using ObjectParser in MatchAllQueryBuilder and IdsQueryBuilder {pull}21273[#21273]
+* Expose splitOnWhitespace in `Query String Query` {pull}20965[#20965] (issue: {issue}20841[#20841])
+* Throw error if query element doesn't end with END_OBJECT {pull}20528[#20528] (issue: {issue}20515[#20515])
+* Remove `lowercase_expanded_terms` and `locale` from query-parser options. {pull}20208[#20208] (issue: {issue}9978[#9978])
+
+REST::
+* Allow passing single scrollID in clear scroll API body {pull}24242[#24242] (issue: {issue}24233[#24233])
+* Validate top-level keys when parsing mget requests {pull}23746[#23746] (issue: {issue}23720[#23720])
+* Cluster stats should not render empty http/transport types {pull}23735[#23735]
+* Add parameter to prefix aggs name with type in search responses {pull}22965[#22965]
+* Add a REST spec for the create API {pull}20924[#20924]
+* Add response params to REST params did you mean {pull}20753[#20753] (issues: {issue}20722[#20722], {issue}20747[#20747])
+* Add did you mean to strict REST params {pull}20747[#20747] (issue: {issue}20722[#20722])
+
+Reindex API::
+* Increase visibility of doExecute so it can be used directly {pull}22614[#22614]
+* Improve error message when reindex-from-remote gets bad json {pull}22536[#22536] (issue: {issue}22330[#22330])
+* Reindex: Better error message for pipeline in wrong place {pull}21985[#21985]
+* Timeout improvements for rest client and reindex {pull}21741[#21741] (issue: {issue}21707[#21707])
+* Add "simple match" support for reindex-from-remote whitelist {pull}21004[#21004]
+* Make reindex-from-remote ignore unknown fields {pull}20591[#20591] (issue: {issue}20504[#20504])
+
+Scripting::
+* Expose multi-valued dates to scripts and document painless's date functions {pull}22875[#22875] (issue: {issue}22162[#22162])
+* Wrap VerifyError in ScriptException {pull}21769[#21769]
+* Log ScriptException's xcontent if file script compilation fails {pull}21767[#21767] (issue: {issue}21733[#21733])
+* Support binary field type in script values {pull}21484[#21484] (issue: {issue}14469[#14469])
+* Mustache: Add {{#url}}{{/url}} function to URL encode strings {pull}20838[#20838]
+* Expose `ctx._now` in update scripts {pull}20835[#20835] (issue: {issue}17895[#17895])
+
+Search::
+* Remove leniency when merging fetched hits in a search response phase {pull}24158[#24158]
+* Set shard count limit to unlimited {pull}24012[#24012]
+* Streamline shard index availability in all SearchPhaseResults {pull}23788[#23788]
+* Search took time should use a relative clock {pull}23662[#23662]
+* Prevent negative `from` parameter in SearchSourceBuilder {pull}23358[#23358] (issue: {issue}23324[#23324])
+* Remove unnecessary result sorting in SearchPhaseController {pull}23321[#23321]
+* Expose `batched_reduce_size` via `_search` {pull}23288[#23288] (issue: {issue}23253[#23253])
+* Adding fromXContent to Suggest and Suggestion class {pull}23226[#23226] (issue: {issue}23202[#23202])
+* Adding fromXContent to Suggestion.Entry and subclasses {pull}23202[#23202]
+* Add CollapseSearchPhase as a successor for the FetchSearchPhase {pull}23165[#23165]
+* Integrate IndexOrDocValuesQuery. {pull}23119[#23119]
+* Detach SearchPhases from AbstractSearchAsyncAction {pull}23118[#23118]
+* Fix GraphQuery expectation after Lucene upgrade to 6.5 {pull}23117[#23117] (issue: {issue}23102[#23102])
+* Nested queries should avoid adding unnecessary filters when possible. {pull}23079[#23079] (issue: {issue}20797[#20797])
+* Add xcontent parsing to completion suggestion option {pull}23071[#23071]
+* Add xcontent parsing to suggestion options {pull}23018[#23018]
+* Separate reduce (aggs, suggest and profile) from merging fetched hits {pull}23017[#23017]
+* Add a setting to disable remote cluster connections on a node {pull}23005[#23005]
+* First step towards separating individual search phases {pull}22802[#22802]
+* Add parsing from xContent to SearchProfileShardResults and nested classes {pull}22649[#22649]
+* Move SearchTransportService and SearchPhaseController creation outside of TransportSearchAction constructor {pull}21754[#21754]
+* Don't carry ShardRouting around when not needed in AbstractSearchAsyncAction {pull}21753[#21753]
+* ShardSearchRequest to take ShardId constructor argument rather than the whole ShardRouting {pull}21750[#21750]
+* Use index uuid as key in the alias filter map rather than the index name {pull}21749[#21749]
+* Add indices and filter information to search shards api output {pull}21738[#21738] (issue: {issue}20916[#20916])
+* remove pointless catch exception in TransportSearchAction {pull}21689[#21689]
+* Optimize query with types filter in the URL (t/t/_search) {pull}20979[#20979]
+* Makes search action cancelable by task management API {pull}20405[#20405]
+
+Search Templates::
+* Add profile and explain parameters to template API {pull}20451[#20451]
+
+Settings::
+* Add secure file setting to keystore {pull}24001[#24001]
+* Add a property to mark setting as final {pull}23872[#23872]
+* Remove obsolete index setting `index.version.minimum_compatible`. {pull}23593[#23593]
+* Provide a method to retrieve a closeable char[] from a SecureString {pull}23389[#23389]
+* Update indices settings api to support CBOR and SMILE format {pull}23309[#23309] (issues: {issue}23242[#23242], {issue}23245[#23245])
+* Improve setting deprecation message {pull}23156[#23156] (issue: {issue}22849[#22849])
+* Add secure settings validation on startup {pull}22894[#22894]
+* Allow comma delimited array settings to have a space after each entry {pull}22591[#22591] (issue: {issue}22297[#22297])
+* Allow affix settings to be dynamic / updatable {pull}22526[#22526]
+* Allow affix settings to delegate to actual settings {pull}22523[#22523]
+* Make s3 repository sensitive settings use secure settings {pull}22479[#22479]
+* Speed up filter and prefix settings operations {pull}22249[#22249]
+* Add precise logging on unknown or invalid settings {pull}20951[#20951] (issue: {issue}20946[#20946])
+
+Snapshot/Restore::
+* Ensure every repository has an incompatible-snapshots blob {pull}24403[#24403] (issue: {issue}22267[#22267])
+* Change snapshot status error to use generic SnapshotException {pull}24355[#24355] (issue: {issue}24225[#24225])
+* Duplicate snapshot name throws InvalidSnapshotNameException {pull}22921[#22921] (issue: {issue}18228[#18228])
+* Fixes retrieval of the latest snapshot index blob {pull}22700[#22700]
+* Use general cluster state batching mechanism for snapshot state updates {pull}22528[#22528] (issue: {issue}14899[#14899])
+* Synchronize snapshot deletions on the cluster state {pull}22313[#22313] (issue: {issue}19957[#19957])
+* Abort snapshots on a node that leaves the cluster {pull}21084[#21084] (issue: {issue}20876[#20876])
+
+Stats::
+* Show JVM arguments {pull}24450[#24450]
+* Add cross-cluster search remote cluster info API {pull}23969[#23969] (issue: {issue}23925[#23925])
+* Add geo_point to FieldStats {pull}21947[#21947] (issue: {issue}20707[#20707])
+* Include unindexed field in FieldStats response {pull}21821[#21821] (issue: {issue}21952[#21952])
+* Remove load average leniency {pull}21380[#21380]
+* Strengthen handling of unavailable cgroup stats {pull}21094[#21094] (issue: {issue}21029[#21029])
+* Add basic cgroup CPU metrics {pull}21029[#21029]
+
+Suggesters::
+* Provide informative error message in case of unknown suggestion context. {pull}24241[#24241]
+* Allow different data types for category in Context suggester {pull}23491[#23491] (issue: {issue}22358[#22358])
+
+Task Manager::
+* Limit IndexRequest toString() length {pull}22832[#22832]
+* Improve the error message if task and node isn't found {pull}22062[#22062] (issue: {issue}22027[#22027])
+* Add descriptions to create snapshot and restore snapshot tasks. {pull}21901[#21901] (issue: {issue}21768[#21768])
+* Add proper descriptions to reindex, update-by-query and delete-by-query tasks. {pull}21841[#21841] (issue: {issue}21768[#21768])
+* Add search task descriptions {pull}21740[#21740]
+
+Tribe Node::
+* Add support for merging custom meta data in tribe node {pull}21552[#21552] (issues: {issue}20544[#20544], {issue}20791[#20791], {issue}9372[#9372])
+
+Upgrade API::
+* Allow plugins to upgrade templates and index metadata on startup {pull}24379[#24379]
+
+[float]
+=== Bug Fixes
+
+
+Aggregations::
+* InternalPercentilesBucket should not rely on ordered percents array {pull}24336[#24336] (issue: {issue}24331[#24331])
+* Align behavior HDR percentiles iterator with percentile() method {pull}24206[#24206]
+* The `filter` and `significant_terms` aggregations should parse the `filter` as a filter, not a query. {pull}23797[#23797]
+* Completion suggestion should also consider text if prefix/regex is missing {pull}23451[#23451] (issue: {issue}23340[#23340])
+* Fixes the per term error in the terms aggregation {pull}23399[#23399]
+* Fixes terms error count for multiple reduce phases {pull}23291[#23291] (issue: {issue}23286[#23286])
+* Fix scaled_float numeric type in aggregations {pull}22351[#22351] (issue: {issue}22350[#22350])
+* Allow terms aggregations on pure boolean scripts. {pull}22201[#22201] (issue: {issue}20941[#20941])
+* Fix numeric terms aggregations with includes/excludes and minDocCount=0 {pull}22141[#22141] (issue: {issue}22140[#22140])
+* Fix `missing` on aggs on `boolean` fields. {pull}22135[#22135] (issue: {issue}22009[#22009])
+* IP range masks exclude the maximum address of the range. {pull}22018[#22018] (issue: {issue}22005[#22005])
+* Fix `other_bucket` on the `filters` agg to be enabled if a key is set. {pull}21994[#21994] (issue: {issue}21951[#21951])
+* Rewrite Queries/Filter in FilterAggregationBuilder and ensure client usage marks query as non-cachable {pull}21303[#21303] (issue: {issue}21301[#21301])
+* Percentiles bucket fails for 100th percentile {pull}21218[#21218]
+* Thread safety for scripted significance heuristics {pull}21113[#21113] (issue: {issue}18120[#18120])
+* `ip_range` aggregation should accept null bounds. {pull}21043[#21043] (issue: {issue}21006[#21006])
+* Fixes bug preventing script sort working on top_hits aggregation {pull}21023[#21023] (issue: {issue}21022[#21022])
+* Fixed writeable name from range to geo_distance {pull}20860[#20860]
+* Fix date_range aggregation to not cache if now is used {pull}20740[#20740]
+* The `top_hits` aggregation should compile scripts only once. {pull}20738[#20738]
+
+Allocation::
+* Discard stale node responses from async shard fetching {pull}24434[#24434] (issue: {issue}24007[#24007])
+* Cannot force allocate primary to a node where the shard already exists {pull}22031[#22031] (issue: {issue}22021[#22021])
+* Promote shadow replica to primary when initializing primary fails {pull}22021[#22021]
+* Trim in-sync allocations set only when it grows {pull}21976[#21976] (issue: {issue}21719[#21719])
+* Allow master to assign primary shard to node that has shard store locked during shard state fetching {pull}21656[#21656] (issue: {issue}19416[#19416])
+* Keep a shadow replicas' allocation id when it is promoted to primary {pull}20863[#20863] (issue: {issue}20650[#20650])
+* IndicesClusterStateService should clean local started when re-assigns an initializing shard with the same aid {pull}20687[#20687]
+* IndexRoutingTable.initializeEmpty shouldn't override supplied primary RecoverySource {pull}20638[#20638] (issue: {issue}20637[#20637])
+* Update incoming recoveries stats when shadow replica is reinitialized {pull}20612[#20612]
+* `index.routing.allocation.initial_recovery` limits replica allocation {pull}20589[#20589]
+
+Analysis::
+* AsciiFoldingFilter's multi-term component should never preserve the original token. {pull}21982[#21982]
+* Pre-built analysis factories do not implement MultiTermAware correctly. {pull}21981[#21981]
+* Can load non-PreBuiltTokenFilter in Analyze API {pull}20396[#20396]
+* Named analyzer should close the analyzer that it wraps {pull}20197[#20197]
+
+Bulk::
+* Reject empty IDs {pull}24118[#24118] (issue: {issue}24116[#24116])
+
+CAT API::
+* Consume `full_id` request parameter early {pull}21270[#21270] (issue: {issue}21266[#21266])
+
+CRUD::
+* Reject external versioning and explicit version numbers on create {pull}21998[#21998]
+* MultiGet should not fail entirely if alias resolves to many indices {pull}20858[#20858] (issue: {issue}20845[#20845])
+* Fixed date math expression support in multi get requests. {pull}20659[#20659] (issue: {issue}17957[#17957])
+
+Cache::
+* Invalidate cached query results if query timed out {pull}22807[#22807] (issue: {issue}22789[#22789])
+* Fix the request cache keys to not hold references to the SearchContext. {pull}21284[#21284]
+* Prevent requests that use scripts or now() from being cached {pull}20750[#20750] (issue: {issue}20645[#20645])
+
+Circuit Breakers::
+* ClusterState publishing shouldn't trigger circuit breakers {pull}20986[#20986] (issues: {issue}20827[#20827], {issue}20960[#20960])
+
+Cluster::
+* Don't set local node on cluster state used for node join validation {pull}23311[#23311] (issues: {issue}21830[#21830], {issue}3[#3], {issue}4[#4], {issue}6[#6], {issue}9[#9])
+* Allow a cluster state applier to create an observer and wait for a better state {pull}23132[#23132] (issue: {issue}21817[#21817])
+* Cluster allocation explain to never return empty response body {pull}23054[#23054]
+* IndicesService handles all exceptions during index deletion {pull}22433[#22433]
+* Remove cluster update task when task times out {pull}21578[#21578] (issue: {issue}21568[#21568])
+
+Core::
+* Check for default.path.data included in path.data {pull}24285[#24285] (issue: {issue}24283[#24283])
+* Improve performance of extracting warning value {pull}24114[#24114] (issue: {issue}24018[#24018])
+* Reject duplicate settings on the command line {pull}24053[#24053]
+* Restrict build info loading to ES jar, not any jar {pull}24049[#24049] (issue: {issue}21955[#21955])
+* Streamline foreign stored context restore and allow to perserve response headers {pull}22677[#22677] (issue: {issue}22647[#22647])
+* Support negative numbers in readVLong {pull}22314[#22314]
+* Add a StreamInput#readArraySize method that ensures sane array sizes {pull}21697[#21697]
+* Use a buffer to do character to byte conversion in StreamOutput#writeString {pull}21680[#21680] (issue: {issue}21660[#21660])
+* Fix ShardInfo#toString {pull}21319[#21319]
+* Protect BytesStreamOutput against overflows of the current number of written bytes. {pull}21174[#21174] (issue: {issue}21159[#21159])
+* Return target index name even if _rollover conditions are not met {pull}21138[#21138]
+* .es_temp_file remains after system crash, causing it not to start again {pull}21007[#21007] (issue: {issue}20992[#20992])
+* StoreStatsCache should also ignore AccessDeniedException when checking file size {pull}20790[#20790] (issue: {issue}17580[#17580])
+
+Dates::
+* Fix time zone rounding edge case for DST overlaps {pull}21550[#21550] (issue: {issue}20833[#20833])
+
+Discovery::
+* ZenDiscovery - only validate min_master_nodes values if local node is master {pull}23915[#23915] (issue: {issue}23695[#23695])
+* Close InputStream when receiving cluster state in PublishClusterStateAction {pull}22711[#22711]
+* Do not reply to pings from another cluster {pull}21894[#21894] (issue: {issue}21874[#21874])
+* Add current cluster state version to zen pings and use them in master election {pull}20384[#20384] (issue: {issue}20348[#20348])
+
+Engine::
+* Close and flush refresh listeners on shard close {pull}22342[#22342]
+* Die with dignity on the Lucene layer {pull}21721[#21721] (issue: {issue}19272[#19272])
+* Fix `InternalEngine#isThrottled` to not always return `false`. {pull}21592[#21592]
+* Retrying replication requests on replica doesn't call `onRetry` {pull}21189[#21189] (issue: {issue}20211[#20211])
+* Take refresh IOExceptions into account when catching ACE in InternalEngine {pull}20546[#20546] (issue: {issue}19975[#19975])
+
+Exceptions::
+* Stop returning "es." internal exception headers as http response headers {pull}22703[#22703] (issue: {issue}17593[#17593])
+* Fixing shard recovery error message to report the number of docs correctly for each node {pull}22515[#22515] (issue: {issue}21893[#21893])
+
+Highlighting::
+* Fix FiltersFunctionScoreQuery highlighting {pull}21827[#21827]
+* Fix highlighting on a stored keyword field {pull}21645[#21645] (issue: {issue}21636[#21636])
+* Fix highlighting of MultiTermQuery within a FunctionScoreQuery {pull}20400[#20400] (issue: {issue}20392[#20392])
+
+Index APIs::
+* Fixes restore of a shrunken index when initial recovery node is gone {pull}24322[#24322] (issue: {issue}24257[#24257])
+* Honor update request timeout {pull}23825[#23825]
+* Ensure shrunk indices carry over version information from its source {pull}22469[#22469] (issue: {issue}22373[#22373])
+* Validate the `_rollover` target index name early to also fail if dry_run=true {pull}21330[#21330] (issue: {issue}21149[#21149])
+* Only negate index expression on all indices with preceding wildcard {pull}20898[#20898] (issues: {issue}19800[#19800], {issue}20033[#20033])
+* Fix IndexNotFoundException in multi index search request. {pull}20188[#20188] (issue: {issue}3839[#3839])
+
+Index Templates::
+* Fix integer overflows when dealing with templates. {pull}21628[#21628] (issue: {issue}21622[#21622])
+
+Ingest::
+* Improve missing ingest processor error {pull}23379[#23379] (issue: {issue}23392[#23392])
+* update _ingest.timestamp to use new ZonedDateTime {pull}23174[#23174] (issue: {issue}23168[#23168])
+* fix date-processor to a new default year for every new pipeline execution {pull}22601[#22601] (issue: {issue}22547[#22547])
+* fix index out of bounds error in KV Processor {pull}22288[#22288] (issue: {issue}22272[#22272])
+* Fixes GrokProcessor's ignorance of named-captures with same name. {pull}22131[#22131] (issue: {issue}22117[#22117])
+* fix trace_match behavior for when there is only one grok pattern {pull}21413[#21413] (issue: {issue}21371[#21371])
+* Stored scripts and ingest node configurations should be included into a snapshot {pull}21227[#21227] (issue: {issue}21184[#21184])
+* make painless the default scripting language for ScriptProcessor {pull}20981[#20981] (issue: {issue}20943[#20943])
+* no null values in ingest configuration error messages {pull}20616[#20616]
+* JSON Processor was not properly added {pull}20613[#20613]
+
+Inner Hits::
+* Replace NestedChildrenQuery with ParentChildrenBlockJoinQuery {pull}24016[#24016] (issue: {issue}24009[#24009])
+* Changed DisMaxQueryBuilder to extract inner hits from leaf queries {pull}23512[#23512] (issue: {issue}23482[#23482])
+* Inner hits and ignore unmapped {pull}21693[#21693] (issue: {issue}21620[#21620])
+* Skip adding a parent field to nested documents. {pull}21522[#21522] (issue: {issue}21503[#21503])
+
+Internal::
+* Fix NPE if field caps request has a field that exists not in all indices {pull}24504[#24504]
+* Add infrastructure to mark contexts as system contexts {pull}23830[#23830]
+* Always restore the ThreadContext for operations delayed due to a block {pull}23349[#23349]
+* Index creation and setting update may not return deprecation logging {pull}22702[#22702]
+* Rethrow ExecutionException from the loader to concurrent callers of Cache#computeIfAbsent {pull}21549[#21549]
+* Restore thread's original context before returning to the ThreadPool {pull}21411[#21411]
+* Fix NPE in SearchContext.toString() {pull}21069[#21069]
+* Prevent AbstractArrays from release bytes more than once {pull}20819[#20819]
+* Source filtering should treat dots in field names as sub objects. {pull}20736[#20736] (issue: {issue}20719[#20719])
+* IndicesAliasesRequest should not implement CompositeIndicesRequest {pull}20726[#20726]
+* Ensure elasticsearch doesn't start with unuspported indices {pull}20514[#20514] (issue: {issue}20512[#20512])
+
+Java API::
+* Don't output empty ext object in SearchSourceBuilder#toXContent {pull}22093[#22093] (issue: {issue}20969[#20969])
+* Transport client: Fix remove address to actually work {pull}21743[#21743]
+* Add a HostFailureListener to notify client code if a node got disconnected {pull}21709[#21709] (issue: {issue}21424[#21424])
+* Fix InternalSearchHit#hasSource to return the proper boolean value {pull}21441[#21441] (issue: {issue}21419[#21419])
+* Null checked for source when calling sourceRef {pull}21431[#21431] (issue: {issue}19279[#19279])
+* ClusterAdminClient.prepareDeletePipeline method should accept pipeline id to delete {pull}21228[#21228]
+* fix IndexResponse#toString to print out shards info {pull}20562[#20562]
+
+Java High Level REST Client::
+* Correctly parse BulkItemResponse.Failure's status {pull}23432[#23432]
+
+Java REST Client::
+* Make buffer limit configurable in HeapBufferedConsumerFactory {pull}23970[#23970] (issue: {issue}23958[#23958])
+* RestClient asynchronous execution should not throw exceptions {pull}23307[#23307]
+* Don't use null charset in RequestLogger {pull}22197[#22197] (issue: {issue}22190[#22190])
+* Rest client: don't reuse the same HttpAsyncResponseConsumer across multiple retries {pull}21378[#21378]
+
+Logging::
+* Do not prematurely shutdown Log4j {pull}21519[#21519] (issue: {issue}21514[#21514])
+* Assert status logger does not warn on Log4j usage {pull}21339[#21339]
+* Fix logger names for Netty {pull}21223[#21223] (issue: {issue}20457[#20457])
+* Fix logger when you can not create an azure storage client {pull}20670[#20670] (issues: {issue}20633[#20633], {issue}20669[#20669])
+* Avoid unnecessary creation of prefix loggers {pull}20571[#20571] (issue: {issue}20570[#20570])
+* Fix logging hierarchy configs {pull}20463[#20463]
+* Fix prefix logging {pull}20429[#20429]
+
+Mapping::
+* Preserve response headers when creating an index {pull}23950[#23950] (issue: {issue}23947[#23947])
+* Improves disabled fielddata error message {pull}23841[#23841] (issue: {issue}22768[#22768])
+* Fix MapperService StackOverflowError {pull}23605[#23605] (issue: {issue}23604[#23604])
+* Fix NPE with scaled floats stats when field is not indexed {pull}23528[#23528] (issue: {issue}23487[#23487])
+* Range types causing `GetFieldMappingsIndexRequest` to fail due to `NullPointerException` in `RangeFieldMapper.doXContentBody` when `include_defaults=true` is on the query string {pull}22925[#22925]
+* Disallow introducing illegal object mappings (double '..') {pull}22891[#22891] (issue: {issue}22794[#22794])
+* The `_all` default mapper is not completely configured. {pull}22236[#22236]
+* Fix MapperService.allEnabled(). {pull}22227[#22227]
+* Dynamic `date` fields should use the `format` that was used to detect it is a date. {pull}22174[#22174] (issue: {issue}9410[#9410])
+* Sub-fields should not accept `include_in_all` parameter {pull}21971[#21971] (issue: {issue}21710[#21710])
+* Mappings: Fix get mapping when no indexes exist to not fail in response generation {pull}21924[#21924] (issue: {issue}21916[#21916])
+* Fail to index fields with dots in field names when one of the intermediate objects is nested. {pull}21787[#21787] (issue: {issue}21726[#21726])
+* Uncommitted mapping updates should not efect existing indices {pull}21306[#21306] (issue: {issue}21189[#21189])
+
+Nested Docs::
+* Fix bug in query builder rewrite that ignores the ignore_unmapped option {pull}22456[#22456]
+
+Network::
+* Respect promises on pipelined responses {pull}23317[#23317] (issues: {issue}23310[#23310], {issue}23322[#23322])
+* Ensure that releasing listener is called {pull}23310[#23310]
+* Pass `forceExecution` flag to transport interceptor {pull}22739[#22739]
+* Ensure new connections won't be opened if transport is closed or closing {pull}22589[#22589] (issue: {issue}22554[#22554])
+* Prevent open channel leaks if handshake times out or is interrupted {pull}22554[#22554]
+* Execute low level handshake in #openConnection {pull}22440[#22440]
+* Handle connection close / reset events gracefully during handshake {pull}22178[#22178]
+* Do not lose host information when pinging {pull}21939[#21939] (issue: {issue}21828[#21828])
+* DiscoveryNode and TransportAddress should preserve host information {pull}21828[#21828]
+* Die with dignity on the network layer {pull}21720[#21720] (issue: {issue}19272[#19272])
+* Fix connection close header handling {pull}20956[#20956] (issue: {issue}20938[#20938])
+* Ensure port range is readable in the exception message {pull}20893[#20893]
+* Prevent double release in TcpTransport if send listener throws an exception {pull}20880[#20880]
+
+Packaging::
+* Fall back to non-atomic move when removing plugins {pull}23548[#23548] (issue: {issue}35[#35])
+* Another fix for handling of paths on Windows {pull}22132[#22132] (issue: {issue}21921[#21921])
+* Fix handling of spaces in Windows paths {pull}21921[#21921] (issues: {issue}20809[#20809], {issue}21525[#21525])
+* Add option to skip kernel parameters on install {pull}21899[#21899] (issue: {issue}21877[#21877])
+* Set vm.max_map_count on systemd package install {pull}21507[#21507]
+* Export ES_JVM_OPTIONS for SysV init {pull}21445[#21445] (issue: {issue}21255[#21255])
+* Debian: configure start-stop-daemon to not go into background {pull}21343[#21343] (issues: {issue}12716[#12716], {issue}21300[#21300])
+* Generate POM files with non-wildcard excludes {pull}21234[#21234] (issue: {issue}21170[#21170])
+* [Packaging] Do not remove scripts directory on upgrade {pull}20452[#20452]
+* [Package] Remove bin/lib/modules directories on RPM uninstall/upgrade {pull}20448[#20448]
+
+Parent/Child::
+* Add null check in case of orphan child document {pull}22772[#22772] (issue: {issue}22770[#22770])
+
+Percolator::
+* Fix memory leak when percolator uses bitset or field data cache {pull}24115[#24115] (issue: {issue}24108[#24108])
+* Fix NPE in percolator's 'now' range check for percolator queries with range queries {pull}22356[#22356] (issue: {issue}22355[#22355])
+
+Plugin Analysis Stempel::
+* Fix thread safety of Stempel's token filter factory {pull}22610[#22610] (issue: {issue}21911[#21911])
+
+Plugin Discovery EC2::
+* Fix ec2 discovery when used with IAM profiles. {pull}21048[#21048] (issue: {issue}21039[#21039])
+
+Plugin Ingest GeoIp::
+* [ingest-geoip] update geoip to not include null-valued results from  {pull}20455[#20455]
+
+Plugin Lang Painless::
+* painless: Fix method references to ctor with the new LambdaBootstrap and cleanup code {pull}24406[#24406]
+* Fix Painless Lambdas for Java 9 {pull}24070[#24070] (issue: {issue}23473[#23473])
+* Fix painless's regex lexer and error messages {pull}23634[#23634]
+* Replace Painless's Cast with casting strategies {pull}23369[#23369]
+* Fix Bad Casts In Painless {pull}23282[#23282] (issue: {issue}23238[#23238])
+* Don't allow casting from void to def in painless {pull}22969[#22969] (issue: {issue}22908[#22908])
+* Fix def invoked qualified method refs {pull}22918[#22918]
+* Whitelist some ScriptDocValues in painless {pull}22600[#22600] (issue: {issue}22584[#22584])
+* Update Painless Loop Counter to be Higher {pull}22560[#22560] (issue: {issue}22508[#22508])
+* Fix some issues with painless's strings {pull}22393[#22393] (issue: {issue}22372[#22372])
+* Test fix for def equals in Painless {pull}21945[#21945] (issue: {issue}21801[#21801])
+* Fix a VerifyError bug in Painless {pull}21765[#21765]
+* Fix Lambdas in Painless to be Able to Use Top-Level Variables Such as params and doc {pull}21635[#21635] (issues: {issue}20869[#20869], {issue}21479[#21479])
+* Fix String Concatenation Bug In Painless {pull}20623[#20623]
+
+Plugin Repository Azure::
+* Azure blob store's readBlob() method first checks if the blob exists {pull}23483[#23483] (issue: {issue}23480[#23480])
+* Fixes default chunk size for Azure repositories {pull}22577[#22577] (issue: {issue}22513[#22513])
+* readonly on azure repository must be taken into account {pull}22055[#22055] (issues: {issue}22007[#22007], {issue}22053[#22053])
+
+Plugin Repository HDFS::
+* Fixing permission errors for `KERBEROS` security mode for HDFS Repository {pull}23439[#23439] (issue: {issue}22156[#22156])
+
+Plugin Repository S3::
+* Handle BlobPath's trailing separator case. Add test cases to BlobPathTests.java {pull}23091[#23091]
+* Fixes leading forward slash in S3 repository base_path {pull}20861[#20861]
+
+Plugins::
+* Fix delete of plugin directory on remove plugin {pull}24266[#24266] (issue: {issue}24252[#24252])
+* Use a marker file when removing a plugin {pull}24252[#24252] (issue: {issue}24231[#24231])
+* Remove hidden file leniency from plugin service {pull}23982[#23982] (issue: {issue}12465[#12465])
+* Add check for null pluginName in remove command {pull}22930[#22930] (issue: {issue}22922[#22922])
+* Use sysprop like with es.path.home to pass conf dir {pull}18870[#18870] (issue: {issue}18689[#18689])
+
+Query DSL::
+* FuzzyQueryBuilder should error when parsing array of values {pull}23762[#23762] (issue: {issue}23759[#23759])
+* Fix parsing for `max_determinized_states` {pull}22749[#22749] (issue: {issue}22722[#22722])
+* Fix script score function that combines _score and weight {pull}22713[#22713] (issue: {issue}21483[#21483])
+* Fixes date range query using epoch with timezone {pull}21542[#21542] (issue: {issue}21501[#21501])
+* Allow overriding all-field leniency when `lenient` option is specified {pull}21504[#21504] (issues: {issue}20925[#20925], {issue}21341[#21341])
+* Max score should be updated when a rescorer is used {pull}20977[#20977] (issue: {issue}20651[#20651])
+* Fixes MultiMatchQuery so that it doesn't provide a null context {pull}20882[#20882]
+* Fix silently accepting malformed queries {pull}20515[#20515] (issue: {issue}20500[#20500])
+* Fix match_phrase_prefix query with single term on _all field {pull}20471[#20471] (issue: {issue}20470[#20470])
+
+REST::
+* [API] change wait_for_completion default according to docs {pull}23672[#23672]
+* Deprecate request_cache for clear-cache {pull}23638[#23638] (issue: {issue}22748[#22748])
+* HTTP transport stashes the ThreadContext instead of the RestController {pull}23456[#23456]
+* Fix date format in warning headers {pull}23418[#23418] (issue: {issue}23275[#23275])
+* Align REST specs for HEAD requests {pull}23313[#23313] (issue: {issue}21125[#21125])
+* Correct warning header to be compliant {pull}23275[#23275] (issue: {issue}22986[#22986])
+* Fix get HEAD requests {pull}23186[#23186] (issue: {issue}21125[#21125])
+* Handle bad HTTP requests {pull}23153[#23153] (issue: {issue}23034[#23034])
+* Fix get source HEAD requests {pull}23151[#23151] (issue: {issue}21125[#21125])
+* Properly encode location header {pull}23133[#23133] (issues: {issue}21057[#21057], {issue}23115[#23115])
+* Fix template HEAD requests {pull}23130[#23130] (issue: {issue}21125[#21125])
+* Fix index HEAD requests {pull}23112[#23112] (issue: {issue}21125[#21125])
+* Fix alias HEAD requests {pull}23094[#23094] (issue: {issue}21125[#21125])
+* Strict level parsing for indices stats {pull}21577[#21577] (issue: {issue}21024[#21024])
+* The routing query string param is supported by mget but was missing from the rest spec {pull}21357[#21357]
+* fix thread_pool_patterns path variable definition {pull}21332[#21332]
+* Read indices options in indices upgrade API {pull}21281[#21281] (issue: {issue}21099[#21099])
+* ensure the XContentBuilder is always closed in RestBuilderListener {pull}21124[#21124]
+* Add correct Content-Length on HEAD requests {pull}21123[#21123] (issue: {issue}21077[#21077])
+* Make sure HEAD / has 0 Content-Length {pull}21077[#21077] (issue: {issue}21075[#21075])
+* Adds percent-encoding for Location headers {pull}21057[#21057] (issue: {issue}21016[#21016])
+* Whitelist node stats indices level parameter {pull}21024[#21024] (issue: {issue}20722[#20722])
+* Remove lenient URL parameter parsing {pull}20722[#20722] (issue: {issue}14719[#14719])
+* XContentBuilder: Avoid building self-referencing objects {pull}20550[#20550] (issues: {issue}19475[#19475], {issue}20540[#20540])
+
+Recovery::
+* Provide target allocation id as part of start recovery request {pull}24333[#24333] (issue: {issue}24167[#24167])
+* Fix primary relocation for shadow replicas {pull}22474[#22474] (issue: {issue}20300[#20300])
+* Don't close store under CancellableThreads {pull}22434[#22434] (issue: {issue}22325[#22325])
+* Use a fresh recovery id when retrying recoveries {pull}22325[#22325] (issue: {issue}22043[#22043])
+* Allow flush/force_merge/upgrade on shard marked as relocated {pull}22078[#22078] (issue: {issue}22043[#22043])
+* Fix concurrency issues between cancelling a relocation and marking shard as relocated {pull}20443[#20443]
+
+Reindex API::
+* Fix throttled reindex_from_remote {pull}23953[#23953] (issues: {issue}23828[#23828], {issue}23945[#23945])
+* Fix reindex with a remote source on a version before 2.0.0 {pull}23805[#23805]
+* Make reindex wait for cleanup before responding {pull}23677[#23677] (issue: {issue}23653[#23653])
+* Reindex: do not log when can't clear old scroll {pull}22942[#22942] (issue: {issue}22937[#22937])
+* Fix reindex-from-remote from <2.0 {pull}22931[#22931] (issue: {issue}22893[#22893])
+* Fix reindex from remote clearing scroll {pull}22525[#22525] (issue: {issue}22514[#22514])
+* Fix source filtering in reindex-from-remote {pull}22514[#22514] (issue: {issue}22507[#22507])
+* Remove content type detection from reindex-from-remote {pull}22504[#22504] (issue: {issue}22329[#22329])
+* Don't close rest client from its callback {pull}22061[#22061] (issue: {issue}22027[#22027])
+* Keep context during reindex's retries {pull}21941[#21941]
+* Ignore IllegalArgumentException with assertVersionSerializable {pull}21409[#21409] (issues: {issue}20767[#20767], {issue}21350[#21350])
+* Bump reindex-from-remote's buffer to 200mb {pull}21222[#21222] (issue: {issue}21185[#21185])
+* Fix reindex-from-remote for parent/child from <2.0 {pull}21070[#21070] (issue: {issue}21044[#21044])
+
+Scripting::
+* Convert script/template objects to json format internally {pull}23308[#23308] (issue: {issue}23245[#23245])
+* Script: Fix value of `ctx._now` to be current epoch time in milliseconds {pull}23175[#23175] (issue: {issue}23169[#23169])
+* Expose `ip` fields as strings in scripts. {pull}21997[#21997] (issue: {issue}21977[#21977])
+* Add support for booleans in scripts {pull}20950[#20950] (issue: {issue}20949[#20949])
+* Native scripts should be created once per index, not per segment. {pull}20609[#20609]
+
+Search::
+* Include all aliases including non-filtering in  `_search_shards` response {pull}24489[#24489]
+* Cross Cluster Search: propagate original indices per cluster {pull}24328[#24328]
+* Query string default field {pull}24214[#24214]
+* Speed up parsing of large `terms` queries. {pull}24210[#24210]
+* IndicesQueryCache should delegate the scorerSupplier method. {pull}24209[#24209]
+* Disable graph analysis at query time for shingle and cjk filters producing tokens of different size {pull}23920[#23920] (issue: {issue}23918[#23918])
+* Fix cross-cluster remote node gateway attributes {pull}23863[#23863]
+* Use a fixed seed for computing term hashCode in TermsSliceQuery {pull}23795[#23795]
+* Honor max concurrent searches in multi-search {pull}23538[#23538] (issue: {issue}23527[#23527])
+* Avoid stack overflow in multi-search {pull}23527[#23527] (issue: {issue}23523[#23523])
+* Fix query_string_query to transform "foo:*" in an exists query on the field name {pull}23433[#23433] (issue: {issue}23356[#23356])
+* Factor out filling of TopDocs in SearchPhaseController {pull}23380[#23380] (issues: {issue}19356[#19356], {issue}23357[#23357])
+* Replace blocking calls in ExpandCollapseSearchResponseListener by asynchronous requests {pull}23053[#23053] (issue: {issue}23048[#23048])
+* Ensure fixed serialization order of InnerHitBuilder {pull}22820[#22820] (issue: {issue}22808[#22808])
+* Improve concurrency of ShardCoreKeyMap. {pull}22316[#22316]
+* Make `-0` compare less than `+0` consistently. {pull}22173[#22173] (issue: {issue}22167[#22167])
+* Fix boost_mode propagation when the function score query builder is rewritten {pull}22172[#22172] (issue: {issue}22138[#22138])
+* FiltersAggregationBuilder: rewriting filter queries, the same way as in FilterAggregationBuilder {pull}22076[#22076]
+* Fix cross_fields type on multi_match query with synonyms {pull}21638[#21638] (issue: {issue}21633[#21633])
+* Fix match_phrase_prefix on boosted fields {pull}21623[#21623] (issue: {issue}21613[#21613])
+* Respect default search timeout {pull}21599[#21599] (issues: {issue}12211[#12211], {issue}21595[#21595])
+* Remove LateParsingQuery to prevent timestamp access after context is frozen {pull}21328[#21328] (issue: {issue}21295[#21295])
+* Make range queries round up upper bounds again. {pull}20582[#20582] (issues: {issue}20579[#20579], {issue}8889[#8889])
+* Throw error when trying to fetch fields from source and source is disabled {pull}20424[#20424] (issues: {issue}20093[#20093], {issue}20408[#20408])
+
+Search Templates::
+* No longer add illegal content type option to stored search templates {pull}24251[#24251] (issue: {issue}24227[#24227])
+* SearchTemplateRequest to implement CompositeIndicesRequest {pull}21865[#21865] (issue: {issue}21747[#21747])
+
+Settings::
+* Do not set path.data in environment if not set {pull}24132[#24132] (issue: {issue}24099[#24099])
+* Correct handling of default and array settings {pull}24074[#24074] (issues: {issue}23981[#23981], {issue}24052[#24052])
+* Fix merge scheduler config settings {pull}23391[#23391]
+* Settings: Fix keystore cli prompting for yes/no to handle console returning null {pull}23320[#23320]
+* Expose `search.highlight.term_vector_multi_value` as a node level setting {pull}22999[#22999]
+* NPE when no setting name passed to elasticsearch-keystore {pull}22609[#22609]
+* Handle spaces in `action.auto_create_index` gracefully {pull}21790[#21790] (issue: {issue}21449[#21449])
+* Fix settings diff generation for affix and group settings {pull}21788[#21788]
+* Don't reset non-dynamic settings unless explicitly requested {pull}21646[#21646] (issue: {issue}21593[#21593])
+* Fix Setting.timeValue() method {pull}20696[#20696] (issue: {issue}20662[#20662])
+* Add a hard limit for `index.number_of_shard` {pull}20682[#20682]
+* Include complex settings in settings requests {pull}20622[#20622]
+
+Snapshot/Restore::
+* Fixes maintaining the shards a snapshot is waiting on {pull}24289[#24289]
+* Fixes snapshot status on failed snapshots {pull}23833[#23833] (issue: {issue}23716[#23716])
+* Fixes snapshot deletion handling on in-progress snapshot failure {pull}23703[#23703] (issue: {issue}23663[#23663])
+* Prioritize listing index-N blobs over index.latest in reading snapshots {pull}23333[#23333]
+* Gracefully handles pre 2.x compressed snapshots {pull}22267[#22267]
+* URLRepository should throw NoSuchFileException to correctly adhere to readBlob contract {pull}22069[#22069] (issue: {issue}22004[#22004])
+* Fixes shard level snapshot metadata loading when index-N file is missing {pull}21813[#21813]
+* Ensures cleanup of temporary index-* generational blobs during snapshotting {pull}21469[#21469] (issue: {issue}21462[#21462])
+* Fixes get snapshot duplicates when asking for _all {pull}21340[#21340] (issue: {issue}21335[#21335])
+
+Stats::
+* Avoid overflow when computing total FS stats {pull}23641[#23641]
+* Handle existence of cgroup version 2 hierarchy {pull}23493[#23493] (issue: {issue}23486[#23486])
+* Handle long overflow when adding paths' totals {pull}23293[#23293] (issue: {issue}23093[#23093])
+* Fix control group pattern {pull}23219[#23219] (issue: {issue}23218[#23218])
+* Fix total disk bytes returning negative value {pull}23093[#23093]
+* Implement stats for geo_point and geo_shape field {pull}22391[#22391] (issue: {issue}22384[#22384])
+* Use reader for doc stats {pull}22317[#22317] (issue: {issue}22285[#22285])
+* Avoid NPE in NodeService#stats if HTTP is disabled {pull}22060[#22060] (issue: {issue}22058[#22058])
+* Add support for "include_segment_file_sizes" in indices stats REST handler {pull}21879[#21879] (issue: {issue}21878[#21878])
+* Remove output_uuid parameter from cluster stats {pull}21020[#21020] (issue: {issue}20722[#20722])
+* Fix FieldStats deserialization of `ip` field {pull}20522[#20522] (issue: {issue}20516[#20516])
+
+Task Manager::
+* Task Management: Make TaskInfo parsing forwards compatible {pull}24073[#24073] (issue: {issue}23250[#23250])
+* Fix hanging cancelling task with no children {pull}22796[#22796]
+* Fix broken TaskInfo.toString() {pull}22698[#22698] (issue: {issue}22387[#22387])
+* Task cancellation command should wait for all child nodes to receive cancellation request before returning {pull}21397[#21397] (issue: {issue}21126[#21126])
+
+Term Vectors::
+* Fix _termvectors with preference to not hit NPE {pull}21959[#21959]
+* Return correct term statistics when a field is not found in a shard {pull}21922[#21922] (issue: {issue}21906[#21906])
+
+Tribe Node::
+* Add socket permissions for tribe nodes {pull}21546[#21546] (issues: {issue}16392[#16392], {issue}21122[#21122])
+
+[float]
+=== Regressions
+
+Bulk::
+* Fix _bulk response when it can't create an index {pull}24048[#24048] (issues: {issue}22488[#22488], {issue}24028[#24028])
+
+Core::
+* Source filtering: only accept array items if the previous include pattern matches {pull}22593[#22593] (issue: {issue}22557[#22557])
+
+Highlighting::
+* Handle SynonymQuery extraction for the FastVectorHighlighter {pull}20829[#20829] (issue: {issue}20781[#20781])
+
+Logging::
+* Restores the original default format of search slow log {pull}21770[#21770] (issue: {issue}21711[#21711])
+
+Network::
+* You had one job Netty logging guard {pull}24469[#24469] (issues: {issue}5624[#5624], {issue}6568[#6568])
+
+Plugin Discovery EC2::
+* Fix ec2 discovery when used with IAM profiles. {pull}21042[#21042] (issue: {issue}21039[#21039])
+
+Plugin Repository S3::
+* Fix s3 repository when used with IAM profiles {pull}21058[#21058] (issue: {issue}21048[#21048])
+
+Plugins::
+* Plugins: Add back user agent when downloading plugins {pull}20872[#20872]
+
+Search::
+* Handle specialized term queries in MappedFieldType.extractTerm(Query) {pull}21889[#21889] (issue: {issue}21882[#21882])
+
+//[float]
+//=== Known Issues
+
+[float]
+=== Upgrades
+
+Aggregations::
+* Upgrade HDRHistogram to 2.1.9 {pull}23254[#23254] (issue: {issue}23239[#23239])
+
+Core::
+* Upgrade to Lucene 6.5.0 {pull}23750[#23750]
+* Upgrade from JNA 4.2.2 to JNA 4.4.0 {pull}23636[#23636]
+* Upgrade to lucene-6.5.0-snapshot-d00c5ca {pull}23385[#23385]
+* Upgrade to lucene-6.5.0-snapshot-f919485. {pull}23087[#23087]
+* Upgrade to Lucene 6.4.0 {pull}22724[#22724]
+* Update Jackson to 2.8.6 {pull}22596[#22596] (issue: {issue}22266[#22266])
+* Upgrade to lucene-6.4.0-snapshot-084f7a0. {pull}22413[#22413]
+* Upgrade to lucene-6.4.0-snapshot-ec38570 {pull}21853[#21853]
+* Upgrade to lucene-6.3.0. {pull}21464[#21464]
+
+Dates::
+* Update Joda Time to version 2.9.5 {pull}21468[#21468] (issues: {issue}20911[#20911], {issue}332[#332], {issue}373[#373], {issue}378[#378], {issue}379[#379], {issue}386[#386], {issue}394[#394], {issue}396[#396], {issue}397[#397], {issue}404[#404], {issue}69[#69])
+
+Internal::
+* Upgrade to Lucene 6.4.1. {pull}22978[#22978]
+
+Logging::
+* Upgrade to Log4j 2.8.2 {pull}23995[#23995]
+* Upgrade Log4j 2 to version 2.7 {pull}20805[#20805] (issue: {issue}20304[#20304])
+
+Network::
+* Upgrade Netty to 4.1.10.Final {pull}24414[#24414]
+* Upgrade to Netty 4.1.9 {pull}23540[#23540] (issues: {issue}23172[#23172], {issue}6308[#6308], {issue}6374[#6374])
+* Upgrade to Netty 4.1.8 {pull}23055[#23055]
+* Upgrade to Netty 4.1.7 {pull}22587[#22587]
+* Upgrade to Netty 4.1.6 {pull}21051[#21051]
+
+//[float]
+//=== Regressions
+
+Plugin Repository Azure::
+* Update to Azure Storage 5.0.0 {pull}23517[#23517] (issue: {issue}23448[#23448])

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -162,7 +162,6 @@ The new <<mapping-ignored-field,`_ignored`>> field allows to know which fields
 got ignored at index time because of the <<ignore-malformed,`ignore_malformed`>>
 option. ({pull}30140[#29658])
 
-
 [float]
 === Enhancements
 
@@ -188,10 +187,26 @@ Machine Learning::
 
 * Account for gaps in data counts after job is reopened ({pull}30294[#30294])
 
+//[float]
+//=== Regressions
+
+//[float]
+//=== Known Issues
+
 [[release-notes-6.3.1]]
 == Elasticsearch version 6.3.1
 
 coming[6.3.1]
+
+//[float]
+[[breaking-6.3.1]]
+//=== Breaking Changes
+
+//[float]
+//=== Breaking Java Changes
+
+//[float]
+//=== Deprecations
 
 //[float]
 //=== New Features
@@ -210,21 +225,17 @@ Reduce the number of object allocations made by {security} when resolving the in
 //[float]
 //=== Known Issues
 
-[[release-notes-6.3.1]]
-== Elasticsearch version 6.3.1
-
-coming[6.3.1]
-
-//[float]
-[[breaking-6.3.1]]
 [[release-notes-6.3.0]]
 == {es} version 6.3.0
 
 coming[6.3.0]
 
-[float]
-[[breaking-6.3.0]]
-=== Breaking Changes
+//[float]
+//[[breaking-6.3.0]]
+//=== Breaking Changes
+
+//[float]
+//=== Breaking Java Changes
 
 [float]
 === Deprecations
@@ -239,12 +250,6 @@ Security::
 * The legacy `XPackExtension` extension mechanism has been removed and replaced
 with an SPI based extension mechanism that is installed and built as an
 elasticsearch plugin.
-
-//[float]
-//=== Breaking Java Changes
-
-//[float]
-//=== Deprecations
 
 //[float]
 //=== New Features


### PR DESCRIPTION
This PR adds the items from the 6.x branch's CHANGELOG.asciidoc into the master file. 
I believe this is the desired behaviour, since it makes it easier to backport changes to all branches.

This PR also fixes some oddities in the ordering of the releases.

Related to #29450

If the the 5.x items should also be added to the master file, this can be done after https://github.com/elastic/elasticsearch/pull/30374 is complete.