### PR TITLE
[DOCS] Clarifies recommendation for audit index output type

### DIFF
--- a/x-pack/docs/en/security/auditing/event-types.asciidoc
+++ b/x-pack/docs/en/security/auditing/event-types.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[float]
 [[audit-event-types]]
 === Audit event types
 

--- a/x-pack/docs/en/security/auditing/output-index.asciidoc
+++ b/x-pack/docs/en/security/auditing/output-index.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[float]
 [[audit-index]]
 === Index audit output
 

--- a/x-pack/docs/en/security/auditing/output-index.asciidoc
+++ b/x-pack/docs/en/security/auditing/output-index.asciidoc
@@ -36,3 +36,8 @@ xpack.security.audit.index.settings:
     number_of_shards: 1
     number_of_replicas: 1
 ----------------------------
+
+NOTE: Audit events are batched for indexing so there is a lag before
+events appear in the index. You can control how frequently batches of
+events are pushed to the index by setting
+`xpack.security.audit.index.flush_interval` in `elasticsearch.yml`.

--- a/x-pack/docs/en/security/auditing/output-logfile.asciidoc
+++ b/x-pack/docs/en/security/auditing/output-logfile.asciidoc
@@ -1,5 +1,4 @@
 [role="xpack"]
-[float]
 [[audit-log-output]]
 === Logfile audit output
 

--- a/x-pack/docs/en/security/auditing/overview.asciidoc
+++ b/x-pack/docs/en/security/auditing/overview.asciidoc
@@ -29,12 +29,7 @@ indexing by setting `xpack.security.audit.outputs` in `elasticsearch.yml`:
 xpack.security.audit.outputs: [ index, logfile ]
 ----------------------------
 
-The `index` output type should be used in conjunction with the `logfile`
-output type Because it is possible for the `index` output type to lose
-messages if the target index is unavailable, the `access.log` should be
-used as the official record of events.
-
-NOTE: Audit events are batched for indexing so there is a lag before
-events appear in the index. You can control how frequently batches of
-events are pushed to the index by setting
-`xpack.security.audit.index.flush_interval` in `elasticsearch.yml`.
+TIP: If you use the `index` output, we strongly recommend that you still use the 
+`logfile` output as the official record of events. If the target index is 
+unavailable (for example, during a rolling upgrade), the `index` output type can 
+lose messages.

--- a/x-pack/docs/en/security/auditing/overview.asciidoc
+++ b/x-pack/docs/en/security/auditing/overview.asciidoc
@@ -29,7 +29,7 @@ indexing by setting `xpack.security.audit.outputs` in `elasticsearch.yml`:
 xpack.security.audit.outputs: [ index, logfile ]
 ----------------------------
 
-TIP: If you use the `index` output, we strongly recommend that you still use the 
-`logfile` output as the official record of events. If the target index is 
-unavailable (for example, during a rolling upgrade), the `index` output type can 
-lose messages.
+TIP: If you choose to enable the `index` output type, we strongly recommend that 
+you still use the `logfile` output as the official record of events. If the 
+target index is unavailable (for example, during a rolling upgrade), the `index` 
+output can lose messages.


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/31139

Also splits the following long page into multiple pages: https://www.elastic.co/guide/en/elastic-stack-overview/master/auditing.html