### PR TITLE
[Docs] Remove mention pattern files in Grok processor

### DIFF
--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1325,7 +1325,7 @@ This pipeline will insert these named captures as new fields within the document
 // NOTCONSOLE
 
 [[custom-patterns]]
-==== Custom Patterns and Pattern Files
+==== Custom Patterns
 
 The Grok processor comes pre-packaged with a base set of pattern. These patterns may not always have
 what you are looking for. Pattern have a very basic format. Each entry describes has a name and the pattern itself.


### PR DESCRIPTION
Pattern files have been removed in 16fa3e546e172d3d194c2711654824d4851d69f8 (~~6.2.4~~  5.0.0).
