### PR TITLE
[ML][TEST] Fix bucket count assertion in ModelPlotsIT

### DIFF
--- a/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
+++ b/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
@@ -30,7 +30,9 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
 
@@ -83,7 +85,11 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
         startDatafeed(datafeedId, 0, System.currentTimeMillis());
         waitUntilJobIsClosed(job.getId());
 
-        assertThat(getBuckets(job.getId()).size(), equalTo(23));
+        // As the initial time is random, there's a chance the first record is
+        // aligned on a bucket start. Thus we check the buckets are in [23, 24]
+        assertThat(getBuckets(job.getId()).size(), greaterThanOrEqualTo(23));
+        assertThat(getBuckets(job.getId()).size(), lessThanOrEqualTo(24));
+
         Set<String> modelPlotTerms = modelPlotTerms(job.getId(), "partition_field_value");
         assertThat(modelPlotTerms, containsInAnyOrder("user_1", "user_2", "user_3"));
     }
@@ -101,7 +107,11 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
         startDatafeed(datafeedId, 0, System.currentTimeMillis());
         waitUntilJobIsClosed(job.getId());
 
-        assertThat(getBuckets(job.getId()).size(), equalTo(23));
+        // As the initial time is random, there's a chance the first record is
+        // aligned on a bucket start. Thus we check the buckets are in [23, 24]
+        assertThat(getBuckets(job.getId()).size(), greaterThanOrEqualTo(23));
+        assertThat(getBuckets(job.getId()).size(), lessThanOrEqualTo(24));
+
         Set<String> modelPlotTerms = modelPlotTerms(job.getId(), "partition_field_value");
         assertThat(modelPlotTerms, containsInAnyOrder("user_2", "user_3"));
     }


### PR DESCRIPTION
As the first record is random, there's a chance it will
be aligned on a bucket start. Thus we need to check the
bucket count is in [23, 24].

Closes #30715 