### PR TITLE
QA: Add xpack tests to rolling upgrade

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractRollingTestCase.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/AbstractRollingTestCase.java
@@ -18,33 +18,8 @@
  */
 package org.elasticsearch.upgrades;
 
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.test.rest.ESRestTestCase;
-import org.elasticsearch.test.rest.yaml.ObjectPath;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Future;
-import java.util.function.Predicate;
-
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLength;
-import static java.util.Collections.emptyMap;
-import static org.elasticsearch.cluster.routing.UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING;
-import static org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING;
-import static org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
 
 public abstract class AbstractRollingTestCase extends ESRestTestCase {
     protected enum ClusterType {

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.yaml.ObjectPath;
 
 import java.io.IOException;

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/XPackIT.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.upgrades;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.common.Booleans;
+import org.junit.Before;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assume.assumeThat;
+
+/**
+ * Basic tests for simple xpack functionality that are only run if the
+ * cluster is the on the "zip" distribution.
+ */
+public class XPackIT extends AbstractRollingTestCase {
+    @Before
+    public void skipIfNotXPack() {
+        assumeThat("test is only supported if the distribution contains xpack",
+                System.getProperty("tests.distribution"), equalTo("zip"));
+        assumeThat("running this on the unupgraded cluster would change its state and it wouldn't work prior to 6.3 anyway",
+                CLUSTER_TYPE, equalTo(ClusterType.UPGRADED));
+        /*
+         * *Mostly* we want this for when we're upgrading from pre-6.3's
+         * zip distribution which doesn't contain xpack to post 6.3's zip
+         * distribution which *does* contain xpack. But we'll also run it
+         * on all upgrades for completeness's sake.
+         */
+    }
+
+    /**
+     * Test a basic feature (SQL) which doesn't require any trial license.
+     * Note that the test methods on this class can run in any order so we
+     * <strong>might</strong> have already installed a trial license.
+     */
+    public void testBasicFeature() throws IOException {
+        Request bulk = new Request("POST", "/sql_test/doc/_bulk");
+        bulk.setJsonEntity(
+              "{\"index\":{}}\n"
+            + "{\"f\": \"1\"}\n"
+            + "{\"index\":{}}\n"
+            + "{\"f\": \"2\"}\n");
+        bulk.addParameter("refresh", "true");
+        client().performRequest(bulk);
+
+        Request sql = new Request("POST", "/_xpack/sql");
+        sql.setJsonEntity("{\"query\": \"SELECT * FROM sql_test WHERE f > 1 ORDER BY f ASC\"}");
+        String response = EntityUtils.toString(client().performRequest(sql).getEntity());
+        assertEquals("{\"columns\":[{\"name\":\"f\",\"type\":\"text\"}],\"rows\":[[\"2\"]]}", response);
+    }
+
+    /**
+     * Test creating a trial license and using it. This is interesting because
+     * our other tests test cover starting a new cluster with the default
+     * distribution and enabling the trial license but this test is the only
+     * one that can upgrade from the oss distribution to the default
+     * distribution with xpack and the create a trial license. We don't
+     * <strong>do</strong> a lot with the trial license because for the most
+     * part those things are tested elsewhere, off in xpack. But we do use the
+     * trial license a little bit to make sure that it works.
+     */
+    public void testTrialLicense() throws IOException {
+        Request startTrial = new Request("POST", "/_xpack/license/start_trial");
+        startTrial.addParameter("acknowledge", "true");
+        client().performRequest(startTrial);
+
+        String noJobs = EntityUtils.toString(
+            client().performRequest(new Request("GET", "/_xpack/ml/anomaly_detectors")).getEntity());
+        assertEquals("{\"count\":0,\"jobs\":[]}", noJobs);
+
+        Request createJob = new Request("PUT", "/_xpack/ml/anomaly_detectors/test_job");
+        createJob.setJsonEntity(
+                  "{\n"
+                + "  \"analysis_config\" : {\n"
+                + "    \"bucket_span\": \"10m\",\n"
+                + "    \"detectors\": [\n"
+                + "      {\n"
+                + "        \"function\": \"sum\",\n"
+                + "        \"field_name\": \"total\"\n"
+                + "      }\n"
+                + "    ]\n"
+                + "  },\n"
+                + "  \"data_description\": {\n"
+                + "    \"time_field\": \"timestamp\",\n"
+                + "    \"time_format\": \"epoch_ms\"\n"
+                + "  }\n"
+                + "}\n");
+        client().performRequest(createJob);
+    }
+}


### PR DESCRIPTION
A rolling upgrade from oss Elasticsearch to the default distribution of
Elasticsearch is significantly different than a full cluster restart to
install a plugin and is again different from starting a new cluster with
xpack installed. So this adds some basic tests to make sure that the
rolling upgrade that enables xpack works at all.

This also removes some unused imports from the tests that I modified in
PR #30728. I didn't mean to leave them.

