### PR TITLE
Remove metadata customs that can break serialization

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -122,8 +122,9 @@ public class MlMetadata implements MetaData.Custom {
         return MLMetadataField.TYPE;
     }
 
-    @Override
-    public EnumSet<MetaData.XContentContext> context() {
+    private static final EnumSet<MetaData.XContentContext> CONTEXT;
+
+    static {
         /*
          * We generally can not expose ML custom metadata because we might be communicating with a client that does not understand such
          * custom metadata. This can happen, for example, when a transport client without the X-Pack plugin is connected to a 6.3.0 cluster
@@ -133,10 +134,16 @@ public class MlMetadata implements MetaData.Custom {
          * undocumented system property. This system property could be removed at any time.
          */
         if (Boolean.parseBoolean(System.getProperty("es.xpack.ml.api_metadata_context", "false"))) {
-            return MetaData.ALL_CONTEXTS;
+            CONTEXT = MetaData.ALL_CONTEXTS;
         } else {
-            return EnumSet.of(MetaData.XContentContext.GATEWAY, MetaData.XContentContext.SNAPSHOT);
+            CONTEXT = EnumSet.of(MetaData.XContentContext.GATEWAY, MetaData.XContentContext.SNAPSHOT);
         }
+    }
+
+    @Override
+    public EnumSet<MetaData.XContentContext> context() {
+
+        return CONTEXT;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -124,7 +124,19 @@ public class MlMetadata implements MetaData.Custom {
 
     @Override
     public EnumSet<MetaData.XContentContext> context() {
-        return MetaData.ALL_CONTEXTS;
+        /*
+         * We generally can not expose ML custom metadata because we might be communicating with a client that does not understand such
+         * custom metadata. This can happen, for example, when a transport client without the X-Pack plugin is connected to a 6.3.0 cluster
+         * running the default distribution. To avoid sending such a client a metadata custom that it can not understand, we do not return
+         * ML custom metadata in response to cluster state requests. However, this a breaking change from previous versions where we assumed
+         * that any client would have X-Pack installed. To reinstate the previous behavior (e.g., for debugging) we provide the following
+         * undocumented system property. This system property could be removed at any time.
+         */
+        if (Boolean.parseBoolean(System.getProperty("es.xpack.ml.api_metadata_context", "false"))) {
+            return MetaData.ALL_CONTEXTS;
+        } else {
+            return EnumSet.of(MetaData.XContentContext.GATEWAY, MetaData.XContentContext.SNAPSHOT);
+        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlMetadata.java
@@ -142,7 +142,6 @@ public class MlMetadata implements MetaData.Custom {
 
     @Override
     public EnumSet<MetaData.XContentContext> context() {
-
         return CONTEXT;
     }
 


### PR DESCRIPTION
This commit removes ML and persistent task custom metadata from the cluster state API to avoid the possibility of sending such custom metadata to a client that can not understand. This can arise in a rolling upgrade to the default distribution from a prior version that did not have X-Pack.

Relates #30731, relates #30857 