### PR TITLE
Remove extra checks from HdfsBlobContainer

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
@@ -47,6 +47,13 @@ import static org.hamcrest.CoreMatchers.notNullValue;
  */
 public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
 
+    public void testReadNonExistingPath() throws IOException {
+        try(BlobStore store = newBlobStore()) {
+            final BlobContainer container = store.blobContainer(new BlobPath());
+            expectThrows(NoSuchFileException.class, () -> container.readBlob("non-existing"));
+        }
+    }
+
     public void testWriteRead() throws IOException {
         try(BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());


### PR DESCRIPTION
Those who fail to read API documentation are doomed to reimplement it. This PR saves one network roundtrip when reading or deleting files from an HDFS repository.