### PR TITLE
Remove BlobContainer.move() method

### DIFF
--- a/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -82,11 +82,6 @@ public class URLBlobContainer extends AbstractBlobContainer {
         throw new UnsupportedOperationException("URL repository doesn't support this operation");
     }
 
-    @Override
-    public void move(String from, String to) throws IOException {
-        throw new UnsupportedOperationException("URL repository doesn't support this operation");
-    }
-
     /**
      * This operation is not supported by URLBlobContainer
      */

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -128,22 +128,6 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
-    public void move(String sourceBlobName, String targetBlobName) throws IOException {
-        logger.trace("move({}, {})", sourceBlobName, targetBlobName);
-        try {
-            String source = keyPath + sourceBlobName;
-            String target = keyPath + targetBlobName;
-
-            logger.debug("moving blob [{}] to [{}] in container {{}}", source, target, blobStore);
-
-            blobStore.moveBlob(source, target);
-        } catch (URISyntaxException | StorageException e) {
-            logger.warn("can not move blob [{}] to [{}] in container {{}}: {}", sourceBlobName, targetBlobName, blobStore, e.getMessage());
-            throw new IOException(e);
-        }
-    }
-
-    @Override
     public Map<String, BlobMetaData> listBlobs() throws IOException {
         logger.trace("listBlobs()");
         return listBlobsByPrefix(null);

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -97,29 +97,21 @@ public class AzureBlobStore extends AbstractComponent implements BlobStore {
         return this.client.doesContainerExist(this.clientName, this.locMode, container);
     }
 
-    public boolean blobExists(String blob) throws URISyntaxException, StorageException
-    {
+    public boolean blobExists(String blob) throws URISyntaxException, StorageException {
         return this.client.blobExists(this.clientName, this.locMode, container, blob);
     }
 
-    public void deleteBlob(String blob) throws URISyntaxException, StorageException
-    {
+    public void deleteBlob(String blob) throws URISyntaxException, StorageException {
         this.client.deleteBlob(this.clientName, this.locMode, container, blob);
     }
 
-    public InputStream getInputStream(String blob) throws URISyntaxException, StorageException, IOException
-    {
+    public InputStream getInputStream(String blob) throws URISyntaxException, StorageException, IOException {
         return this.client.getInputStream(this.clientName, this.locMode, container, blob);
     }
 
-    public Map<String,BlobMetaData> listBlobsByPrefix(String keyPath, String prefix)
+    public Map<String, BlobMetaData> listBlobsByPrefix(String keyPath, String prefix)
         throws URISyntaxException, StorageException {
         return this.client.listBlobsByPrefix(this.clientName, this.locMode, container, keyPath, prefix);
-    }
-
-    public void moveBlob(String sourceBlob, String targetBlob) throws URISyntaxException, StorageException
-    {
-        this.client.moveBlob(this.clientName, this.locMode, container, sourceBlob, targetBlob);
     }
 
     public void writeBlob(String blobName, InputStream inputStream, long blobSize) throws URISyntaxException, StorageException {

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
@@ -57,9 +57,6 @@ public interface AzureStorageService {
     Map<String,BlobMetaData> listBlobsByPrefix(String account, LocationMode mode, String container, String keyPath, String prefix)
         throws URISyntaxException, StorageException;
 
-    void moveBlob(String account, LocationMode mode, String container, String sourceBlob, String targetBlob)
-        throws URISyntaxException, StorageException;
-
     void writeBlob(String account, LocationMode mode, String container, String blobName, InputStream inputStream, long blobSize) throws
         URISyntaxException, StorageException;
 

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageServiceImpl.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageServiceImpl.java
@@ -288,24 +288,6 @@ public class AzureStorageServiceImpl extends AbstractComponent implements AzureS
     }
 
     @Override
-    public void moveBlob(String account, LocationMode mode, String container, String sourceBlob, String targetBlob)
-        throws URISyntaxException, StorageException {
-        logger.debug("moveBlob container [{}], sourceBlob [{}], targetBlob [{}]", container, sourceBlob, targetBlob);
-
-        CloudBlobClient client = this.getSelectedClient(account, mode);
-        CloudBlobContainer blobContainer = client.getContainerReference(container);
-        CloudBlockBlob blobSource = blobContainer.getBlockBlobReference(sourceBlob);
-        if (SocketAccess.doPrivilegedException(() -> blobSource.exists(null, null, generateOperationContext(account)))) {
-            CloudBlockBlob blobTarget = blobContainer.getBlockBlobReference(targetBlob);
-            SocketAccess.doPrivilegedVoidException(() -> {
-                blobTarget.startCopy(blobSource, null, null, null, generateOperationContext(account));
-                blobSource.delete(DeleteSnapshotsOption.NONE, null, null, generateOperationContext(account));
-            });
-            logger.debug("moveBlob container [{}], sourceBlob [{}], targetBlob [{}] -> done", container, sourceBlob, targetBlob);
-        }
-    }
-
-    @Override
     public void writeBlob(String account, LocationMode mode, String container, String blobName, InputStream inputStream, long blobSize)
         throws URISyntaxException, StorageException {
         logger.trace("writeBlob({}, stream, {})", blobName, blobSize);

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
@@ -107,18 +107,6 @@ public class AzureStorageServiceMock extends AbstractComponent implements AzureS
     }
 
     @Override
-    public void moveBlob(String account, LocationMode mode, String container, String sourceBlob, String targetBlob)
-        throws URISyntaxException, StorageException {
-        for (String blobName : blobs.keySet()) {
-            if (endsWithIgnoreCase(blobName, sourceBlob)) {
-                ByteArrayOutputStream outputStream = blobs.get(blobName);
-                blobs.put(blobName.replace(sourceBlob, targetBlob), outputStream);
-                blobs.remove(blobName);
-            }
-        }
-    }
-
-    @Override
     public void writeBlob(String account, LocationMode mode, String container, String blobName, InputStream inputStream, long blobSize)
         throws URISyntaxException, StorageException {
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
@@ -137,7 +125,7 @@ public class AzureStorageServiceMock extends AbstractComponent implements AzureS
      * @param prefix the prefix to look for
      * @see java.lang.String#startsWith
      */
-    public static boolean startsWithIgnoreCase(String str, String prefix) {
+    private static boolean startsWithIgnoreCase(String str, String prefix) {
         if (str == null || prefix == null) {
             return false;
         }
@@ -149,29 +137,6 @@ public class AzureStorageServiceMock extends AbstractComponent implements AzureS
         }
         String lcStr = str.substring(0, prefix.length()).toLowerCase(Locale.ROOT);
         String lcPrefix = prefix.toLowerCase(Locale.ROOT);
-        return lcStr.equals(lcPrefix);
-    }
-
-    /**
-     * Test if the given String ends with the specified suffix,
-     * ignoring upper/lower case.
-     *
-     * @param str    the String to check
-     * @param suffix the suffix to look for
-     * @see java.lang.String#startsWith
-     */
-    public static boolean endsWithIgnoreCase(String str, String suffix) {
-        if (str == null || suffix == null) {
-            return false;
-        }
-        if (str.endsWith(suffix)) {
-            return true;
-        }
-        if (str.length() < suffix.length()) {
-            return false;
-        }
-        String lcStr = str.substring(0, suffix.length()).toLowerCase(Locale.ROOT);
-        String lcPrefix = suffix.toLowerCase(Locale.ROOT);
         return lcStr.equals(lcPrefix);
     }
 

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainer.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainer.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.FileAlreadyExistsException;
 import java.util.Map;
 
 class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
@@ -72,11 +71,6 @@ class GoogleCloudStorageBlobContainer extends AbstractBlobContainer {
     @Override
     public void deleteBlob(String blobName) throws IOException {
         blobStore.deleteBlob(buildKey(blobName));
-    }
-
-    @Override
-    public void move(String sourceBlobName, String targetBlobName) throws IOException {
-        blobStore.moveBlob(buildKey(sourceBlobName), buildKey(targetBlobName));
     }
 
     protected String buildKey(String blobName) {

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -27,7 +27,6 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
-import com.google.cloud.storage.Storage.CopyRequest;
 import com.google.cloud.storage.StorageException;
 import org.elasticsearch.common.SuppressForbidden;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -312,29 +311,6 @@ class GoogleCloudStorageBlobStore extends AbstractComponent implements BlobStore
         if (failed) {
             throw new IOException("Failed to delete all [" + blobIdsToDelete.size() + "] blobs");
         }
-    }
-
-    /**
-     * Moves a blob within the same bucket
-     *
-     * @param sourceBlobName name of the blob to move
-     * @param targetBlobName new name of the blob in the same bucket
-     */
-    void moveBlob(String sourceBlobName, String targetBlobName) throws IOException {
-        final BlobId sourceBlobId = BlobId.of(bucket, sourceBlobName);
-        final BlobId targetBlobId = BlobId.of(bucket, targetBlobName);
-        final CopyRequest request = CopyRequest.newBuilder()
-                .setSource(sourceBlobId)
-                .setTarget(targetBlobId)
-                .build();
-        SocketAccess.doPrivilegedVoidIOException(() -> {
-            // There's no atomic "move" in GCS so we need to copy and delete
-            storage.copy(request).getResult();
-            final boolean deleted = storage.delete(sourceBlobId);
-            if (deleted == false) {
-                throw new IOException("Failed to move source [" + sourceBlobName + "] to target [" + targetBlobName + "]");
-            }
-        });
     }
 
     private static String buildKey(String keyPath, String s) {

--- a/plugins/repository-gcs/src/test/java/com/google/cloud/storage/StorageRpcOptionUtils.java
+++ b/plugins/repository-gcs/src/test/java/com/google/cloud/storage/StorageRpcOptionUtils.java
@@ -21,8 +21,6 @@ package com.google.cloud.storage;
 
 import com.google.cloud.storage.spi.v1.StorageRpc;
 
-import static org.mockito.Mockito.mock;
-
 /**
  * Utility class that exposed Google SDK package protected methods to
  * create specific StorageRpc objects in unit tests.
@@ -41,14 +39,5 @@ public class StorageRpcOptionUtils {
             }
         }
         return null;
-    }
-
-    public static CopyWriter createCopyWriter(final Blob result) {
-        return new CopyWriter(mock(StorageOptions.class), mock(StorageRpc.RewriteResponse.class)) {
-            @Override
-            public Blob getResult() {
-                return result;
-            }
-        };
     }
 }

--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockStorage.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockStorage.java
@@ -38,7 +38,6 @@ import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.StorageRpcOptionUtils;
 import com.google.cloud.storage.StorageTestUtils;
-
 import org.elasticsearch.core.internal.io.IOUtils;
 
 import java.io.ByteArrayInputStream;
@@ -123,24 +122,6 @@ class MockStorage implements Storage {
             blobs.put(blobInfo.getName(), content);
         }
         return get(BlobId.of(blobInfo.getBucket(), blobInfo.getName()));
-    }
-
-    @Override
-    public CopyWriter copy(CopyRequest copyRequest) {
-        if (bucketName.equals(copyRequest.getSource().getBucket()) == false) {
-            throw new StorageException(404, "Source bucket not found");
-        }
-        if (bucketName.equals(copyRequest.getTarget().getBucket()) == false) {
-            throw new StorageException(404, "Target bucket not found");
-        }
-
-        final byte[] bytes = blobs.get(copyRequest.getSource().getName());
-        if (bytes == null) {
-            throw new StorageException(404, "Source blob does not exist");
-        }
-        blobs.put(copyRequest.getTarget().getName(), bytes);
-        return StorageRpcOptionUtils
-                .createCopyWriter(get(BlobId.of(copyRequest.getTarget().getBucket(), copyRequest.getTarget().getName())));
     }
 
     @Override
@@ -268,6 +249,11 @@ class MockStorage implements Storage {
     }
 
     // Everything below this line is not implemented.
+
+    @Override
+    public CopyWriter copy(CopyRequest copyRequest) {
+        return null;
+    }
 
     @Override
     public Bucket create(BucketInfo bucketInfo, BucketTargetOption... options) {

--- a/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
+++ b/plugins/repository-hdfs/src/main/java/org/elasticsearch/repositories/hdfs/HdfsBlobContainer.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Options.CreateOpts;
 import org.apache.hadoop.fs.Path;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -36,9 +35,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.NoSuchFileException;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
@@ -74,14 +70,6 @@ final class HdfsBlobContainer extends AbstractBlobContainer {
         }
 
         store.execute(fileContext -> fileContext.delete(new Path(path, blobName), true));
-    }
-
-    @Override
-    public void move(String sourceBlobName, String targetBlobName) throws IOException {
-        store.execute((Operation<Void>) fileContext -> {
-            fileContext.rename(new Path(path, sourceBlobName), new Path(path, targetBlobName));
-            return null;
-        });
     }
 
     @Override

--- a/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -24,7 +24,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
-import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -154,28 +153,6 @@ class S3BlobContainer extends AbstractBlobContainer {
             });
             return blobsBuilder.immutableMap();
         });
-    }
-
-    @Override
-    public void move(String sourceBlobName, String targetBlobName) throws IOException {
-        try {
-            CopyObjectRequest request = new CopyObjectRequest(blobStore.bucket(), buildKey(sourceBlobName),
-                blobStore.bucket(), buildKey(targetBlobName));
-
-            if (blobStore.serverSideEncryption()) {
-                ObjectMetadata objectMetadata = new ObjectMetadata();
-                objectMetadata.setSSEAlgorithm(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
-                request.setNewObjectMetadata(objectMetadata);
-            }
-
-            SocketAccess.doPrivilegedVoid(() -> {
-                blobStore.client().copyObject(request);
-                blobStore.client().deleteObject(blobStore.bucket(), buildKey(sourceBlobName));
-            });
-
-        } catch (AmazonS3Exception e) {
-            throw new IOException(e);
-        }
     }
 
     @Override

--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/MockAmazonS3.java
@@ -23,8 +23,6 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AbstractAmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.CopyObjectRequest;
-import com.amazonaws.services.s3.model.CopyObjectResult;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsResult;
@@ -146,24 +144,6 @@ class MockAmazonS3 extends AbstractAmazonS3 {
             }
         }
         return listing;
-    }
-
-    @Override
-    public CopyObjectResult copyObject(final CopyObjectRequest request) throws AmazonClientException {
-        assertThat(request.getSourceBucketName(), equalTo(bucket));
-        assertThat(request.getDestinationBucketName(), equalTo(bucket));
-
-        final String sourceBlobName = request.getSourceKey();
-
-        final byte[] content = blobs.get(sourceBlobName);
-        if (content == null) {
-            AmazonS3Exception exception = new AmazonS3Exception("[" + sourceBlobName + "] does not exist.");
-            exception.setStatusCode(404);
-            throw exception;
-        }
-
-        blobs.put(request.getDestinationKey(), content);
-        return new CopyObjectResult();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -142,20 +142,4 @@ public interface BlobContainer {
      * @throws  IOException if there were any failures in reading from the blob container.
      */
     Map<String, BlobMetaData> listBlobsByPrefix(String blobNamePrefix) throws IOException;
-
-    /**
-     * Renames the source blob into the target blob.  If the source blob does not exist or the
-     * target blob already exists, an exception is thrown.  Atomicity of the move operation
-     * can only be guaranteed on an implementation-by-implementation basis.  The only current
-     * implementation of {@link BlobContainer} for which atomicity can be guaranteed is the
-     * {@link org.elasticsearch.common.blobstore.fs.FsBlobContainer}.
-     *
-     * @param   sourceBlobName
-     *          The blob to rename.
-     * @param   targetBlobName
-     *          The name of the blob after the renaming.
-     * @throws  IOException if the source blob does not exist, the target blob already exists,
-     *          or there were any failures in reading from the blob container.
-     */
-    void move(String sourceBlobName, String targetBlobName) throws IOException;
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -3103,7 +3103,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
                     .put("location", repoPath)
                     .put("random_control_io_exception_rate", randomIntBetween(5, 20) / 100f)
                     // test that we can take a snapshot after a failed one, even if a partial index-N was written
-                    .put("atomic_move", false)
+                    .put("allow_atomic_operations", false)
                     .put("random", randomAlphaOfLength(10))));
 
         logger.info("--> indexing some data");

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/BlobContainerWrapper.java
@@ -77,9 +77,4 @@ public class BlobContainerWrapper implements BlobContainer {
     public Map<String, BlobMetaData> listBlobsByPrefix(String blobNamePrefix) throws IOException {
         return delegate.listBlobsByPrefix(blobNamePrefix);
     }
-
-    @Override
-    public void move(String sourceBlobName, String targetBlobName) throws IOException {
-        delegate.move(sourceBlobName, targetBlobName);
-    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.repositories.ESBlobStoreTestCase.randomBytes;
-import static org.elasticsearch.repositories.ESBlobStoreTestCase.readBlobFully;
 import static org.elasticsearch.repositories.ESBlobStoreTestCase.writeRandomBlob;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -66,7 +65,7 @@ public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
         }
     }
 
-    public void testMoveAndList() throws IOException {
+    public void testList() throws IOException {
         try(BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());
             assertThat(container.listBlobs().size(), equalTo(0));
@@ -102,15 +101,6 @@ public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
             assertThat(container.listBlobsByPrefix("foo-").size(), equalTo(numberOfFooBlobs));
             assertThat(container.listBlobsByPrefix("bar-").size(), equalTo(numberOfBarBlobs));
             assertThat(container.listBlobsByPrefix("baz-").size(), equalTo(0));
-
-            String newName = "bar-new";
-            // Move to a new location
-            container.move(name, newName);
-            assertThat(container.listBlobsByPrefix(name).size(), equalTo(0));
-            blobs = container.listBlobsByPrefix(newName);
-            assertThat(blobs.size(), equalTo(1));
-            assertThat(blobs.get(newName).length(), equalTo(generatedBlobs.get(name)));
-            assertThat(data, equalTo(readBlobFully(container, newName, length)));
         }
     }
 


### PR DESCRIPTION
This method removes the `BlobContainer.move()` method that was wastefully implemented on cloud based repository implementations.

closes #30680

