### PR TITLE
[DOCS] Move migration APIs to docs

### DIFF
--- a/docs/reference/migration/apis/assistance.asciidoc
+++ b/docs/reference/migration/apis/assistance.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="basic"]
 [[migration-api-assistance]]
 === Migration Assistance API
 

--- a/docs/reference/migration/apis/deprecation.asciidoc
+++ b/docs/reference/migration/apis/deprecation.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="basic"]
 [[migration-api-deprecation]]
 === Deprecation Info APIs
 

--- a/docs/reference/migration/apis/upgrade.asciidoc
+++ b/docs/reference/migration/apis/upgrade.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="basic"]
 [[migration-api-upgrade]]
 === Migration Upgrade API
 

--- a/docs/reference/migration/migration.asciidoc
+++ b/docs/reference/migration/migration.asciidoc
@@ -1,4 +1,5 @@
 [role="xpack"]
+[testenv="basic"]
 [[migration-api]]
 == Migration APIs
 
@@ -8,6 +9,6 @@ The migration APIs simplify upgrading {xpack} indices from one version to anothe
 * <<migration-api-upgrade>>
 * <<migration-api-deprecation>>
 
-include::migration/assistance.asciidoc[]
-include::migration/upgrade.asciidoc[]
-include::migration/deprecation.asciidoc[]
+include::apis/assistance.asciidoc[]
+include::apis/upgrade.asciidoc[]
+include::apis/deprecation.asciidoc[]

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -21,7 +21,7 @@ directly to configure and access {xpack} features.
 include::info.asciidoc[]
 include::{xes-repo-dir}/rest-api/graph/explore.asciidoc[]
 include::{es-repo-dir}/licensing/index.asciidoc[]
-include::{xes-repo-dir}/rest-api/migration.asciidoc[]
+include::{es-repo-dir}/migration/migration.asciidoc[]
 include::{xes-repo-dir}/rest-api/ml-api.asciidoc[]
 include::{xes-repo-dir}/rest-api/rollup-api.asciidoc[]
 include::{xes-repo-dir}/rest-api/security.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/30665

This PR moves the migration API reference information from x-pack/docs/en/rest-apis/migration to docs/reference/migration/