### PR TITLE
Cross Cluster Search: preserve remote status code

### DIFF
--- a/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/50_missing.yml
+++ b/qa/multi-cluster-search/src/test/resources/rest-api-spec/test/multi_cluster/50_missing.yml
@@ -1,7 +1,7 @@
 ---
 "Search with missing remote index pattern":
   - do:
-      catch: "request"
+      catch: "missing"
       search:
         index: "my_remote_cluster:foo"
 
@@ -34,7 +34,7 @@
   - match: { aggregations.cluster.buckets.0.doc_count: 6 }
 
   - do:
-      catch: "request"
+      catch: "missing"
       search:
         index: "my_remote_cluster:test_index,my_remote_cluster:foo"
         body:

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -215,7 +215,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
                                     ActionListener<Map<String, ClusterSearchShardsResponse>> listener) {
         final CountDown responsesCountDown = new CountDown(remoteIndicesByCluster.size());
         final Map<String, ClusterSearchShardsResponse> searchShardsResponses = new ConcurrentHashMap<>();
-        final AtomicReference<TransportException> transportException = new AtomicReference<>();
+        final AtomicReference<RemoteTransportException> transportException = new AtomicReference<>();
         for (Map.Entry<String, OriginalIndices> entry : remoteIndicesByCluster.entrySet()) {
             final String clusterName = entry.getKey();
             RemoteClusterConnection remoteClusterConnection = remoteClusters.get(clusterName);
@@ -232,7 +232,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
                     public void onResponse(ClusterSearchShardsResponse clusterSearchShardsResponse) {
                         searchShardsResponses.put(clusterName, clusterSearchShardsResponse);
                         if (responsesCountDown.countDown()) {
-                            TransportException exception = transportException.get();
+                            RemoteTransportException exception = transportException.get();
                             if (exception == null) {
                                 listener.onResponse(searchShardsResponses);
                             } else {
@@ -243,8 +243,8 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
 
                     @Override
                     public void onFailure(Exception e) {
-                        TransportException exception = new TransportException("unable to communicate with remote cluster [" +
-                                clusterName + "]", e);
+                        RemoteTransportException exception = new RemoteTransportException("error while communicating with remote cluster ["
+                                + clusterName + "]", e);
                         if (transportException.compareAndSet(null, exception) == false) {
                             exception = transportException.accumulateAndGet(exception, (previous, current) -> {
                                 current.addSuppressed(previous);

--- a/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/50_missing.yml
+++ b/x-pack/qa/multi-cluster-search-security/src/test/resources/rest-api-spec/test/multi_cluster/50_missing.yml
@@ -56,13 +56,13 @@ teardown:
   - match: { hits.total: 0 }
 
   - do:
-      catch: "request"
+      catch: "forbidden"
       headers: { Authorization: "Basic am9lOnMza3JpdA==" }
       search:
         index: "*:foo-bar"
 
   - do:
-      catch: "request"
+      catch: "forbidden"
       headers: { Authorization: "Basic am9lOnMza3JpdA==" }
       search:
         index: "my_remote_cluster:foo-bar"


### PR DESCRIPTION
In case an error is returned when calling search_shards on a remote
cluster, which will lead to throwing an exception in the coordinating
 node, we should make sure that the status code returned by the
 coordinating node is the same as the one returned by the remote
 cluster. Up until now a 500 - Internal Server Error was always
 returned. This commit changes this behaviour so that for instance if an
 index is not found, which causes an 404, a 404 is also returned by the
 coordinating node to the client.

 Closes #27461