### PR TITLE
Rename "thaw" APIs to "unfreeze"

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.freeze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.freeze.json
@@ -1,6 +1,6 @@
 {
   "indices.freeze": {
-    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-freeze-thaw.html",
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-freeze-unfreeze.html",
     "methods": ["POST"],
     "url": {
       "path": "/{index}/_freeze",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.unfreeze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.unfreeze.json
@@ -1,15 +1,15 @@
 {
-  "indices.thaw": {
-    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-freeze-thaw.html",
+  "indices.unfreeze": {
+    "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/master/indices-freeze-unfreeze.html",
     "methods": ["POST"],
     "url": {
-      "path": "/{index}/_thaw",
-      "paths": ["/{index}/_thaw"],
+      "path": "/{index}/_unfreeze",
+      "paths": ["/{index}/_unfreeze"],
       "parts": {
         "index": {
           "type" : "list",
           "required" : true,
-          "description" : "A comma separated list of indices to thaw"
+          "description" : "A comma separated list of indices to unfreeze"
         }
       },
       "params": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.thaw/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.thaw/10_basic.yml
@@ -1,5 +1,5 @@
 ---
-"Basic test for index freeze/thaw":
+"Basic test for index freeze/unfreeze":
   - skip:
       version: " - 6.99.99"
       reason: this feature didn't exist until 7.0
@@ -40,7 +40,7 @@
         body: { "foo": "bar" }
 
   - do:
-      indices.thaw:
+      indices.unfreeze:
         index: test_index
 
   - do:
@@ -50,10 +50,10 @@
   - match: { hits.hits.0._source.foo: bar }
 
 ---
-"Thaw index with wait_for_active_shards set to all":
+"Unfreeze index with wait_for_active_shards set to all":
   - skip:
       version: " - 6.9.99"
-      reason: freeze/thaw was added in 7.0
+      reason: freeze/unfreeze was added in 7.0
 
   - do:
       indices.create:
@@ -67,7 +67,7 @@
         index: test_index
 
   - do:
-      indices.thaw:
+      indices.unfreeze:
         index: test_index
         wait_for_active_shards: all
 

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -142,8 +142,8 @@ import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesActi
 import org.elasticsearch.action.admin.indices.template.get.TransportGetIndexTemplatesAction;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateAction;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexAction;
-import org.elasticsearch.action.admin.indices.thaw.TransportThawIndexAction;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexAction;
+import org.elasticsearch.action.admin.indices.unfreeze.TransportUnfreezeIndexAction;
 import org.elasticsearch.action.admin.indices.upgrade.get.TransportUpgradeStatusAction;
 import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusAction;
 import org.elasticsearch.action.admin.indices.upgrade.post.TransportUpgradeAction;
@@ -277,7 +277,7 @@ import org.elasticsearch.rest.action.admin.indices.RestRecoveryAction;
 import org.elasticsearch.rest.action.admin.indices.RestRefreshAction;
 import org.elasticsearch.rest.action.admin.indices.RestRolloverIndexAction;
 import org.elasticsearch.rest.action.admin.indices.RestSyncedFlushAction;
-import org.elasticsearch.rest.action.admin.indices.RestThawIndexAction;
+import org.elasticsearch.rest.action.admin.indices.RestUnfreezeIndexAction;
 import org.elasticsearch.rest.action.admin.indices.RestUpdateSettingsAction;
 import org.elasticsearch.rest.action.admin.indices.RestUpgradeAction;
 import org.elasticsearch.rest.action.admin.indices.RestUpgradeStatusAction;
@@ -459,7 +459,7 @@ public class ActionModule extends AbstractModule {
         actions.register(OpenIndexAction.INSTANCE, TransportOpenIndexAction.class);
         actions.register(CloseIndexAction.INSTANCE, TransportCloseIndexAction.class);
         actions.register(FreezeIndexAction.INSTANCE, TransportFreezeIndexAction.class);
-        actions.register(ThawIndexAction.INSTANCE, TransportThawIndexAction.class);
+        actions.register(UnfreezeIndexAction.INSTANCE, TransportUnfreezeIndexAction.class);
         actions.register(IndicesExistsAction.INSTANCE, TransportIndicesExistsAction.class);
         actions.register(TypesExistsAction.INSTANCE, TransportTypesExistsAction.class);
         actions.register(GetMappingsAction.INSTANCE, TransportGetMappingsAction.class);
@@ -583,7 +583,7 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestCloseIndexAction(settings, restController));
         registerHandler.accept(new RestOpenIndexAction(settings, restController));
         registerHandler.accept(new RestFreezeIndexAction(settings, restController));
-        registerHandler.accept(new RestThawIndexAction(settings, restController));
+        registerHandler.accept(new RestUnfreezeIndexAction(settings, restController));
 
         registerHandler.accept(new RestUpdateSettingsAction(settings, restController));
         registerHandler.accept(new RestGetSettingsAction(settings, restController));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/freeze/TransportFreezeIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/freeze/TransportFreezeIndexAction.java
@@ -21,9 +21,6 @@ package org.elasticsearch.action.admin.indices.freeze;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.freeze.FreezeIndexAction;
-import org.elasticsearch.action.admin.indices.freeze.FreezeIndexRequest;
-import org.elasticsearch.action.admin.indices.freeze.FreezeIndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -35,7 +32,6 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaDataIndexStateService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.tasks.Task;
@@ -52,9 +48,9 @@ public class TransportFreezeIndexAction extends TransportMasterNodeAction<Freeze
 
     @Inject
     public TransportFreezeIndexAction(Settings settings, TransportService transportService, ClusterService clusterService,
-                                     ThreadPool threadPool, MetaDataIndexStateService indexStateService,
-                                     ClusterSettings clusterSettings, ActionFilters actionFilters,
-                                     IndexNameExpressionResolver indexNameExpressionResolver, DestructiveOperations destructiveOperations) {
+                                      ThreadPool threadPool, MetaDataIndexStateService indexStateService,
+                                      ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver,
+                                      DestructiveOperations destructiveOperations) {
         super(settings, FreezeIndexAction.NAME, transportService, clusterService,
                 threadPool, actionFilters, indexNameExpressionResolver, FreezeIndexRequest::new);
         this.indexStateService = indexStateService;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexAction.java
@@ -17,28 +17,27 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.thaw;
+package org.elasticsearch.action.admin.indices.unfreeze;
 
-import org.elasticsearch.action.support.ActiveShardCount;
-import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
+import org.elasticsearch.action.Action;
+import org.elasticsearch.client.ElasticsearchClient;
 
-/**
- * Cluster state update request that allows to close one or more indices
- */
-public class ThawIndexClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<ThawIndexClusterStateUpdateRequest> {
+public class UnfreezeIndexAction extends Action<UnfreezeIndexRequest, UnfreezeIndexResponse, UnfreezeIndexRequestBuilder> {
 
-    private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
+    public static final UnfreezeIndexAction INSTANCE = new UnfreezeIndexAction();
+    public static final String NAME = "indices:admin/unfreeze";
 
-    ThawIndexClusterStateUpdateRequest() {
-
+    private UnfreezeIndexAction() {
+        super(NAME);
     }
 
-    public ActiveShardCount waitForActiveShards() {
-        return waitForActiveShards;
+    @Override
+    public UnfreezeIndexResponse newResponse() {
+        return new UnfreezeIndexResponse();
     }
 
-    public ThawIndexClusterStateUpdateRequest waitForActiveShards(ActiveShardCount waitForActiveShards) {
-        this.waitForActiveShards = waitForActiveShards;
-        return this;
+    @Override
+    public UnfreezeIndexRequestBuilder newRequestBuilder(ElasticsearchClient client) {
+        return new UnfreezeIndexRequestBuilder(client, this);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexClusterStateUpdateRequest.java
@@ -17,27 +17,28 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.thaw;
+package org.elasticsearch.action.admin.indices.unfreeze;
 
-import org.elasticsearch.action.Action;
-import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
 
-public class ThawIndexAction extends Action<ThawIndexRequest, ThawIndexResponse, ThawIndexRequestBuilder> {
+/**
+ * Cluster state update request that allows to unfreeze one or more indices
+ */
+public class UnfreezeIndexClusterStateUpdateRequest extends IndicesClusterStateUpdateRequest<UnfreezeIndexClusterStateUpdateRequest> {
 
-    public static final ThawIndexAction INSTANCE = new ThawIndexAction();
-    public static final String NAME = "indices:admin/thaw";
+    private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
 
-    private ThawIndexAction() {
-        super(NAME);
+    UnfreezeIndexClusterStateUpdateRequest() {
+
     }
 
-    @Override
-    public ThawIndexResponse newResponse() {
-        return new ThawIndexResponse();
+    public ActiveShardCount waitForActiveShards() {
+        return waitForActiveShards;
     }
 
-    @Override
-    public ThawIndexRequestBuilder newRequestBuilder(ElasticsearchClient client) {
-        return new ThawIndexRequestBuilder(client, this);
+    public UnfreezeIndexClusterStateUpdateRequest waitForActiveShards(ActiveShardCount waitForActiveShards) {
+        this.waitForActiveShards = waitForActiveShards;
+        return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexRequest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.thaw;
+package org.elasticsearch.action.admin.indices.unfreeze;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
@@ -33,21 +33,21 @@ import java.io.IOException;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 /**
- * A request to thaw an index.
+ * A request to unfreeze an index.
  */
-public class ThawIndexRequest extends AcknowledgedRequest<ThawIndexRequest> implements IndicesRequest.Replaceable {
+public class UnfreezeIndexRequest extends AcknowledgedRequest<UnfreezeIndexRequest> implements IndicesRequest.Replaceable {
 
     private String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, false);
     private ActiveShardCount waitForActiveShards = ActiveShardCount.DEFAULT;
 
-    public ThawIndexRequest() {
+    public UnfreezeIndexRequest() {
     }
 
     /**
-     * Constructs a new thaw index request for the specified index.
+     * Constructs a new unfreeze index request for the specified index.
      */
-    public ThawIndexRequest(String... indices) {
+    public UnfreezeIndexRequest(String... indices) {
         this.indices = indices;
     }
 
@@ -61,8 +61,8 @@ public class ThawIndexRequest extends AcknowledgedRequest<ThawIndexRequest> impl
     }
 
     /**
-     * The indices to be thawed
-     * @return the indices to be thawed
+     * The indices to be unfrozen
+     * @return the indices to be unfrozen
      */
     @Override
     public String[] indices() {
@@ -70,12 +70,12 @@ public class ThawIndexRequest extends AcknowledgedRequest<ThawIndexRequest> impl
     }
 
     /**
-     * Sets the indices to be thawed
-     * @param indices the indices to be thawed
+     * Sets the indices to be unfrozen
+     * @param indices the indices to be unfrozen
      * @return the request itself
      */
     @Override
-    public ThawIndexRequest indices(String... indices) {
+    public UnfreezeIndexRequest indices(String... indices) {
         this.indices = indices;
         return this;
     }
@@ -98,7 +98,7 @@ public class ThawIndexRequest extends AcknowledgedRequest<ThawIndexRequest> impl
      * @param indicesOptions the desired behaviour regarding indices to ignore and wildcard indices expressions
      * @return the request itself
      */
-    public ThawIndexRequest indicesOptions(IndicesOptions indicesOptions) {
+    public UnfreezeIndexRequest indicesOptions(IndicesOptions indicesOptions) {
         this.indicesOptions = indicesOptions;
         return this;
     }
@@ -108,20 +108,20 @@ public class ThawIndexRequest extends AcknowledgedRequest<ThawIndexRequest> impl
     }
 
     /**
-     * Sets the number of shard copies that should be active for indices thawing to return.
+     * Sets the number of shard copies that should be active for indices unfreezing to return.
      * Defaults to {@link ActiveShardCount#DEFAULT}, which will wait for one shard copy
      * (the primary) to become active. Set this value to {@link ActiveShardCount#ALL} to
      * wait for all shards (primary and all replicas) to be active before returning.
      * Otherwise, use {@link ActiveShardCount#from(int)} to set this value to any
      * non-negative integer, up to the number of copies per shard (number of replicas + 1),
      * to wait for the desired amount of shard copies to become active before returning.
-     * Indices thawing will only wait up until the timeout value for the number of shard copies
-     * to be active before returning.  Check {@link ThawIndexResponse#isShardsAcknowledged()} to
+     * Indices unfreezing will only wait up until the timeout value for the number of shard copies
+     * to be active before returning.  Check {@link UnfreezeIndexResponse#isShardsAcknowledged()} to
      * determine if the requisite shard copies were all started before returning or timing out.
      *
      * @param waitForActiveShards number of active shard copies to wait on
      */
-    public ThawIndexRequest waitForActiveShards(ActiveShardCount waitForActiveShards) {
+    public UnfreezeIndexRequest waitForActiveShards(ActiveShardCount waitForActiveShards) {
         this.waitForActiveShards = waitForActiveShards;
         return this;
     }
@@ -131,7 +131,7 @@ public class ThawIndexRequest extends AcknowledgedRequest<ThawIndexRequest> impl
      * shard count is passed in, instead of having to first call {@link ActiveShardCount#from(int)}
      * to get the ActiveShardCount.
      */
-    public ThawIndexRequest waitForActiveShards(final int waitForActiveShards) {
+    public UnfreezeIndexRequest waitForActiveShards(final int waitForActiveShards) {
         return waitForActiveShards(ActiveShardCount.from(waitForActiveShards));
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexRequestBuilder.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.thaw;
+package org.elasticsearch.action.admin.indices.unfreeze;
 
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -25,26 +25,26 @@ import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
 import org.elasticsearch.client.ElasticsearchClient;
 
 /**
- * Builder for thaw index request
+ * Builder for unfreeze index request
  */
-public class ThawIndexRequestBuilder extends
-    AcknowledgedRequestBuilder<ThawIndexRequest, ThawIndexResponse, ThawIndexRequestBuilder> {
+public class UnfreezeIndexRequestBuilder extends
+    AcknowledgedRequestBuilder<UnfreezeIndexRequest, UnfreezeIndexResponse, UnfreezeIndexRequestBuilder> {
 
-    public ThawIndexRequestBuilder(ElasticsearchClient client, ThawIndexAction action) {
-        super(client, action, new ThawIndexRequest());
+    public UnfreezeIndexRequestBuilder(ElasticsearchClient client, UnfreezeIndexAction action) {
+        super(client, action, new UnfreezeIndexRequest());
     }
 
-    public ThawIndexRequestBuilder(ElasticsearchClient client, ThawIndexAction action, String... indices) {
-        super(client, action, new ThawIndexRequest(indices));
+    public UnfreezeIndexRequestBuilder(ElasticsearchClient client, UnfreezeIndexAction action, String... indices) {
+        super(client, action, new UnfreezeIndexRequest(indices));
     }
 
     /**
-     * Sets the indices to be thawed
+     * Sets the indices to be unfrozen
      *
-     * @param indices the indices to be thawed
+     * @param indices the indices to be unfrozen
      * @return the request itself
      */
-    public ThawIndexRequestBuilder setIndices(String... indices) {
+    public UnfreezeIndexRequestBuilder setIndices(String... indices) {
         request.indices(indices);
         return this;
     }
@@ -56,26 +56,26 @@ public class ThawIndexRequestBuilder extends
      * @param indicesOptions the desired behaviour regarding indices to ignore and indices wildcard expressions
      * @return the request itself
      */
-    public ThawIndexRequestBuilder setIndicesOptions(IndicesOptions indicesOptions) {
+    public UnfreezeIndexRequestBuilder setIndicesOptions(IndicesOptions indicesOptions) {
         request.indicesOptions(indicesOptions);
         return this;
     }
 
     /**
-     * Sets the number of shard copies that should be active for indices thawing to return.
+     * Sets the number of shard copies that should be active for indices unfreezing to return.
      * Defaults to {@link ActiveShardCount#DEFAULT}, which will wait for one shard copy
      * (the primary) to become active. Set this value to {@link ActiveShardCount#ALL} to
      * wait for all shards (primary and all replicas) to be active before returning.
      * Otherwise, use {@link ActiveShardCount#from(int)} to set this value to any
      * non-negative integer, up to the number of copies per shard (number of replicas + 1),
      * to wait for the desired amount of shard copies to become active before returning.
-     * Indices thawing will only wait up until the timeout value for the number of shard copies
-     * to be active before returning.  Check {@link ThawIndexResponse#isShardsAcknowledged()} to
+     * Indices unfreezing will only wait up until the timeout value for the number of shard copies
+     * to be active before returning.  Check {@link UnfreezeIndexResponse#isShardsAcknowledged()} to
      * determine if the requisite shard copies were all started before returning or timing out.
      *
      * @param waitForActiveShards number of active shard copies to wait on
      */
-    public ThawIndexRequestBuilder setWaitForActiveShards(ActiveShardCount waitForActiveShards) {
+    public UnfreezeIndexRequestBuilder setWaitForActiveShards(ActiveShardCount waitForActiveShards) {
         request.waitForActiveShards(waitForActiveShards);
         return this;
     }
@@ -85,7 +85,7 @@ public class ThawIndexRequestBuilder extends
      * shard count is passed in, instead of having to first call {@link ActiveShardCount#from(int)}
      * to get the ActiveShardCount.
      */
-    public ThawIndexRequestBuilder setWaitForActiveShards(final int waitForActiveShards) {
+    public UnfreezeIndexRequestBuilder setWaitForActiveShards(final int waitForActiveShards) {
         return setWaitForActiveShards(ActiveShardCount.from(waitForActiveShards));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexResponse.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.thaw;
+package org.elasticsearch.action.admin.indices.unfreeze;
 
 import org.elasticsearch.action.support.master.ShardsAcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,21 +28,22 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import java.io.IOException;
 
 /**
- * A response for a thaw index action.
+ * A response for an unfreeze index action.
  */
-public class ThawIndexResponse extends ShardsAcknowledgedResponse {
+public class UnfreezeIndexResponse extends ShardsAcknowledgedResponse {
 
-    private static final ConstructingObjectParser<ThawIndexResponse, Void> PARSER = new ConstructingObjectParser<>("thaw_index", true,
-            args -> new ThawIndexResponse((boolean) args[0], (boolean) args[1]));
+    private static final ConstructingObjectParser<UnfreezeIndexResponse, Void> PARSER =
+        new ConstructingObjectParser<>("unfreeze_index", true,
+            args -> new UnfreezeIndexResponse((boolean) args[0], (boolean) args[1]));
 
     static {
         declareAcknowledgedAndShardsAcknowledgedFields(PARSER);
     }
 
-    ThawIndexResponse() {
+    UnfreezeIndexResponse() {
     }
 
-    ThawIndexResponse(boolean acknowledged, boolean shardsAcknowledged) {
+    UnfreezeIndexResponse(boolean acknowledged, boolean shardsAcknowledged) {
         super(acknowledged, shardsAcknowledged);
     }
 
@@ -60,7 +61,7 @@ public class ThawIndexResponse extends ShardsAcknowledgedResponse {
         writeShardsAcknowledged(out);
     }
 
-    public static ThawIndexResponse fromXContent(XContentParser parser) {
+    public static UnfreezeIndexResponse fromXContent(XContentParser parser) {
         return PARSER.apply(parser, null);
     }
 }

--- a/server/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
+++ b/server/src/main/java/org/elasticsearch/client/IndicesAdminClient.java
@@ -113,9 +113,9 @@ import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResp
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateResponse;
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexRequest;
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexRequestBuilder;
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexResponse;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexRequest;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexRequestBuilder;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexResponse;
 import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusRequest;
 import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusRequestBuilder;
 import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusResponse;
@@ -381,29 +381,29 @@ public interface IndicesAdminClient extends ElasticsearchClient {
     FreezeIndexRequestBuilder prepareFreeze(String... indices);
 
     /**
-     * Thaw an index based on the index name.
+     * Unfreeze an index based on the index name.
      *
-     * @param request The thaw index request
+     * @param request The unfreeze index request
      * @return The result future
-     * @see org.elasticsearch.client.Requests#thawIndexRequest(String)
+     * @see org.elasticsearch.client.Requests#unfreezeIndexRequest(String)
      */
-    ActionFuture<ThawIndexResponse> thaw(ThawIndexRequest request);
+    ActionFuture<UnfreezeIndexResponse> unfreeze(UnfreezeIndexRequest request);
 
     /**
-     * Thaw an index based on the index name.
+     * Unfreeze an index based on the index name.
      *
-     * @param request  The thaw index request
+     * @param request  The unfreeze index request
      * @param listener A listener to be notified with a result
-     * @see org.elasticsearch.client.Requests#thawIndexRequest(String)
+     * @see org.elasticsearch.client.Requests#unfreezeIndexRequest(String)
      */
-    void thaw(ThawIndexRequest request, ActionListener<ThawIndexResponse> listener);
+    void unfreeze(UnfreezeIndexRequest request, ActionListener<UnfreezeIndexResponse> listener);
 
     /**
-     * Thaws one or more indices based on their index name.
+     * Unfreezes one or more indices based on their index name.
      *
-     * @param indices The name of the indices to thaw
+     * @param indices The name of the indices to unfreeze
      */
-    ThawIndexRequestBuilder prepareThaw(String... indices);
+    UnfreezeIndexRequestBuilder prepareUnfreeze(String... indices);
 
     /**
      * Explicitly refresh one or more indices (making the content indexed since the last refresh searchable).

--- a/server/src/main/java/org/elasticsearch/client/Requests.java
+++ b/server/src/main/java/org/elasticsearch/client/Requests.java
@@ -56,7 +56,7 @@ import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.shards.IndicesShardStoresRequest;
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexRequest;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexRequest;
 import org.elasticsearch.action.admin.indices.upgrade.post.UpgradeRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -231,14 +231,14 @@ public class Requests {
     }
 
     /**
-     * Creates a thaw index request.
+     * Creates an unfreeze index request.
      *
-     * @param index The index to thaw
-     * @return The thaw index request
-     * @see org.elasticsearch.client.IndicesAdminClient#thaw(org.elasticsearch.action.admin.indices.thaw.ThawIndexRequest)
+     * @param index The index to unfreeze
+     * @return The unfreeze index request
+     * @see org.elasticsearch.client.IndicesAdminClient#unfreeze(UnfreezeIndexRequest)
      */
-    public static ThawIndexRequest thawIndexRequest(String index) {
-        return new ThawIndexRequest(index);
+    public static UnfreezeIndexRequest unfreezeIndexRequest(String index) {
+        return new UnfreezeIndexRequest(index);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/support/AbstractClient.java
@@ -256,10 +256,10 @@ import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateActio
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateResponse;
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexAction;
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexRequest;
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexRequestBuilder;
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexResponse;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexAction;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexRequest;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexRequestBuilder;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexResponse;
 import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusAction;
 import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusRequest;
 import org.elasticsearch.action.admin.indices.upgrade.get.UpgradeStatusRequestBuilder;
@@ -1453,18 +1453,18 @@ public abstract class AbstractClient extends AbstractComponent implements Client
         }
 
         @Override
-        public ThawIndexRequestBuilder prepareThaw(String... indices) {
-            return new ThawIndexRequestBuilder(this, ThawIndexAction.INSTANCE, indices);
+        public UnfreezeIndexRequestBuilder prepareUnfreeze(String... indices) {
+            return new UnfreezeIndexRequestBuilder(this, UnfreezeIndexAction.INSTANCE, indices);
         }
 
         @Override
-        public ActionFuture<ThawIndexResponse> thaw(final ThawIndexRequest request) {
-            return execute(ThawIndexAction.INSTANCE, request);
+        public ActionFuture<UnfreezeIndexResponse> unfreeze(final UnfreezeIndexRequest request) {
+            return execute(UnfreezeIndexAction.INSTANCE, request);
         }
 
         @Override
-        public void thaw(final ThawIndexRequest request, final ActionListener<ThawIndexResponse> listener) {
-            execute(ThawIndexAction.INSTANCE, request, listener);
+        public void unfreeze(final UnfreezeIndexRequest request, final ActionListener<UnfreezeIndexResponse> listener) {
+            execute(UnfreezeIndexAction.INSTANCE, request, listener);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/ack/UnfreezeIndexClusterStateUpdateResponse.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ack/UnfreezeIndexClusterStateUpdateResponse.java
@@ -19,13 +19,13 @@
 package org.elasticsearch.cluster.ack;
 
 /**
- * A cluster state update response with specific fields for index thawing.
+ * A cluster state update response with specific fields for index unfreezing.
  */
-public class ThawIndexClusterStateUpdateResponse extends ClusterStateUpdateResponse {
+public class UnfreezeIndexClusterStateUpdateResponse extends ClusterStateUpdateResponse {
 
     private final boolean shardsAcknowledged;
 
-    public ThawIndexClusterStateUpdateResponse(boolean acknowledged, boolean shardsAcknowledged) {
+    public UnfreezeIndexClusterStateUpdateResponse(boolean acknowledged, boolean shardsAcknowledged) {
         super(acknowledged);
         this.shardsAcknowledged = shardsAcknowledged;
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUnfreezeIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUnfreezeIndexAction.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.rest.action.admin.indices;
 
-import org.elasticsearch.action.admin.indices.thaw.ThawIndexRequest;
+import org.elasticsearch.action.admin.indices.unfreeze.UnfreezeIndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
@@ -32,29 +32,29 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
 
-public class RestThawIndexAction extends BaseRestHandler {
-    public RestThawIndexAction(Settings settings, RestController controller) {
+public class RestUnfreezeIndexAction extends BaseRestHandler {
+    public RestUnfreezeIndexAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.POST, "/_thaw", this);
-        controller.registerHandler(RestRequest.Method.POST, "/{index}/_thaw", this);
+        controller.registerHandler(RestRequest.Method.POST, "/_unfreeze", this);
+        controller.registerHandler(RestRequest.Method.POST, "/{index}/_unfreeze", this);
     }
 
     @Override
     public String getName() {
-        return "thaw_index_action";
+        return "unfreeze_index_action";
     }
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        ThawIndexRequest thawIndexRequest = new ThawIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
-        thawIndexRequest.timeout(request.paramAsTime("timeout", thawIndexRequest.timeout()));
-        thawIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", thawIndexRequest.masterNodeTimeout()));
-        thawIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, thawIndexRequest.indicesOptions()));
+        UnfreezeIndexRequest unfreezeIndexRequest = new UnfreezeIndexRequest(Strings.splitStringByCommaToArray(request.param("index")));
+        unfreezeIndexRequest.timeout(request.paramAsTime("timeout", unfreezeIndexRequest.timeout()));
+        unfreezeIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", unfreezeIndexRequest.masterNodeTimeout()));
+        unfreezeIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, unfreezeIndexRequest.indicesOptions()));
         String waitForActiveShards = request.param("wait_for_active_shards");
         if (waitForActiveShards != null) {
-            thawIndexRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
+            unfreezeIndexRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
         }
-        return channel -> client.admin().indices().thaw(thawIndexRequest, new RestToXContentListener<>(channel));
+        return channel -> client.admin().indices().unfreeze(unfreezeIndexRequest, new RestToXContentListener<>(channel));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/unfreeze/UnfreezeIndexResponseTests.java
@@ -17,40 +17,40 @@
  * under the License.
  */
 
-package org.elasticsearch.action.admin.indices.thaw;
+package org.elasticsearch.action.admin.indices.unfreeze;
 
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.test.AbstractStreamableXContentTestCase;
 
-public class ThawIndexResponseTests extends AbstractStreamableXContentTestCase<ThawIndexResponse> {
+public class UnfreezeIndexResponseTests extends AbstractStreamableXContentTestCase<UnfreezeIndexResponse> {
 
     @Override
-    protected ThawIndexResponse doParseInstance(XContentParser parser) {
-        return ThawIndexResponse.fromXContent(parser);
+    protected UnfreezeIndexResponse doParseInstance(XContentParser parser) {
+        return UnfreezeIndexResponse.fromXContent(parser);
     }
 
     @Override
-    protected ThawIndexResponse createTestInstance() {
+    protected UnfreezeIndexResponse createTestInstance() {
         boolean acknowledged = randomBoolean();
         boolean shardsAcknowledged = acknowledged && randomBoolean();
-        return new ThawIndexResponse(acknowledged, shardsAcknowledged);
+        return new UnfreezeIndexResponse(acknowledged, shardsAcknowledged);
     }
 
     @Override
-    protected ThawIndexResponse createBlankInstance() {
-        return new ThawIndexResponse();
+    protected UnfreezeIndexResponse createBlankInstance() {
+        return new UnfreezeIndexResponse();
     }
 
     @Override
-    protected ThawIndexResponse mutateInstance(ThawIndexResponse response) {
+    protected UnfreezeIndexResponse mutateInstance(UnfreezeIndexResponse response) {
         if (randomBoolean()) {
             boolean acknowledged = response.isAcknowledged() == false;
             boolean shardsAcknowledged = acknowledged && response.isShardsAcknowledged();
-            return new ThawIndexResponse(acknowledged, shardsAcknowledged);
+            return new UnfreezeIndexResponse(acknowledged, shardsAcknowledged);
         } else {
             boolean shardsAcknowledged = response.isShardsAcknowledged() == false;
             boolean acknowledged = shardsAcknowledged || response.isAcknowledged();
-            return new ThawIndexResponse(acknowledged, shardsAcknowledged);
+            return new UnfreezeIndexResponse(acknowledged, shardsAcknowledged);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/state/FreezeUnfreezeIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/FreezeUnfreezeIndexIT.java
@@ -77,7 +77,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         UnfreezeIndexResponse unfreezeIndexResponse = client.admin().indices().prepareUnfreeze("test1").execute().actionGet();
         assertThat(unfreezeIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1");
+        assertIndexIsUnfrozen("test1");
     }
 
     public void testSimpleFreezeMissingIndex() {
@@ -134,7 +134,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().actionGet();
         assertThat(unfreezeIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1");
+        assertIndexIsUnfrozen("test1");
     }
 
     public void testFreezeUnfreezeMultipleIndices() {
@@ -148,7 +148,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         FreezeIndexResponse freezeIndexResponse2 = client.admin().indices().prepareFreeze("test2").execute().actionGet();
         assertThat(freezeIndexResponse2.isAcknowledged(), equalTo(true));
         assertIndexIsFrozen("test1", "test2");
-        assertIndexIsUnfreezeed("test3");
+        assertIndexIsUnfrozen("test3");
 
         UnfreezeIndexResponse unfreezeIndexResponse1 = client.admin().indices().prepareUnfreeze("test1").execute().actionGet();
         assertThat(unfreezeIndexResponse1.isAcknowledged(), equalTo(true));
@@ -156,7 +156,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         UnfreezeIndexResponse unfreezeIndexResponse2 = client.admin().indices().prepareUnfreeze("test2").execute().actionGet();
         assertThat(unfreezeIndexResponse2.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse2.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1", "test2", "test3");
+        assertIndexIsUnfrozen("test1", "test2", "test3");
     }
 
     public void testFreezeUnfreezeWildcard() {
@@ -168,12 +168,12 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         FreezeIndexResponse freezeIndexResponse = client.admin().indices().prepareFreeze("test*").execute().actionGet();
         assertThat(freezeIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsFrozen("test1", "test2");
-        assertIndexIsUnfreezeed("a");
+        assertIndexIsUnfrozen("a");
 
         UnfreezeIndexResponse unfreezeIndexResponse = client.admin().indices().prepareUnfreeze("test*").execute().actionGet();
         assertThat(unfreezeIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1", "test2", "a");
+        assertIndexIsUnfrozen("test1", "test2", "a");
     }
 
     public void testFreezeUnfreezeAll() {
@@ -189,7 +189,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         UnfreezeIndexResponse unfreezeIndexResponse = client.admin().indices().prepareUnfreeze("_all").execute().actionGet();
         assertThat(unfreezeIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1", "test2", "test3");
+        assertIndexIsUnfrozen("test1", "test2", "test3");
     }
 
     public void testFreezeUnfreezeAllWildcard() {
@@ -205,7 +205,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         UnfreezeIndexResponse unfreezeIndexResponse = client.admin().indices().prepareUnfreeze("*").execute().actionGet();
         assertThat(unfreezeIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1", "test2", "test3");
+        assertIndexIsUnfrozen("test1", "test2", "test3");
     }
 
     public void testFreezeNoIndex() {
@@ -236,17 +236,17 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         assertThat(e.getMessage(), containsString("index is missing"));
     }
 
-    public void testUnfreezeAlreadyUnfreezeedIndex() {
+    public void testUnfreezeAlreadyUnfrozenIndex() {
         Client client = client();
         createIndex("test1");
         ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
-        //no problem if we try to unfreeze an index that's already in unfreezeed state
+        //no problem if we try to unfreeze an index that's already in Unfrozen state
         UnfreezeIndexResponse unfreezeIndexResponse1 = client.admin().indices().prepareUnfreeze("test1").execute().actionGet();
         assertThat(unfreezeIndexResponse1.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse1.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1");
+        assertIndexIsUnfrozen("test1");
     }
 
     public void testFreezeAlreadyFrozenIndex() {
@@ -283,7 +283,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         UnfreezeIndexResponse unfreezeIndexResponse = client.admin().indices().prepareUnfreeze("test1-alias").execute().actionGet();
         assertThat(unfreezeIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1");
+        assertIndexIsUnfrozen("test1");
     }
 
     public void testFreezeUnfreezeAliasMultipleIndices() {
@@ -306,7 +306,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         UnfreezeIndexResponse unfreezeIndexResponse = client.admin().indices().prepareUnfreeze("test-alias").execute().actionGet();
         assertThat(unfreezeIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1", "test2");
+        assertIndexIsUnfrozen("test1", "test2");
     }
 
     public void testUnfreezeWaitingForActiveShardsFailed() throws Exception {
@@ -325,7 +325,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         ensureGreen("test");
     }
 
-    private void assertIndexIsUnfreezeed(String... indices) {
+    private void assertIndexIsUnfrozen(String... indices) {
         checkIndexState(IndexMetaData.State.OPEN, indices);
     }
 
@@ -399,7 +399,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
                 UnfreezeIndexResponse unfreezeIndexResponse = client().admin().indices().prepareUnfreeze("test").execute().actionGet();
                 assertAcked(unfreezeIndexResponse);
                 assertThat(unfreezeIndexResponse.isShardsAcknowledged(), equalTo(true));
-                assertIndexIsUnfreezeed("test");
+                assertIndexIsUnfrozen("test");
             } finally {
                 disableIndexBlock("test", blockSetting);
             }
@@ -410,7 +410,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
             try {
                 enableIndexBlock("test", blockSetting);
                 assertBlocked(client().admin().indices().prepareFreeze("test"));
-                assertIndexIsUnfreezeed("test");
+                assertIndexIsUnfrozen("test");
             } finally {
                 disableIndexBlock("test", blockSetting);
             }
@@ -459,7 +459,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         FreezeIndexResponse freezeIndexResponse2 = client.admin().indices().prepareFreeze("test2").execute().actionGet();
         assertThat(freezeIndexResponse2.isAcknowledged(), equalTo(true));
         assertIndexIsFrozen("test1", "test2");
-        assertIndexIsUnfreezeed("test3");
+        assertIndexIsUnfrozen("test3");
 
         // Yay functional programming
         long preFrozenCompletedCounts = client.admin().cluster().prepareNodesStats().clear().setThreadPool(true).get()
@@ -495,7 +495,7 @@ public class FreezeUnfreezeIndexIT extends ESIntegTestCase {
         UnfreezeIndexResponse unfreezeIndexResponse2 = client.admin().indices().prepareUnfreeze("test2").execute().actionGet();
         assertThat(unfreezeIndexResponse2.isAcknowledged(), equalTo(true));
         assertThat(unfreezeIndexResponse2.isShardsAcknowledged(), equalTo(true));
-        assertIndexIsUnfreezeed("test1", "test2", "test3");
+        assertIndexIsUnfrozen("test1", "test2", "test3");
 
         resp = client.prepareSearch("test*").setQuery(QueryBuilders.matchQuery("foo", 7)).get();
         assertSearchHits(resp, "7");


### PR DESCRIPTION
This moves from `/_thaw` to `/_unfreeze` and all documentation/class names/etc.

Relates to #30188