### PR TITLE
create-index: Update default primary shards count

### DIFF
--- a/docs/reference/indices/create-index.asciidoc
+++ b/docs/reference/indices/create-index.asciidoc
@@ -25,7 +25,7 @@ PUT twitter
 }
 --------------------------------------------------
 // CONSOLE
-<1> Default for `number_of_shards` is 5
+<1> Default for `number_of_shards` is 1
 <2> Default for `number_of_replicas` is 1 (ie one replica for each primary shard)
 
 The above second curl example shows how an index called `twitter` can be


### PR DESCRIPTION
Update the default number of primary shards to match doc update work done in 4852f34d324408176bbd3857b79af4e66c65621a for PR elastic/elasticsearch#30539.

refs elastic/elasticsearch#30746

Closes #30746 

