### PR TITLE
Make DateFieldMapper extensible

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -176,11 +176,11 @@ public class DateFieldMapper extends FieldMapper {
         }
     }
 
-    public static final class DateFieldType extends MappedFieldType {
+    public static class DateFieldType extends MappedFieldType {
         protected FormatDateTimeFormatter dateTimeFormatter;
         protected DateMathParser dateMathParser;
 
-        DateFieldType() {
+        protected DateFieldType() {
             super();
             setTokenized(false);
             setHasDocValues(true);
@@ -188,7 +188,7 @@ public class DateFieldMapper extends FieldMapper {
             setDateTimeFormatter(DEFAULT_DATE_TIME_FORMATTER);
         }
 
-        DateFieldType(DateFieldType other) {
+        protected DateFieldType(DateFieldType other) {
             super(other);
             setDateTimeFormatter(other.dateTimeFormatter);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -78,7 +78,11 @@ public class DateFieldMapper extends FieldMapper {
         private boolean dateTimeFormatterSet = false;
 
         public Builder(String name) {
-            super(name, new DateFieldType(), new DateFieldType());
+            this(name, new DateFieldType());
+        }
+
+        public Builder(String name, DateFieldType dateFieldType) {
+            super(name, dateFieldType, dateFieldType);
             builder = this;
             locale = Locale.ROOT;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -447,7 +447,7 @@ public class DateFieldMapper extends FieldMapper {
 
         long timestamp;
         try {
-            timestamp = fieldType().parse(dateAsString);
+            timestamp = parse(dateAsString);
         } catch (IllegalArgumentException e) {
             if (ignoreMalformed.value()) {
                 context.addIgnoredField(fieldType.name());
@@ -468,6 +468,10 @@ public class DateFieldMapper extends FieldMapper {
         if (fieldType().stored()) {
             fields.add(new StoredField(fieldType().name(), timestamp));
         }
+    }
+
+    protected long parse(String dateAsString) {
+        return fieldType().parse(dateAsString);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -392,7 +392,7 @@ public class DateFieldMapper extends FieldMapper {
 
     private Explicit<Boolean> ignoreMalformed;
 
-    private DateFieldMapper(
+    protected DateFieldMapper(
             String simpleName,
             MappedFieldType fieldType,
             MappedFieldType defaultFieldType,

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -143,7 +143,7 @@ public class DateFieldMapper extends FieldMapper {
 
         @Override
         public Mapper.Builder<?,?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
-            Builder builder = new Builder(name);
+            Builder builder = createBuilder(name);
             TypeParsers.parseField(builder, name, node, parserContext);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();
@@ -169,6 +169,10 @@ public class DateFieldMapper extends FieldMapper {
                 }
             }
             return builder;
+        }
+
+        protected Builder createBuilder(String name) {
+            return new Builder(name);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -60,7 +60,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.index.mapper.TypeParsers.parseDateTimeFormatter;
 
-/** A {@link FieldMapper} for ip addresses. */
+/** A {@link FieldMapper} for datetime related values */
 public class DateFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "date";


### PR DESCRIPTION
This change is a proposal for making DateFieldMapper extensible. I am proposing this change so it's possible to extend DateFieldMapper into another date type that automatically supports indexing and searching for date parts such as `day_of_week`, `week_of_year`, `year`, etc. The actual DateFieldMapper extension for supporting this feature is implemented in a plugin https://github.com/tsouza/elasticsearch-mapper-dateext [WIP].

The plugin can only possibly be implemented is the changes in this PR can be accepted.


