### PR TITLE
Move watcher-history version setting to _meta field

### DIFF
--- a/x-pack/plugin/core/src/main/resources/watch-history.json
+++ b/x-pack/plugin/core/src/main/resources/watch-history.json
@@ -2,7 +2,6 @@
   "index_patterns": [ ".watcher-history-${xpack.watcher.template.version}*" ],
   "order": 2147483647,
   "settings": {
-    "xpack.watcher.template.version": "${xpack.watcher.template.version}",
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0,
     "index.auto_expand_replicas": "0-1",
@@ -10,6 +9,9 @@
   },
   "mappings": {
     "doc": {
+      "_meta": {
+        "watcher-history-version": "${xpack.watcher.template.version}"
+      },
       "dynamic_templates": [
         {
           "disabled_payload_fields": {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -196,6 +196,8 @@ import static java.util.Collections.emptyList;
 
 public class Watcher extends Plugin implements ActionPlugin, ScriptPlugin {
 
+    // This setting is only here for backward compatibility reasons as 6.x indices made use of it. It can be removed in 8.x.
+    @Deprecated
     public static final Setting<String> INDEX_WATCHER_TEMPLATE_VERSION_SETTING =
             new Setting<>("index.xpack.watcher.template.version", "", Function.identity(), Setting.Property.IndexScope);
     public static final Setting<Boolean> ENCRYPT_SENSITIVE_DATA_SETTING =


### PR DESCRIPTION
The `.watcher-history-*` template is currently using a plugin-custom index setting `xpack.watcher.template.version`, which prevents this template from being installed in a mixed OSS / X-Pack cluster, ultimately leading to the situation where an X-Pack node is constantly spamming an OSS master with (failed) template updates. Other X-Pack templates (e.g. `security-index-template` or `security_audit_log`)  achieve the same versioning functionality by using a custom `_meta` field in the mapping instead. This commit switches the `.watcher-history-*` template to use the `_meta` field instead.

Relates to #30731