### PR TITLE
[DOCS] Enables testing for monitoring examples

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -17,7 +17,6 @@ buildRestTests.expectedUnconvertedCandidates = [
         'en/ml/functions/sum.asciidoc',
         'en/ml/functions/time.asciidoc',
         'en/ml/customurl.asciidoc',
-        'en/monitoring/indices.asciidoc',
         'en/rest-api/security/ssl.asciidoc',
         'en/rest-api/security/users.asciidoc',
         'en/rest-api/security/tokens.asciidoc',

--- a/x-pack/docs/en/monitoring/indices.asciidoc
+++ b/x-pack/docs/en/monitoring/indices.asciidoc
@@ -12,7 +12,7 @@ You can retrieve the templates through the `_template` API:
 GET /_template/.monitoring-*
 ----------------------------------
 // CONSOLE
-// TEST[skip:404 error]
+// TEST[catch:missing]
 
 By default, the template configures one shard and one replica for the
 monitoring indices. To override the default settings, add your own template:

--- a/x-pack/docs/en/monitoring/indices.asciidoc
+++ b/x-pack/docs/en/monitoring/indices.asciidoc
@@ -11,6 +11,8 @@ You can retrieve the templates through the `_template` API:
 ----------------------------------
 GET /_template/.monitoring-*
 ----------------------------------
+// CONSOLE
+// TEST[skip:404 error]
 
 By default, the template configures one shard and one replica for the
 monitoring indices. To override the default settings, add your own template:
@@ -36,6 +38,7 @@ PUT /_template/custom_monitoring
     }
 }
 ----------------------------------
+// CONSOLE
 
 IMPORTANT: Only set the `number_of_shards` and `number_of_replicas` in the
 settings section. Overriding other monitoring template settings could cause


### PR DESCRIPTION
This PR attempts to enable code snippet testing for the monitoring/indices.asciidoc page, which is externalized here: 
https://www.elastic.co/guide/en/elasticsearch/reference/master/config-monitoring-indices.html

The first example needs to be skipped, however, since it results in the following 404 error otherwise:

> 1> [2018-06-05T19:46:44,113][INFO ][o.e.s.XDocsClientYamlTestSuiteIT] [test {yaml=en/monitoring/indices/line_11}]: after test
  1> [2018-06-05T19:46:44,113][ERROR][o.e.s.XDocsClientYamlTestSuiteIT] This failing test was generated by documentation starting at en/monitoring/indices.asciidoc:line_11. It may include many snippets. See Elasticsearch's docs/README.asciidoc for an explanation of test generation.
  2> REPRODUCE WITH: ./gradlew :x-pack:docs:integTestRunner -Dtests.seed=CF22EFB6F9816360 -Dtests.class=org.elasticsearch.smoketest.XDocsClientYamlTestSuiteIT -Dtests.method="test {yaml=en/monitoring/indices/line_11}" -Dtests.security.manager=true -Dtests.locale=be -Dtests.timezone=CNT
FAILURE 0.40s | XDocsClientYamlTestSuiteIT.test {yaml=en/monitoring/indices/line_11} <<< FAILURES!
   > Throwable #1: java.lang.AssertionError: Failure at [en/monitoring/indices:10]: expected [2xx] status code but api [raw[method=GET path=_template/.monitoring-*]] returned [404 Not Found] [{}]
   >    at __randomizedtesting.SeedInfo.seed([CF22EFB6F9816360:4776D06C577D0E98]:0)
   >    at org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase.executeSection(ESClientYamlSuiteTestCase.java:373)
   >    at org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase.test(ESClientYamlSuiteTestCase.java:350)
   >    at jdk.internal.reflect.GeneratedMethodAccessor11.invoke(Unknown Source)
   >    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   >    at java.base/java.lang.reflect.Method.invoke(Method.java:564)
   >    at java.base/java.lang.Thread.run(Thread.java:844)
   > Caused by: java.lang.AssertionError: expected [2xx] status code but api [raw[method=GET path=_template/.monitoring-*]] returned [404 Not Found] [{}]

My guess is that this error occurs because the test occurs before any templates have been created. If there are commands that could force that to occur, we could use those in the test setup. 