### PR TITLE
Log warnings when cluster state publication failed to some nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/BlockingClusterStatePublishResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/discovery/BlockingClusterStatePublishResponseHandler.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -35,6 +36,7 @@ public class BlockingClusterStatePublishResponseHandler {
 
     private final CountDownLatch latch;
     private final Set<DiscoveryNode> pendingNodes;
+    private final Set<DiscoveryNode> failedNodes;
 
     /**
      * Creates a new BlockingClusterStatePublishResponseHandler
@@ -44,6 +46,7 @@ public class BlockingClusterStatePublishResponseHandler {
         this.pendingNodes = ConcurrentCollections.newConcurrentSet();
         this.pendingNodes.addAll(publishingToNodes);
         this.latch = new CountDownLatch(pendingNodes.size());
+        this.failedNodes = ConcurrentCollections.newConcurrentSet();
     }
 
     /**
@@ -64,6 +67,8 @@ public class BlockingClusterStatePublishResponseHandler {
     public void onFailure(DiscoveryNode node, Exception e) {
         boolean found = pendingNodes.remove(node);
         assert found : "node [" + node + "] already responded or failed";
+        boolean added = failedNodes.add(node);
+        assert added : "double failures for " + node;
         latch.countDown();
     }
 
@@ -85,5 +90,12 @@ public class BlockingClusterStatePublishResponseHandler {
         // we use a zero length array, because if we try to pre allocate we may need to remove trailing
         // nulls if some nodes responded in the meanwhile
         return pendingNodes.toArray(new DiscoveryNode[0]);
+    }
+
+    /**
+     * returns a set of nodes for which publication has failed.
+     */
+    public Set<DiscoveryNode> getFailedNodes() {
+        return Collections.unmodifiableSet(failedNodes);
     }
 }

--- a/server/src/main/java/org/elasticsearch/discovery/BlockingClusterStatePublishResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/discovery/BlockingClusterStatePublishResponseHandler.java
@@ -68,7 +68,7 @@ public class BlockingClusterStatePublishResponseHandler {
         boolean found = pendingNodes.remove(node);
         assert found : "node [" + node + "] already responded or failed";
         boolean added = failedNodes.add(node);
-        assert added : "double failures for " + node;
+        assert added : "duplicate failures for " + node;
         latch.countDown();
     }
 


### PR DESCRIPTION
If the publishing of a cluster state to a node fails, we currently only log it as debug information and only on the master. This makes it hard to see the cause of (test) failures when logging is set to default levels. This PR adds a warn level log on the node receiving the cluster state when it fails to deserialise the cluster state and a warn level log on the master with a list of nodes for which publication failed.