### PR TITLE
Delete temporary blobs before creating index file

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -3094,7 +3094,6 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertEquals("IndexShardSnapshotFailedException[Aborted]", snapshotInfo.shardFailures().get(0).reason());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/30507")
     public void testSnapshotSucceedsAfterSnapshotFailure() throws Exception {
         logger.info("--> creating repository");
         final Path repoPath = randomRepoPath();


### PR DESCRIPTION
Fixes an (un-released) bug introduced in #30332.

Closes #30507