### PR TITLE
[DOCS] Adds troubleshooting info for deleting jobs

### DIFF
--- a/x-pack/docs/en/ml/troubleshooting.asciidoc
+++ b/x-pack/docs/en/ml/troubleshooting.asciidoc
@@ -122,9 +122,9 @@ See also {stack-ref}/upgrading-elastic-stack.html[Upgrading the Elastic Stack].
 
 === Problems deleting {ml} jobs
 
-Before you can delete a job, you must delete its {dfeeds} and close the job. If 
-you still encounter problems deleting the job, you might need to take extra 
-steps.
+Before you can delete a job, you must stop and delete its {dfeeds} and close the 
+job. If you still encounter problems deleting the job, you might need to take 
+extra steps.
 
 *Symptoms:*
 
@@ -148,7 +148,11 @@ example use the `ps` command and grep for the autodetect process, which is the
 C++ process that runs the {ml} code. Kill these autodetect processes then delete 
 the job. 
 
-If the job still persists, you can delete the results index. If other jobs 
-are using this index, however, they will also be affected. 
+WARNING: Make sure you delete the right autodetect process. Otherwise, you might
+abort a healthy job.  
+
+If the job still persists, you can delete the results index. Only use this option 
+if you know that the problematic job is the only one using the results index. 
+Otherwise, all results for all affected jobs will be lost. 
 
 See also <<stopping-ml>>.

--- a/x-pack/docs/en/ml/troubleshooting.asciidoc
+++ b/x-pack/docs/en/ml/troubleshooting.asciidoc
@@ -134,21 +134,23 @@ job is in a failed state.
 
 *Resolution:*
 
-Try to delete the job again and specify the `force` parameter.  For example:
+Try to stop and delete the job again and specify the `force` parameter.  For 
+example:
 
 [source,js]
 --------------------------------------------------
+POST _xpack/ml/datafeeds/datafeed-total-requests/_stop?force=true
 DELETE _xpack/ml/anomaly_detectors/total-requests?force=true
 -------------------------------------------------- 
 // CONSOLE
-// TEST[setup:server_metrics_job]
+// TEST[setup:server_metrics_startdf]
 
 If the job persists, check whether there are any hung {ml} processes. For 
-example use the `ps` command and grep for the autodetect process, which is the 
+example use the `ps` command and grep for the `autodetect` process, which is the 
 C++ process that runs the {ml} code. Kill these autodetect processes then delete 
 the job. 
 
-WARNING: Make sure you delete the right autodetect process. Otherwise, you might
+WARNING: Make sure you kill the right autodetect process. Otherwise, you might
 abort a healthy job.  
 
 If the job still persists, you can delete the results index. Only use this option 

--- a/x-pack/docs/en/ml/troubleshooting.asciidoc
+++ b/x-pack/docs/en/ml/troubleshooting.asciidoc
@@ -9,6 +9,9 @@ answers for frequently asked questions.
 
 * <<ml-rollingupgrade>>
 * <<ml-mappingclash>>
+* <<ml-jobnames>>
+* <<ml-upgradedf>>
+* <<ml-stopjobs>>
 
 To get help, see <<xpack-help>>.
 
@@ -114,3 +117,38 @@ start the failing nodes you must downgrade the nodes then fix the problem per
 above.
 
 See also {stack-ref}/upgrading-elastic-stack.html[Upgrading the Elastic Stack].
+
+[[ml-stopjobs]]
+
+=== Problems deleting {ml} jobs
+
+Before you can delete a job, you must delete its {dfeeds} and close the job. If 
+you still encounter problems deleting the job, you might need to take extra 
+steps.
+
+*Symptoms:*
+
+* The {dfeed} was stopped and deleted successfully. When you try to delete the 
+job, however, it fails. For example, you receive an error message that says the 
+job is in a failed state. 
+
+*Resolution:*
+
+Try to delete the job again and specify the `force` parameter.  For example:
+
+[source,js]
+--------------------------------------------------
+DELETE _xpack/ml/anomaly_detectors/total-requests?force=true
+-------------------------------------------------- 
+// CONSOLE
+// TEST[setup:server_metrics_job]
+
+If the job persists, check whether there are any hung {ml} processes. For 
+example use the `ps` command and grep for the autodetect process, which is the 
+C++ process that runs the {ml} code. Kill these autodetect processes then delete 
+the job. 
+
+If the job still persists, you can delete the results index. If other jobs 
+are using this index, however, they will also be affected. 
+
+See also <<stopping-ml>>.


### PR DESCRIPTION
This PR adds machine learning troubleshooting information for the scenario where jobs are failing to delete.  It pulls information from https://discuss.elastic.co/t/unable-to-delete-a-failed-job-in-machine-learning-beta/97747/6