### PR TITLE
Add scroll parameter to reindex JSON spec as per #28041

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -34,6 +34,10 @@
           "type": "number",
           "default": 1,
           "description": "The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks."
+        },
+        "scroll": {
+          "type" : "time",
+          "description" : "Specify how long a consistent view of the index should be maintained for scrolled search"
         }
       }
     },


### PR DESCRIPTION
Looks like API specification was missed as part of this development - #28041

Requires backport to `6.x` and `7`