### PR TITLE
Fix index_prefixes cross-type compatibility check

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -292,12 +292,16 @@ public class TextFieldMapper extends FieldMapper {
         @Override
         public void checkCompatibility(MappedFieldType other, List<String> conflicts, boolean strict) {
             super.checkCompatibility(other, conflicts, strict);
-            PrefixFieldType otherFieldType = (PrefixFieldType) other;
-            if (otherFieldType.minChars != this.minChars) {
-                conflicts.add("mapper [" + name() + "] has different min_chars values");
-            }
-            if (otherFieldType.maxChars != this.maxChars) {
-                conflicts.add("mapper [" + name() + "] has different max_chars values");
+            if (strict) {
+                PrefixFieldType otherFieldType = (PrefixFieldType) other;
+                if (otherFieldType.minChars != this.minChars) {
+                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update "
+                        + "[index_prefixes.min_chars] across all types.");
+                }
+                if (otherFieldType.maxChars != this.maxChars) {
+                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update "
+                        + "[index_prefixes.max_chars] across all types.");
+                }
             }
         }
 
@@ -420,6 +424,10 @@ public class TextFieldMapper extends FieldMapper {
                 if (fielddataMinSegmentSize() != otherType.fielddataMinSegmentSize()) {
                     conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update "
                             + "[fielddata_frequency_filter.min_segment_size] across all types.");
+                }
+                if (Objects.equals(this.prefixFieldType, ((TextFieldType) other).prefixFieldType) == false) {
+                    conflicts.add("mapper [" + name() + "] is used by multiple types. Set update_all_types to true to update "
+                        + "[index_prefixes] across all types.");
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -734,25 +734,6 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
             Query q6 = mapper.mappers().getMapper("field").fieldType().prefixQuery("goings",
                 CONSTANT_SCORE_REWRITE, queryShardContext);
             assertThat(q6, instanceOf(PrefixQuery.class));
-
-            indexService.mapperService().merge("type", json, MergeReason.MAPPING_UPDATE, true);
-
-            String badUpdate = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
-                .startObject("properties").startObject("field")
-                .field("type", "text")
-                .field("analyzer", "english")
-                .startObject("index_prefixes")
-                .field("min_chars", 1)
-                .field("max_chars", 10)
-                .endObject()
-                .endObject().endObject()
-                .endObject().endObject());
-
-            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
-                indexService.mapperService()
-                    .merge("type", new CompressedXContent(badUpdate), MergeReason.MAPPING_UPDATE, true);
-            });
-            assertThat(e.getMessage(), containsString("mapper [field._index_prefix] has different min_chars values"));
         }
 
         {


### PR DESCRIPTION
The 6.x line needs to check compatibility between types.

Fixes #30955 