### PR TITLE
[DOCS] Fixes links in Stack Overview pages

### DIFF
--- a/x-pack/docs/en/ml/architecture.asciidoc
+++ b/x-pack/docs/en/ml/architecture.asciidoc
@@ -6,4 +6,5 @@ A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`,
 which is the default behavior. If you set `node.ml` to `false`, the node can
 service API requests but it cannot run jobs. If you want to use {xpackml}
 features, there must be at least one {ml} node in your cluster. For more
-information about this setting, see <<xpack-settings>>.
+information about this setting, see 
+{ref}/ml-settings.html[{ml} settings in {es}]. 

--- a/x-pack/docs/en/ml/configuring.asciidoc
+++ b/x-pack/docs/en/ml/configuring.asciidoc
@@ -3,8 +3,8 @@
 
 If you want to use {xpackml} features, there must be at least one {ml} node in
 your cluster and all master-eligible nodes must have {ml} enabled. By default,
-all nodes are {ml} nodes. For more information about these settings, see
-<<xpack-settings>>.
+all nodes are {ml} nodes. For more information about these settings, see 
+{ref}/modules-node.html#modules-node-xpack[{ml} nodes].
 
 To use the {xpackml} features to analyze your data, you must create a job and
 send your data to that job.

--- a/x-pack/docs/en/ml/getting-started-next.asciidoc
+++ b/x-pack/docs/en/ml/getting-started-next.asciidoc
@@ -51,5 +51,5 @@ multi-metric jobs and split the data or create more complex analysis functions
 as necessary. For examples of more complicated configuration options, see
 <<ml-configuring>>.
 
-If you encounter problems, we're here to help. See <<xpack-help>> and
+If you encounter problems, we're here to help. See <<help>> and
 <<ml-troubleshooting>>.

--- a/x-pack/docs/en/ml/getting-started.asciidoc
+++ b/x-pack/docs/en/ml/getting-started.asciidoc
@@ -1,7 +1,7 @@
 [[ml-getting-started]]
-== Getting Started with Machine Learning
+== Getting started with machine learning
 ++++
-<titleabbrev>Getting Started</titleabbrev>
+<titleabbrev>Getting started</titleabbrev>
 ++++
 
 Ready to get some hands-on experience with the {xpackml} features? This
@@ -50,7 +50,8 @@ you can try all of the {xpack} features with a <<license-management,trial licens
 If you have multiple nodes in your cluster, you can optionally dedicate nodes to
 specific purposes. If you want to control which nodes are
 _machine learning nodes_ or limit which nodes run resource-intensive
-activity related to jobs, see <<xpack-settings>>.
+activity related to jobs, see 
+{ref}/modules-node.html#modules-node-xpack[{ml} node settings].
 
 [float]
 [[ml-gs-users]]

--- a/x-pack/docs/en/ml/troubleshooting.asciidoc
+++ b/x-pack/docs/en/ml/troubleshooting.asciidoc
@@ -10,7 +10,7 @@ answers for frequently asked questions.
 * <<ml-rollingupgrade>>
 * <<ml-mappingclash>>
 
-To get help, see <<xpack-help>>.
+To get help, see <<help>>.
 
 [[ml-rollingupgrade]]
 === Machine learning features unavailable after rolling upgrade

--- a/x-pack/docs/en/security/troubleshooting.asciidoc
+++ b/x-pack/docs/en/security/troubleshooting.asciidoc
@@ -19,7 +19,7 @@ answers for frequently asked questions.
 * <<trb-security-setup>>
 
 
-To get help, see <<xpack-help>>.
+To get help, see <<help>>.
 
 [[security-trb-settings]]
 === Some settings are not returned via the nodes settings API


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/51

These files are affected by the restructuring of the Stack Overview content. 