### PR TITLE
Bump Gradle heap to 1792m

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=false
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx1792m


### PR DESCRIPTION
After we stopped forking the compiler, some folks are running into out of memory errors. This commit is a bump to the Gradle heap to workaround these out of memory errors (until we can better understand their source).

