### PR TITLE
Move IndexLifecycleMetadata installation to put-lifecycle-action

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/IndexLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexlifecycle/IndexLifecycleMetadata.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 public class IndexLifecycleMetadata implements XPackMetaDataCustom {
     public static final String TYPE = "index_lifecycle";
     public static final ParseField POLICIES_FIELD = new ParseField("policies");
+    public static final IndexLifecycleMetadata EMPTY = new IndexLifecycleMetadata(Collections.emptySortedMap());
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<IndexLifecycleMetadata, Void> PARSER = new ConstructingObjectParser<>(

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/IndexLifecycle.java
@@ -49,7 +49,7 @@ import org.elasticsearch.xpack.indexlifecycle.action.RestMoveToStepAction;
 import org.elasticsearch.xpack.indexlifecycle.action.RestPutLifecycleAction;
 import org.elasticsearch.xpack.indexlifecycle.action.RestRetryAction;
 import org.elasticsearch.xpack.indexlifecycle.action.TransportSetPolicyForIndexAction;
-import org.elasticsearch.xpack.indexlifecycle.action.TransportDeleteLifcycleAction;
+import org.elasticsearch.xpack.indexlifecycle.action.TransportDeleteLifecycleAction;
 import org.elasticsearch.xpack.indexlifecycle.action.TransportExplainLifecycleAction;
 import org.elasticsearch.xpack.indexlifecycle.action.TransportGetLifecycleAction;
 import org.elasticsearch.xpack.indexlifecycle.action.TransportMoveToStepAction;
@@ -124,7 +124,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
             return emptyList();
         }
         indexLifecycleInitialisationService
-            .set(new IndexLifecycleService(settings, client, clusterService, getClock(), threadPool, System::currentTimeMillis));
+            .set(new IndexLifecycleService(settings, client, clusterService, getClock(), System::currentTimeMillis));
         return Collections.singletonList(indexLifecycleInitialisationService.get());
     }
 
