### PR TITLE
Reduce CLI scripts to one-liners on Windows

### DIFF
--- a/distribution/src/bin/elasticsearch-cli.bat
+++ b/distribution/src/bin/elasticsearch-cli.bat
@@ -1,0 +1,22 @@
+call "%~dp0elasticsearch-env.bat" || exit /b 1
+
+if defined ES_ADDITIONAL_SOURCES (
+  for %%a in ("%ES_ADDITIONAL_SOURCES:;=","%") do (
+    call %~dp0%%a
+  )
+)
+
+for /f "tokens=1*" %%a in ("%*") do (
+ set main_class=%%a
+ set arguments=%%b
+)
+
+%JAVA% ^
+  %ES_JAVA_OPTS% ^
+  -Des.path.home="%ES_HOME%" ^
+  -Des.path.conf="%ES_PATH_CONF%" ^
+  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
+  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
+  -cp "%ES_CLASSPATH%" ^
+  %main_class% ^
+  %arguments%

--- a/distribution/src/bin/elasticsearch-cli.bat
+++ b/distribution/src/bin/elasticsearch-cli.bat
@@ -7,8 +7,8 @@ if defined ES_ADDITIONAL_SOURCES (
 )
 
 for /f "tokens=1*" %%a in ("%*") do (
- set main_class=%%a
- set arguments=%%b
+  set main_class=%%a
+  set arguments=%%b
 )
 
 %JAVA% ^

--- a/distribution/src/bin/elasticsearch-keystore.bat
+++ b/distribution/src/bin/elasticsearch-keystore.bat
@@ -3,17 +3,10 @@
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
-  org.elasticsearch.common.settings.KeyStoreCli ^
-  %*
+call "%~dp0elasticsearch-cli.bat" ^
+   org.elasticsearch.common.settings.KeyStoreCli ^
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/distribution/src/bin/elasticsearch-plugin.bat
+++ b/distribution/src/bin/elasticsearch-plugin.bat
@@ -3,17 +3,10 @@
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
+call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.plugins.PluginCli ^
-  %*
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/distribution/src/bin/elasticsearch-translog.bat
+++ b/distribution/src/bin/elasticsearch-translog.bat
@@ -3,17 +3,10 @@
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
+call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.index.translog.TranslogToolCli ^
-  %*
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
@@ -7,19 +7,11 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-call "%~dp0x-pack-security-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
+set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
+call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.core.ssl.CertificateGenerateTool ^
-  %*
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
@@ -9,7 +9,7 @@ setlocal enableextensions
 
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-   org.elasticsearch.xpack.core.ssl.CertificateTool ^
+  org.elasticsearch.xpack.core.ssl.CertificateTool ^
   %* ^
   || exit /b 1
 

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
@@ -7,19 +7,11 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-call "%~dp0x-pack-security-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
-  org.elasticsearch.xpack.core.ssl.CertificateTool ^
-  %*
+set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
+call "%~dp0elasticsearch-cli.bat" ^
+   org.elasticsearch.xpack.core.ssl.CertificateTool ^
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
@@ -7,19 +7,11 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-call "%~dp0x-pack-security-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
+set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
+call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.authc.esnative.ESNativeRealmMigrateTool ^
-  %*
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
@@ -7,19 +7,6 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-call "%~dp0x-pack-security-env.bat" || exit /b 1
-
-@echo off
-
-rem Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-rem or more contributor license agreements. Licensed under the Elastic License;
-rem you may not use this file except in compliance with the Elastic License.
-
-setlocal enabledelayedexpansion
-setlocal enableextensions
-
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand ^

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
@@ -11,15 +11,20 @@ call "%~dp0elasticsearch-env.bat" || exit /b 1
 
 call "%~dp0x-pack-security-env.bat" || exit /b 1
 
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
+@echo off
+
+rem Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+rem or more contributor license agreements. Licensed under the Elastic License;
+rem you may not use this file except in compliance with the Elastic License.
+
+setlocal enabledelayedexpansion
+setlocal enableextensions
+
+set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
+call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand ^
-  %*
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
@@ -7,19 +7,11 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-call "%~dp0x-pack-security-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
+set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
+call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.authc.esnative.tool.SetupPasswordTool ^
-  %*
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
@@ -7,19 +7,11 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-call "%~dp0x-pack-security-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
+set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
+call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.crypto.tool.SystemKeyTool ^
-  %*
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
@@ -7,19 +7,11 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-call "%~dp0x-pack-security-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
+set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
+call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.authc.file.tool.UsersTool ^
-  %*
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/x-pack/plugin/security/src/main/bin/x-pack-security-env.bat
+++ b/x-pack/plugin/security/src/main/bin/x-pack-security-env.bat
@@ -2,6 +2,4 @@ rem Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 rem or more contributor license agreements. Licensed under the Elastic License;
 rem you may not use this file except in compliance with the Elastic License.
 
-call "%~dp0x-pack-env.bat" || exit /b 1
-
 set ES_CLASSPATH=!ES_CLASSPATH!;!ES_HOME!/modules/x-pack-security/*

--- a/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
+++ b/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
@@ -7,19 +7,11 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
-call "%~dp0elasticsearch-env.bat" || exit /b 1
-
-call "%~dp0x-pack-watcher-env.bat" || exit /b 1
-
-%JAVA% ^
-  %ES_JAVA_OPTS% ^
-  -Des.path.home="%ES_HOME%" ^
-  -Des.path.conf="%ES_PATH_CONF%" ^
-  -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
-  -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
-  -cp "%ES_CLASSPATH%" ^
+set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-watcher-env
+call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.watcher.trigger.schedule.tool.CronEvalTool ^
-  %*
+  %* ^
+  || exit /b 1
 
 endlocal
 endlocal

--- a/x-pack/plugin/watcher/src/main/bin/x-pack-watcher-env.bat
+++ b/x-pack/plugin/watcher/src/main/bin/x-pack-watcher-env.bat
@@ -2,6 +2,4 @@ rem Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 rem or more contributor license agreements. Licensed under the Elastic License;
 rem you may not use this file except in compliance with the Elastic License.
 
-call "%~dp0x-pack-env.bat" || exit /b 1
-
 set ES_CLASSPATH=!ES_CLASSPATH!;!ES_HOME!/modules/x-pack-watcher/*


### PR DESCRIPTION
This commit reduces the Windows CLI scripts to one-liners by moving all of the redundant logic to an elasticsearch-cli script. This commit is only the Windows side, a previous commit covered the Linux side.

Relates #30759 