### PR TITLE
Lazily retrieve EngineFactory based on IndexSettings

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -451,7 +451,7 @@ public class IndicesService extends AbstractLifecycleComponent
             idxSettings.getNumberOfReplicas(),
             reason);
 
-        final IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry, getEngineFactory(idxSettings));
+        final IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry, this::getEngineFactory);
         for (IndexingOperationListener operationListener : indexingOperationListeners) {
             indexModule.addIndexOperationListener(operationListener);
         }
@@ -475,7 +475,8 @@ public class IndicesService extends AbstractLifecycleComponent
         );
     }
 
-    private EngineFactory getEngineFactory(final IndexSettings idxSettings) {
+    // Visible for testing
+    EngineFactory getEngineFactory(final IndexSettings idxSettings) {
         final List<Optional<EngineFactory>> engineFactories =
                 engineFactoryProviders
                         .stream()
@@ -511,7 +512,7 @@ public class IndicesService extends AbstractLifecycleComponent
      */
     public synchronized MapperService createIndexMapperService(IndexMetaData indexMetaData) throws IOException {
         final IndexSettings idxSettings = new IndexSettings(indexMetaData, this.settings, indexScopedSettings);
-        final IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry, getEngineFactory(idxSettings));
+        final IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry, this::getEngineFactory);
         pluginsService.onIndexModule(indexModule);
         return indexModule.newIndexMapperService(xContentRegistry, mapperRegistry, scriptService);
     }

--- a/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/IndexLevelReplicationTests.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static org.elasticsearch.index.translog.SnapshotMatchers.containsOperationsInAnyOrder;
 import static org.hamcrest.Matchers.anyOf;
@@ -244,8 +245,8 @@ public class IndexLevelReplicationTests extends ESIndexLevelReplicationTestCase 
                 new ThrowingDocumentFailureEngineFactory(failureMessage);
         try (ReplicationGroup shards = new ReplicationGroup(buildIndexMetaData(0)) {
             @Override
-            protected EngineFactory getEngineFactory(ShardRouting routing) {
-                return throwingDocumentFailureEngineFactory;
+            protected Function<IndexSettings, EngineFactory> getEngineFactory(ShardRouting routing) {
+                return s -> throwingDocumentFailureEngineFactory;
             }}) {
 
             // test only primary

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -620,7 +620,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         ShardRouting initializingShardRouting = getInitializingShardRouting(shard.routingEntry());
         IndexShard newShard = new IndexShard(initializingShardRouting, indexService.getIndexSettings(), shard.shardPath(),
             shard.store(), indexService.getIndexSortSupplier(), indexService.cache(), indexService.mapperService(), indexService.similarityService(),
-            shard.getEngineFactory(), indexService.getIndexEventListener(), wrapper,
+            shard.getEngineFactoryFn(), indexService.getIndexEventListener(), wrapper,
             indexService.getThreadPool(), indexService.getBigArrays(), null, Collections.emptyList(), Arrays.asList(listeners), () -> {}, cbs);
         return newShard;
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -841,7 +841,7 @@ public class IndexShardTests extends IndexShardTestCase {
         final IndexMetaData.Builder indexMetadata = IndexMetaData.builder(shardRouting.getIndexName()).settings(settings).primaryTerm(0, 1);
         final AtomicBoolean synced = new AtomicBoolean();
         final IndexShard primaryShard =
-                newShard(shardRouting, indexMetadata.build(), null, new InternalEngineFactory(), () -> synced.set(true));
+                newShard(shardRouting, indexMetadata.build(), null, s -> new InternalEngineFactory(), () -> synced.set(true));
         // add a replica
         recoverShardFromStore(primaryShard);
         final IndexShard replicaShard = newShard(shardId, false);
@@ -1892,7 +1892,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 shard.shardPath(),
                 shard.indexSettings().getIndexMetaData(),
                 wrapper,
-                new InternalEngineFactory(),
+                s -> new InternalEngineFactory(),
                 () -> {},
                 EMPTY_EVENT_LISTENER);
 
@@ -2044,7 +2044,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 shard.shardPath(),
                 shard.indexSettings().getIndexMetaData(),
                 wrapper,
-                new InternalEngineFactory(),
+                s -> new InternalEngineFactory(),
                 () -> {},
                 EMPTY_EVENT_LISTENER);
 
@@ -2529,7 +2529,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 .put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), randomFrom("false", "true", "checksum", "fix")))
             .build();
         final IndexShard newShard = newShard(shardRouting, indexShard.shardPath(), indexMetaData,
-            null, indexShard.engineFactory, indexShard.getGlobalCheckpointSyncer(), EMPTY_EVENT_LISTENER);
+            null, indexShard.engineFactoryFn, indexShard.getGlobalCheckpointSyncer(), EMPTY_EVENT_LISTENER);
 
         Store.MetadataSnapshot storeFileMetaDatas = newShard.snapshotStoreMetadata();
         assertTrue("at least 2 files, commit and data: " + storeFileMetaDatas.toString(), storeFileMetaDatas.size() > 1);
