### PR TITLE
Add test for concurrent add/remove race in cache

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.common.cache;
 
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.yaml.section.Assertion;
 import org.junit.Before;
 
 import java.lang.management.ManagementFactory;
@@ -46,7 +47,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
@@ -887,4 +890,55 @@ public class CacheTests extends ESTestCase {
             assertEquals(RemovalNotification.RemovalReason.INVALIDATED, removalNotifications.get(i).getRemovalReason());
         }
     }
+
+    // test that concurrent adds and removals do not end with an LRU list containing deleted entries
+    public void testComputeIfAbsentRemoveRace() throws BrokenBarrierException, InterruptedException {
+        final int halfNumberOfThreads = randomIntBetween(1, 16);
+        final Cache<Integer, String> cache = CacheBuilder.<Integer, String>builder().build();
+
+        final CyclicBarrier barrier = new CyclicBarrier(1 + 2 * halfNumberOfThreads);
+        for (int i = 0; i < halfNumberOfThreads; i++) {
+            final Thread computeIfAbsentThread = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int j = 0; j < numberOfEntries; j++) {
+                        cache.computeIfAbsent(0, k -> Integer.toString(k));
+                    }
+                    barrier.await();
+                } catch (final BrokenBarrierException | ExecutionException | InterruptedException e) {
+                    fail(e.toString());
+                }
+            });
+            computeIfAbsentThread.start();
+
+            final Thread removeThread = new Thread(() -> {
+                try {
+                    barrier.await();
+                    for (int j = 0; j < numberOfEntries; j++) {
+                        cache.values().iterator().remove();
+                    }
+                    barrier.await();
+                } catch (final BrokenBarrierException | InterruptedException e) {
+                    fail(e.toString());
+                }
+            });
+            removeThread.start();
+        }
+
+        // wait for all threads to be ready
+        barrier.await();
+        // wait for all threads to finish
+        barrier.await();
+
+        int count = 0;
+        Cache.Entry<Integer, String> entry = cache.head;
+        while (entry != null) {
+            count++;
+            assertThat(cache.head.state, equalTo(Cache.State.EXISTING));
+            entry = entry.after;
+        }
+
+        assertThat(count, anyOf(equalTo(0), equalTo(1)));
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -915,7 +915,11 @@ public class CacheTests extends ESTestCase {
                 try {
                     barrier.await();
                     for (int j = 0; j < numberOfEntries; j++) {
-                        cache.values().iterator().remove();
+                        final Iterator<String> values = cache.values().iterator();
+                        if (values.hasNext()) {
+                            values.next();
+                            values.remove();
+                        }
                     }
                     barrier.await();
                 } catch (final BrokenBarrierException | InterruptedException e) {
@@ -942,7 +946,7 @@ public class CacheTests extends ESTestCase {
         Cache.Entry<Integer, String> entry = cache.head;
         while (entry != null) {
             count++;
-            assertThat(cache.head.state, equalTo(Cache.State.EXISTING));
+            assertThat(entry.state, equalTo(Cache.State.EXISTING));
             entry = entry.after;
         }
 

--- a/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -897,6 +897,7 @@ public class CacheTests extends ESTestCase {
         final Cache<Integer, String> cache = CacheBuilder.<Integer, String>builder().build();
 
         final CyclicBarrier barrier = new CyclicBarrier(1 + 2 * halfNumberOfThreads);
+        final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < halfNumberOfThreads; i++) {
             final Thread computeIfAbsentThread = new Thread(() -> {
                 try {
@@ -909,7 +910,7 @@ public class CacheTests extends ESTestCase {
                     fail(e.toString());
                 }
             });
-            computeIfAbsentThread.start();
+            threads.add(computeIfAbsentThread);
 
             final Thread removeThread = new Thread(() -> {
                 try {
@@ -922,13 +923,21 @@ public class CacheTests extends ESTestCase {
                     fail(e.toString());
                 }
             });
-            removeThread.start();
+            threads.add(removeThread);
+        }
+
+        for (final Thread thread : threads) {
+            thread.start();
         }
 
         // wait for all threads to be ready
         barrier.await();
         // wait for all threads to finish
         barrier.await();
+
+        for (final Thread thread : threads) {
+            thread.join();
+        }
 
         int count = 0;
         Cache.Entry<Integer, String> entry = cache.head;

--- a/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.common.cache;
 
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.rest.yaml.section.Assertion;
 import org.junit.Before;
 
 import java.lang.management.ManagementFactory;


### PR DESCRIPTION
This commit adds a test for a situation where there is a concurrent add and remove on the same key. We assert at the end of the test that the LRU list does not contain any deleted entries, that any entries remaining (if there are any) are valid entries.
