### PR TITLE
Fix docs failure on language analyzers

### DIFF
--- a/docs/reference/analysis/analyzers/lang-analyzer.asciidoc
+++ b/docs/reference/analysis/analyzers/lang-analyzer.asciidoc
@@ -378,7 +378,8 @@ PUT /catalan_example
       "filter": {
         "catalan_elision": {
           "type":       "elision",
-          "articles":   [ "d", "l", "m", "n", "s", "t"]
+          "articles":   [ "d", "l", "m", "n", "s", "t"],
+          "articles_case": true
         },
         "catalan_stop": {
           "type":       "stop",
@@ -1156,7 +1157,8 @@ PUT /italian_example
                 "nell", "sull", "coll", "pell",
                 "gl", "agl", "dagl", "degl", "negl",
                 "sugl", "un", "m", "t", "s", "v", "d"
-          ]
+          ],
+          "articles_case": true
         },
         "italian_stop": {
           "type":       "stop",


### PR DESCRIPTION
This commit fixes docs failure on language analyzers when compared to the built in analyzers.
The `elision` filters used by the rebuilt language analyzers should be case insensitive to match
the definition of the prebuilt analyzers.

Closes #30557