### PR TITLE
Reuse expiration date of trial licenses

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
@@ -61,10 +61,10 @@ public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
                         "]. Must be trial or basic.");
             }
             return updateWithLicense(currentState, type);
-        } else if (LicenseUtils.licenseNeedsExtended(currentLicensesMetaData.getLicense())) {
-            return extendBasic(currentState, currentLicensesMetaData);
         } else if (LicenseUtils.signatureNeedsUpdate(currentLicensesMetaData.getLicense())) {
             return updateLicenseSignature(currentState, currentLicensesMetaData);
+        } else if (LicenseUtils.licenseNeedsExtended(currentLicensesMetaData.getLicense())) {
+            return extendBasic(currentState, currentLicensesMetaData);
         } else {
             return currentState;
         }
@@ -75,11 +75,10 @@ public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
         MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
         String type = license.type();
         long issueDate = license.issueDate();
-        long expiryDate;
+        long expiryDate = license.expiryDate();
+        // extend the basic license expiration date if needed since extendBasic will not be called now
         if ("basic".equals(type)) {
             expiryDate = LicenseService.BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS;
-        } else {
-            expiryDate = issueDate + LicenseService.NON_BASIC_SELF_GENERATED_LICENSE_DURATION.getMillis();
         }
         License.Builder specBuilder = License.builder()
                 .uid(license.uid())
@@ -92,6 +91,8 @@ public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
         Version trialVersion = currentLicenseMetaData.getMostRecentTrialVersion();
         LicensesMetaData newLicenseMetadata = new LicensesMetaData(selfGeneratedLicense, trialVersion);
         mdBuilder.putCustom(LicensesMetaData.TYPE, newLicenseMetadata);
+        logger.info("Updating existing license to the new version.\n\nOld license:\n {}\n\n New license:\n{}",
+            license, newLicenseMetadata.getLicense());
         return ClusterState.builder(currentState).metaData(mdBuilder).build();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
@@ -77,7 +77,7 @@ public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
         long issueDate = license.issueDate();
         long expiryDate = license.expiryDate();
         // extend the basic license expiration date if needed since extendBasic will not be called now
-        if ("basic".equals(type)) {
+        if ("basic".equals(type) &&  expiryDate != LicenseService.BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS) {
             expiryDate = LicenseService.BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS;
         }
         License.Builder specBuilder = License.builder()


### PR DESCRIPTION
While updating the license signature to the new license spec, keep
the trial license expiration date to that of the existing license
irrespective to whether this was a self generated or a registered
one.

Resolves #30882