### PR TITLE
[ML] Add secondary sort to ML events

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/ScheduledEventsQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/ScheduledEventsQueryBuilder.java
@@ -93,6 +93,7 @@ public class ScheduledEventsQueryBuilder {
 
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.sort(ScheduledEvent.START_TIME.getPreferredName());
+        searchSourceBuilder.sort(ScheduledEvent.DESCRIPTION.getPreferredName());
         if (from != null) {
             searchSourceBuilder.from(from);
         }


### PR DESCRIPTION
Adds a secondary sort to ML get scheduled events. Fixes a rare test failure in the yml tests where the order of returned events is not deterministic. 
