### PR TITLE
Pass main class by environment variable on Windows

### DIFF
--- a/distribution/src/bin/elasticsearch-cli.bat
+++ b/distribution/src/bin/elasticsearch-cli.bat
@@ -6,11 +6,6 @@ if defined ES_ADDITIONAL_SOURCES (
   )
 )
 
-for /f "tokens=1*" %%a in ("%*") do (
-  set main_class=%%a
-  set arguments=%%b
-)
-
 if defined ES_ADDITIONAL_CLASSPATH_DIRECTORIES (
   for %%a in ("%ES_ADDITIONAL_CLASSPATH_DIRECTORIES:;=","%") do (
     set ES_CLASSPATH=!ES_CLASSPATH!;!ES_HOME!/%%a/*
@@ -24,5 +19,5 @@ if defined ES_ADDITIONAL_CLASSPATH_DIRECTORIES (
   -Des.distribution.flavor="%ES_DISTRIBUTION_FLAVOR%" ^
   -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
   -cp "%ES_CLASSPATH%" ^
-  %main_class% ^
-  %arguments%
+  "%ES_MAIN_CLASS%" ^
+  %*

--- a/distribution/src/bin/elasticsearch-keystore.bat
+++ b/distribution/src/bin/elasticsearch-keystore.bat
@@ -3,8 +3,8 @@
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.common.settings.KeyStoreCli
 call "%~dp0elasticsearch-cli.bat" ^
-   org.elasticsearch.common.settings.KeyStoreCli ^
   %%* ^
   || exit /b 1
 

--- a/distribution/src/bin/elasticsearch-plugin.bat
+++ b/distribution/src/bin/elasticsearch-plugin.bat
@@ -3,9 +3,9 @@
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.plugins.PluginCli
 set ES_ADDITIONAL_CLASSPATH_DIRECTORIES=lib/tools/plugin-cli
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.plugins.PluginCli ^
   %%* ^
   || exit /b 1
 

--- a/distribution/src/bin/elasticsearch-translog.bat
+++ b/distribution/src/bin/elasticsearch-translog.bat
@@ -3,8 +3,8 @@
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.index.translog.TranslogToolCli
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.index.translog.TranslogToolCli ^
   %%* ^
   || exit /b 1
 

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certgen.bat
@@ -7,9 +7,9 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.xpack.core.ssl.CertificateGenerateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.xpack.core.ssl.CertificateGenerateTool ^
   %%* ^
   || exit /b 1
 

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-certutil.bat
@@ -7,9 +7,9 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.xpack.core.ssl.CertificateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.xpack.core.ssl.CertificateTool ^
   %%* ^
   || exit /b 1
 

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-migrate.bat
@@ -7,9 +7,9 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.ESNativeRealmMigrateTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.xpack.security.authc.esnative.ESNativeRealmMigrateTool ^
   %%* ^
   || exit /b 1
 

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-saml-metadata.bat
@@ -7,9 +7,9 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.xpack.security.authc.saml.SamlMetadataCommand ^
   %%* ^
   || exit /b 1
 

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-setup-passwords.bat
@@ -7,9 +7,9 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.esnative.tool.SetupPasswordTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.xpack.security.authc.esnative.tool.SetupPasswordTool ^
   %%* ^
   || exit /b 1
 

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-syskeygen.bat
@@ -7,9 +7,9 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.xpack.security.crypto.tool.SystemKeyTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.xpack.security.crypto.tool.SystemKeyTool ^
   %%* ^
   || exit /b 1
 

--- a/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
+++ b/x-pack/plugin/security/src/main/bin/elasticsearch-users.bat
@@ -7,9 +7,9 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.xpack.security.authc.file.tool.UsersTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-security-env
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.xpack.security.authc.file.tool.UsersTool ^
   %%* ^
   || exit /b 1
 

--- a/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
+++ b/x-pack/plugin/watcher/src/main/bin/elasticsearch-croneval.bat
@@ -7,9 +7,9 @@ rem you may not use this file except in compliance with the Elastic License.
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
+set ES_MAIN_CLASS=org.elasticsearch.xpack.watcher.trigger.schedule.tool.CronEvalTool
 set ES_ADDITIONAL_SOURCES=x-pack-env;x-pack-watcher-env
 call "%~dp0elasticsearch-cli.bat" ^
-  org.elasticsearch.xpack.watcher.trigger.schedule.tool.CronEvalTool ^
   %%* ^
   || exit /b 1
 


### PR DESCRIPTION
A previous refactoring of the CLI scripts migrated all of the CLI tools to shell to a common script, elasticsearch-cli. This approach is fine in Bash where it is easy to tear arguments apart but it doesn't work so well on Windows where quoting is insane. To avoid having to tear the arguments apart to separate the first argument to elasticsearch-cli from the remaining arguments, we instead choose a strategy where we can avoid tearing the arguments apart. To do this, we will instead pass the main class by an environment variable and then we can pass the arguments straight through. This will let us avoid awful quoting issues on Windows. This is the Windows side of that effort and the Bash side was in a previous commit.

Relates #31058

