### PR TITLE
[Security] Include an empty json object in an json array when FLS filters out all fields

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
@@ -195,6 +195,8 @@ public final class FieldSubsetReader extends FilterLeafReader {
                 Map<String, Object> filteredValue = filter((Map<String, ?>)value, includeAutomaton, state);
                 if (filteredValue.isEmpty() == false) {
                     filtered.add(filteredValue);
+                } else {
+                    filtered.add(new HashMap<>());
                 }
             } else if (value instanceof Iterable) {
                 List<Object> filteredValue = filter((Iterable<?>) value, includeAutomaton, initialState);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReader.java
@@ -193,11 +193,7 @@ public final class FieldSubsetReader extends FilterLeafReader {
                     continue;
                 }
                 Map<String, Object> filteredValue = filter((Map<String, ?>)value, includeAutomaton, state);
-                if (filteredValue.isEmpty() == false) {
-                    filtered.add(filteredValue);
-                } else {
-                    filtered.add(new HashMap<>());
-                }
+                filtered.add(filteredValue);
             } else if (value instanceof Iterable) {
                 List<Object> filteredValue = filter((Iterable<?>) value, includeAutomaton, initialState);
                 if (filteredValue.isEmpty() == false) {


### PR DESCRIPTION
Prior to this change an json array element with no fields would be omitted from json array.
Nested inner hits source filtering relies on the fact that the json array element numbering
remains untouched and this causes AOOB exceptions on the ES side during the fetch phase
without this change.

Closes #30624