### PR TITLE
Ignore empty completion input

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -449,6 +449,10 @@ public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapp
         // index
         for (Map.Entry<String, CompletionInputMetaData> completionInput : inputMap.entrySet()) {
             String input = completionInput.getKey();
+            if (input.trim().isEmpty()) {
+                context.addIgnoredField(fieldType.name());
+                continue;
+            }
             // truncate input
             if (input.length() > maxInputLength) {
                 int len = Math.min(maxInputLength, input.length());

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -397,6 +397,19 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
             assertThat(cause, instanceOf(IllegalArgumentException.class));
             assertThat(cause.getMessage(), containsString("[0x1e]"));
         }
+
+        // empty inputs are ignored
+        ParsedDocument doc = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
+                .bytes(XContentFactory.jsonBuilder()
+                    .startObject()
+                    .array("completion", "   ", "")
+                    .endObject()),
+            XContentType.JSON));
+        assertThat(doc.docs().size(), equalTo(1));
+        assertNull(doc.docs().get(0).get("completion"));
+        assertNotNull(doc.docs().get(0).getField("_ignored"));
+        IndexableField ignoredFields = doc.docs().get(0).getField("_ignored");
+        assertThat(ignoredFields.stringValue(), equalTo("completion"));
     }
 
     public void testPrefixQueryType() throws Exception {


### PR DESCRIPTION
This change makes sure that an empty completion input does not throw an IAE when indexing.
Instead the input is ignored and the completion field is added in the list of ignored fields
for the document.

Closes #23121