### PR TITLE
[DOCS] Backports breaking change

### DIFF
--- a/docs/reference/migration/migrate_6_3.asciidoc
+++ b/docs/reference/migration/migrate_6_3.asciidoc
@@ -7,6 +7,7 @@ your application to Elasticsearch 6.3.
 * <<breaking_63_api_changes>>
 * <<breaking_63_plugins_changes>>
 * <<breaking_63_settings_changes>>
+* <<breaking_63_search_changes>>
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
@@ -88,3 +89,11 @@ place) you can start Elasticsearch with the JVM option
 `-Des.thread_pool.write.use_bulk_as_display_name=true` to have Elasticsearch
 continue to display the name of this thread pool as `bulk`. Elasticsearch will
 stop observing this system property in 7.0.0.
+
+[[breaking_63_search_changes]]
+=== Search and Query DSL changes
+
+==== Invalid `_search` request body
+
+Search requests with extra content after the main object will no longer be accepted
+by the `_search` endpoint. A parsing exception will be thrown instead.

--- a/docs/reference/migration/migrate_6_3.asciidoc
+++ b/docs/reference/migration/migrate_6_3.asciidoc
@@ -7,7 +7,6 @@ your application to Elasticsearch 6.3.
 * <<breaking_63_api_changes>>
 * <<breaking_63_plugins_changes>>
 * <<breaking_63_settings_changes>>
-* <<breaking_63_search_changes>>
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
@@ -89,11 +88,3 @@ place) you can start Elasticsearch with the JVM option
 `-Des.thread_pool.write.use_bulk_as_display_name=true` to have Elasticsearch
 continue to display the name of this thread pool as `bulk`. Elasticsearch will
 stop observing this system property in 7.0.0.
-
-[[breaking_63_search_changes]]
-=== Search and Query DSL changes
-
-==== Invalid `_search` request body
-
-Search requests with extra content after the main object will no longer be accepted
-by the `_search` endpoint. A parsing exception will be thrown instead.

--- a/docs/reference/release-notes/6.3.asciidoc
+++ b/docs/reference/release-notes/6.3.asciidoc
@@ -23,13 +23,12 @@ Packaging::
 Plugins::
 * Remove silent batch mode from install plugin {pull}29359[#29359]
 
-Search::
-* Fail _search request with trailing tokens {pull}29428[#29428] (issue: {issue}28995[#28995])
-
 Security::
 * The legacy `XPackExtension` extension mechanism has been removed and replaced
 with an SPI based extension mechanism that is installed and built as an
 elasticsearch plugin.
+
+
 
 [[breaking-java-6.3.0]]
 [float]
@@ -63,6 +62,7 @@ REST API::
 
 Search::
 * Deprecate slicing on `_uid`. {pull}29353[#29353]
+* Generate deprecation warning for _search request with trailing tokens {pull}29428[#29428] (issue: {issue}28995[#28995])
 
 Stats::
 * Deprecate the suggest metrics {pull}29627[#29627] (issue: {issue}29589[#29589])


### PR DESCRIPTION
There is a breaking change in https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-6.3.0.html related to https://github.com/elastic/elasticsearch/pull/29428

This PR backports the content from https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_70_search_changes.html#_invalid_literal__search_literal_request_body to 6.x and 6.3.

Related to https://github.com/elastic/docs/issues/382