### PR TITLE
Build: Fix the license in the pom zip and tar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,23 @@ subprojects {
   description = "Elasticsearch subproject ${project.path}"
 }
 
+apply plugin: 'nebula.info-scm'
+String licenseCommit
+if (VersionProperties.elasticsearch.toString().endsWith('-SNAPSHOT')) {
+  licenseCommit = scminfo.change ?: "master" // leniency for non git builds
+} else {
+  licenseCommit = "v${version}"
+}
+String elasticLicenseUrl = "https://raw.githubusercontent.com/elastic/elasticsearch/${licenseCommit}/licenses/ELASTIC-LICENSE.txt"
+
 subprojects {
+  // Default to the apache license
   project.ext.licenseName = 'The Apache Software License, Version 2.0'
   project.ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+
+  // But stick the Elastic license url in project.ext so we can get it if we need to switch to it
+  project.ext.elasticLicenseUrl = elasticLicenseUrl
+
   // we only use maven publish to add tasks for pom generation
   plugins.withType(MavenPublishPlugin).whenPluginAdded {
     publishing {

--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -228,6 +228,8 @@ subprojects {
   check.dependsOn checkNotice
 
   if (project.name == 'zip' || project.name == 'tar') {
+    project.ext.licenseName = 'Elastic License'
+    project.ext.licenseUrl = ext.elasticLicenseUrl
     task checkMlCppNotice {
       dependsOn buildDist, checkExtraction
       onlyIf toolExists

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -21,7 +21,7 @@ subprojects {
   ext.xpackModule = { String moduleName -> xpackProject("plugin:${moduleName}").path }
 
   ext.licenseName = 'Elastic License'
-  ext.licenseUrl = "https://raw.githubusercontent.com/elastic/elasticsearch/${licenseCommit}/licenses/ELASTIC-LICENSE.txt"
+  ext.licenseUrl = ext.elasticLicenseUrl
 
   project.ext.licenseFile = rootProject.file('licenses/ELASTIC-LICENSE.txt')
   project.ext.noticeFile = xpackRootProject.file('NOTICE.txt')

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -5,14 +5,6 @@ import org.elasticsearch.gradle.precommit.LicenseHeadersTask
 
 Project xpackRootProject = project
 
-apply plugin: 'nebula.info-scm'
-final String licenseCommit
-if (version.endsWith('-SNAPSHOT')) {
-  licenseCommit = xpackRootProject.scminfo.change ?: "master" // leniency for non git builds
-} else {
-  licenseCommit = "v${version}"
-}
-
 subprojects {
   group = 'org.elasticsearch.plugin'
   ext.xpackRootProject = xpackRootProject


### PR DESCRIPTION
For 6.3 we renamed the `tar` and `zip` distributions to `oss-tar` and
`oss-zip`. Then we added new `tar` and `zip` distributions that contain
x-pack and are licensed under the Elastic License. Unfortunately we
accidentally generated POM files along side the new `tar` and `zip`
distributions that incorrectly claimed that they were Apache 2 licensed.
Oooops.

This fixes the license on the POMs generated for the `tar` and `zip`
distributions.
