### PR TITLE
Make AllocatedPersistentTask.isCompleted() protected

### DIFF
--- a/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
+++ b/server/src/main/java/org/elasticsearch/persistent/AllocatedPersistentTask.java
@@ -115,7 +115,7 @@ public class AllocatedPersistentTask extends CancellableTask {
         persistentTasksService.waitForPersistentTaskCondition(persistentTaskId, predicate, timeout, listener);
     }
 
-    final boolean isCompleted() {
+    protected final boolean isCompleted() {
         return state.get() ==  State.COMPLETED;
     }
 


### PR DESCRIPTION
This commit changes the isCompleted() method to be protected so that
classes that extends AllocatedPersistentTask can use it.

Related to #30858