### PR TITLE
Checksum docvalues files when load store metadata

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/test/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -108,7 +108,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/30228") // What if DV is corrupted?
 public class CorruptedFileIT extends ESIntegTestCase {
 
     @Override


### PR DESCRIPTION
In CorruptedFileIT, we corrupt a random segment file then check that the corrupting store is marked as corrupted. However, if a DocValues file is flipped, we will trip an assertion in a FixedBitSet when opening a SoftDeletesDirectoryReaderWrapper. This commit makes sure that we verify the DocValues files when loading the metadata from a store.

Another option is to limit the set of corrupting files in the tests.