### PR TITLE
[DOCS] Omit shard failures assertion for incompatible responses 

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -41,9 +41,11 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
 
     /**
      * Doc write operations start with an index name that cannot
-     * start with -, _ or + and must be lower case.
+     * start with -, _ or + and must be lower case and are followed
+     * by the doc type or doc Id. If the 2nd part of the path
+     * (after the '/') starts with a '_' then it is an API call.
      */
-    private static final Pattern DOCS_WRITE_OP_PATTERN = Pattern.compile("^[^_\\-\\+][a-z_-]+/");
+    private static final Pattern DOCS_WRITE_OP_PATTERN = Pattern.compile("^[^_\\-\\+][a-z_-]+/[^_]");
 
     @Input
     Map<String, String> setups = new HashMap()

--- a/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
+++ b/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.gradle.doc
 
-import static org.elasticsearch.gradle.doc.RestTestsFromSnippetsTask.isDocWriteRequest
+import static org.elasticsearch.gradle.doc.RestTestsFromSnippetsTask.shouldAddShardFailureCheck
 import static org.elasticsearch.gradle.doc.RestTestsFromSnippetsTask.replaceBlockQuote
 
 class RestTestFromSnippetsTaskTest extends GroovyTestCase {
@@ -47,9 +47,8 @@ class RestTestFromSnippetsTaskTest extends GroovyTestCase {
     }
 
     void testIsDocWriteRequest() {
-        assertTrue(isDocWriteRequest("doc-index/doc_id"));
-        assertTrue(isDocWriteRequest("doc_index/doc_type/doc_id"));
-        assertFalse(isDocWriteRequest("doc_index/_search"))
-        assertFalse(isDocWriteRequest("_xpack/ml/datafeeds/datafeed-id/_preview"));
+        assertTrue(shouldAddShardFailureCheck("doc-index/_search"));
+        assertFalse(shouldAddShardFailureCheck("_cat"))
+        assertFalse(shouldAddShardFailureCheck("_xpack/ml/datafeeds/datafeed-id/_preview"));
     }
 }

--- a/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
+++ b/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
@@ -49,7 +49,7 @@ class RestTestFromSnippetsTaskTest extends GroovyTestCase {
     void testIsDocWriteRequest() {
         assertTrue(isDocWriteRequest("doc-index/doc_id"));
         assertTrue(isDocWriteRequest("doc_index/doc_type/doc_id"));
-        assertFalse(isDocWriteRequest("doc_index"))
+        assertFalse(isDocWriteRequest("doc_index/_search"))
         assertFalse(isDocWriteRequest("_xpack/ml/datafeeds/datafeed-id/_preview"));
     }
 }

--- a/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
+++ b/buildSrc/src/test/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTaskTest.groovy
@@ -19,9 +19,7 @@
 
 package org.elasticsearch.gradle.doc
 
-import org.elasticsearch.gradle.doc.SnippetsTask.Snippet
-import org.gradle.api.InvalidUserDataException
-
+import static org.elasticsearch.gradle.doc.RestTestsFromSnippetsTask.isDocWriteRequest
 import static org.elasticsearch.gradle.doc.RestTestsFromSnippetsTask.replaceBlockQuote
 
 class RestTestFromSnippetsTaskTest extends GroovyTestCase {
@@ -46,5 +44,12 @@ class RestTestFromSnippetsTaskTest extends GroovyTestCase {
             replaceBlockQuote("\"foo\": \"\"\"bort\" baz\"\"\""));
         assertEquals("\"foo\": \"bort\\n baz\"",
             replaceBlockQuote("\"foo\": \"\"\"bort\n baz\"\"\""));
+    }
+
+    void testIsDocWriteRequest() {
+        assertTrue(isDocWriteRequest("doc-index/doc_id"));
+        assertTrue(isDocWriteRequest("doc_index/doc_type/doc_id"));
+        assertFalse(isDocWriteRequest("doc_index"))
+        assertFalse(isDocWriteRequest("_xpack/ml/datafeeds/datafeed-id/_preview"));
     }
 }


### PR DESCRIPTION
The failures in the docs snippet testing seen in #31339 [comment](https://github.com/elastic/elasticsearch/pull/31339#issuecomment-397609887) are due to the framework inserting the assertion `is_false: _shards.failures` which causes errors if the response is not a JSON object. 

The ml datafeed preview API does not return a JSON object and is excluded from the check.