### PR TITLE
Build: Remove xpack specific run task

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -320,8 +320,7 @@ task run(type: RunTask) {
       setting 'xpack.watcher.enabled', 'true'
       setting 'xpack.license.self_generated.type', 'trial'
     } else if (licenseType != 'basic') {
-      throw new IllegalArgumentException("Unsupported self-generated license type: [" + licenseType
-      "[basic] or [trial].")
+      throw new IllegalArgumentException("Unsupported self-generated license type: [" + licenseType + "[basic] or [trial].")
     }
     setting 'xpack.security.enabled', 'true'
     setting 'xpack.monitoring.enabled', 'true'

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -312,6 +312,23 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
 
 task run(type: RunTask) {
   distribution = System.getProperty('run.distribution', 'zip')
+  if (distribution == 'zip') {
+    String licenseType = System.getProperty("license_type", "basic")
+    if (licenseType == 'trial') {
+      setting 'xpack.ml.enabled', 'true'
+      setting 'xpack.graph.enabled', 'true'
+      setting 'xpack.watcher.enabled', 'true'
+      setting 'xpack.license.self_generated.type', 'trial'
+    } else if (licenseType != 'basic') {
+      throw new IllegalArgumentException("Unsupported self-generated license type: [" + licenseType
+      "[basic] or [trial].")
+    }
+    setting 'xpack.security.enabled', 'true'
+    setting 'xpack.monitoring.enabled', 'true'
+    setting 'xpack.sql.enabled', 'true'
+    setting 'xpack.rollup.enabled', 'true'
+    keystoreSetting 'bootstrap.password', 'password'
+  }
 }
 
 /**

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -8,8 +8,16 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import org.elasticsearch.gradle.test.RunTask;
 
-apply plugin: 'elasticsearch.standalone-rest-test'
-apply plugin: 'elasticsearch.rest-test'
+apply plugin: 'elasticsearch.es-meta-plugin'
+
+archivesBaseName = 'x-pack'
+
+es_meta_plugin {
+  name = 'x-pack'
+  description = 'Elasticsearch Expanded Pack Plugin'
+  plugins = ['core', 'deprecation', 'graph', 'logstash',
+             'ml', 'monitoring', 'security', 'upgrade', 'watcher', 'sql', 'rollup']
+}
 
 dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -8,16 +8,8 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import org.elasticsearch.gradle.test.RunTask;
 
-apply plugin: 'elasticsearch.es-meta-plugin'
-
-archivesBaseName = 'x-pack'
-
-es_meta_plugin {
-  name = 'x-pack'
-  description = 'Elasticsearch Expanded Pack Plugin'
-  plugins = ['core', 'deprecation', 'graph', 'logstash',
-             'ml', 'monitoring', 'security', 'upgrade', 'watcher', 'sql', 'rollup']
-}
+apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.rest-test'
 
 dependencies {
   testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
@@ -157,22 +149,4 @@ integTestCluster {
       }
       return tmpFile.exists()
   }
-}
-
-run {
-  def licenseType = System.getProperty("license_type", "basic")
-  if (licenseType == 'trial') {
-    setting 'xpack.ml.enabled', 'true'
-    setting 'xpack.graph.enabled', 'true'
-    setting 'xpack.watcher.enabled', 'true'
-    setting 'xpack.license.self_generated.type', 'trial'
-  } else if (licenseType != 'basic') {
-    throw new IllegalArgumentException("Unsupported self-generated license type: [" + licenseType + "]. Must be " +
-    "[basic] or [trial].")
-  }
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.monitoring.enabled', 'true'
-  setting 'xpack.sql.enabled', 'true'
-  setting 'xpack.rollup.enabled', 'true'
-  keystoreSetting 'bootstrap.password', 'password'
 }


### PR DESCRIPTION
With the opening of xpack, we still retained a run task within
:x-pack:plugin. However, the root level run task also runs with the
default distribution. This change removes the extra run task inside
xpack in favor of using the root level task, and moves the
license/configuration code for run into the main run configuration.