### PR TITLE
Allowing the kibana system role to get/put privileges

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -79,7 +79,13 @@ public class ReservedRolesStore {
                         null,
                         MetadataUtils.DEFAULT_RESERVED_METADATA))
                 .put(KibanaUser.ROLE_NAME, new RoleDescriptor(KibanaUser.ROLE_NAME,
-                        new String[] { "monitor", "manage_index_templates", MonitoringBulkAction.NAME, "manage_saml" },
+                        new String[] {
+                            "monitor", "manage_index_templates", MonitoringBulkAction.NAME, "manage_saml",
+                            "cluster:admin/xpack/security/privilege/get",
+                            "cluster:admin/xpack/security/privilege/put",
+                            "cluster:admin/xpack/security/role/get",
+                            "cluster:admin/xpack/security/role/put"
+                        },
                         new RoleDescriptor.IndicesPrivileges[] {
                                 RoleDescriptor.IndicesPrivileges.builder().indices(".kibana*", ".reporting-*").privileges("all").build(),
                                 RoleDescriptor.IndicesPrivileges.builder()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -83,8 +83,6 @@ public class ReservedRolesStore {
                             "monitor", "manage_index_templates", MonitoringBulkAction.NAME, "manage_saml",
                             "cluster:admin/xpack/security/privilege/get",
                             "cluster:admin/xpack/security/privilege/put",
-                            "cluster:admin/xpack/security/role/get",
-                            "cluster:admin/xpack/security/role/put"
                         },
                         new RoleDescriptor.IndicesPrivileges[] {
                                 RoleDescriptor.IndicesPrivileges.builder().indices(".kibana*", ".reporting-*").privileges("all").build(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -189,8 +189,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(kibanaRole.cluster().check(DeletePrivilegesAction.NAME), is(false));
         assertThat(kibanaRole.cluster().check(GetPrivilegesAction.NAME), is(true));
         assertThat(kibanaRole.cluster().check(PutPrivilegesAction.NAME), is(true));
-
-
+        
         // Everything else
         assertThat(kibanaRole.runAs().check(randomAlphaOfLengthBetween(1, 12)), is(false));
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -75,6 +75,12 @@ import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
 import org.elasticsearch.xpack.core.ml.notifications.AuditorField;
 import org.elasticsearch.xpack.core.monitoring.action.MonitoringBulkAction;
+import org.elasticsearch.xpack.core.security.action.privilege.DeletePrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.privilege.GetPrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.role.ClearRolesCacheAction;
+import org.elasticsearch.xpack.core.security.action.role.DeleteRoleAction;
+import org.elasticsearch.xpack.core.security.action.role.GetRolesAction;
 import org.elasticsearch.xpack.core.security.action.role.PutRoleAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlAuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationAction;
@@ -181,6 +187,16 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(kibanaRole.cluster().check(SamlAuthenticateAction.NAME), is(true));
         assertThat(kibanaRole.cluster().check(InvalidateTokenAction.NAME), is(true));
         assertThat(kibanaRole.cluster().check(CreateTokenAction.NAME), is(false));
+
+        // Security
+        assertThat(kibanaRole.cluster().check(DeletePrivilegesAction.NAME), is(false));
+        assertThat(kibanaRole.cluster().check(GetPrivilegesAction.NAME), is(true));
+        assertThat(kibanaRole.cluster().check(PutPrivilegesAction.NAME), is(true));
+        assertThat(kibanaRole.cluster().check(ClearRolesCacheAction.NAME), is(false));
+        assertThat(kibanaRole.cluster().check(DeleteRoleAction.NAME), is(false));
+        assertThat(kibanaRole.cluster().check(GetRolesAction.NAME), is(true));
+        assertThat(kibanaRole.cluster().check(PutRoleAction.NAME), is(true));
+
 
         // Everything else
         assertThat(kibanaRole.runAs().check(randomAlphaOfLengthBetween(1, 12)), is(false));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -78,9 +78,6 @@ import org.elasticsearch.xpack.core.monitoring.action.MonitoringBulkAction;
 import org.elasticsearch.xpack.core.security.action.privilege.DeletePrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.privilege.GetPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesAction;
-import org.elasticsearch.xpack.core.security.action.role.ClearRolesCacheAction;
-import org.elasticsearch.xpack.core.security.action.role.DeleteRoleAction;
-import org.elasticsearch.xpack.core.security.action.role.GetRolesAction;
 import org.elasticsearch.xpack.core.security.action.role.PutRoleAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlAuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationAction;
@@ -192,10 +189,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(kibanaRole.cluster().check(DeletePrivilegesAction.NAME), is(false));
         assertThat(kibanaRole.cluster().check(GetPrivilegesAction.NAME), is(true));
         assertThat(kibanaRole.cluster().check(PutPrivilegesAction.NAME), is(true));
-        assertThat(kibanaRole.cluster().check(ClearRolesCacheAction.NAME), is(false));
-        assertThat(kibanaRole.cluster().check(DeleteRoleAction.NAME), is(false));
-        assertThat(kibanaRole.cluster().check(GetRolesAction.NAME), is(true));
-        assertThat(kibanaRole.cluster().check(PutRoleAction.NAME), is(true));
 
 
         // Everything else


### PR DESCRIPTION
For Kibana to take advantage of the application privileges, the Kibana server will need to update it's privileges when they don't exist or are different than expected. Also on start-up the Kibana server will create the equivalent of the "kibana_user" and "kibana_dashboard_only_user" roles with the appropriate "resource" when they don't exist as "non reserved roles" so that users are able to modify the privileges associated with these roles.