### PR TITLE
Adds step info to ClusterStateWaitSteps

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStep.java
@@ -17,13 +17,19 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Objects;
 
@@ -47,11 +53,11 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
     }
 
     @Override
-    public boolean isConditionMet(Index index, ClusterState clusterState) {
+    public Result isConditionMet(Index index, ClusterState clusterState) {
         if (ActiveShardCount.ALL.enoughShardsActive(clusterState, index.getName()) == false) {
             logger.debug("[{}] lifecycle action for index [{}] cannot make progress because not all shards are active",
                     getKey().getAction(), index.getName());
-            return false;
+            return new Result(false, new Info(-1, false));
         }
         IndexMetaData idxMeta = clusterState.metaData().index(index);
         if (idxMeta == null) {
@@ -88,10 +94,10 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
             logger.debug(
                     "[{}] lifecycle action for index [{}] waiting for [{}] shards " + "to be allocated to nodes matching the given filters",
                     getKey().getAction(), index, allocationPendingAllShards);
-            return false;
+            return new Result(false, new Info(allocationPendingAllShards, true));
         } else {
             logger.debug("[{}] lifecycle action for index [{}] complete", getKey().getAction(), index);
-            return true;
+            return new Result(true, null);
         }
     }
 
@@ -111,5 +117,75 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
         AllocationRoutedStep other = (AllocationRoutedStep) obj;
         return super.equals(obj) && 
                 Objects.equals(waitOnAllShardCopies, other.waitOnAllShardCopies);
+    }
+    
+    public static final class Info implements ToXContentObject {
+
+        private final long numberShardsLeftToAllocate;
+        private final boolean allShardsActive;
+        private final String message;
+
+        static final ParseField SHARDS_TO_ALLOCATE = new ParseField("shards_left_to_allocate");
+        static final ParseField ALL_SHARDS_ACTIVE = new ParseField("all_shards_active");
+        static final ParseField MESSAGE = new ParseField("message");
+        static final ConstructingObjectParser<Info, Void> PARSER = new ConstructingObjectParser<>("allocation_routed_step_info",
+                a -> new Info((long) a[0], (boolean) a[1]));
+        static {
+            PARSER.declareLong(ConstructingObjectParser.constructorArg(), SHARDS_TO_ALLOCATE);
+            PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), ALL_SHARDS_ACTIVE);
+            PARSER.declareString((i, s) -> {}, MESSAGE);
+        }
+
+        public Info(long numberShardsLeftToMerge, boolean allShardsActive) {
+            this.numberShardsLeftToAllocate = numberShardsLeftToMerge;
+            this.allShardsActive = allShardsActive;
+            if (allShardsActive == false) {
+                message = "Waiting for all shard copies to be active";
+            } else {
+                message = "Waiting for [" + numberShardsLeftToAllocate + "] shards "
+                        + "to be allocated to nodes matching the given filters";
+            }
+        }
+
+        public long getNumberShardsLeftToAllocate() {
+            return numberShardsLeftToAllocate;
+        }
+        
+        public boolean allShardsActive() {
+            return allShardsActive;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(MESSAGE.getPreferredName(), message);
+            builder.field(SHARDS_TO_ALLOCATE.getPreferredName(), numberShardsLeftToAllocate);
+            builder.field(ALL_SHARDS_ACTIVE.getPreferredName(), allShardsActive);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(numberShardsLeftToAllocate, allShardsActive);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Info other = (Info) obj;
+            return Objects.equals(numberShardsLeftToAllocate, other.numberShardsLeftToAllocate) &&
+                    Objects.equals(allShardsActive, other.allShardsActive);
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ClusterStateWaitStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ClusterStateWaitStep.java
@@ -6,6 +6,7 @@
 package org.elasticsearch.xpack.core.indexlifecycle;
 
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.index.Index;
 
 public abstract class ClusterStateWaitStep extends Step {
@@ -14,6 +15,24 @@ public abstract class ClusterStateWaitStep extends Step {
         super(key, nextStepKey);
     }
 
-    public abstract boolean isConditionMet(Index index, ClusterState clusterState);
+    public abstract Result isConditionMet(Index index, ClusterState clusterState);
+
+    public static class Result {
+        private final boolean complete;
+        private final ToXContentObject infomationContext;
+
+        public Result(boolean complete, ToXContentObject infomationContext) {
+            this.complete = complete;
+            this.infomationContext = infomationContext;
+        }
+
+        public boolean isComplete() {
+            return complete;
+        }
+
+        public ToXContentObject getInfomationContext() {
+            return infomationContext;
+        }
+    }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/PhaseAfterStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/PhaseAfterStep.java
@@ -24,11 +24,11 @@ public class PhaseAfterStep extends ClusterStateWaitStep {
     }
 
     @Override
-    public boolean isConditionMet(Index index, ClusterState clusterState) {
+    public Result isConditionMet(Index index, ClusterState clusterState) {
         IndexMetaData indexMetaData = clusterState.metaData().index(index);
         long lifecycleDate = indexMetaData.getSettings()
             .getAsLong(LifecycleSettings.LIFECYCLE_INDEX_CREATION_DATE, -1L);
-        return nowSupplier.getAsLong() >= lifecycleDate + after.getMillis();
+        return new Result(nowSupplier.getAsLong() >= lifecycleDate + after.getMillis(), null);
     }
     
     TimeValue getAfter() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStep.java
@@ -8,9 +8,15 @@ package org.elasticsearch.xpack.core.indexlifecycle;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 
+import java.io.IOException;
 import java.util.Objects;
 
 public class ReplicasAllocatedStep extends ClusterStateWaitStep {
@@ -27,14 +33,20 @@ public class ReplicasAllocatedStep extends ClusterStateWaitStep {
     }
 
     @Override
-    public boolean isConditionMet(Index index, ClusterState clusterState) {
+    public Result isConditionMet(Index index, ClusterState clusterState) {
         IndexMetaData idxMeta = clusterState.metaData().index(index);
         if (idxMeta == null) {
             throw new IndexNotFoundException("Index not found when executing " + getKey().getAction() + " lifecycle action.",
                     index.getName());
         }
         // We only want to make progress if the cluster state reflects the number of replicas change and all shards are active
-        return idxMeta.getNumberOfReplicas() == numberReplicas && ActiveShardCount.ALL.enoughShardsActive(clusterState, index.getName());
+        boolean allShardsActive = ActiveShardCount.ALL.enoughShardsActive(clusterState, index.getName());
+        boolean isConditionMet = idxMeta.getNumberOfReplicas() == numberReplicas && allShardsActive;
+        if (isConditionMet) {
+            return new Result(true, null);
+        } else {
+            return new Result(false, new Info(numberReplicas, idxMeta.getNumberOfReplicas(), allShardsActive));
+        }
     }
     
     @Override
@@ -53,5 +65,86 @@ public class ReplicasAllocatedStep extends ClusterStateWaitStep {
         ReplicasAllocatedStep other = (ReplicasAllocatedStep) obj;
         return super.equals(obj) &&
                 Objects.equals(numberReplicas, other.numberReplicas);
+    }
+    
+    public static final class Info implements ToXContentObject {
+
+        private final long expectedReplicas;
+        private final long actualReplicas;
+        private final boolean allShardsActive;
+        private final String message;
+
+        static final ParseField EXPECTED_REPLICAS = new ParseField("expected_replicas");
+        static final ParseField ACTUAL_REPLICAS = new ParseField("actual_replicas");
+        static final ParseField ALL_SHARDS_ACTIVE = new ParseField("all_shards_active");
+        static final ParseField MESSAGE = new ParseField("message");
+        static final ConstructingObjectParser<Info, Void> PARSER = new ConstructingObjectParser<>("replicas_allocated_step_info",
+                a -> new Info((long) a[0], (long) a[1], (boolean) a[2]));
+        static {
+            PARSER.declareLong(ConstructingObjectParser.constructorArg(), EXPECTED_REPLICAS);
+            PARSER.declareLong(ConstructingObjectParser.constructorArg(), ACTUAL_REPLICAS);
+            PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), ALL_SHARDS_ACTIVE);
+            PARSER.declareString((i, s) -> {}, MESSAGE);
+        }
+
+        public Info(long expectedReplicas, long actualReplicas, boolean allShardsActive) {
+            this.expectedReplicas = expectedReplicas;
+            this.actualReplicas = actualReplicas;
+            this.allShardsActive = allShardsActive;
+            if (actualReplicas != expectedReplicas) {
+                message = "Waiting for " + IndexMetaData.SETTING_NUMBER_OF_REPLICAS + " to be updated to " + expectedReplicas;
+            } else if (allShardsActive == false) {
+                message = "Waiting for all shard copies to be active";
+            } else {
+                message = "";
+            }
+        }
+
+        public long getExpectedReplicas() {
+            return expectedReplicas;
+        }
+        
+        public long getActualReplicas() {
+            return actualReplicas;
+        }
+        
+        public boolean allShardsActive() {
+            return allShardsActive;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(MESSAGE.getPreferredName(), message);
+            builder.field(EXPECTED_REPLICAS.getPreferredName(), expectedReplicas);
+            builder.field(ACTUAL_REPLICAS.getPreferredName(), actualReplicas);
+            builder.field(ALL_SHARDS_ACTIVE.getPreferredName(), allShardsActive);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(expectedReplicas, actualReplicas, allShardsActive);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Info other = (Info) obj;
+            return Objects.equals(expectedReplicas, other.expectedReplicas) &&
+                    Objects.equals(actualReplicas, other.actualReplicas) &&
+                    Objects.equals(allShardsActive, other.allShardsActive);
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/SegmentCountStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/SegmentCountStep.java
@@ -90,10 +90,12 @@ public class SegmentCountStep extends AsyncWaitStep {
         private final long numberShardsLeftToMerge;
 
         static final ParseField SHARDS_TO_MERGE = new ParseField("shards_left_to_merge");
+        static final ParseField MESSAGE = new ParseField("message");
         static final ConstructingObjectParser<Info, Void> PARSER = new ConstructingObjectParser<>("segment_count_step_info",
                 a -> new Info((long) a[0]));
         static {
             PARSER.declareLong(ConstructingObjectParser.constructorArg(), SHARDS_TO_MERGE);
+            PARSER.declareString((i, s) -> {}, MESSAGE);
         }
 
         public Info(long numberShardsLeftToMerge) {
@@ -107,6 +109,8 @@ public class SegmentCountStep extends AsyncWaitStep {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
+            builder.field(MESSAGE.getPreferredName(),
+                    "Waiting for [" + numberShardsLeftToMerge + "] shards " + "to forcemerge");
             builder.field(SHARDS_TO_MERGE.getPreferredName(), numberShardsLeftToMerge);
             builder.endObject();
             return builder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkenIndexCheckStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkenIndexCheckStep.java
@@ -7,9 +7,14 @@ package org.elasticsearch.xpack.core.indexlifecycle;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
 
+import java.io.IOException;
 import java.util.Objects;
 
 public class ShrunkenIndexCheckStep extends ClusterStateWaitStep {
@@ -26,14 +31,19 @@ public class ShrunkenIndexCheckStep extends ClusterStateWaitStep {
     }
 
     @Override
-    public boolean isConditionMet(Index index, ClusterState clusterState) {
+    public Result isConditionMet(Index index, ClusterState clusterState) {
         String shrunkenIndexSource = IndexMetaData.INDEX_SHRINK_SOURCE_NAME.get(
             clusterState.metaData().index(index).getSettings());
         if (Strings.isNullOrEmpty(shrunkenIndexSource)) {
             throw new IllegalStateException("step[" + NAME + "] is checking an un-shrunken index[" + index.getName() + "]");
         }
-        return index.getName().equals(shrunkIndexPrefix + shrunkenIndexSource) &&
+        boolean isConditionMet = index.getName().equals(shrunkIndexPrefix + shrunkenIndexSource) &&
                 clusterState.metaData().index(shrunkenIndexSource) == null;
+        if (isConditionMet) {
+            return new Result(true, null);
+        } else {
+            return new Result(false, new Info(shrunkenIndexSource));
+        }
     }
 
     @Override
@@ -52,5 +62,60 @@ public class ShrunkenIndexCheckStep extends ClusterStateWaitStep {
         ShrunkenIndexCheckStep other = (ShrunkenIndexCheckStep) obj;
         return super.equals(obj) && 
                 Objects.equals(shrunkIndexPrefix, other.shrunkIndexPrefix);
+    }
+
+    public static final class Info implements ToXContentObject {
+
+        private final String originalIndexName;
+        private final String message;
+
+        static final ParseField ORIGINAL_INDEX_NAME = new ParseField("original_index_name");
+        static final ParseField MESSAGE = new ParseField("message");
+        static final ConstructingObjectParser<Info, Void> PARSER = new ConstructingObjectParser<>("shrunken_index_check_step_info",
+                a -> new Info((String) a[0]));
+        static {
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), ORIGINAL_INDEX_NAME);
+            PARSER.declareString((i, s) -> {}, MESSAGE);
+        }
+
+        public Info(String originalIndexName) {
+            this.originalIndexName = originalIndexName;
+            this.message = "Waiting for original index [" + originalIndexName + "] to be deleted";
+        }
+
+        public String getOriginalIndexName() {
+            return originalIndexName;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(MESSAGE.getPreferredName(), message);
+            builder.field(ORIGINAL_INDEX_NAME.getPreferredName(), originalIndexName);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(originalIndexName);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Info other = (Info) obj;
+            return Objects.equals(originalIndexName, other.originalIndexName);
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(this);
+        }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStepInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/AllocationRoutedStepInfoTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.indexlifecycle;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.xpack.core.indexlifecycle.AllocationRoutedStep.Info;
+
+import java.io.IOException;
+
+public class AllocationRoutedStepInfoTests extends AbstractXContentTestCase<AllocationRoutedStep.Info> {
+
+    @Override
+    protected Info createTestInstance() {
+        return new Info(randomNonNegativeLong(), randomBoolean());
+    }
+
+    @Override
+    protected Info doParseInstance(XContentParser parser) throws IOException {
+        return Info.PARSER.apply(parser, null);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    public final void testEqualsAndHashcode() {
+        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copyInstance, this::mutateInstance);
+        }
+    }
+
+    protected final Info copyInstance(Info instance) throws IOException {
+        return new Info(instance.getNumberShardsLeftToAllocate(), instance.allShardsActive());
+    }
+
+    protected Info mutateInstance(Info instance) throws IOException {
+        long shardsToAllocate = instance.getNumberShardsLeftToAllocate();
+        boolean allShardsActive = instance.allShardsActive();
+        switch (between(0, 1)) {
+        case 0:
+            shardsToAllocate += between(1, 20);
+            break;
+        case 1:
+            allShardsActive = allShardsActive == false;
+            break;
+        default:
+            throw new AssertionError("Illegal randomisation branch");
+        }
+        return new Info(shardsToAllocate, allShardsActive);
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/PhaseAfterStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/PhaseAfterStepTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.xpack.core.indexlifecycle.ClusterStateWaitStep.Result;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import java.util.concurrent.TimeUnit;
@@ -75,7 +76,9 @@ public class PhaseAfterStepTests extends AbstractStepTestCase<PhaseAfterStep> {
         long after = randomNonNegativeLong();
         long now = creationDate + after + randomIntBetween(0, 2);
         PhaseAfterStep step = new PhaseAfterStep(() -> now, TimeValue.timeValueMillis(after), null, null);
-        assertTrue(step.isConditionMet(index, clusterState));
+        Result result = step.isConditionMet(index, clusterState);
+        assertTrue(result.isComplete());
+        assertNull(result.getInfomationContext());
     }
 
     public void testConditionNotMet() {
@@ -93,6 +96,8 @@ public class PhaseAfterStepTests extends AbstractStepTestCase<PhaseAfterStep> {
         long after = randomNonNegativeLong();
         long now = creationDate + after - randomIntBetween(1, 1000);
         PhaseAfterStep step = new PhaseAfterStep(() -> now, TimeValue.timeValueMillis(after), null, null);
-        assertFalse(step.isConditionMet(index, clusterState));
+        Result result = step.isConditionMet(index, clusterState);
+        assertFalse(result.isComplete());
+        assertNull(result.getInfomationContext());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStepInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStepInfoTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.indexlifecycle;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.xpack.core.indexlifecycle.ReplicasAllocatedStep.Info;
+
+import java.io.IOException;
+
+public class ReplicasAllocatedStepInfoTests extends AbstractXContentTestCase<ReplicasAllocatedStep.Info> {
+
+    @Override
+    protected Info createTestInstance() {
+        return new Info(randomNonNegativeLong(), randomNonNegativeLong(), randomBoolean());
+    }
+
+    @Override
+    protected Info doParseInstance(XContentParser parser) throws IOException {
+        return Info.PARSER.apply(parser, null);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    public final void testEqualsAndHashcode() {
+        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copyInstance, this::mutateInstance);
+        }
+    }
+
+    protected final Info copyInstance(Info instance) throws IOException {
+        return new Info(instance.getExpectedReplicas(), instance.getActualReplicas(), instance.allShardsActive());
+    }
+
+    protected Info mutateInstance(Info instance) throws IOException {
+        long expectedReplicas = instance.getExpectedReplicas();
+        long actualReplicas = instance.getActualReplicas();
+        boolean allShardsActive = instance.allShardsActive();
+        switch (between(0, 2)) {
+        case 0:
+            expectedReplicas += between(1, 20);
+            break;
+        case 1:
+            actualReplicas += between(1, 20);
+            break;
+        case 2:
+            allShardsActive = allShardsActive == false;
+            break;
+        default:
+            throw new AssertionError("Illegal randomisation branch");
+        }
+        return new Info(expectedReplicas, actualReplicas, allShardsActive);
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStepTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.xpack.core.indexlifecycle.ClusterStateWaitStep.Result;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 public class ReplicasAllocatedStepTests extends AbstractStepTestCase<ReplicasAllocatedStep> {
@@ -87,7 +88,9 @@ public class ReplicasAllocatedStepTests extends AbstractStepTestCase<ReplicasAll
                         nodeId, true, ShardRoutingState.STARTED)))
                 .build())
             .build();
-        assertTrue(step.isConditionMet(indexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(indexMetadata.getIndex(), clusterState);
+        assertTrue(result.isComplete());
+        assertNull(result.getInfomationContext());
     }
 
     public void testConditionNotMetAllocation() {
@@ -117,7 +120,10 @@ public class ReplicasAllocatedStepTests extends AbstractStepTestCase<ReplicasAll
                 .build())
             .build();
 
-        assertFalse(step.isConditionMet(indexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(indexMetadata.getIndex(), clusterState);
+        assertFalse(result.isComplete());
+        assertEquals(new ReplicasAllocatedStep.Info(step.getNumberReplicas(), step.getNumberReplicas(), false),
+                result.getInfomationContext());
     }
 
     public void testConditionNotMetNumberReplicas() {
@@ -147,7 +153,10 @@ public class ReplicasAllocatedStepTests extends AbstractStepTestCase<ReplicasAll
                 .build())
             .build();
 
-        assertFalse(step.isConditionMet(indexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(indexMetadata.getIndex(), clusterState);
+        assertFalse(result.isComplete());
+        assertEquals(new ReplicasAllocatedStep.Info(step.getNumberReplicas(), indexMetadata.getNumberOfReplicas(), true),
+                result.getInfomationContext());
     }
 
     public void testConditionIndexMissing() throws Exception {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkShardsAllocatedStepInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkShardsAllocatedStepInfoTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.indexlifecycle;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.xpack.core.indexlifecycle.ShrunkShardsAllocatedStep.Info;
+
+import java.io.IOException;
+
+public class ShrunkShardsAllocatedStepInfoTests extends AbstractXContentTestCase<ShrunkShardsAllocatedStep.Info> {
+
+    @Override
+    protected Info createTestInstance() {
+        return new Info(randomBoolean(), randomIntBetween(0, 10000), randomIntBetween(0, 10000), randomBoolean());
+    }
+
+    @Override
+    protected Info doParseInstance(XContentParser parser) throws IOException {
+        return Info.PARSER.apply(parser, null);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    public final void testEqualsAndHashcode() {
+        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copyInstance, this::mutateInstance);
+        }
+    }
+
+    protected final Info copyInstance(Info instance) throws IOException {
+        return new Info(instance.shrunkIndexExists(), instance.getExpectedShards(), instance.getActualShards(), instance.allShardsActive());
+    }
+
+    protected Info mutateInstance(Info instance) throws IOException {
+        boolean shrunkIndexExists = instance.shrunkIndexExists();
+        int expectedShards = instance.getExpectedShards();
+        int actualShards = instance.getActualShards();
+        boolean allShardsActive = instance.allShardsActive();
+        switch (between(0, 3)) {
+        case 0:
+            shrunkIndexExists = shrunkIndexExists == false;
+            break;
+        case 1:
+            expectedShards += between(1, 20);
+            break;
+        case 2:
+            actualShards += between(1, 20);
+            break;
+        case 3:
+            allShardsActive = allShardsActive == false;
+            break;
+        default:
+            throw new AssertionError("Illegal randomisation branch");
+        }
+        return new Info(shrunkIndexExists, expectedShards, actualShards, allShardsActive);
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkShardsAllocatedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkShardsAllocatedStepTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.xpack.core.indexlifecycle.ClusterStateWaitStep.Result;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 public class ShrunkShardsAllocatedStepTests extends AbstractStepTestCase<ShrunkShardsAllocatedStep> {
@@ -101,7 +102,9 @@ public class ShrunkShardsAllocatedStepTests extends AbstractStepTestCase<ShrunkS
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
             .routingTable(RoutingTable.builder().add(builder.build()).build()).build();
 
-        assertTrue(step.isConditionMet(originalIndexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(originalIndexMetadata.getIndex(), clusterState);
+        assertTrue(result.isComplete());
+        assertNull(result.getInfomationContext());
     }
 
     public void testConditionNotMetBecauseOfActive() {
@@ -139,7 +142,10 @@ public class ShrunkShardsAllocatedStepTests extends AbstractStepTestCase<ShrunkS
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
             .routingTable(RoutingTable.builder().add(builder.build()).build()).build();
 
-        assertFalse(step.isConditionMet(originalIndexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(originalIndexMetadata.getIndex(), clusterState);
+        assertFalse(result.isComplete());
+        assertEquals(new ShrunkShardsAllocatedStep.Info(true, shrinkNumberOfShards, shrinkNumberOfShards, false),
+                result.getInfomationContext());
     }
 
     public void testConditionNotMetBecauseOfShardCount() {
@@ -178,7 +184,10 @@ public class ShrunkShardsAllocatedStepTests extends AbstractStepTestCase<ShrunkS
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
             .routingTable(RoutingTable.builder().add(builder.build()).build()).build();
 
-        assertFalse(step.isConditionMet(originalIndexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(originalIndexMetadata.getIndex(), clusterState);
+        assertFalse(result.isComplete());
+        assertEquals(new ShrunkShardsAllocatedStep.Info(true, shrinkNumberOfShards, actualShrinkNumberShards, true),
+                result.getInfomationContext());
     }
 
     public void testConditionNotMetBecauseOfShrunkIndexDoesntExistYet() {
@@ -203,6 +212,8 @@ public class ShrunkShardsAllocatedStepTests extends AbstractStepTestCase<ShrunkS
             .nodes(DiscoveryNodes.builder().localNodeId(nodeId).masterNodeId(nodeId).add(masterNode).build())
             .build();
 
-        assertFalse(step.isConditionMet(originalIndexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(originalIndexMetadata.getIndex(), clusterState);
+        assertFalse(result.isComplete());
+        assertEquals(new ShrunkShardsAllocatedStep.Info(false, -1, -1, false), result.getInfomationContext());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkenIndexCheckStepInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkenIndexCheckStepInfoTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.indexlifecycle;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.xpack.core.indexlifecycle.ShrunkenIndexCheckStep.Info;
+
+import java.io.IOException;
+
+public class ShrunkenIndexCheckStepInfoTests extends AbstractXContentTestCase<ShrunkenIndexCheckStep.Info> {
+
+    @Override
+    protected Info createTestInstance() {
+        return new Info(randomAlphaOfLengthBetween(10, 20));
+    }
+
+    @Override
+    protected Info doParseInstance(XContentParser parser) throws IOException {
+        return Info.PARSER.apply(parser, null);
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    public final void testEqualsAndHashcode() {
+        for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
+            EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copyInstance, this::mutateInstance);
+        }
+    }
+
+    protected final Info copyInstance(Info instance) throws IOException {
+        return new Info(instance.getOriginalIndexName());
+    }
+
+    protected Info mutateInstance(Info instance) throws IOException {
+        return new Info(randomValueOtherThan(instance.getOriginalIndexName(), () -> randomAlphaOfLengthBetween(10, 20)));
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkenIndexCheckStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkenIndexCheckStepTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.xpack.core.indexlifecycle.ClusterStateWaitStep.Result;
 import org.elasticsearch.xpack.core.indexlifecycle.Step.StepKey;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -63,7 +64,9 @@ public class ShrunkenIndexCheckStepTests extends AbstractStepTestCase<ShrunkenIn
             .build();
 
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).build();
-        assertTrue(step.isConditionMet(indexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(indexMetadata.getIndex(), clusterState);
+        assertTrue(result.isComplete());
+        assertNull(result.getInfomationContext());
     }
 
     public void testConditionNotMetBecauseNotSameShrunkenIndex() {
@@ -78,7 +81,9 @@ public class ShrunkenIndexCheckStepTests extends AbstractStepTestCase<ShrunkenIn
             .put(IndexMetaData.builder(shrinkIndexMetadata))
             .build();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).build();
-        assertFalse(step.isConditionMet(shrinkIndexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(shrinkIndexMetadata.getIndex(), clusterState);
+        assertFalse(result.isComplete());
+        assertEquals(new ShrunkenIndexCheckStep.Info(sourceIndex), result.getInfomationContext());
     }
 
     public void testConditionNotMetBecauseSourceIndexExists() {
@@ -98,7 +103,9 @@ public class ShrunkenIndexCheckStepTests extends AbstractStepTestCase<ShrunkenIn
             .put(IndexMetaData.builder(shrinkIndexMetadata))
             .build();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metaData(metaData).build();
-        assertFalse(step.isConditionMet(shrinkIndexMetadata.getIndex(), clusterState));
+        Result result = step.isConditionMet(shrinkIndexMetadata.getIndex(), clusterState);
+        assertFalse(result.isComplete());
+        assertEquals(new ShrunkenIndexCheckStep.Info(sourceIndex), result.getInfomationContext());
     }
 
     public void testIllegalState() {

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycleRunner.java
@@ -194,6 +194,17 @@ public class IndexLifecycleRunner {
         return newClusterStateBuilder;
     }
 
+    static ClusterState addStepInfoToClusterState(Index index, ClusterState clusterState, ToXContentObject stepInfo) throws IOException {
+        IndexMetaData idxMeta = clusterState.getMetaData().index(index);
+        XContentBuilder infoXContentBuilder = JsonXContent.contentBuilder();
+        stepInfo.toXContent(infoXContentBuilder, ToXContent.EMPTY_PARAMS);
+        String stepInfoString = BytesReference.bytes(infoXContentBuilder).utf8ToString();
+        Settings.Builder indexSettings = Settings.builder().put(idxMeta.getSettings())
+                .put(LifecycleSettings.LIFECYCLE_STEP_INFO_SETTING.getKey(), stepInfoString);
+        ClusterState.Builder newClusterStateBuilder = newClusterStateWithIndexSettings(index, clusterState, indexSettings);
+        return newClusterStateBuilder.build();
+    }
+
     private void moveToStep(Index index, String policy, StepKey currentStepKey, StepKey nextStepKey) {
         logger.debug("moveToStep[" + policy + "] [" + index.getName() + "]" + currentStepKey + " -> "
                 + nextStepKey);

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/SetStepInfoUpdateTask.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/SetStepInfoUpdateTask.java
@@ -8,12 +8,8 @@ package org.elasticsearch.xpack.indexlifecycle;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xpack.core.indexlifecycle.LifecycleSettings;
 import org.elasticsearch.xpack.core.indexlifecycle.Step;
@@ -54,12 +50,7 @@ public class SetStepInfoUpdateTask extends ClusterStateUpdateTask {
         Settings indexSettings = currentState.getMetaData().index(index).getSettings();
         if (policy.equals(LifecycleSettings.LIFECYCLE_NAME_SETTING.get(indexSettings))
                 && currentStepKey.equals(IndexLifecycleRunner.getCurrentStepKey(indexSettings))) {
-            XContentBuilder infoXContentBuilder = JsonXContent.contentBuilder();
-            stepInfo.toXContent(infoXContentBuilder, ToXContent.EMPTY_PARAMS);
-            String stepInfoString = BytesReference.bytes(infoXContentBuilder).utf8ToString();
-            Settings.Builder newSettings = Settings.builder().put(indexSettings).put(LifecycleSettings.LIFECYCLE_STEP_INFO_SETTING.getKey(),
-                    stepInfoString);
-            return IndexLifecycleRunner.newClusterStateWithIndexSettings(index, currentState, newSettings).build();
+            return IndexLifecycleRunner.addStepInfoToClusterState(index, currentState, stepInfo);
         } else {
             // either the policy has changed or the step is now
             // not the same as when we submitted the update task. In


### PR DESCRIPTION
The `ClusterStateWaitStep.isConditionMet()` method now returns a
`Result` object which contains a boolean for if the condition is met
and an `ToXContentObject` to provide information in the case where the
condition is not met.
If the condition is not met, the step information is stored in the
cluster state.