### PR TITLE
Remove extraneous references to 'tokenized' in the mapper code.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -85,14 +85,6 @@ public class BooleanFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Builder tokenized(boolean tokenized) {
-            if (tokenized) {
-                throw new IllegalArgumentException("bool field can't be tokenized");
-            }
-            return super.tokenized(tokenized);
-        }
-
-        @Override
         public BooleanFieldMapper build(BuilderContext context) {
             setupFieldType(context);
             return new BooleanFieldMapper(name, fieldType, defaultFieldType,

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -147,11 +147,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return builder;
         }
 
-        public T tokenized(boolean tokenized) {
-            this.fieldType.setTokenized(tokenized);
-            return builder;
-        }
-
         public T boost(float boost) {
             this.fieldType.setBoost(boost);
             return builder;
@@ -376,9 +371,8 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
         boolean indexed =  fieldType().indexOptions() != IndexOptions.NONE;
         boolean defaultIndexed = defaultFieldType.indexOptions() != IndexOptions.NONE;
-        if (includeDefaults || indexed != defaultIndexed ||
-            fieldType().tokenized() != defaultFieldType.tokenized()) {
-            builder.field("index", indexTokenizeOption(indexed, fieldType().tokenized()));
+        if (includeDefaults || indexed != defaultIndexed) {
+            builder.field("index", indexed);
         }
         if (includeDefaults || fieldType().stored() != defaultFieldType.stored()) {
             builder.field("store", fieldType().stored());
@@ -472,11 +466,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             }
             return builder.toString();
         }
-    }
-
-    /* Only protected so that string can override it */
-    protected Object indexTokenizeOption(boolean indexed, boolean tokenized) {
-        return indexed;
     }
 
     protected abstract String contentType();

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -163,7 +163,7 @@ public abstract class MappedFieldType extends FieldType {
         boolean indexed =  indexOptions() != IndexOptions.NONE;
         boolean mergeWithIndexed = other.indexOptions() != IndexOptions.NONE;
         // TODO: should be validating if index options go "up" (but "down" is ok)
-        if (indexed != mergeWithIndexed || tokenized() != other.tokenized()) {
+        if (indexed != mergeWithIndexed) {
             conflicts.add("mapper [" + name() + "] has different [index] values");
         }
         if (stored() != other.stored()) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
@@ -122,7 +122,7 @@ public class MultiFieldTests extends ESSingleNodeTestCase {
 
         DocumentMapper builderDocMapper = new DocumentMapper.Builder(new RootObjectMapper.Builder("person").add(
                 new TextFieldMapper.Builder("name").store(true)
-                        .addMultiField(new TextFieldMapper.Builder("indexed").index(true).tokenized(true))
+                        .addMultiField(new TextFieldMapper.Builder("indexed").index(true))
                         .addMultiField(new TextFieldMapper.Builder("not_indexed").index(false).store(true))
         ), indexService.mapperService()).build(indexService.mapperService());
 


### PR DESCRIPTION
These are likely left over from when there were three options for the `index` mapping (`no`, `analyzed`, and `not_analyzed`).