### PR TITLE
Ensure intended key is selected in SamlAuthenticatorTests

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
@@ -374,7 +374,7 @@ public class SamlAuthenticatorTests extends SamlTestCase {
         final String xml = getSimpleResponse(now);
 
         // Encrypting with different cert instead of sp cert will mean that the SP cannot decrypt
-        final String encrypted = encryptAssertions(xml, readKeyPair("RSA_1024"));
+        final String encrypted = encryptAssertions(xml, readKeyPair("RSA_4096_updated"));
         assertThat(encrypted, not(equalTo(xml)));
 
         final String signed = signDoc(encrypted);
@@ -896,7 +896,6 @@ public class SamlAuthenticatorTests extends SamlTestCase {
         assertThat(attributes.attributes(), iterableWithSize(1));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/30970")
     public void testIncorrectSigningKeyIsRejected() throws Exception {
         final CryptoTransform signer = randomBoolean() ? this::signDoc : this::signAssertions;
         Instant now = clock.instant();
@@ -938,7 +937,7 @@ public class SamlAuthenticatorTests extends SamlTestCase {
         assertThat(authenticator.authenticate(token(signer.transform(xml, idpSigningCertificatePair))), notNullValue());
 
         // check is rejected when signed by a different key-pair
-        final Tuple<X509Certificate, PrivateKey> wrongKey = readRandomKeyPair(randomSigningAlgorithm());
+        final Tuple<X509Certificate, PrivateKey> wrongKey = readKeyPair("RSA_4096_updated");
         final ElasticsearchSecurityException exception = expectThrows(ElasticsearchSecurityException.class,
                 () -> authenticator.authenticate(token(signer.transform(xml, wrongKey))));
         assertThat(exception.getMessage(), containsString("SAML Signature"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
@@ -953,10 +953,12 @@ public class SamlAuthenticatorTests extends SamlTestCase {
         assertThat(authenticator.authenticate(token(signer.transform(xml, idpSigningCertificatePair))), notNullValue());
 
         final Tuple<X509Certificate, PrivateKey> oldKeyPair = idpSigningCertificatePair;
-        //Ensure we won't read any of the ones we could have picked randomly before
+        // Ensure we won't read any of the ones we could have picked randomly before
         idpSigningCertificatePair = readKeyPair("RSA_4096_updated");
         assertThat(idpSigningCertificatePair.v2(), not(equalTo(oldKeyPair.v2())));
         assertThat(authenticator.authenticate(token(signer.transform(xml, idpSigningCertificatePair))), notNullValue());
+        // Restore the keypair to one from the keypair pool of all algorithms and keys
+        idpSigningCertificatePair = readRandomKeyPair(randomSigningAlgorithm());
     }
 
     public void testParsingRejectsTamperedContent() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
@@ -71,7 +71,7 @@ public abstract class SamlTestCase extends ESTestCase {
     }
 
     /**
-     * Generates key pair for given algorithm and then associates with a certificate.
+     * Reads a key pair and associated certificate for given algorithm and key length
      * For testing, for "EC" algorithm 256 key size is used, others use 2048 as default.
      * @param algorithm
      * @return X509Certificate a signed certificate, it's PrivateKey {@link Tuple}


### PR DESCRIPTION
Uses a specific keypair for tests that require a purposefully wrong
keypair instead of selecting one randomly from the same pull from
which the correct one is selected. Entropy is low because of the
small space and the same key can be randomly selected as both the
correct one and the wrong one, causing the tests to fail.

Resolves #30970