### PR TITLE
Share common parser in some AcknowledgedResponses

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/DeleteRepositoryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/DeleteRepositoryResponse.java
@@ -20,20 +20,12 @@
 package org.elasticsearch.action.admin.cluster.repositories.delete;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 /**
  * Unregister repository response
  */
 public class DeleteRepositoryResponse extends AcknowledgedResponse {
-
-    private static final ConstructingObjectParser<DeleteRepositoryResponse, Void> PARSER =
-        new ConstructingObjectParser<>("delete_repository", true, args -> new DeleteRepositoryResponse((boolean) args[0]));
-
-    static {
-        declareAcknowledgedField(PARSER);
-    }
 
     DeleteRepositoryResponse() {
     }
@@ -43,6 +35,6 @@ public class DeleteRepositoryResponse extends AcknowledgedResponse {
     }
 
     public static DeleteRepositoryResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return new DeleteRepositoryResponse(parseAcknowledged(parser));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryResponse.java
@@ -20,20 +20,12 @@
 package org.elasticsearch.action.admin.cluster.repositories.put;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 /**
  * Register repository response
  */
 public class PutRepositoryResponse extends AcknowledgedResponse {
-
-    private static final ConstructingObjectParser<PutRepositoryResponse, Void> PARSER = new ConstructingObjectParser<>("put_repository",
-        true, args -> new PutRepositoryResponse((boolean) args[0]));
-
-    static {
-        declareAcknowledgedField(PARSER);
-    }
 
     PutRepositoryResponse() {
     }
@@ -43,6 +35,6 @@ public class PutRepositoryResponse extends AcknowledgedResponse {
     }
 
     public static PutRepositoryResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return new PutRepositoryResponse(parseAcknowledged(parser));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesResponse.java
@@ -42,6 +42,6 @@ public class IndicesAliasesResponse extends AcknowledgedResponse {
     }
 
     public static IndicesAliasesResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return new IndicesAliasesResponse(parseAcknowledged(parser));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
@@ -20,20 +20,12 @@
 package org.elasticsearch.action.admin.indices.close;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 /**
  * A response for a close index action.
  */
 public class CloseIndexResponse extends AcknowledgedResponse {
-    private static final ConstructingObjectParser<CloseIndexResponse, Void> PARSER = new ConstructingObjectParser<>("close_index", true,
-            args -> new CloseIndexResponse((boolean) args[0]));
-
-    static {
-        declareAcknowledgedField(PARSER);
-    }
-
     CloseIndexResponse() {
     }
 
@@ -42,6 +34,6 @@ public class CloseIndexResponse extends AcknowledgedResponse {
     }
 
     public static CloseIndexResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return new CloseIndexResponse(parseAcknowledged(parser));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexResponse.java
@@ -20,20 +20,12 @@
 package org.elasticsearch.action.admin.indices.delete;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 /**
  * A response for a delete index action.
  */
 public class DeleteIndexResponse extends AcknowledgedResponse {
-
-    private static final ConstructingObjectParser<DeleteIndexResponse, Void> PARSER = new ConstructingObjectParser<>("delete_index",
-        true, args -> new DeleteIndexResponse((boolean) args[0]));
-
-    static {
-        declareAcknowledgedField(PARSER);
-    }
 
     DeleteIndexResponse() {
     }
@@ -43,6 +35,6 @@ public class DeleteIndexResponse extends AcknowledgedResponse {
     }
 
     public static DeleteIndexResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return new DeleteIndexResponse(parseAcknowledged(parser));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingResponse.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.action.admin.indices.mapping.put;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 /**
@@ -28,15 +27,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
  */
 public class PutMappingResponse extends AcknowledgedResponse {
 
-    private static final ConstructingObjectParser<PutMappingResponse, Void> PARSER = new ConstructingObjectParser<>("put_mapping",
-        true, args -> new PutMappingResponse((boolean) args[0]));
-
-    static {
-        declareAcknowledgedField(PARSER);
-    }
-
     protected PutMappingResponse() {
-
     }
 
     protected PutMappingResponse(boolean acknowledged) {
@@ -44,6 +35,6 @@ public class PutMappingResponse extends AcknowledgedResponse {
     }
 
     public static PutMappingResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return new PutMappingResponse(parseAcknowledged(parser));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsResponse.java
@@ -20,20 +20,12 @@
 package org.elasticsearch.action.admin.indices.settings.put;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 /**
  * A response for an update index settings action
  */
 public class UpdateSettingsResponse extends AcknowledgedResponse {
-
-    private static final ConstructingObjectParser<UpdateSettingsResponse, Void> PARSER = new ConstructingObjectParser<>(
-            "update_index_settings", true, args -> new UpdateSettingsResponse((boolean) args[0]));
-
-    static {
-        declareAcknowledgedField(PARSER);
-    }
 
     UpdateSettingsResponse() {
     }
@@ -43,7 +35,6 @@ public class UpdateSettingsResponse extends AcknowledgedResponse {
     }
 
     public static UpdateSettingsResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return new UpdateSettingsResponse(parseAcknowledged(parser));
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateResponse.java
@@ -19,7 +19,6 @@
 package org.elasticsearch.action.admin.indices.template.put;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 /**
@@ -34,13 +33,7 @@ public class PutIndexTemplateResponse extends AcknowledgedResponse {
         super(acknowledged);
     }
 
-    private static final ConstructingObjectParser<PutIndexTemplateResponse, Void> PARSER;
-    static {
-        PARSER = new ConstructingObjectParser<>("put_index_template", true, args -> new PutIndexTemplateResponse((boolean) args[0]));
-        declareAcknowledgedField(PARSER);
-    }
-
     public static PutIndexTemplateResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return new PutIndexTemplateResponse(parseAcknowledged(parser));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/ingest/WritePipelineResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/WritePipelineResponse.java
@@ -20,21 +20,12 @@
 package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 public class WritePipelineResponse extends AcknowledgedResponse implements ToXContentObject {
 
-    private static final ConstructingObjectParser<WritePipelineResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "write_pipeline_response", true, args -> new WritePipelineResponse((boolean) args[0]));
-
-    static {
-        declareAcknowledgedField(PARSER);
-    }
-
     WritePipelineResponse() {
-
     }
 
     public WritePipelineResponse(boolean acknowledged) {
@@ -42,6 +33,6 @@ public class WritePipelineResponse extends AcknowledgedResponse implements ToXCo
     }
 
     public static WritePipelineResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+        return new WritePipelineResponse(parseAcknowledged(parser));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedResponse.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -86,6 +87,21 @@ public abstract class AcknowledgedResponse extends ActionResponse implements ToX
 
     protected void addCustomFields(XContentBuilder builder, Params params) throws IOException {
 
+    }
+
+    /**
+     * A generic parser that simply parses the acknowledged flag
+     */
+    private static final ConstructingObjectParser<Boolean, Void> ACKNOWLEDGED_FLAG_PARSER = new ConstructingObjectParser<>(
+            "acknowledged_flag", true, args -> (Boolean) args[0]);
+
+    static {
+        ACKNOWLEDGED_FLAG_PARSER.declareField(constructorArg(), (parser, context) -> parser.booleanValue(), ACKNOWLEDGED,
+                ObjectParser.ValueType.BOOLEAN);
+    }
+
+    protected static boolean parseAcknowledged(XContentParser parser) {
+        return ACKNOWLEDGED_FLAG_PARSER.apply(parser, null);
     }
 
     @Override


### PR DESCRIPTION
Several AcknowledgedResponse implementations only parse the boolean acknowledged
flag and then create an instance of their class using that flag. This can be
simplified by adding this basic parser to the superclass, provide a common
helper method and call the appropriate ctor in the fromXContent methods.