### PR TITLE
Remove http status code maps

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpResponse.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpResponse.java
@@ -27,17 +27,13 @@ import org.elasticsearch.http.HttpResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.Map;
-
 public class Netty4HttpResponse extends DefaultFullHttpResponse implements HttpResponse, HttpPipelinedMessage {
 
     private final int sequence;
     private final Netty4HttpRequest request;
 
     Netty4HttpResponse(Netty4HttpRequest request, RestStatus status, BytesReference content) {
-        super(request.nettyRequest().protocolVersion(), getStatus(status), Netty4Utils.toByteBuf(content));
+        super(request.nettyRequest().protocolVersion(), HttpResponseStatus.valueOf(status.getStatus()), Netty4Utils.toByteBuf(content));
         this.sequence = request.sequence();
         this.request = request;
     }
@@ -60,62 +56,5 @@ public class Netty4HttpResponse extends DefaultFullHttpResponse implements HttpR
     public Netty4HttpRequest getRequest() {
         return request;
     }
-
-    private static Map<RestStatus, HttpResponseStatus> MAP;
-
-    static {
-        EnumMap<RestStatus, HttpResponseStatus> map = new EnumMap<>(RestStatus.class);
-        map.put(RestStatus.CONTINUE, HttpResponseStatus.CONTINUE);
-        map.put(RestStatus.SWITCHING_PROTOCOLS, HttpResponseStatus.SWITCHING_PROTOCOLS);
-        map.put(RestStatus.OK, HttpResponseStatus.OK);
-        map.put(RestStatus.CREATED, HttpResponseStatus.CREATED);
-        map.put(RestStatus.ACCEPTED, HttpResponseStatus.ACCEPTED);
-        map.put(RestStatus.NON_AUTHORITATIVE_INFORMATION, HttpResponseStatus.NON_AUTHORITATIVE_INFORMATION);
-        map.put(RestStatus.NO_CONTENT, HttpResponseStatus.NO_CONTENT);
-        map.put(RestStatus.RESET_CONTENT, HttpResponseStatus.RESET_CONTENT);
-        map.put(RestStatus.PARTIAL_CONTENT, HttpResponseStatus.PARTIAL_CONTENT);
-        map.put(RestStatus.MULTI_STATUS, HttpResponseStatus.INTERNAL_SERVER_ERROR); // no status for this??
-        map.put(RestStatus.MULTIPLE_CHOICES, HttpResponseStatus.MULTIPLE_CHOICES);
-        map.put(RestStatus.MOVED_PERMANENTLY, HttpResponseStatus.MOVED_PERMANENTLY);
-        map.put(RestStatus.FOUND, HttpResponseStatus.FOUND);
-        map.put(RestStatus.SEE_OTHER, HttpResponseStatus.SEE_OTHER);
-        map.put(RestStatus.NOT_MODIFIED, HttpResponseStatus.NOT_MODIFIED);
-        map.put(RestStatus.USE_PROXY, HttpResponseStatus.USE_PROXY);
-        map.put(RestStatus.TEMPORARY_REDIRECT, HttpResponseStatus.TEMPORARY_REDIRECT);
-        map.put(RestStatus.BAD_REQUEST, HttpResponseStatus.BAD_REQUEST);
-        map.put(RestStatus.UNAUTHORIZED, HttpResponseStatus.UNAUTHORIZED);
-        map.put(RestStatus.PAYMENT_REQUIRED, HttpResponseStatus.PAYMENT_REQUIRED);
-        map.put(RestStatus.FORBIDDEN, HttpResponseStatus.FORBIDDEN);
-        map.put(RestStatus.NOT_FOUND, HttpResponseStatus.NOT_FOUND);
-        map.put(RestStatus.METHOD_NOT_ALLOWED, HttpResponseStatus.METHOD_NOT_ALLOWED);
-        map.put(RestStatus.NOT_ACCEPTABLE, HttpResponseStatus.NOT_ACCEPTABLE);
-        map.put(RestStatus.PROXY_AUTHENTICATION, HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED);
-        map.put(RestStatus.REQUEST_TIMEOUT, HttpResponseStatus.REQUEST_TIMEOUT);
-        map.put(RestStatus.CONFLICT, HttpResponseStatus.CONFLICT);
-        map.put(RestStatus.GONE, HttpResponseStatus.GONE);
-        map.put(RestStatus.LENGTH_REQUIRED, HttpResponseStatus.LENGTH_REQUIRED);
-        map.put(RestStatus.PRECONDITION_FAILED, HttpResponseStatus.PRECONDITION_FAILED);
-        map.put(RestStatus.REQUEST_ENTITY_TOO_LARGE, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE);
-        map.put(RestStatus.REQUEST_URI_TOO_LONG, HttpResponseStatus.REQUEST_URI_TOO_LONG);
-        map.put(RestStatus.UNSUPPORTED_MEDIA_TYPE, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE);
-        map.put(RestStatus.REQUESTED_RANGE_NOT_SATISFIED, HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
-        map.put(RestStatus.EXPECTATION_FAILED, HttpResponseStatus.EXPECTATION_FAILED);
-        map.put(RestStatus.UNPROCESSABLE_ENTITY, HttpResponseStatus.BAD_REQUEST);
-        map.put(RestStatus.LOCKED, HttpResponseStatus.BAD_REQUEST);
-        map.put(RestStatus.FAILED_DEPENDENCY, HttpResponseStatus.BAD_REQUEST);
-        map.put(RestStatus.TOO_MANY_REQUESTS, HttpResponseStatus.TOO_MANY_REQUESTS);
-        map.put(RestStatus.INTERNAL_SERVER_ERROR, HttpResponseStatus.INTERNAL_SERVER_ERROR);
-        map.put(RestStatus.NOT_IMPLEMENTED, HttpResponseStatus.NOT_IMPLEMENTED);
-        map.put(RestStatus.BAD_GATEWAY, HttpResponseStatus.BAD_GATEWAY);
-        map.put(RestStatus.SERVICE_UNAVAILABLE, HttpResponseStatus.SERVICE_UNAVAILABLE);
-        map.put(RestStatus.GATEWAY_TIMEOUT, HttpResponseStatus.GATEWAY_TIMEOUT);
-        map.put(RestStatus.HTTP_VERSION_NOT_SUPPORTED, HttpResponseStatus.HTTP_VERSION_NOT_SUPPORTED);
-        MAP = Collections.unmodifiableMap(map);
-    }
-
-    private static HttpResponseStatus getStatus(RestStatus status) {
-        return MAP.getOrDefault(status, HttpResponseStatus.INTERNAL_SERVER_ERROR);
-    }
-
 }
 

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpResponse.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpResponse.java
@@ -26,17 +26,13 @@ import org.elasticsearch.http.HttpPipelinedMessage;
 import org.elasticsearch.http.HttpResponse;
 import org.elasticsearch.rest.RestStatus;
 
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.Map;
-
 public class NioHttpResponse extends DefaultFullHttpResponse implements HttpResponse, HttpPipelinedMessage {
 
     private final int sequence;
     private final NioHttpRequest request;
 
     NioHttpResponse(NioHttpRequest request, RestStatus status, BytesReference content) {
-        super(request.nettyRequest().protocolVersion(), getStatus(status), ByteBufUtils.toByteBuf(content));
+        super(request.nettyRequest().protocolVersion(), HttpResponseStatus.valueOf(status.getStatus()), ByteBufUtils.toByteBuf(content));
         this.sequence = request.sequence();
         this.request = request;
     }
@@ -56,63 +52,7 @@ public class NioHttpResponse extends DefaultFullHttpResponse implements HttpResp
         return sequence;
     }
 
-    private static Map<RestStatus, HttpResponseStatus> MAP;
-
     public NioHttpRequest getRequest() {
         return request;
-    }
-
-    static {
-        EnumMap<RestStatus, HttpResponseStatus> map = new EnumMap<>(RestStatus.class);
-        map.put(RestStatus.CONTINUE, HttpResponseStatus.CONTINUE);
-        map.put(RestStatus.SWITCHING_PROTOCOLS, HttpResponseStatus.SWITCHING_PROTOCOLS);
-        map.put(RestStatus.OK, HttpResponseStatus.OK);
-        map.put(RestStatus.CREATED, HttpResponseStatus.CREATED);
-        map.put(RestStatus.ACCEPTED, HttpResponseStatus.ACCEPTED);
-        map.put(RestStatus.NON_AUTHORITATIVE_INFORMATION, HttpResponseStatus.NON_AUTHORITATIVE_INFORMATION);
-        map.put(RestStatus.NO_CONTENT, HttpResponseStatus.NO_CONTENT);
-        map.put(RestStatus.RESET_CONTENT, HttpResponseStatus.RESET_CONTENT);
-        map.put(RestStatus.PARTIAL_CONTENT, HttpResponseStatus.PARTIAL_CONTENT);
-        map.put(RestStatus.MULTI_STATUS, HttpResponseStatus.INTERNAL_SERVER_ERROR); // no status for this??
-        map.put(RestStatus.MULTIPLE_CHOICES, HttpResponseStatus.MULTIPLE_CHOICES);
-        map.put(RestStatus.MOVED_PERMANENTLY, HttpResponseStatus.MOVED_PERMANENTLY);
-        map.put(RestStatus.FOUND, HttpResponseStatus.FOUND);
-        map.put(RestStatus.SEE_OTHER, HttpResponseStatus.SEE_OTHER);
-        map.put(RestStatus.NOT_MODIFIED, HttpResponseStatus.NOT_MODIFIED);
-        map.put(RestStatus.USE_PROXY, HttpResponseStatus.USE_PROXY);
-        map.put(RestStatus.TEMPORARY_REDIRECT, HttpResponseStatus.TEMPORARY_REDIRECT);
-        map.put(RestStatus.BAD_REQUEST, HttpResponseStatus.BAD_REQUEST);
-        map.put(RestStatus.UNAUTHORIZED, HttpResponseStatus.UNAUTHORIZED);
-        map.put(RestStatus.PAYMENT_REQUIRED, HttpResponseStatus.PAYMENT_REQUIRED);
-        map.put(RestStatus.FORBIDDEN, HttpResponseStatus.FORBIDDEN);
-        map.put(RestStatus.NOT_FOUND, HttpResponseStatus.NOT_FOUND);
-        map.put(RestStatus.METHOD_NOT_ALLOWED, HttpResponseStatus.METHOD_NOT_ALLOWED);
-        map.put(RestStatus.NOT_ACCEPTABLE, HttpResponseStatus.NOT_ACCEPTABLE);
-        map.put(RestStatus.PROXY_AUTHENTICATION, HttpResponseStatus.PROXY_AUTHENTICATION_REQUIRED);
-        map.put(RestStatus.REQUEST_TIMEOUT, HttpResponseStatus.REQUEST_TIMEOUT);
-        map.put(RestStatus.CONFLICT, HttpResponseStatus.CONFLICT);
-        map.put(RestStatus.GONE, HttpResponseStatus.GONE);
-        map.put(RestStatus.LENGTH_REQUIRED, HttpResponseStatus.LENGTH_REQUIRED);
-        map.put(RestStatus.PRECONDITION_FAILED, HttpResponseStatus.PRECONDITION_FAILED);
-        map.put(RestStatus.REQUEST_ENTITY_TOO_LARGE, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE);
-        map.put(RestStatus.REQUEST_URI_TOO_LONG, HttpResponseStatus.REQUEST_URI_TOO_LONG);
-        map.put(RestStatus.UNSUPPORTED_MEDIA_TYPE, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE);
-        map.put(RestStatus.REQUESTED_RANGE_NOT_SATISFIED, HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
-        map.put(RestStatus.EXPECTATION_FAILED, HttpResponseStatus.EXPECTATION_FAILED);
-        map.put(RestStatus.UNPROCESSABLE_ENTITY, HttpResponseStatus.BAD_REQUEST);
-        map.put(RestStatus.LOCKED, HttpResponseStatus.BAD_REQUEST);
-        map.put(RestStatus.FAILED_DEPENDENCY, HttpResponseStatus.BAD_REQUEST);
-        map.put(RestStatus.TOO_MANY_REQUESTS, HttpResponseStatus.TOO_MANY_REQUESTS);
-        map.put(RestStatus.INTERNAL_SERVER_ERROR, HttpResponseStatus.INTERNAL_SERVER_ERROR);
-        map.put(RestStatus.NOT_IMPLEMENTED, HttpResponseStatus.NOT_IMPLEMENTED);
-        map.put(RestStatus.BAD_GATEWAY, HttpResponseStatus.BAD_GATEWAY);
-        map.put(RestStatus.SERVICE_UNAVAILABLE, HttpResponseStatus.SERVICE_UNAVAILABLE);
-        map.put(RestStatus.GATEWAY_TIMEOUT, HttpResponseStatus.GATEWAY_TIMEOUT);
-        map.put(RestStatus.HTTP_VERSION_NOT_SUPPORTED, HttpResponseStatus.HTTP_VERSION_NOT_SUPPORTED);
-        MAP = Collections.unmodifiableMap(map);
-    }
-
-    private static HttpResponseStatus getStatus(RestStatus status) {
-        return MAP.getOrDefault(status, HttpResponseStatus.INTERNAL_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
Currently we maintain a compatibility map of http status codes in both
the netty4 and nio modules. These maps convert a RestStatus to a netty
HttpResponseStatus. However, as these fundamentally represent integers,
we can just use the netty valueOf method to convert a RestStatus to a
HttpResponseStatus.