### PR TITLE
Remove dependencies report task dependencies

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -32,11 +32,6 @@ Collection distributions = project('archives').subprojects + project('packages')
 
 // Concatenates the dependencies CSV files into a single file
 task generateDependenciesReport(type: ConcatFilesTask) {
-  project.rootProject.allprojects {
-    afterEvaluate {
-      if (it.tasks.findByName("dependenciesInfo")) dependsOn it.tasks.dependenciesInfo
-    }
-  }
   files = fileTree(dir: project.rootDir,  include: '**/dependencies.csv' )
   headerLine = "name,version,url,license"
   target = new File(System.getProperty('csv')?: "${project.buildDir}/dependencies/es-dependencies.csv")


### PR DESCRIPTION
A previous commit tried to add task dependencies for the :distribution:generateDependenciesReport task so that a user did not have to run "dependenciesInfo :distribution:generateDependenciesReport". However this method did not reliably add all task dependencies due to task ordering issues in previous versions of Gradle and our build. This commit removes this for now and a user will continue to have to run "dependenciesInfo :distribution:generateDependenciesReport".

