### PR TITLE
[DOCS] Moves X-Pack configuration pages in table of contents

### DIFF
--- a/docs/reference/index-shared1.asciidoc
+++ b/docs/reference/index-shared1.asciidoc
@@ -2,5 +2,3 @@
 include::getting-started.asciidoc[]
 
 include::setup.asciidoc[]
-
-include::upgrade.asciidoc[]

--- a/docs/reference/index-shared2.asciidoc
+++ b/docs/reference/index-shared2.asciidoc
@@ -1,2 +1,4 @@
 
+include::upgrade.asciidoc[]
+
 include::migration/index.asciidoc[]

--- a/x-pack/docs/en/index.asciidoc
+++ b/x-pack/docs/en/index.asciidoc
@@ -3,6 +3,16 @@ include::{es-repo-dir}/index-shared1.asciidoc[]
 
 include::setup/setup-xes.asciidoc[]
 
+include::{xes-repo-dir}/monitoring/configuring-monitoring.asciidoc[]
+
+include::{xes-repo-dir}/security/configuring-es.asciidoc[]
+
+include::setup/setup-xclient.asciidoc[]
+
+include::{xes-repo-dir}/settings/configuring-xes.asciidoc[]
+
+include::setup/bootstrap-checks-xes.asciidoc[]
+
 include::{es-repo-dir}/index-shared2.asciidoc[]
 
 include::{es-repo-dir}/index-shared3.asciidoc[]

--- a/x-pack/docs/en/setup/bootstrap-checks-xes.asciidoc
+++ b/x-pack/docs/en/setup/bootstrap-checks-xes.asciidoc
@@ -1,10 +1,6 @@
 [role="xpack"]
 [[bootstrap-checks-xpack]]
 == Bootstrap Checks for {xpack}
-++++
-<titleabbrev>Bootstrap Checks</titleabbrev>
-++++
-
 
 In addition to the <<bootstrap-checks,{es} bootstrap checks>>, there are
 checks that are specific to {xpack} features.

--- a/x-pack/docs/en/setup/setup-xes.asciidoc
+++ b/x-pack/docs/en/setup/setup-xes.asciidoc
@@ -1,9 +1,7 @@
 [role="xpack"]
 [[setup-xpack]]
-= Set up {xpack}
+== Set up {xpack}
 
-[partintro]
---
 {xpack} is an Elastic Stack extension that provides security, alerting,
 monitoring, reporting, machine learning, and many other capabilities. By default, 
 when you install {es}, {xpack} is installed. 
@@ -20,10 +18,3 @@ https://www.elastic.co/subscriptions.
 * <<settings-xpack>>
 * <<bootstrap-checks-xpack>>
 
---
-
-include::{xes-repo-dir}/monitoring/configuring-monitoring.asciidoc[]
-include::{xes-repo-dir}/security/configuring-es.asciidoc[]
-include::setup-xclient.asciidoc[]
-include::{xes-repo-dir}/settings/configuring-xes.asciidoc[]
-include::bootstrap-checks-xes.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/30665

This PR removes the "Set Up X-Pack" section from the highest level of the Elasticsearch Reference's table of contents.  Instead, that content is moved under the existing "Set Up Elasticsearch" section.  For example:

![es-toc](https://user-images.githubusercontent.com/26471269/40204283-dc5954aa-59dc-11e8-8b84-f4b19f15d808.png)

This is a superficial change, but sets the stage for ultimately moving those source files into the elasticsearch/docs folder. In the long run, I expect the "Set up X-Pack" page to be removed when its contents are merged into the "Set Up Elasticsearch" (or some other appropriate) page.
