### PR TITLE
Add “took” timing info to response for _msearch/template API

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -94,7 +94,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                     items[originalSlot].getResponse().setResponse(item.getResponse());
                 }
             }
-            listener.onResponse(new MultiSearchTemplateResponse(items));
+            listener.onResponse(new MultiSearchTemplateResponse(items, r.getTook().millis()));
         }, listener::onFailure));
     }
 }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
@@ -37,6 +37,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
@@ -140,6 +141,7 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
 
         MultiSearchTemplateResponse response = client().execute(MultiSearchTemplateAction.INSTANCE, multiRequest).get();
         assertThat(response.getResponses(), arrayWithSize(5));
+        assertThat(response.getTook().millis(), greaterThan(0l));
 
         MultiSearchTemplateResponse.Item response1 = response.getResponses()[0];
         assertThat(response1.isFailure(), is(false));

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
@@ -141,7 +141,7 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
 
         MultiSearchTemplateResponse response = client().execute(MultiSearchTemplateAction.INSTANCE, multiRequest).get();
         assertThat(response.getResponses(), arrayWithSize(5));
-        assertThat(response.getTook().millis(), greaterThan(0l));
+        assertThat(response.getTook().millis(), greaterThan(0L));
 
         MultiSearchTemplateResponse.Item response1 = response.getResponses()[0];
         assertThat(response1.isFailure(), is(false));


### PR DESCRIPTION
Unlike `_msearch`, the `_msearch/template` API was missing the `took` timing info in the response.
Under the covers the template-based version delegates to a regular msearch so we now just return the timing information from the msearch response.

Closes #30957
