### PR TITLE
Stop forking groovyc

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -536,9 +536,15 @@ class BuildPlugin implements Plugin<Project> {
             // also apply release flag to groovy, which is used in build-tools
             project.tasks.withType(GroovyCompile) {
                 final JavaVersion targetCompatibilityVersion = JavaVersion.toVersion(it.targetCompatibility)
-                options.fork = true
-                options.forkOptions.javaHome = new File(project.compilerJavaHome)
-                options.compilerArgs << '--release' << targetCompatibilityVersion.majorVersion
+                final compilerJavaHomeFile = new File(project.compilerJavaHome)
+                // we only fork if the Gradle JDK is not the same as the compiler JDK
+                if (compilerJavaHomeFile.canonicalPath == Jvm.current().javaHome.canonicalPath) {
+                    options.fork = false
+                } else {
+                    options.fork = true
+                    options.forkOptions.javaHome = compilerJavaHomeFile
+                    options.compilerArgs << '--release' << targetCompatibilityVersion.majorVersion
+                }
             }
         }
     }

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -535,7 +535,6 @@ class BuildPlugin implements Plugin<Project> {
             }
             // also apply release flag to groovy, which is used in build-tools
             project.tasks.withType(GroovyCompile) {
-                final JavaVersion targetCompatibilityVersion = JavaVersion.toVersion(it.targetCompatibility)
                 final compilerJavaHomeFile = new File(project.compilerJavaHome)
                 // we only fork if the Gradle JDK is not the same as the compiler JDK
                 if (compilerJavaHomeFile.canonicalPath == Jvm.current().javaHome.canonicalPath) {
@@ -543,7 +542,7 @@ class BuildPlugin implements Plugin<Project> {
                 } else {
                     options.fork = true
                     options.forkOptions.javaHome = compilerJavaHomeFile
-                    options.compilerArgs << '--release' << targetCompatibilityVersion.majorVersion
+                    options.compilerArgs << '--release' << JavaVersion.toVersion(it.targetCompatibility).majorVersion
                 }
             }
         }


### PR DESCRIPTION
This is a follow-up to our previous change to only fork javac if needed to respect the Java compiler home (via JAVA_HOME). This commit makes the same change for groovyc: we only fork groovyc if the JDK for Gradle is not the JDK specified for the compiler (via JAVA_HOME).

Relates #30462
