### PR TITLE
Update readme for testing x-pack code snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,6 +209,14 @@ Before submitting your changes, run the test suite to make sure that nothing is 
 ./gradlew check
 ```
 
+If your changes affect only the documentation, run:
+
+```sh
+./gradlew -p docs check
+```
+For more information about testing code examples in the documentation, see 
+https://github.com/elastic/elasticsearch/blob/master/docs/README.asciidoc
+
 ### Project layout
 
 This repository is split into many top level directories. The most important

--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -6,7 +6,10 @@ See: https://github.com/elastic/docs
 Snippets marked with `// CONSOLE` are automatically annotated with "VIEW IN
 CONSOLE" and "COPY AS CURL" in the documentation and are automatically tested
 by the command `gradle :docs:check`. To test just the docs from a single page,
-use e.g. `gradle :docs:check -Dtests.method="*rollover*"`.
+use e.g. `gradle :docs:check -Dtests.method="\*rollover*"`.
+To test the docs in the x-pack folder, use the command `./gradlew -p x-pack/docs check`.
+
+NOTE: If you have an elasticsearch-extra folder alongside your elasticsearch folder, you must temporarily rename it when you are testing 6.3 or later branches. 
 
 By default each `// CONSOLE` snippet runs as its own isolated test. You can
 manipulate the test execution in the following ways:

--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -7,7 +7,6 @@ Snippets marked with `// CONSOLE` are automatically annotated with "VIEW IN
 CONSOLE" and "COPY AS CURL" in the documentation and are automatically tested
 by the command `gradle :docs:check`. To test just the docs from a single page,
 use e.g. `gradle :docs:check -Dtests.method="\*rollover*"`.
-To test the docs in the x-pack folder, use the command `./gradlew -p x-pack/docs check`.
 
 NOTE: If you have an elasticsearch-extra folder alongside your elasticsearch folder, you must temporarily rename it when you are testing 6.3 or later branches. 
 


### PR DESCRIPTION
This PR updates the README.asciidoc with instructions for testing the code snippets in the elasticsearch/x-pack/docs directory. 