### PR TITLE
[DOCS] Fix more edit URLs in Stack Overview

### DIFF
--- a/x-pack/docs/en/ml/configuring.asciidoc
+++ b/x-pack/docs/en/ml/configuring.asciidoc
@@ -34,8 +34,17 @@ The scenarios in this section describe some best practices for generating useful
 * <<ml-configuring-pop>>
 * <<ml-configuring-transform>>
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/customurl.asciidoc
 include::customurl.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/aggregations.asciidoc
 include::aggregations.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/categories.asciidoc
 include::categories.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/populations.asciidoc
 include::populations.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/transforms.asciidoc
 include::transforms.asciidoc[]

--- a/x-pack/docs/en/ml/functions.asciidoc
+++ b/x-pack/docs/en/ml/functions.asciidoc
@@ -18,27 +18,6 @@ variations (for example, `count`, `low_count`, and `high_count`). These variatio
 apply one-sided tests, detecting anomalies only when the values are low or
 high, depending one which alternative is used.
 
-//For some functions, you can optionally specify a field name in the
-//`by_field_name` property. The analysis then considers whether there is an
-//anomaly for one of more specific values of that field. In {kib}, use the
-//**Key Fields** field in multi-metric jobs or the **by_field_name** field in
-//advanced jobs.
-////
-TODO: Per Sophie, "This is incorrect... Split Data refers to a partition_field_name. Over fields can only be added in Adv Config...
-
-Can you please remove the explanations for by/over/partition fields from the documentation for analytical functions. It's a complex topic and will be easier to review in a separate exercise."
-////
-
-//For some functions, you can also optionally specify a field name in the
-//`over_field_name` property. This property shifts the analysis to be population-
-//or peer-based and uses the field to split the data.  In {kib}, use the
-//**Split Data** field in multi-metric jobs or the **over_field_name** field in
-//advanced jobs.
-
-//You can specify a `partition_field_name` with any function. The analysis is then
-//segmented with completely independent baselines for each value of that field.
-//In {kib}, use the **partition_field_name** field in advanced jobs.
-
 You can specify a `summary_count_field_name` with any function except `metric`.
 When you use `summary_count_field_name`, the {ml} features expect the input
 data to be pre-aggregated. The value of the `summary_count_field_name` field
@@ -55,13 +34,6 @@ functions are strongly affected by empty buckets. For this reason, there are
 `non_null_sum` and `non_zero_count` functions, which are tolerant to sparse data.
 These functions effectively ignore empty buckets.
 
-////
-Some functions can benefit from overlapping buckets. This improves the overall
-accuracy of the results but at the cost of a 2 bucket delay in seeing the results.
-
-The table below provides a high-level summary of the analytical functions provided by the API. Each of the functions is described in detail over the following pages. Note the examples given in these pages use single Detector Configuration objects.
-////
-
 * <<ml-count-functions>>
 * <<ml-geo-functions>>
 * <<ml-info-functions>>
@@ -70,10 +42,23 @@ The table below provides a high-level summary of the analytical functions provid
 * <<ml-sum-functions>>
 * <<ml-time-functions>>
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/count.asciidoc
 include::functions/count.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/geo.asciidoc
 include::functions/geo.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/info.asciidoc
 include::functions/info.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/metric.asciidoc
 include::functions/metric.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/rare.asciidoc
 include::functions/rare.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/sum.asciidoc
 include::functions/sum.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions/time.asciidoc
 include::functions/time.asciidoc[]

--- a/x-pack/docs/en/ml/getting-started.asciidoc
+++ b/x-pack/docs/en/ml/getting-started.asciidoc
@@ -72,9 +72,20 @@ significant changes to the system. You can alternatively assign the
 
 For more information, see <<built-in-roles>> and <<privileges-list-cluster>>.
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-data.asciidoc
 include::getting-started-data.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-wizards.asciidoc
 include::getting-started-wizards.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-single.asciidoc
 include::getting-started-single.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-multi.asciidoc
 include::getting-started-multi.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-forecast.asciidoc
 include::getting-started-forecast.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-next.asciidoc
 include::getting-started-next.asciidoc[]

--- a/x-pack/docs/en/ml/overview.asciidoc
+++ b/x-pack/docs/en/ml/overview.asciidoc
@@ -17,4 +17,5 @@ include::calendars.asciidoc[]
 There are a few concepts that are core to {ml} in {xpack}. Understanding these
 concepts from the outset will tremendously help ease the learning process.
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/architecture.asciidoc
 include::architecture.asciidoc[]

