### PR TITLE
[ML] Re-enable memory limit integration tests

### DIFF
--- a/x-pack/qa/ml-native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/AutodetectMemoryLimitIT.java
+++ b/x-pack/qa/ml-native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/AutodetectMemoryLimitIT.java
@@ -62,7 +62,7 @@ public class AutodetectMemoryLimitIT extends MlNativeAutodetectIntegTestCase {
         long timestamp = now - 8 * bucketSpan.seconds();
         List<String> data = new ArrayList<>();
         while (timestamp < now) {
-            for (int i = 0; i < 10000; i++) {
+            for (int i = 0; i < 11000; i++) {
                 // It's important that the values used here are either always represented in less than 16 UTF-8 bytes or
                 // always represented in more than 22 UTF-8 bytes.  Otherwise platform differences in when the small string
                 // optimisation is used will make the results of this test very different for the different platforms.

--- a/x-pack/qa/ml-native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/AutodetectMemoryLimitIT.java
+++ b/x-pack/qa/ml-native-multi-node-tests/src/test/java/org/elasticsearch/xpack/ml/integration/AutodetectMemoryLimitIT.java
@@ -37,7 +37,6 @@ public class AutodetectMemoryLimitIT extends MlNativeAutodetectIntegTestCase {
         cleanUp();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pulls/122")
     public void testTooManyPartitions() throws Exception {
         Detector.Builder detector = new Detector.Builder("count", null);
         detector.setPartitionFieldName("user");
@@ -83,7 +82,6 @@ public class AutodetectMemoryLimitIT extends MlNativeAutodetectIntegTestCase {
         assertThat(modelSizeStats.getMemoryStatus(), equalTo(ModelSizeStats.MemoryStatus.HARD_LIMIT));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pulls/122")
     public void testTooManyByFields() throws Exception {
         Detector.Builder detector = new Detector.Builder("count", null);
         detector.setByFieldName("user");
@@ -129,7 +127,6 @@ public class AutodetectMemoryLimitIT extends MlNativeAutodetectIntegTestCase {
         assertThat(modelSizeStats.getMemoryStatus(), equalTo(ModelSizeStats.MemoryStatus.HARD_LIMIT));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pulls/122")
     public void testTooManyByAndOverFields() throws Exception {
         Detector.Builder detector = new Detector.Builder("count", null);
         detector.setByFieldName("department");
@@ -179,7 +176,6 @@ public class AutodetectMemoryLimitIT extends MlNativeAutodetectIntegTestCase {
         assertThat(modelSizeStats.getMemoryStatus(), equalTo(ModelSizeStats.MemoryStatus.HARD_LIMIT));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pulls/122")
     public void testManyDistinctOverFields() throws Exception {
         Detector.Builder detector = new Detector.Builder("sum", "value");
         detector.setOverFieldName("user");


### PR DESCRIPTION
Following on from #31289, the C++ changes have been committed so these tests can be re-enabled. 