### PR TITLE
Call ensureNoSelfReferences() on _agg state variable after scripted metric agg script executions

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -157,7 +157,7 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
 
     @Override
     public String stringify(Object object) {
-        CollectionUtils.ensureNoSelfReferences(object);
+        CollectionUtils.ensureNoSelfReferences(object, "CustomReflectionObjectHandler stringify");
         return super.stringify(object);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -231,15 +231,6 @@ public class CollectionUtils {
      * Deeply inspects a Map, Iterable, or Object array looking for references back to itself.
      * @throws IllegalArgumentException if a self-reference is found
      * @param value The object to evaluate looking for self references
-     */
-    public static void ensureNoSelfReferences(Object value) {
-        ensureNoSelfReferences(value, "");
-    }
-
-    /**
-     * Deeply inspects a Map, Iterable, or Object array looking for references back to itself.
-     * @throws IllegalArgumentException if a self-reference is found
-     * @param value The object to evaluate looking for self references
      * @param messageHint A string to be included in the exception message if the call fails, to provide
      *                    more context to the handler of the exception
      */

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -29,6 +29,7 @@ import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.RandomAccess;
@@ -40,6 +41,7 @@ import org.apache.lucene.util.BytesRefArray;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.InPlaceMergeSorter;
 import org.apache.lucene.util.IntroSorter;
+import org.elasticsearch.common.Strings;
 
 /** Collections-related utility methods. */
 public class CollectionUtils {
@@ -225,10 +227,26 @@ public class CollectionUtils {
         return ints.stream().mapToInt(s -> s).toArray();
     }
 
+    /**
+     * Deeply inspects a Map, Iterable, or Object array looking for references back to itself.
+     * @throws IllegalArgumentException if a self-reference is found
+     * @param value The object to evaluate looking for self references
+     */
     public static void ensureNoSelfReferences(Object value) {
+        ensureNoSelfReferences(value, "");
+    }
+
+    /**
+     * Deeply inspects a Map, Iterable, or Object array looking for references back to itself.
+     * @throws IllegalArgumentException if a self-reference is found
+     * @param value The object to evaluate looking for self references
+     * @param messageHint A string to be included in the exception message if the call fails, to provide
+     *                    more context to the handler of the exception
+     */
+    public static void ensureNoSelfReferences(Object value, String messageHint) {
         Iterable<?> it = convert(value);
         if (it != null) {
-            ensureNoSelfReferences(it, value, Collections.newSetFromMap(new IdentityHashMap<>()));
+            ensureNoSelfReferences(it, value, Collections.newSetFromMap(new IdentityHashMap<>()), messageHint);
         }
     }
 
@@ -247,13 +265,15 @@ public class CollectionUtils {
         }
     }
 
-    private static void ensureNoSelfReferences(final Iterable<?> value, Object originalReference, final Set<Object> ancestors) {
+    private static void ensureNoSelfReferences(final Iterable<?> value, Object originalReference, final Set<Object> ancestors,
+                                               String messageHint) {
         if (value != null) {
             if (ancestors.add(originalReference) == false) {
-                throw new IllegalArgumentException("Iterable object is self-referencing itself");
+                String suffix = Strings.isNullOrEmpty(messageHint) ? "" : String.format(Locale.ROOT, " (%s)", messageHint);
+                throw new IllegalArgumentException("Iterable object is self-referencing itself" + suffix);
             }
             for (Object o : value) {
-                ensureNoSelfReferences(convert(o), o, ancestors);
+                ensureNoSelfReferences(convert(o), o, ancestors, messageHint);
             }
             ancestors.remove(originalReference);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/InternalScriptedMetric.java
@@ -21,6 +21,7 @@ package org.elasticsearch.search.aggregations.metrics.scripted;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
@@ -97,7 +98,11 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
             ExecutableScript.Factory factory = reduceContext.scriptService().compile(
                 firstAggregation.reduceScript, ExecutableScript.AGGS_CONTEXT);
             ExecutableScript script = factory.newInstance(vars);
-            aggregation = Collections.singletonList(script.run());
+
+            Object scriptResult = script.run();
+            CollectionUtils.ensureNoSelfReferences(scriptResult, "reduce script");
+
+            aggregation = Collections.singletonList(scriptResult);
         } else if (reduceContext.isFinalReduce())  {
             aggregation = Collections.singletonList(aggregationObjects);
         } else {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
@@ -69,6 +69,7 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
                 assert bucket == 0 : bucket;
                 leafMapScript.setDocument(doc);
                 leafMapScript.run();
+                CollectionUtils.ensureNoSelfReferences(params, "map script");
             }
         };
     }
@@ -78,7 +79,7 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
         Object aggregation;
         if (combineScript != null) {
             aggregation = combineScript.run();
-            CollectionUtils.ensureNoSelfReferences(aggregation);
+            CollectionUtils.ensureNoSelfReferences(aggregation, "combine script");
         } else {
             aggregation = params.get("_agg");
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregator.java
@@ -69,7 +69,7 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
                 assert bucket == 0 : bucket;
                 leafMapScript.setDocument(doc);
                 leafMapScript.run();
-                CollectionUtils.ensureNoSelfReferences(params, "map script");
+                CollectionUtils.ensureNoSelfReferences(params, "Scripted metric aggs map script");
             }
         };
     }
