### PR TITLE
In the internal highlighter APIs, use the field type as opposed to the mapper.

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FragmentBuilderHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FragmentBuilderHelper.java
@@ -29,7 +29,7 @@ import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.index.analysis.CustomAnalyzer;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.util.Comparator;
 import java.util.List;
@@ -47,10 +47,10 @@ public final class FragmentBuilderHelper {
      * Fixes problems with broken analysis chains if positions and offsets are messed up that can lead to
      * {@link StringIndexOutOfBoundsException} in the {@link FastVectorHighlighter}
      */
-    public static WeightedFragInfo fixWeightedFragInfo(FieldMapper mapper, Field[] values, WeightedFragInfo fragInfo) {
+    public static WeightedFragInfo fixWeightedFragInfo(MappedFieldType fieldType, Field[] values, WeightedFragInfo fragInfo) {
         assert fragInfo != null : "FragInfo must not be null";
-        assert mapper.fieldType().name().equals(values[0].name()) : "Expected FieldMapper for field " + values[0].name();
-        if (!fragInfo.getSubInfos().isEmpty() && containsBrokenAnalysis(mapper.fieldType().indexAnalyzer())) {
+        assert fieldType.name().equals(values[0].name()) : "Expected MappedFieldType for field " + values[0].name();
+        if (!fragInfo.getSubInfos().isEmpty() && containsBrokenAnalysis(fieldType.indexAnalyzer())) {
             /* This is a special case where broken analysis like WDF is used for term-vector creation at index-time
              * which can potentially mess up the offsets. To prevent a SAIIOBException we need to resort
              * the fragments based on their offsets rather than using soley the positions as it is done in

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/Highlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/Highlighter.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.search.fetch.subphase.highlight;
 
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 /**
  * Highlights a search result.
@@ -27,5 +27,5 @@ public interface Highlighter {
 
     HighlightField highlight(HighlighterContext highlighterContext);
 
-    boolean canHighlight(FieldMapper fieldMapper);
+    boolean canHighlight(MappedFieldType fieldType);
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterContext.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.search.fetch.subphase.highlight;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -27,16 +27,20 @@ public class HighlighterContext {
 
     public final String fieldName;
     public final SearchContextHighlight.Field field;
-    public final FieldMapper mapper;
+    public final MappedFieldType fieldType;
     public final SearchContext context;
     public final FetchSubPhase.HitContext hitContext;
     public final Query query;
 
-    public HighlighterContext(String fieldName, SearchContextHighlight.Field field, FieldMapper mapper, SearchContext context,
-            FetchSubPhase.HitContext hitContext, Query query) {
+    public HighlighterContext(String fieldName,
+                              SearchContextHighlight.Field field,
+                              MappedFieldType fieldType,
+                              SearchContext context,
+                              FetchSubPhase.HitContext hitContext,
+                              Query query) {
         this.fieldName = fieldName;
         this.field = field;
-        this.mapper = mapper;
+        this.fieldType = fieldType;
         this.context = context;
         this.hitContext = hitContext;
         this.query = query;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SimpleFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SimpleFragmentsBuilder.java
@@ -23,24 +23,27 @@ import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
 import org.apache.lucene.search.vectorhighlight.FieldFragList.WeightedFragInfo;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 /**
- * Direct Subclass of Lucene's org.apache.lucene.search.vectorhighlight.SimpleFragmentsBuilder 
- * that corrects offsets for broken analysis chains. 
+ * Direct Subclass of Lucene's org.apache.lucene.search.vectorhighlight.SimpleFragmentsBuilder
+ * that corrects offsets for broken analysis chains.
  */
 public class SimpleFragmentsBuilder extends org.apache.lucene.search.vectorhighlight.SimpleFragmentsBuilder {
-    protected final FieldMapper mapper;
+    protected final MappedFieldType fieldType;
 
-    public SimpleFragmentsBuilder(FieldMapper mapper,
-                                        String[] preTags, String[] postTags, BoundaryScanner boundaryScanner) {
+    public SimpleFragmentsBuilder(MappedFieldType fieldType,
+                                  String[] preTags,
+                                  String[] postTags,
+                                  BoundaryScanner boundaryScanner) {
         super(preTags, postTags, boundaryScanner);
-        this.mapper = mapper;
+        this.fieldType = fieldType;
     }
-    
+
     @Override
     protected String makeFragment( StringBuilder buffer, int[] index, Field[] values, WeightedFragInfo fragInfo,
             String[] preTags, String[] postTags, Encoder encoder ){
-        return super.makeFragment(buffer, index, values, FragmentBuilderHelper.fixWeightedFragInfo(mapper, values, fragInfo),
-                preTags, postTags, encoder);
+        WeightedFragInfo weightedFragInfo = FragmentBuilderHelper.fixWeightedFragInfo(fieldType, values, fragInfo);
+        return super.makeFragment(buffer, index, values, weightedFragInfo, preTags, postTags, encoder);
    }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
@@ -26,7 +26,7 @@ import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
 import org.apache.lucene.search.vectorhighlight.FieldFragList.WeightedFragInfo;
 import org.apache.lucene.search.vectorhighlight.ScoreOrderFragmentsBuilder;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
@@ -35,14 +35,17 @@ import java.util.List;
 
 public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder {
 
-    private final FieldMapper mapper;
+    private final MappedFieldType fieldType;
 
     private final SearchContext searchContext;
 
-    public SourceScoreOrderFragmentsBuilder(FieldMapper mapper, SearchContext searchContext, String[] preTags, String[] postTags,
+    public SourceScoreOrderFragmentsBuilder(MappedFieldType fieldType,
+                                            SearchContext searchContext,
+                                            String[] preTags,
+                                            String[] postTags,
                                             BoundaryScanner boundaryScanner) {
         super(preTags, postTags, boundaryScanner);
-        this.mapper = mapper;
+        this.fieldType = fieldType;
         this.searchContext = searchContext;
     }
 
@@ -52,10 +55,10 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
         SourceLookup sourceLookup = searchContext.lookup().source();
         sourceLookup.setSegmentAndDocument((LeafReaderContext) reader.getContext(), docId);
 
-        List<Object> values = sourceLookup.extractRawValues(mapper.fieldType().name());
+        List<Object> values = sourceLookup.extractRawValues(fieldType.name());
         Field[] fields = new Field[values.size()];
         for (int i = 0; i < values.size(); i++) {
-            fields[i] = new Field(mapper.fieldType().name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);
+            fields[i] = new Field(fieldType.name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);
         }
         return fields;
     }
@@ -63,7 +66,7 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
     @Override
     protected String makeFragment( StringBuilder buffer, int[] index, Field[] values, WeightedFragInfo fragInfo,
             String[] preTags, String[] postTags, Encoder encoder ){
-        return super.makeFragment(buffer, index, values, FragmentBuilderHelper.fixWeightedFragInfo(mapper, values, fragInfo),
-                preTags, postTags, encoder);
+        WeightedFragInfo weightedFragInfo = FragmentBuilderHelper.fixWeightedFragInfo(fieldType, values, fragInfo);
+        return super.makeFragment(buffer, index, values, weightedFragInfo, preTags, postTags, encoder);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
@@ -23,7 +23,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
@@ -34,9 +34,12 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
 
     private final SearchContext searchContext;
 
-    public SourceSimpleFragmentsBuilder(FieldMapper mapper, SearchContext searchContext, String[] preTags, String[] postTags,
+    public SourceSimpleFragmentsBuilder(MappedFieldType fieldType,
+                                        SearchContext searchContext,
+                                        String[] preTags,
+                                        String[] postTags,
                                         BoundaryScanner boundaryScanner) {
-        super(mapper, preTags, postTags, boundaryScanner);
+        super(fieldType, preTags, postTags, boundaryScanner);
         this.searchContext = searchContext;
     }
 
@@ -48,13 +51,13 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
         SourceLookup sourceLookup = searchContext.lookup().source();
         sourceLookup.setSegmentAndDocument((LeafReaderContext) reader.getContext(), docId);
 
-        List<Object> values = sourceLookup.extractRawValues(mapper.fieldType().name());
+        List<Object> values = sourceLookup.extractRawValues(fieldType.name());
         if (values.isEmpty()) {
             return EMPTY_FIELDS;
         }
         Field[] fields = new Field[values.size()];
         for (int i = 0; i < values.size(); i++) {
-            fields[i] = new Field(mapper.fieldType().name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);
+            fields[i] = new Field(fieldType.name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);
         }
         return fields;
     }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/CustomHighlighter.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/CustomHighlighter.java
@@ -19,11 +19,7 @@
 package org.elasticsearch.search.fetch.subphase.highlight;
 
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
-import org.elasticsearch.search.fetch.subphase.highlight.Highlighter;
-import org.elasticsearch.search.fetch.subphase.highlight.HighlighterContext;
-import org.elasticsearch.search.fetch.subphase.highlight.SearchContextHighlight;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,7 +64,7 @@ public class CustomHighlighter implements Highlighter {
     }
 
     @Override
-    public boolean canHighlight(FieldMapper fieldMapper) {
+    public boolean canHighlight(MappedFieldType fieldType) {
         return true;
     }
 


### PR DESCRIPTION
A preparatory refactor for the work on field aliases.