### PR TITLE
Remove trial status info from start trial doc

### DIFF
--- a/x-pack/docs/en/rest-api/license/start-trial.asciidoc
+++ b/x-pack/docs/en/rest-api/license/start-trial.asciidoc
@@ -36,24 +36,6 @@ For more information, see
 [float]
 ==== Examples
 
-The following example checks whether you are eligible to start a trial:
-
-[source,js]
-------------------------------------------------------------
-GET _xpack/license/start_trial
-------------------------------------------------------------
-// CONSOLE
-// TEST[skip:license testing issues]
-
-Example response:
-[source,js]
-------------------------------------------------------------
-{
-  "eligible_to_start_trial": true
-}
-------------------------------------------------------------
-// NOTCONSOLE
-
 The following example starts a 30-day trial license. The acknowledge
 parameter is required as you are initiating a license that will expire.
 


### PR DESCRIPTION
This is related to #31325. There is currently information about the
get-trial-status api on the start-trial api documentation page. It also
has the incorrect route for that api. This commit removes that
information as the start-trial page properly links to a page providing
documenation about get-trial-status.
