### PR TITLE
Allow to trim all ops above a certain seq# with a term lower than X, …

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/ResyncReplicationRequest.java
@@ -68,7 +68,7 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
             throw new IllegalStateException("resync replication request serialization is broken in 6.0.0");
         }
         super.readFrom(in);
-        if (in.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+        if (in.getVersion().onOrAfter(Version.V_6_4_0)) {
             trimAboveSeqNo = in.readZLong();
         } else {
             trimAboveSeqNo = SequenceNumbers.UNASSIGNED_SEQ_NO;
@@ -79,7 +79,7 @@ public final class ResyncReplicationRequest extends ReplicatedWriteRequest<Resyn
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().onOrAfter(Version.V_7_0_0_alpha1)) {
+        if (out.getVersion().onOrAfter(Version.V_6_4_0)) {
             out.writeZLong(trimAboveSeqNo);
         }
         out.writeArray(Translog.Operation::writeOperation, operations);

--- a/server/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Checkpoint.java
@@ -53,7 +53,7 @@ final class Checkpoint {
 
     private static final String CHECKPOINT_CODEC = "ckp";
 
-    // size of 7.0.0 checkpoint
+    // size of 6.4.0 checkpoint
 
     static final int V3_FILE_SIZE = CodecUtil.headerLength(CHECKPOINT_CODEC)
         + Integer.BYTES  // ops


### PR DESCRIPTION
Allow to trim all ops above a certain seq# with a term lower than X, post backport fix

Relates to #10708