### PR TITLE
Use quotes around path in elasticsearch-cli.bat

### DIFF
--- a/distribution/src/bin/elasticsearch-cli.bat
+++ b/distribution/src/bin/elasticsearch-cli.bat
@@ -2,7 +2,7 @@ call "%~dp0elasticsearch-env.bat" || exit /b 1
 
 if defined ES_ADDITIONAL_SOURCES (
   for %%a in ("%ES_ADDITIONAL_SOURCES:;=","%") do (
-    call %~dp0%%a
+    call "%~dp0%%a"
   )
 )
 


### PR DESCRIPTION
Looks like a leftover - all other `.bat` fails use quotes around path except `elasticsearch-cli.bat`.
And surely enough, calling the command from a folder with spaces on Windows will lead to errors.
This PR fixes that by adding the missing quotes.