### PR TITLE
Support for Geohash as bounding box in geo_bounding_box

### DIFF
--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -206,7 +206,7 @@ GET /_search
 // CONSOLE
 
 [float]
-===== Geohash
+===== Geohash as corners
 
 [source,js]
 --------------------------------------------------
@@ -222,6 +222,31 @@ GET /_search
                     "pin.location" : {
                         "top_left" : "dr5r9ydj2y73",
                         "bottom_right" : "drj7teegpus6"
+                    }
+                }
+            }
+        }
+    }
+}
+--------------------------------------------------
+// CONSOLE
+
+[float]
+===== Geohash as a bounding box
+
+[source,js]
+--------------------------------------------------
+GET /_search
+{
+    "query": {
+        "bool" : {
+            "must" : {
+                "match_all" : {}
+            },
+            "filter" : {
+                "geo_bounding_box" : {
+                    "pin.location" : {
+                        "geohash" : "dr5r"
                     }
                 }
             }

--- a/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -24,6 +24,7 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -448,6 +449,80 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
         assertEquals(expectedJson, 40.01, parsed.bottomRight().getLat(), delta);
         assertEquals(expectedJson, 1.0, parsed.boost(), delta);
         assertEquals(expectedJson, GeoExecType.MEMORY, parsed.type());
+    }
+
+    public void testFromGeohash() throws IOException {
+        String json =
+            "{\n" +
+                "  \"geo_bounding_box\" : {\n" +
+                "    \"pin.location\" : {\n" +
+                "      \"geohash\" : \"dr\"\n" +
+                "    },\n" +
+                "    \"validation_method\" : \"STRICT\",\n" +
+                "    \"type\" : \"MEMORY\",\n" +
+                "    \"ignore_unmapped\" : false,\n" +
+                "    \"boost\" : 1.0\n" +
+                "  }\n" +
+                "}";
+
+        String expectedJson =
+            "{\n" +
+                "  \"geo_bounding_box\" : {\n" +
+                "    \"pin.location\" : {\n" +
+                "      \"top_left\" : [ -78.75, 45.0 ],\n" +
+                "      \"bottom_right\" : [ -67.5, 39.375 ]\n" +
+                "    },\n" +
+                "    \"validation_method\" : \"STRICT\",\n" +
+                "    \"type\" : \"MEMORY\",\n" +
+                "    \"ignore_unmapped\" : false,\n" +
+                "    \"boost\" : 1.0\n" +
+                "  }\n" +
+                "}";
+        GeoBoundingBoxQueryBuilder parsed = (GeoBoundingBoxQueryBuilder) parseQuery(json);
+        checkGeneratedJson(expectedJson, parsed);
+        assertEquals(json, "pin.location", parsed.fieldName());
+        assertEquals(json, -78.75, parsed.topLeft().getLon(), 0.0001);
+        assertEquals(json, 45.0, parsed.topLeft().getLat(), 0.0001);
+        assertEquals(json, -67.5, parsed.bottomRight().getLon(), 0.0001);
+        assertEquals(json, 39.375, parsed.bottomRight().getLat(), 0.0001);
+        assertEquals(json, 1.0, parsed.boost(), 0.0001);
+        assertEquals(json, GeoExecType.MEMORY, parsed.type());
+    }
+
+    public void testMalformedGeohashes() {
+        String jsonGeohashAndWkt =
+            "{\n" +
+                "  \"geo_bounding_box\" : {\n" +
+                "    \"pin.location\" : {\n" +
+                "      \"geohash\" : \"dr\"," +
+                "      \"wkt\" : \"BBOX (-74.1, -71.12, 40.73, 40.01)\"\n" +
+                "    },\n" +
+                "    \"validation_method\" : \"STRICT\",\n" +
+                "    \"type\" : \"MEMORY\",\n" +
+                "    \"ignore_unmapped\" : false,\n" +
+                "    \"boost\" : 1.0\n" +
+                "  }\n" +
+                "}";
+
+        ElasticsearchParseException e1 = expectThrows(ElasticsearchParseException.class, () -> parseQuery(jsonGeohashAndWkt));
+        assertThat(e1.getMessage(), containsString("Conflicting definition found using well-known text and geohash"));
+
+        String jsonGeohashAndTopLeft=
+            "{\n" +
+                "  \"geo_bounding_box\" : {\n" +
+                "    \"pin.location\" : {\n" +
+                "      \"geohash\" : \"dr\"," +
+                "      \"top_left\" : [ -78.75, 45.0 ]\n" +
+                "    },\n" +
+                "    \"validation_method\" : \"STRICT\",\n" +
+                "    \"type\" : \"MEMORY\",\n" +
+                "    \"ignore_unmapped\" : false,\n" +
+                "    \"boost\" : 1.0\n" +
+                "  }\n" +
+                "}";
+
+        ElasticsearchParseException e2 = expectThrows(ElasticsearchParseException.class, () -> parseQuery(jsonGeohashAndTopLeft));
+        assertThat(e2.getMessage(), containsString("Conflicting definition found using geohash and explicit corners"));
     }
 
     @Override


### PR DESCRIPTION
Adds support for specifying the bounding box in the geo_bounding_box
query using a single geohash. It is already possible to use geohashes
as corners, this change adds support to using a single geohash as a
complete bounding box.

Closes #25154