### PR TITLE
Remove DocumentFieldMappers#smartNameFieldMapper, as it is no longer needed.

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
@@ -79,9 +79,9 @@ public class TokenCountFieldMapperTests extends ESSingleNodeTestCase {
                 new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         // previous mapper has not been modified
-        assertThat(((TokenCountFieldMapper) stage1.mappers().smartNameFieldMapper("tc")).analyzer(), equalTo("keyword"));
+        assertThat(((TokenCountFieldMapper) stage1.mappers().getMapper("tc")).analyzer(), equalTo("keyword"));
         // but the new one has the change
-        assertThat(((TokenCountFieldMapper) stage2.mappers().smartNameFieldMapper("tc")).analyzer(), equalTo("standard"));
+        assertThat(((TokenCountFieldMapper) stage2.mappers().getMapper("tc")).analyzer(), equalTo("standard"));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -186,7 +186,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
                 }
             } else {
                 // not a pattern
-                FieldMapper fieldMapper = allFieldMappers.smartNameFieldMapper(field);
+                FieldMapper fieldMapper = allFieldMappers.getMapper(field);
                 if (fieldMapper != null) {
                     addFieldMapper(fieldPredicate, field, fieldMapper, fieldMappings, request.includeDefaults());
                 } else if (request.probablySingleFieldRequest()) {

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -202,7 +202,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
 
         if (gFields != null && gFields.length > 0) {
             for (String field : gFields) {
-                FieldMapper fieldMapper = docMapper.mappers().smartNameFieldMapper(field);
+                FieldMapper fieldMapper = docMapper.mappers().getMapper(field);
                 if (fieldMapper == null) {
                     if (docMapper.objectMappers().get(field) != null) {
                         // Only fail if we know it is a object field, missing paths / fields shouldn't fail.

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -80,19 +80,6 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper> {
         return fields;
     }
 
-    public FieldMapper smartNameFieldMapper(String name) {
-        FieldMapper fieldMapper = getMapper(name);
-        if (fieldMapper != null) {
-            return fieldMapper;
-        }
-        for (FieldMapper otherFieldMapper : this) {
-            if (otherFieldMapper.fieldType().name().equals(name)) {
-                return otherFieldMapper;
-            }
-        }
-        return null;
-    }
-
     /**
      * A smart analyzer used for indexing that takes into account specific analyzers configured
      * per {@link FieldMapper}.

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -91,7 +91,7 @@ public final class QueryParserHelper {
     public static FieldMapper getFieldMapper(MapperService mapperService, String field) {
         DocumentMapper mapper = mapperService.documentMapper();
         if (mapper != null) {
-            FieldMapper fieldMapper = mapper.mappers().smartNameFieldMapper(field);
+            FieldMapper fieldMapper = mapper.mappers().getMapper(field);
             if (fieldMapper != null) {
                 return fieldMapper;
             }

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -59,7 +59,7 @@ public class BinaryFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper mapper = createIndex("test").mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
 
-        FieldMapper fieldMapper = mapper.mappers().smartNameFieldMapper("field");
+        FieldMapper fieldMapper = mapper.mappers().getMapper("field");
         assertThat(fieldMapper, instanceOf(BinaryFieldMapper.class));
         assertThat(fieldMapper.fieldType().stored(), equalTo(false));
     }
@@ -94,7 +94,7 @@ public class BinaryFieldMapperTests extends ESSingleNodeTestCase {
                     XContentType.JSON));
             BytesRef indexedValue = doc.rootDoc().getBinaryValue("field");
             assertEquals(new BytesRef(value), indexedValue);
-            FieldMapper fieldMapper = mapper.mappers().smartNameFieldMapper("field");
+            FieldMapper fieldMapper = mapper.mappers().getMapper("field");
             Object originalValue = fieldMapper.fieldType().valueForDisplay(indexedValue);
             assertEquals(new BytesArray(value), originalValue);
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperMergeTests.java
@@ -56,11 +56,11 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
 
         DocumentMapper merged = stage1.merge(stage2.mapping());
         // stage1 mapping should not have been modified
-        assertThat(stage1.mappers().smartNameFieldMapper("age"), nullValue());
-        assertThat(stage1.mappers().smartNameFieldMapper("obj1.prop1"), nullValue());
+        assertThat(stage1.mappers().getMapper("age"), nullValue());
+        assertThat(stage1.mappers().getMapper("obj1.prop1"), nullValue());
         // but merged should
-        assertThat(merged.mappers().smartNameFieldMapper("age"), notNullValue());
-        assertThat(merged.mappers().smartNameFieldMapper("obj1.prop1"), notNullValue());
+        assertThat(merged.mappers().getMapper("age"), notNullValue());
+        assertThat(merged.mappers().getMapper("obj1.prop1"), notNullValue());
     }
 
     public void testMergeObjectDynamic() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleIndexingDocTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleIndexingDocTests.java
@@ -69,25 +69,25 @@ public class DoubleIndexingDocTests extends ESSingleNodeTestCase {
         IndexReader reader = DirectoryReader.open(writer);
         IndexSearcher searcher = new IndexSearcher(reader);
 
-        TopDocs topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field1").fieldType().termQuery("value1", context), 10);
+        TopDocs topDocs = searcher.search(mapper.mappers().getMapper("field1").fieldType().termQuery("value1", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field2").fieldType().termQuery("1", context), 10);
+        topDocs = searcher.search(mapper.mappers().getMapper("field2").fieldType().termQuery("1", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field3").fieldType().termQuery("1.1", context), 10);
+        topDocs = searcher.search(mapper.mappers().getMapper("field3").fieldType().termQuery("1.1", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field4").fieldType().termQuery("2010-01-01", context), 10);
+        topDocs = searcher.search(mapper.mappers().getMapper("field4").fieldType().termQuery("2010-01-01", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").fieldType().termQuery("1", context), 10);
+        topDocs = searcher.search(mapper.mappers().getMapper("field5").fieldType().termQuery("1", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").fieldType().termQuery("2", context), 10);
+        topDocs = searcher.search(mapper.mappers().getMapper("field5").fieldType().termQuery("2", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().smartNameFieldMapper("field5").fieldType().termQuery("3", context), 10);
+        topDocs = searcher.search(mapper.mappers().getMapper("field5").fieldType().termQuery("3", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
         writer.close();
         reader.close();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -625,10 +625,10 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
             .setSource(doc.dynamicMappingsUpdate().toString(), XContentType.JSON).get();
 
         defaultMapper = index.mapperService().documentMapper("type");
-        FieldMapper mapper = defaultMapper.mappers().smartNameFieldMapper("s_long");
+        FieldMapper mapper = defaultMapper.mappers().getMapper("s_long");
         assertThat(mapper.fieldType().typeName(), equalTo("long"));
 
-        mapper = defaultMapper.mappers().smartNameFieldMapper("s_double");
+        mapper = defaultMapper.mappers().getMapper("s_double");
         assertThat(mapper.fieldType().typeName(), equalTo("float"));
     }
 
@@ -652,10 +652,10 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
             .setSource(doc.dynamicMappingsUpdate().toString(), XContentType.JSON).get());
 
         defaultMapper = index.mapperService().documentMapper("type");
-        FieldMapper mapper = defaultMapper.mappers().smartNameFieldMapper("s_long");
+        FieldMapper mapper = defaultMapper.mappers().getMapper("s_long");
         assertThat(mapper, instanceOf(TextFieldMapper.class));
 
-        mapper = defaultMapper.mappers().smartNameFieldMapper("s_double");
+        mapper = defaultMapper.mappers().getMapper("s_double");
         assertThat(mapper, instanceOf(TextFieldMapper.class));
     }
 
@@ -703,9 +703,9 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
 
         defaultMapper = index.mapperService().documentMapper("type");
 
-        DateFieldMapper dateMapper1 = (DateFieldMapper) defaultMapper.mappers().smartNameFieldMapper("date1");
-        DateFieldMapper dateMapper2 = (DateFieldMapper) defaultMapper.mappers().smartNameFieldMapper("date2");
-        DateFieldMapper dateMapper3 = (DateFieldMapper) defaultMapper.mappers().smartNameFieldMapper("date3");
+        DateFieldMapper dateMapper1 = (DateFieldMapper) defaultMapper.mappers().getMapper("date1");
+        DateFieldMapper dateMapper2 = (DateFieldMapper) defaultMapper.mappers().getMapper("date2");
+        DateFieldMapper dateMapper3 = (DateFieldMapper) defaultMapper.mappers().getMapper("date3");
         // inherited from dynamic date format
         assertEquals("yyyy-MM-dd", dateMapper1.fieldType().dateTimeFormatter().format());
         // inherited from dynamic date format since the mapping in the template did not specify a format

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
@@ -56,11 +56,11 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         docMapper = index.mapperService().documentMapper("person");
         DocumentFieldMappers mappers = docMapper.mappers();
 
-        assertThat(mappers.smartNameFieldMapper("s"), Matchers.notNullValue());
-        assertEquals(IndexOptions.NONE, mappers.smartNameFieldMapper("s").fieldType().indexOptions());
+        assertThat(mappers.getMapper("s"), Matchers.notNullValue());
+        assertEquals(IndexOptions.NONE, mappers.getMapper("s").fieldType().indexOptions());
 
-        assertThat(mappers.smartNameFieldMapper("l"), Matchers.notNullValue());
-        assertNotSame(IndexOptions.NONE, mappers.smartNameFieldMapper("l").fieldType().indexOptions());
+        assertThat(mappers.getMapper("l"), Matchers.notNullValue());
+        assertNotSame(IndexOptions.NONE, mappers.getMapper("l").fieldType().indexOptions());
 
 
     }


### PR DESCRIPTION
I think this method is left over from when it was possible to specify `path` and `index_name` -- hopefully I'm not missing something.