### PR TITLE
Delay _uid field data deprecation warning

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/UidFieldMapper.java
@@ -113,11 +113,11 @@ public class UidFieldMapper extends MetadataFieldMapper {
         @Override
         public IndexFieldData.Builder fielddataBuilder(String fullyQualifiedIndexName) {
             if (indexOptions() == IndexOptions.NONE) {
-                DEPRECATION_LOGGER.deprecated("Fielddata access on the _uid field is deprecated, use _id instead");
                 return new IndexFieldData.Builder() {
                     @Override
                     public IndexFieldData<?> build(IndexSettings indexSettings, MappedFieldType fieldType, IndexFieldDataCache cache,
                             CircuitBreakerService breakerService, MapperService mapperService) {
+                        DEPRECATION_LOGGER.deprecated("Fielddata access on the _uid field is deprecated, use _id instead");
                         MappedFieldType idFieldType = mapperService.fullName(IdFieldMapper.NAME);
                         IndexFieldData<?> idFieldData = idFieldType.fielddataBuilder(fullyQualifiedIndexName)
                                 .build(indexSettings, idFieldType, cache, breakerService, mapperService);

--- a/server/src/test/java/org/elasticsearch/index/mapper/UidFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/UidFieldTypeTests.java
@@ -25,15 +25,24 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.UidFieldMapper;
 import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+
+import static org.mockito.Matchers.any;
 
 public class UidFieldTypeTests extends FieldTypeTestCase {
     @Override
@@ -131,5 +140,36 @@ public class UidFieldTypeTests extends FieldTypeTestCase {
         assertEquals(new TermInSetQuery("_id", Uid.encodeId("id")), query);
         query = ft.termQuery("type2#id", context);
         assertEquals(new TermInSetQuery("_id"), query);
+    }
+
+    public void testIsAggregatable() {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+            .build();
+        IndexMetaData indexMetaData = IndexMetaData.builder(IndexMetaData.INDEX_UUID_NA_VALUE).settings(indexSettings).build();
+        IndexSettings mockSettings = new IndexSettings(indexMetaData, Settings.EMPTY);
+        MappedFieldType ft = UidFieldMapper.defaultFieldType(mockSettings);
+        assertTrue(ft.isAggregatable());
+    }
+
+    public void testFieldDataDeprecation() {
+        Settings indexSettings = Settings.builder()
+            .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+            .build();
+        IndexMetaData indexMetaData = IndexMetaData.builder(IndexMetaData.INDEX_UUID_NA_VALUE).settings(indexSettings).build();
+        IndexSettings mockSettings = new IndexSettings(indexMetaData, Settings.EMPTY);
+        MappedFieldType ft = UidFieldMapper.defaultFieldType(mockSettings);
+        IndexFieldData.Builder builder = ft.fielddataBuilder("");
+        MapperService mockMapper = Mockito.mock(MapperService.class);
+        Mockito.when(mockMapper.fullName(any())).thenReturn(new IdFieldMapper.IdFieldType());
+        Mockito.when(mockMapper.types()).thenReturn(Collections.singleton("doc"));
+        builder.build(mockSettings, ft, null, new NoneCircuitBreakerService(), mockMapper);
+        assertWarnings("Fielddata access on the _uid field is deprecated, use _id instead");
     }
 }


### PR DESCRIPTION
A deprecation warning is printed when creating the fieldddata builder for the `_uid` field.
This change moves the deprecation logging to the building of the fielddata since otherwise
APIs like `_field_caps` can emit deprecation warning when they just test the capabilities
of the `_uid` field.

Closes #30625