### PR TITLE
[Docs] Replace InetSocketTransportAddress with TransportAdress

### DIFF
--- a/docs/java-api/query-dsl/has-parent-query.asciidoc
+++ b/docs/java-api/query-dsl/has-parent-query.asciidoc
@@ -9,7 +9,7 @@ When using the `has_parent` query it is important to use the `PreBuiltTransportC
 --------------------------------------------------
 Settings settings = Settings.builder().put("cluster.name", "elasticsearch").build();
 TransportClient client = new PreBuiltTransportClient(settings);
-client.addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 9300)));
+client.addTransportAddress(new TransportAddress(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 9300)));
 --------------------------------------------------
 
 Otherwise the parent-join module doesn't get loaded and the `has_parent` query can't be used from the transport client.

--- a/docs/java-api/query-dsl/percolate-query.asciidoc
+++ b/docs/java-api/query-dsl/percolate-query.asciidoc
@@ -9,7 +9,7 @@ See:
 --------------------------------------------------
 Settings settings = Settings.builder().put("cluster.name", "elasticsearch").build();
 TransportClient client = new PreBuiltTransportClient(settings);
-client.addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 9300)));
+client.addTransportAddress(new TransportAddress(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 9300)));
 --------------------------------------------------
 
 Before the `percolate` query can be used an `percolator` mapping should be added and

--- a/x-pack/docs/en/watcher/java.asciidoc
+++ b/x-pack/docs/en/watcher/java.asciidoc
@@ -95,7 +95,7 @@ TransportClient client = new PreBuiltXPackTransportClient(Settings.builder()
     .put("cluster.name", "myClusterName")
     ...
     .build())
-    .addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName("localhost"), 9300));
+    .addTransportAddress(new TransportAddress(InetAddress.getByName("localhost"), 9300));
 
 XPackClient xpackClient = new XPackClient(client);
 WatcherClient watcherClient = xpackClient.watcher();


### PR DESCRIPTION
The former class has been removed in 6.0, the documentation code
snippets should be updated accordingly.