### PR TITLE
Side-step pending deletes check (#30571)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
@@ -1,11 +1,8 @@
 ---
 "Split index ignores target template mapping":
   - skip:
-      # when re-enabling uncomment the below skips
-      version: "all"
-      reason: "AwaitsFix'ing, see https://github.com/elastic/elasticsearch/issues/30503"
-      # version: " - 6.3.99"
-      # reason: expects warnings that pre-6.4.0 will not send
+      version: " - 6.3.99"
+      reason: expects warnings that pre-6.4.0 will not send
       features: "warnings"
 
   # create index

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -731,13 +731,13 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
         private final Logger deletesLogger;
 
-        StoreDirectory(Directory delegateDirectory, Logger deletesLogger) throws IOException {
+        StoreDirectory(Directory delegateDirectory, Logger deletesLogger) {
             super(delegateDirectory);
             this.deletesLogger = deletesLogger;
         }
 
         @Override
-        public void close() throws IOException {
+        public void close() {
             assert false : "Nobody should close this directory except of the Store itself";
         }
 
@@ -758,6 +758,17 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         @Override
         public String toString() {
             return "store(" + in.toString() + ")";
+        }
+
+        @Override
+        public boolean checkPendingDeletions() throws IOException {
+            if (super.checkPendingDeletions()) {
+                deletesLogger.warn("directory has still pending deletes");
+            }
+            // we skip this check since our IW usage always goes forward.
+            // we still might run into situations where we have pending deletes ie. in shrink / split case
+            // and that will cause issues on windows since we open multiple IW instance one after another during the split/shrink recovery
+            return false;
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -23,7 +23,6 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
@@ -77,7 +76,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/30416")
 public class ShrinkIndexIT extends ESIntegTestCase {
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
@@ -24,7 +24,6 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
 import org.apache.lucene.search.join.ScoreMode;
-import org.apache.lucene.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -80,7 +79,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/30416")
 public class SplitIndexIT extends ESIntegTestCase {
 
     @Override


### PR DESCRIPTION
When we split/shrink an index we open several IndexWriter instances
causeing file-deletes to be pending on windows. This subsequently fails
when we open an IW to bootstrap the index history due to pending deletes.
This change sidesteps the check since we know our history goes forward
in terms of files and segments.

Closes #30416