### PR TITLE
Watcher: Ensure secret tests also run triggered watch

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/WatcherXContentParser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/WatcherXContentParser.java
@@ -5,8 +5,6 @@
  */
 package org.elasticsearch.xpack.core.watcher.support.xcontent;
 
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.xcontent.DeprecationHandler;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/ScheduleTriggerEngineMock.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/trigger/ScheduleTriggerEngineMock.java
@@ -53,6 +53,7 @@ public class ScheduleTriggerEngineMock extends ScheduleTriggerEngine {
 
     @Override
     public void start(Collection<Watch> jobs) {
+        jobs.forEach(this::add);
     }
 
     @Override


### PR DESCRIPTION
When encrpytion of secrets is enabled, we should also test that a
scheduled watch is executed as expected and produces the correct value
from a secret.
