### PR TITLE
Move list tasks API under tasks namespace

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/ClusterClient.java
@@ -21,8 +21,6 @@ package org.elasticsearch.client;
 
 import org.apache.http.Header;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
@@ -66,28 +64,6 @@ public final class ClusterClient {
             ActionListener<ClusterUpdateSettingsResponse> listener, Header... headers) {
         restHighLevelClient.performRequestAsyncAndParseEntity(clusterUpdateSettingsRequest, RequestConverters::clusterPutSettings,
                 ClusterUpdateSettingsResponse::fromXContent, listener, emptySet(), headers);
-    }
-
-    /**
-     * Get current tasks using the Task Management API
-     * <p>
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
-     */
-    public ListTasksResponse listTasks(ListTasksRequest request, Header... headers) throws IOException {
-        return restHighLevelClient.performRequestAndParseEntity(request, RequestConverters::listTasks, ListTasksResponse::fromXContent,
-                emptySet(), headers);
-    }
-
-    /**
-     * Asynchronously get current tasks using the Task Management API
-     * <p>
-     * See
-     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
-     */
-    public void listTasksAsync(ListTasksRequest request, ActionListener<ListTasksResponse> listener, Header... headers) {
-        restHighLevelClient.performRequestAsyncAndParseEntity(request, RequestConverters::listTasks, ListTasksResponse::fromXContent,
-                listener, emptySet(), headers);
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -192,6 +192,7 @@ public class RestHighLevelClient implements Closeable {
     private final IndicesClient indicesClient = new IndicesClient(this);
     private final ClusterClient clusterClient = new ClusterClient(this);
     private final SnapshotClient snapshotClient = new SnapshotClient(this);
+    private final TasksClient tasksClient = new TasksClient(this);
 
     /**
      * Creates a {@link RestHighLevelClient} given the low level {@link RestClientBuilder} that allows to build the
@@ -262,6 +263,15 @@ public class RestHighLevelClient implements Closeable {
      */
     public final SnapshotClient snapshot() {
         return snapshotClient;
+    }
+
+    /**
+     * Provides a {@link TasksClient} which can be used to access the Tasks API.
+     *
+     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html">Task Management API on elastic.co</a>
+     */
+    public final TasksClient tasks() {
+        return tasksClient;
     }
 
     /**

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/TasksClient.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.apache.http.Header;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+
+import java.io.IOException;
+
+import static java.util.Collections.emptySet;
+
+/**
+ * A wrapper for the {@link RestHighLevelClient} that provides methods for accessing the Tasks API.
+ * <p>
+ * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html">Task Management API on elastic.co</a>
+ */
+public class TasksClient {
+    private final RestHighLevelClient restHighLevelClient;
+
+    TasksClient(RestHighLevelClient restHighLevelClient) {
+        this.restHighLevelClient = restHighLevelClient;
+    }
+
+    /**
+     * Get current tasks using the Task Management API
+     * <p>
+     * See
+     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
+     */
+    public ListTasksResponse list(ListTasksRequest request, Header... headers) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(request, RequestConverters::listTasks, ListTasksResponse::fromXContent,
+                emptySet(), headers);
+    }
+
+    /**
+     * Asynchronously get current tasks using the Task Management API
+     * <p>
+     * See
+     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"> Task Management API on elastic.co</a>
+     */
+    public void listAsync(ListTasksRequest request, ActionListener<ListTasksResponse> listener, Header... headers) {
+        restHighLevelClient.performRequestAsyncAndParseEntity(request, RequestConverters::listTasks, ListTasksResponse::fromXContent,
+                listener, emptySet(), headers);
+    }
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/ClusterClientIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/ClusterClientIT.java
@@ -20,9 +20,6 @@
 package org.elasticsearch.client;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.TaskGroup;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
@@ -37,16 +34,13 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.tasks.TaskInfo;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -115,31 +109,6 @@ public class ClusterClientIT extends ESRestHighLevelClientTestCase {
         assertThat(exception.status(), equalTo(RestStatus.BAD_REQUEST));
         assertThat(exception.getMessage(), equalTo(
                 "Elasticsearch exception [type=illegal_argument_exception, reason=transient setting [" + setting + "], not recognized]"));
-    }
-
-    public void testListTasks() throws IOException {
-        ListTasksRequest request = new ListTasksRequest();
-        ListTasksResponse response = execute(request, highLevelClient().cluster()::listTasks, highLevelClient().cluster()::listTasksAsync);
-
-        assertThat(response, notNullValue());
-        assertThat(response.getNodeFailures(), equalTo(emptyList()));
-        assertThat(response.getTaskFailures(), equalTo(emptyList()));
-        // It's possible that there are other tasks except 'cluster:monitor/tasks/lists[n]' and 'action":"cluster:monitor/tasks/lists'
-        assertThat(response.getTasks().size(), greaterThanOrEqualTo(2));
-        boolean listTasksFound = false;
-        for (TaskGroup taskGroup : response.getTaskGroups()) {
-            TaskInfo parent = taskGroup.getTaskInfo();
-            if ("cluster:monitor/tasks/lists".equals(parent.getAction())) {
-                assertThat(taskGroup.getChildTasks().size(), equalTo(1));
-                TaskGroup childGroup = taskGroup.getChildTasks().iterator().next();
-                assertThat(childGroup.getChildTasks().isEmpty(), equalTo(true));
-                TaskInfo child = childGroup.getTaskInfo();
-                assertThat(child.getAction(), equalTo("cluster:monitor/tasks/lists[n]"));
-                assertThat(child.getParentTaskId(), equalTo(parent.getTaskId()));
-                listTasksFound = true;
-            }
-        }
-        assertTrue("List tasks were not found", listTasksFound);
     }
 
     public void testPutPipeline() throws IOException {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/TasksIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/TasksIT.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.TaskGroup;
+import org.elasticsearch.tasks.TaskInfo;
+
+import java.io.IOException;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class TasksIT extends ESRestHighLevelClientTestCase {
+
+    public void testListTasks() throws IOException {
+        ListTasksRequest request = new ListTasksRequest();
+        ListTasksResponse response = execute(request, highLevelClient().tasks()::list, highLevelClient().tasks()::listAsync);
+
+        assertThat(response, notNullValue());
+        assertThat(response.getNodeFailures(), equalTo(emptyList()));
+        assertThat(response.getTaskFailures(), equalTo(emptyList()));
+        // It's possible that there are other tasks except 'cluster:monitor/tasks/lists[n]' and 'action":"cluster:monitor/tasks/lists'
+        assertThat(response.getTasks().size(), greaterThanOrEqualTo(2));
+        boolean listTasksFound = false;
+        for (TaskGroup taskGroup : response.getTaskGroups()) {
+            TaskInfo parent = taskGroup.getTaskInfo();
+            if ("cluster:monitor/tasks/lists".equals(parent.getAction())) {
+                assertThat(taskGroup.getChildTasks().size(), equalTo(1));
+                TaskGroup childGroup = taskGroup.getChildTasks().iterator().next();
+                assertThat(childGroup.getChildTasks().isEmpty(), equalTo(true));
+                TaskInfo child = childGroup.getTaskInfo();
+                assertThat(child.getAction(), equalTo("cluster:monitor/tasks/lists[n]"));
+                assertThat(child.getParentTaskId(), equalTo(parent.getTaskId()));
+                listTasksFound = true;
+            }
+        }
+        assertTrue("List tasks were not found", listTasksFound);
+    }
+
+}

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ClusterClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/ClusterClientDocumentationIT.java
@@ -19,13 +19,8 @@
 
 package org.elasticsearch.client.documentation;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
-import org.elasticsearch.action.TaskOperationFailure;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
-import org.elasticsearch.action.admin.cluster.node.tasks.list.TaskGroup;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
@@ -39,21 +34,15 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.indices.recovery.RecoverySettings;
-import org.elasticsearch.tasks.TaskId;
-import org.elasticsearch.tasks.TaskInfo;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * This class is used to generate the Java Cluster API documentation.
@@ -188,89 +177,6 @@ public class ClusterClientDocumentationIT extends ESRestHighLevelClientTestCase 
             // tag::put-settings-execute-async
             client.cluster().putSettingsAsync(request, listener); // <1>
             // end::put-settings-execute-async
-
-            assertTrue(latch.await(30L, TimeUnit.SECONDS));
-        }
-    }
-
-    public void testListTasks() throws IOException {
-        RestHighLevelClient client = highLevelClient();
-        {
-            // tag::list-tasks-request
-            ListTasksRequest request = new ListTasksRequest();
-            // end::list-tasks-request
-
-            // tag::list-tasks-request-filter
-            request.setActions("cluster:*"); // <1>
-            request.setNodes("nodeId1", "nodeId2"); // <2>
-            request.setParentTaskId(new TaskId("parentTaskId", 42)); // <3>
-            // end::list-tasks-request-filter
-
-            // tag::list-tasks-request-detailed
-            request.setDetailed(true); // <1>
-            // end::list-tasks-request-detailed
-
-            // tag::list-tasks-request-wait-completion
-            request.setWaitForCompletion(true); // <1>
-            request.setTimeout(TimeValue.timeValueSeconds(50)); // <2>
-            request.setTimeout("50s"); // <3>
-            // end::list-tasks-request-wait-completion
-        }
-
-        ListTasksRequest request = new ListTasksRequest();
-
-        // tag::list-tasks-execute
-        ListTasksResponse response = client.cluster().listTasks(request);
-        // end::list-tasks-execute
-
-        assertThat(response, notNullValue());
-
-        // tag::list-tasks-response-tasks
-        List<TaskInfo> tasks = response.getTasks(); // <1>
-        // end::list-tasks-response-tasks
-
-        // tag::list-tasks-response-calc
-        Map<String, List<TaskInfo>> perNodeTasks = response.getPerNodeTasks(); // <1>
-        List<TaskGroup> groups = response.getTaskGroups(); // <2>
-        // end::list-tasks-response-calc
-
-        // tag::list-tasks-response-failures
-        List<ElasticsearchException> nodeFailures = response.getNodeFailures(); // <1>
-        List<TaskOperationFailure> taskFailures = response.getTaskFailures(); // <2>
-        // end::list-tasks-response-failures
-
-        assertThat(response.getNodeFailures(), equalTo(emptyList()));
-        assertThat(response.getTaskFailures(), equalTo(emptyList()));
-        assertThat(response.getTasks().size(), greaterThanOrEqualTo(2));
-    }
-
-    public void testListTasksAsync() throws Exception {
-        RestHighLevelClient client = highLevelClient();
-        {
-            ListTasksRequest request = new ListTasksRequest();
-
-            // tag::list-tasks-execute-listener
-            ActionListener<ListTasksResponse> listener =
-                    new ActionListener<ListTasksResponse>() {
-                        @Override
-                        public void onResponse(ListTasksResponse response) {
-                            // <1>
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            // <2>
-                        }
-                    };
-            // end::list-tasks-execute-listener
-
-            // Replace the empty listener by a blocking listener in test
-            final CountDownLatch latch = new CountDownLatch(1);
-            listener = new LatchedActionListener<>(listener, latch);
-
-            // tag::list-tasks-execute-async
-            client.cluster().listTasksAsync(request, listener); // <1>
-            // end::list-tasks-execute-async
 
             assertTrue(latch.await(30L, TimeUnit.SECONDS));
         }

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SnapshotClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SnapshotClientDocumentationIT.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
- * This class is used to generate the Java Cluster API documentation.
+ * This class is used to generate the Java Snapshot API documentation.
  * You need to wrap your code between two tags like:
  * // tag::example
  * // end::example

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TasksClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/TasksClientDocumentationIT.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.documentation;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.TaskOperationFailure;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.TaskGroup;
+import org.elasticsearch.client.ESRestHighLevelClientTestCase;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.tasks.TaskInfo;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * This class is used to generate the Java Tasks API documentation.
+ * You need to wrap your code between two tags like:
+ * // tag::example
+ * // end::example
+ *
+ * Where example is your tag name.
+ *
+ * Then in the documentation, you can extract what is between tag and end tags with
+ * ["source","java",subs="attributes,callouts,macros"]
+ * --------------------------------------------------
+ * include-tagged::{doc-tests}/{@link TasksClientDocumentationIT}.java[example]
+ * --------------------------------------------------
+ *
+ * The column width of the code block is 84. If the code contains a line longer
+ * than 84, the line will be cut and a horizontal scroll bar will be displayed.
+ * (the code indentation of the tag is not included in the width)
+ */
+public class TasksClientDocumentationIT extends ESRestHighLevelClientTestCase {
+
+    public void testListTasks() throws IOException {
+        RestHighLevelClient client = highLevelClient();
+        {
+            // tag::list-tasks-request
+            ListTasksRequest request = new ListTasksRequest();
+            // end::list-tasks-request
+
+            // tag::list-tasks-request-filter
+            request.setActions("cluster:*"); // <1>
+            request.setNodes("nodeId1", "nodeId2"); // <2>
+            request.setParentTaskId(new TaskId("parentTaskId", 42)); // <3>
+            // end::list-tasks-request-filter
+
+            // tag::list-tasks-request-detailed
+            request.setDetailed(true); // <1>
+            // end::list-tasks-request-detailed
+
+            // tag::list-tasks-request-wait-completion
+            request.setWaitForCompletion(true); // <1>
+            request.setTimeout(TimeValue.timeValueSeconds(50)); // <2>
+            request.setTimeout("50s"); // <3>
+            // end::list-tasks-request-wait-completion
+        }
+
+        ListTasksRequest request = new ListTasksRequest();
+
+        // tag::list-tasks-execute
+        ListTasksResponse response = client.tasks().list(request);
+        // end::list-tasks-execute
+
+        assertThat(response, notNullValue());
+
+        // tag::list-tasks-response-tasks
+        List<TaskInfo> tasks = response.getTasks(); // <1>
+        // end::list-tasks-response-tasks
+
+        // tag::list-tasks-response-calc
+        Map<String, List<TaskInfo>> perNodeTasks = response.getPerNodeTasks(); // <1>
+        List<TaskGroup> groups = response.getTaskGroups(); // <2>
+        // end::list-tasks-response-calc
+
+        // tag::list-tasks-response-failures
+        List<ElasticsearchException> nodeFailures = response.getNodeFailures(); // <1>
+        List<TaskOperationFailure> taskFailures = response.getTaskFailures(); // <2>
+        // end::list-tasks-response-failures
+
+        assertThat(response.getNodeFailures(), equalTo(emptyList()));
+        assertThat(response.getTaskFailures(), equalTo(emptyList()));
+        assertThat(response.getTasks().size(), greaterThanOrEqualTo(2));
+    }
+
+    public void testListTasksAsync() throws Exception {
+        RestHighLevelClient client = highLevelClient();
+        {
+            ListTasksRequest request = new ListTasksRequest();
+
+            // tag::list-tasks-execute-listener
+            ActionListener<ListTasksResponse> listener =
+                    new ActionListener<ListTasksResponse>() {
+                        @Override
+                        public void onResponse(ListTasksResponse response) {
+                            // <1>
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            // <2>
+                        }
+                    };
+            // end::list-tasks-execute-listener
+
+            // Replace the empty listener by a blocking listener in test
+            final CountDownLatch latch = new CountDownLatch(1);
+            listener = new LatchedActionListener<>(listener, latch);
+
+            // tag::list-tasks-execute-async
+            client.tasks().listAsync(request, listener); // <1>
+            // end::list-tasks-execute-async
+
+            assertTrue(latch.await(30L, TimeUnit.SECONDS));
+        }
+    }
+}

--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -104,11 +104,9 @@ include::indices/put_template.asciidoc[]
 The Java High Level REST Client supports the following Cluster APIs:
 
 * <<java-rest-high-cluster-put-settings>>
-* <<java-rest-high-cluster-list-tasks>>
 * <<java-rest-high-cluster-put-pipeline>>
 
 include::cluster/put_settings.asciidoc[]
-include::cluster/list_tasks.asciidoc[]
 include::cluster/put_pipeline.asciidoc[]
 
 == Snapshot APIs
@@ -122,3 +120,11 @@ The Java High Level REST Client supports the following Snapshot APIs:
 include::snapshot/get_repository.asciidoc[]
 include::snapshot/create_repository.asciidoc[]
 include::snapshot/delete_repository.asciidoc[]
+
+== Tasks APIs
+
+The Java High Level REST Client supports the following Tasks APIs:
+
+* <<java-rest-high-tasks-list>>
+
+include::tasks/list_tasks.asciidoc[]

--- a/docs/java-rest/high-level/tasks/list_tasks.asciidoc
+++ b/docs/java-rest/high-level/tasks/list_tasks.asciidoc
@@ -1,4 +1,4 @@
-[[java-rest-high-cluster-list-tasks]]
+[[java-rest-high-tasks-list]]
 === List Tasks API
 
 The List Tasks API allows to get information about the tasks currently executing in the cluster.
@@ -10,7 +10,7 @@ A `ListTasksRequest`:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-request]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-request]
 --------------------------------------------------
 There is no required parameters. By default the client will list all tasks and will not wait
 for task completion.
