### PR TITLE
LLRest: Add equals and hashcode tests for Request

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -26,13 +26,16 @@ import java.util.Map;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.client.HttpAsyncResponseConsumerFactory.HeapBufferedResponseConsumerFactory;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
@@ -151,6 +154,103 @@ public class RequestTests extends RestClientTestCase {
         assertArrayEquals(headers, request.getHeaders());
     }
 
-    // TODO equals and hashcode
+    public void testEqualsAndHashCode() {
+        Request request = randomRequest();
+        assertEquals(request, request);
 
+        Request copy = copy(request);
+        assertEquals(request, copy);
+        assertEquals(copy, request);
+        assertEquals(request.hashCode(), copy.hashCode());
+
+        Request mutant = mutate(request);
+        assertNotEquals(request, mutant);
+        assertNotEquals(mutant, request);
+    }
+
+    private Request randomRequest() {
+        Request request = new Request(
+            randomFrom(new String[] {"GET", "PUT", "DELETE", "POST", "HEAD", "OPTIONS"}),
+            randomAsciiAlphanumOfLength(5));
+
+        int parameterCount = between(0, 5);
+        for (int i = 0; i < parameterCount; i++) {
+            request.addParameter(randomAsciiAlphanumOfLength(i), randomAsciiLettersOfLength(3));
+        }
+
+        if (randomBoolean()) {
+            if (randomBoolean()) {
+                request.setJsonEntity(randomAsciiAlphanumOfLength(10));
+            } else {
+                request.setEntity(randomFrom(new HttpEntity[] {
+                    new StringEntity(randomAsciiAlphanumOfLength(10), ContentType.APPLICATION_JSON),
+                    new NStringEntity(randomAsciiAlphanumOfLength(10), ContentType.APPLICATION_JSON),
+                    new ByteArrayEntity(randomBytesOfLength(40), ContentType.APPLICATION_JSON)
+                }));
+            }
+        }
+
+        if (randomBoolean()) {
+            int headerCount = between(1, 5);
+            Header[] headers = new Header[headerCount];
+            for (int i = 0; i < headerCount; i++) {
+                headers[i] = new BasicHeader(randomAsciiAlphanumOfLength(3), randomAsciiAlphanumOfLength(3));
+            }
+            request.setHeaders(headers);
+        }
+
+        if (randomBoolean()) {
+            request.setHttpAsyncResponseConsumerFactory(new HeapBufferedResponseConsumerFactory(1));
+        }
+
+        return request;
+    }
+
+    private Request copy(Request request) {
+        Request copy = new Request(request.getMethod(), request.getEndpoint());
+        copyMutables(request, copy);
+        return copy;
+    }
+
+    private Request mutate(Request request) {
+        if (randomBoolean()) {
+            // Mutate request or method but keep everything else constant
+            Request mutant = randomBoolean()
+                ? new Request(request.getMethod() + "m", request.getEndpoint())
+                : new Request(request.getMethod(), request.getEndpoint() + "m");
+            copyMutables(request, mutant);
+            return mutant;
+        }
+        Request mutant = copy(request);
+        int mutationType = between(0, 3);
+        switch (mutationType) {
+        case 0:
+            mutant.addParameter(randomAsciiAlphanumOfLength(mutant.getParameters().size() + 4), "extra");
+            return mutant;
+        case 1:
+            mutant.setJsonEntity("mutant"); // randomRequest can't produce this value
+            return mutant;
+        case 2:
+            if (mutant.getHeaders().length > 0) {
+                mutant.setHeaders(new Header[0]);
+            } else {
+                mutant.setHeaders(new BasicHeader("extra", "m"));
+            }
+            return mutant;
+        case 3:
+            mutant.setHttpAsyncResponseConsumerFactory(new HeapBufferedResponseConsumerFactory(5));
+            return mutant;
+        default:
+            throw new UnsupportedOperationException("Unknown mutation type [" + mutationType + "]");
+        }
+    }
+
+    private void copyMutables(Request from, Request to) {
+        for (Map.Entry<String, String> param : from.getParameters().entrySet()) {
+            to.addParameter(param.getKey(), param.getValue());
+        }
+        to.setEntity(from.getEntity());
+        to.setHeaders(from.getHeaders());
+        to.setHttpAsyncResponseConsumerFactory(from.getHttpAsyncResponseConsumerFactory());
+    }
 }


### PR DESCRIPTION
Adds tests for the `Request` object's equals and hashcode to remove a
`TODO` and because we use the `equals` method in other testing.