@@ -79,7 +79,7 @@ public class ScriptedMetricAggregator extends MetricsAggregator {
         Object aggregation;
         if (combineScript != null) {
             aggregation = combineScript.run();
-            CollectionUtils.ensureNoSelfReferences(aggregation, "combine script");
+            CollectionUtils.ensureNoSelfReferences(aggregation, "Scripted metric aggs combine script");
         } else {
             aggregation = params.get("_agg");
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorFactory.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.aggregations.metrics.scripted;
 
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.SearchScript;
@@ -89,6 +90,7 @@ public class ScriptedMetricAggregatorFactory extends AggregatorFactory<ScriptedM
         final Script reduceScript = deepCopyScript(this.reduceScript, context);
         if (initScript != null) {
             initScript.run();
+            CollectionUtils.ensureNoSelfReferences(aggParams.get("_agg"), "init script");
         }
         return new ScriptedMetricAggregator(name, mapScript,
                 combineScript, reduceScript, aggParams, context, parent,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorFactory.java
@@ -90,7 +90,7 @@ public class ScriptedMetricAggregatorFactory extends AggregatorFactory<ScriptedM
         final Script reduceScript = deepCopyScript(this.reduceScript, context);
         if (initScript != null) {
             initScript.run();
-            CollectionUtils.ensureNoSelfReferences(aggParams.get("_agg"), "init script");
+            CollectionUtils.ensureNoSelfReferences(aggParams.get("_agg"), "Scripted metric aggs init script");
         }
         return new ScriptedMetricAggregator(name, mapScript,
                 combineScript, reduceScript, aggParams, context, parent,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -458,7 +458,7 @@ public abstract class ValuesSource {
                         final BytesRef value = bytesValues.nextValue();
                         script.setNextAggregationValue(value.utf8ToString());
                         Object run = script.run();
-                        CollectionUtils.ensureNoSelfReferences(run);
+                        CollectionUtils.ensureNoSelfReferences(run, "ValuesSource.BytesValues script");
                         values[i].copyChars(run.toString());
                     }
                     sort();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptBytesValues.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptBytesValues.java
@@ -45,7 +45,7 @@ public class ScriptBytesValues extends SortingBinaryDocValues implements ScorerA
         if (o == null) {
             values[i].clear();
         } else {
-            CollectionUtils.ensureNoSelfReferences(o);
+            CollectionUtils.ensureNoSelfReferences(o, "ScriptBytesValues value");
             values[i].copyChars(o.toString());
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/ScriptFieldsFetchSubPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/ScriptFieldsFetchSubPhase.java
@@ -65,7 +65,7 @@ public final class ScriptFieldsFetchSubPhase implements FetchSubPhase {
                 final Object value;
                 try {
                     value = leafScripts[i].run();
-                    CollectionUtils.ensureNoSelfReferences(value);
+                    CollectionUtils.ensureNoSelfReferences(value, "ScriptFieldsFetchSubPhase leaf script " + i);
                 } catch (RuntimeException e) {
                     if (scriptFields.get(i).ignoreException()) {
                         continue;

--- a/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -343,7 +343,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
                             @Override
                             public BytesRef binaryValue() {
                                 final Object run = leafScript.run();
-                                CollectionUtils.ensureNoSelfReferences(run);
+                                CollectionUtils.ensureNoSelfReferences(run, "ScriptSortBuilder leaf script");
                                 spare.copyChars(run.toString());
                                 return spare.get();
                             }

--- a/server/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
@@ -183,25 +183,14 @@ public class CollectionUtilsTests extends ESTestCase {
     }
 
     public void testEnsureNoSelfReferences() {
-        CollectionUtils.ensureNoSelfReferences(emptyMap());
-        CollectionUtils.ensureNoSelfReferences(null);
-
-        Map<String, Object> map = new HashMap<>();
-        map.put("field", map);
-
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->  CollectionUtils.ensureNoSelfReferences(map));
-        assertThat(e.getMessage(), containsString("Iterable object is self-referencing itself"));
-    }
-
-    public void testEnsureNoSelfReferencesWithMessageHint() {
-        CollectionUtils.ensureNoSelfReferences(emptyMap());
-        CollectionUtils.ensureNoSelfReferences(null);
+        CollectionUtils.ensureNoSelfReferences(emptyMap(), "test with empty map");
+        CollectionUtils.ensureNoSelfReferences(null, "test with null");
 
         Map<String, Object> map = new HashMap<>();
         map.put("field", map);
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> CollectionUtils.ensureNoSelfReferences(map, "unit test"));
-        assertThat(e.getMessage(), containsString("Iterable object is self-referencing itself (unit test)"));
+            () ->  CollectionUtils.ensureNoSelfReferences(map, "test with self ref"));
+        assertThat(e.getMessage(), containsString("Iterable object is self-referencing itself (test with self ref)"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/CollectionUtilsTests.java
@@ -192,4 +192,16 @@ public class CollectionUtilsTests extends ESTestCase {
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () ->  CollectionUtils.ensureNoSelfReferences(map));
         assertThat(e.getMessage(), containsString("Iterable object is self-referencing itself"));
     }
+
+    public void testEnsureNoSelfReferencesWithMessageHint() {
+        CollectionUtils.ensureNoSelfReferences(emptyMap());
+        CollectionUtils.ensureNoSelfReferences(null);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("field", map);
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            () -> CollectionUtils.ensureNoSelfReferences(map, "unit test"));
+        assertThat(e.getMessage(), containsString("Iterable object is self-referencing itself (unit test)"));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -843,8 +843,8 @@ public abstract class BaseXContentTestCase extends ESTestCase {
     }
 
     public void testEnsureNoSelfReferences() throws IOException {
-        CollectionUtils.ensureNoSelfReferences(emptyMap());
-        CollectionUtils.ensureNoSelfReferences(null);
+        builder().map(emptyMap());
+        builder().map(null);
 
         Map<String, Object> map = new HashMap<>();
         map.put("field", map);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorTests.java
@@ -295,7 +295,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () ->
                     search(newSearcher(indexReader, true, true), new MatchAllDocsQuery(), aggregationBuilder)
                 );
-                assertEquals("Iterable object is self-referencing itself (init script)", ex.getMessage());
+                assertEquals("Iterable object is self-referencing itself (Scripted metric aggs init script)", ex.getMessage());
             }
         }
     }
@@ -315,7 +315,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () ->
                     search(newSearcher(indexReader, true, true), new MatchAllDocsQuery(), aggregationBuilder)
                 );
-                assertEquals("Iterable object is self-referencing itself (map script)", ex.getMessage());
+                assertEquals("Iterable object is self-referencing itself (Scripted metric aggs map script)", ex.getMessage());
             }
         }
     }
