### PR TITLE
Enable custom credentials for core REST tests

### DIFF
--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -32,8 +32,8 @@ integTestCluster {
   setting 'xpack.license.self_generated.type', 'trial'
   setupCommand 'setupDummyUser',
                'bin/elasticsearch-users',
-               'useradd', System.getProperty('tests.rest.cluster.username'),
-               '-p', System.getProperty('tests.rest.cluster.password'),
+               'useradd', System.getProperty('tests.rest.cluster.username', 'test_user'),
+               '-p', System.getProperty('tests.rest.cluster.password', 'x-pack-test-password'),
                '-r', 'superuser'
   waitCondition = { node, ant ->
     File tmpFile = new File(node.cwd, 'wait.success')

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -19,6 +19,9 @@ integTestRunner {
      'cat.templates/10_basic/Sort templates',
      'cat.templates/10_basic/Multiple template',
     ].join(',')
+
+  systemProperty 'tests.rest.cluster.username', System.getProperty('tests.rest.cluster.username', 'test_user')
+  systemProperty 'tests.rest.cluster.password', System.getProperty('tests.rest.cluster.password', 'x-pack-test-password')
 }
 
 integTestCluster {
@@ -28,7 +31,10 @@ integTestCluster {
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
   setupCommand 'setupDummyUser',
-               'bin/elasticsearch-users', 'useradd', 'test_user', '-p', 'x-pack-test-password', '-r', 'superuser'
+               'bin/elasticsearch-users',
+               'useradd', System.getProperty('tests.rest.cluster.username'),
+               '-p', System.getProperty('tests.rest.cluster.password'),
+               '-r', 'superuser'
   waitCondition = { node, ant ->
     File tmpFile = new File(node.cwd, 'wait.success')
     ant.get(src: "http://${node.httpUri()}/_cluster/health?wait_for_nodes=>=${numNodes}&wait_for_status=yellow",

--- a/x-pack/qa/core-rest-tests-with-security/src/test/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
+++ b/x-pack/qa/core-rest-tests-with-security/src/test/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
@@ -3,11 +3,11 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+
 package org.elasticsearch.xpack.security;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 import org.apache.lucene.util.TimeUnits;
 import org.elasticsearch.common.settings.SecureString;
@@ -16,13 +16,15 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 
+import java.util.Objects;
+
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 
 @TimeoutSuite(millis = 30 * TimeUnits.MINUTE) // as default timeout seems not enough on the jenkins VMs
 public class CoreWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
-    private static final String USER = "test_user";
-    private static final String PASS = "x-pack-test-password";
+    private static final String USER = Objects.requireNonNull(System.getProperty("tests.rest.cluster.username"));
+    private static final String PASS = Objects.requireNonNull(System.getProperty("tests.rest.cluster.password"));
 
     public CoreWithSecurityClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);


### PR DESCRIPTION
The core REST tests with security currently use a hardcoded username and password. This is not amenable to running these tests in scenarios where the user controls the creation of the cluster and owns the credentials for this cluster. This commit enables running the core REST tests with security with a custom username and password.

Relates #30119
