### PR TITLE
Remove assert statements from field caps documentation.

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchDocumentationIT.java
@@ -98,7 +98,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -725,21 +724,25 @@ public class SearchDocumentationIT extends ESRestHighLevelClientTestCase {
         // end::field-caps-execute
 
         // tag::field-caps-response
-        assertThat(response.get().keySet(), contains("user"));
-        Map<String, FieldCapabilities> userResponse = response.getField("user");
-
-        assertThat(userResponse.keySet(), containsInAnyOrder("keyword", "text")); // <1>
+        Map<String, FieldCapabilities> userResponse = response.getField("user");  // <1>
         FieldCapabilities textCapabilities = userResponse.get("keyword");
 
-        assertTrue(textCapabilities.isSearchable());
-        assertFalse(textCapabilities.isAggregatable());
+        boolean isSearchable = textCapabilities.isSearchable();
+        boolean isAggregatable = textCapabilities.isAggregatable();
 
-        assertArrayEquals(textCapabilities.indices(), // <2>
-                          new String[]{"authors", "contributors"});
-        assertNull(textCapabilities.nonSearchableIndices()); // <3>
-        assertArrayEquals(textCapabilities.nonAggregatableIndices(), // <4>
-                          new String[]{"authors"});
+        String[] indices = textCapabilities.indices(); // <2>
+        String[] nonSearchableIndices = textCapabilities.nonSearchableIndices(); // <3>
+        String[] nonAggregatableIndices = textCapabilities.nonAggregatableIndices();//<4>
         // end::field-caps-response
+
+        assertThat(userResponse.keySet(), containsInAnyOrder("keyword", "text"));
+
+        assertTrue(isSearchable);
+        assertFalse(isAggregatable);
+
+        assertArrayEquals(indices, new String[]{"authors", "contributors"});
+        assertNull(nonSearchableIndices);
+        assertArrayEquals(nonAggregatableIndices, new String[]{"authors"});
 
         // tag::field-caps-execute-listener
         ActionListener<FieldCapabilitiesResponse> listener = new ActionListener<FieldCapabilitiesResponse>() {

--- a/docs/java-rest/high-level/search/field-caps.asciidoc
+++ b/docs/java-rest/high-level/search/field-caps.asciidoc
@@ -76,7 +76,7 @@ information about how each index contributes to the field's capabilities.
 --------------------------------------------------
 include-tagged::{doc-tests}/SearchDocumentationIT.java[field-caps-response]
 --------------------------------------------------
-<1> The `user` field has two possible types, `keyword` and `text`.
-<2> This field only has type `keyword` in the `authors` and `contributors` indices.
-<3> Null, since the field is searchable in all indices for which it has the `keyword` type.
-<4> The `user` field is not aggregatable in the `authors` index.
+<1> A map with entries for the field's possible types, in this case `keyword` and `text`.
+<2> All indices where the `user` field has type `keyword`.
+<3> The subset of these indices where the `user` field isn't searchable, or null if it's always searchable.
+<4> Another subset of these indices where the `user` field isn't aggregatable, or null if it's always aggregatable.


### PR DESCRIPTION
Specifically, reorganized the test in `SearchDocumentationIT` so the assertions aren't shown in the generated documentation.