### PR TITLE
[DOCS] Add code snippet testing for more ML APIs

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -70,8 +70,6 @@ buildRestTests.expectedUnconvertedCandidates = [
         'en/rest-api/ml/preview-datafeed.asciidoc',
         'en/rest-api/ml/revert-snapshot.asciidoc',
         'en/rest-api/ml/update-snapshot.asciidoc',
-        'en/rest-api/ml/validate-detector.asciidoc',
-        'en/rest-api/ml/validate-job.asciidoc',
         'en/rest-api/watcher/stats.asciidoc',
         'en/watcher/example-watches/watching-time-series-data.asciidoc',
 ]

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -57,7 +57,6 @@ buildRestTests.expectedUnconvertedCandidates = [
         'en/rest-api/license/delete-license.asciidoc',
         'en/rest-api/license/update-license.asciidoc',
         'en/ml/api-quickref.asciidoc',
-        'en/rest-api/ml/delete-calendar-event.asciidoc',
         'en/rest-api/ml/delete-snapshot.asciidoc',
         'en/rest-api/ml/forecast.asciidoc',
         'en/rest-api/ml/get-bucket.asciidoc',

--- a/x-pack/docs/en/rest-api/ml/delete-calendar-event.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/delete-calendar-event.asciidoc
@@ -44,7 +44,7 @@ calendar:
 DELETE _xpack/ml/calendars/planned-outages/events/LS8LJGEBMTCMA-qz49st
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:automatically-generated ID]
+// TEST[catch:missing]
 
 When the event is removed, you receive the following results:
 [source,js]
@@ -53,3 +53,4 @@ When the event is removed, you receive the following results:
   "acknowledged": true
 }
 ----
+// NOTCONSOLE

--- a/x-pack/docs/en/rest-api/ml/validate-detector.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/validate-detector.asciidoc
@@ -45,7 +45,6 @@ POST _xpack/ml/anomaly_detectors/_validate/detector
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:todo]
 
 When the validation completes, you receive the following results:
 [source,js]
@@ -54,3 +53,4 @@ When the validation completes, you receive the following results:
   "acknowledged": true
 }
 ----
+// TESTRESPONSE

--- a/x-pack/docs/en/rest-api/ml/validate-detector.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/validate-detector.asciidoc
@@ -28,7 +28,6 @@ see <<ml-detectorconfig,detector configuration objects>>.
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
 {xpack-ref}/security-privileges.html[Security Privileges].
-//<<privileges-list-cluster>>.
 
 
 ==== Examples

--- a/x-pack/docs/en/rest-api/ml/validate-job.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/validate-job.asciidoc
@@ -28,7 +28,6 @@ see <<ml-job-resource,Job Resources>>.
 You must have `manage_ml`, or `manage` cluster privileges to use this API.
 For more information, see
 {xpack-ref}/security-privileges.html[Security Privileges].
-//<<privileges-list-cluster>>.
 
 
 ==== Examples
@@ -56,7 +55,6 @@ POST _xpack/ml/anomaly_detectors/_validate
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:todo]
 
 When the validation is complete, you receive the following results:
 [source,js]
@@ -65,3 +63,4 @@ When the validation is complete, you receive the following results:
   "acknowledged": true
 }
 ----
+// TESTRESPONSE


### PR DESCRIPTION
This PR adds code snippet testing for more machine learning APIs.  

Related to https://github.com/elastic/elasticsearch/issues/30665