### PR TITLE
Allow null message in SlackMessage

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessage.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessage.java
@@ -26,8 +26,16 @@ public class SlackMessage implements MessageElement {
     final String from;
     final String[] to;
     final String icon;
-    final String text;
-    final Attachment[] attachments;
+    String text;
+    Attachment[] attachments;
+
+    public SlackMessage(String from, String[] to, String icon) {
+        this(from, to, icon, null, null); // Empty text and empty attachments
+    }
+
+    public SlackMessage(String from, String[] to, String icon, String text) {
+        this(from, to, icon, text, null); // Empty attachments
+    }
 
     public SlackMessage(String from, String[] to, String icon, String text, Attachment[] attachments) {
         this.from = from;
@@ -56,6 +64,10 @@ public class SlackMessage implements MessageElement {
     public Attachment[] getAttachments() {
         return attachments;
     }
+
+    public void setText(String text) { this.text = text;}
+
+    public void setAttachments(Attachment[] attachments) { this.attachments = attachments;}
 
     @Override
     public boolean equals(Object o) {
@@ -202,7 +214,7 @@ public class SlackMessage implements MessageElement {
                 attachments.addAll(dynamicAttachments.render(engine, model, defaults.attachment));
             }
             if (attachments == null) {
-                return new SlackMessage(from, to, icon, text, null);
+                return new SlackMessage(from, to, icon, text);
             }
             return new SlackMessage(from, to, icon, text, attachments.toArray(new Attachment[attachments.size()]));
         }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageTests.java
@@ -575,7 +575,7 @@ public class SlackMessageTests extends ESTestCase {
         HttpResponse response = new HttpResponse(500);
         String path = randomAlphaOfLength(20);
         HttpRequest request = HttpRequest.builder("localhost", 1234).path(path).build();
-        SlackMessage slackMessage = new SlackMessage("from", new String[] {"to"}, "icon", "text", null);
+        SlackMessage slackMessage = new SlackMessage("from", new String[] {"to"}, "icon", "text");
         SentMessages sentMessages = new SentMessages("foo",
                 Arrays.asList(SentMessages.SentMessage.responded("recipient", slackMessage, request, response)));
 
@@ -602,6 +602,14 @@ public class SlackMessageTests extends ESTestCase {
         }
     }
 
+    // Create template from null message or null attachment ok
+    // Can have message as null
+
+    public void canHaveNullTextAndAttachment()  throws Exception {
+        SlackMessage slackMessage = new SlackMessage("from", new String[] {"to"}, "icon");
+        assertThat(slackMessage.getText(), is(null));
+        assertThat(slackMessage.getAttachments(), is(null));
+    }
     private static void writeFieldIfNotNull(XContentBuilder builder, String field, Object value) throws IOException {
         if (value != null) {
             builder.field(field, value);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/slack/message/SlackMessageTests.java
@@ -602,9 +602,6 @@ public class SlackMessageTests extends ESTestCase {
         }
     }
 
-    // Create template from null message or null attachment ok
-    // Can have message as null
-
     public void canHaveNullTextAndAttachment()  throws Exception {
         SlackMessage slackMessage = new SlackMessage("from", new String[] {"to"}, "icon");
         assertThat(slackMessage.getText(), is(null));


### PR DESCRIPTION
Adding constructors to the slack message class to support more flexibility in null parameters. Additionally provided setters for use-cases where this can be added before message template is created.

https://github.com/elastic/elasticsearch/issues/30071

Read and executed all template tasks for contribution. Signed CLA but maybe submitted too soon for check to pass.