@@ -332,7 +332,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () ->
                     search(newSearcher(indexReader, true, true), new MatchAllDocsQuery(), aggregationBuilder)
                 );
-                assertEquals("Iterable object is self-referencing itself (combine script)", ex.getMessage());
+                assertEquals("Iterable object is self-referencing itself (Scripted metric aggs combine script)", ex.getMessage());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorTests.java
@@ -73,6 +73,13 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
             Collections.singletonMap("divisor", 4));
     private static final String CONFLICTING_PARAM_NAME = "initialValue";
 
+    private static final Script INIT_SCRIPT_SELF_REF = new Script(ScriptType.INLINE, MockScriptEngine.NAME, "initScriptSelfRef",
+            Collections.emptyMap());
+    private static final Script MAP_SCRIPT_SELF_REF = new Script(ScriptType.INLINE, MockScriptEngine.NAME, "mapScriptSelfRef",
+            Collections.emptyMap());
+    private static final Script COMBINE_SCRIPT_SELF_REF = new Script(ScriptType.INLINE, MockScriptEngine.NAME, "combineScriptSelfRef",
+            Collections.emptyMap());
+
     private static final Map<String, Function<Map<String, Object>, Object>> SCRIPTS = new HashMap<>();
 
     @BeforeClass
@@ -126,6 +133,25 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
             Map<String, Object> agg = (Map<String, Object>) params.get("_agg");
             int divisor = ((Integer) params.get("divisor"));
             return ((List<Integer>) agg.get("collector")).stream().mapToInt(Integer::intValue).map(i -> i / divisor).sum();
+        });
+
+        SCRIPTS.put("initScriptSelfRef", params -> {
+            Map<String, Object> agg = (Map<String, Object>) params.get("_agg");
+            agg.put("collector", new ArrayList<Integer>());
+            agg.put("selfRef", agg);
+            return agg;
+        });
+
+        SCRIPTS.put("mapScriptSelfRef", params -> {
+            Map<String, Object> agg = (Map<String, Object>) params.get("_agg");
+            agg.put("selfRef", agg);
+            return agg;
+        });
+
+        SCRIPTS.put("combineScriptSelfRef", params -> {
+           Map<String, Object> agg = (Map<String, Object>) params.get("_agg");
+           agg.put("selfRef", agg);
+           return agg;
         });
     }
 
