### PR TITLE
Core: Convert TransportAction.execute uses to client calls

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -23,9 +23,9 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.TransportMultiSearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -42,16 +42,16 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
 
     private final ScriptService scriptService;
     private final NamedXContentRegistry xContentRegistry;
-    private final TransportMultiSearchAction multiSearchAction;
+    private final NodeClient client;
 
     @Inject
     public TransportMultiSearchTemplateAction(Settings settings, ThreadPool threadPool, TransportService transportService,
                                               ActionFilters actionFilters, ScriptService scriptService,
-                                              NamedXContentRegistry xContentRegistry, TransportMultiSearchAction multiSearchAction) {
+                                              NamedXContentRegistry xContentRegistry, NodeClient client) {
         super(settings, MultiSearchTemplateAction.NAME, threadPool, transportService, actionFilters, MultiSearchTemplateRequest::new);
         this.scriptService = scriptService;
         this.xContentRegistry = xContentRegistry;
-        this.multiSearchAction = multiSearchAction;
+        this.client = client;
     }
 
     @Override
@@ -81,7 +81,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
             }
         }
 
-        multiSearchAction.execute(multiSearchRequest, ActionListener.wrap(r -> {
+        client.multiSearch(multiSearchRequest, ActionListener.wrap(r -> {
             for (int i = 0; i < r.getResponses().length; i++) {
                 MultiSearchResponse.Item item = r.getResponses()[i];
                 int originalSlot = originalSlots.get(i);

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
@@ -22,11 +22,12 @@ package org.elasticsearch.script.mustache;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -50,20 +51,18 @@ public class TransportSearchTemplateAction extends HandledTransportAction<Search
     private static final String TEMPLATE_LANG = MustacheScriptEngine.NAME;
 
     private final ScriptService scriptService;
-    private final TransportSearchAction searchAction;
     private final NamedXContentRegistry xContentRegistry;
+    private final NodeClient client;
 
     @Inject
     public TransportSearchTemplateAction(Settings settings, ThreadPool threadPool, TransportService transportService,
-                                         ActionFilters actionFilters,
-                                         ScriptService scriptService,
-                                         TransportSearchAction searchAction,
-                                         NamedXContentRegistry xContentRegistry) {
+                                         ActionFilters actionFilters, ScriptService scriptService, NamedXContentRegistry xContentRegistry,
+                                         NodeClient client) {
         super(settings, SearchTemplateAction.NAME, threadPool, transportService, actionFilters,
               (Supplier<SearchTemplateRequest>) SearchTemplateRequest::new);
         this.scriptService = scriptService;
-        this.searchAction = searchAction;
         this.xContentRegistry = xContentRegistry;
+        this.client = client;
     }
 
     @Override
@@ -72,7 +71,7 @@ public class TransportSearchTemplateAction extends HandledTransportAction<Search
         try {
             SearchRequest searchRequest = convert(request, response, scriptService, xContentRegistry);
             if (searchRequest != null) {
-                searchAction.execute(searchRequest, new ActionListener<SearchResponse>() {
+                client.search(searchRequest, new ActionListener<SearchResponse>() {
                     @Override
                     public void onResponse(SearchResponse searchResponse) {
                         try {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
@@ -55,8 +55,7 @@ public class CreateIndexResponse extends ShardsAcknowledgedResponse {
 
     private String index;
 
-    protected CreateIndexResponse() {
-    }
+    public CreateIndexResponse() {}
 
     protected CreateIndexResponse(boolean acknowledged, boolean shardsAcknowledged, String index) {
         super(acknowledged, shardsAcknowledged);

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
@@ -23,9 +23,9 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
-import org.elasticsearch.action.admin.cluster.node.info.TransportNodesInfoAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -47,16 +47,16 @@ public class PutPipelineTransportAction extends TransportMasterNodeAction<PutPip
 
     private final PipelineStore pipelineStore;
     private final ClusterService clusterService;
-    private final TransportNodesInfoAction nodesInfoAction;
+    private final NodeClient client;
 
     @Inject
     public PutPipelineTransportAction(Settings settings, ThreadPool threadPool, ClusterService clusterService,
                                       TransportService transportService, ActionFilters actionFilters,
                                       IndexNameExpressionResolver indexNameExpressionResolver, NodeService nodeService,
-                                      TransportNodesInfoAction nodesInfoAction) {
+                                      NodeClient client) {
         super(settings, PutPipelineAction.NAME, transportService, clusterService, threadPool, actionFilters, indexNameExpressionResolver, PutPipelineRequest::new);
         this.clusterService = clusterService;
-        this.nodesInfoAction = nodesInfoAction;
+        this.client = client;
         this.pipelineStore = nodeService.getIngestService().getPipelineStore();
     }
 
@@ -75,7 +75,7 @@ public class PutPipelineTransportAction extends TransportMasterNodeAction<PutPip
         NodesInfoRequest nodesInfoRequest = new NodesInfoRequest();
         nodesInfoRequest.clear();
         nodesInfoRequest.ingest(true);
-        nodesInfoAction.execute(nodesInfoRequest, new ActionListener<NodesInfoResponse>() {
+        client.admin().cluster().nodesInfo(nodesInfoRequest, new ActionListener<NodesInfoResponse>() {
             @Override
             public void onResponse(NodesInfoResponse nodeInfos) {
                 try {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action.search;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -43,27 +43,27 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
 
     private final int availableProcessors;
     private final ClusterService clusterService;
-    private final TransportAction<SearchRequest, SearchResponse> searchAction;
     private final LongSupplier relativeTimeProvider;
+    private final NodeClient client;
 
     @Inject
     public TransportMultiSearchAction(Settings settings, ThreadPool threadPool, TransportService transportService,
-                                      ClusterService clusterService, TransportSearchAction searchAction, ActionFilters actionFilters) {
+                                      ClusterService clusterService, ActionFilters actionFilters, NodeClient client) {
         super(settings, MultiSearchAction.NAME, threadPool, transportService, actionFilters, MultiSearchRequest::new);
         this.clusterService = clusterService;
-        this.searchAction = searchAction;
         this.availableProcessors = EsExecutors.numberOfProcessors(settings);
         this.relativeTimeProvider = System::nanoTime;
+        this.client = client;
     }
 
     TransportMultiSearchAction(ThreadPool threadPool, ActionFilters actionFilters, TransportService transportService,
-                               ClusterService clusterService, TransportAction<SearchRequest, SearchResponse> searchAction,
-                               int availableProcessors, LongSupplier relativeTimeProvider) {
+                               ClusterService clusterService, int availableProcessors,
+                               LongSupplier relativeTimeProvider, NodeClient client) {
         super(Settings.EMPTY, MultiSearchAction.NAME, threadPool, transportService, actionFilters, MultiSearchRequest::new);
         this.clusterService = clusterService;
-        this.searchAction = searchAction;
         this.availableProcessors = availableProcessors;
         this.relativeTimeProvider = relativeTimeProvider;
+        this.client = client;
     }
 
     @Override
@@ -141,7 +141,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
          * when we handle the response rather than going recursive, we fork to another thread, otherwise we recurse.
          */
         final Thread thread = Thread.currentThread();
-        searchAction.execute(request.request, new ActionListener<SearchResponse>() {
+        client.search(request.request, new ActionListener<SearchResponse>() {
             @Override
             public void onResponse(final SearchResponse searchResponse) {
                 handleResponse(request.responseSlot, new MultiSearchResponse.Item(searchResponse, null));

--- a/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -24,8 +24,6 @@ import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
-import org.elasticsearch.action.bulk.TransportBulkAction;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexRequest;
@@ -34,6 +32,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.action.support.single.instance.TransportInstanceSingleOperationAction;
+import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -66,22 +65,21 @@ import static org.elasticsearch.action.bulk.TransportSingleItemBulkWriteAction.w
 
 public class TransportUpdateAction extends TransportInstanceSingleOperationAction<UpdateRequest, UpdateResponse> {
 
-    private final TransportBulkAction bulkAction;
     private final AutoCreateIndex autoCreateIndex;
-    private final TransportCreateIndexAction createIndexAction;
     private final UpdateHelper updateHelper;
     private final IndicesService indicesService;
+    private final NodeClient client;
 
     @Inject
     public TransportUpdateAction(Settings settings, ThreadPool threadPool, ClusterService clusterService, TransportService transportService,
-                                 TransportBulkAction bulkAction, TransportCreateIndexAction createIndexAction, UpdateHelper updateHelper, ActionFilters actionFilters,
-                                 IndexNameExpressionResolver indexNameExpressionResolver, IndicesService indicesService, AutoCreateIndex autoCreateIndex) {
+                                 UpdateHelper updateHelper, ActionFilters actionFilters,
+                                 IndexNameExpressionResolver indexNameExpressionResolver, IndicesService indicesService,
+                                 AutoCreateIndex autoCreateIndex, NodeClient client) {
         super(settings, UpdateAction.NAME, threadPool, clusterService, transportService, actionFilters, indexNameExpressionResolver, UpdateRequest::new);
-        this.bulkAction = bulkAction;
-        this.createIndexAction = createIndexAction;
         this.updateHelper = updateHelper;
         this.indicesService = indicesService;
         this.autoCreateIndex = autoCreateIndex;
+        this.client = client;
     }
 
     @Override
@@ -116,7 +114,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     protected void doExecute(final UpdateRequest request, final ActionListener<UpdateResponse> listener) {
         // if we don't have a master, we don't have metadata, that's fine, let it find a master using create index API
         if (autoCreateIndex.shouldAutoCreate(request.index(), clusterService.state())) {
-            createIndexAction.execute(new CreateIndexRequest().index(request.index()).cause("auto(update api)").masterNodeTimeout(request.timeout()), new ActionListener<CreateIndexResponse>() {
+            client.admin().indices().create(new CreateIndexRequest().index(request.index()).cause("auto(update api)").masterNodeTimeout(request.timeout()), new ActionListener<CreateIndexResponse>() {
                 @Override
                 public void onResponse(CreateIndexResponse result) {
                     innerExecute(request, listener);
@@ -177,7 +175,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 IndexRequest upsertRequest = result.action();
                 // we fetch it from the index request so we don't generate the bytes twice, its already done in the index request
                 final BytesReference upsertSourceBytes = upsertRequest.source();
-                bulkAction.execute(toSingleItemBulkRequest(upsertRequest), wrapBulkResponse(
+                client.bulk(toSingleItemBulkRequest(upsertRequest), wrapBulkResponse(
                         ActionListener.<IndexResponse>wrap(response -> {
                             UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getSeqNo(), response.getPrimaryTerm(), response.getVersion(), response.getResult());
                             if (request.fetchSource() != null && request.fetchSource().fetchSource()) {
@@ -197,7 +195,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 IndexRequest indexRequest = result.action();
                 // we fetch it from the index request so we don't generate the bytes twice, its already done in the index request
                 final BytesReference indexSourceBytes = indexRequest.source();
-                bulkAction.execute(toSingleItemBulkRequest(indexRequest), wrapBulkResponse(
+                client.bulk(toSingleItemBulkRequest(indexRequest), wrapBulkResponse(
                         ActionListener.<IndexResponse>wrap(response -> {
                             UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getSeqNo(), response.getPrimaryTerm(), response.getVersion(), response.getResult());
                             update.setGetResult(UpdateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), indexSourceBytes));
@@ -208,7 +206,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 break;
             case DELETED:
                 DeleteRequest deleteRequest = result.action();
-                bulkAction.execute(toSingleItemBulkRequest(deleteRequest), wrapBulkResponse(
+                client.bulk(toSingleItemBulkRequest(deleteRequest), wrapBulkResponse(
                         ActionListener.<DeleteResponse>wrap(response -> {
                             UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getSeqNo(), response.getPrimaryTerm(), response.getVersion(), response.getResult());
                             update.setGetResult(UpdateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), null));

--- a/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
@@ -25,7 +25,6 @@ import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;

--- a/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
@@ -69,15 +69,11 @@ public class TaskResultsService extends AbstractComponent {
 
     private final ClusterService clusterService;
 
-    private final TransportCreateIndexAction createIndexAction;
-
     @Inject
-    public TaskResultsService(Settings settings, Client client, ClusterService clusterService,
-                              TransportCreateIndexAction createIndexAction) {
+    public TaskResultsService(Settings settings, Client client, ClusterService clusterService) {
         super(settings);
         this.client = client;
         this.clusterService = clusterService;
-        this.createIndexAction = createIndexAction;
     }
 
     public void storeResult(TaskResult taskResult, ActionListener<Void> listener) {
@@ -91,7 +87,7 @@ public class TaskResultsService extends AbstractComponent {
             createIndexRequest.mapping(TASK_TYPE, taskResultIndexMapping(), XContentType.JSON);
             createIndexRequest.cause("auto(task api)");
 
-            createIndexAction.execute(null, createIndexRequest, new ActionListener<CreateIndexResponse>() {
+            client.admin().indices().create(createIndexRequest, new ActionListener<CreateIndexResponse>() {
                 @Override
                 public void onResponse(CreateIndexResponse result) {
                     doStoreResult(taskResult, listener);

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -21,13 +21,20 @@
 package org.elasticsearch.action.bulk;
 
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
+import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
@@ -99,14 +106,15 @@ public class TransportBulkActionTookTests extends ESTestCase {
         IndexNameExpressionResolver resolver = new Resolver(Settings.EMPTY);
         ActionFilters actionFilters = new ActionFilters(new HashSet<>());
 
-        TransportCreateIndexAction createIndexAction = new TransportCreateIndexAction(
-                Settings.EMPTY,
-                transportService,
-                clusterService,
-                threadPool,
-                null,
-                actionFilters,
-                resolver);
+        NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
+            @Override
+            public <Request extends ActionRequest,
+                    Response extends ActionResponse,
+                    RequestBuilder extends ActionRequestBuilder<Request, Response>
+                > void doExecute(Action<Response> action, Request request, ActionListener<Response> listener) {
+                listener.onResponse((Response)new CreateIndexResponse());
+            }
+        };
 
         if (controlled) {
 
@@ -116,7 +124,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
                     transportService,
                     clusterService,
                     null,
-                    createIndexAction,
+                    client,
                     actionFilters,
                     resolver,
                     null,
@@ -141,7 +149,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
                     transportService,
                     clusterService,
                     null,
-                    createIndexAction,
+                    client,
                     actionFilters,
                     resolver,
                     null,
@@ -223,7 +231,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
                 TransportService transportService,
                 ClusterService clusterService,
                 TransportShardBulkAction shardBulkAction,
-                TransportCreateIndexAction createIndexAction,
+                NodeClient client,
                 ActionFilters actionFilters,
                 IndexNameExpressionResolver indexNameExpressionResolver,
                 AutoCreateIndex autoCreateIndex,
@@ -235,7 +243,7 @@ public class TransportBulkActionTookTests extends ESTestCase {
                     clusterService,
                     null,
                     shardBulkAction,
-                    createIndexAction,
+                    client,
                     actionFilters,
                     indexNameExpressionResolver,
                     autoCreateIndex,
@@ -253,24 +261,4 @@ public class TransportBulkActionTookTests extends ESTestCase {
         }
 
     }
-
-    static class TestTransportCreateIndexAction extends TransportCreateIndexAction {
-
-        TestTransportCreateIndexAction(
-                Settings settings,
-                TransportService transportService,
-                ClusterService clusterService,
-                ThreadPool threadPool,
-                MetaDataCreateIndexService createIndexService,
-                ActionFilters actionFilters,
-                IndexNameExpressionResolver indexNameExpressionResolver) {
-            super(settings, transportService, clusterService, threadPool, createIndexService, actionFilters, indexNameExpressionResolver);
-        }
-
-        @Override
-        protected void doExecute(Task task, CreateIndexRequest request, ActionListener<CreateIndexResponse> listener) {
-            listener.onResponse(newResponse());
-        }
-    }
-
 }

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -24,20 +24,14 @@ import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.Action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.MetaDataCreateIndexService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -108,10 +102,8 @@ public class TransportBulkActionTookTests extends ESTestCase {
 
         NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
             @Override
-            public <Request extends ActionRequest,
-                    Response extends ActionResponse,
-                    RequestBuilder extends ActionRequestBuilder<Request, Response>
-                > void doExecute(Action<Response> action, Request request, ActionListener<Response> listener) {
+            public <Request extends ActionRequest, Response extends ActionResponse>
+            void doExecute(Action<Response> action, Request request, ActionListener<Response> listener) {
                 listener.onResponse((Response)new CreateIndexResponse());
             }
         };

--- a/server/src/test/java/org/elasticsearch/action/search/TransportMultiSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportMultiSearchActionTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
-import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -107,15 +107,14 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         final ExecutorService commonExecutor = threadPool.executor(threadPoolNames.get(0));
         final ExecutorService rarelyExecutor = threadPool.executor(threadPoolNames.get(1));
         final Set<SearchRequest> requests = Collections.newSetFromMap(Collections.synchronizedMap(new IdentityHashMap<>()));
-        TransportAction<SearchRequest, SearchResponse> searchAction = new TransportAction<SearchRequest, SearchResponse>
-                (Settings.EMPTY, "action", threadPool, actionFilters, taskManager) {
+        NodeClient client = new NodeClient(settings, threadPool) {
             @Override
-            protected void doExecute(SearchRequest request, ActionListener<SearchResponse> listener) {
+            public void search(final SearchRequest request, final ActionListener<SearchResponse> listener) {
                 requests.add(request);
                 int currentConcurrentSearches = counter.incrementAndGet();
                 if (currentConcurrentSearches > maxAllowedConcurrentSearches) {
                     errorHolder.set(new AssertionError("Current concurrent search [" + currentConcurrentSearches +
-                            "] is higher than is allowed [" + maxAllowedConcurrentSearches + "]"));
+                        "] is higher than is allowed [" + maxAllowedConcurrentSearches + "]"));
                 }
                 final ExecutorService executorService = rarely() ? rarelyExecutor : commonExecutor;
                 executorService.execute(() -> {
@@ -126,8 +125,7 @@ public class TransportMultiSearchActionTests extends ESTestCase {
         };
 
         TransportMultiSearchAction action =
-                new TransportMultiSearchAction(threadPool, actionFilters, transportService, clusterService, searchAction, 10,
-                System::nanoTime);
+            new TransportMultiSearchAction(threadPool, actionFilters, transportService, clusterService, 10, System::nanoTime, client);
 
         // Execute the multi search api and fail if we find an error after executing:
         try {


### PR DESCRIPTION
This commit converts some of the existing calls to
TransportAction.execute to use the equivalent client method for the
desired action.
