### PR TITLE
Scripting: Remove getDate methods from ScriptDocValues

### DIFF
--- a/docs/reference/migration/migrate_7_0.asciidoc
+++ b/docs/reference/migration/migrate_7_0.asciidoc
@@ -34,6 +34,7 @@ Elasticsearch 6.x in order to be readable by Elasticsearch 7.x.
 * <<breaking_70_api_changes>>
 * <<breaking_70_java_changes>>
 * <<breaking_70_settings_changes>>
+* <<breaking_70_scripting_changes>>
 
 
 include::migrate_7_0/aggregations.asciidoc[]
@@ -47,3 +48,4 @@ include::migrate_7_0/plugins.asciidoc[]
 include::migrate_7_0/api.asciidoc[]
 include::migrate_7_0/java.asciidoc[]
 include::migrate_7_0/settings.asciidoc[]
+include::migrate_7_0/scripting.asciidoc[]

--- a/docs/reference/migration/migrate_7_0/scripting.asciidoc
+++ b/docs/reference/migration/migrate_7_0/scripting.asciidoc
@@ -1,0 +1,13 @@
+[[breaking_70_scripting_changes]]
+=== Scripting changes
+
+==== getDate() and getDates() removed
+
+Fields of type `long` and `date` had `getDate()` and `getDates()` methods
+(for multi valued fields) to get an object with date specific helper methods
+for the current doc value. In 5.3.0, `date` fields were changed to expose
+this same date object directly when calling `doc["myfield"].value`, and
+the getter methods for date objects were deprecated. These methods have
+now been removed. Instead, use `.value` on `date` fields, or explicitly
+parse `long` fields into a date object using
+`Instance.ofEpochMillis(doc["myfield"].value)`.

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/spi/org.elasticsearch.txt
@@ -74,16 +74,12 @@ class org.elasticsearch.index.fielddata.ScriptDocValues$Longs {
   Long get(int)
   long getValue()
   List getValues()
-  org.joda.time.ReadableDateTime getDate()
-  List getDates()
 }
 
 class org.elasticsearch.index.fielddata.ScriptDocValues$Dates {
   org.joda.time.ReadableDateTime get(int)
   org.joda.time.ReadableDateTime getValue()
   List getValues()
-  org.joda.time.ReadableDateTime getDate()
-  List getDates()
 }
 
 class org.elasticsearch.index.fielddata.ScriptDocValues$Doubles {

--- a/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_script_doc_values.yml
+++ b/modules/lang-painless/src/test/resources/rest-api-spec/test/painless/50_script_doc_values.yml
@@ -106,28 +106,6 @@ setup:
                             source: "doc.date.value"
     - match: { hits.hits.0.fields.field.0: '2017-01-01T12:11:12.000Z' }
 
-    - do:
-        warnings:
-            - getDate is no longer necessary on date fields as the value is now a date.
-        search:
-            body:
-                script_fields:
-                    field:
-                        script:
-                            source: "doc['date'].date"
-    - match: { hits.hits.0.fields.field.0: '2017-01-01T12:11:12.000Z' }
-
-    - do:
-        warnings:
-            - getDates is no longer necessary on date fields as the values are now dates.
-        search:
-            body:
-                script_fields:
-                    field:
-                        script:
-                            source: "doc['date'].dates.get(0)"
-    - match: { hits.hits.0.fields.field.0: '2017-01-01T12:11:12.000Z' }
-
 ---
 "geo_point":
     - do:
@@ -212,28 +190,6 @@ setup:
                         script:
                             source: "doc['long'].value"
     - match: { hits.hits.0.fields.field.0: 12348732141234 }
-
-    - do:
-        warnings:
-            - getDate on numeric fields is deprecated. Use a date field to get dates.
-        search:
-            body:
-                script_fields:
-                    field:
-                        script:
-                            source: "doc['long'].date"
-    - match: { hits.hits.0.fields.field.0: '2361-04-26T03:22:21.234Z' }
-
-    - do:
-        warnings:
-            - getDates on numeric fields is deprecated. Use a date field to get dates.
-        search:
-            body:
-                script_fields:
-                    field:
-                        script:
-                            source: "doc['long'].dates.get(0)"
-    - match: { hits.hits.0.fields.field.0: '2361-04-26T03:22:21.234Z' }
 
 ---
 "integer":

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -94,38 +94,19 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
     }
 
     public static final class Longs extends ScriptDocValues<Long> {
-        protected static final DeprecationLogger deprecationLogger = new DeprecationLogger(ESLoggerFactory.getLogger(Longs.class));
-
         private final SortedNumericDocValues in;
-        /**
-         * Callback for deprecated fields. In production this should always point to
-         * {@link #deprecationLogger} but tests will override it so they can test that
-         * we use the required permissions when calling it.
-         */
-        private final Consumer<String> deprecationCallback;
         private long[] values = new long[0];
         private int count;
-        private Dates dates;
-        private int docId = -1;
 
         /**
          * Standard constructor.
          */
         public Longs(SortedNumericDocValues in) {
-            this(in, deprecationLogger::deprecated);
-        }
-
-        /**
-         * Constructor for testing the deprecation callback.
-         */
-        Longs(SortedNumericDocValues in, Consumer<String> deprecationCallback) {
             this.in = in;
-            this.deprecationCallback = deprecationCallback;
         }
 
         @Override
         public void setNextDocId(int docId) throws IOException {
-            this.docId = docId;
             if (in.advanceExact(docId)) {
                 resize(in.docValueCount());
                 for (int i = 0; i < count; i++) {
@@ -133,9 +114,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
                 }
             } else {
                 resize(0);
-            }
-            if (dates != null) {
-                dates.setNextDocId(docId);
             }
         }
 
@@ -148,35 +126,11 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             values = ArrayUtil.grow(values, count);
         }
 
