### PR TITLE
Mention ip_range datatypes from ip type page

### DIFF
--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -36,6 +36,8 @@ GET my_index/_search
 // CONSOLE
 // TESTSETUP
 
+NOTE: you can also store ip ranges in a single field using an <<range,ip_range datatype>>.
+
 [[ip-params]]
 ==== Parameters for `ip` fields
 

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -36,7 +36,7 @@ GET my_index/_search
 // CONSOLE
 // TESTSETUP
 
-NOTE: you can also store ip ranges in a single field using an <<range,ip_range datatype>>.
+NOTE: You can also store ip ranges in a single field using an <<range,ip_range datatype>>.
 
 [[ip-params]]
 ==== Parameters for `ip` fields


### PR DESCRIPTION
A link to the ip_range datatype page provides a way for newer users to know it exists if they land directly on the ip datatype page first via a search.
