### PR TITLE
Fix handling of percent-encoded spaces in Windows batch files

### DIFF
--- a/distribution/src/bin/elasticsearch-keystore.bat
+++ b/distribution/src/bin/elasticsearch-keystore.bat
@@ -5,7 +5,7 @@ setlocal enableextensions
 
 call "%~dp0elasticsearch-cli.bat" ^
    org.elasticsearch.common.settings.KeyStoreCli ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/distribution/src/bin/elasticsearch-plugin.bat
+++ b/distribution/src/bin/elasticsearch-plugin.bat
@@ -6,7 +6,7 @@ setlocal enableextensions
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/plugin-cli
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.plugins.PluginCli ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/distribution/src/bin/elasticsearch-translog.bat
+++ b/distribution/src/bin/elasticsearch-translog.bat
@@ -5,7 +5,7 @@ setlocal enableextensions
 
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.index.translog.TranslogToolCli ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
@@ -10,7 +10,7 @@ setlocal enableextensions
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.core.ssl.CertificateGenerateTool ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
@@ -10,7 +10,7 @@ setlocal enableextensions
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.core.ssl.CertificateTool ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
@@ -10,7 +10,7 @@ setlocal enableextensions
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.authc.esnative.ESNativeRealmMigrateTool ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
@@ -10,7 +10,7 @@ setlocal enableextensions
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
@@ -10,7 +10,7 @@ setlocal enableextensions
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.authc.esnative.tool.SetupPasswordTool ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
@@ -10,7 +10,7 @@ setlocal enableextensions
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.crypto.tool.SystemKeyTool ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
@@ -10,7 +10,7 @@ setlocal enableextensions
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.security.authc.file.tool.UsersTool ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal

--- a/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
+++ b/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
@@ -10,7 +10,7 @@ setlocal enableextensions
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-watcher-env
 call "%~dp0elasticsearch-cli.bat" ^
   org.elasticsearch.xpack.watcher.trigger.schedule.tool.CronEvalTool ^
-  %* ^
+  %%* ^
   || exit /b 1
 
 endlocal


### PR DESCRIPTION
If you invoke elasticsearch-plugin (or any other CLI script on Windows) with a path that has a percent-encoded space (or any other percent-encoded character) because the CLI scripts now shell into a common shell script (elasticsearch-cli) the percent-encoded space ends up being interpreted as a parameter. For example passing install --batch file:/c:/encoded%20%space/analysis-icu-7.0.0.zip to elasticsearch-plugin leads to the %20 being interpreted as %2 followed by a zero. Here, the %2 is interpreted as the second parameter (--batch) and the InstallPluginCommand class ends up seeing file:/c/encoded--batch0space/analysis-icu-7.0.0.zip as the path which will not exist. This commit addresses this by escaping the %* that is used to pass the parameters to the common CLI script so that the common script sees the correct parameters without the %2 being substituted.

Closes #30915
