### PR TITLE
[DOCS] Add code snippet testing in more ML APIs

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -56,7 +56,6 @@ buildRestTests.expectedUnconvertedCandidates = [
         'en/rest-api/ml/get-influencer.asciidoc',
         'en/rest-api/ml/get-snapshot.asciidoc',
         'en/rest-api/ml/post-data.asciidoc',
-        'en/rest-api/ml/preview-datafeed.asciidoc',
         'en/rest-api/ml/revert-snapshot.asciidoc',
         'en/rest-api/ml/update-snapshot.asciidoc',
         'en/rest-api/watcher/stats.asciidoc',
@@ -296,7 +295,9 @@ setups['farequote_index'] = '''
                   responsetime:
                     type: float
                   airline:
-                     type: keyword   
+                     type: keyword
+                  doc_count:
+                     type: integer       
 '''
 setups['farequote_data'] = setups['farequote_index'] + '''
   - do:
@@ -306,11 +307,11 @@ setups['farequote_data'] = setups['farequote_index'] + '''
           refresh: true
           body: |
             {"index": {"_id":"1"}}
-            {"airline":"JZA","responsetime":990.4628,"time":"2016-02-07T00:00:00+0000"}
+            {"airline":"JZA","responsetime":990.4628,"time":"2016-02-07T00:00:00+0000", "doc_count": "5"}
             {"index": {"_id":"2"}}
-            {"airline":"JBU","responsetime":877.5927,"time":"2016-02-07T00:00:00+0000"}
+            {"airline":"JBU","responsetime":877.5927,"time":"2016-02-07T00:00:00+0000", "doc_count": "23"}
             {"index": {"_id":"3"}}            
-            {"airline":"KLM","responsetime":1355.4812,"time":"2016-02-07T00:00:00+0000"}
+            {"airline":"KLM","responsetime":1355.4812,"time":"2016-02-07T00:00:00+0000", "doc_count": "42"}
 '''
 setups['farequote_job'] = setups['farequote_data'] + '''
   - do:
@@ -332,6 +333,16 @@ setups['farequote_job'] = setups['farequote_data'] + '''
             }
           }
 '''
+setups['farequote_datafeed'] = setups['farequote_job'] + '''
+  - do:
+      xpack.ml.put_datafeed:
+        datafeed_id: "datafeed-farequote"
+        body:  >
+          {
+          "job_id":"farequote",
+          "indexes":"farequote"
+          }
+'''          
 setups['server_metrics_index'] = '''
   - do:
         indices.create:

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -48,7 +48,6 @@ buildRestTests.expectedUnconvertedCandidates = [
         'en/watcher/trigger/schedule/yearly.asciidoc',
         'en/watcher/troubleshooting.asciidoc',
         'en/rest-api/ml/delete-snapshot.asciidoc',
-        'en/rest-api/ml/forecast.asciidoc',
         'en/rest-api/ml/get-bucket.asciidoc',
         'en/rest-api/ml/get-job-stats.asciidoc',
         'en/rest-api/ml/get-overall-buckets.asciidoc',
@@ -60,11 +59,6 @@ buildRestTests.expectedUnconvertedCandidates = [
         'en/rest-api/ml/preview-datafeed.asciidoc',
         'en/rest-api/ml/revert-snapshot.asciidoc',
         'en/rest-api/ml/update-snapshot.asciidoc',
-<<<<<<< HEAD
-=======
-        'en/rest-api/ml/validate-detector.asciidoc',
-        'en/rest-api/security/authenticate.asciidoc',
->>>>>>> [DOCS] Test validate job API
         'en/rest-api/watcher/stats.asciidoc',
         'en/watcher/example-watches/watching-time-series-data.asciidoc',
 ]

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -60,6 +60,11 @@ buildRestTests.expectedUnconvertedCandidates = [
         'en/rest-api/ml/preview-datafeed.asciidoc',
         'en/rest-api/ml/revert-snapshot.asciidoc',
         'en/rest-api/ml/update-snapshot.asciidoc',
+<<<<<<< HEAD
+=======
+        'en/rest-api/ml/validate-detector.asciidoc',
+        'en/rest-api/security/authenticate.asciidoc',
+>>>>>>> [DOCS] Test validate job API
         'en/rest-api/watcher/stats.asciidoc',
         'en/watcher/example-watches/watching-time-series-data.asciidoc',
 ]

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -307,11 +307,11 @@ setups['farequote_data'] = setups['farequote_index'] + '''
           refresh: true
           body: |
             {"index": {"_id":"1"}}
-            {"airline":"JZA","responsetime":990.4628,"time":"2016-02-07T00:00:00+0000", "doc_count": "5"}
+            {"airline":"JZA","responsetime":990.4628,"time":"2016-02-07T00:00:00+0000", "doc_count": 5}
             {"index": {"_id":"2"}}
-            {"airline":"JBU","responsetime":877.5927,"time":"2016-02-07T00:00:00+0000", "doc_count": "23"}
+            {"airline":"JBU","responsetime":877.5927,"time":"2016-02-07T00:00:00+0000", "doc_count": 23}
             {"index": {"_id":"3"}}            
-            {"airline":"KLM","responsetime":1355.4812,"time":"2016-02-07T00:00:00+0000", "doc_count": "42"}
+            {"airline":"KLM","responsetime":1355.4812,"time":"2016-02-07T00:00:00+0000", "doc_count": 42}
 '''
 setups['farequote_job'] = setups['farequote_data'] + '''
   - do:

--- a/x-pack/docs/en/rest-api/ml/forecast.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/forecast.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Forecast Jobs</titleabbrev>
 ++++
 
-Predict the future behavior of a time series by using historical behavior. 
+Predicts the future behavior of a time series by using its historical behavior. 
 
 ==== Request
 
@@ -62,7 +62,7 @@ POST _xpack/ml/anomaly_detectors/total-requests/_forecast
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:todo]
+// TEST[setup:server_metrics_openjob]
 
 When the forecast is created, you receive the following results:
 [source,js]
