### PR TITLE
Adds `index.lifecycle.step_info` setting and uses it on ERROR and incomplete steps

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AsyncWaitStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AsyncWaitStep.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.indexlifecycle;
 
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.index.Index;
 
 public abstract class AsyncWaitStep extends Step {
@@ -25,7 +26,7 @@ public abstract class AsyncWaitStep extends Step {
 
     public interface Listener {
 
-        void onResponse(boolean conditionMet);
+        void onResponse(boolean conditionMet, ToXContentObject infomationContext);
 
         void onFailure(Exception e);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecycleSettings.java
@@ -22,6 +22,7 @@ public class LifecycleSettings {
     public static final String LIFECYCLE_ACTION_TIME = "index.lifecycle.action_time";
     public static final String LIFECYCLE_STEP_TIME = "index.lifecycle.step_time";
     public static final String LIFECYCLE_FAILED_STEP = "index.lifecycle.failed_step";
+    public static final String LIFECYCLE_STEP_INFO = "index.lifecycle.step_info";
 
     // NORELEASE: we should probably change the default to something other than three seconds for initial release
     public static final Setting<TimeValue> LIFECYCLE_POLL_INTERVAL_SETTING = Setting.positiveTimeSetting(LIFECYCLE_POLL_INTERVAL,
@@ -44,4 +45,6 @@ public class LifecycleSettings {
         -1L, -1L, Setting.Property.Dynamic, Setting.Property.IndexScope);
     public static final Setting<Long> LIFECYCLE_STEP_TIME_SETTING = Setting.longSetting(LIFECYCLE_STEP_TIME,
         -1L, -1L, Setting.Property.Dynamic, Setting.Property.IndexScope);
+    public static final Setting<String> LIFECYCLE_STEP_INFO_SETTING = Setting.simpleString(LIFECYCLE_STEP_INFO, Setting.Property.Dynamic,
+            Setting.Property.IndexScope, Setting.Property.NotCopyableOnResize);
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/SegmentCountStepInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/SegmentCountStepInfoTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.indexlifecycle;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.xpack.core.indexlifecycle.SegmentCountStep.Info;
+
+import java.io.IOException;
+
+public class SegmentCountStepInfoTests extends AbstractXContentTestCase<SegmentCountStep.Info> {
+
+    @Override
+    protected Info createTestInstance() {
+        return new Info(randomNonNegativeLong());
+    }
+
+    @Override
+    protected Info doParseInstance(XContentParser parser) throws IOException {
+        return Info.PARSER.apply(parser, null);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    public final void testEqualsAndHashcode() {
+        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copyInstance, this::mutateInstance);
+        }
+    }
+
+    protected final Info copyInstance(Info instance) throws IOException {
+        return new Info(instance.getNumberShardsLeftToMerge());
+    }
+
+    protected Info mutateInstance(Info instance) throws IOException {
+        return createTestInstance();
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/SegmentCountStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/SegmentCountStepTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.indices.segments.ShardSegments;
 import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.engine.Segment;
 import org.elasticsearch.rest.RestStatus;
@@ -112,12 +113,14 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         }).when(indicesClient).segments(any(), any());
 
         SetOnce<Boolean> conditionMetResult = new SetOnce<>();
+        SetOnce<ToXContentObject> conditionInfo = new SetOnce<>();
 
         SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments, bestCompression);
         step.evaluateCondition(index, new AsyncWaitStep.Listener() {
             @Override
-            public void onResponse(boolean conditionMet) {
+            public void onResponse(boolean conditionMet, ToXContentObject info) {
                 conditionMetResult.set(conditionMet);
+                conditionInfo.set(info);
             }
 
             @Override
@@ -127,6 +130,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         });
 
         assertTrue(conditionMetResult.get());
+        assertEquals(new SegmentCountStep.Info(0L), conditionInfo.get());
     }
 
     public void testIsConditionFails() {
@@ -167,12 +171,14 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         }).when(indicesClient).segments(any(), any());
 
         SetOnce<Boolean> conditionMetResult = new SetOnce<>();
+        SetOnce<ToXContentObject> conditionInfo = new SetOnce<>();
 
         SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments, bestCompression);
         step.evaluateCondition(index, new AsyncWaitStep.Listener() {
             @Override
-            public void onResponse(boolean conditionMet) {
+            public void onResponse(boolean conditionMet, ToXContentObject info) {
                 conditionMetResult.set(conditionMet);
+                conditionInfo.set(info);
             }
 
             @Override
@@ -182,6 +188,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         });
 
         assertFalse(conditionMetResult.get());
+        assertEquals(new SegmentCountStep.Info(1L), conditionInfo.get());
     }
 
     public void testThrowsException() {
@@ -210,7 +217,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments, bestCompression);
         step.evaluateCondition(index, new AsyncWaitStep.Listener() {
             @Override
-            public void onResponse(boolean conditionMet) {
+            public void onResponse(boolean conditionMet, ToXContentObject info) {
                 throw new AssertionError("unexpected method call");
             }
 

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
@@ -97,6 +97,8 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             LifecycleSettings.LIFECYCLE_ACTION_SETTING,
             LifecycleSettings.LIFECYCLE_STEP_TIME_SETTING,
             LifecycleSettings.LIFECYCLE_STEP_SETTING,
+            LifecycleSettings.LIFECYCLE_STEP_INFO_SETTING,
+            LifecycleSettings.LIFECYCLE_FAILED_STEP_SETTING,
             RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING);
     }
 

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
@@ -174,7 +174,9 @@ public class IndexLifecycleRunner {
         long nowAsMillis = nowSupplier.getAsLong();
         Settings.Builder newSettings = Settings.builder().put(existingSettings).put(LifecycleSettings.LIFECYCLE_PHASE, nextStep.getPhase())
                 .put(LifecycleSettings.LIFECYCLE_ACTION, nextStep.getAction()).put(LifecycleSettings.LIFECYCLE_STEP, nextStep.getName())
-                .put(LifecycleSettings.LIFECYCLE_STEP_TIME, nowAsMillis);
+                .put(LifecycleSettings.LIFECYCLE_STEP_TIME, nowAsMillis)
+                // clear any step info from the current step
+                .put(LifecycleSettings.LIFECYCLE_STEP_INFO, (String) null);
         if (currentStep.getPhase().equals(nextStep.getPhase()) == false) {
             newSettings.put(LifecycleSettings.LIFECYCLE_PHASE_TIME, nowAsMillis);
         }

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/SetStepInfoUpdateTask.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/SetStepInfoUpdateTask.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.indexlifecycle;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.xpack.core.indexlifecycle.LifecycleSettings;
+import org.elasticsearch.xpack.core.indexlifecycle.Step;
+
+import java.io.IOException;
+
+public class SetStepInfoUpdateTask extends ClusterStateUpdateTask {
+    private final Index index;
+    private final String policy;
+    private final Step.StepKey currentStepKey;
+    private ToXContentObject stepInfo;
+
+    public SetStepInfoUpdateTask(Index index, String policy, Step.StepKey currentStepKey, ToXContentObject stepInfo) {
+        this.index = index;
+        this.policy = policy;
+        this.currentStepKey = currentStepKey;
+        this.stepInfo = stepInfo;
+    }
+
+    Index getIndex() {
+        return index;
+    }
+
+    String getPolicy() {
+        return policy;
+    }
+
+    Step.StepKey getCurrentStepKey() {
+        return currentStepKey;
+    }
+
+    ToXContentObject getStepInfo() {
+        return stepInfo;
+    }
+
+    @Override
+    public ClusterState execute(ClusterState currentState) throws IOException {
+        Settings indexSettings = currentState.getMetaData().index(index).getSettings();
+        if (policy.equals(LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexSettings))
+                && currentStepKey.equals(IndexLifecycleRunner.getCurrentStepKey(indexSettings))) {
+            XContentBuilder infoXContentBuilder = JsonXContent.contentBuilder();
+            stepInfo.toXContent(infoXContentBuilder, ToXContent.EMPTY_PARAMS);
+            String stepInfoString = BytesReference.bytes(infoXContentBuilder).utf8ToString();
+            Settings.Builder newSettings = Settings.builder().put(indexSettings).put(LifecycleSettings.LIFECYCLE_STEP_INFO_SETTING.getKey(),
+                    stepInfoString);
+            return IndexLifecycleRunner.newClusterStateWithIndexSettings(index, currentState, newSettings).build();
+        } else {
+            // either the policy has changed or the step is now
+            // not the same as when we submitted the update task. In
+            // either case we don't want to do anything now
+            return currentState;
+        }
+    }
+
+    @Override
+    public void onFailure(String source, Exception e) {
+        throw new ElasticsearchException("policy [" + policy + "] for index [" + index.getName()
+                + "] failed trying to set step info for step [" + currentStepKey + "].", e);
+    }
+}

--- a/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -508,10 +509,14 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                 () -> now);
         assertClusterStateOnNextStep(clusterState, index, currentStep, nextStep, newClusterState, now);
 
+        Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_PHASE, currentStep.getPhase())
+                .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
+                .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName());
+        if (randomBoolean()) {
+            indexSettingsBuilder.put(LifecycleSettings.LIFECYCLE_STEP_INFO, randomAlphaOfLength(20));
+        }
         clusterState = buildClusterState(indexName,
-                Settings.builder().put(LifecycleSettings.LIFECYCLE_PHASE, currentStep.getPhase())
-                        .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
-                        .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName()));
+                indexSettingsBuilder);
         index = clusterState.metaData().index(indexName).getIndex();
         newClusterState = IndexLifecycleRunner.moveClusterStateToNextStep(index, clusterState, currentStep, nextStep, () -> now);
         assertClusterStateOnNextStep(clusterState, index, currentStep, nextStep, newClusterState, now);
