### PR TITLE
Cleanup nio http thread names

### DIFF
--- a/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/RoundRobinSupplier.java
+++ b/libs/elasticsearch-nio/src/main/java/org/elasticsearch/nio/RoundRobinSupplier.java
@@ -38,6 +38,7 @@ final class RoundRobinSupplier<S> implements Supplier<S> {
         this.selectorsSet.set(true);
     }
 
+    @Override
     public S get() {
         S[] selectors = this.selectors;
         return selectors[counter.getAndIncrement() % selectors.length];

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpServerTransport.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpServerTransport.java
@@ -108,9 +108,6 @@ public class NioHttpServerTransport extends AbstractHttpServerTransport {
             (s) -> Integer.toString(EsExecutors.numberOfProcessors(s) * 2),
             (s) -> Setting.parseInt(s, 1, "http.nio.worker_count"), Setting.Property.NodeScope);
 
-    private static final String TRANSPORT_WORKER_THREAD_NAME_PREFIX = "http_nio_transport_worker";
-    private static final String TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX = "http_nio_transport_acceptor";
-
     private final BigArrays bigArrays;
     private final ThreadPool threadPool;
     private final NamedXContentRegistry xContentRegistry;
@@ -177,8 +174,8 @@ public class NioHttpServerTransport extends AbstractHttpServerTransport {
         try {
             int acceptorCount = NIO_HTTP_ACCEPTOR_COUNT.get(settings);
             int workerCount = NIO_HTTP_WORKER_COUNT.get(settings);
-            nioGroup = new NioGroup(daemonThreadFactory(this.settings, TRANSPORT_ACCEPTOR_THREAD_NAME_PREFIX), acceptorCount,
-                daemonThreadFactory(this.settings, TRANSPORT_WORKER_THREAD_NAME_PREFIX), workerCount,
+            nioGroup = new NioGroup(daemonThreadFactory(this.settings, HTTP_SERVER_ACCEPTOR_THREAD_NAME_PREFIX), acceptorCount,
+                daemonThreadFactory(this.settings, HTTP_SERVER_WORKER_THREAD_NAME_PREFIX), workerCount,
                 (s) -> new EventHandler(this::nonChannelExceptionCaught, s));
             channelFactory = new HttpChannelFactory();
             this.boundAddress = createBoundHttpAddress();

--- a/server/src/main/java/org/elasticsearch/http/HttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpServerTransport.java
@@ -29,6 +29,8 @@ public interface HttpServerTransport extends LifecycleComponent {
 
     String HTTP_SERVER_WORKER_THREAD_NAME_PREFIX = "http_server_worker";
 
+    String HTTP_SERVER_ACCEPTOR_THREAD_NAME_PREFIX = "http_server_acceptor";
+
     BoundTransportAddress boundAddress();
 
     HttpInfo info();

--- a/server/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transports.java
@@ -40,6 +40,7 @@ public enum Transports {
         final String threadName = t.getName();
         for (String s : Arrays.asList(
                 HttpServerTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX,
+                HttpServerTransport.HTTP_SERVER_ACCEPTOR_THREAD_NAME_PREFIX,
                 TcpTransport.TRANSPORT_SERVER_WORKER_THREAD_NAME_PREFIX,
                 TcpTransport.TRANSPORT_CLIENT_BOSS_THREAD_NAME_PREFIX,
                 TEST_MOCK_TRANSPORT_THREAD_PREFIX,


### PR DESCRIPTION
This is related to #28898. This commit adds the acceptor thread name to
the method checking if this thread is a transport thread. Additionally,
it modifies the nio http transport to use the same worker name as the
netty4 http server transport.