### PR TITLE
[DOCS] Adds monitoring breaking change

### DIFF
--- a/docs/reference/migration/migrate_6_3.asciidoc
+++ b/docs/reference/migration/migrate_6_3.asciidoc
@@ -88,3 +88,11 @@ place) you can start Elasticsearch with the JVM option
 `-Des.thread_pool.write.use_bulk_as_display_name=true` to have Elasticsearch
 continue to display the name of this thread pool as `bulk`. Elasticsearch will
 stop observing this system property in 7.0.0.
+
+==== Enabling monitoring 
+
+By default when you install {xpack}, monitoring is enabled but data collection
+is disabled. To enable data collection, use the new
+`xpack.monitoring.collection.enabled` setting. You can update this setting by
+using the <<cluster-update-settings,Cluster Update Settings API>>. For more
+information, see <<monitoring-settings>>.


### PR DESCRIPTION
There was a breaking change in the 6.3.0 Elasticsearch Release Notes related to monitoring.

This PR adds that information to the appropriate "Breaking Changes" page. 

Related to https://github.com/elastic/docs/issues/382