@@ -3029,8 +3029,8 @@ public class IndexShardTests extends IndexShardTestCase {
         ShardPath shardPath = new ShardPath(false, nodePath.resolve(shardId), nodePath.resolve(shardId), shardId);
         AtomicBoolean markedInactive = new AtomicBoolean();
         AtomicReference<IndexShard> primaryRef = new AtomicReference<>();
-        IndexShard primary = newShard(shardRouting, shardPath, metaData, null, new InternalEngineFactory(), () -> {
-        }, new IndexEventListener() {
+        IndexShard primary = newShard(shardRouting, shardPath, metaData, null,
+            s -> new InternalEngineFactory(), () -> { }, new IndexEventListener() {
             @Override
             public void onShardInactive(IndexShard indexShard) {
                 markedInactive.set(true);

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -105,7 +105,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
                     shard.shardPath(),
                     shard.indexSettings().getIndexMetaData(),
                     null,
-                    new InternalEngineFactory(),
+                    s -> new InternalEngineFactory(),
                     () -> {},
                     EMPTY_EVENT_LISTENER);
 

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -59,6 +59,7 @@ import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.InternalEngineFactory;
 import org.elasticsearch.index.seqno.GlobalCheckpointSyncAction;
@@ -160,8 +161,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                 primary ? RecoverySource.StoreRecoverySource.EMPTY_STORE_INSTANCE : RecoverySource.PeerRecoverySource.INSTANCE);
         }
 
-        protected EngineFactory getEngineFactory(ShardRouting routing) {
-            return new InternalEngineFactory();
+        protected Function<IndexSettings, EngineFactory> getEngineFactory(ShardRouting routing) {
+            return indexSettings -> new InternalEngineFactory();
         }
 
         public int indexDocs(final int numOfDoc) throws Exception {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherPluginTests.java
@@ -69,7 +69,7 @@ public class WatcherPluginTests extends ESTestCase {
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(Watch.INDEX, settings);
         AnalysisRegistry registry = new AnalysisRegistry(TestEnvironment.newEnvironment(settings), emptyMap(), emptyMap(), emptyMap(),
                 emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap());
-        IndexModule indexModule = new IndexModule(indexSettings, registry, new InternalEngineFactory());
+        IndexModule indexModule = new IndexModule(indexSettings, registry, s -> new InternalEngineFactory());
         // this will trip an assertion if the watcher indexing operation listener is null (which it is) but we try to add it
         watcher.onIndexModule(indexModule);
 


### PR DESCRIPTION
This commit changes the way that `EngineFactory`s are returned, instead of the
EngineFactory being set at time of shard creation, this changes the pluggability
so that an existing `IndexShard` can return a different engine factory depending
on dynamic index settings.

Relates to #31141
