### PR TITLE
SyncedFlushResponse to implement ToXContentObject

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/SyncedFlushResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/SyncedFlushResponse.java
@@ -21,25 +21,26 @@ package org.elasticsearch.client;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.xcontent.ToXContentFragment;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentLocation;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentFragment;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentLocation;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Collections;
-import java.util.List;
-import java.util.ArrayList;
-
-public class SyncedFlushResponse extends ActionResponse implements ToXContentFragment {
+public class SyncedFlushResponse extends ActionResponse implements ToXContentObject {
 
     public static final String SHARDS_FIELD = "_shards";
 
@@ -86,6 +87,7 @@ public class SyncedFlushResponse extends ActionResponse implements ToXContentFra
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
         builder.startObject(SHARDS_FIELD);
         totalCounts.toXContent(builder, params);
         builder.endObject();
@@ -96,6 +98,7 @@ public class SyncedFlushResponse extends ActionResponse implements ToXContentFra
             indexResult.toXContent(builder, params);
             builder.endObject();
         }
+        builder.endObject();
         return builder;
     }
 

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/SyncedFlushResponseTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/SyncedFlushResponseTests.java
@@ -18,14 +18,6 @@
  */
 package org.elasticsearch.client;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-
 import com.carrotsearch.hppc.ObjectIntHashMap;
 import com.carrotsearch.hppc.ObjectIntMap;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -42,6 +34,14 @@ import org.elasticsearch.indices.flush.ShardsSyncedFlushResult;
 import org.elasticsearch.indices.flush.SyncedFlushService;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 public class SyncedFlushResponseTests extends ESTestCase {
 
     public void testXContentSerialization() throws IOException {
@@ -55,9 +55,7 @@ public class SyncedFlushResponseTests extends ESTestCase {
         serverResponsebuilder.endObject();
         XContentBuilder clientResponsebuilder = XContentBuilder.builder(xContentType.xContent());
         assertNotNull(plan.result);
-        clientResponsebuilder.startObject();
         plan.clientResult.toXContent(clientResponsebuilder, ToXContent.EMPTY_PARAMS);
-        clientResponsebuilder.endObject();
         Map<String, Object> serverContentMap = convertFailureListToSet(
             serverResponsebuilder
                 .generator()


### PR DESCRIPTION
The response currently implements ToXContentFragment although the only time it's used
it is supposed to print out a complete object rather than a fragment. Note that this
is the client version of the response, used only in the high-level client.