### PR TITLE
[Docs] Fix single page :docs:check invocation

### DIFF
--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -6,7 +6,7 @@ See: https://github.com/elastic/docs
 Snippets marked with `// CONSOLE` are automatically annotated with "VIEW IN
 CONSOLE" and "COPY AS CURL" in the documentation and are automatically tested
 by the command `gradle :docs:check`. To test just the docs from a single page,
-use e.g. `gradle :docs:check -Dtests.method="\*rollover*"`.
+use e.g. `gradle :docs:check -Dtests.method="*rollover*"`.
 
 By default each `// CONSOLE` snippet runs as its own isolated test. You can
 manipulate the test execution in the following ways:


### PR DESCRIPTION
The docs/README shows how to run the :docs:check goal on a subset of pages,
however using the current example fails. Removing the masking character before
the first wildcard fixes the problem.