### PR TITLE
Restore "Add more yaml tests for get alias API "

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -21,13 +21,57 @@ setup:
 "Get all aliases via /_alias":
 
   - do:
+      indices.create:
+        index: test_index_3
+
+  - do:
       indices.get_alias: {}
 
   - match: {test_index.aliases.test_alias: {}}
   - match: {test_index.aliases.test_blias: {}}
   - match: {test_index_2.aliases.test_alias: {}}
   - match: {test_index_2.aliases.test_blias: {}}
+  - match: {test_index_3.aliases: {}}
 
+---
+"Get aliases via /_alias/_all":
+  - skip:
+      version: " - 5.99.99"
+      reason:  5.x returns indices that have no aliases
+
+  - do:
+      indices.create:
+        index: test_index_3
+
+  - do:
+      indices.get_alias:
+        name: _all
+
+  - match: {test_index.aliases.test_alias: {}}
+  - match: {test_index.aliases.test_blias: {}}
+  - match: {test_index_2.aliases.test_alias: {}}
+  - match: {test_index_2.aliases.test_blias: {}}
+  - is_false: test_index_3
+
+---
+"Get aliases via /_alias/*":
+  - skip:
+      version: " - 5.99.99"
+      reason:  5.x returns indices that have no aliases
+
+  - do:
+      indices.create:
+        index: test_index_3
+
+  - do:
+      indices.get_alias:
+        name: _all
+
+  - match: {test_index.aliases.test_alias: {}}
+  - match: {test_index.aliases.test_blias: {}}
+  - match: {test_index_2.aliases.test_alias: {}}
+  - match: {test_index_2.aliases.test_blias: {}}
+  - is_false: test_index_3
 
 ---
 "Get all aliases via /{index}/_alias/":


### PR DESCRIPTION
These additional tests were reverted in 6.x due to failing bwc tests. They should be skipped against 5.6 nodes, bwc tests fail when the node hit by the request is on 5.6.

Relates to #29513
Relates to #25114
Closes #30806