-        public SortedNumericDocValues getInternalValues() {
-            return this.in;
-        }
-
         public long getValue() {
             if (count == 0) {
                 return 0L;
             }
             return values[0];
-        }
-
-        @Deprecated
-        public ReadableDateTime getDate() throws IOException {
-            deprecated("getDate on numeric fields is deprecated. Use a date field to get dates.");
-            if (dates == null) {
-                dates = new Dates(in);
-                dates.setNextDocId(docId);
-            }
-            return dates.getValue();
-        }
-
-        @Deprecated
-        public List<ReadableDateTime> getDates() throws IOException {
-            deprecated("getDates on numeric fields is deprecated. Use a date field to get dates.");
-            if (dates == null) {
-                dates = new Dates(in);
-                dates.setNextDocId(docId);
-            }
-            return dates;
         }
 
         @Override
@@ -188,22 +142,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         public int size() {
             return count;
         }
-
-        /**
-         * Log a deprecation log, with the server's permissions, not the permissions of the
-         * script calling this method. We need to do this to prevent errors when rolling
-         * the log file.
-         */
-        private void deprecated(String message) {
-            // Intentionally not calling SpecialPermission.check because this is supposed to be called by scripts
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    deprecationCallback.accept(message);
-                    return null;
-                }
-            });
-        }
     }
 
     public static final class Dates extends ScriptDocValues<ReadableDateTime> {
@@ -212,12 +150,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         private static final ReadableDateTime EPOCH = new DateTime(0, DateTimeZone.UTC);
 
         private final SortedNumericDocValues in;
-        /**
-         * Callback for deprecated fields. In production this should always point to
-         * {@link #deprecationLogger} but tests will override it so they can test that
-         * we use the required permissions when calling it.
-         */
-        private final Consumer<String> deprecationCallback;
         /**
          * Values wrapped in {@link MutableDateTime}. Null by default an allocated on first usage so we allocate a reasonably size. We keep
          * this array so we don't have allocate new {@link MutableDateTime}s on every usage. Instead we reuse them for every document.
@@ -229,15 +161,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
          * Standard constructor.
          */
         public Dates(SortedNumericDocValues in) {
-            this(in, deprecationLogger::deprecated);
-        }
-
-        /**
-         * Constructor for testing deprecation logging.
-         */
-        Dates(SortedNumericDocValues in, Consumer<String> deprecationCallback) {
             this.in = in;
-            this.deprecationCallback = deprecationCallback;
         }
 
         /**
@@ -249,24 +173,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
                 return EPOCH;
             }
             return get(0);
-        }
-
-        /**
-         * Fetch the first value. Added for backwards compatibility with 5.x when date fields were {@link Longs}.
-         */
-        @Deprecated
-        public ReadableDateTime getDate() {
-            deprecated("getDate is no longer necessary on date fields as the value is now a date.");
-            return getValue();
-        }
-
-        /**
-         * Fetch all the values. Added for backwards compatibility with 5.x when date fields were {@link Longs}.
-         */
-        @Deprecated
-        public List<ReadableDateTime> getDates() {
-            deprecated("getDates is no longer necessary on date fields as the values are now dates.");
-            return this;
         }
 
         @Override
@@ -325,22 +231,6 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
             for (int i = 0; i < count; i++) {
                 dates[i] = new MutableDateTime(in.nextValue(), DateTimeZone.UTC);
             }
-        }
-
-        /**
-         * Log a deprecation log, with the server's permissions, not the permissions of the
-         * script calling this method. We need to do this to prevent errors when rolling
-         * the log file.
-         */
-        private void deprecated(String message) {
-            // Intentionally not calling SpecialPermission.check because this is supposed to be called by scripts
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    deprecationCallback.accept(message);
-                    return null;
-                }
-            });
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesLongsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesLongsTests.java
@@ -47,7 +47,7 @@ public class ScriptDocValuesLongsTests extends ESTestCase {
                 values[d][i] = randomLong();
             }
         }
