### PR TITLE
Deprecates indexing and querying a context completion field without context

### DIFF
--- a/docs/reference/migration/migrate_6_0/search.asciidoc
+++ b/docs/reference/migration/migrate_6_0/search.asciidoc
@@ -208,3 +208,9 @@ For 6.x and starting in 6.3 a deprecation warning will be printed to warn
 against search requests that contain extra tokens after the main object.
 These extra tokens were ignored by the query parser before 6.3 but the next
  major version will not accept invalid body anymore.
+
+==== Context suggester without contexts
+
+The ability to query and index context enabled suggestions without contexts
+has been deprecated. Context enabled suggestion queries without contexts have
+to visit every suggestion, which degrades the search performance considerably.

--- a/docs/reference/search/suggesters/context-suggest.asciidoc
+++ b/docs/reference/search/suggesters/context-suggest.asciidoc
@@ -84,6 +84,10 @@ PUT place_path_category
 NOTE: Adding context mappings increases the index size for completion field. The completion index
 is entirely heap resident, you can monitor the completion field index size using <<indices-stats>>.
 
+NOTE: deprecated[7.0.0, Indexing a suggestion without context on a context enabled completion field is deprecated
+and will be removed in the next major release. If you want to index a suggestion that matches all contexts you should
+add a special context for it.]
+
 [[suggester-context-category]]
 [float]
 ==== Category Context
@@ -156,9 +160,9 @@ POST place/_search?pretty
 // CONSOLE
 // TEST[continued]
 
-NOTE: When no categories are provided at query-time, all indexed documents are considered.
-Querying with no categories on a category enabled completion field should be avoided, as it
-will degrade search performance.
+Note: deprecated[7.0.0, When no categories are provided at query-time, all indexed documents are considered.
+Querying with no categories on a category enabled completion field is deprecated and will be removed in the next major release
+as it degrades search performance considerably.]
 
 Suggestions with certain categories can be boosted higher than others.
 The following filters suggestions by categories and additionally boosts

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/30_context.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/30_context.yml
@@ -336,16 +336,80 @@ setup:
   - length: { suggest.result.0.options: 1  }
   - match:  { suggest.result.0.options.0.text: "foo" }
 
+---
+"Indexing and Querying without contexts is deprecated":
+  - skip:
+      version: " - 6.99.99"
+      reason: this feature was deprecated in 7.0
+      features: "warnings"
+
   - do:
-       search:
+      index:
+        index: test
+        type:  test
+        id:    1
+        body:
+          suggest_context:
+            input: "foo"
+            contexts:
+              color: "red"
+          suggest_multi_contexts:
+            input: "bar"
+            contexts:
+              color: "blue"
+
+  - do:
+      warnings:
+        - "The ability to index a suggestion with no context on a context enabled completion field is deprecated and will be removed in the next major release."
+      index:
+        index: test
+        type:  test
+        id:    2
+        body:
+          suggest_context:
+            input: "foo"
+
+  - do:
+      indices.refresh: {}
+      
+  - do:
+      warnings:
+        - "The ability to query with no context on a context enabled completion field is deprecated and will be removed in the next major release."
+      search:
         body:
           suggest:
             result:
               text: "foo"
               completion:
-                skip_duplicates: true
                 field: suggest_context
 
   - length: { suggest.result: 1  }
-  - length: { suggest.result.0.options: 1  }
-  - match:  { suggest.result.0.options.0.text: "foo" }
+
+  - do:
+      warnings:
+        - "The ability to query with no context on a context enabled completion field is deprecated and will be removed in the next major release."
+      search:
+        body:
+          suggest:
+            result:
+              text: "foo"
+              completion:
+                field: suggest_context
+                contexts: {}
+
+  - length: { suggest.result: 1  }
+
+  - do:
+      warnings:
+          - "The ability to query with no context on a context enabled completion field is deprecated and will be removed in the next major release."
+      search:
+        body:
+          suggest:
+            result:
+              text: "foo"
+              completion:
+                field: suggest_multi_contexts
+                contexts:
+                  location: []
+
+  - length: { suggest.result: 1  }

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/30_context.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/30_context.yml
@@ -339,8 +339,8 @@ setup:
 ---
 "Indexing and Querying without contexts is deprecated":
   - skip:
