### PR TITLE
remove requirement for shards/replicas in allocation check steps

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAction.java
@@ -79,7 +79,7 @@ public class ReplicasAction implements LifecycleAction {
         StepKey enoughKey = new StepKey(phase, NAME, ReplicasAllocatedStep.NAME);
         Settings replicaSettings = Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).build();
         return Arrays.asList(new UpdateSettingsStep(updateReplicasKey, enoughKey, client, replicaSettings),
-                new ReplicasAllocatedStep(enoughKey, nextStepKey, numberOfReplicas));
+                new ReplicasAllocatedStep(enoughKey, nextStepKey));
     }
 
     public int getNumberOfReplicas() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStep.java
@@ -21,15 +21,9 @@ import java.util.Objects;
 
 public class ReplicasAllocatedStep extends ClusterStateWaitStep {
     public static final String NAME = "enough-shards-allocated";
-    private int numberReplicas;
 
-    public ReplicasAllocatedStep(StepKey key, StepKey nextStepKey, int numberReplicas) {
+    public ReplicasAllocatedStep(StepKey key, StepKey nextStepKey) {
         super(key, nextStepKey);
-        this.numberReplicas = numberReplicas;
-    }
-
-    int getNumberReplicas() {
-        return numberReplicas;
     }
 
     @Override
@@ -41,73 +35,54 @@ public class ReplicasAllocatedStep extends ClusterStateWaitStep {
         }
         // We only want to make progress if the cluster state reflects the number of replicas change and all shards are active
         boolean allShardsActive = ActiveShardCount.ALL.enoughShardsActive(clusterState, index.getName());
-        boolean isConditionMet = idxMeta.getNumberOfReplicas() == numberReplicas && allShardsActive;
-        if (isConditionMet) {
+        if (allShardsActive) {
             return new Result(true, null);
         } else {
-            return new Result(false, new Info(numberReplicas, idxMeta.getNumberOfReplicas(), allShardsActive));
+            return new Result(false, new Info(idxMeta.getNumberOfReplicas(), allShardsActive));
         }
     }
-    
+
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), numberReplicas);
+        return super.hashCode();
     }
-    
+
     @Override
     public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        ReplicasAllocatedStep other = (ReplicasAllocatedStep) obj;
-        return super.equals(obj) &&
-                Objects.equals(numberReplicas, other.numberReplicas);
+        return obj != null && getClass() == obj.getClass() && super.equals(obj);
     }
-    
+
     public static final class Info implements ToXContentObject {
 
-        private final long expectedReplicas;
         private final long actualReplicas;
         private final boolean allShardsActive;
         private final String message;
 
-        static final ParseField EXPECTED_REPLICAS = new ParseField("expected_replicas");
         static final ParseField ACTUAL_REPLICAS = new ParseField("actual_replicas");
         static final ParseField ALL_SHARDS_ACTIVE = new ParseField("all_shards_active");
         static final ParseField MESSAGE = new ParseField("message");
         static final ConstructingObjectParser<Info, Void> PARSER = new ConstructingObjectParser<>("replicas_allocated_step_info",
-                a -> new Info((long) a[0], (long) a[1], (boolean) a[2]));
+                a -> new Info((long) a[0], (boolean) a[1]));
         static {
-            PARSER.declareLong(ConstructingObjectParser.constructorArg(), EXPECTED_REPLICAS);
             PARSER.declareLong(ConstructingObjectParser.constructorArg(), ACTUAL_REPLICAS);
             PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), ALL_SHARDS_ACTIVE);
             PARSER.declareString((i, s) -> {}, MESSAGE);
         }
 
