### PR TITLE
[DOCS] Skips testing for forecast API

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -58,7 +58,6 @@ buildRestTests.expectedUnconvertedCandidates = [
         'en/rest-api/license/update-license.asciidoc',
         'en/ml/api-quickref.asciidoc',
         'en/rest-api/ml/delete-snapshot.asciidoc',
-        'en/rest-api/ml/forecast.asciidoc',
         'en/rest-api/ml/get-bucket.asciidoc',
         'en/rest-api/ml/get-job-stats.asciidoc',
         'en/rest-api/ml/get-overall-buckets.asciidoc',

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -438,6 +438,11 @@ setups['server_metrics_startdf'] = setups['server_metrics_openjob'] + '''
       xpack.ml.start_datafeed:
         datafeed_id: "datafeed-total-requests"
 '''
+setups['server_metrics_flush'] = setups['server_metrics_startdf'] + '''
+  - do:
+      xpack.ml.flush_job:
+        job_id: "total-requests" 
+'''
 setups['calendar_outages'] = '''
   - do:
         xpack.ml.put_calendar:

--- a/x-pack/docs/en/rest-api/ml/forecast.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/forecast.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Forecast Jobs</titleabbrev>
 ++++
 
-Predict the future behavior of a time series by using historical behavior. 
+Predicts the future behavior of a time series by using historical behavior. 
 
 ==== Request
 
@@ -62,7 +62,7 @@ POST _xpack/ml/anomaly_detectors/total-requests/_forecast
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:todo]
+// TEST[skip:requires delay]
 
 When the forecast is created, you receive the following results:
 [source,js]
@@ -72,7 +72,6 @@ When the forecast is created, you receive the following results:
   "forecast_id": "wkCWa2IB2lF8nSE_TzZo"
 }
 ----
+// NOTCONSOLE
 
 You can subsequently see the forecast in the *Single Metric Viewer* in {kib}.
-//and in the results that you retrieve by using {ml} APIs such as the
-//<<ml-get-bucket,get bucket API>> and <<ml-get-record,get records API>>.

--- a/x-pack/docs/en/rest-api/ml/forecast.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/forecast.asciidoc
@@ -62,7 +62,7 @@ POST _xpack/ml/anomaly_detectors/total-requests/_forecast
 }
 --------------------------------------------------
 // CONSOLE
-// TEST[skip:requires delay]
+// TEST[setup:server_metrics_flush]
 
 When the forecast is created, you receive the following results:
 [source,js]
@@ -72,6 +72,6 @@ When the forecast is created, you receive the following results:
   "forecast_id": "wkCWa2IB2lF8nSE_TzZo"
 }
 ----
-// NOTCONSOLE
+// TESTRESPONSE[s/"forecast_id": "wkCWa2IB2lF8nSE_TzZo"/"forecast_id": $body.forecast_id/]
 
 You can subsequently see the forecast in the *Single Metric Viewer* in {kib}.


### PR DESCRIPTION
This PR skips code snippet testing for the machine learning forecast API, since (even though it works from the console with basic farequote data), the gradle checks fail as follows:

> 1> [2018-06-18T20:45:24,050][INFO ][o.e.s.XDocsClientYamlTestSuiteIT] Stash dump on test failure [{
>   1>   "stash" : {
>   1>     "body" : {
>   1>       "error" : {
>   1>         "root_cause" : [
>   1>           {
>   1>             "type" : "status_exception",
>   1>             "reason" : "Cannot run forecast: Forecast cannot be executed as job requires data to have been processed and modeled",
>   1>             "stack_trace" : "ElasticsearchStatusException[Cannot run forecast: Forecast cannot be executed as job requires data to have been processed and modeled]

I suspect the CI is too quick and the setup data has not been modelled yet. 