### PR TITLE
Add detailed assert message to IndexAuditUpgradeIT

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexAuditUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/IndexAuditUpgradeIT.java
@@ -71,6 +71,6 @@ public class IndexAuditUpgradeIT extends AbstractUpgradeTestCase {
         assertNotNull(nodesAgg);
         List<Map<String, Object>> buckets = (List<Map<String, Object>>) nodesAgg.get("buckets");
         assertNotNull(buckets);
-        assertEquals(numBuckets, buckets.size());
+        assertEquals("Found node buckets " + buckets, numBuckets, buckets.size());
     }
 }


### PR DESCRIPTION
Print out the returned buckets if the size does not match the
expectation.

Relates: #30562
