### PR TITLE
BlobContainer.move() should fail if source does not exist or target already exists

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -130,6 +130,12 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     @Override
     public void move(String sourceBlobName, String targetBlobName) throws IOException {
         logger.trace("move({}, {})", sourceBlobName, targetBlobName);
+        if (blobExists(sourceBlobName) == false) {
+            throw new NoSuchFileException(sourceBlobName);
+        }
+        if (blobExists(targetBlobName)) {
+            throw new FileAlreadyExistsException(sourceBlobName);
+        }
         try {
             String source = keyPath + sourceBlobName;
             String target = keyPath + targetBlobName;

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainer.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainer.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.NoSuchFileException;
 import java.util.Map;
 
 class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
@@ -79,6 +80,12 @@ class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
 
     @Override
     public void move(String sourceBlobName, String targetBlobName) throws IOException {
+        if (blobExists(sourceBlobName) == false) {
+            throw new NoSuchFileException(sourceBlobName);
+        }
+        if (blobExists(targetBlobName)) {
+            throw new FileAlreadyExistsException(sourceBlobName);
+        }
         blobStore.moveBlob(buildKey(sourceBlobName), buildKey(targetBlobName));
     }
 

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -78,6 +78,13 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
 
     @Override
     public void move(String sourceBlobName, String targetBlobName) throws IOException {
+        if (blobExists(sourceBlobName) == false) {
+            throw new NoSuchFileException(sourceBlobName);
+        }
+        if (blobExists(targetBlobName)) {
+            throw new FileAlreadyExistsException(sourceBlobName);
+        }
+
         store.execute((Operation<Void>) fileContext -> {
             fileContext.rename(new Path(path, sourceBlobName), new Path(path, targetBlobName));
             return null;

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -158,6 +158,13 @@ class S3BlobContainer extends AbstractBlobContainer {
 
     @Override
     public void move(String sourceBlobName, String targetBlobName) throws IOException {
+        if (blobExists(sourceBlobName) == false) {
+            throw new NoSuchFileException(sourceBlobName);
+        }
+        if (blobExists(targetBlobName)) {
+            throw new FileAlreadyExistsException(sourceBlobName);
+        }
+
         try {
             CopyObjectRequest request = new CopyObjectRequest(blobStore.bucket(), buildKey(sourceBlobName),
                 blobStore.bucket(), buildKey(targetBlobName));


### PR DESCRIPTION
The implementations of `BlobContainer.move()` are supposed to throw exceptions when the source does not exist or when the target blob already exists. This contract is expected by the `writeAtomic()` method which should fail in such cases. Today, only `FsBlobContainer` respects this contract. While cloud based repositories do not provide atomic writes, we can add additionnal checks to check for file existence and fail if necessary.