### PR TITLE
Pass main class by environment variable

### DIFF
--- a/distribution/src/bin/elasticsearch-cli
+++ b/distribution/src/bin/elasticsearch-cli
@@ -24,5 +24,5 @@ exec \
   -Des.distribution.flavor="$ES_DISTRIBUTION_FLAVOR" \
   -Des.distribution.type="$ES_DISTRIBUTION_TYPE" \
   -cp "$ES_CLASSPATH" \
-  $1 \
-  "${@:2}"
+  "$ES_MAIN_CLASS" \
+  "$@"

--- a/distribution/src/bin/elasticsearch-keystore
+++ b/distribution/src/bin/elasticsearch-keystore
@@ -1,5 +1,5 @@
 #!/bin/bash
 
+ES_MAIN_CLASS=org.elasticsearch.common.settings.KeyStoreCli \
 "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.common.settings.KeyStoreCli \
   "$@"

--- a/distribution/src/bin/elasticsearch-plugin
+++ b/distribution/src/bin/elasticsearch-plugin
@@ -1,6 +1,6 @@
 #!/bin/bash
 
+ES_MAIN_CLASS=org.elasticsearch.plugins.PluginCli \
 ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/plugin-cli \
   "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.plugins.PluginCli \
   "$@"

--- a/distribution/src/bin/elasticsearch-translog
+++ b/distribution/src/bin/elasticsearch-translog
@@ -1,5 +1,5 @@
 #!/bin/bash
 
+ES_MAIN_CLASS=org.elasticsearch.index.translog.TranslogToolCli \
 "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.index.translog.TranslogToolCli \
   "$@"

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certgen
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certgen
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+ES_MAIN_CLASS=org.elasticsearch.xpack.core.ssl.CertificateGenerateTool \
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-security-env" \
   "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.xpack.core.ssl.CertificateGenerateTool \
   "$@"

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certutil
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certutil
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-ES_MAIN_CLASS=org.elasticsearch.xpack.core.ssl.CertificateTool
+ES_MAIN_CLASS=org.elasticsearch.xpack.core.ssl.CertificateTool \
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-security-env" \
   "`dirname "$0"`"/elasticsearch-cli \
   "$@"

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certutil
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certutil
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+ES_MAIN_CLASS=org.elasticsearch.xpack.core.ssl.CertificateTool
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-security-env" \
   "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.xpack.core.ssl.CertificateTool \
   "$@"

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-migrate
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-migrate
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.ESNativeRealmMigrateTool \
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-security-env" \
   "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.xpack.security.authc.esnative.ESNativeRealmMigrateTool \
   "$@"

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand \
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-security-env" \
   "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand \
   "$@"

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.tool.SetupPasswordTool \
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-security-env" \
   "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.xpack.security.authc.esnative.tool.SetupPasswordTool \
   "$@"

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+ES_MAIN_CLASS=org.elasticsearch.xpack.security.crypto.tool.SystemKeyTool \
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-security-env" \
   "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.xpack.security.crypto.tool.SystemKeyTool \
   "$@"

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-users
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-users
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.file.tool.UsersTool
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-security-env" \
   "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.xpack.security.authc.file.tool.UsersTool \
   "$@"

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-users
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-users
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.file.tool.UsersTool
+ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.file.tool.UsersTool \
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-security-env" \
   "`dirname "$0"`"/elasticsearch-cli \
   "$@"

--- a/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval
+++ b/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval
@@ -4,7 +4,7 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
+ES_MAIN_CLASS=org.elasticsearch.xpack.watcher.trigger.schedule.tool.CronEvalTool \
 ES_ADDITIONAL_SOURCES="x-pack-env;x-pack-watcher-env" \
   "`dirname "$0"`"/elasticsearch-cli \
-  org.elasticsearch.xpack.watcher.trigger.schedule.tool.CronEvalTool \
   "$@"


### PR DESCRIPTION
A previous refactoring of the CLI scripts migrated all of the CLI tools to shell to a common script, elasticsearch-cli. This approach is fine in Bash where it is easy to tear arguments apart but it doesn't work so well on Windows where quoting is insane. To avoid having to tear the arguments apart to separate the first argument to elasticsearch-cli from the remaining arguments, we instead choose a strategy where we can avoid tearing the arguments apart. To do this, we will instead pass the main class by an environment variable and then we can pass the arguments straight through. This will let us avoid awful quoting issues on Windows. This is the non-Windows side of that effort and the Windows side will be in a follow-up.

Relates #31058

