### PR TITLE
Remove Discovery.AckListener.onTimeout()

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -386,7 +386,7 @@ public class MasterService extends AbstractLifecycleComponent {
                 }
             });
 
-            return new DelegetingAckListener(ackListeners);
+            return new DelegatingAckListener(ackListeners);
         }
 
         public boolean clusterStateUnchanged() {
@@ -541,11 +541,11 @@ public class MasterService extends AbstractLifecycleComponent {
         }
     }
 
-    private static class DelegetingAckListener implements Discovery.AckListener {
+    private static class DelegatingAckListener implements Discovery.AckListener {
 
         private final List<Discovery.AckListener> listeners;
 
-        private DelegetingAckListener(List<Discovery.AckListener> listeners) {
+        private DelegatingAckListener(List<Discovery.AckListener> listeners) {
             this.listeners = listeners;
         }
 
@@ -554,11 +554,6 @@ public class MasterService extends AbstractLifecycleComponent {
             for (Discovery.AckListener listener : listeners) {
                 listener.onNodeAck(node, e);
             }
-        }
-
-        @Override
-        public void onTimeout() {
-            throw new UnsupportedOperationException("no timeout delegation");
         }
     }
 
@@ -614,7 +609,6 @@ public class MasterService extends AbstractLifecycleComponent {
             }
         }
 
-        @Override
         public void onTimeout() {
             if (countDown.fastForward()) {
                 logger.trace("timeout waiting for acknowledgement for cluster_state update (version: {})", clusterStateVersion);

--- a/server/src/main/java/org/elasticsearch/discovery/Discovery.java
+++ b/server/src/main/java/org/elasticsearch/discovery/Discovery.java
@@ -49,7 +49,6 @@ public interface Discovery extends LifecycleComponent {
 
     interface AckListener {
         void onNodeAck(DiscoveryNode node, @Nullable Exception e);
-        void onTimeout();
     }
 
     class FailedToCommitClusterStateException extends ElasticsearchException {

--- a/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
@@ -814,7 +814,6 @@ public class PublishClusterStateActionTests extends ESTestCase {
 
     public static class AssertingAckListener implements Discovery.AckListener {
         private final List<Tuple<DiscoveryNode, Throwable>> errors = new CopyOnWriteArrayList<>();
-        private final AtomicBoolean timeoutOccurred = new AtomicBoolean();
         private final CountDownLatch countDown;
 
         public AssertingAckListener(int nodeCount) {
@@ -835,7 +834,6 @@ public class PublishClusterStateActionTests extends ESTestCase {
 
         public List<Tuple<DiscoveryNode, Throwable>> awaitErrors(long timeout, TimeUnit unit) throws InterruptedException {
             countDown.await(timeout, unit);
-            assertFalse(timeoutOccurred.get());
             return errors;
         }
 

--- a/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/zen/PublishClusterStateActionTests.java
@@ -829,16 +829,6 @@ public class PublishClusterStateActionTests extends ESTestCase {
             countDown.countDown();
         }
 
-        @Override
-        public void onTimeout() {
-            timeoutOccurred.set(true);
-            // Fast forward the counter - no reason to wait here
-            long currentCount = countDown.getCount();
-            for (long i = 0; i < currentCount; i++) {
-                countDown.countDown();
-            }
-        }
-
         public void await(long timeout, TimeUnit unit) throws InterruptedException {
             assertThat(awaitErrors(timeout, unit), emptyIterable());
         }


### PR DESCRIPTION
The MasterService takes responsibility for timeouts of the AckListeners that it
creates, and the rest of the Discovery subsystem is unaware of these timeouts,
so there's no need for this to appear in the Discovery.AckListener interface.

Also fix a typo in the name of DelegatingAckListener.