--- a/x-pack/docs/en/security/authentication/overview.asciidoc
+++ b/x-pack/docs/en/security/authentication/overview.asciidoc
@@ -24,28 +24,41 @@ attach your user credentials to the requests sent to {es}. For example, when
 using realms that support usernames and passwords you can simply attach 
 {wikipedia}/Basic_access_authentication[basic auth] header to the requests.
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/built-in-users.asciidoc
 include::built-in-users.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/internal-users.asciidoc
 include::internal-users.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/realms.asciidoc
 include::realms.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/active-directory-realm.asciidoc
 include::active-directory-realm.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/file-realm.asciidoc
 include::file-realm.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/ldap-realm.asciidoc
 include::ldap-realm.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/native-realm.asciidoc
 include::native-realm.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/pki-realm.asciidoc
 include::pki-realm.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/saml-realm.asciidoc
 include::saml-realm.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/custom-realm.asciidoc
 include::custom-realm.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/anonymous-access.asciidoc
 include::anonymous-access.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/user-cache.asciidoc
 include::user-cache.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/saml-guide.asciidoc
 include::saml-guide.asciidoc[]

--- a/x-pack/docs/en/security/authorization/overview.asciidoc
+++ b/x-pack/docs/en/security/authorization/overview.asciidoc
@@ -49,18 +49,26 @@ As an administrator, you will need to define the roles that you want to use,
 then assign users to the roles. These can be assigned to users in a number of
 ways depending on the realms by which the users are authenticated.
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
 include::built-in-roles.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/managing-roles.asciidoc
 include::managing-roles.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/privileges.asciidoc
 include::privileges.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
 include::alias-privileges.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
 include::mapping-roles.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
 include::field-and-document-access-control.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/run-as-privilege.asciidoc
 include::run-as-privilege.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/custom-roles-provider.asciidoc
 include::custom-roles-provider.asciidoc[]

--- a/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
@@ -32,14 +32,20 @@ or at least communicate with the cluster in a secured way:
 * {kibana-ref}/secure-reporting.html[Reporting]
 * {winlogbeat-ref}/securing-beats.html[Winlogbeat]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
 include::ccs-clients-integrations/cross-cluster.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/java.asciidoc
 include::ccs-clients-integrations/java.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/http.asciidoc
 include::ccs-clients-integrations/http.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/hadoop.asciidoc
 include::ccs-clients-integrations/hadoop.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/beats.asciidoc
 include::ccs-clients-integrations/beats.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations/monitoring.asciidoc
 include::ccs-clients-integrations/monitoring.asciidoc[]

--- a/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/cross-cluster.asciidoc
@@ -155,4 +155,5 @@ GET two:logs-2017.04/_search <1>
 // TEST[skip:todo]
 //TBD: Is there a missing description of the <1> callout above?
 
+:edit_url: https://github.com/elastic/kibana/edit/{branch}/x-pack/docs/en/security/cross-cluster-kibana.asciidoc
 include::{xkb-repo-dir}/security/cross-cluster-kibana.asciidoc[]

--- a/x-pack/docs/en/security/reference.asciidoc
+++ b/x-pack/docs/en/security/reference.asciidoc
@@ -7,4 +7,5 @@
 * {ref}/security-api.html[Security API]
 * {ref}/xpack-commands.html[Security Commands]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/reference/files.asciidoc
 include::reference/files.asciidoc[]

--- a/x-pack/docs/en/security/securing-communications.asciidoc
+++ b/x-pack/docs/en/security/securing-communications.asciidoc
@@ -17,6 +17,7 @@ This section shows how to:
 The authentication of new nodes helps prevent a rogue node from joining the
 cluster and receiving data through replication.
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/securing-communications/setting-up-ssl.asciidoc
 include::securing-communications/setting-up-ssl.asciidoc[]
 
 //TO-DO: These sections can be removed when all links to them are removed.

--- a/x-pack/docs/en/security/securing-communications/securing-elasticsearch.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/securing-elasticsearch.asciidoc
@@ -29,8 +29,17 @@ information, see <<security-settings>>.
 For more information about encrypting communications across the Elastic Stack,
 see {xpack-ref}/encrypting-communications.html[Encrypting Communications].
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/securing-communications/node-certificates.asciidoc
 include::node-certificates.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/securing-communications/tls-transport.asciidoc
 include::tls-transport.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/securing-communications/tls-http.asciidoc
 include::tls-http.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/securing-communications/tls-ad.asciidoc
 include::tls-ad.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/securing-communications/tls-ldap.asciidoc
 include::tls-ldap.asciidoc[]

