### PR TITLE
Get Mapping API to honour allow_no_indices and ignore_unavailable

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/30_missing_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/30_missing_index.yml
@@ -13,3 +13,24 @@
       indices.get_mapping:
         index: test_index
 
+---
+"Index missing, ignore_unavailable=true":
+ - skip:
+    version: " - 6.99.99"
+    reason: ignore_unavailable was ignored in previous versions
+  - do:
+      indices.get_mapping:
+        index: test_index
+        ignore_unavailable: true
+
+  - match: { '':  {} }
+
+---
+"Index missing, ignore_unavailable=true, allow_no_indices=false":
+  - do:
+      catch: missing
+      indices.get_mapping:
+        index: test_index
+        ignore_unavailable: true
+        allow_no_indices: false
+

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/30_missing_index.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/30_missing_index.yml
@@ -15,9 +15,9 @@
 
 ---
 "Index missing, ignore_unavailable=true":
- - skip:
-    version: " - 6.99.99"
-    reason: ignore_unavailable was ignored in previous versions
+  - skip:
+      version: " - 6.99.99"
+      reason: ignore_unavailable was ignored in previous versions
   - do:
       indices.get_mapping:
         index: test_index

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
@@ -94,12 +94,26 @@ setup:
 
 ---
 "Get test-* with wildcard_expansion=none":
+ - skip:
+    version: " - 6.99.99"
+    reason: allow_no_indices (defaults to true) was ignored in previous versions
+ - do:
+    indices.get_mapping:
+        index: test-x*
+        expand_wildcards: none
+
+ - match: { '':  {} }
+---
+"Get test-* with wildcard_expansion=none allow_no_indices=false":
+ - skip:
+    version: " - 6.99.99"
+    reason: allow_no_indices was ignored in previous versions
  - do:
     catch: missing
     indices.get_mapping:
         index: test-x*
         expand_wildcards: none
-
+        allow_no_indices: false
 ---
 "Get test-* with wildcard_expansion=open,closed":
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetMappingAction.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.TypeMissingException;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
@@ -89,14 +88,9 @@ public class RestGetMappingAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(final GetMappingsResponse response, final XContentBuilder builder) throws Exception {
                 final ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappingsByIndex = response.getMappings();
-                if (mappingsByIndex.isEmpty() && (indices.length != 0 || types.length != 0)) {
-                    if (indices.length != 0 && types.length == 0) {
-                        builder.close();
-                        return new BytesRestResponse(channel, new IndexNotFoundException(String.join(",", indices)));
-                    } else {
-                        builder.close();
-                        return new BytesRestResponse(channel, new TypeMissingException("_all", String.join(",", types)));
-                    }
+                if (mappingsByIndex.isEmpty() && types.length != 0) {
+                    builder.close();
+                    return new BytesRestResponse(channel, new TypeMissingException("_all", String.join(",", types)));
                 }
 
                 final Set<String> typeNames = new HashSet<>();


### PR DESCRIPTION
Get Mapping currently throws index not found exception (and returns
404 status code) from the REST layer whenever an index was specified
and no indices have been returned. We should not have this logic in the
REST layer though as only our index resolver should decide whether we
need to throw exceptions or not based on provided indices and corresponding
indices options.

Closes #31485