### PR TITLE
Update has-child-query.asciidoc

### DIFF
--- a/docs/java-api/query-dsl/has-child-query.asciidoc
+++ b/docs/java-api/query-dsl/has-child-query.asciidoc
@@ -9,7 +9,7 @@ When using the `has_child` query it is important to use the `PreBuiltTransportCl
 --------------------------------------------------
 Settings settings = Settings.builder().put("cluster.name", "elasticsearch").build();
 TransportClient client = new PreBuiltTransportClient(settings);
-client.addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 9300)));
+client.addTransportAddress(new TransportAddress(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 9300)));
 --------------------------------------------------
 
 Otherwise the parent-join module doesn't get loaded and the `has_child` query can't be used from the transport client.


### PR DESCRIPTION
Changed `InetSocketTransportAddress` to `TransportAddress`, as that seems to be  the thing now.