### PR TITLE
[Tests] Fix alias names in PutIndexTemplateRequestTests

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/Alias.java
@@ -28,7 +28,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.ToXContent.Params;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -42,7 +43,7 @@ import java.util.Map;
 /**
  * Represents an alias, to be associated with an index
  */
-public class Alias implements Streamable, ToXContentObject {
+public class Alias implements Streamable, ToXContentFragment {
 
     private static final ParseField FILTER = new ParseField("filter");
     private static final ParseField ROUTING = new ParseField("routing");
@@ -246,6 +247,11 @@ public class Alias implements Streamable, ToXContentObject {
 
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestTests.java
@@ -150,7 +150,9 @@ public class PutIndexTemplateRequestTests extends AbstractXContentTestCase<PutIn
         request.patterns(Arrays.asList(generateRandomStringArray(20, 100, false, false)));
         int numAlias = between(0, 5);
         for (int i = 0; i < numAlias; i++) {
-            Alias alias = new Alias(randomRealisticUnicodeOfLengthBetween(1, 10));
+            // some ASCII or Latin-1 control characters, especially newline, can lead to
+            // problems with yaml parsers, that's why we filter them here (see #30911)
+            Alias alias = new Alias(randomRealisticUnicodeOfLengthBetween(1, 10).replaceAll("\\p{Cc}", ""));
             if (randomBoolean()) {
                 alias.indexRouting(randomRealisticUnicodeOfLengthBetween(1, 10));
             }


### PR DESCRIPTION
The randomized alias names can contain unicode controll charactes that don't
survive an xContent rendering and parsing roundtrip when using the YAML xContent
type. This fix filters the randomized unicode string for control characters to
avoid this particular problem.

Closes #30911