### PR TITLE
SQL: Fix rest endpoint names in node stats

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlClearCursorAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlClearCursorAction.java
@@ -37,6 +37,6 @@ public class RestSqlClearCursorAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "sql_translate_action";
+        return "xpack_sql_clear_cursor_action";
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlQueryAction.java
@@ -114,6 +114,6 @@ public class RestSqlQueryAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "xpack_sql_action";
+        return "xpack_sql_query_action";
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlTranslateAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/RestSqlTranslateAction.java
@@ -40,7 +40,7 @@ public class RestSqlTranslateAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "sql_translate_action";
+        return "xpack_sql_translate_action";
     }
 }
 


### PR DESCRIPTION
Fixes wrong name for the sql translate endpoint and makes rest endpoint
names in stats more consistent.
