### PR TITLE
[WIP] Improve repository registration

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
@@ -65,8 +65,9 @@ public class TransportPutRepositoryAction extends TransportMasterNodeAction<PutR
     }
 
     @Override
-    protected void masterOperation(final PutRepositoryRequest request, ClusterState state, final ActionListener<PutRepositoryResponse> listener) {
-
+    protected void masterOperation(final PutRepositoryRequest request,
+                                   final ClusterState state,
+                                   final ActionListener<PutRepositoryResponse> listener) {
         repositoriesService.registerRepository(
                 new RepositoriesService.RegisterRepositoryRequest("put_repository [" + request.name() + "]",
                         request.name(), request.type(), request.verify())


### PR DESCRIPTION
This is a work in progress pull request, I opened it to gather @ywelsch's opinion on it.

The current `RepositoriesService` has some issues, the most notable being that repository instances are created and started on the cluster state update thread (reported in #9488). Another one is that repository can fail to be created on non-master nodes and today the instance is just abruptly closed. Another one is that a repository is closed when it is unregistered but there is no control if the instance is used somewhere else.

I think that the respository registration could be improved when it registers a repository. It could first check if the repository is used and fails directly in this case, without executing a cluster state update. Same thing if the repository metadata are unchanged, no need to trigger another cluster state update. 

It could also create the repository and starts it first on the master node, and only adds it to the cluster state if everything is ok. If something goes wrong the newly created repository instance is just closed and an error is reported to the listener. This way the cluster state update is a light operation - it replaces the repository instance in a in memory map and puts the old repository (in case of an update) to a list of repository to be closed once the cluster state is applied. On non-master node, we can always create the repository instance and also keep around the previous repository instance to close it later. If the repository failed to be created, the error is logged and the in memory repository becomes a FailedRepository instance that throws UnsupportedException every time it is used. The repository must be deleted and recreated in this case.

In addition to this pull request (but not implemented here) I think that `Repository` could be a `RefCounted` so everything that uses a Repository instance could use `incRef()/decRef()` and we could close the repository is a cleaner way that is done today.