### PR TITLE
Fixed small typo in cardinality-aggregation.asciidoc

### DIFF
--- a/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/cardinality-aggregation.asciidoc
@@ -63,7 +63,7 @@ POST /sales/_search?size=0
 defines a unique count below which counts are expected to be close to
 accurate. Above this value, counts might become a bit more fuzzy. The maximum
 supported value is 40000, thresholds above this number will have the same
-effect as a threshold of 40000. The default values is +3000+.
+effect as a threshold of 40000. The default value is +3000+.
 
 ==== Counts are approximate
 


### PR DESCRIPTION
I was reading https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html#_precision_control and saw a small typo there.