### PR TITLE
Preserve response headers in MasterService#submitStateUpdateTasks

### DIFF
--- a/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/40_token_filters.yml
+++ b/modules/analysis-common/src/test/resources/rest-api-spec/test/analysis-common/40_token_filters.yml
@@ -1028,8 +1028,8 @@
 ---
 "delimited_payload_filter":
     - skip:
-        version: " - 6.99.99"
-        reason:  AwaitsFix, https://github.com/elastic/elasticsearch/issues/31422. delimited_payload_filter deprecated in 6.2, replaced by delimited_payload
+        version: " - 6.1.99"
+        reason: delimited_payload_filter deprecated in 6.2, replaced by delimited_payload
         features: "warnings"
 
     - do:

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -730,7 +730,7 @@ public class MasterService extends AbstractLifecycleComponent {
             return;
         }
         final ThreadContext threadContext = threadPool.getThreadContext();
-        final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(false);
+        final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(true);
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             threadContext.markAsSystemContext();
 


### PR DESCRIPTION
An integration test was expecting deprecation warnings in the rest
response headers which were missing suddenly after some change in MasterService
which had unexpected side effects. This change fixes this by preserving the
response headers of the thread context.

Closes #31422