### PR TITLE
Security: fix token bwc with pre 6.0.0-beta2

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -9,7 +9,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.apache.lucene.util.UnicodeUtil;
@@ -1041,7 +1040,9 @@ public final class TokenService extends AbstractComponent {
             KeyAndCache keyAndCache = keyCache.activeKeyCache;
             Version.writeVersion(userToken.getVersion(), out);
             out.writeByteArray(keyAndCache.getSalt().bytes);
-            out.writeByteArray(keyAndCache.getKeyHash().bytes);
+            if (userToken.getVersion().onOrAfter(Version.V_6_0_0_beta2)) {
+                out.writeByteArray(keyAndCache.getKeyHash().bytes);
+            }
             final byte[] initializationVector = getNewInitializationVector();
             out.writeByteArray(initializationVector);
             try (CipherOutputStream encryptedOutput =
@@ -1369,16 +1370,18 @@ public final class TokenService extends AbstractComponent {
                 return;
             }
 
+            TokenMetaData custom = event.state().custom(TokenMetaData.TYPE);
             if (state.nodes().isLocalNodeElectedMaster()) {
-                if (XPackPlugin.isReadyForXPackCustomMetadata(state)) {
-                    installTokenMetadata(state.metaData());
-                } else {
-                    logger.debug("cannot add token metadata to cluster as the following nodes might not understand the metadata: {}",
-                        () -> XPackPlugin.nodesNotReadyForXPackCustomMetadata(state));
+                if (custom == null) {
+                    if (XPackPlugin.isReadyForXPackCustomMetadata(state)) {
+                        installTokenMetadata();
+                    } else {
+                        logger.debug("cannot add token metadata to cluster as the following nodes might not understand the metadata: {}",
+                            () -> XPackPlugin.nodesNotReadyForXPackCustomMetadata(state));
+                    }
                 }
             }
 
-            TokenMetaData custom = event.state().custom(TokenMetaData.TYPE);
             if (custom != null && custom.equals(getTokenMetaData()) == false) {
                 logger.info("refresh keys");
                 try {
@@ -1394,33 +1397,31 @@ public final class TokenService extends AbstractComponent {
     // to prevent too many cluster state update tasks to be queued for doing the same update
     private final AtomicBoolean installTokenMetadataInProgress = new AtomicBoolean(false);
 
-    private void installTokenMetadata(MetaData metaData) {
-        if (metaData.custom(TokenMetaData.TYPE) == null) {
-            if (installTokenMetadataInProgress.compareAndSet(false, true)) {
-                clusterService.submitStateUpdateTask("install-token-metadata", new ClusterStateUpdateTask(Priority.URGENT) {
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        XPackPlugin.checkReadyForXPackCustomMetadata(currentState);
+    private void installTokenMetadata() {
+        if (installTokenMetadataInProgress.compareAndSet(false, true)) {
+            clusterService.submitStateUpdateTask("install-token-metadata", new ClusterStateUpdateTask(Priority.URGENT) {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    XPackPlugin.checkReadyForXPackCustomMetadata(currentState);
 
-                        if (currentState.custom(TokenMetaData.TYPE) == null) {
-                            return ClusterState.builder(currentState).putCustom(TokenMetaData.TYPE, getTokenMetaData()).build();
-                        } else {
-                            return currentState;
-                        }
+                    if (currentState.custom(TokenMetaData.TYPE) == null) {
+                        return ClusterState.builder(currentState).putCustom(TokenMetaData.TYPE, getTokenMetaData()).build();
+                    } else {
+                        return currentState;
                     }
+                }
 
-                    @Override
-                    public void onFailure(String source, Exception e) {
-                        installTokenMetadataInProgress.set(false);
-                        logger.error("unable to install token metadata", e);
-                    }
+                @Override
+                public void onFailure(String source, Exception e) {
+                    installTokenMetadataInProgress.set(false);
+                    logger.error("unable to install token metadata", e);
+                }
 
-                    @Override
-                    public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
-                        installTokenMetadataInProgress.set(false);
-                    }
-                });
-            }
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    installTokenMetadataInProgress.set(false);
+                }
+            });
         }
     }
 

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -146,7 +146,6 @@ subprojects {
       if (version.onOrAfter('6.0.0') == false) {
         // this is needed since in 5.6 we don't bootstrap the token service if there is no explicit initial password
         keystoreSetting 'xpack.security.authc.token.passphrase', 'xpack_token_passphrase'
-        setting 'xpack.security.authc.token.enabled', 'true'
       }
       dependsOn copyTestNodeKeystore
       extraConfigFile 'testnode.jks', new File(outputDir + '/testnode.jks')

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/TokenBackwardsCompatibilityIT.java
@@ -74,9 +74,6 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
         assumeTrue("the master must be on the latest version before we can write", isMasterOnLatestVersion());
         assumeFalse("can't be run twice because it invalidates a token so we skip the first attempt",
                 Booleans.parseBoolean(System.getProperty("tests.first_round")));
-        Version upgradeFromVersion = Version.fromString(System.getProperty("tests.upgrade_from_version"));
-        assumeFalse("this test fails for unknown reasons when run before 5.6.0",
-                upgradeFromVersion.before(Version.V_6_0_0));
 
         Response getResponse = client().performRequest("GET", "token_backwards_compatibility_it/doc/old_cluster_token2");
         assertOK(getResponse);
@@ -124,7 +121,7 @@ public class TokenBackwardsCompatibilityIT extends AbstractUpgradeTestCase {
     }
 
     public void testUpgradedCluster() throws Exception {
-        assumeTrue("this test should only run against the mixed cluster", CLUSTER_TYPE == ClusterType.UPGRADED);
+        assumeTrue("this test should only run against the upgraded cluster", CLUSTER_TYPE == ClusterType.UPGRADED);
         Response getResponse = client().performRequest("GET", "token_backwards_compatibility_it/doc/old_cluster_token2");
         assertOK(getResponse);
         Map<String, Object> source = (Map<String, Object>) entityAsMap(getResponse).get("_source");


### PR DESCRIPTION
This commit fixes a backwards compatibility bug in the token service
that causes token decoding to fail when there is a pre 6.0.0-beta2 node
in the cluster. The token encoding is actually the culprit as a version
check is missing around the serialization of the key hash bytes. This
value was added in 6.0.0-beta2 and cannot be sent to nodes that do not
know about this value. The version check has been added and the token
service unit tests have been enhanced to randomly run with some 5.6.x
nodes in the cluster service.

Additionally, a small change was made to the way we check to see if the
token metadata needs to be installed. Previously we would pass the
metadata to the install method and check that the token metadata is
null. This null check is now done prior to checking if the metadata can
be installed.

Relates #30743
Closes #31195