### PR TITLE
QA: Fix resolution of default distribution

### DIFF
--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -5,6 +5,20 @@ subprojects { Project subproj ->
   subproj.tasks.withType(RestIntegTestTask) {
     subproj.extensions.configure("${it.name}Cluster") { cluster ->
       cluster.distribution = System.getProperty('tests.distribution', 'oss-zip')
+      if (cluster.distribution == 'zip') {
+        /*
+         * Add Elastic's repositories so we can resolve older versions of the
+         * default distribution. Those aren't in maven central.
+         */
+        repositories {
+          maven {
+            url "https://artifacts.elastic.co/maven"
+          }
+          maven {
+            url "https://snapshots.elastic.co/maven"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
If you run `./gradlew -p qa bwcTest -Dtests.distribution=zip` then we
need to resolve older versions of the default distribution. Since those
aren't available in maven central, we need add the elastic maven repo to
the project.
