### PR TITLE
[ML] Add ML filter update API

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -84,6 +84,7 @@ import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateCalendarJobAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateFilterAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateProcessAction;
@@ -220,6 +221,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 OpenJobAction.INSTANCE,
                 GetFiltersAction.INSTANCE,
                 PutFilterAction.INSTANCE,
+                UpdateFilterAction.INSTANCE,
                 DeleteFilterAction.INSTANCE,
                 KillProcessAction.INSTANCE,
                 GetBucketsAction.INSTANCE,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.action.Action;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.client.ElasticsearchClient;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+
+public class UpdateFilterAction extends Action<PutFilterAction.Response> {
+
+    public static final UpdateFilterAction INSTANCE = new UpdateFilterAction();
+    public static final String NAME = "cluster:admin/xpack/ml/filters/update";
+
+    private UpdateFilterAction() {
+        super(NAME);
+    }
+
+    @Override
+    public PutFilterAction.Response newResponse() {
+        return new PutFilterAction.Response();
+    }
+
+    public static class Request extends ActionRequest implements ToXContentObject {
+
+        public static final ParseField ADD_ITEMS = new ParseField("add_items");
+        public static final ParseField REMOVE_ITEMS = new ParseField("remove_items");
+
+        private static final ObjectParser<Request, Void> PARSER = new ObjectParser<>(NAME, Request::new);
+
+        static {
+            PARSER.declareString((request, filterId) -> request.filterId = filterId, MlFilter.ID);
+            PARSER.declareStringOrNull(Request::setDescription, MlFilter.DESCRIPTION);
+            PARSER.declareStringArray(Request::setAddItems, ADD_ITEMS);
+            PARSER.declareStringArray(Request::setRemoveItems, REMOVE_ITEMS);
+        }
+
+        public static Request parseRequest(String filterId, XContentParser parser) {
+            Request request = PARSER.apply(parser, null);
+            if (request.filterId == null) {
+                request.filterId = filterId;
+            } else if (!Strings.isNullOrEmpty(filterId) && !filterId.equals(request.filterId)) {
+                // If we have both URI and body filter ID, they must be identical
+                throw new IllegalArgumentException(Messages.getMessage(Messages.INCONSISTENT_ID, MlFilter.ID.getPreferredName(),
+                        request.filterId, filterId));
+            }
+            return request;
+        }
+
+        private String filterId;
+        @Nullable
+        private String description;
+        private SortedSet<String> addItems = Collections.emptySortedSet();
+        private SortedSet<String> removeItems = Collections.emptySortedSet();
+
+        public Request() {
+        }
+
+        public Request(String filterId) {
+            this.filterId = ExceptionsHelper.requireNonNull(filterId, MlFilter.ID.getPreferredName());
+        }
+
+        public String getFilterId() {
+            return filterId;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public SortedSet<String> getAddItems() {
+            return addItems;
+        }
+
+        public void setAddItems(Collection<String> addItems) {
+            ExceptionsHelper.requireNonNull(addItems, ADD_ITEMS.getPreferredName());
+            this.addItems = new TreeSet<>();
+            this.addItems.addAll(addItems);
+        }
+
+        public SortedSet<String> getRemoveItems() {
+            return removeItems;
+        }
+
+        public void setRemoveItems(Collection<String> removeItems) {
+            ExceptionsHelper.requireNonNull(removeItems, REMOVE_ITEMS.getPreferredName());
+            this.removeItems = new TreeSet<>();
+            this.removeItems.addAll(removeItems);
+        }
+
+        public boolean isNoop() {
+            return description == null && addItems.isEmpty() && removeItems.isEmpty();
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+            super.readFrom(in);
+            filterId = in.readString();
+            description = in.readOptionalString();
+            addItems = new TreeSet<>();
+            addItems.addAll(Arrays.asList(in.readStringArray()));
+            removeItems = new TreeSet<>();
+            removeItems.addAll(Arrays.asList(in.readStringArray()));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(filterId);
+            out.writeOptionalString(description);
+            out.writeStringArray(addItems.toArray(new String[addItems.size()]));
+            out.writeStringArray(removeItems.toArray(new String[removeItems.size()]));
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field(MlFilter.ID.getPreferredName(), filterId);
+            if (description != null) {
+                builder.field(MlFilter.DESCRIPTION.getPreferredName(), description);
+            }
+            if (addItems.isEmpty() == false) {
+                builder.field(ADD_ITEMS.getPreferredName(), addItems);
+            }
+            if (removeItems.isEmpty() == false) {
+                builder.field(REMOVE_ITEMS.getPreferredName(), removeItems);
+            }
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(filterId, description, addItems, removeItems);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Request other = (Request) obj;
+            return Objects.equals(filterId, other.filterId)
+                    && Objects.equals(description, other.description)
+                    && Objects.equals(addItems, other.addItems)
+                    && Objects.equals(removeItems, other.removeItems);
+        }
+    }
+
+    public static class RequestBuilder extends ActionRequestBuilder<Request, PutFilterAction.Response> {
+
+        public RequestBuilder(ElasticsearchClient client) {
+            super(client, INSTANCE, new Request());
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterAction.java
@@ -102,9 +102,7 @@ public class UpdateFilterAction extends Action<PutFilterAction.Response> {
         }
 
         public void setAddItems(Collection<String> addItems) {
-            ExceptionsHelper.requireNonNull(addItems, ADD_ITEMS.getPreferredName());
-            this.addItems = new TreeSet<>();
-            this.addItems.addAll(addItems);
+            this.addItems = new TreeSet<>(ExceptionsHelper.requireNonNull(addItems, ADD_ITEMS.getPreferredName()));
         }
 
         public SortedSet<String> getRemoveItems() {
@@ -112,9 +110,7 @@ public class UpdateFilterAction extends Action<PutFilterAction.Response> {
         }
 
         public void setRemoveItems(Collection<String> removeItems) {
-            ExceptionsHelper.requireNonNull(removeItems, REMOVE_ITEMS.getPreferredName());
-            this.removeItems = new TreeSet<>();
-            this.removeItems.addAll(removeItems);
+            this.removeItems = new TreeSet<>(ExceptionsHelper.requireNonNull(removeItems, REMOVE_ITEMS.getPreferredName()));
         }
 
         public boolean isNoop() {
@@ -131,10 +127,8 @@ public class UpdateFilterAction extends Action<PutFilterAction.Response> {
             super.readFrom(in);
             filterId = in.readString();
             description = in.readOptionalString();
-            addItems = new TreeSet<>();
-            addItems.addAll(Arrays.asList(in.readStringArray()));
-            removeItems = new TreeSet<>();
-            removeItems.addAll(Arrays.asList(in.readStringArray()));
+            addItems = new TreeSet<>(Arrays.asList(in.readStringArray()));
+            removeItems = new TreeSet<>(Arrays.asList(in.readStringArray()));
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/MlFilter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/MlFilter.java
@@ -56,7 +56,7 @@ public class MlFilter implements ToXContentObject, Writeable {
     private final String description;
     private final SortedSet<String> items;
 
-    public MlFilter(String id, String description, SortedSet<String> items) {
+    private MlFilter(String id, String description, SortedSet<String> items) {
         this.id = Objects.requireNonNull(id, ID.getPreferredName() + " must not be null");
         this.description = description;
         this.items = Objects.requireNonNull(items, ITEMS.getPreferredName() + " must not be null");
@@ -160,6 +160,11 @@ public class MlFilter implements ToXContentObject, Writeable {
 
         public Builder setDescription(String description) {
             this.description = description;
+            return this;
+        }
+
+        public Builder setItems(SortedSet<String> items) {
+            this.items = items;
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/MlFilter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/MlFilter.java
@@ -69,8 +69,7 @@ public class MlFilter implements ToXContentObject, Writeable {
         } else {
             description = null;
         }
-        items = new TreeSet<>();
-        items.addAll(Arrays.asList(in.readStringArray()));
+        items = new TreeSet<>(Arrays.asList(in.readStringArray()));
     }
 
     @Override
@@ -169,8 +168,7 @@ public class MlFilter implements ToXContentObject, Writeable {
         }
 
         public Builder setItems(List<String> items) {
-            this.items = new TreeSet<>();
-            this.items.addAll(items);
+            this.items = new TreeSet<>(items);
             return this;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -42,6 +42,8 @@ public final class Messages {
     public static final String DATAFEED_FREQUENCY_MUST_BE_MULTIPLE_OF_AGGREGATIONS_INTERVAL =
             "Datafeed frequency [{0}] must be a multiple of the aggregation interval [{1}]";
 
+    public static final String FILTER_NOT_FOUND = "No filter with id [{0}] exists";
+
     public static final String INCONSISTENT_ID =
             "Inconsistent {0}; ''{1}'' specified in the body differs from ''{2}'' specified as a URL argument";
     public static final String INVALID_ID = "Invalid {0}; ''{1}'' can contain lowercase alphanumeric (a-z and 0-9), hyphens or " +

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSnapshot.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSnapshot.java
@@ -19,9 +19,9 @@ import org.elasticsearch.common.xcontent.ObjectParser.ValueType;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.utils.time.TimeUtils;
 
@@ -345,7 +345,7 @@ public class ModelSnapshot implements ToXContentObject, Writeable {
 
     public static ModelSnapshot fromJson(BytesReference bytesReference) {
         try (InputStream stream = bytesReference.streamInput();
-             XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(bytesReference))
+             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                 .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
             return LENIENT_PARSER.apply(parser, null).build();
         } catch (IOException e) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
@@ -38,6 +38,10 @@ public class ExceptionsHelper {
         return new ElasticsearchException(msg, cause);
     }
 
+    public static ElasticsearchStatusException conflictStatusException(String msg, Throwable cause, Object... args) {
+        return new ElasticsearchStatusException(msg, RestStatus.CONFLICT, cause, args);
+    }
+
     public static ElasticsearchStatusException conflictStatusException(String msg, Object... args) {
         return new ElasticsearchStatusException(msg, RestStatus.CONFLICT, args);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/UpdateFilterActionRequestTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractStreamableXContentTestCase;
+import org.elasticsearch.xpack.core.ml.action.UpdateFilterAction.Request;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class UpdateFilterActionRequestTests extends AbstractStreamableXContentTestCase<Request> {
+
+    private String filterId = randomAlphaOfLength(20);
+
+    @Override
+    protected Request createTestInstance() {
+        UpdateFilterAction.Request request = new UpdateFilterAction.Request(filterId);
+        if (randomBoolean()) {
+            request.setDescription(randomAlphaOfLength(20));
+        }
+        if (randomBoolean()) {
+            request.setAddItems(generateRandomStrings());
+        }
+        if (randomBoolean()) {
+            request.setRemoveItems(generateRandomStrings());
+        }
+        return request;
+    }
+
+    private static Collection<String> generateRandomStrings() {
+        int size = randomIntBetween(0, 10);
+        List<String> strings = new ArrayList<>(size);
+        for (int i = 0; i < size; ++i) {
+            strings.add(randomAlphaOfLength(20));
+        }
+        return strings;
+    }
+
+    @Override
+    protected boolean supportsUnknownFields() {
+        return false;
+    }
+
+    @Override
+    protected Request createBlankInstance() {
+        return new Request();
+    }
+
+    @Override
+    protected Request doParseInstance(XContentParser parser) {
+        return Request.parseRequest(filterId, parser);
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/MlFilterTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/MlFilterTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 
 import java.io.IOException;
+import java.util.SortedSet;
 import java.util.TreeSet;
 
 import static org.hamcrest.Matchers.contains;
@@ -43,7 +44,7 @@ public class MlFilterTests extends AbstractSerializingTestCase<MlFilter> {
         for (int i = 0; i < size; i++) {
             items.add(randomAlphaOfLengthBetween(1, 20));
         }
-        return new MlFilter(filterId, description, items);
+        return MlFilter.builder(filterId).setDescription(description).setItems(items).build();
     }
 
     @Override
@@ -57,13 +58,13 @@ public class MlFilterTests extends AbstractSerializingTestCase<MlFilter> {
     }
 
     public void testNullId() {
-        NullPointerException ex = expectThrows(NullPointerException.class, () -> new MlFilter(null, "", new TreeSet<>()));
+        NullPointerException ex = expectThrows(NullPointerException.class, () -> MlFilter.builder(null).build());
         assertEquals(MlFilter.ID.getPreferredName() + " must not be null", ex.getMessage());
     }
 
     public void testNullItems() {
-        NullPointerException ex =
-                expectThrows(NullPointerException.class, () -> new MlFilter(randomAlphaOfLengthBetween(1, 20), "", null));
+        NullPointerException ex = expectThrows(NullPointerException.class,
+                () -> MlFilter.builder(randomAlphaOfLength(20)).setItems((SortedSet<String>) null).build());
         assertEquals(MlFilter.ITEMS.getPreferredName() + " must not be null", ex.getMessage());
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -97,6 +97,7 @@ import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.StopDatafeedAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateCalendarJobAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateDatafeedAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateFilterAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateProcessAction;
@@ -148,6 +149,7 @@ import org.elasticsearch.xpack.ml.action.TransportStartDatafeedAction;
 import org.elasticsearch.xpack.ml.action.TransportStopDatafeedAction;
 import org.elasticsearch.xpack.ml.action.TransportUpdateCalendarJobAction;
 import org.elasticsearch.xpack.ml.action.TransportUpdateDatafeedAction;
+import org.elasticsearch.xpack.ml.action.TransportUpdateFilterAction;
 import org.elasticsearch.xpack.ml.action.TransportUpdateJobAction;
 import org.elasticsearch.xpack.ml.action.TransportUpdateModelSnapshotAction;
 import org.elasticsearch.xpack.ml.action.TransportUpdateProcessAction;
@@ -196,6 +198,7 @@ import org.elasticsearch.xpack.ml.rest.datafeeds.RestUpdateDatafeedAction;
 import org.elasticsearch.xpack.ml.rest.filter.RestDeleteFilterAction;
 import org.elasticsearch.xpack.ml.rest.filter.RestGetFiltersAction;
 import org.elasticsearch.xpack.ml.rest.filter.RestPutFilterAction;
+import org.elasticsearch.xpack.ml.rest.filter.RestUpdateFilterAction;
 import org.elasticsearch.xpack.ml.rest.job.RestCloseJobAction;
 import org.elasticsearch.xpack.ml.rest.job.RestDeleteJobAction;
 import org.elasticsearch.xpack.ml.rest.job.RestFlushJobAction;
@@ -460,6 +463,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
             new RestOpenJobAction(settings, restController),
             new RestGetFiltersAction(settings, restController),
             new RestPutFilterAction(settings, restController),
+            new RestUpdateFilterAction(settings, restController),
             new RestDeleteFilterAction(settings, restController),
             new RestGetInfluencersAction(settings, restController),
             new RestGetRecordsAction(settings, restController),
@@ -511,6 +515,7 @@ public class MachineLearning extends Plugin implements ActionPlugin, AnalysisPlu
                 new ActionHandler<>(OpenJobAction.INSTANCE, TransportOpenJobAction.class),
                 new ActionHandler<>(GetFiltersAction.INSTANCE, TransportGetFiltersAction.class),
                 new ActionHandler<>(PutFilterAction.INSTANCE, TransportPutFilterAction.class),
+                new ActionHandler<>(UpdateFilterAction.INSTANCE, TransportUpdateFilterAction.class),
                 new ActionHandler<>(DeleteFilterAction.INSTANCE, TransportDeleteFilterAction.class),
                 new ActionHandler<>(KillProcessAction.INSTANCE, TransportKillProcessAction.class),
                 new ActionHandler<>(GetBucketsAction.INSTANCE, TransportGetBucketsAction.class),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
@@ -21,8 +21,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -80,9 +80,8 @@ public class TransportGetFiltersAction extends HandledTransportAction<GetFilters
                     if (getDocResponse.isExists()) {
                         BytesReference docSource = getDocResponse.getSourceAsBytesRef();
                         try (InputStream stream = docSource.streamInput();
-                             XContentParser parser =
-                                     XContentFactory.xContent(getDocResponse.getSourceAsBytes())
-                                             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
+                             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                                     .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
                             MlFilter filter = MlFilter.LENIENT_PARSER.apply(parser, null).build();
                             responseBody = new QueryPage<>(Collections.singletonList(filter), 1, MlFilter.RESULTS_FIELD);
 
@@ -122,7 +121,7 @@ public class TransportGetFiltersAction extends HandledTransportAction<GetFilters
                 for (SearchHit hit : response.getHits().getHits()) {
                     BytesReference docSource = hit.getSourceRef();
                     try (InputStream stream = docSource.streamInput();
-                         XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(docSource)).createParser(
+                         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(
                                  NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
                         docs.add(MlFilter.LENIENT_PARSER.apply(parser, null).build());
                     } catch (IOException e) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutFilterAction.java
@@ -5,11 +5,12 @@
  */
 package org.elasticsearch.xpack.ml.action;
 
+import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.bulk.BulkAction;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
-import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.WriteRequest;
@@ -19,12 +20,12 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.MlMetaIndex;
 import org.elasticsearch.xpack.core.ml.action.PutFilterAction;
 import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.ml.job.JobManager;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -36,42 +37,44 @@ import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 public class TransportPutFilterAction extends HandledTransportAction<PutFilterAction.Request, PutFilterAction.Response> {
 
     private final Client client;
-    private final JobManager jobManager;
 
     @Inject
-    public TransportPutFilterAction(Settings settings, TransportService transportService, ActionFilters actionFilters,
-                                    Client client, JobManager jobManager) {
+    public TransportPutFilterAction(Settings settings, TransportService transportService, ActionFilters actionFilters, Client client) {
         super(settings, PutFilterAction.NAME, transportService, actionFilters,
-            (Supplier<PutFilterAction.Request>) PutFilterAction.Request::new);
+                (Supplier<PutFilterAction.Request>) PutFilterAction.Request::new);
         this.client = client;
-        this.jobManager = jobManager;
     }
 
     @Override
     protected void doExecute(PutFilterAction.Request request, ActionListener<PutFilterAction.Response> listener) {
         MlFilter filter = request.getFilter();
         IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, filter.documentId());
+        indexRequest.opType(DocWriteRequest.OpType.CREATE);
+        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(MlMetaIndex.INCLUDE_TYPE_KEY, "true"));
             indexRequest.source(filter.toXContent(builder, params));
         } catch (IOException e) {
             throw new IllegalStateException("Failed to serialise filter with id [" + filter.getId() + "]", e);
         }
-        BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
-        bulkRequestBuilder.add(indexRequest);
-        bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
-        executeAsyncWithOrigin(client, ML_ORIGIN, BulkAction.INSTANCE, bulkRequestBuilder.request(),
-                new ActionListener<BulkResponse>() {
+        executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest,
+                new ActionListener<IndexResponse>() {
                     @Override
-                    public void onResponse(BulkResponse indexResponse) {
-                        jobManager.updateProcessOnFilterChanged(filter);
+                    public void onResponse(IndexResponse indexResponse) {
                         listener.onResponse(new PutFilterAction.Response(filter));
                     }
 
                     @Override
                     public void onFailure(Exception e) {
-                        listener.onFailure(ExceptionsHelper.serverError("Error putting filter with id [" + filter.getId() + "]", e));
+                        Exception reportedException;
+                        if (e instanceof VersionConflictEngineException) {
+                            reportedException = new ResourceAlreadyExistsException("A filter with id [" + filter.getId()
+                                    + "] already exists");
+                        } else {
+                            reportedException = ExceptionsHelper.serverError("Error putting filter with id [" + filter.getId() + "]", e);
+                        }
+                        listener.onFailure(reportedException);
                     }
                 });
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.action;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.get.GetAction;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexAction;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ml.MlMetaIndex;
+import org.elasticsearch.xpack.core.ml.action.PutFilterAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateFilterAction;
+import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
+import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.job.JobManager;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFilterAction.Request, PutFilterAction.Response> {
+
+    private final Client client;
+    private final JobManager jobManager;
+
+    @Inject
+    public TransportUpdateFilterAction(Settings settings, ThreadPool threadPool,
+                                       TransportService transportService, ActionFilters actionFilters,
+                                       Client client, JobManager jobManager) {
+        super(settings, UpdateFilterAction.NAME, threadPool, transportService, actionFilters,
+                (Supplier<UpdateFilterAction.Request>) UpdateFilterAction.Request::new);
+        this.client = client;
+        this.jobManager = jobManager;
+    }
+
+    @Override
+    protected void doExecute(UpdateFilterAction.Request request, ActionListener<PutFilterAction.Response> listener) {
+        ActionListener<FilterWithVersion> filterListener = ActionListener.wrap(filterWithVersion -> {
+            updateFilter(filterWithVersion, request, listener);
+        }, listener::onFailure);
+
+        getFilterWithVersion(request.getFilterId(), filterListener);
+    }
+
+    private void updateFilter(FilterWithVersion filterWithVersion, UpdateFilterAction.Request request,
+                              ActionListener<PutFilterAction.Response> listener) {
+        MlFilter filter = filterWithVersion.filter;
+
+        if (request.isNoop()) {
+            listener.onResponse(new PutFilterAction.Response(filter));
+            return;
+        }
+
+        String description = filter.getDescription();
+        SortedSet<String> items = new TreeSet<>();
+        items.addAll(filter.getItems());
+
+        if (request.getDescription() != null) {
+            description = request.getDescription();
+        }
+
+        items.addAll(request.getAddItems());
+
+        // Check if removed items are present to avoid typos
+        for (String toRemove : request.getRemoveItems()) {
+            boolean wasPresent = items.remove(toRemove);
+            if (wasPresent == false) {
+                listener.onFailure(ExceptionsHelper.badRequestException("Cannot remove item [" + toRemove
+                        + "] as it is not present in filter [" + filter.getId() + "]"));
+                return;
+            }
+        }
+
+        MlFilter updatedFilter = MlFilter.builder(filter.getId()).setDescription(description).setItems(items).build();
+        indexUpdatedFilter(updatedFilter, filterWithVersion.version, request, listener);
+    }
+
+    private void indexUpdatedFilter(MlFilter filter, long version, UpdateFilterAction.Request request,
+                                    ActionListener<PutFilterAction.Response> listener) {
+        IndexRequest indexRequest = new IndexRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, filter.documentId());
+        indexRequest.version(version);
+        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(MlMetaIndex.INCLUDE_TYPE_KEY, "true"));
+            indexRequest.source(filter.toXContent(builder, params));
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to serialise filter with id [" + filter.getId() + "]", e);
+        }
+
+        executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, indexRequest, new ActionListener<IndexResponse>() {
+            @Override
+            public void onResponse(IndexResponse indexResponse) {
+                jobManager.notifyFilterChanged(filter, request.getAddItems(), request.getRemoveItems());
+                listener.onResponse(new PutFilterAction.Response(filter));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Exception reportedException;
+                if (e instanceof VersionConflictEngineException) {
+                    reportedException = ExceptionsHelper.conflictStatusException("Error updating filter with id [" + filter.getId()
+                            + "] because it was modified while the update was in progress", e);
+                } else {
+                    reportedException = ExceptionsHelper.serverError("Error updating filter with id [" + filter.getId() + "]", e);
+                }
+                listener.onFailure(reportedException);
+            }
+        });
+    }
+
+    private void getFilterWithVersion(String filterId, ActionListener<FilterWithVersion> listener) {
+        GetRequest getRequest = new GetRequest(MlMetaIndex.INDEX_NAME, MlMetaIndex.TYPE, MlFilter.documentId(filterId));
+        executeAsyncWithOrigin(client, ML_ORIGIN, GetAction.INSTANCE, getRequest, new ActionListener<GetResponse>() {
+            @Override
+            public void onResponse(GetResponse getDocResponse) {
+                try {
+                    if (getDocResponse.isExists()) {
+                        BytesReference docSource = getDocResponse.getSourceAsBytesRef();
+                        try (InputStream stream = docSource.streamInput();
+                             XContentParser parser =
+                                     XContentFactory.xContent(getDocResponse.getSourceAsBytes())
+                                             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
+                            MlFilter filter = MlFilter.LENIENT_PARSER.apply(parser, null).build();
+                            listener.onResponse(new FilterWithVersion(filter, getDocResponse.getVersion()));
+                        }
+                    } else {
+                        this.onFailure(new ResourceNotFoundException(Messages.getMessage(Messages.FILTER_NOT_FOUND, filterId)));
+                    }
+                } catch (Exception e) {
+                    this.onFailure(e);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    private static class FilterWithVersion {
+
+        private final MlFilter filter;
+        private final long version;
+
+        private FilterWithVersion(MlFilter filter, long version) {
+            this.filter = filter;
+            this.version = version;
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateFilterAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.MlMetaIndex;
 import org.elasticsearch.xpack.core.ml.action.PutFilterAction;
@@ -54,10 +53,9 @@ public class TransportUpdateFilterAction extends HandledTransportAction<UpdateFi
     private final JobManager jobManager;
 
     @Inject
-    public TransportUpdateFilterAction(Settings settings, ThreadPool threadPool,
-                                       TransportService transportService, ActionFilters actionFilters,
-                                       Client client, JobManager jobManager) {
-        super(settings, UpdateFilterAction.NAME, threadPool, transportService, actionFilters,
+    public TransportUpdateFilterAction(Settings settings, TransportService transportService, ActionFilters actionFilters, Client client,
+                                       JobManager jobManager) {
+        super(settings, UpdateFilterAction.NAME, transportService, actionFilters,
                 (Supplier<UpdateFilterAction.Request>) UpdateFilterAction.Request::new);
         this.client = client;
         this.jobManager = jobManager;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -403,24 +403,53 @@ public class JobManager extends AbstractComponent {
         return buildNewClusterState(currentState, builder);
     }
 
-    public void updateProcessOnFilterChanged(MlFilter filter) {
+    public void notifyFilterChanged(MlFilter filter, Set<String> addedItems, Set<String> removedItems) {
+        if (addedItems.isEmpty() && removedItems.isEmpty()) {
+            return;
+        }
+
         ClusterState clusterState = clusterService.state();
         QueryPage<Job> jobs = expandJobs("*", true, clusterService.state());
         for (Job job : jobs.results()) {
-            if (isJobOpen(clusterState, job.getId())) {
-                Set<String> jobFilters = job.getAnalysisConfig().extractReferencedFilters();
-                if (jobFilters.contains(filter.getId())) {
-                    updateJobProcessNotifier.submitJobUpdate(UpdateParams.filterUpdate(job.getId(), filter), ActionListener.wrap(
-                            isUpdated -> {
-                                if (isUpdated) {
-                                    auditor.info(job.getId(),
-                                            Messages.getMessage(Messages.JOB_AUDIT_FILTER_UPDATED_ON_PROCESS, filter.getId()));
-                                }
-                            }, e -> {}
-                    ));
+            Set<String> jobFilters = job.getAnalysisConfig().extractReferencedFilters();
+            if (jobFilters.contains(filter.getId())) {
+                if (isJobOpen(clusterState, job.getId())) {
+                    updateJobProcessNotifier.submitJobUpdate(UpdateParams.filterUpdate(job.getId(), filter),
+                            ActionListener.wrap(isUpdated -> {
+                                auditFilterChanges(job.getId(), filter.getId(), addedItems, removedItems);
+                            }, e -> {}));
+                } else {
+                    auditFilterChanges(job.getId(), filter.getId(), addedItems, removedItems);
                 }
             }
         }
+    }
+
+    private void auditFilterChanges(String jobId, String filterId, Set<String> addedItems, Set<String> removedItems) {
+        StringBuilder auditMsg = new StringBuilder("Filter [");
+        auditMsg.append(filterId);
+        auditMsg.append("] has been modified; ");
+
+        if (addedItems.isEmpty() == false) {
+            auditMsg.append("added items: ");
+            appendCommaSeparatedSet(addedItems, auditMsg);
+            if (removedItems.isEmpty() == false) {
+                auditMsg.append(", ");
+            }
+        }
+
+        if (removedItems.isEmpty() == false) {
+            auditMsg.append("removed items: ");
+            appendCommaSeparatedSet(removedItems, auditMsg);
+        }
+
+        auditor.info(jobId, auditMsg.toString());
+    }
+
+    private static void appendCommaSeparatedSet(Set<String> items, StringBuilder sb) {
+        sb.append("[");
+        Strings.collectionToDelimitedString(items, ", ", "'", "'", sb);
+        sb.append("]");
     }
 
     public void updateProcessOnCalendarChanged(List<String> calendarJobIds) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedBucketsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedBucketsIterator.java
@@ -11,8 +11,8 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
@@ -30,7 +30,7 @@ class BatchedBucketsIterator extends BatchedResultsIterator<Bucket> {
     protected Result<Bucket> map(SearchHit hit) {
         BytesReference source = hit.getSourceRef();
         try (InputStream stream = source.streamInput();
-             XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source)).createParser(NamedXContentRegistry.EMPTY,
+             XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY,
                      LoggingDeprecationHandler.INSTANCE, stream)) {
             Bucket bucket = Bucket.LENIENT_PARSER.apply(parser, null);
             return new Result<>(hit.getIndex(), bucket);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedInfluencersIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedInfluencersIterator.java
@@ -11,8 +11,8 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.job.results.Influencer;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
@@ -29,7 +29,7 @@ class BatchedInfluencersIterator extends BatchedResultsIterator<Influencer> {
     protected Result<Influencer> map(SearchHit hit) {
         BytesReference source = hit.getSourceRef();
         try (InputStream stream = source.streamInput();
-             XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source)).createParser(NamedXContentRegistry.EMPTY,
+             XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY,
                      LoggingDeprecationHandler.INSTANCE, stream)) {
             Influencer influencer = Influencer.LENIENT_PARSER.apply(parser, null);
             return new Result<>(hit.getIndex(), influencer);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedRecordsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/BatchedRecordsIterator.java
@@ -11,8 +11,8 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.job.results.AnomalyRecord;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
@@ -30,7 +30,7 @@ class BatchedRecordsIterator extends BatchedResultsIterator<AnomalyRecord> {
     protected Result<AnomalyRecord> map(SearchHit hit) {
         BytesReference source = hit.getSourceRef();
         try (InputStream stream = source.streamInput();
-             XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source)).createParser(NamedXContentRegistry.EMPTY,
+             XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY,
                 LoggingDeprecationHandler.INSTANCE, stream)){
             AnomalyRecord record = AnomalyRecord.LENIENT_PARSER.apply(parser, null);
             return new Result<>(hit.getIndex(), record);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
@@ -50,7 +50,6 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -477,7 +476,7 @@ public class JobProvider {
                                     Consumer<Exception> errorHandler) {
         BytesReference source = hit.getSourceRef();
         try (InputStream stream = source.streamInput();
-             XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source))
+             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                      .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
             return objectParser.apply(parser, null);
         } catch (IOException e) {
@@ -528,7 +527,7 @@ public class JobProvider {
                     for (SearchHit hit : hits.getHits()) {
                         BytesReference source = hit.getSourceRef();
                         try (InputStream stream = source.streamInput();
-                             XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source))
+                             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                                      .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
                             Bucket bucket = Bucket.LENIENT_PARSER.apply(parser, null);
                             results.add(bucket);
@@ -661,7 +660,7 @@ public class JobProvider {
                     for (SearchHit hit : hits) {
                         BytesReference source = hit.getSourceRef();
                         try (InputStream stream = source.streamInput();
-                             XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source))
+                             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                                      .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
                             CategoryDefinition categoryDefinition = CategoryDefinition.LENIENT_PARSER.apply(parser, null);
                             if (augment) {
@@ -710,7 +709,7 @@ public class JobProvider {
                     for (SearchHit hit : searchResponse.getHits().getHits()) {
                         BytesReference source = hit.getSourceRef();
                         try (InputStream stream = source.streamInput();
-                             XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source))
+                             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                                      .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
                             results.add(AnomalyRecord.LENIENT_PARSER.apply(parser, null));
                         } catch (IOException e) {
@@ -759,7 +758,7 @@ public class JobProvider {
                     for (SearchHit hit : response.getHits().getHits()) {
                         BytesReference source = hit.getSourceRef();
                         try (InputStream stream = source.streamInput();
-                             XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source))
+                             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                                      .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
                             influencers.add(Influencer.LENIENT_PARSER.apply(parser, null));
                         } catch (IOException e) {
@@ -904,7 +903,7 @@ public class JobProvider {
         for (SearchHit hit : searchResponse.getHits().getHits()) {
             BytesReference source = hit.getSourceRef();
             try (InputStream stream = source.streamInput();
-                 XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source))
+                 XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                          .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
                 ModelPlot modelPlot = ModelPlot.LENIENT_PARSER.apply(parser, null);
                 results.add(modelPlot);
@@ -1232,10 +1231,8 @@ public class JobProvider {
                         BytesReference docSource = getDocResponse.getSourceAsBytesRef();
 
                         try (InputStream stream = docSource.streamInput();
-                             XContentParser parser =
-                                     XContentFactory.xContent(XContentHelper.xContentType(docSource))
-                                             .createParser(NamedXContentRegistry.EMPTY,
-                                                     LoggingDeprecationHandler.INSTANCE, stream)) {
+                             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                                             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)) {
                             Calendar calendar = Calendar.LENIENT_PARSER.apply(parser, null).build();
                             listener.onResponse(calendar);
                         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/filter/RestUpdateFilterAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/filter/RestUpdateFilterAction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.ml.rest.filter;
+
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.ml.action.UpdateFilterAction;
+import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
+import org.elasticsearch.xpack.ml.MachineLearning;
+
+import java.io.IOException;
+
+public class RestUpdateFilterAction extends BaseRestHandler {
+
+    public RestUpdateFilterAction(Settings settings, RestController controller) {
+        super(settings);
+        controller.registerHandler(RestRequest.Method.POST,
+                MachineLearning.BASE_PATH + "filters/{" + MlFilter.ID.getPreferredName() + "}/_update", this);
+    }
+
+    @Override
+    public String getName() {
+        return "xpack_ml_update_filter_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        String filterId = restRequest.param(MlFilter.ID.getPreferredName());
+        XContentParser parser = restRequest.contentOrSourceParamParser();
+        UpdateFilterAction.Request putFilterRequest = UpdateFilterAction.Request.parseRequest(filterId, parser);
+        return channel -> client.execute(UpdateFilterAction.INSTANCE, putFilterRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -5,7 +5,6 @@
  */
 package org.elasticsearch.xpack.ml.job;
 
-import com.google.common.collect.Sets;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
@@ -49,6 +48,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.TreeSet;
 
 import static org.elasticsearch.xpack.core.ml.job.config.JobTests.buildJobBuilder;
 import static org.elasticsearch.xpack.ml.action.TransportOpenJobActionTests.addJobTask;
@@ -229,8 +229,7 @@ public class JobManagerTests extends ESTestCase {
 
         MlFilter filter = MlFilter.builder("foo_filter").setItems("a", "b").build();
 
-        jobManager.notifyFilterChanged(filter, Sets.newTreeSet(Arrays.asList("item 1", "item 2")),
-                Sets.newTreeSet(Arrays.asList("item 3")));
+        jobManager.notifyFilterChanged(filter, new TreeSet<>(Arrays.asList("item 1", "item 2")), new TreeSet<>(Arrays.asList("item 3")));
 
         ArgumentCaptor<UpdateParams> updateParamsCaptor = ArgumentCaptor.forClass(UpdateParams.class);
         verify(updateJobProcessNotifier, times(2)).submitJobUpdate(updateParamsCaptor.capture(), any(ActionListener.class));
@@ -275,7 +274,7 @@ public class JobManagerTests extends ESTestCase {
 
         MlFilter filter = MlFilter.builder("foo_filter").build();
 
-        jobManager.notifyFilterChanged(filter, Sets.newTreeSet(Arrays.asList("a", "b")), Collections.emptySet());
+        jobManager.notifyFilterChanged(filter, new TreeSet<>(Arrays.asList("a", "b")), Collections.emptySet());
 
         verify(auditor).info(jobReferencingFilter.getId(), "Filter [foo_filter] has been modified; added items: ['a', 'b']");
         Mockito.verifyNoMoreInteractions(auditor, updateJobProcessNotifier);
@@ -305,7 +304,7 @@ public class JobManagerTests extends ESTestCase {
 
         MlFilter filter = MlFilter.builder("foo_filter").build();
 
-        jobManager.notifyFilterChanged(filter, Collections.emptySet(), Sets.newTreeSet(Arrays.asList("a", "b")));
+        jobManager.notifyFilterChanged(filter, Collections.emptySet(), new TreeSet<>(Arrays.asList("a", "b")));
 
         verify(auditor).info(jobReferencingFilter.getId(), "Filter [foo_filter] has been modified; removed items: ['a', 'b']");
         Mockito.verifyNoMoreInteractions(auditor, updateJobProcessNotifier);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -5,6 +5,7 @@
  */
 package org.elasticsearch.xpack.ml.job;
 
+import com.google.common.collect.Sets;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
@@ -41,6 +42,7 @@ import org.elasticsearch.xpack.ml.notifications.Auditor;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -174,7 +176,16 @@ public class JobManagerTests extends ESTestCase {
         });
     }
 
-    public void testUpdateProcessOnFilterChanged() {
+    public void testNotifyFilterChangedGivenNoop() {
+        MlFilter filter = MlFilter.builder("my_filter").build();
+        JobManager jobManager = createJobManager();
+
+        jobManager.notifyFilterChanged(filter, Collections.emptySet(), Collections.emptySet());
+
+        Mockito.verifyNoMoreInteractions(auditor, updateJobProcessNotifier);
+    }
+
+    public void testNotifyFilterChanged() {
         Detector.Builder detectorReferencingFilter = new Detector.Builder("count", null);
         detectorReferencingFilter.setByFieldName("foo");
         DetectionRule filterRule = new DetectionRule.Builder(RuleScope.builder().exclude("foo", "foo_filter")).build();
@@ -208,11 +219,18 @@ public class JobManagerTests extends ESTestCase {
                 .build();
         when(clusterService.state()).thenReturn(clusterState);
 
+        doAnswer(invocationOnMock -> {
+            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[1];
+            listener.onResponse(true);
+            return null;
+        }).when(updateJobProcessNotifier).submitJobUpdate(any(), any());
+
         JobManager jobManager = createJobManager();
 
         MlFilter filter = MlFilter.builder("foo_filter").setItems("a", "b").build();
 
-        jobManager.updateProcessOnFilterChanged(filter);
+        jobManager.notifyFilterChanged(filter, Sets.newTreeSet(Arrays.asList("item 1", "item 2")),
+                Sets.newTreeSet(Arrays.asList("item 3")));
 
         ArgumentCaptor<UpdateParams> updateParamsCaptor = ArgumentCaptor.forClass(UpdateParams.class);
         verify(updateJobProcessNotifier, times(2)).submitJobUpdate(updateParamsCaptor.capture(), any(ActionListener.class));
@@ -223,6 +241,74 @@ public class JobManagerTests extends ESTestCase {
         assertThat(capturedUpdateParams.get(0).getFilter(), equalTo(filter));
         assertThat(capturedUpdateParams.get(1).getJobId(), equalTo(jobReferencingFilter2.getId()));
         assertThat(capturedUpdateParams.get(1).getFilter(), equalTo(filter));
+
+        verify(auditor).info(jobReferencingFilter1.getId(), "Filter [foo_filter] has been modified; added items: " +
+                "['item 1', 'item 2'], removed items: ['item 3']");
+        verify(auditor).info(jobReferencingFilter2.getId(), "Filter [foo_filter] has been modified; added items: " +
+                "['item 1', 'item 2'], removed items: ['item 3']");
+        verify(auditor).info(jobReferencingFilter3.getId(), "Filter [foo_filter] has been modified; added items: " +
+                "['item 1', 'item 2'], removed items: ['item 3']");
+        Mockito.verifyNoMoreInteractions(auditor, updateJobProcessNotifier);
+    }
+
+    public void testNotifyFilterChangedGivenOnlyAddedItems() {
+        Detector.Builder detectorReferencingFilter = new Detector.Builder("count", null);
+        detectorReferencingFilter.setByFieldName("foo");
+        DetectionRule filterRule = new DetectionRule.Builder(RuleScope.builder().exclude("foo", "foo_filter")).build();
+        detectorReferencingFilter.setRules(Collections.singletonList(filterRule));
+        AnalysisConfig.Builder filterAnalysisConfig = new AnalysisConfig.Builder(Collections.singletonList(
+                detectorReferencingFilter.build()));
+
+        Job.Builder jobReferencingFilter = buildJobBuilder("job-referencing-filter");
+        jobReferencingFilter.setAnalysisConfig(filterAnalysisConfig);
+
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
+        mlMetadata.putJob(jobReferencingFilter.build(), false);
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+                .metaData(MetaData.builder()
+                        .putCustom(MLMetadataField.TYPE, mlMetadata.build()))
+                .build();
+        when(clusterService.state()).thenReturn(clusterState);
+
+        JobManager jobManager = createJobManager();
+
+        MlFilter filter = MlFilter.builder("foo_filter").build();
+
+        jobManager.notifyFilterChanged(filter, Sets.newTreeSet(Arrays.asList("a", "b")), Collections.emptySet());
+
+        verify(auditor).info(jobReferencingFilter.getId(), "Filter [foo_filter] has been modified; added items: ['a', 'b']");
+        Mockito.verifyNoMoreInteractions(auditor, updateJobProcessNotifier);
+    }
+
+    public void testNotifyFilterChangedGivenOnlyRemovedItems() {
+        Detector.Builder detectorReferencingFilter = new Detector.Builder("count", null);
+        detectorReferencingFilter.setByFieldName("foo");
+        DetectionRule filterRule = new DetectionRule.Builder(RuleScope.builder().exclude("foo", "foo_filter")).build();
+        detectorReferencingFilter.setRules(Collections.singletonList(filterRule));
+        AnalysisConfig.Builder filterAnalysisConfig = new AnalysisConfig.Builder(Collections.singletonList(
+                detectorReferencingFilter.build()));
+
+        Job.Builder jobReferencingFilter = buildJobBuilder("job-referencing-filter");
+        jobReferencingFilter.setAnalysisConfig(filterAnalysisConfig);
+
+        MlMetadata.Builder mlMetadata = new MlMetadata.Builder();
+        mlMetadata.putJob(jobReferencingFilter.build(), false);
+
+        ClusterState clusterState = ClusterState.builder(new ClusterName("_name"))
+                .metaData(MetaData.builder()
+                        .putCustom(MLMetadataField.TYPE, mlMetadata.build()))
+                .build();
+        when(clusterService.state()).thenReturn(clusterState);
+
+        JobManager jobManager = createJobManager();
+
+        MlFilter filter = MlFilter.builder("foo_filter").build();
+
+        jobManager.notifyFilterChanged(filter, Collections.emptySet(), Sets.newTreeSet(Arrays.asList("a", "b")));
+
+        verify(auditor).info(jobReferencingFilter.getId(), "Filter [foo_filter] has been modified; removed items: ['a', 'b']");
+        Mockito.verifyNoMoreInteractions(auditor, updateJobProcessNotifier);
     }
 
     public void testUpdateProcessOnCalendarChanged() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -229,7 +229,8 @@ public class JobManagerTests extends ESTestCase {
 
         MlFilter filter = MlFilter.builder("foo_filter").setItems("a", "b").build();
 
-        jobManager.notifyFilterChanged(filter, new TreeSet<>(Arrays.asList("item 1", "item 2")), new TreeSet<>(Arrays.asList("item 3")));
+        jobManager.notifyFilterChanged(filter, new TreeSet<>(Arrays.asList("item 1", "item 2")),
+                new TreeSet<>(Collections.singletonList("item 3")));
 
         ArgumentCaptor<UpdateParams> updateParamsCaptor = ArgumentCaptor.forClass(UpdateParams.class);
         verify(updateJobProcessNotifier, times(2)).submitJobUpdate(updateParamsCaptor.capture(), any(ActionListener.class));

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ml.update_filter.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.ml.update_filter.json
@@ -1,0 +1,20 @@
+{
+  "xpack.ml.update_filter": {
+    "methods": [ "POST" ],
+    "url": {
+      "path": "/_xpack/ml/filters/{filter_id}/_update",
+      "paths": [ "/_xpack/ml/filters/{filter_id}/_update" ],
+      "parts": {
+        "filter_id": {
+          "type": "string",
+          "required": true,
+          "description": "The ID of the filter to update"
+        }
+      }
+    },
+    "body": {
+      "description" : "The filter update",
+      "required" : true
+    }
+  }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/custom_all_field.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/custom_all_field.yml
@@ -30,6 +30,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-custom-all-test-1
         type:   doc
@@ -56,6 +57,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-custom-all-test-2
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_model_snapshot.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/delete_model_snapshot.yml
@@ -34,6 +34,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-delete-model-snapshot
         type:   doc
@@ -76,6 +77,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-delete-model-snapshot
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
@@ -158,7 +158,6 @@ setup:
 
 ---
 "Test update filter":
-
   - do:
       xpack.ml.put_filter:
         filter_id: "test_update_filter"
@@ -197,7 +196,6 @@ setup:
 
 ---
 "Test update filter given remove item is not present":
-
   - do:
       catch: /Cannot remove item \[not present item\] as it is not present in filter \[filter-foo\]/
       xpack.ml.update_filter:

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
@@ -112,25 +112,25 @@ setup:
 "Test create filter api":
   - do:
       xpack.ml.put_filter:
-        filter_id: filter-foo2
+        filter_id: new-filter
         body:  >
           {
             "description": "A newly created filter",
             "items": ["abc", "xyz"]
           }
 
-  - match: { filter_id: filter-foo2 }
+  - match: { filter_id: new-filter }
   - match: { description: "A newly created filter" }
   - match: { items: ["abc", "xyz"]}
 
   - do:
       xpack.ml.get_filters:
-        filter_id: "filter-foo2"
+        filter_id: "new-filter"
 
   - match: { count:   1 }
   - match:
       filters.0:
-        filter_id: "filter-foo2"
+        filter_id: "new-filter"
         description: "A newly created filter"
         items: ["abc", "xyz"]
 
@@ -144,6 +144,67 @@ setup:
           {
             "filter_id": "body_id",
             "items": ["abc", "xyz"]
+          }
+
+---
+"Test update filter given no filter matches filter_id":
+  - do:
+      catch: missing
+      xpack.ml.update_filter:
+        filter_id: "missing_filter"
+        body:  >
+          {
+          }
+
+---
+"Test update filter":
+
+  - do:
+      xpack.ml.put_filter:
+        filter_id: "test_update_filter"
+        body:  >
+          {
+            "description": "old description",
+            "items": ["a", "b"]
+          }
+  - match: { filter_id: test_update_filter }
+
+  - do:
+      xpack.ml.update_filter:
+        filter_id: "test_update_filter"
+        body:  >
+          {
+            "description": "new description",
+            "add_items": ["c", "d"],
+            "remove_items": ["a"]
+          }
+  - match: { filter_id: test_update_filter }
+  - match: { description: "new description" }
+  - match: { items: ["b", "c", "d"] }
+
+  - do:
+      xpack.ml.get_filters:
+        filter_id: "test_update_filter"
+  - match:
+      filters.0:
+        filter_id: "test_update_filter"
+        description: "new description"
+        items: ["b", "c", "d"]
+
+  - do:
+      xpack.ml.delete_filter:
+        filter_id: test_update_filter
+
+---
+"Test update filter given remove item is not present":
+
+  - do:
+      catch: /Cannot remove item \[not present item\] as it is not present in filter \[filter-foo\]/
+      xpack.ml.update_filter:
+        filter_id: "filter-foo"
+        body:  >
+          {
+            "remove_items": ["not present item"]
           }
 
 ---

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/filter_crud.yml
@@ -4,6 +4,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index: .ml-meta
         type: doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_model_snapshots.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/get_model_snapshots.yml
@@ -18,6 +18,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-get-model-snapshots
         type:   doc
@@ -33,6 +34,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-state
         type:   doc
@@ -44,6 +46,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-get-model-snapshots
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/index_layout.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/index_layout.yml
@@ -556,6 +556,8 @@
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
+
       index:
         index:  .ml-anomalies-shared
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -419,6 +419,8 @@
   - match: { job_id: "jobs-crud-model-memory-limit-decrease" }
 
   - do:
+      headers:
+        Content-Type: application/json
       index:
         index: .ml-anomalies-shared
         type: doc
@@ -929,6 +931,8 @@
 "Test cannot create job with existing result document":
 
   - do:
+      headers:
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_buckets.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_buckets.yml
@@ -18,6 +18,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-buckets
         type:   doc
@@ -34,6 +35,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-buckets
         type:   doc
@@ -50,6 +52,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-buckets
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_categories.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_categories.yml
@@ -18,6 +18,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-categories
         type:   doc
@@ -26,6 +27,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-categories
         type:   doc
@@ -34,6 +36,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-unrelated
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_influencers.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_influencers.yml
@@ -18,6 +18,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-get-influencers-test
         type:   doc
@@ -36,6 +37,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-get-influencers-test
         type:   doc
@@ -55,6 +57,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-get-influencers-test
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
@@ -59,6 +59,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc
@@ -75,6 +76,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc
@@ -91,6 +93,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc
@@ -123,6 +126,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc
@@ -139,6 +143,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc
@@ -155,6 +160,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc
@@ -171,6 +177,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc
@@ -187,6 +194,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc
@@ -203,6 +211,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_records.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_result_records.yml
@@ -18,6 +18,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-records
         type:   doc
@@ -34,6 +35,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-jobs-get-result-records
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -226,6 +226,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index: .ml-anomalies-shared
         type: doc
@@ -250,6 +251,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index: .ml-anomalies-shared
         type: doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/ml_anomalies_default_mappings.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/ml_anomalies_default_mappings.yml
@@ -19,6 +19,7 @@
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-shared
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/revert_model_snapshot.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/revert_model_snapshot.yml
@@ -34,6 +34,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
         type:   doc
@@ -61,6 +62,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
         type:   doc
@@ -88,6 +90,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
         type:   doc
@@ -103,6 +106,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
         type:   doc
@@ -118,6 +122,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
         type:   doc
@@ -133,6 +138,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
         type:   doc
@@ -148,6 +154,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
          index:  .ml-anomalies-revert-model-snapshot
          type:   doc
@@ -163,6 +170,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
         type:   doc
@@ -180,6 +188,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-revert-model-snapshot
         type:   doc

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/update_model_snapshot.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/update_model_snapshot.yml
@@ -18,6 +18,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-update-model-snapshot
         type:   doc
@@ -67,6 +68,7 @@ setup:
   - do:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
       index:
         index:  .ml-anomalies-update-model-snapshot
         type:   doc

--- a/x-pack/qa/smoke-test-ml-with-security/build.gradle
+++ b/x-pack/qa/smoke-test-ml-with-security/build.gradle
@@ -42,6 +42,7 @@ integTestRunner {
     'ml/filter_crud/Test get filter API with bad ID',
     'ml/filter_crud/Test invalid param combinations',
     'ml/filter_crud/Test non-existing filter',
+    'ml/filter_crud/Test update filter given remove item is not present',
     'ml/get_datafeed_stats/Test get datafeed stats given missing datafeed_id',
     'ml/get_datafeeds/Test get datafeed given missing datafeed_id',
     'ml/jobs_crud/Test cannot create job with existing categorizer state document',


### PR DESCRIPTION
This adds an api to allow updating a filter:

POST _xpack/ml/filters/{filter_id}/_update

The request body may have:

- description: setting a new description
- add_items: a list of the items to add
- remove_items: a list of the items to remove

This commit also changes the PUT filter api to
error when the filter_id is already used. As
now there is an api for updating filters, the
put api should only be used to create new ones.

Also, updating a filter results into a notification
message auditing the change for every job that is
using that filter.