### PR TITLE
SQL: Extend ScriptTemplate to support functions

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/ScalarFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/ScalarFunction.java
@@ -77,7 +77,7 @@ public abstract class ScalarFunction extends Function {
     protected ScriptTemplate asScriptFrom(ScalarFunctionAttribute scalar) {
         ScriptTemplate nested = scalar.script();
         Params p = paramsBuilder().script(nested.params()).build();
-        return new ScriptTemplate(formatScript(nested.template()), p, dataType());
+        return new ScriptTemplate(formatScript(nested.template()), p, nested.functions(), dataType());
     }
 
     protected ScriptTemplate asScriptFromFoldable(Expression foldable) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeFunction.java
@@ -108,7 +108,8 @@ public abstract class DateTimeFunction extends UnaryScalarFunction {
              */
 
             sf = new ScriptFunction("dateTime", "ZonedDateTime dateTime(def millis, def tzId, def chrono) {"
-                    + "ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.of(tzId)).get(ChronoField.get(ChronoField.valueOf(chrono)))"
+                    + "ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), "
+                          + "ZoneId.of(tzId)).get(ChronoField.get(ChronoField.valueOf(chrono)))"
                     + "}");
 
             template = formatTemplate("dateTime(doc[{}].value.millis, {}, {})");

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/script/ScriptFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/script/ScriptFunction.java
@@ -1,20 +1,8 @@
 /*
- * ELASTICSEARCH CONFIDENTIAL
- * __________________
- *
- *  [2017] Elasticsearch Incorporated. All Rights Reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Elasticsearch Incorporated and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Elasticsearch Incorporated
- * and its suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Elasticsearch Incorporated.
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
  */
-
 package org.elasticsearch.xpack.sql.expression.function.scalar.script;
 
 import java.util.Locale;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/script/ScriptFunction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/scalar/script/ScriptFunction.java
@@ -1,0 +1,58 @@
+/*
+ * ELASTICSEARCH CONFIDENTIAL
+ * __________________
+ *
+ *  [2017] Elasticsearch Incorporated. All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Elasticsearch Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Elasticsearch Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Elasticsearch Incorporated.
+ */
+
+package org.elasticsearch.xpack.sql.expression.function.scalar.script;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public class ScriptFunction {
+
+    final String name;
+    final String definition;
+
+    public ScriptFunction(String name, String definition) {
+        this.name = name;
+        this.definition = definition;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, definition);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ScriptFunction other = (ScriptFunction) obj;
+        return Objects.equals(name, other.name) && Objects.equals(definition, other.definition);
+    }
+
+    @Override
+    public String toString() {
+        return format(Locale.ROOT, "%s=%s", name, definition);
+    }
+}

--- a/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/CsvSpecTestCase.java
+++ b/x-pack/qa/sql/src/main/java/org/elasticsearch/xpack/qa/sql/jdbc/CsvSpecTestCase.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.qa.sql.jdbc;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.elasticsearch.xpack.qa.sql.jdbc.CsvTestUtils.CsvTestCase;
 import org.elasticsearch.xpack.sql.jdbc.jdbc.JdbcConfiguration;
 


### PR DESCRIPTION
Add support for Painless function definitions to ScriptTemplate for
better script (including chaining).