### PR TITLE
[ML] Hide internal Job update options from the REST API

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateJobAction.java
@@ -45,7 +45,7 @@ public class UpdateJobAction extends Action<UpdateJobAction.Request, PutJobActio
     public static class Request extends AcknowledgedRequest<UpdateJobAction.Request> implements ToXContentObject {
 
         public static UpdateJobAction.Request parseRequest(String jobId, XContentParser parser) {
-            JobUpdate update = JobUpdate.PARSER.apply(parser, null).setJobId(jobId).build();
+            JobUpdate update = JobUpdate.EXTERNAL_PARSER.apply(parser, null).setJobId(jobId).build();
             return new UpdateJobAction.Request(jobId, update);
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.mock;
 
 public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
 
+    private boolean useInternalParser = randomBoolean();
+
     @Override
     protected JobUpdate createTestInstance() {
         JobUpdate.Builder update = new JobUpdate.Builder(randomAlphaOfLength(4));
@@ -84,13 +86,13 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         if (randomBoolean()) {
             update.setCustomSettings(Collections.singletonMap(randomAlphaOfLength(10), randomAlphaOfLength(10)));
         }
-        if (randomBoolean()) {
+        if (useInternalParser && randomBoolean()) {
             update.setModelSnapshotId(randomAlphaOfLength(10));
         }
-        if (randomBoolean()) {
+        if (useInternalParser && randomBoolean()) {
             update.setEstablishedModelMemory(randomNonNegativeLong());
         }
-        if (randomBoolean()) {
+        if (useInternalParser && randomBoolean()) {
             update.setJobVersion(randomFrom(Version.CURRENT, Version.V_6_2_0, Version.V_6_1_0));
         }
 
@@ -104,7 +106,11 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
 
     @Override
     protected JobUpdate doParseInstance(XContentParser parser) {
-        return JobUpdate.PARSER.apply(parser, null).build();
+        if (useInternalParser) {
+            return JobUpdate.INTERNAL_PARSER.apply(parser, null).build();
+        } else {
+            return JobUpdate.EXTERNAL_PARSER.apply(parser, null).build();
+        }
     }
 
     public void testMergeWithJob() {
@@ -141,7 +147,7 @@ public class JobUpdateTests extends AbstractSerializingTestCase<JobUpdate> {
         JobUpdate update = updateBuilder.build();
 
         Job.Builder jobBuilder = new Job.Builder("foo");
-        jobBuilder.setGroups(Arrays.asList("group-1"));
+        jobBuilder.setGroups(Collections.singletonList("group-1"));
         Detector.Builder d1 = new Detector.Builder("info_content", "domain");
         d1.setOverFieldName("mlcategory");
         Detector.Builder d2 = new Detector.Builder("min", "field");

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_model_snapshot.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_model_snapshot.yml
@@ -88,7 +88,24 @@ setup:
             "description": "second",
             "latest_record_time_stamp": "2016-06-01T00:00:00Z",
             "latest_result_time_stamp": "2016-06-01T00:00:00Z",
-            "snapshot_doc_count": 3
+            "snapshot_doc_count": 3,
+            "model_size_stats": {
+                "job_id" : "delete-model-snapshot",
+                "result_type" : "model_size_stats",
+                "model_bytes" : 0,
+                "total_by_field_count" : 101,
+                "total_over_field_count" : 0,
+                "total_partition_field_count" : 0,
+                "bucket_allocation_failures_count" : 0,
+                "memory_status" : "ok",
+                "log_time" : 1495808248662,
+                "timestamp" : 1495808248662
+            },
+            "quantiles": {
+              "job_id": "delete-model-snapshot",
+              "timestamp": 1495808248662,
+              "quantile_state": "quantiles-1"
+            }
           }
 
   - do:
@@ -106,12 +123,10 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      xpack.ml.update_job:
+      xpack.ml.revert_model_snapshot:
         job_id: delete-model-snapshot
-        body:  >
-          {
-            "model_snapshot_id": "active-snapshot"
-          }
+        snapshot_id: "active-snapshot"
+
 
 ---
 "Test delete snapshot missing snapshotId":


### PR DESCRIPTION
Internal fields `Model Snapshot ID`, `Established Model Memory` and `Job Version` should not be settable via a request to `anomaly_detectors/JOB_ID/_update`

Partial backport of #30512