### PR TITLE
Added max_expansion param to span_multi

### DIFF
--- a/docs/reference/query-dsl/span-multi-term-query.asciidoc
+++ b/docs/reference/query-dsl/span-multi-term-query.asciidoc
@@ -37,10 +37,9 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
-WARNING: By default `span_multi queries are rewritten to a `span_or` query
-containing **all** the expanded terms. This can be expensive if the number of expanded
-terms is large. To avoid an unbounded expansion you can set the
-<<query-dsl-multi-term-rewrite,rewrite method>> of the multi term query to `top_terms_*`
-rewrite. Or, if you use `span_multi` on `prefix` query only, you can
-activate the <<index-prefix-config,`index_prefixes`>> field option of the `text` field instead. This will
+WARNING: `span_multi` queries will hit too many clauses failure if the number of terms that match the query exceeds the
+boolean query limit (defaults to 1024).To avoid an unbounded expansion you can set the <<query-dsl-multi-term-rewrite,
+rewrite method>> of the multi term query to `top_terms_*` rewrite. Or, if you use `span_multi` on `prefix` query only,
+you can activate the <<index-prefix-config,`index_prefixes`>> field option of the `text` field instead. This will
 rewrite any prefix query on the field to a a single term query that matches the indexed prefix.
+

--- a/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/test/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.search.query;
 
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.util.English;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
@@ -33,8 +35,12 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.Operator;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.SpanMultiTermQueryBuilder;
+import org.elasticsearch.index.query.SpanNearQueryBuilder;
+import org.elasticsearch.index.query.SpanTermQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.WrapperQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
@@ -52,6 +58,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Random;
@@ -1817,6 +1824,32 @@ public class SearchQueryIT extends ESIntegTestCase {
         RangeQueryBuilder range = new RangeQueryBuilder("int_range").relation("intersects").from(Integer.MIN_VALUE).to(Integer.MAX_VALUE);
         SearchResponse searchResponse = client().prepareSearch("test").setQuery(range).get();
         assertHitCount(searchResponse, 1);
+    }
+
+    public void testTermExpansionExceptionOnSpanFailure() throws ExecutionException, InterruptedException {
+        Settings.Builder builder = Settings.builder();
+        builder.put(SETTING_NUMBER_OF_SHARDS, 1).build();
+
+        createIndex("test", builder.build());
+        ArrayList<IndexRequestBuilder> reqs = new ArrayList<>();
+        int origBoolMaxClauseCount = BooleanQuery.getMaxClauseCount();
+        try {
+            BooleanQuery.setMaxClauseCount(2);
+            for (int i = 0; i < BooleanQuery.getMaxClauseCount() + 1; i++) {
+                reqs.add(client().prepareIndex("test", "_doc", Integer.toString(i)).setSource("body", "foo" +
+                    Integer.toString(i) + " bar baz"));
+            }
+            indexRandom(true, false, reqs);
+
+            QueryBuilder queryBuilder = new SpanNearQueryBuilder(new SpanMultiTermQueryBuilder(QueryBuilders.wildcardQuery
+                ("body", "f*")), 0).addClause(new SpanTermQueryBuilder("body", "bar"));
+
+            expectThrows(ElasticsearchException.class, () ->
+                client().prepareSearch().setIndices("test").setQuery(queryBuilder).get());
+        } finally {
+            BooleanQuery.setMaxClauseCount(origBoolMaxClauseCount);
+        }
+
     }
 
 }


### PR DESCRIPTION
Causes span query to throw exception if term expansions with in
multi_term inner query exceeds max_expansion param

Example query:

{"span_multi" : {"match" : {"prefix" : {"user" : {"value" : "ki","boost" : 1.08}}},"max_expansions" : 22 ,"boost" :1.0}}

I was trying to patch one older version of ES to avoid heap crash, but noticed that its logged as an issue here - https://github.com/elastic/elasticsearch/issues/27432 
