### PR TITLE
[Tests] Fix edge case in ScriptedMetricAggregatorTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/scripted/ScriptedMetricAggregatorTests.java
@@ -118,7 +118,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
         SCRIPTS.put("initScriptParams", params -> {
             Map<String, Object> agg = (Map<String, Object>) params.get("_agg");
             Integer initialValue = (Integer)params.get("initialValue");
-            ArrayList<Integer> collector = new ArrayList();
+            ArrayList<Integer> collector = new ArrayList<>();
             collector.add(initialValue);
             agg.put("collector", collector);
             return agg;
@@ -175,7 +175,6 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
     /**
      * without combine script, the "_aggs" map should contain a list of the size of the number of documents matched
      */
-    @SuppressWarnings("unchecked")
     public void testScriptedMetricWithoutCombine() throws IOException {
         try (Directory directory = newDirectory()) {
             int numDocs = randomInt(100);
@@ -190,8 +189,11 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 ScriptedMetric scriptedMetric = search(newSearcher(indexReader, true, true), new MatchAllDocsQuery(), aggregationBuilder);
                 assertEquals(AGG_NAME, scriptedMetric.getName());
                 assertNotNull(scriptedMetric.aggregation());
+                @SuppressWarnings("unchecked")
                 Map<String, Object> agg = (Map<String, Object>) scriptedMetric.aggregation();
-                assertEquals(numDocs, ((List<Integer>) agg.get("collector")).size());
+                @SuppressWarnings("unchecked")
+                List<Integer> list = (List<Integer>) agg.get("collector");
+                assertEquals(numDocs, list.size());
             }
         }
     }
@@ -300,10 +302,9 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/31307")
     public void testSelfReferencingAggStateAfterMap() throws IOException {
         try (Directory directory = newDirectory()) {
-            Integer numDocs = randomInt(100);
+            Integer numDocs = randomIntBetween(1, 100);
             try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
                 for (int i = 0; i < numDocs; i++) {
                     indexWriter.addDocument(singleton(new SortedNumericDocValuesField("number", i)));


### PR DESCRIPTION
An expected exception is only thrown when there are documents in the index
created in the test setup. Fixed the test by making sure there is at least one.

Closes #31307