-        public Info(long expectedReplicas, long actualReplicas, boolean allShardsActive) {
-            this.expectedReplicas = expectedReplicas;
+        public Info(long actualReplicas, boolean allShardsActive) {
             this.actualReplicas = actualReplicas;
             this.allShardsActive = allShardsActive;
-            if (actualReplicas != expectedReplicas) {
-                message = "Waiting for " + IndexMetaData.SETTING_NUMBER_OF_REPLICAS + " to be updated to " + expectedReplicas;
-            } else if (allShardsActive == false) {
+            if (allShardsActive == false) {
                 message = "Waiting for all shard copies to be active";
             } else {
                 message = "";
             }
         }
 
-        public long getExpectedReplicas() {
-            return expectedReplicas;
-        }
-        
         public long getActualReplicas() {
             return actualReplicas;
         }
-        
+
         public boolean allShardsActive() {
             return allShardsActive;
         }
@@ -116,7 +91,6 @@ public class ReplicasAllocatedStep extends ClusterStateWaitStep {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(MESSAGE.getPreferredName(), message);
-            builder.field(EXPECTED_REPLICAS.getPreferredName(), expectedReplicas);
             builder.field(ACTUAL_REPLICAS.getPreferredName(), actualReplicas);
             builder.field(ALL_SHARDS_ACTIVE.getPreferredName(), allShardsActive);
             builder.endObject();
@@ -125,7 +99,7 @@ public class ReplicasAllocatedStep extends ClusterStateWaitStep {
 
         @Override
         public int hashCode() {
-            return Objects.hash(expectedReplicas, actualReplicas, allShardsActive);
+            return Objects.hash(actualReplicas, allShardsActive);
         }
 
         @Override
@@ -137,8 +111,7 @@ public class ReplicasAllocatedStep extends ClusterStateWaitStep {
                 return false;
             }
             Info other = (Info) obj;
-            return Objects.equals(expectedReplicas, other.expectedReplicas) &&
-                    Objects.equals(actualReplicas, other.actualReplicas) &&
+            return Objects.equals(actualReplicas, other.actualReplicas) &&
                     Objects.equals(allShardsActive, other.allShardsActive);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkAction.java
@@ -86,8 +86,7 @@ public class ShrinkAction implements LifecycleAction {
         SetSingleNodeAllocateStep setSingleNodeStep = new SetSingleNodeAllocateStep(setSingleNodeKey, allocationRoutedKey, client);
         AllocationRoutedStep allocationStep = new AllocationRoutedStep(allocationRoutedKey, shrinkKey, false);
         ShrinkStep shrink = new ShrinkStep(shrinkKey, enoughShardsKey, client, numberOfShards, SHRUNKEN_INDEX_PREFIX);
-        ShrunkShardsAllocatedStep allocated = new ShrunkShardsAllocatedStep(enoughShardsKey, aliasKey, numberOfShards,
-                SHRUNKEN_INDEX_PREFIX);
+        ShrunkShardsAllocatedStep allocated = new ShrunkShardsAllocatedStep(enoughShardsKey, aliasKey, SHRUNKEN_INDEX_PREFIX);
         ShrinkSetAliasStep aliasSwapAndDelete = new ShrinkSetAliasStep(aliasKey, isShrunkIndexKey, client, SHRUNKEN_INDEX_PREFIX);
         ShrunkenIndexCheckStep waitOnShrinkTakeover = new ShrunkenIndexCheckStep(isShrunkIndexKey, nextStepKey, SHRUNKEN_INDEX_PREFIX);
         return Arrays.asList(setSingleNodeStep, allocationStep, shrink, allocated, aliasSwapAndDelete, waitOnShrinkTakeover);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStepInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ReplicasAllocatedStepInfoTests.java
@@ -17,7 +17,7 @@ public class ReplicasAllocatedStepInfoTests extends AbstractXContentTestCase<Rep
 
     @Override
     protected Info createTestInstance() {
-        return new Info(randomNonNegativeLong(), randomNonNegativeLong(), randomBoolean());
+        return new Info(randomNonNegativeLong(), randomBoolean());
     }
 
     @Override
@@ -37,27 +37,18 @@ public class ReplicasAllocatedStepInfoTests extends AbstractXContentTestCase<Rep
     }
 
     protected final Info copyInstance(Info instance) throws IOException {
-        return new Info(instance.getExpectedReplicas(), instance.getActualReplicas(), instance.allShardsActive());
+        return new Info(instance.getActualReplicas(), instance.allShardsActive());
     }
 
     protected Info mutateInstance(Info instance) throws IOException {
-        long expectedReplicas = instance.getExpectedReplicas();
         long actualReplicas = instance.getActualReplicas();
         boolean allShardsActive = instance.allShardsActive();
-        switch (between(0, 2)) {
-        case 0:
-            expectedReplicas += between(1, 20);
-            break;
-        case 1:
+        if (randomBoolean()) {
             actualReplicas += between(1, 20);
-            break;
-        case 2:
+        } else {
             allShardsActive = allShardsActive == false;
-            break;
-        default:
-            throw new AssertionError("Illegal randomisation branch");
         }
-        return new Info(expectedReplicas, actualReplicas, allShardsActive);
+        return new Info(actualReplicas, allShardsActive);
     }
 
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrinkActionTests.java
@@ -70,7 +70,6 @@ public class ShrinkActionTests extends AbstractSerializingTestCase<ShrinkAction>
         assertTrue(steps.get(3) instanceof ShrunkShardsAllocatedStep);
         assertThat(steps.get(3).getKey(), equalTo(expectedFourthKey));
         assertThat(steps.get(3).getNextStepKey(), equalTo(expectedFifthKey));
-        assertThat(((ShrunkShardsAllocatedStep) steps.get(3)).getNumberOfShards(), equalTo(action.getNumberOfShards()));
         assertThat(((ShrunkShardsAllocatedStep) steps.get(3)).getShrunkIndexPrefix(), equalTo(ShrinkAction.SHRUNKEN_INDEX_PREFIX));
         assertTrue(steps.get(4) instanceof ShrinkSetAliasStep);
         assertThat(steps.get(4).getKey(), equalTo(expectedFifthKey));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkShardsAllocatedStepInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexlifecycle/ShrunkShardsAllocatedStepInfoTests.java
@@ -17,7 +17,7 @@ public class ShrunkShardsAllocatedStepInfoTests extends AbstractXContentTestCase
 
     @Override
     protected Info createTestInstance() {
-        return new Info(randomBoolean(), randomIntBetween(0, 10000), randomIntBetween(0, 10000), randomBoolean());
+        return new Info(randomBoolean(), randomIntBetween(0, 10000), randomBoolean());
     }
 
     @Override
@@ -37,31 +37,27 @@ public class ShrunkShardsAllocatedStepInfoTests extends AbstractXContentTestCase
     }
 
     protected final Info copyInstance(Info instance) throws IOException {
-        return new Info(instance.shrunkIndexExists(), instance.getExpectedShards(), instance.getActualShards(), instance.allShardsActive());
+        return new Info(instance.shrunkIndexExists(), instance.getActualShards(), instance.allShardsActive());
     }
 
     protected Info mutateInstance(Info instance) throws IOException {
         boolean shrunkIndexExists = instance.shrunkIndexExists();
-        int expectedShards = instance.getExpectedShards();
         int actualShards = instance.getActualShards();
         boolean allShardsActive = instance.allShardsActive();
-        switch (between(0, 3)) {
+        switch (between(0, 2)) {
         case 0:
             shrunkIndexExists = shrunkIndexExists == false;
             break;
         case 1:
-            expectedShards += between(1, 20);
-            break;
-        case 2:
             actualShards += between(1, 20);
             break;
-        case 3:
+        case 2:
             allShardsActive = allShardsActive == false;
             break;
         default:
             throw new AssertionError("Illegal randomisation branch");
         }
-        return new Info(shrunkIndexExists, expectedShards, actualShards, allShardsActive);
+        return new Info(shrunkIndexExists, actualShards, allShardsActive);
     }
 
 }


### PR DESCRIPTION
As we are preparing to support policy updates/changes, we noticed
that restricting allocation wait steps with pinned replicas/shard
counts makes this difficult to continue from. For example,
as user may update or switch a policy to increase replicas. If this
is done, then the check will never pass and user intervention will
be required. If we simply remove this restriction, we still check
that the index is allocated correctly, but without depending on
the newly configured replicas setting in the policy.
