### PR TITLE
[DOCS] Adds release highlight pages

### DIFF
--- a/docs/reference/index-shared4.asciidoc
+++ b/docs/reference/index-shared4.asciidoc
@@ -5,4 +5,6 @@ include::testing.asciidoc[]
 
 include::glossary.asciidoc[]
 
+include::release-notes/highlights.asciidoc[]
+
 include::{docdir}/../CHANGELOG.asciidoc[]

--- a/docs/reference/release-notes/highlights-7.0.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.0.0.asciidoc
@@ -1,0 +1,6 @@
+[[release-highlights-7.0.0]]
+== 7.0.0 release highlights
+
+coming[7.0.0]
+
+See also <<breaking-changes-7.0>> and <<release-notes-7.0.0>>. 

--- a/docs/reference/release-notes/highlights-7.0.0.asciidoc
+++ b/docs/reference/release-notes/highlights-7.0.0.asciidoc
@@ -1,5 +1,8 @@
 [[release-highlights-7.0.0]]
 == 7.0.0 release highlights
+++++
+<titleabbrev>7.0.0</titleabbrev>
+++++
 
 coming[7.0.0]
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,0 +1,13 @@
+[[release-highlights]]
+= {es} Release Highlights
+
+[partintro]
+--
+This section summarizes the most important changes in each release. For the 
+full list, see <<es-release-notes>> and <<breaking-changes>>. 
+
+* <<release-highlights-7.0.0>>
+
+--
+
+include::highlights-7.0.0.asciidoc[]


### PR DESCRIPTION
This PR creates the file structure for a new set of "release highlight" pages. 

These highlight pages will summarize the most significant changes in each release (starting in 6.3.0). 

At this time I have created the highlights at the same level as the release notes in the Elasticsearch Reference's table of contents:  
![toc](https://user-images.githubusercontent.com/26471269/40017869-7dbad884-576f-11e8-98eb-120a022b4537.png)

However, once we know the final implementation for the changelog files, we can restructure the table of contents as necessary.

NOTE: At this time, these highlight pages are not meant to replace the blogs that go out with releases (e.g. https://www.elastic.co/blog/elasticsearch-6-2-0-released) though some of the same items might be covered in both places. 