### PR TITLE
Change required version for Get Settings transport API changes to 6.4.0

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -71,7 +71,7 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         names = in.readStringArray();
         humanReadable = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
             includeDefaults = in.readBoolean();
         }
     }
@@ -83,7 +83,7 @@ public class GetSettingsRequest extends MasterNodeReadRequest<GetSettingsRequest
         indicesOptions.writeIndicesOptions(out);
         out.writeStringArray(names);
         out.writeBoolean(humanReadable);
-        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
             out.writeBoolean(includeDefaults);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -114,7 +114,7 @@ public class GetSettingsResponse extends ActionResponse implements ToXContentObj
         }
         ImmutableOpenMap.Builder<String, Settings> defaultSettingsBuilder = ImmutableOpenMap.builder();
 
-        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0_alpha1)) {
+        if (in.getVersion().onOrAfter(org.elasticsearch.Version.V_6_4_0)) {
             int defaultSettingsSize = in.readVInt();
             for (int i = 0; i < defaultSettingsSize ; i++) {
                 defaultSettingsBuilder.put(in.readString(), Settings.readSettingsFromStream(in));
@@ -132,7 +132,7 @@ public class GetSettingsResponse extends ActionResponse implements ToXContentObj
             out.writeString(cursor.key);
             Settings.writeSettingsToStream(cursor.value, out);
         }
-        if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_7_0_0_alpha1)) {
+        if (out.getVersion().onOrAfter(org.elasticsearch.Version.V_6_4_0)) {
             out.writeVInt(indexToDefaultSettings.size());
             for (ObjectObjectCursor<String, Settings> cursor : indexToDefaultSettings) {
                 out.writeString(cursor.key);


### PR DESCRIPTION
Get Settings API changes have now been backported to version 6.4, and
therefore the latest version must send and expect the extra fields when
communicating with 6.4+ code.

Relates #29229 #30494
