### PR TITLE
[ML][TEST] Fix bucket count assertion in all tests in ModelPlotsIT

### DIFF
--- a/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
+++ b/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
@@ -129,7 +129,11 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
         startDatafeed(datafeedId, 0, System.currentTimeMillis());
         waitUntilJobIsClosed(job.getId());
 
-        assertThat(getBuckets(job.getId()).size(), equalTo(23));
+        // As the initial time is random, there's a chance the first record is
+        // aligned on a bucket start. Thus we check the buckets are in [23, 24]
+        assertThat(getBuckets(job.getId()).size(), greaterThanOrEqualTo(23));
+        assertThat(getBuckets(job.getId()).size(), lessThanOrEqualTo(24));
+
         Set<String> modelPlotTerms = modelPlotTerms(job.getId(), "by_field_value");
         assertThat(modelPlotTerms, containsInAnyOrder("user_2", "user_3"));
     }


### PR DESCRIPTION
This fixes the last remaining test that was missed in #30717.

Closes #30715