@@ -19,7 +19,7 @@ for task completion.
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-request-filter]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-request-filter]
 --------------------------------------------------
 <1> Request only cluster-related tasks
 <2> Request all tasks running on nodes nodeId1 and nodeId2
@@ -27,13 +27,13 @@ include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-request
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-request-detailed]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-request-detailed]
 --------------------------------------------------
 <1> Should the information include detailed, potentially slow to generate data. Defaults to `false`
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-request-wait-completion]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-request-wait-completion]
 --------------------------------------------------
 <1> Should this request wait for all found tasks to complete. Defaults to `false`
 <2> Timeout for the request as a `TimeValue`. Applicable only if `setWaitForCompletion` is `true`.
@@ -45,7 +45,7 @@ Defaults to 30 seconds
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-execute]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-execute]
 --------------------------------------------------
 
 [[java-rest-high-cluster-list-tasks-async]]
@@ -57,7 +57,7 @@ passed to the asynchronous method:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-execute-async]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-execute-async]
 --------------------------------------------------
 <1> The `ListTasksRequest` to execute and the `ActionListener` to use
 when the execution completes
@@ -71,7 +71,7 @@ A typical listener for `ListTasksResponse` looks like:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-execute-listener]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-execute-listener]
 --------------------------------------------------
 <1> Called when the execution is successfully completed. The response is
 provided as an argument
@@ -82,20 +82,20 @@ provided as an argument
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-response-tasks]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-response-tasks]
 --------------------------------------------------
 <1> List of currently running tasks
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-response-calc]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-response-calc]
 --------------------------------------------------
 <1> List of tasks grouped by a node
 <2> List of tasks grouped by a parent task
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/ClusterClientDocumentationIT.java[list-tasks-response-failures]
+include-tagged::{doc-tests}/TasksClientDocumentationIT.java[list-tasks-response-failures]
 --------------------------------------------------
 <1> List of node failures
 <2> List of tasks failures


### PR DESCRIPTION
Our API spec define the tasks API as e.g. tasks.list, meaning that they belong to their own namespace. This commit moves them from the cluster namespace to their own namespace.

Relates to #29546