### PR TITLE
Make TransportClusterStateAction abide to our style

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -115,9 +115,9 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
                 mdBuilder = MetaData.builder(currentState.metaData());
             }
 
-            // Filter our metadata that shouldn't be returned by API
-            for(ObjectObjectCursor<String, Custom> custom : currentState.metaData().customs()) {
-                if(!custom.value.context().contains(MetaData.XContentContext.API)) {
+            // filter out metadata that shouldn't be returned by the API
+            for (ObjectObjectCursor<String, Custom> custom : currentState.metaData().customs()) {
+                if (custom.value.context().contains(MetaData.XContentContext.API) == false) {
                     mdBuilder.removeCustom(custom.key);
                 }
             }


### PR DESCRIPTION
I still do not like == false. However, I am so use to reading it that today I read this line of code and could not understand how it could possibly be doing the right thing. It was only when I finally noticed the ! that the code made sense. This commit changes this code to be in our style of == false. I still do not like == false.