-      version: " - 6.99.99"
-      reason: this feature was deprecated in 7.0
+      version: " - 6.3.99"
+      reason: this feature was deprecated in 6.4
       features: "warnings"
 
   - do:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/40_typed_keys.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/40_typed_keys.yml
@@ -22,7 +22,9 @@ setup:
                           "type" : "category"
 
   - do:
-     bulk:
+      warnings:
+        - "The ability to index a suggestion with no context on a context enabled completion field is deprecated and will be removed in the next major release."
+      bulk:
         refresh: true
         index: test
         type: test
@@ -34,8 +36,14 @@ setup:
 
 ---
 "Test typed keys parameter for suggesters":
+  - skip:
+      version: " - 6.99.99"
+      reason: queying a context suggester with no context was deprecated in 7.0
+      features: "warnings"
 
   - do:
+      warnings:
+        - "The ability to query with no context on a context enabled completion field is deprecated and will be removed in the next major release."
       search:
         typed_keys: true
         body:

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/40_typed_keys.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/suggest/40_typed_keys.yml
@@ -20,10 +20,10 @@ setup:
                         -
                           "name" : "format"
                           "type" : "category"
+---
+"Test typed keys parameter for suggesters":
 
   - do:
-      warnings:
-        - "The ability to index a suggestion with no context on a context enabled completion field is deprecated and will be removed in the next major release."
       bulk:
         refresh: true
         index: test
@@ -32,18 +32,9 @@ setup:
           - '{"index": {}}'
           - '{"title": "Elasticsearch in Action", "suggestions": {"input": "ELK in Action", "contexts": {"format": "ebook"}}}'
           - '{"index": {}}'
-          - '{"title": "Elasticsearch - The Definitive Guide", "suggestions": {"input": ["Elasticsearch in Action"]}}'
-
----
-"Test typed keys parameter for suggesters":
-  - skip:
-      version: " - 6.99.99"
-      reason: queying a context suggester with no context was deprecated in 7.0
-      features: "warnings"
+          - '{"title": "Elasticsearch - The Definitive Guide", "suggestions": {"input": ["Elasticsearch in Action"], "contexts": {"format": "ebook"}}}'
 
   - do:
-      warnings:
-        - "The ability to query with no context on a context enabled completion field is deprecated and will be removed in the next major release."
       search:
         typed_keys: true
         body:
@@ -54,10 +45,6 @@ setup:
             term_suggester:
               term:
                 field: title
-            completion_suggester:
-              prefix: "Elastic"
-              completion:
-                field: suggestions
             context_suggester:
               prefix: "Elastic"
               completion:
@@ -69,6 +56,5 @@ setup:
                 field: title
 
   - is_true: suggest.term#term_suggester
-  - is_true: suggest.completion#completion_suggester
   - is_true: suggest.completion#context_suggester
   - is_true: suggest.phrase#phrase_suggester

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -83,7 +83,6 @@ import static org.elasticsearch.index.mapper.TypeParsers.parseMultiField;
  *  for query-time filtering and boosting (see {@link ContextMappings}
  */
 public class CompletionFieldMapper extends FieldMapper implements ArrayValueMapperParser {
-
     public static final String CONTENT_TYPE = "completion";
 
     public static class Defaults {

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestionBuilder.java
@@ -57,6 +57,7 @@ import java.util.Objects;
  * indexing.
  */
 public class CompletionSuggestionBuilder extends SuggestionBuilder<CompletionSuggestionBuilder> {
+
     private static final XContentType CONTEXT_BYTES_XCONTENT_TYPE = XContentType.JSON;
     static final String SUGGESTION_NAME = "completion";
     static final ParseField CONTEXTS_FIELD = new ParseField("contexts", "context");


### PR DESCRIPTION
This is a backport of #30712