### PR TITLE
Rename NoopEngine -> NoOpEngine

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -42,7 +42,7 @@ import java.util.function.LongSupplier;
 import java.util.stream.Stream;
 
 /**
- * NoopEngine is an engine implementation that does nothing but the bare minimum
+ * NoOpEngine is an engine implementation that does nothing but the bare minimum
  * required in order to have an engine. All attempts to do something (search,
  * index, get), throw {@link UnsupportedOperationException}. This does maintain
  * a translog with a deletion policy so that when flushing, no translog is
@@ -52,7 +52,7 @@ import java.util.stream.Stream;
  * Directory so that the last commit's user data can be read for the historyUUID
  * and last committed segment info.
  */
-final class NoopEngine extends Engine {
+final class NoOpEngine extends Engine {
 
     private static final Translog.Snapshot EMPTY_TRANSLOG_SNAPSHOT = new Translog.Snapshot() {
         @Override
@@ -79,7 +79,7 @@ final class NoopEngine extends Engine {
     private final String historyUUID;
     private final SegmentInfos lastCommittedSegmentInfos;
 
-    NoopEngine(EngineConfig engineConfig) {
+    NoOpEngine(EngineConfig engineConfig) {
         super(engineConfig);
 
         store.incRef();
@@ -114,7 +114,7 @@ final class NoopEngine extends Engine {
                 }
             }
         }
-        logger.trace("created new NoopEngine");
+        logger.trace("created new NoOpEngine");
     }
 
     private Translog openTranslog(EngineConfig engineConfig, TranslogDeletionPolicy translogDeletionPolicy,
@@ -169,32 +169,32 @@ final class NoopEngine extends Engine {
 
     @Override
     public IndexResult index(Index index) {
-        throw new UnsupportedOperationException("indexing is not supported on a noop engine");
+        throw new UnsupportedOperationException("indexing is not supported on a noOp engine");
     }
 
     @Override
     public DeleteResult delete(Delete delete) {
-        throw new UnsupportedOperationException("deletion is not supported on a noop engine");
+        throw new UnsupportedOperationException("deletion is not supported on a noOp engine");
     }
 
     @Override
     public NoOpResult noOp(NoOp noOp) {
-        throw new UnsupportedOperationException("noop is not supported on a noop engine");
+        throw new UnsupportedOperationException("noOp is not supported on a noOp engine");
     }
 
     @Override
     public SyncedFlushResult syncFlush(String syncId, CommitId expectedCommitId) throws EngineException {
-        throw new UnsupportedOperationException("synced flush is not supported on a noop engine");
+        throw new UnsupportedOperationException("synced flush is not supported on a noOp engine");
     }
 
     @Override
     public GetResult get(Get get, BiFunction<String, SearcherScope, Searcher> searcherFactory) throws EngineException {
-        throw new UnsupportedOperationException("gets are not supported on a noop engine");
+        throw new UnsupportedOperationException("gets are not supported on a noOp engine");
     }
 
     @Override
     public Searcher acquireSearcher(String source, SearcherScope scope) throws EngineException {
-        throw new UnsupportedOperationException("searching is not supported on a noop engine");
+        throw new UnsupportedOperationException("searching is not supported on a noOp engine");
     }
 
     @Override
@@ -278,7 +278,7 @@ final class NoopEngine extends Engine {
     // Override the refreshNeeded method so that we don't attempt to acquire a searcher checking if we need to refresh
     @Override
     public boolean refreshNeeded() {
-        // We never need to refresh a noop engine so always return false
+        // We never need to refresh a noOp engine so always return false
         return false;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineTests.java
@@ -41,12 +41,12 @@ import java.util.Collections;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class NoopEngineTests extends EngineTestCase {
+public class NoOpEngineTests extends EngineTestCase {
     private static final IndexSettings INDEX_SETTINGS = IndexSettingsModule.newIndexSettings("index", Settings.EMPTY);
 
     public void testNoopEngine() throws IOException {
         engine.close();
-        final NoopEngine engine = new NoopEngine(noopConfig(INDEX_SETTINGS, store, primaryTranslogDir));
+        final NoOpEngine engine = new NoOpEngine(noOpConfig(INDEX_SETTINGS, store, primaryTranslogDir));
         expectThrows(UnsupportedOperationException.class, () -> engine.index(null));
         expectThrows(UnsupportedOperationException.class, () -> engine.delete(null));
         expectThrows(UnsupportedOperationException.class, () -> engine.noOp(null));
@@ -63,11 +63,11 @@ public class NoopEngineTests extends EngineTestCase {
 
     public void testTwoNoopEngines() throws IOException {
         engine.close();
-        // It's so noop you can even open two engines for the same store without tripping anything,
+        // It's so noOp you can even open two engines for the same store without tripping anything,
         // this ensures we're not doing any kind of locking on the store or filesystem level in
-        // the noop engine
-        final NoopEngine engine1 = new NoopEngine(noopConfig(INDEX_SETTINGS, store, primaryTranslogDir));
-        final NoopEngine engine2 = new NoopEngine(noopConfig(INDEX_SETTINGS, store, primaryTranslogDir));
+        // the noOp engine
+        final NoOpEngine engine1 = new NoOpEngine(noOpConfig(INDEX_SETTINGS, store, primaryTranslogDir));
+        final NoOpEngine engine2 = new NoOpEngine(noOpConfig(INDEX_SETTINGS, store, primaryTranslogDir));
         engine1.close();
         engine2.close();
     }
@@ -97,24 +97,24 @@ public class NoopEngineTests extends EngineTestCase {
         long maxSeqNo = engine.getSeqNoStats(100L).getMaxSeqNo();
         engine.close();
 
-        final NoopEngine noopEngine = new NoopEngine(noopConfig(INDEX_SETTINGS, store, primaryTranslogDir, tracker));
-        assertThat(noopEngine.getLocalCheckpoint(), equalTo(localCheckpoint));
-        assertThat(noopEngine.getSeqNoStats(100L).getMaxSeqNo(), equalTo(maxSeqNo));
-        try (Engine.IndexCommitRef ref = noopEngine.acquireLastIndexCommit(false)) {
+        final NoOpEngine noOpEngine = new NoOpEngine(noOpConfig(INDEX_SETTINGS, store, primaryTranslogDir, tracker));
+        assertThat(noOpEngine.getLocalCheckpoint(), equalTo(localCheckpoint));
+        assertThat(noOpEngine.getSeqNoStats(100L).getMaxSeqNo(), equalTo(maxSeqNo));
+        try (Engine.IndexCommitRef ref = noOpEngine.acquireLastIndexCommit(false)) {
             try (IndexReader reader = DirectoryReader.open(ref.getIndexCommit())) {
                 assertThat(reader.numDocs(), equalTo(docs));
             }
         }
-        noopEngine.close();
+        noOpEngine.close();
     }
 
     public void testNoopEngineWithInvalidTranslogUUID() throws IOException {
         Path newTranslogDir = createTempDir();
-        // A new translog will have a different UUID than the existing store/noop engine does
+        // A new translog will have a different UUID than the existing store/noOp engine does
         Translog newTranslog = createTranslog(newTranslogDir, () -> 1L);
         newTranslog.close();
         EngineCreationFailureException e = expectThrows(EngineCreationFailureException.class,
-            () -> new NoopEngine(noopConfig(INDEX_SETTINGS, store, newTranslogDir)));
+            () -> new NoOpEngine(noOpConfig(INDEX_SETTINGS, store, newTranslogDir)));
         assertThat(e.getCause(), instanceOf(TranslogCorruptedException.class));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -466,11 +466,11 @@ public abstract class EngineTestCase extends ESTestCase {
         return config;
     }
 
-    protected EngineConfig noopConfig(IndexSettings indexSettings, Store store, Path translogPath) {
-        return noopConfig(indexSettings, store, translogPath, null);
+    protected EngineConfig noOpConfig(IndexSettings indexSettings, Store store, Path translogPath) {
+        return noOpConfig(indexSettings, store, translogPath, null);
     }
 
-    protected EngineConfig noopConfig(IndexSettings indexSettings, Store store, Path translogPath, LongSupplier globalCheckpointSupplier) {
+    protected EngineConfig noOpConfig(IndexSettings indexSettings, Store store, Path translogPath, LongSupplier globalCheckpointSupplier) {
         return config(indexSettings, store, translogPath, newMergePolicy(), null, null, globalCheckpointSupplier);
     }
 


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/31163#discussion_r194932000
Jason requested renaming NoopEngine to NoOpEngine. This commit renames the class
and relevant parts.

Relates to #31141