### PR TITLE
Adjust versions for resize copy settings

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/10_basic.yml
@@ -1,8 +1,8 @@
 ---
 "Shrink index via API":
   - skip:
-      version: " - 6.99.99"
-      reason: expects warnings that pre-7.0.0 will not send
+      version: " - 6.3.99"
+      reason: expects warnings that pre-6.4.0 will not send
       features: "warnings"
   # creates an index with one document solely allocated on the master node
   # and shrinks it into a new index with a single shard

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/20_source_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/20_source_mapping.yml
@@ -1,8 +1,8 @@
 ---
 "Shrink index ignores target template mapping":
     - skip:
-        version: " - 6.99.99"
-        reason: expects warnings that pre-7.0.0 will not send
+        version: " - 6.3.99"
+        reason: expects warnings that pre-6.4.0 will not send
         features: "warnings"
 
     - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.shrink/30_copy_settings.yml
@@ -1,8 +1,8 @@
 ---
 "Copy settings during shrink index":
   - skip:
-      version: " - 6.99.99"
-      reason: expects warnings that pre-7.0.0 will not send
+      version: " - 6.3.99"
+      reason: expects warnings that pre-6.4.0 will not send
       features: "warnings"
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/10_basic.yml
@@ -33,8 +33,8 @@ setup:
 ---
 "Split index via API":
   - skip:
-      version: " - 6.99.99"
-      reason: expects warnings that pre-7.0.0 will not send
+      version: " - 6.3.99"
+      reason: expects warnings that pre-6.4.0 will not send
       features: "warnings"
 
   # make it read-only
@@ -110,8 +110,8 @@ setup:
       # when re-enabling uncomment the below skips
       version: "all"
       reason: "AwaitsFix'ing, see https://github.com/elastic/elasticsearch/issues/30503"
-      # version: " - 6.99.99"
-      # reason: expects warnings that pre-7.0.0 will not send
+      # version: " - 6.3.99"
+      # reason: expects warnings that pre-6.4.0 will not send
       features: "warnings"
   - do:
       indices.create:
@@ -213,8 +213,8 @@ setup:
 ---
 "Create illegal split indices":
   - skip:
-      version: " - 6.99.99"
-      reason: expects warnings that pre-7.0.0 will not send
+      version: " - 6.3.99"
+      reason: expects warnings that pre-6.4.0 will not send
       features: "warnings"
 
   # try to do an illegal split with number_of_routing_shards set

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
@@ -4,8 +4,8 @@
       # when re-enabling uncomment the below skips
       version: "all"
       reason: "AwaitsFix'ing, see https://github.com/elastic/elasticsearch/issues/30503"
-      # version: " - 6.99.99"
-      # reason: expects warnings that pre-7.0.0 will not send
+      # version: " - 6.3.99"
+      # reason: expects warnings that pre-6.4.0 will not send
       features: "warnings"
 
   # create index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -1,8 +1,8 @@
 ---
 "Copy settings during split index":
   - skip:
-      version: " - 6.99.99"
-      reason: expects warnings that pre-7.0.0 will not send
+      version: " - 6.3.99"
+      reason: expects warnings that pre-6.4.0 will not send
       features: "warnings"
 
   - do:

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
@@ -101,8 +101,6 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         }
         if (in.getVersion().before(Version.V_6_4_0)) {
             copySettings = null;
-        } else if (in.getVersion().onOrAfter(Version.V_6_4_0) && in.getVersion().before(Version.V_7_0_0_alpha1)){
-            copySettings = in.readBoolean();
         } else {
             copySettings = in.readOptionalBoolean();
         }
@@ -116,10 +114,9 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         if (out.getVersion().onOrAfter(ResizeAction.COMPATIBILITY_VERSION)) {
             out.writeEnum(type);
         }
+        // noinspection StatementWithEmptyBody
         if (out.getVersion().before(Version.V_6_4_0)) {
 
-        } else if (out.getVersion().onOrAfter(Version.V_6_4_0) && out.getVersion().before(Version.V_7_0_0_alpha1)) {
-            out.writeBoolean(copySettings == null ? false : copySettings);
         } else {
             out.writeOptionalBoolean(copySettings);
         }


### PR DESCRIPTION
Now that the change to deprecate copy settings and disallow it being explicitly set to false is backported, this commit adjusts the BWC versions in master.

Relates #30404