### PR TITLE
Add missing task dependencies

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/BuildPlugin.groovy
@@ -744,6 +744,7 @@ class BuildPlugin implements Plugin<Project> {
             additionalTest.testClassesDir = test.testClassesDir
             additionalTest.configure(commonTestConfig(project))
             additionalTest.configure(config)
+            additionalTest.dependsOn(project.tasks.testClasses)
             test.dependsOn(additionalTest)
         });
         return test

--- a/modules/repository-url/build.gradle
+++ b/modules/repository-url/build.gradle
@@ -34,6 +34,7 @@ File repositoryDir = new File(project.buildDir, "shared-repository")
 
 /** A task to start the URLFixture which exposes the repositoryDir over HTTP **/
 task urlFixture(type: AntFixture) {
+    dependsOn testClasses
     doFirst {
         repositoryDir.mkdirs()
     }


### PR DESCRIPTION
Add missing dependencies on testClasses for a few tasks. 
This fixes _some_ failures that can happen when running with `--parallel`.
The problem can be reproduced in isolation with:
`~/elasticsearch/modules/repository-url$ ../../gradlew clean urlFixture`