### PR TITLE
Changes PhaseAfterStep to take the name of the previous phase

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicy.java
@@ -178,15 +178,19 @@ public class LifecyclePolicy extends AbstractDiffable<LifecyclePolicy>
         // add steps for each phase, in reverse
         while (phaseIterator.hasPrevious()) {
 
+            Phase previousPhase = phaseIterator.previous();
+
             // add `after` step for phase before next
             if (phase != null) {
-                Step.StepKey afterStepKey = new Step.StepKey(phase.getName(), "pre-" + lastStepKey.getAction(), "after");
+                // after step should have the name of the previous phase since the index is still in the 
+                // previous phase until the after condition is reached
+                Step.StepKey afterStepKey = new Step.StepKey(previousPhase.getName(), PhaseAfterStep.NAME, PhaseAfterStep.NAME);
                 Step phaseAfterStep = new PhaseAfterStep(nowSupplier, phase.getAfter(), afterStepKey, lastStepKey);
                 steps.add(phaseAfterStep);
                 lastStepKey = phaseAfterStep.getKey();
             }
 
-            phase = phaseIterator.previous();
+            phase = previousPhase;
             List<LifecycleAction> orderedActions = type.getOrderedActions(phase);
             ListIterator<LifecycleAction> actionIterator = orderedActions.listIterator(orderedActions.size());
             // add steps for each action, in reverse
@@ -203,7 +207,8 @@ public class LifecyclePolicy extends AbstractDiffable<LifecyclePolicy>
         }
 
         if (phase != null) {
-            Step.StepKey afterStepKey = new Step.StepKey(phase.getName(), "pre-" + lastStepKey.getAction(), "after");
+            // The very first after step is in a phase before the hot phase so call this "new"
+            Step.StepKey afterStepKey = new Step.StepKey("new", PhaseAfterStep.NAME, PhaseAfterStep.NAME);
             Step phaseAfterStep = new PhaseAfterStep(nowSupplier, phase.getAfter(), afterStepKey, lastStepKey);
             steps.add(phaseAfterStep);
             lastStepKey = phaseAfterStep.getKey();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/PhaseAfterStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/PhaseAfterStep.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.function.LongSupplier;
 
 public class PhaseAfterStep extends ClusterStateWaitStep {
+    public static final String NAME = "after";
     private final TimeValue after;
     private final LongSupplier nowSupplier;
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/LifecyclePolicyTests.java
@@ -135,7 +135,7 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
         phases.put(firstPhase.getName(), firstPhase);
         LifecyclePolicy policy = new LifecyclePolicy(TestLifecycleType.INSTANCE, lifecycleName, phases);
         StepKey firstStepKey = InitializePolicyContextStep.KEY;
-        StepKey secondStepKey = new StepKey("test", "pre-test", "after");
+        StepKey secondStepKey = new StepKey("new", PhaseAfterStep.NAME, PhaseAfterStep.NAME);
         List<Step> steps = policy.toSteps(client, nowSupplier);
         assertThat(steps.size(), equalTo(4));
         assertSame(steps.get(0).getKey(), firstStepKey);
@@ -151,10 +151,11 @@ public class LifecyclePolicyTests extends AbstractSerializingTestCase<LifecycleP
         Client client = mock(Client.class);
         LongSupplier nowSupplier = () -> 0L;
         MockStep secondActionStep = new MockStep(new StepKey("second_phase", "test2", "test"), TerminalPolicyStep.KEY);
-        MockStep secondAfter = new MockStep(new StepKey("second_phase", "pre-test2", "after"), secondActionStep.getKey());
+        MockStep secondAfter = new MockStep(new StepKey("first_phase", PhaseAfterStep.NAME, PhaseAfterStep.NAME),
+                secondActionStep.getKey());
         MockStep firstActionAnotherStep = new MockStep(new StepKey("first_phase", "test", "bar"), secondAfter.getKey());
         MockStep firstActionStep = new MockStep(new StepKey("first_phase", "test", "foo"), firstActionAnotherStep.getKey());
-        MockStep firstAfter = new MockStep(new StepKey("first_phase", "pre-test", "after"), firstActionStep.getKey());
+        MockStep firstAfter = new MockStep(new StepKey("new", PhaseAfterStep.NAME, PhaseAfterStep.NAME), firstActionStep.getKey());
         MockStep init = new MockStep(InitializePolicyContextStep.KEY, firstAfter.getKey());
 
         lifecycleName = randomAlphaOfLengthBetween(1, 20);

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/index_lifecycle/20_move_to_step.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/index_lifecycle/20_move_to_step.yml
@@ -76,8 +76,8 @@ teardown:
         index: "my_index"
         body:
           current_step:
-            phase: "hot"
-            action: "pre-pre-readonly"
+            phase: "new"
+            action: "after"
             name: "after"
           next_step:
             phase: "warm"
@@ -118,8 +118,8 @@ teardown:
         index: my_index
   - match: { my_index.settings.index.lifecycle.name: "my_moveable_timeseries_lifecycle" }
   - match: { my_index.settings.index.lifecycle.step: "after" }
-  - match: { my_index.settings.index.lifecycle.action: "pre-pre-readonly" }
-  - match: { my_index.settings.index.lifecycle.phase: "hot" }
+  - match: { my_index.settings.index.lifecycle.action: "after" }
+  - match: { my_index.settings.index.lifecycle.phase: "new" }
 
 ---
 "Test Invalid Move To Step With Invalid Next Step":
@@ -130,8 +130,8 @@ teardown:
         index: "my_index"
         body:
           current_step:
-            phase: "hot"
-            action: "pre-pre-readonly"
+            phase: "new"
+            action: "after"
             name: "after"
           next_step:
             phase: "invalid"
@@ -146,8 +146,8 @@ teardown:
         index: my_index
   - match: { my_index.settings.index.lifecycle.name: "my_moveable_timeseries_lifecycle" }
   - match: { my_index.settings.index.lifecycle.step: "after" }
-  - match: { my_index.settings.index.lifecycle.action: "pre-pre-readonly" }
-  - match: { my_index.settings.index.lifecycle.phase: "hot" }
+  - match: { my_index.settings.index.lifecycle.action: "after" }
+  - match: { my_index.settings.index.lifecycle.phase: "new" }
 
 ---
 "Test Invalid Move To Step With Invalid Policy":


### PR DESCRIPTION
This changes the way the phase after step is built so its key has the
phase name of the phase that preceeds it rather than the phase that
follows it. This is more intuitive to the user since the index is in
the warm phase until the after condition for the cold phase is met.