### PR TITLE
New DayName SQL function, optional timezone & locale sql and painless…

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -1011,7 +1011,8 @@ public final class Definition {
                     "and parameters " + whitelistMethod.painlessParameterTypeNames, iae);
         }
 
-        if (javaMethod.getReturnType() != defClassToObjectClass(painlessReturnClass)) {
+        // allow convariant return types in implementing classes.
+        if (!defClassToObjectClass(painlessReturnClass).isAssignableFrom(javaMethod.getReturnType())) {
             throw new IllegalArgumentException("specified return type class [" + painlessReturnClass + "] " +
                     "does not match the return type class [" + javaMethod.getReturnType() + "] for the " +
                     "method with name [" + whitelistMethod.javaMethodName + "] " +

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -86,6 +86,50 @@ class org.elasticsearch.index.fielddata.ScriptDocValues$Dates {
   List getDates()
 }
 
+class org.elasticsearch.index.fielddata.ScriptDocValues$Dates {
+  org.joda.time.ReadableDateTime get(int)
+  org.joda.time.ReadableDateTime getValue()
+  List getValues()
+  org.joda.time.ReadableDateTime getDate()
+  List getDates()
+}
+
+# Extends joda times ReadableDateTime and adds "extension methods" like getDayName
+class org.elasticsearch.index.fielddata.ScriptDocValues$PainlessDateTime {
+  String getDayName()
+  String getDayName(String)
+  String getDayName(String,String)
+  int getCenturyOfEra()
+  int getDayOfMonth()
+  int getDayOfMonth(String)
+  int getDayOfWeek()
+  int getDayOfWeek(String)
+  int getDayOfYear()
+  int getDayOfYear(String)
+  int getEra()
+  int getHourOfDay()
+  int getHourOfDay(String)
+  int getMillisOfDay()
+  int getMillisOfSecond()
+  int getMinuteOfDay()
+  int getMinuteOfDay(String)
+  int getMinuteOfHour()
+  int getMinuteOfHour(String)
+  int getMonthOfYear()
+  int getMonthOfYear(String)
+  int getSecondOfDay()
+  int getSecondOfMinute()
+  int getWeekOfWeekyear()
+  int getWeekOfWeekyear(String)
+  int getWeekyear()
+  int getYear()
+  int getYear(String)
+  int getYearOfCentury()
+  int getYearOfEra()
+  String toString(String)
+  String toString(String,Locale)
+}
+
 class org.elasticsearch.index.fielddata.ScriptDocValues$Doubles {
   Double get(int)
   double getValue()

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -29,18 +29,35 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.common.util.LocaleUtils;
+import org.joda.time.Chronology;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeField;
+import org.joda.time.DateTimeFieldType;
 import org.joda.time.DateTimeZone;
+import org.joda.time.DurationFieldType;
+import org.joda.time.Instant;
 import org.joda.time.MutableDateTime;
 import org.joda.time.ReadableDateTime;
+import org.joda.time.ReadableDuration;
+import org.joda.time.ReadableInstant;
+import org.joda.time.ReadablePeriod;
+import org.joda.time.format.DateTimeFormatter;
 
 import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.AbstractList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Comparator;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
@@ -55,6 +72,9 @@ import java.util.function.UnaryOperator;
  * values form multiple documents.
  */
 public abstract class ScriptDocValues<T> extends AbstractList<T> {
+
+    static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
     /**
      * Set the current doc ID.
      */
@@ -160,7 +180,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         @Deprecated
-        public ReadableDateTime getDate() throws IOException {
+        public PainlessDateTime getDate() throws IOException {
             deprecated("getDate on numeric fields is deprecated. Use a date field to get dates.");
             if (dates == null) {
                 dates = new Dates(in);
@@ -170,7 +190,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
 
         @Deprecated
-        public List<ReadableDateTime> getDates() throws IOException {
+        public List<PainlessDateTime> getDates() throws IOException {
             deprecated("getDates on numeric fields is deprecated. Use a date field to get dates.");
             if (dates == null) {
                 dates = new Dates(in);
@@ -206,10 +226,10 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
     }
 
-    public static final class Dates extends ScriptDocValues<ReadableDateTime> {
+    public static final class Dates extends ScriptDocValues<PainlessDateTime> {
         protected static final DeprecationLogger deprecationLogger = new DeprecationLogger(ESLoggerFactory.getLogger(Dates.class));
 
-        private static final ReadableDateTime EPOCH = new DateTime(0, DateTimeZone.UTC);
+        private static final PainlessDateTime EPOCH = dateTime(0);
 
         private final SortedNumericDocValues in;
         /**
@@ -222,7 +242,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
          * Values wrapped in {@link MutableDateTime}. Null by default an allocated on first usage so we allocate a reasonably size. We keep
          * this array so we don't have allocate new {@link MutableDateTime}s on every usage. Instead we reuse them for every document.
          */
-        private MutableDateTime[] dates;
+        private PainlessDateTime[] dates;
         private int count;
 
         /**
@@ -244,7 +264,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
          * Fetch the first field value or 0 millis after epoch if there are no
          * in.
          */
-        public ReadableDateTime getValue() {
+        public PainlessDateTime getValue() {
             if (count == 0) {
                 return EPOCH;
             }
@@ -255,7 +275,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
          * Fetch the first value. Added for backwards compatibility with 5.x when date fields were {@link Longs}.
          */
         @Deprecated
-        public ReadableDateTime getDate() {
+        public PainlessDateTime getDate() {
             deprecated("getDate is no longer necessary on date fields as the value is now a date.");
             return getValue();
         }
@@ -264,13 +284,13 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
          * Fetch all the values. Added for backwards compatibility with 5.x when date fields were {@link Longs}.
          */
         @Deprecated
-        public List<ReadableDateTime> getDates() {
+        public List<PainlessDateTime> getDates() {
             deprecated("getDates is no longer necessary on date fields as the values are now dates.");
             return this;
         }
 
         @Override
-        public ReadableDateTime get(int index) {
+        public PainlessDateTime get(int index) {
             if (index >= count) {
                 throw new IndexOutOfBoundsException(
                         "attempted to fetch the [" + index + "] date when there are only ["
@@ -303,28 +323,36 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             }
             if (dates == null) {
                 // Happens for the document. We delay allocating dates so we can allocate it with a reasonable size.
-                dates = new MutableDateTime[count];
+                dates = new PainlessDateTime[count];
                 for (int i = 0; i < dates.length; i++) {
-                    dates[i] = new MutableDateTime(in.nextValue(), DateTimeZone.UTC);
+                    dates[i] = dateTime();
                 }
                 return;
             }
             if (count > dates.length) {
                 // Happens when we move to a new document and it has more dates than any documents before it.
-                MutableDateTime[] backup = dates;
-                dates = new MutableDateTime[count];
+                PainlessDateTime[] backup = dates;
+                dates = new PainlessDateTime[count];
                 System.arraycopy(backup, 0, dates, 0, backup.length);
                 for (int i = 0; i < backup.length; i++) {
                     dates[i].setMillis(in.nextValue());
                 }
                 for (int i = backup.length; i < dates.length; i++) {
-                    dates[i] = new MutableDateTime(in.nextValue(), DateTimeZone.UTC);
+                    dates[i] = dateTime();
                 }
                 return;
             }
             for (int i = 0; i < count; i++) {
-                dates[i] = new MutableDateTime(in.nextValue(), DateTimeZone.UTC);
+                dates[i] = dateTime();
             }
+        }
+
+        private PainlessDateTime dateTime() throws IOException {
+            return dateTime(in.nextValue());
+        }
+
+        private static PainlessDateTime dateTime(final long value) {
+            return new PainlessDateTime(new MutableDateTime(value, DateTimeZone.UTC));
         }
 
         /**
@@ -341,6 +369,693 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
                     return null;
                 }
             });
+        }
+    }
+
+    /**
+     * Wrap {@link MutableDateTime} so we can easily overload the "properties"
+     * with parameters and add new getters such as getDayName.
+     */
+    public static class PainlessDateTime extends MutableDateTime {
+        private final MutableDateTime target;
+
+        PainlessDateTime(MutableDateTime target) {
+            this.target = target;
+        }
+
+        // "extension methods" for MutableDateTime which support overloaded forms
+        // of all property getters...
+
+        public String getDayName() {
+            return this.getDayName(this.target, Locale.getDefault());
+        }
+
+        public String getDayName(final String timeZoneId) {
+            return getDayName(this.setTimeZoneId(timeZoneId), Locale.getDefault());
+        }
+
+        public String getDayName(final String timeZoneId, final String locale) {
+            return getDayName(this.setTimeZoneId(timeZoneId), locale(locale));
+        }
+
+        private ReadableDateTime setTimeZoneId(final String timeZoneId) {
+            final TimeZone timeZone = TimeZone.getTimeZone(timeZoneId);
+            return UTC.equals(timeZone) ?
+                this.target :
+                this.target.toDateTime()
+                    .withZone(DateTimeZone.forTimeZone(timeZone));
+        }
+
+        private Locale locale(final String locale) {
+            return LocaleUtils.parse(locale);
+        }
+
+        private String getDayName(final ReadableDateTime dateTime, Locale locale) {
+            final java.time.Instant instant = java.time.Instant.ofEpochMilli(dateTime.getMillis());
+            final ZoneId zoneId = ZoneId.of(dateTime.getZone().getID(), ZoneId.SHORT_IDS);
+            final ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, zoneId);
+
+            // DayName.FORMAT
+            return zdt.format(java.time.format.DateTimeFormatter.ofPattern("EEEE", locale)); // long form name of week.
+        }
+
+        // delegate all public methods to target...
+
+        @Override
+        public DateTimeField getRoundingField() {
+            return target.getRoundingField();
+        }
+
+        @Override
+        public int getRoundingMode() {
+            return target.getRoundingMode();
+        }
+
+        @Override
+        public void setRounding(DateTimeField field) {
+            target.setRounding(field);
+        }
+
+        @Override
+        public void setRounding(DateTimeField field, int mode) {
+            target.setRounding(field, mode);
+        }
+
+        @Override
+        public void setMillis(long instant) {
+            target.setMillis(instant);
+        }
+
+        @Override
+        public void setMillis(ReadableInstant instant) {
+            target.setMillis(instant);
+        }
+
+        @Override
+        public void add(long duration) {
+            target.add(duration);
+        }
+
+        @Override
+        public void add(ReadableDuration duration) {
+            target.add(duration);
+        }
+
+        @Override
+        public void add(ReadableDuration duration, int scalar) {
+            target.add(duration, scalar);
+        }
+
+        @Override
+        public void add(ReadablePeriod period) {
+            target.add(period);
+        }
+
+        @Override
+        public void add(ReadablePeriod period, int scalar) {
+            target.add(period, scalar);
+        }
+
+        @Override
+        public void setChronology(Chronology chronology) {
+            target.setChronology(chronology);
+        }
+
+        @Override
+        public void setZone(DateTimeZone newZone) {
+            target.setZone(newZone);
+        }
+
+        @Override
+        public void setZoneRetainFields(DateTimeZone newZone) {
+            target.setZoneRetainFields(newZone);
+        }
+
+        @Override
+        public void set(DateTimeFieldType type, int value) {
+            target.set(type, value);
+        }
+
+        @Override
+        public void add(DurationFieldType type, int amount) {
+            target.add(type, amount);
+        }
+
+        @Override
+        public void setYear(int year) {
+            target.setYear(year);
+        }
+
+        @Override
+        public void addYears(int years) {
+            target.addYears(years);
+        }
+
+        @Override
+        public void setWeekyear(int weekyear) {
+            target.setWeekyear(weekyear);
+        }
+
+        @Override
+        public void addWeekyears(int weekyears) {
+            target.addWeekyears(weekyears);
+        }
+
+        @Override
+        public void setMonthOfYear(int monthOfYear) {
+            target.setMonthOfYear(monthOfYear);
+        }
+
+        @Override
+        public void addMonths(int months) {
+            target.addMonths(months);
+        }
+
+        @Override
+        public void setWeekOfWeekyear(int weekOfWeekyear) {
+            target.setWeekOfWeekyear(weekOfWeekyear);
+        }
+
+        @Override
+        public void addWeeks(int weeks) {
+            target.addWeeks(weeks);
+        }
+
+        @Override
+        public void setDayOfYear(int dayOfYear) {
+            target.setDayOfYear(dayOfYear);
+        }
+
+        @Override
+        public void setDayOfMonth(int dayOfMonth) {
+            target.setDayOfMonth(dayOfMonth);
+        }
+
+        @Override
+        public void setDayOfWeek(int dayOfWeek) {
+            target.setDayOfWeek(dayOfWeek);
+        }
+
+        @Override
+        public void addDays(int days) {
+            target.addDays(days);
+        }
+
+        @Override
+        public void setHourOfDay(int hourOfDay) {
+            target.setHourOfDay(hourOfDay);
+        }
+
+        @Override
+        public void addHours(int hours) {
+            target.addHours(hours);
+        }
+
+        @Override
+        public void setMinuteOfDay(int minuteOfDay) {
+            target.setMinuteOfDay(minuteOfDay);
+        }
+
+        @Override
+        public void setMinuteOfHour(int minuteOfHour) {
+            target.setMinuteOfHour(minuteOfHour);
+        }
+
+        @Override
+        public void addMinutes(int minutes) {
+            target.addMinutes(minutes);
+        }
+
+        @Override
+        public void setSecondOfDay(int secondOfDay) {
+            target.setSecondOfDay(secondOfDay);
+        }
+
+        @Override
+        public void setSecondOfMinute(int secondOfMinute) {
+            target.setSecondOfMinute(secondOfMinute);
+        }
+
+        @Override
+        public void addSeconds(int seconds) {
+            target.addSeconds(seconds);
+        }
+
+        @Override
+        public void setMillisOfDay(int millisOfDay) {
+            target.setMillisOfDay(millisOfDay);
+        }
+
+        @Override
+        public void setMillisOfSecond(int millisOfSecond) {
+            target.setMillisOfSecond(millisOfSecond);
+        }
+
+        @Override
+        public void addMillis(int millis) {
+            target.addMillis(millis);
+        }
+
+        @Override
+        public void setDate(long instant) {
+            target.setDate(instant);
+        }
+
+        @Override
+        public void setDate(ReadableInstant instant) {
+            target.setDate(instant);
+        }
+
+        @Override
+        public void setDate(int year, int monthOfYear, int dayOfMonth) {
+            target.setDate(year, monthOfYear, dayOfMonth);
+        }
+
+        @Override
+        public void setTime(long millis) {
+            target.setTime(millis);
+        }
+
+        @Override
+        public void setTime(ReadableInstant instant) {
+            target.setTime(instant);
+        }
+
+        @Override
+        public void setTime(int hour, int minuteOfHour, int secondOfMinute, int millisOfSecond) {
+            target.setTime(hour, minuteOfHour, secondOfMinute, millisOfSecond);
+        }
+
+        @Override
+        public void setDateTime(int year,
+                                int monthOfYear,
+                                int dayOfMonth,
+                                int hourOfDay,
+                                int minuteOfHour,
+                                int secondOfMinute,
+                                int millisOfSecond) {
+            target.setDateTime(year, monthOfYear, dayOfMonth, hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond);
+        }
+
+        @Override
+        public Property property(DateTimeFieldType type) {
+            return target.property(type);
+        }
+
+        @Override
+        public Property era() {
+            return target.era();
+        }
+
+        @Override
+        public Property centuryOfEra() {
+            return target.centuryOfEra();
+        }
+
+        @Override
+        public Property yearOfCentury() {
+            return target.yearOfCentury();
+        }
+
+        @Override
+        public Property yearOfEra() {
+            return target.yearOfEra();
+        }
+
+        @Override
+        public Property year() {
+            return target.year();
+        }
+
+        @Override
+        public Property weekyear() {
+            return target.weekyear();
+        }
+
+        @Override
+        public Property monthOfYear() {
+            return target.monthOfYear();
+        }
+
+        @Override
+        public Property weekOfWeekyear() {
+            return target.weekOfWeekyear();
+        }
+
+        @Override
+        public Property dayOfYear() {
+            return target.dayOfYear();
+        }
+
+        @Override
+        public Property dayOfMonth() {
+            return target.dayOfMonth();
+        }
+
+        @Override
+        public Property dayOfWeek() {
+            return target.dayOfWeek();
+        }
+
+        @Override
+        public Property hourOfDay() {
+            return target.hourOfDay();
+        }
+
+        @Override
+        public Property minuteOfDay() {
+            return target.minuteOfDay();
+        }
+
+        @Override
+        public Property minuteOfHour() {
+            return target.minuteOfHour();
+        }
+
+        @Override
+        public Property secondOfDay() {
+            return target.secondOfDay();
+        }
+
+        @Override
+        public Property secondOfMinute() {
+            return target.secondOfMinute();
+        }
+
+        @Override
+        public Property millisOfDay() {
+            return target.millisOfDay();
+        }
+
+        @Override
+        public Property millisOfSecond() {
+            return target.millisOfSecond();
+        }
+
+        @Override
+        public MutableDateTime copy() {
+            return new PainlessDateTime(target.copy());
+        }
+
+        @Override
+        public Object clone() {
+            return new PainlessDateTime((MutableDateTime) target.clone());
+        }
+
+        @Override
+        public long getMillis() {
+            return target.getMillis();
+        }
+
+        @Override
+        public Chronology getChronology() {
+            return target.getChronology();
+        }
+
+        @Override
+        public int get(DateTimeFieldType type) {
+            return target.get(type);
+        }
+
+        @Override
+        public int getEra() {
+            return target.getEra();
+        }
+
+        @Override
+        public int getCenturyOfEra() {
+            return target.getCenturyOfEra();
+        }
+
+        @Override
+        public int getYearOfEra() {
+            return target.getYearOfEra();
+        }
+
+        @Override
+        public int getYearOfCentury() {
+            return target.getYearOfCentury();
+        }
+
+        @Override
+        public int getYear() {
+            return target.getYear();
+        }
+
+        public int getYear(final String timeZoneId) {
+            return this.setTimeZoneId(timeZoneId).getYear();
+        }
+
+        @Override
+        public int getWeekyear() {
+            return target.getWeekyear();
+        }
+
+        @Override
+        public int getMonthOfYear() {
+            return target.getMonthOfYear();
+        }
+
+        public int getMonthOfYear(final String timeZoneId) {
+            return this.setTimeZoneId(timeZoneId).getMonthOfYear();
+        }
+
+        @Override
+        public int getWeekOfWeekyear() {
+            return target.getWeekOfWeekyear();
+        }
+
+        public int getWeekOfWeekyear(final String timeZoneId) {
+            return this.setTimeZoneId(timeZoneId).getWeekOfWeekyear();
+        }
+
+        @Override
+        public int getDayOfYear() {
+            return target.getDayOfYear();
+        }
+
+        public int getDayOfYear(final String timeZoneId) {
+            return this.setTimeZoneId(timeZoneId).getDayOfYear();
+        }
+
+        @Override
+        public int getDayOfMonth() {
+            return target.getDayOfMonth();
+        }
+
+        public int getDayOfMonth(final String timeZoneId) {
+            return this.setTimeZoneId(timeZoneId).getDayOfMonth();
+        }
+
+        @Override
+        public int getDayOfWeek() {
+            return target.getDayOfWeek();
+        }
+
+        public int getDayOfWeek(final String timeZoneId) {
+            return this.setTimeZoneId(timeZoneId).getDayOfWeek();
+        }
+
+        @Override
+        public int getHourOfDay() {
+            return target.getHourOfDay();
+        }
+
+        public int getHourOfDay(final String timeZoneId) {
+            return this.setTimeZoneId(timeZoneId).getHourOfDay();
+        }
+
+        @Override
+        public int getMinuteOfDay() {
+            return target.getMinuteOfDay();
+        }
+
+        public int getMinuteOfDay(final String timeZoneId) {
+            return this.setTimeZoneId(timeZoneId).getMinuteOfDay();
+        }
+
+        @Override
+        public int getMinuteOfHour() {
+            return target.getMinuteOfHour();
+        }
+
+        public int getMinuteOfHour(final String timeZoneId) {
+            return this.setTimeZoneId(timeZoneId).getMinuteOfHour();
+        }
+
+        @Override
+        public int getSecondOfDay() {
+            return target.getSecondOfDay();
+        }
+
+        @Override
+        public int getSecondOfMinute() {
+            return target.getSecondOfMinute();
+        }
+
+        @Override
+        public int getMillisOfDay() {
+            return target.getMillisOfDay();
+        }
+
+        @Override
+        public int getMillisOfSecond() {
+            return target.getMillisOfSecond();
+        }
+
+        @Override
+        public Calendar toCalendar(Locale locale) {
+            return target.toCalendar(locale);
+        }
+
+        @Override
+        public GregorianCalendar toGregorianCalendar() {
+            return target.toGregorianCalendar();
+        }
+
+        @Override
+        public String toString() {
+            return target.toString();
+        }
+
+        @Override
+        public String toString(String pattern) {
+            return target.toString(pattern);
+        }
+
+        @Override
+        public String toString(String pattern, Locale locale) throws IllegalArgumentException {
+            return target.toString(pattern, locale);
+        }
+
+        @Override
+        public DateTimeZone getZone() {
+            return target.getZone();
+        }
+
+        @Override
+        public boolean isSupported(DateTimeFieldType type) {
+            return target.isSupported(type);
+        }
+
+        @Override
+        public int get(DateTimeField field) {
+            return target.get(field);
+        }
+
+        @Override
+        public Instant toInstant() {
+            return target.toInstant();
+        }
+
+        @Override
+        public DateTime toDateTime() {
+            return target.toDateTime();
+        }
+
+        @Override
+        public DateTime toDateTimeISO() {
+            return target.toDateTimeISO();
+        }
+
+        @Override
+        public DateTime toDateTime(DateTimeZone zone) {
+            return target.toDateTime(zone);
+        }
+
+        @Override
+        public DateTime toDateTime(Chronology chronology) {
+            return target.toDateTime(chronology);
+        }
+
+        @Override
+        public MutableDateTime toMutableDateTime() {
+            return target.toMutableDateTime();
+        }
+
+        @Override
+        public MutableDateTime toMutableDateTimeISO() {
+            return target.toMutableDateTimeISO();
+        }
+
+        @Override
+        public MutableDateTime toMutableDateTime(DateTimeZone zone) {
+            return target.toMutableDateTime(zone);
+        }
+
+        @Override
+        public MutableDateTime toMutableDateTime(Chronology chronology) {
+            return target.toMutableDateTime(chronology);
+        }
+
+        @Override
+        public Date toDate() {
+            return target.toDate();
+        }
+
+        @Override
+        public boolean equals(Object readableInstant) {
+            return this == readableInstant || target.equals(readableInstant);
+        }
+
+        @Override
+        public int hashCode() {
+            return target.hashCode();
+        }
+
+        @Override
+        public int compareTo(ReadableInstant other) {
+            return target.compareTo(other);
+        }
+
+        @Override
+        public boolean isAfter(long instant) {
+            return target.isAfter(instant);
+        }
+
+        @Override
+        public boolean isAfterNow() {
+            return target.isAfterNow();
+        }
+
+        @Override
+        public boolean isAfter(ReadableInstant instant) {
+            return target.isAfter(instant);
+        }
+
+        @Override
+        public boolean isBefore(long instant) {
+            return target.isBefore(instant);
+        }
+
+        @Override
+        public boolean isBeforeNow() {
+            return target.isBeforeNow();
+        }
+
+        @Override
+        public boolean isBefore(ReadableInstant instant) {
+            return target.isBefore(instant);
+        }
+
+        @Override
+        public boolean isEqual(long instant) {
+            return target.isEqual(instant);
+        }
+
+        @Override
+        public boolean isEqualNow() {
+            return target.isEqualNow();
+        }
+
+        @Override
+        public boolean isEqual(ReadableInstant instant) {
+            return target.isEqual(instant);
+        }
+
+        @Override
+        public String toString(DateTimeFormatter formatter) {
+            return target.toString(formatter);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesDatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesDatesTests.java
@@ -69,7 +69,7 @@ public class ScriptDocValuesDatesTests extends ESTestCase {
                 assertEquals(expectedDates[d][i], dates.get(i));
             }
 
-            Exception e = expectThrows(UnsupportedOperationException.class, () -> dates.add(new DateTime()));
+            Exception e = expectThrows(UnsupportedOperationException.class, () -> dates.add(null));
             assertEquals("doc values are unmodifiable", e.getMessage());
         }
 

--- a/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesLongsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesLongsTests.java
@@ -95,7 +95,7 @@ public class ScriptDocValuesLongsTests extends ESTestCase {
                 assertEquals(dates[d][i], longs.getDates().get(i));
             }
 
-            Exception e = expectThrows(UnsupportedOperationException.class, () -> longs.getDates().add(new DateTime()));
+            Exception e = expectThrows(UnsupportedOperationException.class, () -> longs.getDates().add(null));
             assertEquals("doc values are unmodifiable", e.getMessage());
         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.sql.expression.UnresolvedAlias;
 import org.elasticsearch.xpack.sql.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.sql.expression.UnresolvedStar;
 import org.elasticsearch.xpack.sql.expression.function.Function;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.FunctionDefinition;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.expression.function.Functions;
@@ -50,7 +51,6 @@ import org.elasticsearch.xpack.sql.type.DataType;
 import org.elasticsearch.xpack.sql.type.DataTypeConversion;
 import org.elasticsearch.xpack.sql.type.DataTypes;
 import org.elasticsearch.xpack.sql.type.UnsupportedEsField;
-import org.joda.time.DateTimeZone;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,7 +61,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TimeZone;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -86,16 +85,14 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
      * Information about the index against which the SQL is being analyzed.
      */
     private final IndexResolution indexResolution;
-    /**
-     * Time zone in which we're executing this SQL. It is attached to functions
-     * that deal with date and time.
-     */
-    private final TimeZone timeZone;
 
-    public Analyzer(FunctionRegistry functionRegistry, IndexResolution results, TimeZone timeZone) {
+
+    private final FunctionContext context;
+
+    public Analyzer(FunctionRegistry functionRegistry, IndexResolution results, FunctionContext context) {
         this.functionRegistry = functionRegistry;
         this.indexResolution = results;
-        this.timeZone = timeZone;
+        this.context = context;
     }
 
     @Override
@@ -197,7 +194,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                  .collect(toList())
                 );
     }
-    
+
     private static boolean hasStar(List<? extends Expression> exprs) {
         for (Expression expression : exprs) {
             if (expression instanceof UnresolvedStar) {
@@ -794,7 +791,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                     }
                     // TODO: look into Generator for significant terms, etc..
                     FunctionDefinition def = functionRegistry.resolveFunction(normalizedName);
-                    Function f = uf.buildResolved(timeZone, def);
+                    Function f = uf.buildResolved(context, def);
 
                     list.add(f);
                     return f;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionContext.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionContext.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.LocaleUtils;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.TimeZone;
+
+/**
+ * Rather than pass around numerous defaults for functions, all default type values are passed in
+ * via a function context.
+ */
+public final class FunctionContext {
+
+    public static FunctionContext read(final StreamInput in) throws IOException {
+        final TimeZone timeZone = TimeZone.getTimeZone(in.readString());
+        final Locale locale = LocaleUtils.parse(in.readString());
+        return new FunctionContext(timeZone, locale);
+    }
+
+    /**
+     * Time zone in which we're executing this SQL. It is attached to functions
+     * that deal with date and time.
+     */
+    private final TimeZone timeZone;
+    /**
+     * Locale in which we're executing this SQL. It is attached to functions
+     * that deal with date and time.
+     */
+    private final Locale locale;
+
+    public FunctionContext(final TimeZone timeZone, final Locale locale) {
+        Objects.requireNonNull(timeZone, "timeZone");
+        Objects.requireNonNull(locale, "locale");
+
+        this.timeZone = timeZone;
+        this.locale = locale;
+    }
+
+    public TimeZone timeZone() {
+        return timeZone;
+    }
+
+    public Locale locale() {
+        return this.locale;
+    }
+
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(timeZone().getID());
+        out.writeString(locale().toString());
+    }
+
+    public int hashCode() {
+        return Objects.hash(this.timeZone(), this.locale());
+    }
+
+    public boolean equals(final Object other) {
+        return this == other || other instanceof FunctionContext && equals0((FunctionContext) other);
+    }
+
+    private boolean equals0(final FunctionContext other) {
+        return this.timeZone().equals(other.timeZone()) &&
+            this.locale().equals(other.locale());
+    }
+
+    public String toString() {
+        return this.timeZone().getID() + " " + this.locale();
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionDefinition.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/FunctionDefinition.java
@@ -17,7 +17,7 @@ public class FunctionDefinition {
      */
     @FunctionalInterface
     public interface Builder {
-        Function build(UnresolvedFunction uf, boolean distinct, TimeZone tz);
+        Function build(UnresolvedFunction uf, boolean distinct, FunctionContext context);
     }
     private final String name;
     private final List<String> aliases;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/UnresolvedFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/UnresolvedFunction.java
@@ -79,8 +79,8 @@ public class UnresolvedFunction extends Function implements Unresolvable {
     /**
      * Build a function to replace this one after resolving the function.
      */
-    public Function buildResolved(TimeZone timeZone, FunctionDefinition def) {
-        return resolutionType.buildResolved(this, timeZone, def);
+    public Function buildResolved(FunctionContext context, FunctionDefinition def) {
+        return resolutionType.buildResolved(this, context, def);
     }
 
     /**
@@ -191,8 +191,8 @@ public class UnresolvedFunction extends Function implements Unresolvable {
                 return uf;
             }
             @Override
-            public Function buildResolved(UnresolvedFunction uf, TimeZone tz, FunctionDefinition def) {
-                return def.builder().build(uf, false, tz);
+            public Function buildResolved(UnresolvedFunction uf, FunctionContext context, FunctionDefinition def) {
+                return def.builder().build(uf, false, context);
             }
             @Override
             protected boolean isValidAlternative(FunctionDefinition def) {
@@ -212,8 +212,8 @@ public class UnresolvedFunction extends Function implements Unresolvable {
                 return uf.withMessage("* is not valid with DISTINCT");
             }
             @Override
-            public Function buildResolved(UnresolvedFunction uf, TimeZone tz, FunctionDefinition def) {
-                return def.builder().build(uf, true, tz);
+            public Function buildResolved(UnresolvedFunction uf, FunctionContext context, FunctionDefinition def) {
+                return def.builder().build(uf, true, context);
             }
             @Override
             protected boolean isValidAlternative(FunctionDefinition def) {
@@ -233,9 +233,9 @@ public class UnresolvedFunction extends Function implements Unresolvable {
                 return uf.withMessage("Can't extract from *");
             }
             @Override
-            public Function buildResolved(UnresolvedFunction uf, TimeZone tz, FunctionDefinition def) {
+            public Function buildResolved(UnresolvedFunction uf, FunctionContext context, FunctionDefinition def) {
                 if (def.datetime()) {
-                    return def.builder().build(uf, false, tz);
+                    return def.builder().build(uf, false, context);
                 }
                 return uf.withMessage("Invalid datetime field [" + uf.name() + "]. Use any datetime function.");
             }
@@ -260,7 +260,9 @@ public class UnresolvedFunction extends Function implements Unresolvable {
         /**
          * Build the real function from this one and resolution metadata.
          */
-        protected abstract Function buildResolved(UnresolvedFunction uf, TimeZone tz, FunctionDefinition def);
+        protected abstract Function buildResolved(UnresolvedFunction uf,
+                                                  FunctionContext context,
+                                                  FunctionDefinition def);
         /**
          * Is {@code def} a valid alternative for function invocations
          * of this kind. Used to filter the list of "did you mean"

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
@@ -5,15 +5,13 @@
  */
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
+import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.xpack.sql.expression.Expression;
-import org.elasticsearch.xpack.sql.expression.Expressions;
-import org.elasticsearch.xpack.sql.expression.FieldAttribute;
-import org.elasticsearch.xpack.sql.expression.function.aggregate.AggregateFunctionAttribute;
-import org.elasticsearch.xpack.sql.expression.function.scalar.UnaryScalarFunction;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
+import org.elasticsearch.xpack.sql.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.expression.function.scalar.processor.definition.ProcessorDefinition;
 import org.elasticsearch.xpack.sql.expression.function.scalar.processor.definition.ProcessorDefinitions;
-import org.elasticsearch.xpack.sql.expression.function.scalar.processor.definition.UnaryProcessorDefinition;
 import org.elasticsearch.xpack.sql.expression.function.scalar.script.ParamsBuilder;
 import org.elasticsearch.xpack.sql.expression.function.scalar.script.ScriptTemplate;
 import org.elasticsearch.xpack.sql.tree.Location;
@@ -22,124 +20,166 @@ import org.elasticsearch.xpack.sql.type.DataType;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.sql.expression.function.scalar.script.ParamsBuilder.paramsBuilder;
-import static org.elasticsearch.xpack.sql.expression.function.scalar.script.ScriptTemplate.formatTemplate;
 
-public abstract class DateTimeFunction extends UnaryScalarFunction {
+abstract public class DateTimeFunction extends ScalarFunction {
 
-    private final TimeZone timeZone;
+    final static TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+    private final FunctionContext context;
     private final String name;
 
-    DateTimeFunction(Location location, Expression field, TimeZone timeZone) {
-        super(location, field);
-        this.timeZone = timeZone;
+    DateTimeFunction(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments);
+        this.context = context;
 
         StringBuilder sb = new StringBuilder(super.name());
         // add timezone as last argument
-        sb.insert(sb.length() - 1, " [" + timeZone.getID() + "]");
+        sb.insert(sb.length() - 1, " [" + context + " ]");
 
         this.name = sb.toString();
     }
 
     @Override
     protected final NodeInfo<DateTimeFunction> info() {
-        return NodeInfo.create(this, ctorForInfo(), field(), timeZone());
+        return NodeInfo.create(this, ctorForInfo(), arguments(), context());
     }
-    protected abstract NodeInfo.NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo();
 
-    public TimeZone timeZone() {
-        return timeZone;
+    abstract NodeInfo.NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo();
+
+    public final Expression field() {
+        return this.arguments().get(0);
+    }
+
+    public final FunctionContext context() {
+        return context;
     }
 
     @Override
-    public boolean foldable() {
-        return field().foldable();
+    public final Expression replaceChildren(List<Expression> newChildren) {
+        return this.replaceChildren(this.location(), newChildren, this.context());
+    }
+
+    abstract Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context);
+
+    @Override
+    public final boolean foldable() {
+        return this.arguments().stream()
+            .map( e -> e.foldable())
+            .allMatch( b -> b);
     }
 
     @Override
-    public Object fold() {
-        DateTime folded = (DateTime) field().fold();
-        if (folded == null) {
+    public final Object fold() {
+        // the standard for function is DateTime, String timeZoneId, String locale
+        DateTime dateTime = null;
+        TimeZone timeZone = context.timeZone();
+        Locale locale = context.locale();
+
+        int i = 0;
+        for (Expression a : this.arguments()) {
+            switch (i) {
+                case 0:
+                    dateTime = (DateTime) a.fold();
+                    break;
+                case 1:
+                    timeZone = TimeZone.getTimeZone((String) a.fold());
+                    break;
+                case 2:
+                    locale = LocaleUtils.parse((String) a.fold());
+                    break;
+            }
+            i++;
+        }
+
+        if (dateTime == null) {
             return null;
         }
-
-        ZonedDateTime time = ZonedDateTime.ofInstant(
-            Instant.ofEpochMilli(folded.getMillis()), ZoneId.of(timeZone.getID()));
-        return time.get(chronoField());
-    }
-
-    @Override
-    protected TypeResolution resolveType() {
-        if (field().dataType() == DataType.DATE) {
-            return TypeResolution.TYPE_RESOLVED;
-        }
-        return new TypeResolution("Function [" + functionName() + "] cannot be applied on a non-date expression (["
-                + Expressions.name(field()) + "] of type [" + field().dataType().esType + "])");
-    }
-
-    @Override
-    protected ScriptTemplate asScriptFrom(FieldAttribute field) {
-        ParamsBuilder params = paramsBuilder();
-
-        String template = null;
-        if (TimeZone.getTimeZone("UTC").equals(timeZone)) {
-            // TODO: it would be nice to be able to externalize the extract function and reuse the script across all extractors
-            template = formatTemplate("doc[{}].value.get" + extractFunction() + "()");
-            params.variable(field.name());
-        } else {
-            // TODO ewwww
-            /*
-             * This uses the Java 8 time API because Painless doesn't whitelist creation of new
-             * Joda classes.
-             *
-             * The actual script is
-             * ZonedDateTime.ofInstant(Instant.ofEpochMilli(<insert doc field>.value.millis),
-             *      ZoneId.of(<insert user tz>)).get(ChronoField.get(MONTH_OF_YEAR))
-             */
-
-            template = formatTemplate("ZonedDateTime.ofInstant(Instant.ofEpochMilli(doc[{}].value.millis), "
-                    + "ZoneId.of({})).get(ChronoField.valueOf({}))");
-            params.variable(field.name())
-                  .variable(timeZone.getID())
-                  .variable(chronoField().name());
+        if (!UTC.equals(timeZone)) {
+            dateTime = dateTime.toDateTime().withZone(DateTimeZone.forTimeZone(timeZone));
         }
 
-        return new ScriptTemplate(template, params.build(), dataType());
+        return this.extractor().extract(dateTime, locale);
     }
-
 
     @Override
-    protected ScriptTemplate asScriptFrom(AggregateFunctionAttribute aggregate) {
-        throw new UnsupportedOperationException();
+    final protected TypeResolution resolveType() {
+        // this assumes the parameter count check is done in ctor, not here.
+        List<DataType> types = this.arguments().stream()
+            .map(a -> a.dataType())
+            .collect(Collectors.toList());
+        List<DataType> expected;
+
+        final int argumentCount = types.size();
+        switch (argumentCount) {
+            case 1:
+                expected = Collections.singletonList(DataType.DATE);
+                break;
+            case 2:
+                expected = Arrays.asList(DataType.DATE, DataType.KEYWORD);
+                break;
+            case 3:
+                expected = Arrays.asList(DataType.DATE, DataType.KEYWORD, DataType.KEYWORD);
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected argument count " + argumentCount);
+        }
+
+        return expected.equals(types) ?
+            TypeResolution.TYPE_RESOLVED :
+            new TypeResolution("Function [" + functionName() + "] with " +
+                argumentCount + " parameters expects ([" + commaSeparated(expected) + "] but got [" +
+                commaSeparated(types) + "])");
     }
 
-    protected String extractFunction() {
+    private static String commaSeparated(final List<DataType> dataTypes) {
+        return dataTypes.stream()
+            .map( s -> s.esType)
+            .collect(Collectors.joining(", "));
+    }
+
+    private String extractFunction() {
         return getClass().getSimpleName();
     }
 
-    /**
-     * Used for generating the painless script version of this function when the time zone is not UTC
-     */
-    protected abstract ChronoField chronoField();
-
     @Override
     protected final ProcessorDefinition makeProcessorDefinition() {
-        return new UnaryProcessorDefinition(location(), this, ProcessorDefinitions.toProcessorDefinition(field()),
-                new DateTimeProcessor(extractor(), timeZone));
+        return new DateTimeProcessorDefinition(location(),
+            this,
+            this.arguments().stream()
+                .map(f -> ProcessorDefinitions.toProcessorDefinition(f))
+                .collect(Collectors.toList()),
+            this.extractor(),
+            this.context());
     }
 
-    protected abstract DateTimeExtractor extractor();
+    abstract DateTimeExtractor extractor();
 
     @Override
-    public DataType dataType() {
-        return DataType.INTEGER;
+    public final ScriptTemplate asScript() {
+        ParamsBuilder params = paramsBuilder();
+
+        // doc[{}].value.get$extractFunction({},{})
+        StringBuilder template = new StringBuilder();
+        template.append("doc[{}].value.get");
+        template.append(extractFunction());
+        template.append("(");
+
+        // add place holders for each parameter.
+        this.arguments().stream()
+            .forEach(e -> params.variable(asScript(e)));
+
+        template.append(")");
+
+        return new ScriptTemplate(template.toString(), params.build(), dataType());
     }
 
     // used for applying ranges
@@ -147,22 +187,25 @@ public abstract class DateTimeFunction extends UnaryScalarFunction {
 
     // add tz along the rest of the params
     @Override
-    public String name() {
+    final public String name() {
         return name;
     }
 
     @Override
-    public boolean equals(Object obj) {
+    final public boolean equals(Object obj) {
+        if(obj == this) {
+            return true;
+        }
         if (obj == null || obj.getClass() != getClass()) {
             return false;
         }
         DateTimeFunction other = (DateTimeFunction) obj;
-        return Objects.equals(other.field(), field())
-            && Objects.equals(other.timeZone, timeZone);
+        return Objects.equals(other.arguments(), arguments())
+            && Objects.equals(other.context(), context());
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(field(), timeZone);
+    final public int hashCode() {
+        return Objects.hash(arguments(), context());
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeProcessorDefinition.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeProcessorDefinition.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
+import org.elasticsearch.xpack.sql.expression.function.scalar.processor.definition.ProcessorDefinition;
+import org.elasticsearch.xpack.sql.expression.function.scalar.processor.definition.VarArgsProcessorDefinition;
+import org.elasticsearch.xpack.sql.expression.function.scalar.processor.runtime.Processor;
+import org.elasticsearch.xpack.sql.tree.Location;
+import org.elasticsearch.xpack.sql.tree.NodeInfo;
+
+import java.util.List;
+
+public class DateTimeProcessorDefinition extends VarArgsProcessorDefinition {
+
+    private DateTimeProcessor.DateTimeExtractor extractor;
+    private FunctionContext context;
+
+    DateTimeProcessorDefinition(Location location,
+                                Expression expression,
+                                List<ProcessorDefinition> definitions,
+                                DateTimeProcessor.DateTimeExtractor extractor,
+                                FunctionContext context ) {
+        super(location, expression, definitions);
+        extractor.checkArgumentCount(definitions);
+        this.extractor = extractor;
+        this.context = context;
+    }
+
+    @Override
+    protected Processor asProcessor(final List<Processor> processors) {
+        return new DateTimeProcessor(processors, extractor, context);
+    }
+
+    @Override
+    public ProcessorDefinition replaceChildren(List<ProcessorDefinition> newChildren) {
+        return new DateTimeProcessorDefinition(this.location(),
+            this.expression(),
+            newChildren,
+            this.extractor,
+            this.context);
+    }
+
+    @Override
+    protected NodeInfo<? extends ProcessorDefinition> info() {
+        return NodeInfo.create(this,
+            DateTimeProcessorDefinition::new,
+            expression(),
+            this.children(),
+            this.extractor,
+            this.context);
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayName.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayName.java
@@ -10,34 +10,49 @@ import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
+import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.util.List;
 
 /**
- * Extract the hour of the day from a datetime.
+ * Extract the day name from a datetime.
+ * <pre>
+ * DATENAME("2017-12-05T00:00:00")
+ * returns "Tuesday"
+ * </pre>
+ *
  */
-public class HourOfDay extends NumberDateTimeFunction {
-    public HourOfDay(Location location, List<Expression> arguments, FunctionContext context) {
+public class DayName extends DateTimeFunction {
+
+    // DateTimeFormatter.ofPattern
+    static final String FORMAT = "EEEE";
+
+    public DayName(Location location, List<Expression> arguments, FunctionContext context) {
         super(location, arguments, context);
     }
 
     @Override
     NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
-        return HourOfDay::new;
+        return DayName::new;
     }
 
     @Override
     Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
-        return new HourOfDay(location, newChildren, context);
+        return new DayName(location, newChildren, context);
     }
 
     @Override
     DateTimeExtractor extractor() {
-        return DateTimeExtractor.HOUR_OF_DAY;
+        return DateTimeExtractor.DAYNAME;
     }
 
     @Override
     public String dateTimeFormat() {
-        return "hour";
+        return FORMAT;
+    }
+
+    @Override
+    public DataType dataType() {
+        return DataType.KEYWORD;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfMonth.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfMonth.java
@@ -6,43 +6,38 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.time.temporal.ChronoField;
-import java.util.TimeZone;
+import java.util.List;
 
 /**
  * Extract the day of the month from a datetime.
  */
-public class DayOfMonth extends DateTimeFunction {
-    public DayOfMonth(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+public class DayOfMonth extends NumberDateTimeFunction {
+    public DayOfMonth(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments, context);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+    NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
         return DayOfMonth::new;
     }
 
     @Override
-    protected DayOfMonth replaceChild(Expression newChild) {
-        return new DayOfMonth(location(), newChild, timeZone());
+    Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
+        return new DayOfMonth(location, newChildren, context);
+    }
+
+    @Override
+    DateTimeExtractor extractor() {
+        return DateTimeExtractor.DAY_OF_MONTH;
     }
 
     @Override
     public String dateTimeFormat() {
         return "d";
-    }
-
-    @Override
-    protected ChronoField chronoField() {
-        return ChronoField.DAY_OF_MONTH;
-    }
-
-    @Override
-    protected DateTimeExtractor extractor() {
-        return DateTimeExtractor.DAY_OF_MONTH;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfWeek.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfWeek.java
@@ -6,43 +6,39 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.time.temporal.ChronoField;
-import java.util.TimeZone;
+import java.util.List;
 
 /**
  * Extract the day of the week from a datetime. 1 is Monday, 2 is Tuesday, etc.
  */
-public class DayOfWeek extends DateTimeFunction {
-    public DayOfWeek(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+public class DayOfWeek extends NumberDateTimeFunction {
+
+    public DayOfWeek(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments, context);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+    NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
         return DayOfWeek::new;
     }
 
     @Override
-    protected DayOfWeek replaceChild(Expression newChild) {
-        return new DayOfWeek(location(), newChild, timeZone());
+    Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
+        return new DayOfWeek(location, newChildren, context);
+    }
+
+    @Override
+    DateTimeExtractor extractor() {
+        return DateTimeExtractor.DAY_OF_YEAR;
     }
 
     @Override
     public String dateTimeFormat() {
         return "e";
-    }
-
-    @Override
-    protected ChronoField chronoField() {
-        return ChronoField.DAY_OF_WEEK;
-    }
-
-    @Override
-    protected DateTimeExtractor extractor() {
-        return DateTimeExtractor.DAY_OF_WEEK;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfYear.java
@@ -6,44 +6,38 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
-import org.elasticsearch.xpack.sql.expression.function.scalar.UnaryScalarFunction;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.time.temporal.ChronoField;
-import java.util.TimeZone;
+import java.util.List;
 
 /**
  * Extract the day of the year from a datetime.
  */
-public class DayOfYear extends DateTimeFunction {
-    public DayOfYear(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+public class DayOfYear extends NumberDateTimeFunction {
+    public DayOfYear(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments, context);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+    NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
         return DayOfYear::new;
     }
 
     @Override
-    protected UnaryScalarFunction replaceChild(Expression newChild) {
-        return new DayOfYear(location(), newChild, timeZone());
+    Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
+        return new DayOfYear(location, newChildren, context);
+    }
+
+    @Override
+    DateTimeExtractor extractor() {
+        return DateTimeExtractor.DAY_OF_YEAR;
     }
 
     @Override
     public String dateTimeFormat() {
         return "D";
-    }
-
-    @Override
-    protected ChronoField chronoField() {
-        return ChronoField.DAY_OF_YEAR;
-    }
-
-    @Override
-    protected DateTimeExtractor extractor() {
-        return DateTimeExtractor.DAY_OF_YEAR;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfDay.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfDay.java
@@ -6,44 +6,39 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.time.temporal.ChronoField;
-import java.util.TimeZone;
+import java.util.List;
 
 /**
  * Extract the minute of the day from a datetime.
  */
-public class MinuteOfDay extends DateTimeFunction {
+public class MinuteOfDay extends NumberDateTimeFunction {
 
-    public MinuteOfDay(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+    public MinuteOfDay(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments, context);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+    NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
         return MinuteOfDay::new;
     }
 
     @Override
-    protected MinuteOfDay replaceChild(Expression newChild) {
-        return new MinuteOfDay(location(), newChild, timeZone());
+    Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
+        return new MinuteOfDay(location, newChildren, context);
+    }
+
+    @Override
+    DateTimeExtractor extractor() {
+        return DateTimeExtractor.MINUTE_OF_DAY;
     }
 
     @Override
     public String dateTimeFormat() {
         throw new UnsupportedOperationException("is there a format for it?");
-    }
-
-    @Override
-    protected ChronoField chronoField() {
-        return ChronoField.MINUTE_OF_DAY;
-    }
-
-    @Override
-    protected DateTimeExtractor extractor() {
-        return DateTimeExtractor.MINUTE_OF_DAY;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfHour.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MinuteOfHour.java
@@ -6,43 +6,39 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.time.temporal.ChronoField;
-import java.util.TimeZone;
+import java.util.List;
 
 /**
  * Exract the minute of the hour from a datetime.
  */
-public class MinuteOfHour extends DateTimeFunction {
-    public MinuteOfHour(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+public class MinuteOfHour extends NumberDateTimeFunction {
+
+    public MinuteOfHour(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments, context);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+    NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
         return MinuteOfHour::new;
     }
 
     @Override
-    protected MinuteOfHour replaceChild(Expression newChild) {
-        return new MinuteOfHour(location(), newChild, timeZone());
+    Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
+        return new MinuteOfHour(location, newChildren, context);
+    }
+
+    @Override
+    DateTimeExtractor extractor() {
+        return DateTimeExtractor.MINUTE_OF_HOUR;
     }
 
     @Override
     public String dateTimeFormat() {
         return "m";
-    }
-
-    @Override
-    protected ChronoField chronoField() {
-        return ChronoField.MINUTE_OF_HOUR;
-    }
-
-    @Override
-    protected DateTimeExtractor extractor() {
-        return DateTimeExtractor.MINUTE_OF_HOUR;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MonthOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/MonthOfYear.java
@@ -6,43 +6,38 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.time.temporal.ChronoField;
-import java.util.TimeZone;
+import java.util.List;
 
 /**
  * Extract the month of the year from a datetime.
  */
-public class MonthOfYear extends DateTimeFunction {
-    public MonthOfYear(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+public class MonthOfYear extends NumberDateTimeFunction {
+    public MonthOfYear(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments, context);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+    NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
         return MonthOfYear::new;
     }
 
     @Override
-    protected MonthOfYear replaceChild(Expression newChild) {
-        return new MonthOfYear(location(), newChild, timeZone());
+    Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
+        return new MonthOfYear(location, newChildren, context);
+    }
+
+    @Override
+    DateTimeExtractor extractor() {
+        return DateTimeExtractor.MONTH_OF_YEAR;
     }
 
     @Override
     public String dateTimeFormat() {
         return "M";
-    }
-
-    @Override
-    protected ChronoField chronoField() {
-        return ChronoField.MONTH_OF_YEAR;
-    }
-
-    @Override
-    protected DateTimeExtractor extractor() {
-        return DateTimeExtractor.MONTH_OF_YEAR;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NumberDateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/NumberDateTimeFunction.java
@@ -7,22 +7,20 @@ package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
 import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
+import org.elasticsearch.xpack.sql.expression.function.scalar.script.ScriptTemplate;
 import org.elasticsearch.xpack.sql.tree.Location;
+import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.util.List;
 
-/**
- * DateTimeFunctions that can be mapped as histogram. This means the dates order is maintained
- * Unfortunately this means only YEAR works since everything else changes the order
- */
-public abstract class DateTimeHistogramFunction extends NumberDateTimeFunction {
+abstract class NumberDateTimeFunction extends DateTimeFunction {
 
-    DateTimeHistogramFunction(Location location, List<Expression> arguments, FunctionContext context) {
+    NumberDateTimeFunction(Location location, List<Expression> arguments, FunctionContext context) {
         super(location, arguments, context);
     }
 
-    /**
-     * used for aggregration (date histogram)
-     */
-    public abstract String interval();
+    @Override
+    public final DataType dataType() {
+        return DataType.INTEGER;
+    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/SecondOfMinute.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/SecondOfMinute.java
@@ -6,29 +6,29 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.time.temporal.ChronoField;
-import java.util.TimeZone;
+import java.util.List;
 
 /**
  * Extract the second of the minute from a datetime.
  */
-public class SecondOfMinute extends DateTimeFunction {
-    public SecondOfMinute(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+public class SecondOfMinute extends NumberDateTimeFunction {
+    public SecondOfMinute(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments, context);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+    NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
         return SecondOfMinute::new;
     }
 
     @Override
-    protected SecondOfMinute replaceChild(Expression newChild) {
-        return new SecondOfMinute(location(), newChild, timeZone());
+    public Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
+        return new SecondOfMinute(location, newChildren, context);
     }
 
     @Override
@@ -37,12 +37,7 @@ public class SecondOfMinute extends DateTimeFunction {
     }
 
     @Override
-    protected ChronoField chronoField() {
-        return ChronoField.SECOND_OF_MINUTE;
-    }
-
-    @Override
-    protected DateTimeExtractor extractor() {
+    DateTimeExtractor extractor() {
         return DateTimeExtractor.SECOND_OF_MINUTE;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/WeekOfYear.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/WeekOfYear.java
@@ -6,43 +6,38 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
-import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.time.temporal.ChronoField;
-import java.util.TimeZone;
+import java.util.List;
 
 /**
  * Extract the week of the year from a datetime.
  */
-public class WeekOfYear extends DateTimeFunction {
-    public WeekOfYear(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+public class WeekOfYear extends NumberDateTimeFunction {
+
+    public WeekOfYear(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments, context);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+    NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
         return WeekOfYear::new;
     }
 
     @Override
-    protected WeekOfYear replaceChild(Expression newChild) {
-        return new WeekOfYear(location(), newChild, timeZone());
+    Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
+        return new WeekOfYear(location, newChildren, context);
+    }
+
+    @Override
+    DateTimeProcessor.DateTimeExtractor extractor() {
+        return DateTimeProcessor.DateTimeExtractor.WEEK_OF_YEAR;
     }
 
     @Override
     public String dateTimeFormat() {
         return "w";
-    }
-
-    @Override
-    protected ChronoField chronoField() {
-        return ChronoField.ALIGNED_WEEK_OF_YEAR;
-    }
-
-    @Override
-    protected DateTimeExtractor extractor() {
-        return DateTimeExtractor.WEEK_OF_YEAR;
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/Year.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/Year.java
@@ -6,29 +6,29 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor.DateTimeExtractor;
 import org.elasticsearch.xpack.sql.tree.Location;
 import org.elasticsearch.xpack.sql.tree.NodeInfo.NodeCtor2;
 
-import java.time.temporal.ChronoField;
-import java.util.TimeZone;
+import java.util.List;
 
 /**
  * Extract the year from a datetime.
  */
 public class Year extends DateTimeHistogramFunction {
-    public Year(Location location, Expression field, TimeZone timeZone) {
-        super(location, field, timeZone);
+    public Year(Location location, List<Expression> arguments, FunctionContext context) {
+        super(location, arguments, context);
     }
 
     @Override
-    protected NodeCtor2<Expression, TimeZone, DateTimeFunction> ctorForInfo() {
+    NodeCtor2<List<Expression>, FunctionContext, DateTimeFunction> ctorForInfo() {
         return Year::new;
     }
 
     @Override
-    protected Year replaceChild(Expression newChild) {
-        return new Year(location(), newChild, timeZone());
+    Expression replaceChildren(Location location, List<Expression> newChildren, FunctionContext context) {
+        return new Year(location, newChildren, context);
     }
 
     @Override
@@ -38,12 +38,7 @@ public class Year extends DateTimeHistogramFunction {
 
     @Override
     public Expression orderBy() {
-        return field();
-    }
-
-    @Override
-    protected ChronoField chronoField() {
-        return ChronoField.YEAR;
+        return arguments().get(0);
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/processor/definition/VarArgsProcessorDefinition.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/processor/definition/VarArgsProcessorDefinition.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.processor.definition;
+
+import org.elasticsearch.xpack.sql.execution.search.SqlSourceBuilder;
+import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.scalar.arithmetic.BinaryArithmeticProcessorDefinition;
+import org.elasticsearch.xpack.sql.expression.function.scalar.processor.runtime.Processor;
+import org.elasticsearch.xpack.sql.tree.Location;
+import org.elasticsearch.xpack.sql.tree.NodeInfo;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class VarArgsProcessorDefinition extends ProcessorDefinition {
+
+    private final List<ProcessorDefinition> definitions;
+
+    protected VarArgsProcessorDefinition(Location location, Expression expression, List<ProcessorDefinition> definitions) {
+        super(location, expression, definitions);
+        this.definitions = definitions;
+    }
+
+    @Override
+    public final boolean resolved() {
+        return this.definitions.stream()
+            .allMatch(d -> d.resolved());
+    }
+
+    @Override
+    public final Processor asProcessor() {
+        return this.asProcessor(this.definitions.stream()
+            .map(d -> d.asProcessor())
+            .collect(Collectors.toList()));
+    }
+
+    protected abstract Processor asProcessor(List<Processor> processors);
+
+    @Override
+    public final ProcessorDefinition resolveAttributes(AttributeResolver resolver) {
+        List<ProcessorDefinition> resolved = this.definitions.stream()
+            .map(d -> d.resolveAttributes(resolver))
+            .collect(Collectors.toList());
+        return this.definitions.equals(resolved) ? this : replaceChildren(resolved);
+    }
+
+    @Override
+    public final void collectFields(SqlSourceBuilder sourceBuilder) {
+        this.definitions.stream()
+            .forEach(d -> d.collectFields(sourceBuilder));
+    }
+
+    @Override
+    public final boolean supportedByAggsOnlyQuery() {
+        return this.definitions.stream()
+            .allMatch(d -> d.supportedByAggsOnlyQuery());
+    }
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/processor/runtime/VarArgsProcessor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/processor/runtime/VarArgsProcessor.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.xpack.sql.expression.function.scalar.processor.runtime;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeProcessor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Convenient base class for any processor that combines many processors into one.
+ */
+abstract public class VarArgsProcessor implements Processor {
+
+    private static List<Processor> read(StreamInput in) throws IOException {
+        final int count = in.readInt();
+        final List<Processor> processors = new ArrayList<>(count);
+
+        for(int i = 0; i < count; i++) {
+            processors.add(in.readNamedWriteable(Processor.class));
+        }
+
+        return processors;
+    }
+
+    private final List<Processor> processors;
+
+    protected VarArgsProcessor(final List<Processor> processors) {
+        this.processors = processors;
+    }
+
+    protected VarArgsProcessor(StreamInput in) throws IOException {
+        this(read(in));
+    }
+
+    @Override
+    final public Object process(Object input) {
+        return input == null ?
+            null :
+            this.doProcess(this.processors.stream()
+                .map(p -> p.process(input))
+                .collect(Collectors.toList()));
+    }
+
+    abstract protected Object doProcess(final List<Object> inputs);
+
+    @Override
+    final public void writeTo(StreamOutput out) throws IOException {
+        final List<Processor> processors = this.processors();
+        out.writeInt(processors.size());
+
+        for(Processor p : processors) {
+            out.writeNamedWriteable(p);
+        }
+
+        this.writeToAdditional(out);
+    }
+
+    protected abstract void writeToAdditional(StreamOutput out) throws IOException;
+
+    protected List<Processor> processors() {
+        return this.processors;
+    }
+
+    @Override
+    final public int hashCode() {
+        return this.hashCode(this.processors);
+    }
+
+    protected abstract int hashCode(final List<Processor> processors);
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null || other.getClass() != getClass()) {
+            return false;
+        }
+        VarArgsProcessor otherProcessor = (VarArgsProcessor) other;
+        return Objects.equals(this.processors, otherProcessor.processors)
+            && equals0(otherProcessor);
+    }
+
+    protected abstract boolean equals0(VarArgsProcessor other);
+}

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
@@ -290,7 +290,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                                          */
                                         if (exp instanceof DateTimeHistogramFunction) {
                                             action = ((UnaryProcessorDefinition) p).action();
-                                            tz = ((DateTimeFunction) exp).timeZone();
+                                            tz = ((DateTimeFunction) exp).context().timeZone();
                                         }
                                         return new AggPathInput(exp.location(), exp, new GroupByRef(matchingGroup.id(), null, tz), action);
                                     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryTranslator.java
@@ -250,7 +250,7 @@ abstract class QueryTranslator {
                     // dates are handled differently because of date histograms
                     if (exp instanceof DateTimeHistogramFunction) {
                         DateTimeHistogramFunction dthf = (DateTimeHistogramFunction) exp;
-                        key = new GroupByDateKey(aggId, nameOf(exp), dthf.interval(), dthf.timeZone());
+                        key = new GroupByDateKey(aggId, nameOf(exp), dthf.interval(), dthf.context().timeZone());
                     }
                     // all other scalar functions become a script
                     else if (exp instanceof ScalarFunction) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/FieldAttributeTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.sql.expression.Attribute;
 import org.elasticsearch.xpack.sql.expression.Expressions;
 import org.elasticsearch.xpack.sql.expression.FieldAttribute;
 import org.elasticsearch.xpack.sql.expression.NamedExpression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.logical.LogicalPlan;
@@ -22,6 +23,7 @@ import org.elasticsearch.xpack.sql.type.EsField;
 import org.elasticsearch.xpack.sql.type.TypesTests;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -49,7 +51,7 @@ public class FieldAttributeTests extends ESTestCase {
 
         EsIndex test = new EsIndex("test", mapping);
         getIndexResult = IndexResolution.valid(test);
-        analyzer = new Analyzer(functionRegistry, getIndexResult, TimeZone.getTimeZone("UTC"));
+        analyzer = analyzer();
     }
 
     private LogicalPlan plan(String sql) {
@@ -166,7 +168,7 @@ public class FieldAttributeTests extends ESTestCase {
 
         EsIndex index = new EsIndex("test", mapping);
         getIndexResult = IndexResolution.valid(index);
-        analyzer = new Analyzer(functionRegistry, getIndexResult, TimeZone.getTimeZone("UTC"));
+        analyzer = analyzer();
 
         VerificationException ex = expectThrows(VerificationException.class, () -> plan("SELECT test.bar FROM test"));
         assertEquals(
@@ -193,5 +195,13 @@ public class FieldAttributeTests extends ESTestCase {
         assertThat(attribute, instanceOf(FieldAttribute.class));
         assertThat(attribute.qualifier(), is("test"));
         assertThat(attribute.name(), is("test.test"));
+    }
+
+    private Analyzer analyzer() {
+        return new Analyzer(functionRegistry, getIndexResult, functionContext());
+    }
+
+    private FunctionContext functionContext() {
+        return new FunctionContext(TimeZone.getTimeZone("UTC"), Locale.getDefault());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/analyzer/VerifierErrorMessagesTests.java
@@ -9,11 +9,13 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.analysis.AnalysisException;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.type.EsField;
 import org.elasticsearch.xpack.sql.type.TypesTests;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -27,7 +29,7 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     }
 
     private String verify(IndexResolution getIndexResult, String sql) {
-        Analyzer analyzer = new Analyzer(new FunctionRegistry(), getIndexResult, TimeZone.getTimeZone("UTC"));
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), getIndexResult, functionContext());
         AnalysisException e = expectThrows(AnalysisException.class, () -> analyzer.analyze(parser.createStatement(sql), true));
         assertTrue(e.getMessage().startsWith("Found "));
         String header = "Found 1 problem(s)\nline ";
@@ -143,5 +145,9 @@ public class VerifierErrorMessagesTests extends ESTestCase {
     public void testUnsupportedType() {
         assertEquals("1:8: Cannot use field [unsupported] type [ip_range] as is unsupported",
                 verify("SELECT unsupported FROM test"));
+    }
+
+    private FunctionContext functionContext() {
+        return new FunctionContext(TimeZone.getTimeZone("UTC"), Locale.getDefault());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunctionTestcase.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunctionTestcase.java
@@ -1,0 +1,72 @@
+package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.util.Locale;
+import java.util.TimeZone;
+
+public abstract class DateTimeFunctionTestcase<F extends DateTimeFunction> extends ESTestCase {
+
+    static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+    final DateTime dateTime(long millisSinceEpoch) {
+        return new DateTime(millisSinceEpoch, DateTimeZone.forTimeZone(UTC));
+    }
+
+    final DateTime dateTime(final int year, final int month, final int day) {
+        return new DateTime(year, month, day, 12, 0);
+    }
+
+    final Object process(Object value, String timeZone) {
+        return process(value, timeZone(timeZone));
+    }
+
+    final Object process(Object value, TimeZone timeZone) {
+        return process(value, functionContext(timeZone));
+    }
+
+    final Object process(Object value, FunctionContext context) {
+        return build(value, context).asProcessorDefinition().asProcessor().process(value);
+    }
+
+    final void processAndCheck(final DateTime dateTime, final String timeZone, final Object expected) {
+        processAndCheck(dateTime, timeZone(timeZone), expected);
+    }
+
+    final void processAndCheck(final DateTime dateTime, final TimeZone timeZone, final Object expected) {
+        this.processAndCheck(dateTime, timeZone, this.defaultLocale(), expected);
+    }
+
+    final void processAndCheck(final DateTime dateTime,
+                               final TimeZone timeZone,
+                               final Locale locale,
+                               final Object expected) {
+        Locale backup = null;
+        if(null!=locale) {
+            backup = Locale.getDefault();
+            Locale.setDefault(locale);
+        }
+        try {
+            assertEquals(dateTime + " " + locale, expected, process(dateTime, timeZone));
+        } finally {
+            if(null!=backup) {
+                Locale.setDefault(backup);
+            }
+        }
+    }
+
+    protected FunctionContext functionContext(final TimeZone timeZone) {
+        return new FunctionContext(timeZone, defaultLocale());
+    }
+
+    abstract F build(Object value, FunctionContext context);
+
+    abstract Locale defaultLocale();
+
+    private TimeZone timeZone(final String timeZone) {
+        return TimeZone.getTimeZone(timeZone);
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayNameTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayNameTests.java
@@ -6,34 +6,40 @@
 package org.elasticsearch.xpack.sql.expression.function.scalar.datetime;
 
 import org.elasticsearch.xpack.sql.expression.Literal;
+import org.elasticsearch.xpack.sql.expression.function.Function;
 import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.type.DataType;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.TimeZone;
 
-public class DayOfYearTests extends DateTimeFunctionTestcase<DayOfYear> {
+public class DayNameTests extends DateTimeFunctionTestcase<DayName> {
 
-    public void testUTC() {
-        processAndCheck(dateTime(0), UTC, 1);
+    public void test19700101_Thursday() {
+        processAndCheck(dateTime(0), UTC, "Thursday");
     }
 
-    public void testGMT_plus0100() {
-        processAndCheck(dateTime(0), "GMT+01:00", 1);
+    public void test20180503_GMT_Plus100_Thursday() {
+        processAndCheck(dateTime(2018,5,3), "GMT+01:00", "Thursday");
     }
 
-    public void testGMT_minus0100() {
-        processAndCheck(dateTime(0), "GMT-01:00", 365);
+    public void test20180502_GMTMinus100_Friday() {
+        processAndCheck(dateTime(2018,5,4), "GMT-01:00", "Friday");
     }
 
     @Override
-    DayOfYear build(Object value, FunctionContext context) {
-        return new DayOfYear(null,
+    DayName build(Object value, FunctionContext context) {
+        return new DayName(null,
             Collections.singletonList(new Literal(null, value, DataType.DATE)),
             context);
     }
 
+    // test expectations assume English
     Locale defaultLocale() {
         return Locale.ENGLISH;
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfMonthTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DayOfMonthTests.java
@@ -11,25 +11,24 @@ import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.util.Collections;
 import java.util.Locale;
-import java.util.TimeZone;
 
-public class DayOfYearTests extends DateTimeFunctionTestcase<DayOfYear> {
+public class DayOfMonthTests extends DateTimeFunctionTestcase<DayOfMonth> {
 
-    public void testUTC() {
+    public void test19700101() {
         processAndCheck(dateTime(0), UTC, 1);
     }
 
-    public void testGMT_plus0100() {
-        processAndCheck(dateTime(0), "GMT+01:00", 1);
+    public void test20170102() {
+        processAndCheck(dateTime(2017, 1, 2), UTC, 2);
     }
 
-    public void testGMT_minus0100() {
-        processAndCheck(dateTime(0), "GMT-01:00", 365);
+    public void test20170131() {
+        processAndCheck(dateTime(2017,1,31), UTC, 31);
     }
 
     @Override
-    DayOfYear build(Object value, FunctionContext context) {
-        return new DayOfYear(null,
+    DayOfMonth build(Object value, FunctionContext context) {
+        return new DayOfMonth(null,
             Collections.singletonList(new Literal(null, value, DataType.DATE)),
             context);
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/YearTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/YearTests.java
@@ -11,25 +11,24 @@ import org.elasticsearch.xpack.sql.type.DataType;
 
 import java.util.Collections;
 import java.util.Locale;
-import java.util.TimeZone;
 
-public class DayOfYearTests extends DateTimeFunctionTestcase<DayOfYear> {
+public class YearTests extends DateTimeFunctionTestcase<Year> {
 
-    public void testUTC() {
-        processAndCheck(dateTime(0), UTC, 1);
+    public void test1970() {
+        processAndCheck(dateTime(0), UTC, 1970);
     }
 
-    public void testGMT_plus0100() {
-        processAndCheck(dateTime(0), "GMT+01:00", 1);
+    public void test2017() {
+        processAndCheck(dateTime(2017, 1, 1), UTC, 2017);
     }
 
-    public void testGMT_minus0100() {
-        processAndCheck(dateTime(0), "GMT-01:00", 365);
+    public void test2000() {
+        processAndCheck(dateTime(2000, 1, 1), UTC, 2000);
     }
 
     @Override
-    DayOfYear build(Object value, FunctionContext context) {
-        return new DayOfYear(null,
+    Year build(Object value, FunctionContext context) {
+        return new Year(null,
             Collections.singletonList(new Literal(null, value, DataType.DATE)),
             context);
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/optimizer/OptimizerRunTests.java
@@ -9,12 +9,14 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.sql.type.EsField;
 import org.elasticsearch.xpack.sql.type.TypesTests;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -34,8 +36,12 @@ public class OptimizerRunTests extends ESTestCase {
 
         EsIndex test = new EsIndex("test", mapping);
         getIndexResult = IndexResolution.valid(test);
-        analyzer = new Analyzer(functionRegistry, getIndexResult, TimeZone.getTimeZone("UTC"));
+        analyzer = new Analyzer(functionRegistry, getIndexResult, functionContext());
         optimizer = new Optimizer();
+    }
+
+    private FunctionContext functionContext() {
+        return new FunctionContext(TimeZone.getTimeZone("UTC"), Locale.getDefault());
     }
 
     private LogicalPlan plan(String sql) {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysCatalogsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysCatalogsTests.java
@@ -12,12 +12,14 @@ import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolver;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.logical.command.Command;
 import org.elasticsearch.xpack.sql.session.SqlSession;
 import org.elasticsearch.xpack.sql.type.TypesTests;
 
+import java.util.Locale;
 import java.util.TimeZone;
 
 import static java.util.Collections.singletonList;
@@ -33,7 +35,7 @@ public class SysCatalogsTests extends ESTestCase {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private Tuple<Command, SqlSession> sql(String sql) {
         EsIndex test = new EsIndex("test", TypesTests.loadMapping("mapping-multi-field-with-nested.json", true));
-        Analyzer analyzer = new Analyzer(new FunctionRegistry(), IndexResolution.valid(test), TimeZone.getTimeZone("UTC"));
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), IndexResolution.valid(test), functionContext());
         Command cmd = (Command) analyzer.analyze(parser.createStatement(sql), true);
 
         IndexResolver resolver = mock(IndexResolver.class);
@@ -55,5 +57,9 @@ public class SysCatalogsTests extends ESTestCase {
             assertEquals(1, r.size());
             assertEquals("cluster", r.column(0));
         }, ex -> fail(ex.getMessage())));
+    }
+
+    private FunctionContext functionContext() {
+        return new FunctionContext(TimeZone.getTimeZone("UTC"), Locale.getDefault());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysParserTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysParserTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolver;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.logical.command.Command;
@@ -21,6 +22,7 @@ import org.elasticsearch.xpack.sql.type.EsField;
 import org.elasticsearch.xpack.sql.type.TypesTests;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -39,7 +41,7 @@ public class SysParserTests extends ESTestCase {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private Tuple<Command, SqlSession> sql(String sql) {
         EsIndex test = new EsIndex("test", mapping);
-        Analyzer analyzer = new Analyzer(new FunctionRegistry(), IndexResolution.valid(test), TimeZone.getTimeZone("UTC"));
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), IndexResolution.valid(test), functionContext());
         Command cmd = (Command) analyzer.analyze(parser.createStatement(sql), true);
 
         IndexResolver resolver = mock(IndexResolver.class);
@@ -68,7 +70,7 @@ public class SysParserTests extends ESTestCase {
             assertFalse(r.column(9, Boolean.class));
             // make sure precision is returned as boolean (not int)
             assertFalse(r.column(10, Boolean.class));
-            
+
             for (int i = 0; i < r.size(); i++) {
                 assertEquals(names.get(i), r.column(0));
                 r.advanceRow();
@@ -150,5 +152,9 @@ public class SysParserTests extends ESTestCase {
             }
 
         }, ex -> fail(ex.getMessage())));
+    }
+
+    private FunctionContext functionContext() {
+        return new FunctionContext(TimeZone.getTimeZone("UTC"), Locale.getDefault());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTableTypesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTableTypesTests.java
@@ -12,12 +12,14 @@ import org.elasticsearch.xpack.sql.analysis.analyzer.Analyzer;
 import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolver;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.logical.command.Command;
 import org.elasticsearch.xpack.sql.session.SqlSession;
 import org.elasticsearch.xpack.sql.type.TypesTests;
 
+import java.util.Locale;
 import java.util.TimeZone;
 
 import static org.mockito.Mockito.mock;
@@ -28,7 +30,7 @@ public class SysTableTypesTests extends ESTestCase {
 
     private Tuple<Command, SqlSession> sql(String sql) {
         EsIndex test = new EsIndex("test", TypesTests.loadMapping("mapping-multi-field-with-nested.json", true));
-        Analyzer analyzer = new Analyzer(new FunctionRegistry(), IndexResolution.valid(test), TimeZone.getTimeZone("UTC"));
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), IndexResolution.valid(test), functionContext());
         Command cmd = (Command) analyzer.analyze(parser.createStatement(sql), true);
 
         IndexResolver resolver = mock(IndexResolver.class);
@@ -45,5 +47,9 @@ public class SysTableTypesTests extends ESTestCase {
             r.advanceRow();
             assertEquals("ALIAS", r.column(0));
         }, ex -> fail(ex.getMessage())));
+    }
+
+    private FunctionContext functionContext() {
+        return new FunctionContext(TimeZone.getTimeZone("UTC"), Locale.getDefault());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolver;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolver.IndexInfo;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolver.IndexType;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.logical.command.Command;
@@ -27,6 +28,7 @@ import org.elasticsearch.xpack.sql.type.TypesTests;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.function.Consumer;
@@ -203,7 +205,7 @@ public class SysTablesTests extends ESTestCase {
 
     private Tuple<Command, SqlSession> sql(String sql, List<SqlTypedParamValue> params) {
         EsIndex test = new EsIndex("test", mapping);
-        Analyzer analyzer = new Analyzer(new FunctionRegistry(), IndexResolution.valid(test), TimeZone.getTimeZone("UTC"));
+        Analyzer analyzer = new Analyzer(new FunctionRegistry(), IndexResolution.valid(test), functionContext());
         Command cmd = (Command) analyzer.analyze(parser.createStatement(sql, params), true);
 
         IndexResolver resolver = mock(IndexResolver.class);
@@ -211,6 +213,10 @@ public class SysTablesTests extends ESTestCase {
 
         SqlSession session = new SqlSession(null, null, null, resolver, null, null, null);
         return new Tuple<>(cmd, session);
+    }
+
+    private FunctionContext functionContext() {
+        return new FunctionContext(TimeZone.getTimeZone("UTC"), Locale.getDefault());
     }
 
     private void executeCommand(String sql, Consumer<SchemaRowSet> consumer, IndexInfo... infos) throws Exception {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryTranslatorTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.sql.analysis.index.EsIndex;
 import org.elasticsearch.xpack.sql.analysis.index.IndexResolution;
 import org.elasticsearch.xpack.sql.analysis.index.MappingException;
 import org.elasticsearch.xpack.sql.expression.Expression;
+import org.elasticsearch.xpack.sql.expression.function.FunctionContext;
 import org.elasticsearch.xpack.sql.expression.function.FunctionRegistry;
 import org.elasticsearch.xpack.sql.parser.SqlParser;
 import org.elasticsearch.xpack.sql.plan.logical.Filter;
@@ -25,6 +26,7 @@ import org.elasticsearch.xpack.sql.type.EsField;
 import org.elasticsearch.xpack.sql.type.TypesTests;
 import org.joda.time.DateTime;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -34,7 +36,7 @@ public class QueryTranslatorTests extends ESTestCase {
     private IndexResolution getIndexResult;
     private FunctionRegistry functionRegistry;
     private Analyzer analyzer;
-    
+
     public QueryTranslatorTests() {
         parser = new SqlParser();
         functionRegistry = new FunctionRegistry();
@@ -43,7 +45,7 @@ public class QueryTranslatorTests extends ESTestCase {
 
         EsIndex test = new EsIndex("test", mapping);
         getIndexResult = IndexResolution.valid(test);
-        analyzer = new Analyzer(functionRegistry, getIndexResult, TimeZone.getTimeZone("UTC"));
+        analyzer = new Analyzer(functionRegistry, getIndexResult, functionContext());
     }
 
     private LogicalPlan plan(String sql) {
@@ -138,5 +140,9 @@ public class QueryTranslatorTests extends ESTestCase {
         RangeQuery rq = (RangeQuery) query;
         assertEquals("date", rq.field());
         assertEquals(DateTime.parse("1969-05-13T12:34:56Z"), rq.lower());
+    }
+
+    private FunctionContext functionContext() {
+        return new FunctionContext(TimeZone.getTimeZone("UTC"), Locale.getDefault());
     }
 }


### PR DESCRIPTION
… date getters  #29981

- introduced new DayName sql function
- ALL date sql functions now support optional timezone.
- DayName includes optional tz + optional locale.
- all painless date getters are overloaded to match supported param lists of
   sql functions also take optional tz + dayname optional locale
- introduced a pass a "context" to all date functions which hold
  - "default tz"
  - "default" locale
- introduced new sub class of ReadableDateTime called PainlessDateTime,
  supporting overloads for all date getters (optional tz etc).
- Fixed Definition when processing whitelist to allow covariant return types when checking
  class vs implementing interface etc.
- #29981 (Implement sql DayName fn)

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.

yes to all, except classwork.