### PR TITLE
REST hl client: adjust wait_for_active_shards param in cluster health

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RequestConverters.java
@@ -721,7 +721,7 @@ final class RequestConverters {
             .withWaitForStatus(healthRequest.waitForStatus())
             .withWaitForNoRelocatingShards(healthRequest.waitForNoRelocatingShards())
             .withWaitForNoInitializingShards(healthRequest.waitForNoInitializingShards())
-            .withWaitForActiveShards(healthRequest.waitForActiveShards())
+            .withWaitForActiveShards(healthRequest.waitForActiveShards(), ActiveShardCount.NONE)
             .withWaitForNodes(healthRequest.waitForNodes())
             .withWaitForEvents(healthRequest.waitForEvents())
             .withTimeout(healthRequest.timeout())
@@ -1047,7 +1047,11 @@ final class RequestConverters {
         }
 
         Params withWaitForActiveShards(ActiveShardCount activeShardCount) {
-            if (activeShardCount != null && activeShardCount != ActiveShardCount.DEFAULT) {
+            return withWaitForActiveShards(activeShardCount, ActiveShardCount.DEFAULT);
+        }
+
+        Params withWaitForActiveShards(ActiveShardCount activeShardCount, ActiveShardCount defaultActiveShardCount) {
+            if (activeShardCount != null && activeShardCount != defaultActiveShardCount) {
                 return putParam("wait_for_active_shards", activeShardCount.toString().toLowerCase(Locale.ROOT));
             }
             return this;

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1562,7 +1562,7 @@ public class RequestConvertersTests extends ESTestCase {
             default:
                 throw new UnsupportedOperationException();
         }
-        setRandomWaitForActiveShards(healthRequest::waitForActiveShards, expectedParams, "0");
+        setRandomWaitForActiveShards(healthRequest::waitForActiveShards, ActiveShardCount.NONE, expectedParams);
         if (randomBoolean()) {
             ClusterHealthRequest.Level level = randomFrom(ClusterHealthRequest.Level.values());
             healthRequest.level(level);
@@ -2187,23 +2187,24 @@ public class RequestConvertersTests extends ESTestCase {
     }
 
     private static void setRandomWaitForActiveShards(Consumer<ActiveShardCount> setter, Map<String, String> expectedParams) {
-        setRandomWaitForActiveShards(setter, expectedParams, null);
+        setRandomWaitForActiveShards(setter, ActiveShardCount.DEFAULT, expectedParams);
     }
 
-    private static void setRandomWaitForActiveShards(Consumer<ActiveShardCount> setter,Map<String, String> expectedParams,
-            String defaultValue) {
+    private static void setRandomWaitForActiveShards(Consumer<ActiveShardCount> setter, ActiveShardCount defaultActiveShardCount,
+                                                     Map<String, String> expectedParams) {
         if (randomBoolean()) {
+            int waitForActiveShardsInt = randomIntBetween(-1, 5);
             String waitForActiveShardsString;
-            int waitForActiveShards = randomIntBetween(-1, 5);
-            if (waitForActiveShards == -1) {
+            if (waitForActiveShardsInt == -1) {
                 waitForActiveShardsString = "all";
             } else {
-                waitForActiveShardsString = String.valueOf(waitForActiveShards);
+                waitForActiveShardsString = String.valueOf(waitForActiveShardsInt);
             }
-            setter.accept(ActiveShardCount.parseString(waitForActiveShardsString));
-            expectedParams.put("wait_for_active_shards", waitForActiveShardsString);
-        } else if (defaultValue != null) {
-            expectedParams.put("wait_for_active_shards", defaultValue);
+            ActiveShardCount activeShardCount = ActiveShardCount.parseString(waitForActiveShardsString);
+            setter.accept(activeShardCount);
+            if (defaultActiveShardCount.equals(activeShardCount) == false) {
+                expectedParams.put("wait_for_active_shards", waitForActiveShardsString);
+            }
         }
     }
 


### PR DESCRIPTION
The default wait_for_active_shards is NONE for cluster health, which
differs from all the other API in master, hence we need to make sure to
set the parameter whenever it differs from NONE (0). The test around
this also had a bug, which is why this was not originally uncovered.

Note that this PR targets master only as in 6.x the problem was resolved while backporting, given that other already supported API already have a different default there, which also helped uncovering the issue. This change also aligns the `setRandomWaitForActiveShards` with the existing corresponding method from 6.x.

Relates to #29331