### PR TITLE
[DOCS] Removes breaking change

### DIFF
--- a/docs/reference/release-notes/6.3.asciidoc
+++ b/docs/reference/release-notes/6.3.asciidoc
@@ -1,5 +1,5 @@
 [[release-notes-6.3.0]]
-== 6.3.0 Release Notes
+== {es} version 6.3.0
 
 Also see <<breaking-changes-6.3>>.
 
@@ -30,10 +30,6 @@ Security::
 * The legacy `XPackExtension` extension mechanism has been removed and replaced
 with an SPI based extension mechanism that is installed and built as an
 elasticsearch plugin.
-
-Task Management::
-* Remove metadata customs that can break serialization {pull}30945[#30945] (issues: {issue}30731[#30731], {issue}30857[#30857])
-
 
 [[breaking-java-6.3.0]]
 [float]


### PR DESCRIPTION
This PR removes a breaking change from the Elasticsearch 6.3.0 release notes, since the PR seems to have been closed not merged: https://github.com/elastic/elasticsearch/pull/30945

If this item *does* need to remain in the list, I think we need to add info to the "Breaking Changes" (https://github.com/elastic/elasticsearch/blob/6.x/docs/reference/migration/migrate_6_3.asciidoc) pages as well. 

Related to https://github.com/elastic/docs/issues/382