### PR TITLE
[DOCS] Adds security breaking change

### DIFF
--- a/docs/reference/migration/migrate_6_3.asciidoc
+++ b/docs/reference/migration/migrate_6_3.asciidoc
@@ -55,6 +55,12 @@ accept these permissions either by keeping standard input open and attaching a
 TTY (i.e., using interactive mode to accept the permissions), or by passing the
 `--batch` flag.
 
+==== Implementing custom realms with SPI instead of XPackExtension
+
+The legacy `XPackExtension` extension mechanism has been removed and replaced
+with an SPI based extension mechanism that is installed and built as an
+elasticsearch plugin. For more information about using SPI loaded security extensions in custom realms, see {stack-ov}/custom-realms.html[Integrating with other authentication systems]. 
+
 [[breaking_63_settings_changes]]
 === Settings changes
 


### PR DESCRIPTION
There is a breaking change in the 6.3.0 Elasticsearch Release Notes related to removing XPackExtension in favour of SecurityExtensions.  

This PR adds a matching blurb in the "Breaking changes" documentation.

Related to https://github.com/elastic/docs/issues/382