### PR TITLE
Update Fuzzy Query docs to clarify default behavior re max_expansions

### DIFF
--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -5,10 +5,10 @@ The fuzzy query uses similarity based on Levenshtein edit distance.
 
 ==== String fields
 
-The `fuzzy` query generates matching terms that are within  the
+The `fuzzy` query generates matching terms that are within the
 maximum edit distance specified in `fuzziness` and then checks the term
 dictionary to find out which of those generated terms actually exist in the
-index.
+index. The final query uses up to `max_expansions` matching terms.
 
 Here is a simple example:
 

--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -5,7 +5,7 @@ The fuzzy query uses similarity based on Levenshtein edit distance.
 
 ==== String fields
 
-The `fuzzy` query generates all possible matching terms that are within  the
+The `fuzzy` query generates matching terms that are within  the
 maximum edit distance specified in `fuzziness` and then checks the term
 dictionary to find out which of those generated terms actually exist in the
 index.


### PR DESCRIPTION
Stating that the Fuzzy Query generates "all possible" matching terms is misleading, given that the query's default behavior is to generate a maximum of 50 matching terms.

Maybe it's worthwhile to use one of those Warning boxes somewhere towards the top of the page to clarify this? I suspect many users will read "generates all possible matching terms" and immediately begin using the query, expecting it to generate all possible terms _by default_ (having done exactly that myself).