### PR TITLE
[LookupRealm] Support for lookup realm

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Realm.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Realm.java
@@ -39,7 +39,6 @@ public abstract class Realm implements Comparable<Realm> {
         this.logger = config.logger(getClass());
     }
 
-
     /**
      * @return The type of this realm
      */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
@@ -11,12 +11,16 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class RealmConfig {
 
     final String name;
     final boolean enabled;
     final int order;
     private final String type;
+    private final Collection<String> lookupRealmNames;
     final Settings settings;
 
     private final Environment env;
@@ -33,8 +37,9 @@ public class RealmConfig {
         order = RealmSettings.ORDER_SETTING.get(settings);
         type = RealmSettings.TYPE_SETTING.get(settings);
         this.threadContext = threadContext;
+        this.lookupRealmNames = Collections.unmodifiableCollection(RealmSettings.LOOKUP_REALMS_SETTING.get(settings));
     }
-    
+
     public String name() {
         return name;
     }
@@ -42,13 +47,17 @@ public class RealmConfig {
     public boolean enabled() {
         return enabled;
     }
-    
+
     public int order() {
         return order;
     }
 
     public String type() {
         return type;
+    }
+
+    public Collection<String> lookupRealms() {
+        return lookupRealmNames;
     }
 
     public Settings settings() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.xpack.core.security.SecurityExtension;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -50,6 +51,8 @@ public class RealmSettings {
     static final Setting<String> TYPE_SETTING = Setting.simpleString("type", Setting.Property.NodeScope);
     static final Setting<Boolean> ENABLED_SETTING = Setting.boolSetting("enabled", true, Setting.Property.NodeScope);
     static final Setting<Integer> ORDER_SETTING = Setting.intSetting("order", Integer.MAX_VALUE, Setting.Property.NodeScope);
+    static final Setting<List<String>> LOOKUP_REALMS_SETTING =
+            Setting.listSetting("lookup_realms", Collections.emptyList(), Function.identity(), Setting.Property.NodeScope);
 
     /**
      * Add the {@link Setting} configuration for <em>all</em> realms to the provided list.
@@ -181,6 +184,7 @@ public class RealmSettings {
         settingSet.add(TYPE_SETTING);
         settingSet.add(ENABLED_SETTING);
         settingSet.add(ORDER_SETTING);
+        settingSet.add(LOOKUP_REALMS_SETTING);
         final AbstractScopedSettings validator = new AbstractScopedSettings(settings, settingSet, Setting.Property.NodeScope) { };
         try {
             validator.validate(settings, false);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/LookupRealmsAwareRealmTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/LookupRealmsAwareRealmTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.core.security.authc;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class LookupRealmsAwareRealmTests extends ESTestCase {
+    private ThreadPool threadPool;
+    private Realm realm;
+
+    @Before
+    public void setup() throws Exception {
+        threadPool = new TestThreadPool("lookup realms aware tests");
+        final RealmConfig realmConfig = mock(RealmConfig.class);
+        when(realmConfig.threadContext()).thenReturn(threadPool.getThreadContext());
+        realm = new DummyRealm(realmConfig);
+    }
+
+    @After
+    public void cleanup() throws InterruptedException {
+        terminate(threadPool);
+    }
+
+    public void testLookupUser() {
+        final PlainActionFuture<User> future = new PlainActionFuture<>();
+        realm.lookupUser(randomFrom("user1", "user2"), future);
+        assertThat(future.actionGet(), is(nullValue()));
+    }
+
+    public void testLookupUserUsingLookupRealms() {
+        final User user1 = new User("user1", "r1", "r2");
+        final User user2 = new User("user2", "r1");
+        final Realm lookupRealm1 = createDummyRealm("lookup-realm-1", user1, 0);
+        final Realm lookupRealm2 = createDummyRealm("lookup-realm-2", user2, 1);
+        final List<Realm> lookupRealms = Arrays.asList(lookupRealm1, lookupRealm2);
+        final List<String> realmNames = lookupRealms.stream().map((realm) -> realm.name()).collect(Collectors.toList());
+        when(realm.config.lookupRealms()).thenReturn(realmNames);
+        realm.setLookupRealms(lookupRealms);
+
+        final PlainActionFuture<User> future = new PlainActionFuture<>();
+        final User usr = randomFrom(user1, user2);
+        realm.lookupUser(usr.principal(), future);
+        assertThat(future.actionGet(), is(notNullValue()));
+        assertThat(future.actionGet(), is(sameInstance(usr)));
+    }
+
+    public void testLookupUserUsingLookupRealmsInOrderOfLookupRealms() {
+        final User user1 = new User("user1", "r1", "r2");
+        final User user2 = new User("user1", "r1");
+        final Realm lookupRealm1 = createDummyRealm("lookup-realm-1", user1, 1);
+        final Realm lookupRealm2 = createDummyRealm("lookup-realm-2", user2, 0);
+        Realm[] realms = new Realm[] { lookupRealm1, lookupRealm2 };
+        Arrays.sort(realms);
+        final List<Realm> lookupRealms = Arrays.asList(realms);
+        final List<String> realmNames = lookupRealms.stream().map((realm) -> realm.name()).collect(Collectors.toList());
+        when(realm.config.lookupRealms()).thenReturn(realmNames);
+        realm.setLookupRealms(lookupRealms);
+        final PlainActionFuture<User> future = new PlainActionFuture<>();
+
+        realm.lookupUser("user1", future);
+
+        assertThat(future.actionGet(), is(notNullValue()));
+        assertThat(future.actionGet(), is(sameInstance(user2)));
+    }
+
+    public void testSetLookupRealmsWithNullOrEmptyLookupRealmsButConfigSpecifiesLookupRealmDepenency() {
+        final List<Realm> lookupRealms = randomBoolean() ? null : Collections.emptyList();
+        when(realm.config.lookupRealms()).thenReturn(Arrays.asList(new String[] { randomAlphaOfLength(5) }));
+        assertThat(realm.hasLookupDependency(), is(true));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> realm.setLookupRealms(lookupRealms));
+        assertThat(e.getMessage(),
+                is(equalTo("list of injected lookup realms is null or empty whereas realm config has lookup realms dependencies as : "
+                        + realm.config.lookupRealms())));
+    }
+
+    public void testLookupUserUsingNullOrEmptyLookupRealms() {
+        final List<Realm> lookupRealms = randomBoolean() ? null : Collections.emptyList();
+        realm.setLookupRealms(lookupRealms);
+        final PlainActionFuture<User> future = new PlainActionFuture<>();
+
+        realm.lookupUser("user1", future);
+
+        assertThat(future.actionGet(), is(nullValue()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Realm createDummyRealm(final String realmName, final User user, int order) {
+        final RealmConfig realmConfig = mock(RealmConfig.class);
+        when(realmConfig.name()).thenReturn(realmName);
+        when(realmConfig.enabled()).thenReturn(true);
+        when(realmConfig.order()).thenReturn(order);
+        final Realm lookupRealm = spy(new DummyRealm(realmConfig));
+        Mockito.doAnswer(invocation -> {
+            final String username = (String) invocation.getArguments()[0];
+            final ActionListener<User> listener = (ActionListener<User>) invocation.getArguments()[1];
+            if (username.equals(user.principal())) {
+                listener.onResponse(user);
+            } else {
+                listener.onResponse(null);
+            }
+            return null;
+        }).when(lookupRealm).lookupUser(any(String.class), any(ActionListener.class));
+        return lookupRealm;
+    }
+
+    private static class DummyRealm extends Realm {
+        DummyRealm(RealmConfig realmConfig) {
+            super("type-2", realmConfig);
+        }
+
+        @Override
+        public boolean supports(AuthenticationToken token) {
+            return false;
+        }
+
+        @Override
+        public AuthenticationToken token(ThreadContext context) {
+            return null;
+        }
+
+        @Override
+        public void authenticate(AuthenticationToken token, ActionListener<AuthenticationResult> listener) {
+        }
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/RealmConfigBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/RealmConfigBootstrapCheck.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.bootstrap.BootstrapCheck;
+import org.elasticsearch.bootstrap.BootstrapContext;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.security.SecurityExtension;
+import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.authc.RealmConfig;
+import org.elasticsearch.xpack.core.security.authc.RealmSettings;
+import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
+import org.elasticsearch.xpack.security.authc.InternalRealms;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Performs bootstrap checks required across security realms using realm
+ * configuration.<br>
+ * The checks also run for realms provided by security extensions.<br>
+ * Not all checks could be performed with bootstrap check, the kind of checks
+ * performed are like invalid/missing types, allowed no of instances for realm
+ * type or lookup realms validation.
+ */
+public class RealmConfigBootstrapCheck implements BootstrapCheck {
+    private static final Logger LOGGER = Loggers.getLogger(RealmConfigBootstrapCheck.class);
+
+    private final List<SecurityExtension> securityExtensions;
+
+    public RealmConfigBootstrapCheck(final List<SecurityExtension> securityExtensions) {
+        this.securityExtensions = Collections.unmodifiableList(securityExtensions);
+    }
+
+    @Override
+    public BootstrapCheckResult check(BootstrapContext context) {
+        BootstrapCheckResult result = BootstrapCheckResult.success();
+        final ThreadPool threadPool = new ThreadPool(context.settings);
+        try (ResourceWatcherService watcherService = new ResourceWatcherService(context.settings, threadPool)) {
+            final Map<String, Realm.Factory> extensionsRealmTypes = new HashMap<>();
+            securityExtensions.stream().forEach(e -> extensionsRealmTypes.putAll(e.getRealms(watcherService)));
+
+            final Settings realmsSettings = RealmSettings.get(context.settings);
+            final Map<String, RealmConfig> realmConfigByName = new HashMap<>();
+            final Set<String> registeredRealmTypes = new HashSet<>();
+            final Set<String> internalRealmTypes = new HashSet<>();
+            final Set<String> realmNamesUsedAsLookups = new HashSet<>();
+            final Set<String> candidateLookupRealms = new HashSet<>();
+            for (String name : realmsSettings.names()) {
+                final RealmConfig config = createRealmConfig(extensionsRealmTypes, realmsSettings, name, context, internalRealmTypes,
+                        registeredRealmTypes, threadPool);
+                if (config == null) {
+                    continue;
+                }
+                realmConfigByName.put(name, config);
+                if (config.lookupRealms().isEmpty()) {
+                    candidateLookupRealms.add(config.name());
+                }
+                realmNamesUsedAsLookups.addAll(config.lookupRealms());
+            }
+
+            realmNamesUsedAsLookups.stream().forEach(realmName -> {
+                if (realmConfigByName.containsKey(realmName) == false) {
+                    throw new IllegalArgumentException(realmName + " used as lookup realm does not exist or is disabled");
+                }
+                if (candidateLookupRealms.contains(realmName) == false) {
+                    throw new IllegalArgumentException(realmName + " used as lookup realm is itself dependent on other realms for lookup");
+                }
+            });
+        } catch (Exception e) {
+            result = BootstrapCheckResult.failure(e.getMessage());
+        } finally {
+            try {
+                threadPool.close();
+            } catch (IOException e) {
+                LOGGER.debug("Exception occurred while closing thread pool", e);
+            }
+            threadPool.shutdown();
+            boolean cleanShutDown = false;
+            try {
+                cleanShutDown = threadPool.awaitTermination(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                LOGGER.debug("Timeout while waiting for thread pool clean shutdown", e);
+            }
+            if (cleanShutDown == false) {
+                threadPool.shutdownNow();
+            }
+        }
+        return result;
+    }
+
+    private RealmConfig createRealmConfig(final Map<String, Realm.Factory> extensionsRealmTypes, final Settings realmsSettings,
+            final String name, final BootstrapContext context, final Set<String> internalRealmTypes, final Set<String> registeredRealmTypes,
+            ThreadPool threadPool) throws Exception {
+        final Settings realmSettings = realmsSettings.getAsSettings(name);
+        final String type = realmSettings.get("type");
+        if (Strings.isNullOrEmpty(type)) {
+            throw new IllegalArgumentException("missing realm type for [" + name + "] realm");
+        }
+        final boolean isInternalRealmType = InternalRealms.TYPE_REALM_CLASS_REGISTRY.get(type) != null;
+        if (isInternalRealmType == false && extensionsRealmTypes.get(type) == null) {
+            throw new IllegalArgumentException("unknown realm type [" + type + "] set for realm [" + name + "]");
+        }
+        final RealmConfig config = new RealmConfig(name, realmSettings, context.settings, null, threadPool.getThreadContext());
+        if (!config.enabled()) {
+            LOGGER.debug("realm [{}/{}] is disabled", type, name);
+            return null;
+        }
+        if (FileRealmSettings.TYPE.equals(type) || NativeRealmSettings.TYPE.equals(type)) {
+            // this is an internal realm factory, let's make sure we didn't already
+            // registered one (there can only be one instance of an internal realm)
+            if (internalRealmTypes.contains(type)) {
+                throw new IllegalArgumentException("multiple [" + type + "] realms are configured. [" + type
+                        + "] is an internal realm and therefore there can only be one such realm configured");
+            }
+            internalRealmTypes.add(type);
+        }
+        registeredRealmTypes.add(type);
+
+        return config;
+    }
+
+    @Override
+    public boolean alwaysEnforce() {
+        return true;
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -277,13 +277,14 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
         if (enabled && transportClientMode == false) {
             validateAutoCreateIndex(settings);
         }
-
+        this.securityExtensions.addAll(extensions);
         if (enabled) {
             // we load them all here otherwise we can't access secure settings since they are closed once the checks are
             // fetched
             final List<BootstrapCheck> checks = new ArrayList<>();
             checks.addAll(Arrays.asList(
                     new TokenSSLBootstrapCheck(),
+                    new RealmConfigBootstrapCheck(securityExtensions),
                     new PkiRealmBootstrapCheck(settings, getSslService()),
                     new TLSLicenseBootstrapCheck()));
             checks.addAll(InternalRealms.getBootstrapChecks(settings, env));
@@ -291,7 +292,6 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
         } else {
             this.bootstrapChecks = Collections.emptyList();
         }
-        this.securityExtensions.addAll(extensions);
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * An authentication service that delegates the authentication process to its configured {@link Realm realms}.
@@ -379,7 +380,8 @@ public class AuthenticationService extends AbstractComponent {
          * names of users that exist using a timing attack
          */
         private void lookupRunAsUser(final User user, String runAsUsername, Consumer<User> userConsumer) {
-            final List<Realm> realmsList = realms.asList();
+            final List<Realm> realmsList =
+                    realms.asList().stream().filter((realm) -> realm.hasLookupDependency() == false).collect(Collectors.toList());
             final BiConsumer<Realm, ActionListener<User>> realmLookupConsumer = (realm, lookupUserListener) ->
                     realm.lookupUser(runAsUsername, ActionListener.wrap((lookedupUser) -> {
                         if (lookedupUser != null) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
@@ -32,10 +32,8 @@ import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingSt
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,13 +45,24 @@ import java.util.Set;
  */
 public final class InternalRealms {
 
+    public static final Map<String, Class<? extends Realm>> TYPE_REALM_CLASS_REGISTRY;
+    static {
+        Map<String, Class<? extends Realm>> map = new HashMap<>();
+        map.put(ReservedRealm.TYPE, ReservedRealm.class);
+        map.put(NativeRealmSettings.TYPE, NativeRealm.class);
+        map.put(FileRealmSettings.TYPE, FileRealm.class);
+        map.put(LdapRealmSettings.AD_TYPE, LdapRealm.class);
+        map.put(LdapRealmSettings.LDAP_TYPE, LdapRealm.class);
+        map.put(SamlRealmSettings.TYPE, SamlRealm.class);
+        map.put(PkiRealmSettings.TYPE, PkiRealm.class);
+        TYPE_REALM_CLASS_REGISTRY = Collections.unmodifiableMap(map);
+    }
+
     /**
      * The list of all <em>internal</em> realm types, excluding {@link ReservedRealm#TYPE}.
      */
-    private static final Set<String> XPACK_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            NativeRealmSettings.TYPE, FileRealmSettings.TYPE, LdapRealmSettings.AD_TYPE, LdapRealmSettings.LDAP_TYPE, PkiRealmSettings.TYPE,
-            SamlRealmSettings.TYPE
-    )));
+    private static final Set<String> XPACK_TYPES =
+            Collections.unmodifiableSet(Sets.difference(TYPE_REALM_CLASS_REGISTRY.keySet(), Collections.singleton(ReservedRealm.TYPE)));
 
     /**
      * The list of all standard realm types, which are those provided by x-pack and do not have extensive

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/RealmConfigBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/RealmConfigBootstrapCheckTests.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security;
+
+import org.elasticsearch.bootstrap.BootstrapCheck;
+import org.elasticsearch.bootstrap.BootstrapContext;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.security.SecurityExtension;
+import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.ldap.LdapRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.pki.PkiRealmSettings;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;;
+
+public class RealmConfigBootstrapCheckTests extends ESTestCase {
+    private Settings.Builder builder;
+
+    @Before
+    public void setup() {
+        builder = Settings.builder();
+        builder.put("path.home", createTempDir());
+        builder.put("node.name", randomAlphaOfLength(5));
+    }
+
+    public void testRealmsNoErrors() throws Exception {
+        withRealm(PkiRealmSettings.TYPE, randomInt(5), builder);
+        withRealm(FileRealmSettings.TYPE, 1, builder);
+        withRealm(NativeRealmSettings.TYPE, 1, builder);
+        assertThat(runCheck(builder.build()).isSuccess(), is(true));
+    }
+
+    public void testRealmsWithMultipleInternalRealmsConfiguredFailingBootstrapCheck() throws Exception {
+        withRealm(PkiRealmSettings.TYPE, 2, builder);
+        withRealm(FileRealmSettings.TYPE, 2, builder);
+        withRealm(NativeRealmSettings.TYPE, 1, builder);
+        final BootstrapCheck.BootstrapCheckResult result = runCheck(builder.build());
+        assertThat(result.isFailure(), is(true));
+        assertThat(result.getMessage(), equalTo("multiple [" + FileRealmSettings.TYPE + "] realms are configured. ["
+                + FileRealmSettings.TYPE + "] is an internal realm and therefore there can only be one such realm configured"));
+    }
+
+    public void testRealmsWithEmptyTypeConfiguredFailingBootstrapCheck() throws Exception {
+        withRealm(PkiRealmSettings.TYPE, 2, builder);
+        withRealm(FileRealmSettings.TYPE, 1, builder);
+        withRealm(NativeRealmSettings.TYPE, 1, builder);
+        final String name = randomAlphaOfLength(4);
+        builder.put("xpack.security.authc.realms." + name + ".type", "");
+        final BootstrapCheck.BootstrapCheckResult result = runCheck(builder.build());
+        assertThat(result.isFailure(), is(true));
+        assertThat(result.getMessage(), equalTo("missing realm type for [" + name + "] realm"));
+    }
+
+    public void testLookupAwareRealmDependingOnLookupRealms() throws Exception {
+        withRealm(FileRealmSettings.TYPE, 1, builder);
+        final String ldapRealmName = randomAlphaOfLength(5);
+        withRealm(LdapRealmSettings.LDAP_TYPE, ldapRealmName, builder);
+        final String dummyLookupAwareRealmName = "dlrar-" + randomAlphaOfLength(5);
+        withRealm(DummySecurityExtension.DLRAR_TYPE, dummyLookupAwareRealmName, builder, new String[] { ldapRealmName });
+        final String pkiRealmName = "pki-" + randomAlphaOfLength(5);
+        withRealm(PkiRealmSettings.TYPE, pkiRealmName, builder, new String[] { ldapRealmName });
+        final BootstrapCheck.BootstrapCheckResult result = runCheck(builder.build());
+
+        assertThat(result.isSuccess(), is(true));
+    }
+
+    public void testLookupAwareRealmDependingOnNonExistingOrDisabledRealms() throws Exception {
+        withRealm(FileRealmSettings.TYPE, 1, builder);
+        final String ldapRealmName = randomAlphaOfLength(5);
+        final boolean nonexisting = randomBoolean();
+        if (nonexisting == false) {
+            withRealm(LdapRealmSettings.LDAP_TYPE, ldapRealmName, builder, false);
+        }
+        final String pkiRealmName = "pki-" + randomAlphaOfLength(5);
+        withRealm(PkiRealmSettings.TYPE, pkiRealmName, builder, new String[] { ldapRealmName });
+        final BootstrapCheck.BootstrapCheckResult result = runCheck(builder.build());
+
+        assertThat(result.isFailure(), is(true));
+        assertThat(result.getMessage(), equalTo(ldapRealmName + " used as lookup realm does not exist or is disabled"));
+    }
+
+    public void testLookupAwareRealmDependingAnotherLookupAwareRealm() throws Exception {
+        withRealm(FileRealmSettings.TYPE, 1, builder);
+        final String ldapRealmName = randomAlphaOfLength(5);
+        withRealm(LdapRealmSettings.LDAP_TYPE, ldapRealmName, builder);
+        final String dummyLookupAwareRealmName = "dlrar-" + randomAlphaOfLength(5);
+        withRealm(DummySecurityExtension.DLRAR_TYPE, dummyLookupAwareRealmName, builder, new String[] { ldapRealmName });
+        final String pkiRealmName = "pki-" + randomAlphaOfLength(5);
+        withRealm(PkiRealmSettings.TYPE, pkiRealmName, builder, new String[] { dummyLookupAwareRealmName });
+        final BootstrapCheck.BootstrapCheckResult result = runCheck(builder.build());
+
+        assertThat(result.isFailure(), is(true));
+        assertThat(result.getMessage(),
+                equalTo(dummyLookupAwareRealmName + " used as lookup realm is itself dependent on other realms for lookup"));
+    }
+
+    public void testRealmsWithUnknownTypeConfiguredFailingBootstrapCheck() throws Exception {
+        withRealm(PkiRealmSettings.TYPE, 2, builder);
+        withRealm(FileRealmSettings.TYPE, 1, builder);
+        final String name = randomAlphaOfLength(4);
+        final String type = randomAlphaOfLength(5);
+        builder.put("xpack.security.authc.realms." + name + ".type", type);
+        final BootstrapCheck.BootstrapCheckResult result = runCheck(builder.build());
+        assertThat(result.isFailure(), is(true));
+        assertThat(result.getMessage(), equalTo("unknown realm type [" + type + "] set for realm [" + name + "]"));
+    }
+
+    private static void withRealm(String type, int instances, Settings.Builder builder) {
+        for (int i = 0; i < instances; i++) {
+            withRealm(type, randomAlphaOfLength(4), builder);
+        }
+    }
+
+    private static void withRealm(String type, String realmName, Settings.Builder builder, String... lookupRealms) {
+        withRealm(type, realmName, builder, true, lookupRealms);
+    }
+
+    private static void withRealm(String type, String realmName, Settings.Builder builder, Boolean enabled, String... lookupRealms) {
+        builder.put("xpack.security.authc.realms." + realmName + ".type", type);
+        if (lookupRealms != null) {
+            builder.put("xpack.security.authc.realms." + realmName + ".lookup_realms", Strings.arrayToCommaDelimitedString(lookupRealms));
+        }
+        if (enabled != null) {
+            builder.put("xpack.security.authc.realms." + realmName + ".enabled", Boolean.toString(enabled));
+        }
+    }
+
+    private BootstrapCheck.BootstrapCheckResult runCheck(Settings settings) throws Exception {
+        final List<SecurityExtension> securityExtensions = new ArrayList<>();
+        securityExtensions.add(new DummySecurityExtension());
+        return new RealmConfigBootstrapCheck(securityExtensions).check(new BootstrapContext(settings, null));
+    }
+
+    private static class DummySecurityExtension implements SecurityExtension {
+        static final String DLRAR_TYPE = "DLRAR";
+
+        @Override
+        public Map<String, Realm.Factory> getRealms(ResourceWatcherService resourceWatcherService) {
+            final Map<String, Realm.Factory> realmsFactory = new HashMap<>();
+            realmsFactory.put(DLRAR_TYPE, (config) -> {
+                Realm dummyLookupRealmsAwareRealm = mock(Realm.class);
+                when(dummyLookupRealmsAwareRealm.type()).thenReturn(DLRAR_TYPE);
+                return dummyLookupRealmsAwareRealm;
+            });
+            return realmsFactory;
+        }
+    }
+}


### PR DESCRIPTION
There are times where authentication is performed by
an identity server but for user details, one might want to
use external authorization server to fetch details like group
information, user metadata etc.
In our case, we have a chain of authentication realms which handle
authentication and creation of `User` with roles and metadata
information.
Use case: We want to do authentication using a realm
but query users in another realm connecting to external servers.
For eg., `PkiRealm` authenticates users based on the client
presented certificate. In turn, the identified username could be used
to query group information from an external LDAP server.

This commit adds support to specify lookup realms via configuration.
We already have `lookupUser` support and this implementation makes use
of it. Introduced a new configuration `lookup_realms` that is used to
specify list of realm names for lookup. This makes realm a lookup
realms aware realm.

Lookup Realm: Any realm which does not depend on other realms for user
lookup

LookupRealm Aware realms: Realms which depend on other realms for user
lookup, driven by configuration `lookup_realms`

Based on this configuration, we inject lookup realm dependencies in the
constructed realms.

`Realm` now has a default implementation for `lookupUser` where we
iterate over lookup realms to find user.

This change also adds RealmConfigBootstrapCheck for validating realm
config settings including checks for `lookup_realms`. Thing to
note here is _Creation of few objects like `ThreadPool`,
`WatcherResourceService` as they were required but not sure if this would
be of any problem like if they need not be created outside lifecycle service._

Next PR: for making PKI realm depend on other realms for user lookup as an
example lookup realms usage.

Closes #31267