### PR TITLE
QA: Node name selector for yml tests

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/README.asciidoc
@@ -198,9 +198,7 @@ header. The warnings must match exactly. Using it looks like this:
 ....
 
 If the arguments to `do` include `node_selector` then the request is only
-sent to nodes that match the `node_selector`. Currently only the `version`
-selector is supported and it has the same logic as the `version` field in
-`skip`. It looks like this:
+sent to nodes that match the `node_selector`. It looks like this:
 
 ....
 "test id":
@@ -215,6 +213,14 @@ selector is supported and it has the same logic as the `version` field in
           id:     1
           body:   { foo: bar }
 ....
+
+If you list multiple selectors then the request will only go to nodes that
+match all of those selectors. The following selectors are supported:
+* `version`: Only nodes who's version is within the range will receive the
+request. The syntax for the pattern is the same as when `version` is within
+`skip`.
+* `name`: Only nodes who's name matches the name exactly will receive the
+request.
 
 === `set`
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -370,6 +370,27 @@ public class DoSection implements ExecutableSection {
 
     private static NodeSelector buildNodeSelector(XContentLocation location, String name, String value) {
         switch (name) {
+        case "name":
+            return new NodeSelector() {
+                @Override
+                public void select(Iterable<Node> nodes) {
+                    for (Iterator<Node> itr = nodes.iterator(); itr.hasNext();) {
+                        Node node = itr.next();
+                        if (node.getName() == null) {
+                            throw new IllegalStateException("expected [name] metadata to be set but got "
+                                    + node);
+                        }
+                        if (false == value.equals(node.getName())) {
+                            itr.remove();
+                        }
+                    }
+                }
+
+                @Override
+                public String toString() {
+                    return "name is [" + value + "]";
+                }
+            };
         case "version":
             Version[] range = SkipSection.parseVersionRange(value);
             return new NodeSelector() {


### PR DESCRIPTION
In 6.x we need to be able to select which node receives a request by
node name. This implements that.

Relates to #30523
