### PR TITLE
SQL: Improve compatibility with MS query

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTables.java
@@ -33,17 +33,21 @@ public class SysTables extends Command {
     private final LikePattern pattern;
     private final LikePattern clusterPattern;
     private final EnumSet<IndexType> types;
+    // flag indicating whether tables are reported as `TABLE` or `BASE TABLE`
+    private final boolean legacyTableTypes;
 
-    public SysTables(Location location, LikePattern clusterPattern, LikePattern pattern, EnumSet<IndexType> types) {
+    public SysTables(Location location, LikePattern clusterPattern, LikePattern pattern, EnumSet<IndexType> types,
+            boolean legacyTableTypes) {
         super(location);
         this.clusterPattern = clusterPattern;
         this.pattern = pattern;
         this.types = types;
+        this.legacyTableTypes = legacyTableTypes;
     }
 
     @Override
     protected NodeInfo<SysTables> info() {
-        return NodeInfo.create(this, SysTables::new, clusterPattern, pattern, types);
+        return NodeInfo.create(this, SysTables::new, clusterPattern, pattern, types, legacyTableTypes);
     }
 
     @Override
@@ -111,7 +115,7 @@ public class SysTables extends Command {
                  .map(t -> asList(cluster,
                          EMPTY,
                          t.name(),
-                         t.type().toSql(),
+                         legacyName(t.type()),
                          EMPTY,
                          null,
                          null,
@@ -120,6 +124,10 @@ public class SysTables extends Command {
                          null))
                 .collect(toList())))
         , listener::onFailure));
+    }
+
+    private String legacyName(IndexType indexType) {
+        return legacyTableTypes && indexType == IndexType.INDEX ? "TABLE" : indexType.toSql();
     }
 
     @Override

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -105,6 +105,23 @@ public class SysTablesTests extends ESTestCase {
         }, index);
     }
 
+    public void testSysTablesOnlyIndicesInLegacyMode() throws Exception {
+        executeCommand("SYS TABLES LIKE 'test' TYPE 'TABLE'", r -> {
+            assertEquals(1, r.size());
+            assertEquals("test", r.column(2));
+            assertEquals("TABLE", r.column(3));
+        }, index);
+
+    }
+
+    public void testSysTablesOnlyIndicesLegacyModeParameterized() throws Exception {
+        executeCommand("SYS TABLES LIKE 'test' TYPE ?", asList(param("TABLE")), r -> {
+            assertEquals(1, r.size());
+            assertEquals("test", r.column(2));
+            assertEquals("TABLE", r.column(3));
+        }, index);
+    }
+
     public void testSysTablesOnlyIndicesParameterized() throws Exception {
         executeCommand("SYS TABLES LIKE 'test' TYPE ?", asList(param("ALIAS")), r -> {
             assertEquals(1, r.size());
@@ -128,6 +145,18 @@ public class SysTablesTests extends ESTestCase {
             assertEquals("test", r.column(2));
             assertTrue(r.advanceRow());
             assertEquals("alias", r.column(2));
+        }, index, alias);
+    }
+
+    public void testSysTablesOnlyIndicesLegacyAndAliasesParameterized() throws Exception {
+        List<SqlTypedParamValue> params = asList(param("ALIAS"), param("TABLE"));
+        executeCommand("SYS TABLES LIKE 'test' TYPE ?, ?", params, r -> {
+            assertEquals(2, r.size());
+            assertEquals("test", r.column(2));
+            assertEquals("TABLE", r.column(3));
+            assertTrue(r.advanceRow());
+            assertEquals("alias", r.column(2));
+            assertEquals("ALIAS", r.column(3));
         }, index, alias);
     }
 


### PR DESCRIPTION
Support TABLE as an argument for SYS TABLE commands to help with some legacy ODBC clients.

Fix #30398