### PR TITLE
Do not serialize basic license exp in x-pack info

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackInfoResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackInfoResponse.java
@@ -123,13 +123,15 @@ public class XPackInfoResponse extends ActionResponse {
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            return builder.startObject()
-                    .field("uid", uid)
-                    .field("type", type)
-                    .field("mode", mode)
-                    .field("status", status.label())
-                    .timeField("expiry_date_in_millis", "expiry_date", expiryDate)
-                    .endObject();
+            builder.startObject()
+                .field("uid", uid)
+                .field("type", type)
+                .field("mode", mode)
+                .field("status", status.label());
+            if (expiryDate != LicenseService.BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS) {
+                builder.timeField("expiry_date_in_millis", "expiry_date", expiryDate);
+            }
+            return builder.endObject();
         }
 
         public void writeTo(StreamOutput out) throws IOException {


### PR DESCRIPTION
This is a bug that was identified by the kibana team. Currently on a
get-license call we do not serialize the hard-coded expiration for basic
licenses. However, the kibana team calls the x-pack info route which
still does serialize the expiration date. This commit removes that
serialization in the rest response.