### PR TITLE
[ML][TEST] Mute tests using rules

### DIFF
--- a/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.core.ml.job.config.RuleCondition;
 import org.elasticsearch.xpack.core.ml.job.config.RuleConditionType;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
 import org.junit.After;
+import org.junit.Ignore;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,6 +45,7 @@ import static org.hamcrest.Matchers.isOneOf;
 /**
  * An integration test for detection rules
  */
+@Ignore
 public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
 
     @After

--- a/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
+++ b/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/DetectionRulesIT.java
@@ -45,7 +45,6 @@ import static org.hamcrest.Matchers.isOneOf;
 /**
  * An integration test for detection rules
  */
-@Ignore
 public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
 
     @After
@@ -53,6 +52,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         cleanUp();
     }
 
+    @AwaitsFix(bugUrl = "this test is muted temporarily until the new rules implementation is merged in")
     public void testNumericalRule() throws Exception {
         RuleCondition condition1 = RuleCondition.createNumerical(
                 RuleConditionType.NUMERICAL_ACTUAL,
@@ -154,6 +154,7 @@ public class DetectionRulesIT extends MlNativeAutodetectIntegTestCase {
         assertThat(secondHaldRecordByFieldValues, contains("by_field_value_1", "by_field_value_2"));
     }
 
+    @AwaitsFix(bugUrl = "this test is muted temporarily until the new rules implementation is merged in")
     public void testCategoricalRule() throws Exception {
         MlFilter safeIps = new MlFilter("safe_ips", Arrays.asList("111.111.111.111", "222.222.222.222"));
         assertThat(putMlFilter(safeIps), is(true));

--- a/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
+++ b/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
@@ -35,7 +35,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-@Ignore
 public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
 
     @After
@@ -43,6 +42,7 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         cleanUp();
     }
 
+    @AwaitsFix(bugUrl = "this test is muted temporarily until the new rules implementation is merged in")
     public void testScheduledEvents() throws IOException {
 
         TimeValue bucketSpan = TimeValue.timeValueMinutes(30);
@@ -154,6 +154,7 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         assertThat(records, is(empty()));
     }
 
+    @AwaitsFix(bugUrl = "this test is muted temporarily until the new rules implementation is merged in")
     public void testScheduledEventWithInterimResults() throws IOException {
         TimeValue bucketSpan = TimeValue.timeValueMinutes(30);
         Job.Builder job = createJob("scheduled-events-interim-results", bucketSpan);
@@ -195,6 +196,7 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
     /**
      * Test an open job picks up changes to scheduled events/calendars
      */
+    @AwaitsFix(bugUrl = "this test is muted temporarily until the new rules implementation is merged in")
     public void testOnlineUpdate() throws Exception {
         TimeValue bucketSpan = TimeValue.timeValueMinutes(30);
         Job.Builder job = createJob("scheduled-events-online-update", bucketSpan);

--- a/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
+++ b/x-pack/qa/ml-native-tests/src/test/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.junit.After;
+import org.junit.Ignore;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -34,6 +35,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@Ignore
 public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
 
     @After


### PR DESCRIPTION
This is in preparation of pushing the new
rules design in the `ml-cpp` side. These
tests will be switched on again after merging
in the new rules implementation.