--- a/x-pack/docs/en/watcher/actions.asciidoc
+++ b/x-pack/docs/en/watcher/actions.asciidoc
@@ -259,20 +259,28 @@ PUT _xpack/watcher/watch/log_event_watch
 <1> A `condition` that only applies to the `notify_pager` action, which
     restricts its execution to when the condition succeeds (at least 5 hits in this case).
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/email.asciidoc
 include::actions/email.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/webhook.asciidoc
 include::actions/webhook.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/index.asciidoc
 include::actions/index.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/logging.asciidoc
 include::actions/logging.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/hipchat.asciidoc
 include::actions/hipchat.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/slack.asciidoc
 include::actions/slack.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/pagerduty.asciidoc
 include::actions/pagerduty.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/actions/jira.asciidoc
 include::actions/jira.asciidoc[]
 
 [float]

--- a/x-pack/docs/en/watcher/condition.asciidoc
+++ b/x-pack/docs/en/watcher/condition.asciidoc
@@ -28,12 +28,17 @@ conditions are met.
 In addition to the watch wide condition, you can also configure conditions
 per <<action-conditions, action>>.
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/always.asciidoc
 include::condition/always.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/never.asciidoc
 include::condition/never.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/compare.asciidoc
 include::condition/compare.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/array-compare.asciidoc
 include::condition/array-compare.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/condition/script.asciidoc
 include::condition/script.asciidoc[]

--- a/x-pack/docs/en/watcher/example-watches.asciidoc
+++ b/x-pack/docs/en/watcher/example-watches.asciidoc
@@ -9,6 +9,8 @@ For more example watches you can use as a starting point for building custom
 watches, see the https://github.com/elastic/examples/tree/master/Alerting[Example
 Watches] in the Elastic Examples repo.
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/example-watches/example-watch-clusterstatus.asciidoc
 include::example-watches/example-watch-clusterstatus.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/example-watches/example-watch-meetupdata.asciidoc
 include::example-watches/example-watch-meetupdata.asciidoc[]

--- a/x-pack/docs/en/watcher/input.asciidoc
+++ b/x-pack/docs/en/watcher/input.asciidoc
@@ -19,10 +19,14 @@ execution context.
 NOTE: If you don't define an input for a watch, an empty payload is loaded
       into the execution context.
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/input/simple.asciidoc
 include::input/simple.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/input/search.asciidoc
 include::input/search.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/input/http.asciidoc
 include::input/http.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/input/chain.asciidoc
 include::input/chain.asciidoc[]

--- a/x-pack/docs/en/watcher/java.asciidoc
+++ b/x-pack/docs/en/watcher/java.asciidoc
@@ -101,20 +101,29 @@ XPackClient xpackClient = new XPackClient(client);
 WatcherClient watcherClient = xpackClient.watcher();
 --------------------------------------------------
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java/put-watch.asciidoc
 include::java/put-watch.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java/get-watch.asciidoc
 include::java/get-watch.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java/delete-watch.asciidoc
 include::java/delete-watch.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java/execute-watch.asciidoc
 include::java/execute-watch.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java/ack-watch.asciidoc
 include::java/ack-watch.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java/activate-watch.asciidoc
 include::java/activate-watch.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java/deactivate-watch.asciidoc
 include::java/deactivate-watch.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java/stats.asciidoc
 include::java/stats.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/java/service.asciidoc
 include::java/service.asciidoc[]

--- a/x-pack/docs/en/watcher/transform.asciidoc
+++ b/x-pack/docs/en/watcher/transform.asciidoc
@@ -55,8 +55,11 @@ part of the definition of the `my_webhook` action.
 <1> A watch level `transform`
 <2> An action level `transform`
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/transform/search.asciidoc
 include::transform/search.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/transform/script.asciidoc
 include::transform/script.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/transform/chain.asciidoc
 include::transform/chain.asciidoc[]

--- a/x-pack/docs/en/watcher/trigger.asciidoc
+++ b/x-pack/docs/en/watcher/trigger.asciidoc
@@ -9,4 +9,5 @@ the trigger and triggering the watch when needed.
 {watcher} is designed to support different types of triggers, but only time-based
 <<trigger-schedule, `schedule`>> triggers are currently available.
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/trigger/schedule.asciidoc
 include::trigger/schedule.asciidoc[]

--- a/x-pack/docs/en/watcher/trigger/schedule.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule.asciidoc
@@ -26,16 +26,23 @@ once per minute. For more information about throttling, see
 * <<schedule-cron, `cron`>>
 * <<schedule-interval, `interval`>>
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/hourly.asciidoc
 include::schedule/hourly.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/daily.asciidoc
 include::schedule/daily.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/weekly.asciidoc
 include::schedule/weekly.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/monthly.asciidoc
 include::schedule/monthly.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/yearly.asciidoc
 include::schedule/yearly.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/cron.asciidoc
 include::schedule/cron.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/schedule/interval.asciidoc
 include::schedule/interval.asciidoc[]


### PR DESCRIPTION
This PR explicitly sets more occurrences of the :edit_url: attribute, since the "edit" link was not working for pages in the Stack Overview that were pulled from the elasticsearch repo. 