### PR TITLE
Move allocation awareness attributes to list setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -544,20 +544,20 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
 
     static class AttributesKey {
 
-        final String[] attributes;
+        final List<String> attributes;
 
-        AttributesKey(String[] attributes) {
+        AttributesKey(List<String> attributes) {
             this.attributes = attributes;
         }
 
         @Override
         public int hashCode() {
-            return Arrays.hashCode(attributes);
+            return attributes.hashCode();
         }
 
         @Override
         public boolean equals(Object obj) {
-            return obj instanceof AttributesKey && Arrays.equals(attributes, ((AttributesKey) obj).attributes);
+            return obj instanceof AttributesKey && attributes.equals(((AttributesKey) obj).attributes);
         }
     }
 
@@ -621,11 +621,11 @@ public class IndexShardRoutingTable implements Iterable<ShardRouting> {
         return Collections.unmodifiableList(to);
     }
 
-    public ShardIterator preferAttributesActiveInitializingShardsIt(String[] attributes, DiscoveryNodes nodes) {
+    public ShardIterator preferAttributesActiveInitializingShardsIt(List<String> attributes, DiscoveryNodes nodes) {
         return preferAttributesActiveInitializingShardsIt(attributes, nodes, shuffler.nextSeed());
     }
 
-    public ShardIterator preferAttributesActiveInitializingShardsIt(String[] attributes, DiscoveryNodes nodes, int seed) {
+    public ShardIterator preferAttributesActiveInitializingShardsIt(List<String> attributes, DiscoveryNodes nodes, int seed) {
         AttributesKey key = new AttributesKey(attributes);
         AttributesRoutings activeRoutings = getActiveAttribute(key, nodes);
         AttributesRoutings initializingRoutings = getInitializingAttribute(key, nodes);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,7 +50,7 @@ public class OperationRouting extends AbstractComponent {
             Setting.boolSetting("cluster.routing.use_adaptive_replica_selection", true,
                     Setting.Property.Dynamic, Setting.Property.NodeScope);
 
-    private String[] awarenessAttributes;
+    private List<String> awarenessAttributes;
     private boolean useAdaptiveReplicaSelection;
 
     public OperationRouting(Settings settings, ClusterSettings clusterSettings) {
@@ -65,7 +66,7 @@ public class OperationRouting extends AbstractComponent {
         this.useAdaptiveReplicaSelection = useAdaptiveReplicaSelection;
     }
 
-    private void setAwarenessAttributes(String[] awarenessAttributes) {
+    private void setAwarenessAttributes(List<String> awarenessAttributes) {
         this.awarenessAttributes = awarenessAttributes;
     }
 
@@ -139,7 +140,7 @@ public class OperationRouting extends AbstractComponent {
                                                         @Nullable ResponseCollectorService collectorService,
                                                         @Nullable Map<String, Long> nodeCounts) {
         if (preference == null || preference.isEmpty()) {
-            if (awarenessAttributes.length == 0) {
+            if (awarenessAttributes.isEmpty()) {
                 if (useAdaptiveReplicaSelection) {
                     return indexShard.activeInitializingShardsRankedIt(collectorService, nodeCounts);
                 } else {
@@ -174,7 +175,7 @@ public class OperationRouting extends AbstractComponent {
                 }
                 // no more preference
                 if (index == -1 || index == preference.length() - 1) {
-                    if (awarenessAttributes.length == 0) {
+                    if (awarenessAttributes.isEmpty()) {
                         if (useAdaptiveReplicaSelection) {
                             return indexShard.activeInitializingShardsRankedIt(collectorService, nodeCounts);
                         } else {
@@ -218,7 +219,7 @@ public class OperationRouting extends AbstractComponent {
             // shard ID into the hash of the user-supplied preference key.
             routingHash = 31 * routingHash + indexShard.shardId.hashCode();
         }
-        if (awarenessAttributes.length == 0) {
+        if (awarenessAttributes.isEmpty()) {
             return indexShard.activeInitializingShardsIt(routingHash);
         } else {
             return indexShard.preferAttributesActiveInitializingShardsIt(awarenessAttributes, nodes, routingHash);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -22,6 +22,7 @@ package org.elasticsearch.cluster.routing.allocation.decider;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import com.carrotsearch.hppc.ObjectIntHashMap;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -33,6 +34,8 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+
+import static java.util.Collections.emptyList;
 
 /**
  * This {@link AllocationDecider} controls shard allocation based on
@@ -78,13 +81,13 @@ public class AwarenessAllocationDecider extends AllocationDecider {
 
     public static final String NAME = "awareness";
 
-    public static final Setting<String[]> CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING =
-        new Setting<>("cluster.routing.allocation.awareness.attributes", "", s -> Strings.tokenizeToStringArray(s, ","), Property.Dynamic,
+    public static final Setting<List<String>> CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING =
+        Setting.listSetting("cluster.routing.allocation.awareness.attributes", emptyList(), Function.identity(), Property.Dynamic,
             Property.NodeScope);
     public static final Setting<Settings> CLUSTER_ROUTING_ALLOCATION_AWARENESS_FORCE_GROUP_SETTING =
         Setting.groupSetting("cluster.routing.allocation.awareness.force.", Property.Dynamic, Property.NodeScope);
 
-    private volatile String[] awarenessAttributes;
+    private volatile List<String> awarenessAttributes;
 
     private volatile Map<String, List<String>> forcedAwarenessAttributes;
 
@@ -109,7 +112,7 @@ public class AwarenessAllocationDecider extends AllocationDecider {
         this.forcedAwarenessAttributes = forcedAwarenessAttributes;
     }
 
-    private void setAwarenessAttributes(String[] awarenessAttributes) {
+    private void setAwarenessAttributes(List<String> awarenessAttributes) {
         this.awarenessAttributes = awarenessAttributes;
     }
 
@@ -124,7 +127,7 @@ public class AwarenessAllocationDecider extends AllocationDecider {
     }
 
     private Decision underCapacity(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation, boolean moveToNode) {
-        if (awarenessAttributes.length == 0) {
+        if (awarenessAttributes.isEmpty()) {
             return allocation.decision(Decision.YES, NAME,
                 "allocation awareness is not enabled, set cluster setting [%s] to enable it",
                 CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey());
@@ -138,7 +141,7 @@ public class AwarenessAllocationDecider extends AllocationDecider {
                 return allocation.decision(Decision.NO, NAME,
                     "node does not contain the awareness attribute [%s]; required attributes cluster setting [%s=%s]",
                     awarenessAttribute, CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(),
-                    allocation.debugDecision() ? Strings.arrayToCommaDelimitedString(awarenessAttributes) : null);
+                    allocation.debugDecision() ? Strings.collectionToCommaDelimitedString(awarenessAttributes) : null);
             }
 
             // build attr_value -> nodes map

--- a/server/src/test/java/org/elasticsearch/cluster/routing/IndexShardRoutingTableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/IndexShardRoutingTableTests.java
@@ -24,11 +24,13 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class IndexShardRoutingTableTests extends ESTestCase {
     public void testEqualsAttributesKey() {
-        String[] attr1 = {"a"};
-        String[] attr2 = {"b"};
+        List<String> attr1 = Arrays.asList("a");
+        List<String> attr2 = Arrays.asList("b");
         IndexShardRoutingTable.AttributesKey attributesKey1 = new IndexShardRoutingTable.AttributesKey(attr1);
         IndexShardRoutingTable.AttributesKey attributesKey2 = new IndexShardRoutingTable.AttributesKey(attr1);
         IndexShardRoutingTable.AttributesKey attributesKey3 = new IndexShardRoutingTable.AttributesKey(attr2);


### PR DESCRIPTION
Allows the setting to be specified using proper array syntax, for example:

```
"cluster.routing.allocation.awareness.attributes": [ "foo", "bar", "baz" ]
```

Closes #30617