### PR TITLE
Skip get_alias tests for 5.x

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -20,8 +20,8 @@ setup:
 ---
 "Get all aliases via /_alias":
   - skip:
-      version: all
-      reason: Nik will look on Monday
+      version: " - 5.99.99"
+      reason: 5.x doesn't return indices without aliases (at transport)
   - do:
       indices.create:
         index: test_index_3

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/20_empty.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_alias/20_empty.yml
@@ -12,8 +12,8 @@ setup:
 ---
 "Check empty aliases when getting all aliases via /_alias":
   - skip:
-      version: all
-      reason: Nik will look on Monday
+      version: " - 5.99.99"
+      reason: 5.x doesn't return indices without aliases (at transport)
   - do:
       indices.get_alias: {}
 


### PR DESCRIPTION
Some recent failures on the mixed cluster tests were caused by #31308.
Instead of executing get index API when calling GET /_alias we now go
through the get alias API. The behaviour of such API is slightly
different on 5.6 compared to 6.x and master as to whether indices that
have no aliases are returned or not. In fact #25114 was not backported
to 5.6.

When the 5.6 node is the elected master, if the get alias API goes
through such node or another 5.x node, the get index API will be used
internally and all tests are fine. If some 6.x node is hit though by the
client request, we will go through the get alias API, but we will do it
through the elected master which will not return indices without aliases
(at transport, see MetaData#findAliases on 5.6). That means that in a
mixed cluster this API will return a different result depending on which
node is the elected master and which one is hit by the request.

Another option to prevent this weird behaviour on a mixed cluster, would be 
to revert #31308 on 6.x. The change itself is fine on master though, which is
the most important thing.