### PR TITLE
Fix reference to XContentBuilder.string()

### DIFF
--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -99,11 +99,13 @@ Note that you can also add arrays with `startArray(String)` and
 other XContentBuilder objects.
 
 If you need to see the generated JSON content, you can use the
-`string()` method.
+`Strings.toString()` method.
 
 [source,java]
 --------------------------------------------------
-String json = builder.string();
+import org.elasticsearch.common.Strings;
+
+String json = Strings.toString(builder);
 --------------------------------------------------
 
 


### PR DESCRIPTION
In 6.3 this was moved to `Strings.toString(XContentBuilder)` as part of the
XContent extraction. This commit fixes the docs to reference the new method.

Resolves #31326