@@ -529,10 +534,14 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                 () -> now);
         assertClusterStateOnNextStep(clusterState, index, currentStep, nextStep, newClusterState, now);
 
+        Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_PHASE, currentStep.getPhase())
+                .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
+                .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName());
+        if (randomBoolean()) {
+            indexSettingsBuilder.put(LifecycleSettings.LIFECYCLE_STEP_INFO, randomAlphaOfLength(20));
+        }
         clusterState = buildClusterState(indexName,
-                Settings.builder().put(LifecycleSettings.LIFECYCLE_PHASE, currentStep.getPhase())
-                        .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
-                        .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName()));
+                indexSettingsBuilder);
         index = clusterState.metaData().index(indexName).getIndex();
         newClusterState = IndexLifecycleRunner.moveClusterStateToNextStep(index, clusterState, currentStep, nextStep, () -> now);
         assertClusterStateOnNextStep(clusterState, index, currentStep, nextStep, newClusterState, now);
@@ -550,10 +559,14 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
                 () -> now);
         assertClusterStateOnNextStep(clusterState, index, currentStep, nextStep, newClusterState, now);
 
+        Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_PHASE, currentStep.getPhase())
+                .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
+                .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName());
+        if (randomBoolean()) {
+            indexSettingsBuilder.put(LifecycleSettings.LIFECYCLE_STEP_INFO, randomAlphaOfLength(20));
+        }
         clusterState = buildClusterState(indexName,
-                Settings.builder().put(LifecycleSettings.LIFECYCLE_PHASE, currentStep.getPhase())
-                        .put(LifecycleSettings.LIFECYCLE_ACTION, currentStep.getAction())
-                        .put(LifecycleSettings.LIFECYCLE_STEP, currentStep.getName()));
+                indexSettingsBuilder);
         index = clusterState.metaData().index(indexName).getIndex();
         newClusterState = IndexLifecycleRunner.moveClusterStateToNextStep(index, clusterState, currentStep, nextStep, () -> now);
         assertClusterStateOnNextStep(clusterState, index, currentStep, nextStep, newClusterState, now);
