### PR TITLE
stable filemode for zip distributions

### DIFF
--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -104,15 +104,23 @@ tasks.withType(AbstractArchiveTask) {
   baseName = "elasticsearch${ subdir.contains('oss') ? '-oss' : ''}"
 }
 
+Closure commonZipConfig = {
+  dirMode 0755
+  fileMode 0644
+}
+
 task buildIntegTestZip(type: Zip) {
+  configure(commonZipConfig)
   with archiveFiles(transportModulesFiles, 'zip', false)
 }
 
 task buildZip(type: Zip) {
+  configure(commonZipConfig)
   with archiveFiles(modulesFiles(false), 'zip', false)
 }
 
 task buildOssZip(type: Zip) {
+  configure(commonZipConfig)
   with archiveFiles(modulesFiles(true), 'zip', true)
 }
 


### PR DESCRIPTION
Applies default file and directory permissions to zip distributions
similar to how they're set for the tar distributions. Previously zip
distributions would retain permissions they had on the build host's
working tree, which could vary depending on its umask

For #30799