### PR TITLE
Skip shard deprecation messages in REST tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -277,8 +277,8 @@ public class DoSection implements ExecutableSection {
                         + "if you wish to continue using the default of [5] shards, "
                         + "you must manage this on the create index request or with an index template")) {
                     /*
-                     * This warning header will come back in the vast majority of our tests that create an index when running against an older
-                     * master. Rather than rewrite our tests to assert this warning header, we assume that it is expected.
+                     * This warning header will come back in the vast majority of our tests that create an index when running against an
+                     * older master. Rather than rewrite our tests to assert this warning header, we assume that it is expected.
                      */
                 } else {
                     if (expected.remove(message) == false) {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -270,20 +270,20 @@ public class DoSection implements ExecutableSection {
         for (final String header : warningHeaders) {
             final Matcher matcher = WARNING_HEADER_PATTERN.matcher(header);
             final boolean matches = matcher.matches();
-            final String message = matcher.group(1);
-            // noinspection StatementWithEmptyBody
-            if (masterVersion.before(Version.V_7_0_0_alpha1)
-                    && message.equals("the default number of shards will change from [5] to [1] in 7.0.0; "
-                    + "if you wish to continue using the default of [5] shards, "
-                    + "you must manage this on the create index request or with an index template")) {
-                /*
-                 * This warning header will come back in the vast majority of our tests that create an index when running against an older
-                 * master. Rather than rewrite our tests to assert this warning header, we assume that it is expected.
-                 */
-            }
-            else if (matches) {
-                if (expected.remove(message) == false) {
-                    unexpected.add(header);
+            if (matches) {
+                final String message = matcher.group(1);
+                if (masterVersion.before(Version.V_7_0_0_alpha1)
+                        && message.equals("the default number of shards will change from [5] to [1] in 7.0.0; "
+                        + "if you wish to continue using the default of [5] shards, "
+                        + "you must manage this on the create index request or with an index template")) {
+                    /*
+                     * This warning header will come back in the vast majority of our tests that create an index when running against an older
+                     * master. Rather than rewrite our tests to assert this warning header, we assume that it is expected.
+                     */
+                } else {
+                    if (expected.remove(message) == false) {
+                        unexpected.add(header);
+                    }
                 }
             } else {
                 unmatched.add(header);

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -277,8 +277,8 @@ public class DoSection implements ExecutableSection {
                     + "if you wish to continue using the default of [5] shards, "
                     + "you must manage this on the create index request or with an index template")) {
                 /*
-                 * This warning header will come back in the vast majority of our tests that create an index. Rather than rewrite our
-                 * tests to assert this warning header, we assume that it is expected.
+                 * This warning header will come back in the vast majority of our tests that create an index when running against an older
+                 * master. Rather than rewrite our tests to assert this warning header, we assume that it is expected.
                  */
             }
             else if (matches) {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -272,6 +272,7 @@ public class DoSection implements ExecutableSection {
             final boolean matches = matcher.matches();
             if (matches) {
                 final String message = matcher.group(1);
+                // noinspection StatementWithEmptyBody
                 if (masterVersion.before(Version.V_7_0_0_alpha1)
                         && message.equals("the default number of shards will change from [5] to [1] in 7.0.0; "
                         + "if you wish to continue using the default of [5] shards, "


### PR DESCRIPTION
A 6.x node can send a deprecation message that the default number of shards will change from five to one in 7.0.0. In a mixed cluster, whether or not a create index request sees five or one shard and produces a deprecation message depends on the version of the master node. This means that during BWC tests a test can see this deprecation message depending on the version of the master node. In 6.x when we introduced this deprecation message we assumed that whereever we see this deprecation message is expected. However, in a mixed cluster test we need a similar mechanism but it would only apply if the version of the master node is earlier than 7.0.0. This commit takes advantage of a recent change to expose the version of the master node to do sections of REST tests. With this in hand, we can skip asserting on the deprecation message if the version of the master node is before 7.0.0 and otherwise seeing that deprecation message would be completely unexpected.

Relates #30539, relates #30587, relates #30623
