### PR TITLE
Enable muted Repository test

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/snapshot.get_repository/10_basic.yml
@@ -51,9 +51,6 @@ setup:
 
 ---
 "Verify created repository":
-  - skip:
-      version:     "all"
-      reason:      AwaitsFix for https://github.com/elastic/elasticsearch/issues/30807
   - do:
       snapshot.verify_repository:
         repository: test_repo_get_2


### PR DESCRIPTION
The exiting test was muted due to bwc changes, this fixes it.

Closes #30807
