### PR TITLE
Remove AllocatedPersistentTask.getState()

### DIFF
--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
@@ -123,7 +123,7 @@ public class PersistentTasksNodeService extends AbstractComponent implements Clu
 
             for (Long id : notVisitedTasks) {
                 AllocatedPersistentTask task = runningTasks.get(id);
-                if (task.getState() == AllocatedPersistentTask.State.COMPLETED) {
+                if (task.isCompleted()) {
                     // Result was sent to the caller and the caller acknowledged acceptance of the result
                     logger.trace("Found completed persistent task [{}] with id [{}] and allocation id [{}] - removing",
                             task.getAction(), task.getPersistentTaskId(), task.getAllocationId());


### PR DESCRIPTION
This commit removes the method `AllocatedPersistentTask.getState()` and replaces it with a new `isCompleted()` method. The `getState()` method is related to the persistent task framework and exposes an internal state. 

In the current situation, classes that extend `AllocatedPersistentTask` could override it and this could lead to issues. By removing this method we also allow such classes to provide their own getState() implementation that could expose their custom state.

Related to #29608