### PR TITLE
Move default location of dependencies report

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -39,7 +39,7 @@ task generateDependenciesReport(type: ConcatFilesTask) {
   }
   files = fileTree(dir: project.rootDir,  include: '**/dependencies.csv' )
   headerLine = "name,version,url,license"
-  target = new File(System.getProperty('csv')?: "${project.buildDir}/dependencies/es-dependencies.csv")
+  target = new File(System.getProperty('csv')?: "${project.buildDir}/reports/dependencies/es-dependencies.csv")
 }
 
 /*****************************************************************************


### PR DESCRIPTION
This commit moves the default location of the full dependencies report to be under the reports directory to align it with the location for the dependenciesInfo task output.

