### PR TITLE
Add TRACE, CONNECT, and PATCH http methods

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -119,7 +119,19 @@ public class Netty4HttpRequest extends RestRequest {
             return Method.OPTIONS;
         }
 
-        return Method.GET;
+        if (httpMethod == HttpMethod.PATCH) {
+            return Method.PATCH;
+        }
+
+        if (httpMethod == HttpMethod.TRACE) {
+            return Method.TRACE;
+        }
+
+        if (httpMethod == HttpMethod.CONNECT) {
+            return Method.CONNECT;
+        }
+
+        throw new IllegalArgumentException("Unexpected http method: " + httpMethod);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -130,7 +130,7 @@ public abstract class RestRequest implements ToXContent.Params {
     }
 
     public enum Method {
-        GET, POST, PUT, DELETE, OPTIONS, HEAD
+        GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH, TRACE, CONNECT
     }
 
     public abstract Method method();


### PR DESCRIPTION
This is related to #31017. That issue identified that these three http
methods were treated like GET requests. This commit adds them to
RestRequest. This means that these methods will be handled properly and
generate 405s.