### PR TITLE
[TEST] Reduce forecast overflow to disk test memory limit

### DIFF
--- a/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
+++ b/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ForecastIT.java
@@ -217,7 +217,7 @@ public class ForecastIT extends MlNativeAutodetectIntegTestCase {
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         dataDescription.setTimeFormat("epoch");
         Job.Builder job = new Job.Builder("forecast-it-test-overflow-to-disk");
-        AnalysisLimits limits = new AnalysisLimits(2048L, null);
+        AnalysisLimits limits = new AnalysisLimits(1200L, null);
         job.setAnalysisLimits(limits);
         job.setAnalysisConfig(analysisConfig);
         job.setDataDescription(dataDescription);


### PR DESCRIPTION
By default ML native processes are only allowed to use
30% of RAM, so the previous 2GB setting prevented the
test passing on VMs with only 4GB RAM.  This change
reduces the limit to 1200MB, which means it can now
pass on VMs with 4GB RAM.

Relates #30399