@@ -609,6 +622,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         }
         assertEquals(now, (long) LifecycleSettings.LIFECYCLE_STEP_TIME_SETTING.get(newIndexSettings));
         assertFalse(LifecycleSettings.LIFECYCLE_FAILED_STEP_SETTING.exists(newIndexSettings));
+        assertEquals("", LifecycleSettings.LIFECYCLE_STEP_INFO_SETTING.get(newIndexSettings));
     }
 
     private void assertClusterStateOnErrorStep(ClusterState oldClusterState, Index index, StepKey currentStep, ClusterState newClusterState,

--- a/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunnerTests.java
@@ -656,7 +656,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         private final String key;
         private final String value;
 
-        public RandomStepInfo() {
+        RandomStepInfo() {
             this.key = randomAlphaOfLength(20);
             this.value = randomAlphaOfLength(20);
         }

--- a/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/MoveToErrorStepUpdateTaskTests.java
+++ b/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/MoveToErrorStepUpdateTaskTests.java
@@ -11,13 +11,19 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.indexlifecycle.ErrorStep;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleSettings;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 import org.junit.Before;
+
+import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
@@ -43,13 +49,14 @@ public class MoveToErrorStepUpdateTaskTests extends ESTestCase {
         clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).build();
     }
 
-    public void testExecuteSuccessfullyMoved() {
+    public void testExecuteSuccessfullyMoved() throws IOException {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         long now = randomNonNegativeLong();
+        Exception cause = new ElasticsearchException("THIS IS AN EXPECTED CAUSE");
 
         setStateToKey(currentStepKey);
 
-        MoveToErrorStepUpdateTask task = new MoveToErrorStepUpdateTask(index, policy, currentStepKey, () -> now);
+        MoveToErrorStepUpdateTask task = new MoveToErrorStepUpdateTask(index, policy, currentStepKey, cause, () -> now);
         ClusterState newState = task.execute(clusterState);
         StepKey actualKey = IndexLifecycleRunner.getCurrentStepKey(newState.metaData().index(index).getSettings());
         assertThat(actualKey, equalTo(new StepKey(currentStepKey.getPhase(), currentStepKey.getAction(), ErrorStep.NAME)));
@@ -58,24 +65,34 @@ public class MoveToErrorStepUpdateTaskTests extends ESTestCase {
         assertThat(LifecycleSettings.LIFECYCLE_PHASE_TIME_SETTING.get(newState.metaData().index(index).getSettings()), equalTo(-1L));
         assertThat(LifecycleSettings.LIFECYCLE_ACTION_TIME_SETTING.get(newState.metaData().index(index).getSettings()), equalTo(-1L));
         assertThat(LifecycleSettings.LIFECYCLE_STEP_TIME_SETTING.get(newState.metaData().index(index).getSettings()), equalTo(now));
+
+        XContentBuilder causeXContentBuilder = JsonXContent.contentBuilder();
+        causeXContentBuilder.startObject();
+        ElasticsearchException.generateFailureXContent(causeXContentBuilder, ToXContent.EMPTY_PARAMS, cause, false);
+        causeXContentBuilder.endObject();
+        String expectedCauseValue = BytesReference.bytes(causeXContentBuilder).utf8ToString();
+        assertThat(LifecycleSettings.LIFECYCLE_STEP_INFO_SETTING.get(newState.metaData().index(index).getSettings()),
+                equalTo(expectedCauseValue));
     }
 
-    public void testExecuteNoopDifferentStep() {
+    public void testExecuteNoopDifferentStep() throws IOException {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         StepKey notCurrentStepKey = new StepKey("not-current", "not-current", "not-current");
         long now = randomNonNegativeLong();
+        Exception cause = new ElasticsearchException("THIS IS AN EXPECTED CAUSE");
         setStateToKey(notCurrentStepKey);
-        MoveToErrorStepUpdateTask task = new MoveToErrorStepUpdateTask(index, policy, currentStepKey, () -> now);
+        MoveToErrorStepUpdateTask task = new MoveToErrorStepUpdateTask(index, policy, currentStepKey, cause, () -> now);
         ClusterState newState = task.execute(clusterState);
         assertThat(newState, sameInstance(clusterState));
     }
 
-    public void testExecuteNoopDifferentPolicy() {
+    public void testExecuteNoopDifferentPolicy() throws IOException {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         long now = randomNonNegativeLong();
+        Exception cause = new ElasticsearchException("THIS IS AN EXPECTED CAUSE");
         setStateToKey(currentStepKey);
         setStatePolicy("not-" + policy);
-        MoveToErrorStepUpdateTask task = new MoveToErrorStepUpdateTask(index, policy, currentStepKey, () -> now);
+        MoveToErrorStepUpdateTask task = new MoveToErrorStepUpdateTask(index, policy, currentStepKey, cause, () -> now);
         ClusterState newState = task.execute(clusterState);
         assertThat(newState, sameInstance(clusterState));
     }
@@ -83,10 +100,11 @@ public class MoveToErrorStepUpdateTaskTests extends ESTestCase {
     public void testOnFailure() {
         StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
         long now = randomNonNegativeLong();
+        Exception cause = new ElasticsearchException("THIS IS AN EXPECTED CAUSE");
 
         setStateToKey(currentStepKey);
 
-        MoveToErrorStepUpdateTask task = new MoveToErrorStepUpdateTask(index, policy, currentStepKey, () -> now);
+        MoveToErrorStepUpdateTask task = new MoveToErrorStepUpdateTask(index, policy, currentStepKey, cause, () -> now);
         Exception expectedException = new RuntimeException();
         ElasticsearchException exception = expectThrows(ElasticsearchException.class,
                 () -> task.onFailure(randomAlphaOfLength(10), expectedException));

--- a/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/index-lifecycle/src/test/java/org/elasticsearch/xpack/indexlifecycle/SetStepInfoUpdateTaskTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.indexlifecycle;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.indexlifecycle.LifecycleSettings;
+import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class SetStepInfoUpdateTaskTests extends ESTestCase {
+
+    String policy;
+    ClusterState clusterState;
+    Index index;
+
+    @Before
+    public void setupClusterState() {
+        policy = randomAlphaOfLength(10);
+        IndexMetaData indexMetadata = IndexMetaData.builder(randomAlphaOfLength(5))
+            .settings(settings(Version.CURRENT)
+                .put(LifecycleSettings.LIFECYCLE_NAME, policy))
+            .numberOfShards(randomIntBetween(1, 5)).numberOfReplicas(randomIntBetween(0, 5)).build();
+        index = indexMetadata.getIndex();
+        MetaData metaData = MetaData.builder()
+            .persistentSettings(settings(Version.CURRENT).build())
+            .put(IndexMetaData.builder(indexMetadata))
+            .build();
+        clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).build();
+    }
+
+    public void testExecuteSuccessfullySet() throws IOException {
+        StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
+        ToXContentObject stepInfo = getRandomStepInfo();
+        setStateToKey(currentStepKey);
+
+        SetStepInfoUpdateTask task = new SetStepInfoUpdateTask(index, policy, currentStepKey, stepInfo);
+        ClusterState newState = task.execute(clusterState);
+        StepKey actualKey = IndexLifecycleRunner.getCurrentStepKey(newState.metaData().index(index).getSettings());
+        assertThat(actualKey, equalTo(currentStepKey));
+        assertThat(LifecycleSettings.LIFECYCLE_PHASE_TIME_SETTING.get(newState.metaData().index(index).getSettings()), equalTo(-1L));
+        assertThat(LifecycleSettings.LIFECYCLE_ACTION_TIME_SETTING.get(newState.metaData().index(index).getSettings()), equalTo(-1L));
+        assertThat(LifecycleSettings.LIFECYCLE_STEP_TIME_SETTING.get(newState.metaData().index(index).getSettings()), equalTo(-1L));
+
+        XContentBuilder infoXContentBuilder = JsonXContent.contentBuilder();
+        stepInfo.toXContent(infoXContentBuilder, ToXContent.EMPTY_PARAMS);
+        String expectedCauseValue = BytesReference.bytes(infoXContentBuilder).utf8ToString();
+        assertThat(LifecycleSettings.LIFECYCLE_STEP_INFO_SETTING.get(newState.metaData().index(index).getSettings()),
+                equalTo(expectedCauseValue));
+    }
+
+    private ToXContentObject getRandomStepInfo() {
+        String key = randomAlphaOfLength(20);
+        String value = randomAlphaOfLength(20);
+        return (b, p) -> {
+            b.startObject();
+            b.field(key, value);
+            b.endObject();
+            return b;
+        };
+    }
+
+    public void testExecuteNoopDifferentStep() throws IOException {
+        StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
+        StepKey notCurrentStepKey = new StepKey("not-current", "not-current", "not-current");
+        ToXContentObject stepInfo = getRandomStepInfo();
+        setStateToKey(notCurrentStepKey);
+        SetStepInfoUpdateTask task = new SetStepInfoUpdateTask(index, policy, currentStepKey, stepInfo);
+        ClusterState newState = task.execute(clusterState);
+        assertThat(newState, sameInstance(clusterState));
+    }
+
+    public void testExecuteNoopDifferentPolicy() throws IOException {
+        StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
+        ToXContentObject stepInfo = getRandomStepInfo();
+        setStateToKey(currentStepKey);
+        setStatePolicy("not-" + policy);
+        SetStepInfoUpdateTask task = new SetStepInfoUpdateTask(index, policy, currentStepKey, stepInfo);
+        ClusterState newState = task.execute(clusterState);
+        assertThat(newState, sameInstance(clusterState));
+    }
+
+    public void testOnFailure() {
+        StepKey currentStepKey = new StepKey("current-phase", "current-action", "current-name");
+        ToXContentObject stepInfo = getRandomStepInfo();
+
+        setStateToKey(currentStepKey);
+
+        SetStepInfoUpdateTask task = new SetStepInfoUpdateTask(index, policy, currentStepKey, stepInfo);
+        Exception expectedException = new RuntimeException();
+        ElasticsearchException exception = expectThrows(ElasticsearchException.class,
+                () -> task.onFailure(randomAlphaOfLength(10), expectedException));
+        assertEquals("policy [" + policy + "] for index [" + index.getName() + "] failed trying to set step info for step ["
+                + currentStepKey + "].", exception.getMessage());
+        assertSame(expectedException, exception.getCause());
+    }
+
+    private void setStatePolicy(String policy) {
+        clusterState = ClusterState.builder(clusterState)
+            .metaData(MetaData.builder(clusterState.metaData())
+                .updateSettings(Settings.builder()
+                    .put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), index.getName())).build();
+
+    }
+    private void setStateToKey(StepKey stepKey) {
+        clusterState = ClusterState.builder(clusterState)
+            .metaData(MetaData.builder(clusterState.metaData())
+                .updateSettings(Settings.builder()
+                    .put(LifecycleSettings.LIFECYCLE_PHASE, stepKey.getPhase())
+                    .put(LifecycleSettings.LIFECYCLE_ACTION, stepKey.getAction())
+                    .put(LifecycleSettings.LIFECYCLE_STEP, stepKey.getName()).build(), index.getName())).build();
+    }
+}


### PR DESCRIPTION
This change make a new `index.lifecycle.step_info` setting which can be
used to store a JSON blob of containing context about the current step.
It then adds code so that when we move to the error step we serialise
the exception to JSON  and store it in this setting so the user can get
information on why the step failed.

The `Listener` for `AsyncWaitStep` now takes a `ToXContentObject` which
represents information about the status of the condition if it has not
completed. This object is then serialised to a JSON string and stored
in the `index.lifecycle.step_info` index setting. This information is
only stored if the step is not complete. If the step is complete the
step info is ignored sice we will move straight to the next step where
the info is no longer relevant.

Changes for the `ClusterStateWaitStep` will be very similar but will be
made in a following commits on this PR after this approach has been agreed. 
I do not intend to have information for `AsyncActionStep` to have the
ability to set step info since actions should either be done or not
done and if they error they should transition to the ERROR step.