@@ -253,6 +279,60 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 );
                 assertEquals("Parameter name \"" + CONFLICTING_PARAM_NAME + "\" used in both aggregation and script parameters",
                     ex.getMessage());
+            }
+        }
+    }
+
+    public void testSelfReferencingAggStateAfterInit() throws IOException {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                // No need to add docs for this test
+            }
+            try (IndexReader indexReader = DirectoryReader.open(directory)) {
+                ScriptedMetricAggregationBuilder aggregationBuilder = new ScriptedMetricAggregationBuilder(AGG_NAME);
+                aggregationBuilder.initScript(INIT_SCRIPT_SELF_REF).mapScript(MAP_SCRIPT);
+
+                IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () ->
+                    search(newSearcher(indexReader, true, true), new MatchAllDocsQuery(), aggregationBuilder)
+                );
+                assertEquals("Iterable object is self-referencing itself (init script)", ex.getMessage());
+            }
+        }
+    }
+
+    public void testSelfReferencingAggStateAfterMap() throws IOException {
+        try (Directory directory = newDirectory()) {
+            Integer numDocs = randomInt(100);
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                for (int i = 0; i < numDocs; i++) {
+                    indexWriter.addDocument(singleton(new SortedNumericDocValuesField("number", i)));
+                }
+            }
+            try (IndexReader indexReader = DirectoryReader.open(directory)) {
+                ScriptedMetricAggregationBuilder aggregationBuilder = new ScriptedMetricAggregationBuilder(AGG_NAME);
+                aggregationBuilder.initScript(INIT_SCRIPT).mapScript(MAP_SCRIPT_SELF_REF);
+
+                IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () ->
+                    search(newSearcher(indexReader, true, true), new MatchAllDocsQuery(), aggregationBuilder)
+                );
+                assertEquals("Iterable object is self-referencing itself (map script)", ex.getMessage());
+            }
+        }
+    }
+
+    public void testSelfReferencingAggStateAfterCombine() throws IOException {
+        try (Directory directory = newDirectory()) {
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                // No need to add docs for this test
+            }
+            try (IndexReader indexReader = DirectoryReader.open(directory)) {
+                ScriptedMetricAggregationBuilder aggregationBuilder = new ScriptedMetricAggregationBuilder(AGG_NAME);
+                aggregationBuilder.initScript(INIT_SCRIPT).mapScript(MAP_SCRIPT).combineScript(COMBINE_SCRIPT_SELF_REF);
+
+                IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () ->
+                    search(newSearcher(indexReader, true, true), new MatchAllDocsQuery(), aggregationBuilder)
+                );
+                assertEquals("Iterable object is self-referencing itself (combine script)", ex.getMessage());
             }
         }
     }


### PR DESCRIPTION
I noticed this issue when working on PR #30111. @s1monw committed changes in January in #28335 checking for self-references in collections that come from scripts. In the case of scripted metric aggs, we have the `params._agg` map and `_aggs` list that the various involved scripts all modify. The original change added the self-reference check for the result of the combine script, but `params._agg` can play effectively the same role for init and map scripts so arguably it should be held to the same standard.

This PR adds a similar check after execution of the init, map, and reduce scripts. I also added unit tests for the init, map, and combine cases. Reduce doesn't seem to be quite as convenient to unit test (please correct me if I'm missing something here!) but I didn't see this as a blocker since the existing checks aren't unit tested in general anyway. Another option is to consolidate these test cases into `ScriptedMetricIT`which should be able to check all four scripts; conceptually unit tests are a better fit though.

As part of this I added an overload for `CollectionUtils.ensureNoSelfReferences()` that takes an additional string parameter to slightly customize the error message, because this allows for unit test verification that a single particular check actually failed.

I haven't discussed any of this with anyone so any feedback is appreciated, and I realize this might be closed as paranoid overkill.

**Potential further improvements**
Taking this to its logical conclusion, it seem like `params` as well as all other variables available on the script context should be automatically checked for self-references. Seems like for Painless at least this could be implemented (maybe as another item on #31009 with the other new safety checks?) although it might be overkill as I don't know how important it is to avoid the potential for stack overflows here.

@rjernst @colings86 this conflicts with my changes in #30111 but I wanted to go ahead with this in a separate PR because I had some time to look at it. Of course I will handle any conflicts depending on which one gets merged first (and if this one gets merged at all).