### PR TITLE
[TEST] remove endless waits in RestClientTests

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
@@ -27,11 +27,13 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.client.RestClientTestUtil.getHttpMethods;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -57,17 +59,20 @@ public class RestClientTests extends RestClientTestCase {
             restClient.performRequestAsync(new Request("unsupported", randomAsciiLettersOfLength(5)), new ResponseListener() {
                 @Override
                 public void onSuccess(Response response) {
-                    fail("should have failed because of unsupported method");
+                    throw new UnsupportedOperationException("onSuccess cannot be called when using a mocked http client");
                 }
 
                 @Override
                 public void onFailure(Exception exception) {
-                    assertThat(exception, instanceOf(UnsupportedOperationException.class));
-                    assertEquals("http method not supported: unsupported", exception.getMessage());
-                    latch.countDown();
+                    try {
+                        assertThat(exception, instanceOf(UnsupportedOperationException.class));
+                        assertEquals("http method not supported: unsupported", exception.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
                 }
             });
-            latch.await();
+            assertTrue("time out waiting for request to return", latch.await(1000, TimeUnit.MILLISECONDS));
         }
     }
 
@@ -81,17 +86,20 @@ public class RestClientTests extends RestClientTestCase {
             restClient.performRequestAsync("unsupported", randomAsciiLettersOfLength(5), new ResponseListener() {
                 @Override
                 public void onSuccess(Response response) {
-                    fail("should have failed because of unsupported method");
+                    throw new UnsupportedOperationException("onSuccess cannot be called when using a mocked http client");
                 }
 
                 @Override
                 public void onFailure(Exception exception) {
-                    assertThat(exception, instanceOf(UnsupportedOperationException.class));
-                    assertEquals("http method not supported: unsupported", exception.getMessage());
-                    latch.countDown();
+                    try {
+                        assertThat(exception, instanceOf(UnsupportedOperationException.class));
+                        assertEquals("http method not supported: unsupported", exception.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
                 }
             });
-            latch.await();
+            assertTrue("time out waiting for request to return", latch.await(1000, TimeUnit.MILLISECONDS));
         }
     }
 
@@ -105,17 +113,20 @@ public class RestClientTests extends RestClientTestCase {
             restClient.performRequestAsync(randomAsciiLettersOfLength(5), randomAsciiLettersOfLength(5), null, new ResponseListener() {
                 @Override
                 public void onSuccess(Response response) {
-                    fail("should have failed because of null parameters");
+                    throw new UnsupportedOperationException("onSuccess cannot be called when using a mocked http client");
                 }
 
                 @Override
                 public void onFailure(Exception exception) {
-                    assertThat(exception, instanceOf(NullPointerException.class));
-                    assertEquals("parameters cannot be null", exception.getMessage());
-                    latch.countDown();
+                    try {
+                        assertThat(exception, instanceOf(NullPointerException.class));
+                        assertEquals("parameters cannot be null", exception.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
                 }
             });
-            latch.await();
+            assertTrue("time out waiting for request to return", latch.await(1000, TimeUnit.MILLISECONDS));
         }
     }
 
@@ -129,18 +140,21 @@ public class RestClientTests extends RestClientTestCase {
             ResponseListener listener = new ResponseListener() {
                 @Override
                 public void onSuccess(Response response) {
-                    fail("should have failed because of null headers");
+                    throw new UnsupportedOperationException("onSuccess cannot be called when using a mocked http client");
                 }
 
                 @Override
                 public void onFailure(Exception exception) {
-                    assertThat(exception, instanceOf(NullPointerException.class));
-                    assertEquals("header cannot be null", exception.getMessage());
-                    latch.countDown();
+                    try {
+                        assertThat(exception, instanceOf(NullPointerException.class));
+                        assertEquals("header cannot be null", exception.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
                 }
             };
             restClient.performRequestAsync("GET", randomAsciiLettersOfLength(5), listener, (Header) null);
-            latch.await();
+            assertTrue("time out waiting for request to return", latch.await(1000, TimeUnit.MILLISECONDS));
         }
     }
 
@@ -150,17 +164,20 @@ public class RestClientTests extends RestClientTestCase {
             restClient.performRequestAsync(new Request("GET", "::http:///"), new ResponseListener() {
                 @Override
                 public void onSuccess(Response response) {
-                    fail("should have failed because of wrong endpoint");
+                    throw new UnsupportedOperationException("onSuccess cannot be called when using a mocked http client");
                 }
 
                 @Override
                 public void onFailure(Exception exception) {
-                    assertThat(exception, instanceOf(IllegalArgumentException.class));
-                    assertEquals("Expected scheme name at index 0: ::http:///", exception.getMessage());
-                    latch.countDown();
+                    try {
+                        assertThat(exception, instanceOf(IllegalArgumentException.class));
+                        assertEquals("Expected scheme name at index 0: ::http:///", exception.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
                 }
             });
-            latch.await();
+            assertTrue("time out waiting for request to return", latch.await(1000, TimeUnit.MILLISECONDS));
         }
     }
 
@@ -174,17 +191,20 @@ public class RestClientTests extends RestClientTestCase {
             restClient.performRequestAsync("GET", "::http:///", new ResponseListener() {
                 @Override
                 public void onSuccess(Response response) {
-                    fail("should have failed because of wrong endpoint");
+                    throw new UnsupportedOperationException("onSuccess cannot be called when using a mocked http client");
                 }
 
                 @Override
                 public void onFailure(Exception exception) {
-                    assertThat(exception, instanceOf(IllegalArgumentException.class));
-                    assertEquals("Expected scheme name at index 0: ::http:///", exception.getMessage());
-                    latch.countDown();
+                    try {
+                        assertThat(exception, instanceOf(IllegalArgumentException.class));
+                        assertEquals("Expected scheme name at index 0: ::http:///", exception.getMessage());
+                    } finally {
+                        latch.countDown();
+                    }
                 }
             });
-            latch.await();
+            assertTrue("time out waiting for request to return", latch.await(1000, TimeUnit.MILLISECONDS));
         }
     }
 


### PR DESCRIPTION
This commit adds a max wait timeout of one second to all the latch.await
calls made in RestClientTests. It also makes clearer that the `onSuccess`
listener method will never be called given that the underlying http
client is mocked and makes sure that `latch.countDown` is always called