### PR TITLE
Bump Gradle heap to 2 GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.daemon=false
-org.gradle.jvmargs=-Xmx1792m
+org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
We are still seeing rare failures with the Gradle heap set to 1792m, especially on machines with high core count. Given it appears we are close to the needed threshold, this commit bumps the heap one more time to 2 GB.