@@ -72,7 +72,7 @@ When the forecast is created, you receive the following results:
   "forecast_id": "wkCWa2IB2lF8nSE_TzZo"
 }
 ----
+// TESTRESPONSE[s/"forecast_id": "wkCWa2IB2lF8nSE_TzZo"/"forecast_id": $body.forecast_id/]
 
 You can subsequently see the forecast in the *Single Metric Viewer* in {kib}.
-//and in the results that you retrieve by using {ml} APIs such as the
-//<<ml-get-bucket,get bucket API>> and <<ml-get-record,get records API>>.
+

--- a/x-pack/docs/en/rest-api/ml/forecast.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/forecast.asciidoc
@@ -62,7 +62,7 @@ POST _xpack/ml/anomaly_detectors/total-requests/_forecast
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[setup:server_metrics_openjob]
+// TEST[skip:requires delay]
 
 When the forecast is created, you receive the following results:
 [source,js]
@@ -72,7 +72,7 @@ When the forecast is created, you receive the following results:
   "forecast_id": "wkCWa2IB2lF8nSE_TzZo"
 }
 ----
-// TESTRESPONSE[s/"forecast_id": "wkCWa2IB2lF8nSE_TzZo"/"forecast_id": $body.forecast_id/]
+// NOTCONSOLE
 
 You can subsequently see the forecast in the *Single Metric Viewer* in {kib}.
 

--- a/x-pack/docs/en/rest-api/ml/preview-datafeed.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/preview-datafeed.asciidoc
@@ -31,7 +31,6 @@ structure of the data that will be passed to the anomaly detection engine.
 You must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster
 privileges to use this API. For more information, see
 {xpack-ref}/security-privileges.html[Security Privileges].
-//<<privileges-list-cluster>>.
 
 
 ==== Security Integration
@@ -54,27 +53,30 @@ The following example obtains a preview of the `datafeed-farequote` {dfeed}:
 GET _xpack/ml/datafeeds/datafeed-farequote/_preview
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:todo]
+// TEST[setup:farequote_datafeed]
 
 The data that is returned for this example is as follows:
 [source,js]
 ----
 [
   {
-    "@timestamp": 1454803200000,
-    "airline": "AAL",
-    "responsetime": 132.20460510253906
-  },
-  {
-    "@timestamp": 1454803200000,
+    "time": 1454803200000,
     "airline": "JZA",
+    "doc_count": 5,
     "responsetime": 990.4628295898438
   },
   {
-    "@timestamp": 1454803200000,
+    "time": 1454803200000,
     "airline": "JBU",
+    "doc_count": 23,
     "responsetime": 877.5927124023438
   },
-  ...
+  {
+    "time": 1454803200000,
+    "airline": "KLM",
+    "doc_count": 42,
+    "responsetime": 1355.481201171875
+  }
 ]
 ----
+// TESTRESPONSE


### PR DESCRIPTION
This PR adds code snippet testing for more machine learning APIs.  

Related to https://github.com/elastic/elasticsearch/issues/30665