### PR TITLE
Fix IndexTemplateMetaData parsing from xContent

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaData.java
@@ -270,7 +270,8 @@ public class IndexTemplateMetaData extends AbstractDiffable<IndexTemplateMetaDat
 
     public static class Builder {
 
-        private static final Set<String> VALID_FIELDS = Sets.newHashSet("template", "order", "mappings", "settings", "index_patterns");
+        private static final Set<String> VALID_FIELDS = Sets.newHashSet(
+            "template", "order", "mappings", "settings", "index_patterns", "aliases", "version");
         static {
             VALID_FIELDS.addAll(IndexMetaData.customPrototypes.keySet());
         }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetaDataTests.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.cluster.metadata.AliasMetaData.newAliasMetaDataBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.contains;
 
 public class IndexTemplateMetaDataTests extends ESTestCase {
 
@@ -165,6 +166,56 @@ public class IndexTemplateMetaDataTests extends ESTestCase {
             final IllegalArgumentException ex = expectThrows(IllegalArgumentException.class,
                 () -> IndexTemplateMetaData.Builder.fromXContent(parser, randomAlphaOfLengthBetween(1, 100)));
             assertThat(ex.getMessage(), equalTo("Index patterns must not be null or empty; got null"));
+        }
+    }
+
+    public void testParseTemplateWithAliases() throws Exception {
+        String templateInJSON = "{\"aliases\": {\"log\":{}}, \"index_patterns\": [\"pattern-1\"]}";
+        try (XContentParser parser =
+                 XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+                     DeprecationHandler.THROW_UNSUPPORTED_OPERATION, new BytesArray(templateInJSON), XContentType.JSON)) {
+            IndexTemplateMetaData template = IndexTemplateMetaData.Builder.fromXContent(parser, randomAlphaOfLengthBetween(1, 100));
+            assertThat(template.aliases().containsKey("log"), equalTo(true));
+            assertThat(template.patterns(), contains("pattern-1"));
+        }
+    }
+
+    public void testFromToXContent() throws Exception {
+        String templateName = randomUnicodeOfCodepointLengthBetween(1, 10);
+        IndexTemplateMetaData.Builder templateBuilder = IndexTemplateMetaData.builder(templateName);
+        templateBuilder.patterns(Arrays.asList("pattern-1"));
+        int numAlias = between(0, 5);
+        for (int i = 0; i < numAlias; i++) {
+            AliasMetaData.Builder alias = AliasMetaData.builder(randomRealisticUnicodeOfLengthBetween(1, 100));
+            if (randomBoolean()) {
+                alias.indexRouting(randomRealisticUnicodeOfLengthBetween(1, 100));
+            }
+            if (randomBoolean()) {
+                alias.searchRouting(randomRealisticUnicodeOfLengthBetween(1, 100));
+            }
+            templateBuilder.putAlias(alias);
+        }
+        if (randomBoolean()) {
+            templateBuilder.settings(Settings.builder().put("index.setting-1", randomLong()));
+            templateBuilder.settings(Settings.builder().put("index.setting-2", randomTimeValue()));
+        }
+        if (randomBoolean()) {
+            templateBuilder.order(randomInt());
+        }
+        if (randomBoolean()) {
+            templateBuilder.version(between(0, 100));
+        }
+        if (randomBoolean()) {
+            templateBuilder.putMapping("doc", "{\"doc\":{\"properties\":{\"type\":\"text\"}}}");
+        }
+        IndexTemplateMetaData template = templateBuilder.build();
+        XContentBuilder builder = XContentBuilder.builder(randomFrom(XContentType.JSON.xContent()));
+        builder.startObject();
+        IndexTemplateMetaData.Builder.toXContent(template, builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        try (XContentParser parser = createParser(shuffleXContent(builder))) {
+            IndexTemplateMetaData parsed = IndexTemplateMetaData.Builder.fromXContent(parser, templateName);
+            assertThat(parsed, equalTo(template));
         }
     }
 }


### PR DESCRIPTION
We failed to register "aliases" and "version" into the list of keywords
in the IndexTemplateMetaData; then fail to parse the following index
template.

```
{
    "aliases": {"log": {}},
    "index_patterns": ["pattern-1"]
}
```
This commit registers that missing keywords.