@@ -164,7 +164,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin {
         return Arrays.asList(
                 new ActionHandler<>(PutLifecycleAction.INSTANCE, TransportPutLifecycleAction.class),
                 new ActionHandler<>(GetLifecycleAction.INSTANCE, TransportGetLifecycleAction.class),
-                new ActionHandler<>(DeleteLifecycleAction.INSTANCE, TransportDeleteLifcycleAction.class),
+                new ActionHandler<>(DeleteLifecycleAction.INSTANCE, TransportDeleteLifecycleAction.class),
                 new ActionHandler<>(ExplainLifecycleAction.INSTANCE, TransportExplainLifecycleAction.class),
                 new ActionHandler<>(SetPolicyForIndexAction.INSTANCE, TransportSetPolicyForIndexAction.class),
                 new ActionHandler<>(MoveToStepAction.INSTANCE, TransportMoveToStepAction.class),

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/PolicyStepsRegistry.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/PolicyStepsRegistry.java
@@ -59,6 +59,8 @@ public class PolicyStepsRegistry {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void update(ClusterState currentState, Client client, LongSupplier nowSupplier) {
         IndexLifecycleMetadata meta = currentState.metaData().custom(IndexLifecycleMetadata.TYPE);
+        assert meta != null : "IndexLifecycleMetadata cannot be null when updating the policy steps registry";
+
         Diff<Map<String, LifecyclePolicyMetadata>> diff = DiffableUtils.diff(lifecyclePolicyMap, meta.getPolicyMetadatas(),
             DiffableUtils.getStringKeySerializer());
         DiffableUtils.MapDiff<String, LifecyclePolicyMetadata, DiffableUtils.KeySerializer<String>> mapDiff = (DiffableUtils.MapDiff) diff;

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportDeleteLifecycleAction.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportDeleteLifecycleAction.java
@@ -32,11 +32,12 @@ import java.util.Iterator;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-public class TransportDeleteLifcycleAction extends TransportMasterNodeAction<Request, Response> {
+public class TransportDeleteLifecycleAction extends TransportMasterNodeAction<Request, Response> {
 
     @Inject
-    public TransportDeleteLifcycleAction(Settings settings, TransportService transportService, ClusterService clusterService,
-            ThreadPool threadPool, ActionFilters actionFilters, IndexNameExpressionResolver indexNameExpressionResolver) {
+    public TransportDeleteLifecycleAction(Settings settings, TransportService transportService, ClusterService clusterService,
+                                          ThreadPool threadPool, ActionFilters actionFilters,
+                                          IndexNameExpressionResolver indexNameExpressionResolver) {
         super(settings, DeleteLifecycleAction.NAME, transportService, clusterService, threadPool, actionFilters,
                 indexNameExpressionResolver, Request::new);
     }
@@ -74,7 +75,8 @@ public class TransportDeleteLifcycleAction extends TransportMasterNodeAction<Req
                         }
                         ClusterState.Builder newState = ClusterState.builder(currentState);
                         IndexLifecycleMetadata currentMetadata = currentState.metaData().custom(IndexLifecycleMetadata.TYPE);
-                        if (currentMetadata.getPolicyMetadatas().containsKey(request.getPolicyName()) == false) {
+                        if (currentMetadata == null
+                                || currentMetadata.getPolicyMetadatas().containsKey(request.getPolicyName()) == false) {
                             throw new ResourceNotFoundException("Lifecycle policy not found: {}", request.getPolicyName());
                         }
                         SortedMap<String, LifecyclePolicyMetadata> newPolicies = new TreeMap<>(currentMetadata.getPolicyMetadatas());

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportPutLifecycleAction.java
@@ -32,6 +32,10 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+/**
+ * This class is responsible for bootstrapping {@link IndexLifecycleMetadata} into the cluster-state, as well
+ * as adding the desired new policy to be inserted.
+ */
 public class TransportPutLifecycleAction extends TransportMasterNodeAction<Request, Response> {
 
     @Inject
@@ -64,6 +68,9 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<Reque
                     public ClusterState execute(ClusterState currentState) throws Exception {
                         ClusterState.Builder newState = ClusterState.builder(currentState);
                         IndexLifecycleMetadata currentMetadata = currentState.metaData().custom(IndexLifecycleMetadata.TYPE);
+                        if (currentMetadata == null) { // first time using index-lifecycle feature, bootstrap metadata
+                            currentMetadata = IndexLifecycleMetadata.EMPTY;
+                        }
                         if (currentMetadata.getPolicyMetadatas().containsKey(request.getPolicy().getName())) {
                             throw new ResourceAlreadyExistsException("Lifecycle policy already exists: {}",
                                     request.getPolicy().getName());

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportSetPolicyForIndexAction.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/TransportSetPolicyForIndexAction.java
@@ -68,6 +68,11 @@ public class TransportSetPolicyForIndexAction extends TransportMasterNodeAction<
                     public ClusterState execute(ClusterState currentState) throws Exception {
                         IndexLifecycleMetadata ilmMetadata = (IndexLifecycleMetadata) currentState.metaData()
                                 .custom(IndexLifecycleMetadata.TYPE);
+
+                        if (ilmMetadata == null) {
+                            throw new ResourceNotFoundException("Policy does not exist [{}]", newPolicyName);
+                        }
+
                         LifecyclePolicy newPolicy = ilmMetadata.getPolicies().get(newPolicyName);
 
                         if (newPolicy == null) {

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/index_lifecycle/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/index_lifecycle/10_basic.yml
@@ -7,6 +7,16 @@ setup:
 ---
 "Test Basic Policy CRUD":
   - do:
+      catch: missing
+      xpack.index_lifecycle.get_lifecycle:
+        lifecycle: "my_timeseries_lifecycle"
+
+  - do:
+      catch: missing
+      xpack.index_lifecycle.delete_lifecycle:
+        lifecycle: "my_timeseries_lifecycle"
+
+  - do:
       acknowlege: true
       xpack.index_lifecycle.put_lifecycle:
         lifecycle: "my_timeseries_lifecycle"


### PR DESCRIPTION
There is a problematic scenario with x-pack-cluster master-nodes
attempting to install custom metadata into the cluster-state and
broadcasting that to non-x-pack-enabled nodes. Since those nodes
are not aware of this custom metadata, their cluster-state recovery
will be broken. This change ensures that newly-elected x-pack master
nodes bootstrap IndexLifecycleMetadata upon the first request to
leverage its features. This means that PutLifecycleAction is
now responsible for installing the metadata. Since this X-Pack API
can only be called once all nodes in the cluster have x-pack enabled,
it is safe to assume that the cluster will appropriately handle the
cluster-state recovery with the new set of index-lifecycle metadata.

in response to rolling upgrade test failure here: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+index-lifecycle+feature-branch/69/