### PR TITLE
[CCR] Fixed follow and unfollow api url path according to design.

### DIFF
--- a/x-pack/plugin/ccr/qa/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster-with-security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -85,7 +85,7 @@ public class FollowIndexSecurityIT extends ESRestTestCase {
             followIndex("leader_cluster:" + indexName1, indexName1);
             assertBusy(() -> verifyDocuments(client(), indexName1, numDocs));
             assertThat(countCcrNodeTasks(), equalTo(1));
-            assertOK(client().performRequest("POST", "/_xpack/ccr/" + indexName1 + "/_unfollow"));
+            assertOK(client().performRequest("POST", "/" + indexName1 + "/_xpack/ccr/_unfollow"));
             // Make sure that there are no other ccr relates operations running:
             assertBusy(() -> {
                 Map<String, Object> clusterState = toMap(adminClient().performRequest("GET", "/_cluster/state"));
@@ -140,7 +140,7 @@ public class FollowIndexSecurityIT extends ESRestTestCase {
 
     private static void followIndex(String leaderIndex, String followIndex) throws IOException {
         Map<String, String> params = Collections.singletonMap("leader_index", leaderIndex);
-        assertOK(client().performRequest("POST", "/_xpack/ccr/" + followIndex + "/_follow", params));
+        assertOK(client().performRequest("POST", "/" + followIndex + "/_xpack/ccr/_follow", params));
     }
 
     void verifyDocuments(RestClient client, String index, int expectedNumDocs) throws IOException {

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexIT.java
@@ -94,7 +94,7 @@ public class FollowIndexIT extends ESRestTestCase {
 
     private static void followIndex(String leaderIndex, String followIndex) throws IOException {
         Map<String, String> params = Collections.singletonMap("leader_index", leaderIndex);
-        assertOK(client().performRequest("POST", "/_xpack/ccr/" + followIndex + "/_follow", params));
+        assertOK(client().performRequest("POST", "/" + followIndex + "/_xpack/ccr/_follow", params));
     }
 
     private static void verifyDocuments(String index, int expectedNumDocs) throws IOException {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/UnfollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/UnfollowIndexAction.java
@@ -130,6 +130,11 @@ public class UnfollowIndexAction extends Action<UnfollowIndexAction.Request, Unf
         protected void doExecute(Request request, ActionListener<Response> listener) {
             client.admin().cluster().state(new ClusterStateRequest(), ActionListener.wrap(r -> {
                 IndexMetaData followIndexMetadata = r.getState().getMetaData().index(request.followIndex);
+                if (followIndexMetadata == null) {
+                    listener.onFailure(new IllegalArgumentException("follow index [" + request.followIndex + "] does not exist"));
+                    return;
+                }
+
                 final int numShards = followIndexMetadata.getNumberOfShards();
                 final AtomicInteger counter = new AtomicInteger(numShards);
                 final AtomicReferenceArray<Object> responses = new AtomicReferenceArray<>(followIndexMetadata.getNumberOfShards());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowExistingIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowExistingIndexAction.java
@@ -18,13 +18,11 @@ import java.io.IOException;
 import static org.elasticsearch.xpack.ccr.action.FollowExistingIndexAction.INSTANCE;
 import static org.elasticsearch.xpack.ccr.action.FollowExistingIndexAction.Request;
 
-// TODO: change to confirm with API design
 public class RestFollowExistingIndexAction extends BaseRestHandler {
 
     public RestFollowExistingIndexAction(Settings settings, RestController controller) {
         super(settings);
-        // TODO: figure out why: '/{follow_index}/_xpack/ccr/_follow' path clashes with create index api.
-        controller.registerHandler(RestRequest.Method.POST, "/_xpack/ccr/{follow_index}/_follow", this);
+        controller.registerHandler(RestRequest.Method.POST, "/{index}/_xpack/ccr/_follow", this);
     }
 
     @Override
@@ -36,7 +34,7 @@ public class RestFollowExistingIndexAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         Request request = new Request();
         request.setLeaderIndex(restRequest.param("leader_index"));
-        request.setFollowIndex(restRequest.param("follow_index"));
+        request.setFollowIndex(restRequest.param("index"));
         if (restRequest.hasParam(ShardFollowTask.MAX_CHUNK_SIZE.getPreferredName())) {
             request.setBatchSize(Long.valueOf(restRequest.param(ShardFollowTask.MAX_CHUNK_SIZE.getPreferredName())));
         }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestUnfollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestUnfollowIndexAction.java
@@ -17,13 +17,11 @@ import java.io.IOException;
 import static org.elasticsearch.xpack.ccr.action.UnfollowIndexAction.INSTANCE;
 import static org.elasticsearch.xpack.ccr.action.UnfollowIndexAction.Request;
 
-// TODO: change to confirm with API design
 public class RestUnfollowIndexAction extends BaseRestHandler {
 
     public RestUnfollowIndexAction(Settings settings, RestController controller) {
         super(settings);
-        // TODO: figure out why: '/{follow_index}/_xpack/ccr/_unfollow' path clashes with create index api.
-        controller.registerHandler(RestRequest.Method.POST, "/_xpack/ccr/{follow_index}/_unfollow", this);
+        controller.registerHandler(RestRequest.Method.POST, "/{index}/_xpack/ccr/_unfollow", this);
     }
 
     @Override
@@ -34,7 +32,7 @@ public class RestUnfollowIndexAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         Request request = new Request();
-        request.setFollowIndex(restRequest.param("follow_index"));
+        request.setFollowIndex(restRequest.param("index"));
         return channel -> client.execute(INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/ShardChangesIT.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/ShardChangesIT.java
@@ -276,6 +276,12 @@ public class ShardChangesIT extends ESIntegTestCase {
         });
     }
 
+    public void testUnfollowNonExistingIndex() {
+        UnfollowIndexAction.Request unfollowRequest = new UnfollowIndexAction.Request();
+        unfollowRequest.setFollowIndex("non-existing-index");
+        expectThrows(IllegalArgumentException.class, () -> client().execute(UnfollowIndexAction.INSTANCE, unfollowRequest).actionGet());
+    }
+
     public void testFollowNonExistentIndex() throws Exception {
         assertAcked(client().admin().indices().prepareCreate("test-leader").get());
         assertAcked(client().admin().indices().prepareCreate("test-follower").get());

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ccr.follow_existing_index.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ccr.follow_existing_index.json
@@ -3,10 +3,10 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_xpack/ccr/{follow_index}/_follow",
-      "paths": [ "/_xpack/ccr/{follow_index}/_follow" ],
+      "path": "/{index}/_xpack/ccr/_follow",
+      "paths": [ "/{index}/_xpack/ccr/_follow" ],
       "parts": {
-        "follow_index": {
+        "index": {
           "type": "string",
           "required": true,
           "description": "The name of the index that follows to leader index."

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ccr.unfollow_index.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ccr.unfollow_index.json
@@ -3,10 +3,10 @@
     "documentation": "http://www.elastic.co/guide/en/elasticsearch/reference/current",
     "methods": [ "POST" ],
     "url": {
-      "path": "/_xpack/ccr/{follow_index}/_unfollow",
-      "paths": [ "/_xpack/ccr/{follow_index}/_unfollow" ],
+      "path": "/{index}/_xpack/ccr/_unfollow",
+      "paths": [ "/{index}/_xpack/ccr/_unfollow" ],
       "parts": {
-        "follow_index": {
+        "index": {
           "type": "string",
           "required": true,
           "description": "The name of the follow index that should stop following its leader index."

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ccr/follow_and_unfollow.yml
@@ -25,10 +25,10 @@
   - do:
       xpack.ccr.follow_existing_index:
         leader_index: foo
-        follow_index: bar
+        index: bar
   - is_true: acknowledged
 
   - do:
       xpack.ccr.unfollow_index:
-        follow_index: bar
+        index: bar
   - is_true: acknowledged


### PR DESCRIPTION
The TODOs in the rest actions was incorrect. The problem was that
these rest actions used `follow_index` as first named variable in the path
under which the rest actions were registered. Other candidate rest actions that
also have a named variable as first element in the path (but with a different
name) get resolved as rest parameters too and passed down to the rest
action that actually ends up getting executed.

In the case of the follow index api, a `index` parameter got passed down
to `RestFollowExistingAction`, but that param was never used. This caused the
follow index api call to fail, because of unused http parameters.

This change doesn't fixes that problem, but works around it by using
`index` as named variable for the follow index (instead of `follow_index`).

Also this PR adds a check to fail nicely if an index is specified to unfollow api
that does not exist.

Relates to #30102
