### PR TITLE
DayName SQL function #29981

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistry.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionRegistry.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.sql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.sql.expression.function.aggregate.SumOfSquares;
 import org.elasticsearch.xpack.sql.expression.function.aggregate.VarPop;
 import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.Mod;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayName;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayOfMonth;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayOfWeek;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DayOfYear;
@@ -105,6 +106,7 @@ public class FunctionRegistry {
             def(MonthOfYear.class, MonthOfYear::new, "MONTH"),
             def(Year.class, Year::new),
             def(WeekOfYear.class, WeekOfYear::new, "WEEK"),
+            def(DayName.class, DayName::new, "DAYNAME"),
             // Math
             def(Abs.class, Abs::new),
             def(ACos.class, ACos::new),

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayName.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayName.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.FieldAttribute;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
+import org.elasticsearch.xpack.sql.expression.function.scalar.script.ParamsBuilder;
+import org.elasticsearch.xpack.sql.tree.Location;
+import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
+import org.elasticsearch.xpack.sql.type.DataType;
+
+import java.time.temporal.ChronoField;
+import java.util.TimeZone;
+
+import static org.elasticsearch.xpack.sql.expression.function.scalar.script.ScriptTemplate.formatTemplate;
+
+/**
+ * Extract the day name from a datetime.
+ * <pre>
+ * DATENAME("2017-12-05T00:00:00")
+ * returns "Tuesday"
+ * </pre>
+ *
+ */
+public class DayName extends DateTimeFunction {
+
+    // DateTimeFormatter.ofPattern
+    static final String FORMAT = "EEEE";
+
+    public DayName(Location location, Expression field, TimeZone timeZone) {
+        super(location, field, timeZone);
+    }
+
+    @Override
+    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+        return DayName::new;
+    }
+
+    @Override
+    protected DayName replaceChild(Expression newChild) {
+        return new DayName(location(), newChild, timeZone());
+    }
+
+    @Override
+    public String dateTimeFormat() {
+        return FORMAT;
+    }
+
+    @Override
+    public DataType dataType() {
+        return DataType.TEXT;
+    }
+
+    @Override
+    protected ChronoField chronoField() {
+        return ChronoField.DAY_OF_WEEK;
+    }
+
+    @Override
+    protected DateTimeExtractor extractor() {
+        return DateTimeExtractor.DAYNAME;
+    }
+
+    // overridden because original fetches field and returns a number, while this needs to format the datetime.
+    @Override
+    String scriptTemplateTimezone(final FieldAttribute field, final ParamsBuilder params) {
+        params.variable(field.name()) // doc $param 1
+            .variable(this.timeZone().getID()) // ZoneId.of $param 2
+            .variable(FORMAT); // ofPattern $param 3
+
+        return formatTemplate("ZonedDateTime.ofInstant(Instant.ofEpochMilli(doc[{}].value.millis), " +
+            "ZoneId.of({}).format(DateTimeFormatter.ofPattern({}))");
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunctionTestcase.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunctionTestcase.java
@@ -1,0 +1,63 @@
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.test.ESTestCase;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.util.Locale;
+import java.util.TimeZone;
+
+public abstract class DateTimeFunctionTestcase<F extends DateTimeFunction> extends ESTestCase {
+
+    static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+    final DateTime dateTime(long millisSinceEpoch) {
+        return new DateTime(millisSinceEpoch, DateTimeZone.forTimeZone(UTC));
+    }
+
+    final DateTime dateTime(final int year, final int month, final int day) {
+        return new DateTime(year, month, day, 12, 0);
+    }
+
+    final Object process(Object value, String timeZone) {
+        return process(value, timeZone(timeZone));
+    }
+
+    final Object process(Object value, TimeZone timeZone) {
+        return build(value, timeZone).asProcessorDefinition().asProcessor().process(value);
+    }
+
+    final void processAndCheck(final DateTime dateTime, final String timeZone, final Object expected) {
+        processAndCheck(dateTime, timeZone(timeZone), expected);
+    }
+
+    final void processAndCheck(final DateTime dateTime, final TimeZone timeZone, final Object expected) {
+        this.processAndCheck(dateTime, timeZone, this.defaultLocale(), expected);
+    }
+
+    final void processAndCheck(final DateTime dateTime,
+                               final TimeZone timeZone,
+                               final Locale locale,
+                               final Object expected) {
+        Locale backup = null;
+        if(null!=locale) {
+            backup = Locale.getDefault();
+            Locale.setDefault(locale);
+        }
+        try {
+            assertEquals(dateTime + " " + locale, expected, process(dateTime, timeZone));
+        } finally {
+            if(null!=backup) {
+                Locale.setDefault(backup);
+            }
+        }
+    }
+
+    abstract F build(Object value, TimeZone timeZone);
+
+    abstract Locale defaultLocale();
+
+    private TimeZone timeZone(final String timeZone) {
+        return TimeZone.getTimeZone(timeZone);
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayNameTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayNameTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.xpack.sql.expression.Literal;
+import org.elasticsearch.xpack.sql.type.DataType;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class DayNameTests extends DateTimeFunctionTestcase<DayName> {
+
+    public void test19700101_Thursday() {
+        processAndCheck(dateTime(0), UTC, "Thursday");
+    }
+
+    public void test20180503_GMT_Plus100_Thursday() {
+        processAndCheck(dateTime(2018,5,3), "GMT+01:00", "Thursday");
+    }
+
+    public void test20180502_GMTMinus100_Friday() {
+        processAndCheck(dateTime(2018,5,4), "GMT-01:00", "Friday");
+    }
+
+    @Override
+    DayName build(Object value, TimeZone timeZone) {
+        return new DayName(null, new Literal(null, value, DataType.DATE), timeZone);
+    }
+
+    // test expectations assume English
+    Locale defaultLocale() {
+        return Locale.ENGLISH;
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYearTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYearTests.java
@@ -5,32 +5,32 @@
  */
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.expression.Literal;
 import org.elasticsearch.xpack.sql.type.DataType;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
+import java.util.Locale;
 import java.util.TimeZone;
 
-public class DayOfYearTests extends ESTestCase {
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+public class DayOfYearTests extends DateTimeFunctionTestcase<DayOfYear> {
 
-    public void testAsColumnProcessor() {
-        assertEquals(1, extract(dateTime(0), UTC));
-        assertEquals(1, extract(dateTime(0), TimeZone.getTimeZone("GMT+01:00")));
-        assertEquals(365, extract(dateTime(0), TimeZone.getTimeZone("GMT-01:00")));
+    public void testUTC() {
+        processAndCheck(dateTime(0), UTC, 1);
     }
 
-    private DateTime dateTime(long millisSinceEpoch) {
-        return new DateTime(millisSinceEpoch, DateTimeZone.forTimeZone(UTC));
+    public void testGMT_plus0100() {
+        processAndCheck(dateTime(0), "GMT+01:00", 1);
     }
 
-    private Object extract(Object value, TimeZone timeZone) {
-        return build(value, timeZone).asProcessorDefinition().asProcessor().process(value);
+    public void testGMT_minus0100() {
+        processAndCheck(dateTime(0), "GMT-01:00", 365);
     }
 
-    private DayOfYear build(Object value, TimeZone timeZone) {
+    @Override
+    DayOfYear build(Object value, TimeZone timeZone) {
         return new DayOfYear(null, new Literal(null, value, DataType.DATE), timeZone);
+    }
+
+    Locale defaultLocale() {
+        return null;
     }
 }


### PR DESCRIPTION
- couldnt add an optional <Timezoneid> parameter to function because
DateTimeFunction extends UnaryScalarFunction which forces only ONE
parameter. Abandoned attempt VariableArgumentsScalarFunction,
because that would change entire DTF hierarchy.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
SIGNED

- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
YES

- If submitting code, have you built your formula locally prior to submission with `gradle check`?
YES - passed, unrelated failures, must have appeared in the last day or two, was fine with "previous master".

>> rch.transport.RemoteTransportException: [node-0][127.0.0.1:51406][indices:data/read/search[phase/query]]
Caused by: org.elasticsearch.search.aggregations.AggregationExecutionException: Aggregation [ip_terms] cannot support regular expression style include/exclude settings as they can only be applied to string fields. Use an array of values for include/exclude clauses
        at org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsAggregatorFactory.doCreateInternal(SignificantTermsAggregatorFactory.java:219) ~[elasticsearch-7.0.0-alpha1-SNAPSHOT.jar:7.0.0-alpha1-SNAPSHOT]
        at org.elasticsearch.searc

- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
master

- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
OSX - shouldnt matter, no native stuff

- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.

DONE