-        Longs longs = wrap(values, deprecationMessage -> {fail("unexpected deprecation: " + deprecationMessage);});
+        Longs longs = wrap(values);
 
         for (int round = 0; round < 10; round++) {
             int d = between(0, values.length - 1);
@@ -66,69 +66,7 @@ public class ScriptDocValuesLongsTests extends ESTestCase {
         }
     }
 
-    public void testDates() throws IOException {
-        long[][] values = new long[between(3, 10)][];
-        ReadableDateTime[][] dates = new ReadableDateTime[values.length][];
-        for (int d = 0; d < values.length; d++) {
-            values[d] = new long[randomBoolean() ? randomBoolean() ? 0 : 1 : between(2, 100)];
-            dates[d] = new ReadableDateTime[values[d].length];
-            for (int i = 0; i < values[d].length; i++) {
-                dates[d][i] = new DateTime(randomNonNegativeLong(), DateTimeZone.UTC);
-                values[d][i] = dates[d][i].getMillis();
-            }
-        }
-        Set<String> warnings = new HashSet<>();
-        Longs longs = wrap(values, deprecationMessage -> {
-            warnings.add(deprecationMessage);
-            /* Create a temporary directory to prove we are running with the
-             * server's permissions. */
-            createTempDir();
-        });
-
-        for (int round = 0; round < 10; round++) {
-            int d = between(0, values.length - 1);
-            longs.setNextDocId(d);
-            assertEquals(dates[d].length > 0 ? dates[d][0] : new DateTime(0, DateTimeZone.UTC), longs.getDate());
-
-            assertEquals(values[d].length, longs.getDates().size());
-            for (int i = 0; i < values[d].length; i++) {
-                assertEquals(dates[d][i], longs.getDates().get(i));
-            }
-
-            Exception e = expectThrows(UnsupportedOperationException.class, () -> longs.getDates().add(new DateTime()));
-            assertEquals("doc values are unmodifiable", e.getMessage());
-        }
-
-        /*
-         * Invoke getDates without any privileges to verify that
-         * it still works without any. In particularly, this
-         * verifies that the callback that we've configured
-         * above works. That callback creates a temporary
-         * directory which is not possible with "noPermissions".
-         */
-        PermissionCollection noPermissions = new Permissions();
-        AccessControlContext noPermissionsAcc = new AccessControlContext(
-            new ProtectionDomain[] {
-                new ProtectionDomain(null, noPermissions)
-            }
-        );
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-                try {
-                    longs.getDates();
-                } catch (IOException e) {
-                    throw new RuntimeException("unexpected", e);
-                }
-                return null;
-            }
-        }, noPermissionsAcc);
-
-        assertThat(warnings, containsInAnyOrder(
-                "getDate on numeric fields is deprecated. Use a date field to get dates.",
-                "getDates on numeric fields is deprecated. Use a date field to get dates."));
-    }
-
-    private Longs wrap(long[][] values, Consumer<String> deprecationCallback) {
+    private Longs wrap(long[][] values) {
         return new Longs(new AbstractSortedNumericDocValues() {
             long[] current;
             int i;
@@ -147,6 +85,6 @@ public class ScriptDocValuesLongsTests extends ESTestCase {
             public long nextValue() {
                 return current[i++];
             }
-        }, deprecationCallback);
+        });
     }
 }


### PR DESCRIPTION
The getDate() and getDates() existed prior to 5.x on long fields in
scripting. In 5.x, a new Date type for ScriptDocValues was added. The
getDate() and getDates() methods were left on long fields and added to date
fields to ease the transition. This commit removes those methods for
7.0.

Closes #23008