### PR TITLE
Isolate REST client single host tests

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
@@ -35,7 +35,9 @@ import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.nio.entity.NStringEntity;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.mocksocket.MockHttpServer;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
@@ -69,20 +71,20 @@ import static org.junit.Assert.fail;
  */
 public class RestClientSingleHostIntegTests extends RestClientTestCase {
 
-    private static HttpServer httpServer;
-    private static RestClient restClient;
-    private static String pathPrefix;
-    private static Header[] defaultHeaders;
+    private HttpServer httpServer;
+    private RestClient restClient;
+    private String pathPrefix;
+    private Header[] defaultHeaders;
 
-    @BeforeClass
-    public static void startHttpServer() throws Exception {
+    @Before
+    public void startHttpServer() throws Exception {
         pathPrefix = randomBoolean() ? "/testPathPrefix/" + randomAsciiLettersOfLengthBetween(1, 5) : "";
         httpServer = createHttpServer();
         defaultHeaders = RestClientTestUtil.randomHeaders(getRandom(), "Header-default");
         restClient = createRestClient(false, true);
     }
 
-    private static HttpServer createHttpServer() throws Exception {
+    private HttpServer createHttpServer() throws Exception {
         HttpServer httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         httpServer.start();
         //returns a different status code depending on the path
@@ -127,7 +129,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
         }
     }
 
-    private static RestClient createRestClient(final boolean useAuth, final boolean usePreemptiveAuth) {
+    private RestClient createRestClient(final boolean useAuth, final boolean usePreemptiveAuth) {
         // provide the username/password for every request
         final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("user", "pass"));
@@ -155,8 +157,8 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
         return restClientBuilder.build();
     }
 
-    @AfterClass
-    public static void stopHttpServers() throws IOException {
+    @After
+    public void stopHttpServers() throws IOException {
         restClient.close();
         restClient = null;
         httpServer.stop(0);


### PR DESCRIPTION
These tests are sharing the same server and client for every test. Yet, we are seeing some tests fail with mysterious connection resets. It is not clear what is happening but one theory is that the tests are interfering with each other. This commit moves to use a separate server and client per test.

Relates #29558
