### PR TITLE
Preserve response headers on cluster update task

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -730,7 +730,7 @@ public class MasterService extends AbstractLifecycleComponent {
             return;
         }
         final ThreadContext threadContext = threadPool.getThreadContext();
-        final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(false);
+        final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.markAsSystemContext();
 


### PR DESCRIPTION
#31241 changed the cluster state update tasks to run under system context. The context wrapping did not preserve response headers, though. This has led to a test failure on 6.x #31408, as the deprecation warnings were not carried back anymore to the caller when creating an index. This cannot as easily be fixed because these response headers are generated on the execute method of the cluster state update thread (which could potentially be shared by multiple tasks). The general situation with the response headers looks a bit messy. For example, #23950 made sure to preserve the response headers when creating an index and updating settings for an index. The subsequent #25961 seems to have undone that for index creation (removing the wrapping of the action listener), but it looks like that did not break any tests?

In order to make #31241 less breaking and err on the side of caution, I've changed the restorable context supplier to preserve response headers.

Closes #31408
