### PR TITLE
[DOCS] Clarifies xpack.security.audit.index.client.hosts setting

### DIFF
--- a/x-pack/docs/en/settings/audit-settings.asciidoc
+++ b/x-pack/docs/en/settings/audit-settings.asciidoc
@@ -121,7 +121,9 @@ To index audit events to a remote {es} cluster, you configure the following
 
 `xpack.security.audit.index.client.hosts`::
 Specifies a comma-separated list of `host:port` pairs. These hosts should be
-nodes in the remote cluster.
+nodes in the remote cluster. If you are using default values for the 
+<<common-network-settings,`transport.tcp.port`>> setting, you can omit the 
+`port` value. Otherwise, it must match the `transport.tcp.port` setting. 
 
 `xpack.security.audit.index.client.cluster.name`::
 Specifies the name of the remote cluster.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/29692#issuecomment-389365633

