### PR TITLE
Simplify number of shards setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -341,13 +341,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             return searchTransportService.getConnection(clusterName, discoveryNode);
         };
         if (searchRequest.isMaxConcurrentShardRequestsSet() == false) {
-            // we try to set a default of max concurrent shard requests based on
-            // the node count but upper-bound it by 256 by default to keep it sane. A single
-            // search request that fans out lots of shards should hit a cluster too hard while 256 is already a lot.
-            // we multiply it by the default number of shards such that a single request in a cluster of 1 would hit all shards of a
-            // default index.
-            searchRequest.setMaxConcurrentShardRequests(Math.min(256, nodeCount
-                * IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.getDefault(Settings.EMPTY)));
+            /*
+             * We try to set a default of max concurrent shard requests based on the node count but upper-bound it by 256 by default to keep
+             * it sane. A single search request that fans out to lots of shards should not hit a cluster too hard while 256 is already a
+             * lot.
+             */
+            searchRequest.setMaxConcurrentShardRequests(Math.min(256, nodeCount));
         }
         boolean preFilterSearchShards = shouldPreFilterSearchShards(searchRequest, shardIterators);
         searchAsyncAction(task, searchRequest, shardIterators, timeProvider, connectionLookup, clusterState.version(),

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java
@@ -181,8 +181,7 @@ public class IndexMetaData implements Diffable<IndexMetaData>, ToXContentFragmen
         if (maxNumShards < 1) {
             throw new IllegalArgumentException("es.index.max_number_of_shards must be > 0");
         }
-        return Setting.intSetting(SETTING_NUMBER_OF_SHARDS, Math.min(5, maxNumShards), 1, maxNumShards,
-            Property.IndexScope, Property.Final);
+        return Setting.intSetting(SETTING_NUMBER_OF_SHARDS, 1, 1, maxNumShards, Property.IndexScope, Property.Final);
     }
 
     public static final String INDEX_SETTING_PREFIX = "index.";


### PR DESCRIPTION
This is code that was leftover from the move to one shard by default. Here in index metadata we were preserving the default number of shards settings independently of the area of code where we set this value on an index that does not explicitly have an number of shards setting. This took into consideration the es.index.max_number_of_shards system property, and was used in search requests to set the default maximum number of concurrent shard requests. We set the default there based on the default number of shards so that in a one-node case a search request could concurrently hit all shards on an index with the defaults. Now that we default to one shard, we expect fewer shards in clusters and this adjustment of the node count as the max number of concurrent shard requests is no longer needed. This commit then changes the default number of shards settings to be consistent with the value used when an index is created, and removes the now unneeded adjustment in search requests.

Relates #30539