### PR TITLE
[DOCS] Fixes accounting circuit breaker setting names

### DIFF
--- a/docs/reference/modules/indices/circuit_breaker.asciidoc
+++ b/docs/reference/modules/indices/circuit_breaker.asciidoc
@@ -80,12 +80,12 @@ The accounting circuit breaker allows Elasticsearch to limit the memory
 usage of things held in memory that are not released when a request is
 completed. This includes things like the Lucene segment memory.
 
-`network.breaker.accounting.limit`::
+`indices.breaker.accounting.limit`::
 
     Limit for accounting breaker, defaults to 100% of JVM heap. This means that it is bound
     by the limit configured for the parent circuit breaker.
 
-`network.breaker.accounting.overhead`::
+`indices.breaker.accounting.overhead`::
 
     A constant that all accounting estimations are multiplied with to determine a
     final estimation. Defaults to 1


### PR DESCRIPTION
The documentation for the account circuit breaker listed the settings for it's limit and overhead to be `network.breaker.accounting.limit` and `network.breaker.accounting.overhead` when in `HieratchyCircuitBreakerService` it seems the settings are actually `indices.breaker.accounting.limit` and `indices.breaker.accounting.overhead`.
