### PR TITLE
Close xcontent parsers (partial)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -558,9 +558,10 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
         builder.startObject("mappings");
         for (Map.Entry<String, String> entry : mappings.entrySet()) {
             builder.field(entry.getKey());
-            XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, entry.getValue());
-            builder.copyCurrentStructure(parser);
+            try (XContentParser parser = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION, entry.getValue())) {
+                builder.copyCurrentStructure(parser);
+            }
         }
         builder.endObject();
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
@@ -58,12 +58,13 @@ public class ClusterUpdateSettingsRequestTests extends ESTestCase {
             assertThat(iae.getMessage(),
                     containsString("[cluster_update_settings_request] unknown field [" + unsupportedField + "], parser not found"));
         } else {
-            XContentParser parser = createParser(xContentType.xContent(), originalBytes);
-            ClusterUpdateSettingsRequest parsedRequest = ClusterUpdateSettingsRequest.fromXContent(parser);
+            try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
+                ClusterUpdateSettingsRequest parsedRequest = ClusterUpdateSettingsRequest.fromXContent(parser);
 
-            assertNull(parser.nextToken());
-            assertThat(parsedRequest.transientSettings(), equalTo(request.transientSettings()));
-            assertThat(parsedRequest.persistentSettings(), equalTo(request.persistentSettings()));
+                assertNull(parser.nextToken());
+                assertThat(parsedRequest.transientSettings(), equalTo(request.transientSettings()));
+                assertThat(parsedRequest.persistentSettings(), equalTo(request.persistentSettings()));
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestTests.java
@@ -134,11 +134,12 @@ public class CreateIndexRequestTests extends ESTestCase {
         for (Map.Entry<String, String> expectedEntry : expected.entrySet()) {
             String expectedValue = expectedEntry.getValue();
             String actualValue = actual.get(expectedEntry.getKey());
-            XContentParser expectedJson = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
+            try (XContentParser expectedJson = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
                     LoggingDeprecationHandler.INSTANCE, expectedValue);
-            XContentParser actualJson = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
-                    LoggingDeprecationHandler.INSTANCE, actualValue);
-            assertEquals(expectedJson.map(), actualJson.map());
+                 XContentParser actualJson = JsonXContent.jsonXContent.createParser(NamedXContentRegistry.EMPTY,
+                    LoggingDeprecationHandler.INSTANCE, actualValue)){
+                assertEquals(expectedJson.map(), actualJson.map());
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
@@ -148,7 +148,7 @@ public class PutMappingRequestTests extends ESTestCase {
     private void assertMappingsEqual(String expected, String actual) throws IOException {
 
         try (XContentParser expectedJson = createParser(XContentType.JSON.xContent(), expected);
-        XContentParser actualJson = createParser(XContentType.JSON.xContent(), actual)) {
+            XContentParser actualJson = createParser(XContentType.JSON.xContent(), actual)) {
             assertEquals(expectedJson.mapOrdered(), actualJson.mapOrdered());
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestTests.java
@@ -147,9 +147,10 @@ public class PutMappingRequestTests extends ESTestCase {
 
     private void assertMappingsEqual(String expected, String actual) throws IOException {
 
-        XContentParser expectedJson = createParser(XContentType.JSON.xContent(), expected);
-        XContentParser actualJson = createParser(XContentType.JSON.xContent(), actual);
-        assertEquals(expectedJson.mapOrdered(), actualJson.mapOrdered());
+        try (XContentParser expectedJson = createParser(XContentType.JSON.xContent(), expected);
+        XContentParser actualJson = createParser(XContentType.JSON.xContent(), actual)) {
+            assertEquals(expectedJson.mapOrdered(), actualJson.mapOrdered());
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequestTests;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.RandomCreateIndexGenerator;
 import org.elasticsearch.test.ESTestCase;
@@ -93,7 +94,9 @@ public class ResizeRequestTests extends ESTestCase {
 
         ResizeRequest parsedResizeRequest = new ResizeRequest(resizeRequest.getTargetIndexRequest().index(),
                 resizeRequest.getSourceIndex());
-        parsedResizeRequest.fromXContent(createParser(xContentType.xContent(), originalBytes));
+        try (XContentParser xParser = createParser(xContentType.xContent(), originalBytes)) {
+            parsedResizeRequest.fromXContent(xParser);
+        }
 
         assertEquals(resizeRequest.getSourceIndex(), parsedResizeRequest.getSourceIndex());
         assertEquals(resizeRequest.getTargetIndexRequest().index(), parsedResizeRequest.getTargetIndexRequest().index());

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
@@ -54,7 +54,7 @@ public class MultiGetRequestTests extends ESTestCase {
             builder.endArray();
         }
         builder.endObject();
-        try (final XContentParser parser = createParser(builder)) {
+        try (XContentParser parser = createParser(builder)) {
             final MultiGetRequest mgr = new MultiGetRequest();
             final ParsingException e = expectThrows(
                 ParsingException.class,

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
@@ -54,9 +54,9 @@ public class MultiGetRequestTests extends ESTestCase {
             builder.endArray();
         }
         builder.endObject();
-        final XContentParser parser = createParser(builder);
-        final MultiGetRequest mgr = new MultiGetRequest();
-        final ParsingException e = expectThrows(
+        try (final XContentParser parser = createParser(builder)) {
+            final MultiGetRequest mgr = new MultiGetRequest();
+            final ParsingException e = expectThrows(
                 ParsingException.class,
                 () -> {
                     final String defaultIndex = randomAlphaOfLength(5);
@@ -64,9 +64,10 @@ public class MultiGetRequestTests extends ESTestCase {
                     final FetchSourceContext fetchSource = FetchSourceContext.FETCH_SOURCE;
                     mgr.add(defaultIndex, defaultType, null, fetchSource, null, parser, true);
                 });
-        assertThat(
+            assertThat(
                 e.toString(),
                 containsString("unknown key [doc] for a START_ARRAY, expected [docs] or [ids]"));
+        }
     }
 
     public void testUnexpectedField() throws IOException {
@@ -141,16 +142,17 @@ public class MultiGetRequestTests extends ESTestCase {
             MultiGetRequest expected = createTestInstance();
             XContentType xContentType = randomFrom(XContentType.values());
             BytesReference shuffled = toShuffledXContent(expected, xContentType, ToXContent.EMPTY_PARAMS, false);
-            XContentParser parser = createParser(XContentFactory.xContent(xContentType), shuffled);
-            MultiGetRequest actual = new MultiGetRequest();
-            actual.add(null, null, null, null, null, parser, true);
-            assertThat(parser.nextToken(), nullValue());
+            try (XContentParser parser = createParser(XContentFactory.xContent(xContentType), shuffled)) {
+                MultiGetRequest actual = new MultiGetRequest();
+                actual.add(null, null, null, null, null, parser, true);
+                assertThat(parser.nextToken(), nullValue());
 
-            assertThat(actual.items.size(), equalTo(expected.items.size()));
-            for (int i = 0; i < expected.items.size(); i++) {
-                MultiGetRequest.Item expectedItem = expected.items.get(i);
-                MultiGetRequest.Item actualItem = actual.items.get(i);
-                assertThat(actualItem, equalTo(expectedItem));
+                assertThat(actual.items.size(), equalTo(expected.items.size()));
+                for (int i = 0; i < expected.items.size(); i++) {
+                    MultiGetRequest.Item expectedItem = expected.items.get(i);
+                    MultiGetRequest.Item actualItem = actual.items.get(i);
+                    assertThat(actualItem, equalTo(expectedItem));
+                }
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetResponseTests.java
@@ -39,10 +39,11 @@ public class MultiGetResponseTests extends ESTestCase {
             MultiGetResponse expected = createTestInstance();
             XContentType xContentType = randomFrom(XContentType.values());
             BytesReference shuffled = toShuffledXContent(expected, xContentType, ToXContent.EMPTY_PARAMS, false);
-
-            XContentParser parser = createParser(XContentFactory.xContent(xContentType), shuffled);
-            MultiGetResponse parsed = MultiGetResponse.fromXContent(parser);
-            assertNull(parser.nextToken());
+            MultiGetResponse parsed;
+            try (XContentParser parser = createParser(XContentFactory.xContent(xContentType), shuffled)) {
+                parsed = MultiGetResponse.fromXContent(parser);
+                assertNull(parser.nextToken());
+            }
             assertNotSame(expected, parsed);
 
             assertThat(parsed.getResponses().length, equalTo(expected.getResponses().length));
@@ -60,6 +61,7 @@ public class MultiGetResponseTests extends ESTestCase {
                     assertThat(actualItem.getResponse(), equalTo(expectedItem.getResponse()));
                 }
             }
+
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchResponseTests.java
@@ -40,9 +40,11 @@ public class MultiSearchResponseTests extends ESTestCase {
             MultiSearchResponse expected = createTestInstance();
             XContentType xContentType = randomFrom(XContentType.values());
             BytesReference shuffled = toShuffledXContent(expected, xContentType, ToXContent.EMPTY_PARAMS, false);
-            XContentParser parser = createParser(XContentFactory.xContent(xContentType), shuffled);
-            MultiSearchResponse actual = MultiSearchResponse.fromXContext(parser);
-            assertThat(parser.nextToken(), nullValue());
+            MultiSearchResponse actual;
+            try (XContentParser parser = createParser(XContentFactory.xContent(xContentType), shuffled)) {
+                actual = MultiSearchResponse.fromXContext(parser);
+                assertThat(parser.nextToken(), nullValue());
+            }
 
             assertThat(actual.getTook(), equalTo(expected.getTook()));
             assertThat(actual.getResponses().length, equalTo(expected.getResponses().length));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -182,12 +182,10 @@ public class MetaDataTests extends ESTestCase {
                 .endObject()
             .endObject());
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, metadata)) {
-            try {
-                MetaData.Builder.fromXContent(parser);
-                fail();
-            } catch (IllegalArgumentException e) {
-                assertEquals("Unexpected field [random]", e.getMessage());
-            }
+            MetaData.Builder.fromXContent(parser);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Unexpected field [random]", e.getMessage());
         }
     }
 
@@ -199,12 +197,10 @@ public class MetaDataTests extends ESTestCase {
                 .endObject()
             .endObject());
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, metadata)) {
-            try {
-                IndexMetaData.Builder.fromXContent(parser);
-                fail();
-            } catch (IllegalArgumentException e) {
-                assertEquals("Unexpected field [random]", e.getMessage());
-            }
+            IndexMetaData.Builder.fromXContent(parser);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Unexpected field [random]", e.getMessage());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataTests.java
@@ -181,12 +181,13 @@ public class MetaDataTests extends ESTestCase {
                     .field("random", "value")
                 .endObject()
             .endObject());
-        XContentParser parser = createParser(JsonXContent.jsonXContent, metadata);
-        try {
-            MetaData.Builder.fromXContent(parser);
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertEquals("Unexpected field [random]", e.getMessage());
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, metadata)) {
+            try {
+                MetaData.Builder.fromXContent(parser);
+                fail();
+            } catch (IllegalArgumentException e) {
+                assertEquals("Unexpected field [random]", e.getMessage());
+            }
         }
     }
 
@@ -197,12 +198,13 @@ public class MetaDataTests extends ESTestCase {
                     .field("random", "value")
                 .endObject()
             .endObject());
-        XContentParser parser = createParser(JsonXContent.jsonXContent, metadata);
-        try {
-            IndexMetaData.Builder.fromXContent(parser);
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertEquals("Unexpected field [random]", e.getMessage());
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, metadata)) {
+            try {
+                IndexMetaData.Builder.fromXContent(parser);
+                fail();
+            } catch (IllegalArgumentException e) {
+                assertEquals("Unexpected field [random]", e.getMessage());
+            }
         }
     }
 
@@ -225,9 +227,10 @@ public class MetaDataTests extends ESTestCase {
         builder.startObject();
         originalMeta.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        final MetaData fromXContentMeta = MetaData.fromXContent(parser);
-        assertThat(fromXContentMeta.indexGraveyard(), equalTo(originalMeta.indexGraveyard()));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            final MetaData fromXContentMeta = MetaData.fromXContent(parser);
+            assertThat(fromXContentMeta.indexGraveyard(), equalTo(originalMeta.indexGraveyard()));
+        }
     }
 
     public void testSerializationWithIndexGraveyard() throws IOException {

--- a/server/src/test/java/org/elasticsearch/common/geo/BaseGeoParsingTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/BaseGeoParsingTestCase.java
@@ -50,15 +50,17 @@ abstract class BaseGeoParsingTestCase extends ESTestCase {
     public abstract void testParseGeometryCollection() throws IOException;
 
     protected void assertValidException(XContentBuilder builder, Class expectedException) throws IOException {
-        XContentParser parser = createParser(builder);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, expectedException);
+        try (XContentParser parser = createParser(builder)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, expectedException);
+        }
     }
 
     protected void assertGeometryEquals(Shape expected, XContentBuilder geoJson) throws IOException {
-        XContentParser parser = createParser(geoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertEquals(expected, ShapeParser.parse(parser).build());
+        try (XContentParser parser = createParser(geoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertEquals(expected, ShapeParser.parse(parser).build());
+        }
     }
 
     protected ShapeCollection<Shape> shapeCollection(Shape... shapes) {

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoJsonShapeParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoJsonShapeParserTests.java
@@ -193,18 +193,20 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .startArray().value(50).value(-39).endArray()
                 .endArray()
                 .endObject();
-        XContentParser parser = createParser(multilinesGeoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(multilinesGeoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
 
         // test #4: "envelope" with empty coordinates
         multilinesGeoJson = XContentFactory.jsonBuilder().startObject().field("type", "envelope")
                 .startArray("coordinates")
                 .endArray()
                 .endObject();
-        parser = createParser(multilinesGeoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(multilinesGeoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
     }
 
     @Override
@@ -266,9 +268,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
         Polygon expected = GEOMETRY_FACTORY.createPolygon(shell, null);
         Mapper.BuilderContext mockBuilderContext = new Mapper.BuilderContext(indexSettings, new ContentPath());
         final GeoShapeFieldMapper mapperBuilder = new GeoShapeFieldMapper.Builder("test").ignoreZValue(true).build(mockBuilderContext);
-        XContentParser parser = createParser(polygonGeoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertEquals(jtsGeom(expected), ShapeParser.parse(parser, mapperBuilder).build());
+        try (XContentParser parser = createParser(polygonGeoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertEquals(jtsGeom(expected), ShapeParser.parse(parser, mapperBuilder).build());
+        }
     }
 
     public void testInvalidDimensionalPolygon() throws IOException {
@@ -285,9 +288,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
             .endArray()
             .endArray()
             .endObject();
-        XContentParser parser = createParser(polygonGeoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(polygonGeoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
     }
 
     public void testParseInvalidPoint() throws IOException {
@@ -299,9 +303,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                         .startArray().value(-74.011).value(40.753).endArray()
                     .endArray()
                 .endObject();
-        XContentParser parser = createParser(invalidPoint1);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(invalidPoint1)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
 
         // test case 2: create an invalid point object with an empty number of coordinates
         XContentBuilder invalidPoint2 = XContentFactory.jsonBuilder()
@@ -310,9 +315,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .startArray("coordinates")
                     .endArray()
                 .endObject();
-        parser = createParser(invalidPoint2);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(invalidPoint2)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
     }
 
     public void testParseInvalidMultipoint() throws IOException {
@@ -322,9 +328,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .field("type", "multipoint")
                     .startArray("coordinates").value(-74.011).value(40.753).endArray()
                 .endObject();
-        XContentParser parser = createParser(invalidMultipoint1);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(invalidMultipoint1)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
 
         // test case 2: create an invalid multipoint object with null coordinate
         XContentBuilder invalidMultipoint2 = XContentFactory.jsonBuilder()
@@ -333,9 +340,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .startArray("coordinates")
                     .endArray()
                 .endObject();
-        parser = createParser(invalidMultipoint2);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(invalidMultipoint2)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
 
         // test case 3: create a valid formatted multipoint object with invalid number (0) of coordinates
         XContentBuilder invalidMultipoint3 = XContentFactory.jsonBuilder()
@@ -345,9 +353,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                         .startArray().endArray()
                     .endArray()
                 .endObject();
-        parser = createParser(invalidMultipoint3);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(invalidMultipoint3)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
     }
 
     public void testParseInvalidMultiPolygon() throws IOException {
@@ -380,9 +389,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, multiPolygonGeoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, InvalidShapeException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, multiPolygonGeoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, InvalidShapeException.class);
+        }
     }
 
     public void testParseInvalidDimensionalMultiPolygon() throws IOException {
@@ -419,9 +429,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
             .endArray()
             .endObject());
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, multiPolygonGeoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, multiPolygonGeoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
     }
 
 
@@ -440,11 +451,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson);
-        parser.nextToken();
-        Shape shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertPolygon(shape);
+            ElasticsearchGeoAssertions.assertPolygon(shape);
+        }
 
         // test 2: ccw poly crossing dateline
         polygonGeoJson = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
@@ -460,11 +472,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+            ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+        }
 
         // test 3: cw poly not crossing dateline
         polygonGeoJson = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
@@ -480,11 +493,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertPolygon(shape);
+            ElasticsearchGeoAssertions.assertPolygon(shape);
+        }
 
         // test 4: cw poly crossing dateline
         polygonGeoJson = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
@@ -500,11 +514,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+            ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+        }
     }
 
     public void testParseOGCPolygonWithHoles() throws IOException {
@@ -528,11 +543,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson);
-        parser.nextToken();
-        Shape shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertPolygon(shape);
+            ElasticsearchGeoAssertions.assertPolygon(shape);
+        }
 
         // test 2: ccw poly crossing dateline
         polygonGeoJson = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
@@ -554,11 +570,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+            ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+        }
 
         // test 3: cw poly not crossing dateline
         polygonGeoJson = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
@@ -580,11 +597,13 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertPolygon(shape);
+            ElasticsearchGeoAssertions.assertPolygon(shape);
+        }
+
 
         // test 4: cw poly crossing dateline
         polygonGeoJson = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "Polygon")
@@ -606,11 +625,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+            ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+        }
     }
 
     public void testParseInvalidPolygon() throws IOException {
@@ -627,9 +647,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endArray()
                 .endObject());
-        XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
 
         // test case 2: create an invalid polygon with only 1 point
         invalidPoly = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "polygon")
@@ -640,9 +661,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, invalidPoly);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
 
         // test case 3: create an invalid polygon with 0 points
         invalidPoly = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "polygon")
@@ -653,9 +675,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, invalidPoly);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
 
         // test case 4: create an invalid polygon with null value points
         invalidPoly = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "polygon")
@@ -666,9 +689,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, invalidPoly);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, IllegalArgumentException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, IllegalArgumentException.class);
+        }
 
         // test case 5: create an invalid polygon with 1 invalid LinearRing
         invalidPoly = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "polygon")
@@ -677,18 +701,20 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, invalidPoly);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, IllegalArgumentException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, IllegalArgumentException.class);
+        }
 
         // test case 6: create an invalid polygon with 0 LinearRings
         invalidPoly = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "polygon")
                 .startArray("coordinates").endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, invalidPoly);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
 
         // test case 7: create an invalid polygon with 0 LinearRings
         invalidPoly = Strings.toString(XContentFactory.jsonBuilder().startObject().field("type", "polygon")
@@ -697,9 +723,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        parser = createParser(JsonXContent.jsonXContent, invalidPoly);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidPoly)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+        }
     }
 
     public void testParsePolygonWithHole() throws IOException {
@@ -764,9 +791,10 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                 .endArray()
                 .endObject());
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, InvalidShapeException.class);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, polygonGeoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, InvalidShapeException.class);
+        }
     }
 
     @Override
@@ -980,11 +1008,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .endArray()
                 .endObject();
 
-        XContentParser parser = createParser(polygonGeoJson);
-        parser.nextToken();
-        Shape shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertPolygon(shape);
+            ElasticsearchGeoAssertions.assertPolygon(shape);
+        }
 
         // test 2: valid ccw (right handed system) poly not crossing dateline (with 'ccw' field)
         polygonGeoJson = XContentFactory.jsonBuilder()
@@ -1009,11 +1038,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .endArray()
                 .endObject();
 
-        parser = createParser(polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertPolygon(shape);
+            ElasticsearchGeoAssertions.assertPolygon(shape);
+        }
 
         // test 3: valid ccw (right handed system) poly not crossing dateline (with 'counterclockwise' field)
         polygonGeoJson = XContentFactory.jsonBuilder()
@@ -1038,11 +1068,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .endArray()
                 .endObject();
 
-        parser = createParser(polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertPolygon(shape);
+            ElasticsearchGeoAssertions.assertPolygon(shape);
+        }
 
         // test 4: valid cw (left handed system) poly crossing dateline (with 'left' field)
         polygonGeoJson = XContentFactory.jsonBuilder()
@@ -1067,11 +1098,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .endArray()
                 .endObject();
 
-        parser = createParser(polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+            ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+        }
 
         // test 5: valid cw multipoly (left handed system) poly crossing dateline (with 'cw' field)
         polygonGeoJson = XContentFactory.jsonBuilder()
@@ -1096,11 +1128,12 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .endArray()
                 .endObject();
 
-        parser = createParser(polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+            ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+        }
 
         // test 6: valid cw multipoly (left handed system) poly crossing dateline (with 'clockwise' field)
         polygonGeoJson = XContentFactory.jsonBuilder()
@@ -1125,10 +1158,11 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
                     .endArray()
                 .endObject();
 
-        parser = createParser(polygonGeoJson);
-        parser.nextToken();
-        shape = ShapeParser.parse(parser).build();
+        try (XContentParser parser = createParser(polygonGeoJson)) {
+            parser.nextToken();
+            Shape shape = ShapeParser.parse(parser).build();
 
-        ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+            ElasticsearchGeoAssertions.assertMultiPolygon(shape);
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoUtilTests.java
@@ -59,13 +59,14 @@ public class GeoUtilTests extends ESTestCase {
         XContentBuilder builder = jsonBuilder().startObject();
         tokenGenerator.accept(builder);
         builder.endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken()); // {
-        assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken()); // field name
-        assertTrue(parser.nextToken().isValue()); // field value
-        int precision = GeoUtils.parsePrecision(parser);
-        assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken()); // }
-        assertNull(parser.nextToken()); // no more tokens
-        return precision;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken()); // {
+            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken()); // field name
+            assertTrue(parser.nextToken().isValue()); // field value
+            int precision = GeoUtils.parsePrecision(parser);
+            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken()); // }
+            assertNull(parser.nextToken()); // no more tokens
+            return precision;
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/geo/builders/AbstractShapeBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/builders/AbstractShapeBuilderTestCase.java
@@ -79,12 +79,13 @@ public abstract class AbstractShapeBuilderTestCase<SB extends ShapeBuilder> exte
             }
             XContentBuilder builder = testShape.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
             XContentBuilder shuffled = shuffleXContent(builder);
-            XContentParser shapeContentParser = createParser(shuffled);
-            shapeContentParser.nextToken();
-            ShapeBuilder parsedShape = ShapeParser.parse(shapeContentParser);
-            assertNotSame(testShape, parsedShape);
-            assertEquals(testShape, parsedShape);
-            assertEquals(testShape.hashCode(), parsedShape.hashCode());
+            try (XContentParser shapeContentParser = createParser(shuffled)) {
+                shapeContentParser.nextToken();
+                ShapeBuilder parsedShape = ShapeParser.parse(shapeContentParser);
+                assertNotSame(testShape, parsedShape);
+                assertEquals(testShape, parsedShape);
+                assertEquals(testShape.hashCode(), parsedShape.hashCode());
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/unit/FuzzinessTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/FuzzinessTests.java
@@ -45,13 +45,14 @@ public class FuzzinessTests extends ESTestCase {
                 XContentBuilder json = jsonBuilder().startObject()
                         .field(Fuzziness.X_FIELD_NAME, floatValue)
                         .endObject();
-                XContentParser parser = createParser(json);
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
-                Fuzziness fuzziness = Fuzziness.parse(parser);
-                assertThat(fuzziness.asFloat(), equalTo(floatValue));
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+                try (XContentParser parser = createParser(json)) {
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.VALUE_NUMBER));
+                    Fuzziness fuzziness = Fuzziness.parse(parser);
+                    assertThat(fuzziness.asFloat(), equalTo(floatValue));
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+                }
             }
             {
                 Integer intValue = frequently() ? randomIntBetween(0, 2) : randomIntBetween(0, 100);
@@ -63,28 +64,29 @@ public class FuzzinessTests extends ESTestCase {
                 XContentBuilder json = jsonBuilder().startObject()
                         .field(Fuzziness.X_FIELD_NAME, randomBoolean() ? value.toString() : value)
                         .endObject();
-                XContentParser parser = createParser(json);
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
-                assertThat(parser.nextToken(), anyOf(equalTo(XContentParser.Token.VALUE_NUMBER), equalTo(XContentParser.Token.VALUE_STRING)));
-                Fuzziness fuzziness = Fuzziness.parse(parser);
-                if (value.intValue() >= 1) {
-                    assertThat(fuzziness.asDistance(), equalTo(Math.min(2, value.intValue())));
-                }
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
-                if (intValue.equals(value)) {
-                    switch (intValue) {
-                        case 1:
-                            assertThat(fuzziness, sameInstance(Fuzziness.ONE));
-                            break;
-                        case 2:
-                            assertThat(fuzziness, sameInstance(Fuzziness.TWO));
-                            break;
-                        case 0:
-                            assertThat(fuzziness, sameInstance(Fuzziness.ZERO));
-                            break;
-                        default:
-                            break;
+                try (XContentParser parser = createParser(json)) {
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
+                    assertThat(parser.nextToken(), anyOf(equalTo(XContentParser.Token.VALUE_NUMBER), equalTo(XContentParser.Token.VALUE_STRING)));
+                    Fuzziness fuzziness = Fuzziness.parse(parser);
+                    if (value.intValue() >= 1) {
+                        assertThat(fuzziness.asDistance(), equalTo(Math.min(2, value.intValue())));
+                    }
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
+                    if (intValue.equals(value)) {
+                        switch (intValue) {
+                            case 1:
+                                assertThat(fuzziness, sameInstance(Fuzziness.ONE));
+                                break;
+                            case 2:
+                                assertThat(fuzziness, sameInstance(Fuzziness.TWO));
+                                break;
+                            case 0:
+                                assertThat(fuzziness, sameInstance(Fuzziness.ZERO));
+                                break;
+                            default:
+                                break;
+                        }
                     }
                 }
             }
@@ -102,15 +104,16 @@ public class FuzzinessTests extends ESTestCase {
                         .field(Fuzziness.X_FIELD_NAME, auto)
                         .endObject();
                 }
-                XContentParser parser = createParser(json);
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
-                Fuzziness fuzziness = Fuzziness.parse(parser);
-                if (isDefaultAutoFuzzinessTested) {
-                    assertThat(fuzziness, sameInstance(Fuzziness.AUTO));
+                try (XContentParser parser = createParser(json)) {
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
+                    Fuzziness fuzziness = Fuzziness.parse(parser);
+                    if (isDefaultAutoFuzzinessTested) {
+                        assertThat(fuzziness, sameInstance(Fuzziness.AUTO));
+                    }
+                    assertThat(parser.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
                 }
-                assertThat(parser.nextToken(), equalTo(XContentParser.Token.END_OBJECT));
             }
         }
 
@@ -152,15 +155,16 @@ public class FuzzinessTests extends ESTestCase {
             .field(Fuzziness.X_FIELD_NAME, auto)
             .endObject();
 
-        XContentParser parser = createParser(json);
-        assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
-        assertThat(parser.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
-        assertThat(parser.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
-        Fuzziness fuzziness = Fuzziness.parse(parser);
+        try (XContentParser parser = createParser(json)) {
+            assertThat(parser.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
+            assertThat(parser.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
+            assertThat(parser.nextToken(), equalTo(XContentParser.Token.VALUE_STRING));
+            Fuzziness fuzziness = Fuzziness.parse(parser);
 
-        Fuzziness deserializedFuzziness = doSerializeRoundtrip(fuzziness);
-        assertEquals(fuzziness, deserializedFuzziness);
-        assertEquals(fuzziness.asString(), deserializedFuzziness.asString());
+            Fuzziness deserializedFuzziness = doSerializeRoundtrip(fuzziness);
+            assertEquals(fuzziness, deserializedFuzziness);
+            assertEquals(fuzziness.asString(), deserializedFuzziness.asString());
+        }
     }
 
     private static Fuzziness doSerializeRoundtrip(Fuzziness in) throws IOException {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/BaseXContentTestCase.java
@@ -274,14 +274,15 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         final byte[] randomBytes = randomBytes();
         BytesReference bytes = BytesReference.bytes(builder().startObject().field("binary", randomBytes).endObject());
 
-        XContentParser parser = createParser(xcontentType().xContent(), bytes);
-        assertSame(parser.nextToken(), Token.START_OBJECT);
-        assertSame(parser.nextToken(), Token.FIELD_NAME);
-        assertEquals(parser.currentName(), "binary");
-        assertTrue(parser.nextToken().isValue());
-        assertArrayEquals(randomBytes, parser.binaryValue());
-        assertSame(parser.nextToken(), Token.END_OBJECT);
-        assertNull(parser.nextToken());
+        try (XContentParser parser = createParser(xcontentType().xContent(), bytes)) {
+            assertSame(parser.nextToken(), Token.START_OBJECT);
+            assertSame(parser.nextToken(), Token.FIELD_NAME);
+            assertEquals(parser.currentName(), "binary");
+            assertTrue(parser.nextToken().isValue());
+            assertArrayEquals(randomBytes, parser.binaryValue());
+            assertSame(parser.nextToken(), Token.END_OBJECT);
+            assertNull(parser.nextToken());
+        }
     }
 
     public void testBinaryValue() throws Exception {
@@ -290,14 +291,15 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         final byte[] randomBytes = randomBytes();
         BytesReference bytes = BytesReference.bytes(builder().startObject().field("binary").value(randomBytes).endObject());
 
-        XContentParser parser = createParser(xcontentType().xContent(), bytes);
-        assertSame(parser.nextToken(), Token.START_OBJECT);
-        assertSame(parser.nextToken(), Token.FIELD_NAME);
-        assertEquals(parser.currentName(), "binary");
-        assertTrue(parser.nextToken().isValue());
-        assertArrayEquals(randomBytes, parser.binaryValue());
-        assertSame(parser.nextToken(), Token.END_OBJECT);
-        assertNull(parser.nextToken());
+        try (XContentParser parser = createParser(xcontentType().xContent(), bytes)) {
+            assertSame(parser.nextToken(), Token.START_OBJECT);
+            assertSame(parser.nextToken(), Token.FIELD_NAME);
+            assertEquals(parser.currentName(), "binary");
+            assertTrue(parser.nextToken().isValue());
+            assertArrayEquals(randomBytes, parser.binaryValue());
+            assertSame(parser.nextToken(), Token.END_OBJECT);
+            assertNull(parser.nextToken());
+        }
     }
 
     public void testBinaryValueWithOffsetLength() throws Exception {
@@ -315,14 +317,15 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         }
         builder.endObject();
 
-        XContentParser parser = createParser(xcontentType().xContent(), BytesReference.bytes(builder));
-        assertSame(parser.nextToken(), Token.START_OBJECT);
-        assertSame(parser.nextToken(), Token.FIELD_NAME);
-        assertEquals(parser.currentName(), "bin");
-        assertTrue(parser.nextToken().isValue());
-        assertArrayEquals(Arrays.copyOfRange(randomBytes, offset, offset + length), parser.binaryValue());
-        assertSame(parser.nextToken(), Token.END_OBJECT);
-        assertNull(parser.nextToken());
+        try (XContentParser parser = createParser(xcontentType().xContent(), BytesReference.bytes(builder))) {
+            assertSame(parser.nextToken(), Token.START_OBJECT);
+            assertSame(parser.nextToken(), Token.FIELD_NAME);
+            assertEquals(parser.currentName(), "bin");
+            assertTrue(parser.nextToken().isValue());
+            assertArrayEquals(Arrays.copyOfRange(randomBytes, offset, offset + length), parser.binaryValue());
+            assertSame(parser.nextToken(), Token.END_OBJECT);
+            assertNull(parser.nextToken());
+        }
     }
 
     public void testBinaryUTF8() throws Exception {
@@ -333,14 +336,15 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         builder.field("utf8").utf8Value(randomBytesRef.bytes, randomBytesRef.offset, randomBytesRef.length);
         builder.endObject();
 
-        XContentParser parser = createParser(xcontentType().xContent(), BytesReference.bytes(builder));
-        assertSame(parser.nextToken(), Token.START_OBJECT);
-        assertSame(parser.nextToken(), Token.FIELD_NAME);
-        assertEquals(parser.currentName(), "utf8");
-        assertTrue(parser.nextToken().isValue());
-        assertThat(new BytesRef(parser.charBuffer()).utf8ToString(), equalTo(randomBytesRef.utf8ToString()));
-        assertSame(parser.nextToken(), Token.END_OBJECT);
-        assertNull(parser.nextToken());
+        try (XContentParser parser = createParser(xcontentType().xContent(), BytesReference.bytes(builder))) {
+            assertSame(parser.nextToken(), Token.START_OBJECT);
+            assertSame(parser.nextToken(), Token.FIELD_NAME);
+            assertEquals(parser.currentName(), "utf8");
+            assertTrue(parser.nextToken().isValue());
+            assertThat(new BytesRef(parser.charBuffer()).utf8ToString(), equalTo(randomBytesRef.utf8ToString()));
+            assertSame(parser.nextToken(), Token.END_OBJECT);
+            assertNull(parser.nextToken());
+        }
     }
 
     public void testText() throws Exception {
@@ -351,14 +355,15 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         final BytesReference random = new BytesArray(randomBytes());
         XContentBuilder builder = builder().startObject().field("text", new Text(random)).endObject();
 
-        XContentParser parser = createParser(xcontentType().xContent(), BytesReference.bytes(builder));
-        assertSame(parser.nextToken(), Token.START_OBJECT);
-        assertSame(parser.nextToken(), Token.FIELD_NAME);
-        assertEquals(parser.currentName(), "text");
-        assertTrue(parser.nextToken().isValue());
-        assertThat(new BytesRef(parser.charBuffer()).utf8ToString(), equalTo(random.utf8ToString()));
-        assertSame(parser.nextToken(), Token.END_OBJECT);
-        assertNull(parser.nextToken());
+        try (XContentParser parser = createParser(xcontentType().xContent(), BytesReference.bytes(builder))) {
+            assertSame(parser.nextToken(), Token.START_OBJECT);
+            assertSame(parser.nextToken(), Token.FIELD_NAME);
+            assertEquals(parser.currentName(), "text");
+            assertTrue(parser.nextToken().isValue());
+            assertThat(new BytesRef(parser.charBuffer()).utf8ToString(), equalTo(random.utf8ToString()));
+            assertSame(parser.nextToken(), Token.END_OBJECT);
+            assertNull(parser.nextToken());
+        }
     }
 
     public void testReadableInstant() throws Exception {
@@ -741,18 +746,19 @@ public abstract class BaseXContentTestCase extends ESTestCase {
             generator.writeEndObject();
         }
 
-        XContentParser parser = xcontentType().xContent()
-            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, os.toByteArray());
-        assertEquals(Token.START_OBJECT, parser.nextToken());
-        assertEquals(Token.FIELD_NAME, parser.nextToken());
-        assertEquals("bar", parser.currentName());
-        assertEquals(Token.START_OBJECT, parser.nextToken());
-        assertEquals(Token.FIELD_NAME, parser.nextToken());
-        assertEquals("foo", parser.currentName());
-        assertEquals(Token.VALUE_NULL, parser.nextToken());
-        assertEquals(Token.END_OBJECT, parser.nextToken());
-        assertEquals(Token.END_OBJECT, parser.nextToken());
-        assertNull(parser.nextToken());
+        try (XContentParser parser = xcontentType().xContent()
+            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, os.toByteArray())) {
+            assertEquals(Token.START_OBJECT, parser.nextToken());
+            assertEquals(Token.FIELD_NAME, parser.nextToken());
+            assertEquals("bar", parser.currentName());
+            assertEquals(Token.START_OBJECT, parser.nextToken());
+            assertEquals(Token.FIELD_NAME, parser.nextToken());
+            assertEquals("foo", parser.currentName());
+            assertEquals(Token.VALUE_NULL, parser.nextToken());
+            assertEquals(Token.END_OBJECT, parser.nextToken());
+            assertEquals(Token.END_OBJECT, parser.nextToken());
+            assertNull(parser.nextToken());
+        }
     }
 
     public void testRawValue() throws Exception {
@@ -776,14 +782,15 @@ public abstract class BaseXContentTestCase extends ESTestCase {
             generator.writeRawValue(new BytesArray(rawData).streamInput(), source.type());
         }
 
-        XContentParser parser = xcontentType().xContent()
-            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, os.toByteArray());
-        assertEquals(Token.START_OBJECT, parser.nextToken());
-        assertEquals(Token.FIELD_NAME, parser.nextToken());
-        assertEquals("foo", parser.currentName());
-        assertEquals(Token.VALUE_NULL, parser.nextToken());
-        assertEquals(Token.END_OBJECT, parser.nextToken());
-        assertNull(parser.nextToken());
+        try (XContentParser parser = xcontentType().xContent()
+            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, os.toByteArray())) {
+            assertEquals(Token.START_OBJECT, parser.nextToken());
+            assertEquals(Token.FIELD_NAME, parser.nextToken());
+            assertEquals("foo", parser.currentName());
+            assertEquals(Token.VALUE_NULL, parser.nextToken());
+            assertEquals(Token.END_OBJECT, parser.nextToken());
+            assertNull(parser.nextToken());
+        }
 
         os = new ByteArrayOutputStream();
         try (XContentGenerator generator = xcontentType().xContent().createGenerator(os)) {
@@ -793,18 +800,19 @@ public abstract class BaseXContentTestCase extends ESTestCase {
             generator.writeEndObject();
         }
 
-        parser = xcontentType().xContent()
-            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, os.toByteArray());
-        assertEquals(Token.START_OBJECT, parser.nextToken());
-        assertEquals(Token.FIELD_NAME, parser.nextToken());
-        assertEquals("test", parser.currentName());
-        assertEquals(Token.START_OBJECT, parser.nextToken());
-        assertEquals(Token.FIELD_NAME, parser.nextToken());
-        assertEquals("foo", parser.currentName());
-        assertEquals(Token.VALUE_NULL, parser.nextToken());
-        assertEquals(Token.END_OBJECT, parser.nextToken());
-        assertEquals(Token.END_OBJECT, parser.nextToken());
-        assertNull(parser.nextToken());
+        try (XContentParser parser = xcontentType().xContent()
+            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, os.toByteArray())) {
+            assertEquals(Token.START_OBJECT, parser.nextToken());
+            assertEquals(Token.FIELD_NAME, parser.nextToken());
+            assertEquals("test", parser.currentName());
+            assertEquals(Token.START_OBJECT, parser.nextToken());
+            assertEquals(Token.FIELD_NAME, parser.nextToken());
+            assertEquals("foo", parser.currentName());
+            assertEquals(Token.VALUE_NULL, parser.nextToken());
+            assertEquals(Token.END_OBJECT, parser.nextToken());
+            assertEquals(Token.END_OBJECT, parser.nextToken());
+            assertNull(parser.nextToken());
+        }
 
     }
 
@@ -822,11 +830,12 @@ public abstract class BaseXContentTestCase extends ESTestCase {
         generator.flush();
         byte[] serialized = os.toByteArray();
 
-        XContentParser parser = xcontentType().xContent()
-            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, serialized);
-        Map<String, Object> map = parser.map();
-        assertEquals("bar", map.get("foo"));
-        assertEquals(bigInteger, map.get("bigint"));
+        try (XContentParser parser = xcontentType().xContent()
+            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, serialized)) {
+            Map<String, Object> map = parser.map();
+            assertEquals("bar", map.get("foo"));
+            assertEquals(bigInteger, map.get("bigint"));
+        }
     }
 
     public void testEnsureNameNotNull() {
@@ -984,44 +993,46 @@ public abstract class BaseXContentTestCase extends ESTestCase {
                     .field("key", 1)
                     .field("key", 2)
                 .endObject();
-
-        JsonParseException pex = expectThrows(JsonParseException.class, () -> createParser(builder).map());
-        assertThat(pex.getMessage(), startsWith("Duplicate field 'key'"));
+        try (XContentParser xParser = createParser(builder)) {
+            JsonParseException pex = expectThrows(JsonParseException.class, () -> xParser.map());
+            assertThat(pex.getMessage(), startsWith("Duplicate field 'key'"));
+        }
     }
 
     public void testNamedObject() throws IOException {
         Object test1 = new Object();
         Object test2 = new Object();
         NamedXContentRegistry registry = new NamedXContentRegistry(Arrays.asList(
-                new NamedXContentRegistry.Entry(Object.class, new ParseField("test1"), p -> test1),
-                new NamedXContentRegistry.Entry(Object.class, new ParseField("test2", "deprecated"), p -> test2),
-                new NamedXContentRegistry.Entry(Object.class, new ParseField("str"), p -> p.text())));
+            new NamedXContentRegistry.Entry(Object.class, new ParseField("test1"), p -> test1),
+            new NamedXContentRegistry.Entry(Object.class, new ParseField("test2", "deprecated"), p -> test2),
+            new NamedXContentRegistry.Entry(Object.class, new ParseField("str"), p -> p.text())));
         XContentBuilder b = XContentBuilder.builder(xcontentType().xContent());
         b.value("test");
-        XContentParser p = xcontentType().xContent().createParser(registry, LoggingDeprecationHandler.INSTANCE,
-                BytesReference.bytes(b).streamInput());
-        assertEquals(test1, p.namedObject(Object.class, "test1", null));
-        assertEquals(test2, p.namedObject(Object.class, "test2", null));
-        assertEquals(test2, p.namedObject(Object.class, "deprecated", null));
-        assertWarnings("Deprecated field [deprecated] used, expected [test2] instead");
-        {
+        try (XContentParser p = xcontentType().xContent().createParser(registry, LoggingDeprecationHandler.INSTANCE,
+            BytesReference.bytes(b).streamInput())) {
+            assertEquals(test1, p.namedObject(Object.class, "test1", null));
+            assertEquals(test2, p.namedObject(Object.class, "test2", null));
+            assertEquals(test2, p.namedObject(Object.class, "deprecated", null));
+            assertWarnings("Deprecated field [deprecated] used, expected [test2] instead");
             p.nextToken();
             assertEquals("test", p.namedObject(Object.class, "str", null));
-            NamedObjectNotFoundException e = expectThrows(NamedObjectNotFoundException.class,
+            {
+                NamedObjectNotFoundException e = expectThrows(NamedObjectNotFoundException.class,
                     () -> p.namedObject(Object.class, "unknown", null));
-            assertThat(e.getMessage(), endsWith("unable to parse Object with name [unknown]: parser not found"));
+                assertThat(e.getMessage(), endsWith("unable to parse Object with name [unknown]: parser not found"));
+            }
+            {
+                Exception e = expectThrows(NamedObjectNotFoundException.class, () -> p.namedObject(String.class, "doesn't matter", null));
+                assertEquals("unknown named object category [java.lang.String]", e.getMessage());
+            }
         }
-        {
-            Exception e = expectThrows(NamedObjectNotFoundException.class, () -> p.namedObject(String.class, "doesn't matter", null));
-            assertEquals("unknown named object category [java.lang.String]", e.getMessage());
-        }
-        {
-            XContentParser emptyRegistryParser = xcontentType().xContent()
-                .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, new byte[] {});
+        try (XContentParser emptyRegistryParser = xcontentType().xContent()
+            .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, new byte[] {})) {
             Exception e = expectThrows(NamedObjectNotFoundException.class,
-                    () -> emptyRegistryParser.namedObject(String.class, "doesn't matter", null));
+                () -> emptyRegistryParser.namedObject(String.class, "doesn't matter", null));
             assertEquals("named objects are not supported for this parser", e.getMessage());
         }
+
     }
 
     private static void expectUnclosedException(ThrowingRunnable runnable) {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/cbor/CborXContentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/cbor/CborXContentParserTests.java
@@ -33,9 +33,10 @@ public class CborXContentParserTests extends ESTestCase {
         for (int i = 0; i < 2; i++) {
             // Running this part twice triggers the issue.
             // See https://github.com/elastic/elasticsearch/issues/8629
-            XContentParser parser = createParser(CborXContent.cborXContent, ref);
-            while (parser.nextToken() != null) {
-                parser.charBuffer();
+            try (XContentParser parser = createParser(CborXContent.cborXContent, ref)) {
+                while (parser.nextToken() != null) {
+                    parser.charBuffer();
+                }
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/cbor/JsonVsCborTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/cbor/JsonVsCborTests.java
@@ -62,8 +62,10 @@ public class JsonVsCborTests extends ESTestCase {
 
         xsonGen.close();
         jsonGen.close();
-
-        verifySameTokens(createParser(JsonXContent.jsonXContent, jsonOs.bytes()), createParser(CborXContent.cborXContent, xsonOs.bytes()));
+        try (XContentParser json0sParser = createParser(JsonXContent.jsonXContent, jsonOs.bytes());
+             XContentParser xson0sParser = createParser(CborXContent.cborXContent, xsonOs.bytes())) {
+            verifySameTokens(json0sParser, xson0sParser);
+        }
     }
 
     private void verifySameTokens(XContentParser parser1, XContentParser parser2) throws IOException {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/smile/JsonVsSmileTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/smile/JsonVsSmileTests.java
@@ -63,8 +63,10 @@ public class JsonVsSmileTests extends ESTestCase {
         xsonGen.close();
         jsonGen.close();
 
-        verifySameTokens(createParser(JsonXContent.jsonXContent, jsonOs.bytes()),
-                createParser(SmileXContent.smileXContent, xsonOs.bytes()));
+        try (XContentParser jsonParser = createParser(JsonXContent.jsonXContent, jsonOs.bytes());
+            XContentParser smileParser = createParser(SmileXContent.smileXContent, xsonOs.bytes())) {
+            verifySameTokens(jsonParser, smileParser);
+        }
     }
 
     private void verifySameTokens(XContentParser parser1, XContentParser parser2) throws IOException {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
@@ -75,15 +75,15 @@ public abstract class AbstractXContentFilteringTestCase extends AbstractFilterin
     }
 
     static void assertXContentBuilderAsBytes(final XContentBuilder expected, final XContentBuilder actual) {
-        try {
-            XContent xContent = XContentFactory.xContent(actual.contentType());
+        XContent xContent = XContentFactory.xContent(actual.contentType());
+        try (
             XContentParser jsonParser =
                 xContent.createParser(NamedXContentRegistry.EMPTY,
                     DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.bytes(expected).streamInput());
             XContentParser testParser =
                 xContent.createParser(NamedXContentRegistry.EMPTY,
                     DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.bytes(actual).streamInput());
-
+        ) {
             while (true) {
                 XContentParser.Token token1 = jsonParser.nextToken();
                 XContentParser.Token token2 = testParser.nextToken();

--- a/server/src/test/java/org/elasticsearch/index/IndexTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexTests.java
@@ -56,9 +56,10 @@ public class IndexTests extends ESTestCase {
         final Index original = new Index(name, uuid);
         final XContentBuilder builder = JsonXContent.contentBuilder();
         original.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        parser.nextToken(); // the beginning of the parser
-        assertThat(Index.fromXContent(parser), equalTo(original));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            parser.nextToken(); // the beginning of the parser
+            assertThat(Index.fromXContent(parser), equalTo(original));
+        }
     }
 
     public void testEquals() {

--- a/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/BoolQueryBuilderTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.XContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.AbstractQueryTestCase;
@@ -169,8 +170,10 @@ public class BoolQueryBuilderTests extends AbstractQueryTestCase<BoolQueryBuilde
     public void testEmptyBooleanQuery() throws Exception {
         XContentBuilder contentBuilder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         contentBuilder.startObject().startObject("bool").endObject().endObject();
-        Query parsedQuery = parseQuery(createParser(contentBuilder)).toQuery(createShardContext());
-        assertThat(parsedQuery, Matchers.instanceOf(MatchAllDocsQuery.class));
+        try (XContentParser xParser = createParser(contentBuilder)) {
+            Query parsedQuery = parseQuery(xParser).toQuery(createShardContext());
+            assertThat(parsedQuery, Matchers.instanceOf(MatchAllDocsQuery.class));
+        }
     }
 
     public void testDefaultMinShouldMatch() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
@@ -124,11 +124,12 @@ public class InnerHitBuilderTests extends ESTestCase {
             innerHit.toXContent(builder, ToXContent.EMPTY_PARAMS);
             //fields is printed out as an object but parsed into a List where order matters, we disable shuffling
             XContentBuilder shuffled = shuffleXContent(builder, "fields");
-            XContentParser parser = createParser(shuffled);
-            InnerHitBuilder secondInnerHits = InnerHitBuilder.fromXContent(parser);
-            assertThat(innerHit, not(sameInstance(secondInnerHits)));
-            assertThat(innerHit, equalTo(secondInnerHits));
-            assertThat(innerHit.hashCode(), equalTo(secondInnerHits.hashCode()));
+            try (XContentParser parser = createParser(shuffled)) {
+                InnerHitBuilder secondInnerHits = InnerHitBuilder.fromXContent(parser);
+                assertThat(innerHit, not(sameInstance(secondInnerHits)));
+                assertThat(innerHit, equalTo(secondInnerHits));
+                assertThat(innerHit.hashCode(), equalTo(secondInnerHits.hashCode()));
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
@@ -198,37 +198,33 @@ public class GeoPointParsingTests  extends ESTestCase {
         content.startObject();
         content.field("lat", lat).field("lon", lon);
         content.endObject();
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
-            parser.nextToken();
-            return parser;
-        }
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
     }
 
     private XContentParser arrayLatLon(double lat, double lon) throws IOException {
         XContentBuilder content = JsonXContent.contentBuilder();
         content.startArray().value(lon).value(lat).endArray();
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
-            parser.nextToken();
-            return parser;
-        }
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
     }
 
     private XContentParser stringLatLon(double lat, double lon) throws IOException {
         XContentBuilder content = JsonXContent.contentBuilder();
         content.value(Double.toString(lat) + ", " + Double.toString(lon));
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
-            parser.nextToken();
-            return parser;
-        }
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
     }
 
     private XContentParser geohash(double lat, double lon) throws IOException {
         XContentBuilder content = JsonXContent.contentBuilder();
         content.value(stringEncode(lon, lat));
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
-            parser.nextToken();
-            return parser;
-        }
+        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
+        parser.nextToken();
+        return parser;
     }
 
     public static void assertPointsEqual(final GeoPoint point1, final GeoPoint point2) {

--- a/server/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
@@ -107,16 +107,17 @@ public class GeoPointParsingTests  extends ESTestCase {
         content.endObject();
         content.endObject();
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser.nextToken();
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-        assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
-
-        XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser2.nextToken();
-        e = expectThrows(ElasticsearchParseException.class, () ->
-            GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
-        assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+            assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
+        }
+        try (XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser2.nextToken();
+            Exception e = expectThrows(ElasticsearchParseException.class, () ->
+                GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
+            assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
+        }
     }
 
     public void testInvalidPointLatHashMix() throws IOException {
@@ -125,16 +126,17 @@ public class GeoPointParsingTests  extends ESTestCase {
         content.field("lat", 0).field("geohash", stringEncode(0d, 0d));
         content.endObject();
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser.nextToken();
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-        assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
-
-        XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser2.nextToken();
-        e = expectThrows(ElasticsearchParseException.class, () ->
-            GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
-        assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+            assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
+        }
+        try (XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser2.nextToken();
+            Exception e = expectThrows(ElasticsearchParseException.class, () ->
+                GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
+            assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
+        }
     }
 
     public void testInvalidPointLonHashMix() throws IOException {
@@ -143,17 +145,18 @@ public class GeoPointParsingTests  extends ESTestCase {
         content.field("lon", 0).field("geohash", stringEncode(0d, 0d));
         content.endObject();
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser.nextToken();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
 
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-        assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
-
-        XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser2.nextToken();
-        e = expectThrows(ElasticsearchParseException.class, () ->
-            GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
-        assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+            assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
+        }
+        try (XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser2.nextToken();
+            Exception e = expectThrows(ElasticsearchParseException.class, () ->
+                GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
+            assertThat(e.getMessage(), is("field must be either lat/lon or geohash"));
+        }
     }
 
     public void testInvalidField() throws IOException {
@@ -162,17 +165,18 @@ public class GeoPointParsingTests  extends ESTestCase {
         content.field("lon", 0).field("lat", 0).field("test", 0);
         content.endObject();
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser.nextToken();
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-        assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+            assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
+        }
 
-
-        XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser2.nextToken();
-        e = expectThrows(ElasticsearchParseException.class, () ->
-            GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
-        assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
+        try (XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser2.nextToken();
+            Exception e = expectThrows(ElasticsearchParseException.class, () ->
+                GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
+            assertThat(e.getMessage(), is("field must be either [lat], [lon] or [geohash]"));
+        }
     }
 
     public void testInvalidGeoHash() throws IOException {
@@ -181,11 +185,12 @@ public class GeoPointParsingTests  extends ESTestCase {
         content.field("geohash", "!!!!");
         content.endObject();
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser.nextToken();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
 
-        Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-        assertThat(e.getMessage(), is("unsupported symbol [!] in geohash [!!!!]"));
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
+            assertThat(e.getMessage(), is("unsupported symbol [!] in geohash [!!!!]"));
+        }
     }
 
     private XContentParser objectLatLon(double lat, double lon) throws IOException {
@@ -193,33 +198,37 @@ public class GeoPointParsingTests  extends ESTestCase {
         content.startObject();
         content.field("lat", lat).field("lon", lon);
         content.endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser.nextToken();
-        return parser;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
+            return parser;
+        }
     }
 
     private XContentParser arrayLatLon(double lat, double lon) throws IOException {
         XContentBuilder content = JsonXContent.contentBuilder();
         content.startArray().value(lon).value(lat).endArray();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser.nextToken();
-        return parser;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
+            return parser;
+        }
     }
 
     private XContentParser stringLatLon(double lat, double lon) throws IOException {
         XContentBuilder content = JsonXContent.contentBuilder();
         content.value(Double.toString(lat) + ", " + Double.toString(lon));
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser.nextToken();
-        return parser;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
+            return parser;
+        }
     }
 
     private XContentParser geohash(double lat, double lon) throws IOException {
         XContentBuilder content = JsonXContent.contentBuilder();
         content.value(stringEncode(lon, lat));
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content));
-        parser.nextToken();
-        return parser;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
+            parser.nextToken();
+            return parser;
+        }
     }
 
     public static void assertPointsEqual(final GeoPoint point1, final GeoPoint point2) {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
@@ -57,7 +57,7 @@ public class IngestMetadataTests extends ESTestCase {
         ingestMetadata.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         XContentBuilder shuffled = shuffleXContent(builder);
-        try (final XContentParser parser = createParser(shuffled)) {
+        try (XContentParser parser = createParser(shuffled)) {
             MetaData.Custom custom = IngestMetadata.fromXContent(parser);
             assertTrue(custom instanceof IngestMetadata);
             IngestMetadata m = (IngestMetadata) custom;

--- a/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
@@ -57,15 +57,16 @@ public class IngestMetadataTests extends ESTestCase {
         ingestMetadata.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         XContentBuilder shuffled = shuffleXContent(builder);
-        final XContentParser parser = createParser(shuffled);
-        MetaData.Custom custom = IngestMetadata.fromXContent(parser);
-        assertTrue(custom instanceof IngestMetadata);
-        IngestMetadata m = (IngestMetadata) custom;
-        assertEquals(2, m.getPipelines().size());
-        assertEquals("1", m.getPipelines().get("1").getId());
-        assertEquals("2", m.getPipelines().get("2").getId());
-        assertEquals(pipeline.getConfigAsMap(), m.getPipelines().get("1").getConfigAsMap());
-        assertEquals(pipeline2.getConfigAsMap(), m.getPipelines().get("2").getConfigAsMap());
+        try (final XContentParser parser = createParser(shuffled)) {
+            MetaData.Custom custom = IngestMetadata.fromXContent(parser);
+            assertTrue(custom instanceof IngestMetadata);
+            IngestMetadata m = (IngestMetadata) custom;
+            assertEquals(2, m.getPipelines().size());
+            assertEquals("1", m.getPipelines().get("1").getId());
+            assertEquals("2", m.getPipelines().get("2").getId());
+            assertEquals(pipeline.getConfigAsMap(), m.getPipelines().get("1").getConfigAsMap());
+            assertEquals(pipeline2.getConfigAsMap(), m.getPipelines().get("2").getConfigAsMap());
+        }
     }
 
     public void testDiff() throws Exception {

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetaDataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetaDataTests.java
@@ -174,8 +174,10 @@ public class PersistentTasksCustomMetaDataTests extends AbstractDiffableSerializ
         XContentType xContentType = randomFrom(XContentType.values());
         BytesReference shuffled = toShuffledXContent(testInstance, xContentType, params, false);
 
-        XContentParser parser = createParser(XContentFactory.xContent(xContentType), shuffled);
-        PersistentTasksCustomMetaData newInstance = doParseInstance(parser);
+        PersistentTasksCustomMetaData newInstance;
+        try (XContentParser parser = createParser(XContentFactory.xContent(xContentType), shuffled)) {
+            newInstance = doParseInstance(parser);
+        }
         assertNotSame(newInstance, testInstance);
 
         assertEquals(testInstance.tasks().size(), newInstance.tasks().size());

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -239,7 +239,8 @@ public class RepositoryDataTests extends ESTestCase {
         try (XContentParser xParser = createParser(builder)) {
             ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () ->
                 RepositoryData.snapshotsFromXContent(xParser, randomNonNegativeLong()));
-            assertThat(e.getMessage(), equalTo("Detected a corrupted repository, index [docs/_id] references an unknown snapshot uuid [null]"));
+            assertThat(e.getMessage(), equalTo("Detected a corrupted repository, " +
+                "index [docs/_id] references an unknown snapshot uuid [null]"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -62,11 +62,12 @@ public class RepositoryDataTests extends ESTestCase {
         RepositoryData repositoryData = generateRandomRepoData();
         XContentBuilder builder = JsonXContent.contentBuilder();
         repositoryData.snapshotsToXContent(builder, ToXContent.EMPTY_PARAMS);
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        long gen = (long) randomIntBetween(0, 500);
-        RepositoryData fromXContent = RepositoryData.snapshotsFromXContent(parser, gen);
-        assertEquals(repositoryData, fromXContent);
-        assertEquals(gen, fromXContent.getGenId());
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            long gen = (long) randomIntBetween(0, 500);
+            RepositoryData fromXContent = RepositoryData.snapshotsFromXContent(parser, gen);
+            assertEquals(repositoryData, fromXContent);
+            assertEquals(gen, fromXContent.getGenId());
+        }
     }
 
     public void testAddSnapshots() {
@@ -166,7 +167,10 @@ public class RepositoryDataTests extends ESTestCase {
 
         XContentBuilder builder = XContentBuilder.builder(xContent);
         repositoryData.snapshotsToXContent(builder, ToXContent.EMPTY_PARAMS);
-        RepositoryData parsedRepositoryData = RepositoryData.snapshotsFromXContent(createParser(builder), repositoryData.getGenId());
+        RepositoryData parsedRepositoryData;
+        try (XContentParser xParser = createParser(builder)) {
+            parsedRepositoryData = RepositoryData.snapshotsFromXContent(xParser, repositoryData.getGenId());
+        }
         assertEquals(repositoryData, parsedRepositoryData);
 
         Map<String, SnapshotId> snapshotIds = new HashMap<>();
@@ -195,10 +199,12 @@ public class RepositoryDataTests extends ESTestCase {
         final XContentBuilder corruptedBuilder = XContentBuilder.builder(xContent);
         corruptedRepositoryData.snapshotsToXContent(corruptedBuilder, ToXContent.EMPTY_PARAMS);
 
-        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () ->
-            RepositoryData.snapshotsFromXContent(createParser(corruptedBuilder), corruptedRepositoryData.getGenId()));
-        assertThat(e.getMessage(), equalTo("Detected a corrupted repository, index " + corruptedIndexId + " references an unknown " +
-            "snapshot uuid [_does_not_exist]"));
+        try (XContentParser xParser = createParser(corruptedBuilder)) {
+            ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () ->
+                RepositoryData.snapshotsFromXContent(xParser, corruptedRepositoryData.getGenId()));
+            assertThat(e.getMessage(), equalTo("Detected a corrupted repository, index " + corruptedIndexId + " references an unknown " +
+                "snapshot uuid [_does_not_exist]"));
+        }
     }
 
     public void testIndexThatReferenceANullSnapshot() throws IOException {
@@ -230,9 +236,11 @@ public class RepositoryDataTests extends ESTestCase {
         }
         builder.endObject();
 
-        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () ->
-            RepositoryData.snapshotsFromXContent(createParser(builder), randomNonNegativeLong()));
-        assertThat(e.getMessage(), equalTo("Detected a corrupted repository, index [docs/_id] references an unknown snapshot uuid [null]"));
+        try (XContentParser xParser = createParser(builder)) {
+            ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () ->
+                RepositoryData.snapshotsFromXContent(xParser, randomNonNegativeLong()));
+            assertThat(e.getMessage(), equalTo("Detected a corrupted repository, index [docs/_id] references an unknown snapshot uuid [null]"));
+        }
     }
 
     public static RepositoryData generateRandomRepoData() {

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeActionTests.java
@@ -37,28 +37,29 @@ import static org.mockito.Mockito.mock;
 public class RestAnalyzeActionTests extends ESTestCase {
 
     public void testParseXContentForAnalyzeRequest() throws Exception {
-        XContentParser content = createParser(XContentFactory.jsonBuilder()
+        try (XContentParser content = createParser(XContentFactory.jsonBuilder()
             .startObject()
                 .field("text", "THIS IS A TEST")
                 .field("tokenizer", "keyword")
                 .array("filter", "lowercase")
-            .endObject());
+            .endObject())) {
 
-        AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
+            AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
 
-        RestAnalyzeAction.buildFromContent(content, analyzeRequest);
+            RestAnalyzeAction.buildFromContent(content, analyzeRequest);
 
-        assertThat(analyzeRequest.text().length, equalTo(1));
-        assertThat(analyzeRequest.text(), equalTo(new String[]{"THIS IS A TEST"}));
-        assertThat(analyzeRequest.tokenizer().name, equalTo("keyword"));
-        assertThat(analyzeRequest.tokenFilters().size(), equalTo(1));
-        for (AnalyzeRequest.NameOrDefinition filter : analyzeRequest.tokenFilters()) {
-            assertThat(filter.name, equalTo("lowercase"));
+            assertThat(analyzeRequest.text().length, equalTo(1));
+            assertThat(analyzeRequest.text(), equalTo(new String[]{"THIS IS A TEST"}));
+            assertThat(analyzeRequest.tokenizer().name, equalTo("keyword"));
+            assertThat(analyzeRequest.tokenFilters().size(), equalTo(1));
+            for (AnalyzeRequest.NameOrDefinition filter : analyzeRequest.tokenFilters()) {
+                assertThat(filter.name, equalTo("lowercase"));
+            }
         }
     }
 
     public void testParseXContentForAnalyzeRequestWithCustomFilters() throws Exception {
-        XContentParser content = createParser(XContentFactory.jsonBuilder()
+        try (XContentParser content = createParser(XContentFactory.jsonBuilder()
             .startObject()
                 .field("text", "THIS IS A TEST")
                 .field("tokenizer", "keyword")
@@ -76,21 +77,22 @@ public class RestAnalyzeActionTests extends ESTestCase {
                     .endObject()
                 .endArray()
                 .field("normalizer", "normalizer")
-            .endObject());
+            .endObject())) {
 
-        AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
+            AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
 
-        RestAnalyzeAction.buildFromContent(content, analyzeRequest);
+            RestAnalyzeAction.buildFromContent(content, analyzeRequest);
 
-        assertThat(analyzeRequest.text().length, equalTo(1));
-        assertThat(analyzeRequest.text(), equalTo(new String[]{"THIS IS A TEST"}));
-        assertThat(analyzeRequest.tokenizer().name, equalTo("keyword"));
-        assertThat(analyzeRequest.tokenFilters().size(), equalTo(2));
-        assertThat(analyzeRequest.tokenFilters().get(0).name, equalTo("lowercase"));
-        assertThat(analyzeRequest.tokenFilters().get(1).definition, notNullValue());
-        assertThat(analyzeRequest.charFilters().size(), equalTo(1));
-        assertThat(analyzeRequest.charFilters().get(0).definition, notNullValue());
-        assertThat(analyzeRequest.normalizer(), equalTo("normalizer"));
+            assertThat(analyzeRequest.text().length, equalTo(1));
+            assertThat(analyzeRequest.text(), equalTo(new String[]{"THIS IS A TEST"}));
+            assertThat(analyzeRequest.tokenizer().name, equalTo("keyword"));
+            assertThat(analyzeRequest.tokenFilters().size(), equalTo(2));
+            assertThat(analyzeRequest.tokenFilters().get(0).name, equalTo("lowercase"));
+            assertThat(analyzeRequest.tokenFilters().get(1).definition, notNullValue());
+            assertThat(analyzeRequest.charFilters().size(), equalTo(1));
+            assertThat(analyzeRequest.charFilters().get(0).definition, notNullValue());
+            assertThat(analyzeRequest.normalizer(), equalTo("normalizer"));
+        }
     }
 
     public void testParseXContentForAnalyzeRequestWithInvalidJsonThrowsException() throws Exception {
@@ -103,84 +105,83 @@ public class RestAnalyzeActionTests extends ESTestCase {
 
     public void testParseXContentForAnalyzeRequestWithUnknownParamThrowsException() throws Exception {
         AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
-        XContentParser invalidContent = createParser(XContentFactory.jsonBuilder()
+        try (XContentParser invalidContent = createParser(XContentFactory.jsonBuilder()
             .startObject()
                 .field("text", "THIS IS A TEST")
                 .field("unknown", "keyword")
-            .endObject());
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            .endObject())) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> RestAnalyzeAction.buildFromContent(invalidContent, analyzeRequest));
-        assertThat(e.getMessage(), startsWith("Unknown parameter [unknown]"));
+            assertThat(e.getMessage(), startsWith("Unknown parameter [unknown]"));
+        }
     }
 
     public void testParseXContentForAnalyzeRequestWithInvalidStringExplainParamThrowsException() throws Exception {
         AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
-        XContentParser invalidExplain = createParser(XContentFactory.jsonBuilder()
+        try (XContentParser invalidExplain = createParser(XContentFactory.jsonBuilder()
             .startObject()
                 .field("explain", "fals")
-            .endObject());
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> RestAnalyzeAction.buildFromContent(invalidExplain, analyzeRequest));
-        assertThat(e.getMessage(), startsWith("explain must be either 'true' or 'false'"));
+            .endObject())) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> RestAnalyzeAction.buildFromContent(invalidExplain, analyzeRequest));
+            assertThat(e.getMessage(), startsWith("explain must be either 'true' or 'false'"));
+        }
     }
 
     public void testParseXContentForAnalyzeRequestWithInvalidNormalizerThrowsException() throws Exception {
         AnalyzeRequest analyzeRequest = new AnalyzeRequest("for test");
-        XContentParser invalidExplain = createParser(XContentFactory.jsonBuilder()
+        try (XContentParser invalidExplain = createParser(XContentFactory.jsonBuilder()
             .startObject()
             .field("normalizer", true)
-            .endObject());
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-            () -> RestAnalyzeAction.buildFromContent(invalidExplain, analyzeRequest));
-        assertThat(e.getMessage(), startsWith("normalizer should be normalizer's name"));
+            .endObject())) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> RestAnalyzeAction.buildFromContent(invalidExplain, analyzeRequest));
+            assertThat(e.getMessage(), startsWith("normalizer should be normalizer's name"));
+        }
     }
 
     public void testDeprecatedParamIn2xException() throws Exception {
-        {
-            XContentParser parser = createParser(XContentFactory.jsonBuilder()
-                    .startObject()
-                        .field("text", "THIS IS A TEST")
-                        .field("tokenizer", "keyword")
-                        .array("filters", "lowercase")
-                    .endObject());
+        try (XContentParser parser = createParser(XContentFactory.jsonBuilder()
+            .startObject()
+            .field("text", "THIS IS A TEST")
+            .field("tokenizer", "keyword")
+            .array("filters", "lowercase")
+            .endObject())) {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> RestAnalyzeAction.buildFromContent(parser,
-                    new AnalyzeRequest("for test")));
+                new AnalyzeRequest("for test")));
             assertThat(e.getMessage(), startsWith("Unknown parameter [filters]"));
         }
 
-        {
-            XContentParser parser = createParser(XContentFactory.jsonBuilder()
-                    .startObject()
-                        .field("text", "THIS IS A TEST")
-                        .field("tokenizer", "keyword")
-                        .array("token_filters", "lowercase")
-                    .endObject());
+        try (XContentParser parser = createParser(XContentFactory.jsonBuilder()
+            .startObject()
+            .field("text", "THIS IS A TEST")
+            .field("tokenizer", "keyword")
+            .array("token_filters", "lowercase")
+            .endObject())) {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> RestAnalyzeAction.buildFromContent(parser,
-                    new AnalyzeRequest("for test")));
+                new AnalyzeRequest("for test")));
             assertThat(e.getMessage(), startsWith("Unknown parameter [token_filters]"));
         }
 
-        {
-            XContentParser parser = createParser(XContentFactory.jsonBuilder()
-                    .startObject()
-                        .field("text", "THIS IS A TEST")
-                        .field("tokenizer", "keyword")
-                        .array("char_filters", "lowercase")
-                    .endObject());
+        try (XContentParser parser = createParser(XContentFactory.jsonBuilder()
+            .startObject()
+            .field("text", "THIS IS A TEST")
+            .field("tokenizer", "keyword")
+            .array("char_filters", "lowercase")
+            .endObject())) {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> RestAnalyzeAction.buildFromContent(parser,
-                    new AnalyzeRequest("for test")));
+                new AnalyzeRequest("for test")));
             assertThat(e.getMessage(), startsWith("Unknown parameter [char_filters]"));
         }
 
-        {
-            XContentParser parser = createParser(XContentFactory.jsonBuilder()
-                    .startObject()
-                        .field("text", "THIS IS A TEST")
-                        .field("tokenizer", "keyword")
-                        .array("token_filter", "lowercase")
-                    .endObject());
+        try (XContentParser parser = createParser(XContentFactory.jsonBuilder()
+            .startObject()
+            .field("text", "THIS IS A TEST")
+            .field("tokenizer", "keyword")
+            .array("token_filter", "lowercase")
+            .endObject())) {
             IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> RestAnalyzeAction.buildFromContent(parser,
-                    new AnalyzeRequest("for test")));
+                new AnalyzeRequest("for test")));
             assertThat(e.getMessage(), startsWith("Unknown parameter [token_filter]"));
         }
     }

--- a/server/src/test/java/org/elasticsearch/script/ScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptTests.java
@@ -89,9 +89,11 @@ public class ScriptTests extends ESTestCase {
         Script expectedScript = createScript();
         try (XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()))) {
             expectedScript.toXContent(builder, ToXContent.EMPTY_PARAMS);
-            Settings settings = Settings.fromXContent(createParser(builder));
-            Script actualScript = Script.parse(settings);
-            assertThat(actualScript, equalTo(expectedScript));
+            try (XContentParser xParser = createParser(builder)) {
+                Settings settings = Settings.fromXContent(xParser);
+                Script actualScript = Script.parse(settings);
+                assertThat(actualScript, equalTo(expectedScript));
+            }
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/NestedIdentityTests.java
+++ b/server/src/test/java/org/elasticsearch/search/NestedIdentityTests.java
@@ -58,10 +58,11 @@ public class NestedIdentityTests extends ESTestCase {
             builder.prettyPrint();
         }
         builder = nestedIdentity.innerToXContent(builder, ToXContent.EMPTY_PARAMS);
-        XContentParser parser = createParser(builder);
-        NestedIdentity parsedNestedIdentity = NestedIdentity.fromXContent(parser);
-        assertEquals(nestedIdentity, parsedNestedIdentity);
-        assertNull(parser.nextToken());
+        try (XContentParser parser = createParser(builder)) {
+            NestedIdentity parsedNestedIdentity = NestedIdentity.fromXContent(parser);
+            assertEquals(nestedIdentity, parsedNestedIdentity);
+            assertNull(parser.nextToken());
+        }
     }
 
     public void testToXContent() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregationCollectorTests.java
@@ -56,13 +56,14 @@ public class AggregationCollectorTests extends ESSingleNodeTestCase {
     }
 
     private boolean needsScores(IndexService index, String agg) throws IOException {
-        XContentParser aggParser = createParser(JsonXContent.jsonXContent, agg);
-        aggParser.nextToken();
-        SearchContext context = createSearchContext(index);
-        final AggregatorFactories factories = AggregatorFactories.parseAggregators(aggParser).build(context, null);
-        final Aggregator[] aggregators = factories.createTopLevelAggregators();
-        assertEquals(1, aggregators.length);
-        return aggregators[0].needsScores();
+        try (XContentParser aggParser = createParser(JsonXContent.jsonXContent, agg)) {
+            aggParser.nextToken();
+            SearchContext context = createSearchContext(index);
+            final AggregatorFactories factories = AggregatorFactories.parseAggregators(aggParser).build(context, null);
+            final Aggregator[] aggregators = factories.createTopLevelAggregators();
+            assertEquals(1, aggregators.length);
+            return aggregators[0].needsScores();
+        }
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/BasePipelineAggregationTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/BasePipelineAggregationTestCase.java
@@ -106,13 +106,14 @@ public abstract class BasePipelineAggregationTestCase<AF extends AbstractPipelin
         }
         factoriesBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
         XContentBuilder shuffled = shuffleXContent(builder);
-        XContentParser parser = createParser(shuffled);
-        String contentString = factoriesBuilder.toString();
-        logger.info("Content string: {}", contentString);
-        PipelineAggregationBuilder newAgg = parse(parser);
-        assertNotSame(newAgg, testAgg);
-        assertEquals(testAgg, newAgg);
-        assertEquals(testAgg.hashCode(), newAgg.hashCode());
+        try (XContentParser parser = createParser(shuffled)) {
+            String contentString = factoriesBuilder.toString();
+            logger.info("Content string: {}", contentString);
+            PipelineAggregationBuilder newAgg = parse(parser);
+            assertNotSame(newAgg, testAgg);
+            assertEquals(testAgg, newAgg);
+            assertEquals(testAgg.hashCode(), newAgg.hashCode());
+        }
     }
 
     protected PipelineAggregationBuilder parse(XContentParser parser) throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/FiltersTests.java
@@ -94,34 +94,37 @@ public class FiltersTests extends BaseAggregationTestCase<FiltersAggregationBuil
         builder.startObject();
         builder.startArray("filters").endArray();
         builder.endObject();
-        XContentParser parser = createParser(shuffleXContent(builder));
-        parser.nextToken();
-        FiltersAggregationBuilder filters = FiltersAggregationBuilder.parse("agg_name", parser);
-        // The other bucket is disabled by default
-        assertFalse(filters.otherBucket());
+        try (XContentParser parser = createParser(shuffleXContent(builder))) {
+            parser.nextToken();
+            FiltersAggregationBuilder filters = FiltersAggregationBuilder.parse("agg_name", parser);
+            // The other bucket is disabled by default
+            assertFalse(filters.otherBucket());
 
-        builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
-        builder.startObject();
-        builder.startArray("filters").endArray();
-        builder.field("other_bucket_key", "some_key");
-        builder.endObject();
-        parser = createParser(shuffleXContent(builder));
-        parser.nextToken();
-        filters = FiltersAggregationBuilder.parse("agg_name", parser);
-        // but setting a key enables it automatically
-        assertTrue(filters.otherBucket());
+            builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+            builder.startObject();
+            builder.startArray("filters").endArray();
+            builder.field("other_bucket_key", "some_key");
+            builder.endObject();
+        }
+        try (XContentParser parser = createParser(shuffleXContent(builder))) {
+            parser.nextToken();
+            FiltersAggregationBuilder filters = FiltersAggregationBuilder.parse("agg_name", parser);
+            // but setting a key enables it automatically
+            assertTrue(filters.otherBucket());
 
-        builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
-        builder.startObject();
-        builder.startArray("filters").endArray();
-        builder.field("other_bucket", false);
-        builder.field("other_bucket_key", "some_key");
-        builder.endObject();
-        parser = createParser(shuffleXContent(builder));
-        parser.nextToken();
-        filters = FiltersAggregationBuilder.parse("agg_name", parser);
-        // unless the other bucket is explicitly disabled
-        assertFalse(filters.otherBucket());
+            builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
+            builder.startObject();
+            builder.startArray("filters").endArray();
+            builder.field("other_bucket", false);
+            builder.field("other_bucket_key", "some_key");
+            builder.endObject();
+        }
+        try (XContentParser parser = createParser(shuffleXContent(builder))) {
+            parser.nextToken();
+            FiltersAggregationBuilder filters = FiltersAggregationBuilder.parse("agg_name", parser);
+            // unless the other bucket is explicitly disabled
+            assertFalse(filters.otherBucket());
+        }
     }
 
     public void testRewrite() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/significant/SignificanceHeuristicTests.java
@@ -264,9 +264,8 @@ public class SignificanceHeuristicTests extends ESTestCase {
     protected void checkParseException(ParseFieldRegistry<SignificanceHeuristicParser> significanceHeuristicParserRegistry,
             String faultyHeuristicDefinition, String expectedError) throws IOException {
 
-        try {
-            XContentParser stParser = createParser(JsonXContent.jsonXContent,
-                    "{\"field\":\"text\", " + faultyHeuristicDefinition + ",\"min_doc_count\":200}");
+        try (XContentParser stParser = createParser(JsonXContent.jsonXContent,
+                    "{\"field\":\"text\", " + faultyHeuristicDefinition + ",\"min_doc_count\":200}")) {
             stParser.nextToken();
             SignificantTermsAggregationBuilder.getParser(significanceHeuristicParserRegistry).parse("testagg", stParser);
             fail();
@@ -301,9 +300,10 @@ public class SignificanceHeuristicTests extends ESTestCase {
 
     protected SignificanceHeuristic parseFromString(ParseFieldRegistry<SignificanceHeuristicParser> significanceHeuristicParserRegistry,
             String heuristicString) throws IOException {
-        XContentParser stParser = createParser(JsonXContent.jsonXContent,
-                "{\"field\":\"text\", " + heuristicString + ", \"min_doc_count\":200}");
-        return parseSignificanceHeuristic(significanceHeuristicParserRegistry, stParser);
+        try (XContentParser stParser = createParser(JsonXContent.jsonXContent,
+                "{\"field\":\"text\", " + heuristicString + ", \"min_doc_count\":200}")) {
+            return parseSignificanceHeuristic(significanceHeuristicParserRegistry, stParser);
+        }
     }
 
     void testBackgroundAssertions(SignificanceHeuristic heuristicIsSuperset, SignificanceHeuristic heuristicNotSuperset) {

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -64,7 +64,9 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
             builder.prettyPrint();
         }
         testSearchSourceBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        assertParseSearchSource(testSearchSourceBuilder, createParser(builder));
+        try (XContentParser xParser = createParser(builder)) {
+            assertParseSearchSource(testSearchSourceBuilder, xParser);
+        }
     }
 
     public void testFromXContentInvalid() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightFieldTests.java
@@ -62,16 +62,17 @@ public class HighlightFieldTests extends ESTestCase {
         builder.startObject(); // we need to wrap xContent output in proper object to create a parser for it
         builder = highlightField.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
-        XContentParser parser = createParser(builder);
-        parser.nextToken(); // skip to the opening object token, fromXContent advances from here and starts with the field name
-        parser.nextToken();
-        HighlightField parsedField = HighlightField.fromXContent(parser);
-        assertEquals(highlightField, parsedField);
-        if (highlightField.fragments() != null) {
-            assertEquals(XContentParser.Token.END_ARRAY, parser.currentToken());
+        try (XContentParser parser = createParser(builder)) {
+            parser.nextToken(); // skip to the opening object token, fromXContent advances from here and starts with the field name
+            parser.nextToken();
+            HighlightField parsedField = HighlightField.fromXContent(parser);
+            assertEquals(highlightField, parsedField);
+            if (highlightField.fragments() != null) {
+                assertEquals(XContentParser.Token.END_ARRAY, parser.currentToken());
+            }
+            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
+            assertNull(parser.nextToken());
         }
-        assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
-        assertNull(parser.nextToken());
     }
 
     public void testToXContent() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
@@ -276,11 +276,10 @@ public class QueryRescorerBuilderTests extends ESTestCase {
      * create a new parser from the rescorer string representation and reset context with it
      */
     private XContentParser createParser(String rescoreElement) throws IOException {
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, rescoreElement)) {
-            // move to first token, this is where the internal fromXContent
-            assertTrue(parser.nextToken() == XContentParser.Token.START_OBJECT);
-            return parser;
-        }
+        XContentParser parser = createParser(JsonXContent.jsonXContent, rescoreElement);
+        // move to first token, this is where the internal fromXContent
+        assertTrue(parser.nextToken() == XContentParser.Token.START_OBJECT);
+        return parser;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
@@ -121,12 +121,13 @@ public class QueryRescorerBuilderTests extends ESTestCase {
             XContentBuilder shuffled = shuffleXContent(builder);
 
 
-            XContentParser parser = createParser(shuffled);
-            parser.nextToken();
-            RescorerBuilder<?> secondRescoreBuilder = RescorerBuilder.parseFromXContent(parser);
-            assertNotSame(rescoreBuilder, secondRescoreBuilder);
-            assertEquals(rescoreBuilder, secondRescoreBuilder);
-            assertEquals(rescoreBuilder.hashCode(), secondRescoreBuilder.hashCode());
+            try (XContentParser parser = createParser(shuffled)) {
+                parser.nextToken();
+                RescorerBuilder<?> secondRescoreBuilder = RescorerBuilder.parseFromXContent(parser);
+                assertNotSame(rescoreBuilder, secondRescoreBuilder);
+                assertEquals(rescoreBuilder, secondRescoreBuilder);
+                assertEquals(rescoreBuilder.hashCode(), secondRescoreBuilder.hashCode());
+            }
         }
     }
 
@@ -217,74 +218,69 @@ public class QueryRescorerBuilderTests extends ESTestCase {
                 "    \"window_size\" : 20,\n" +
                 "    \"bad_rescorer_name\" : { }\n" +
                 "}\n";
-        {
-            XContentParser parser = createParser(rescoreElement);
-            Exception e = expectThrows(NamedObjectNotFoundException.class, () -> RescorerBuilder.parseFromXContent(parser));
-            assertEquals("[3:27] unable to parse RescorerBuilder with name [bad_rescorer_name]: parser not found", e.getMessage());
-        }
-
+            try (XContentParser parser = createParser(rescoreElement)) {
+                Exception e = expectThrows(NamedObjectNotFoundException.class, () -> RescorerBuilder.parseFromXContent(parser));
+                assertEquals("[3:27] unable to parse RescorerBuilder with name [bad_rescorer_name]: parser not found", e.getMessage());
+            }
         rescoreElement = "{\n" +
                 "    \"bad_fieldName\" : 20\n" +
                 "}\n";
-        {
-            XContentParser parser = createParser(rescoreElement);
-            Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
-            assertEquals("rescore doesn't support [bad_fieldName]", e.getMessage());
-        }
+            try (XContentParser parser = createParser(rescoreElement)) {
+                Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
+                assertEquals("rescore doesn't support [bad_fieldName]", e.getMessage());
+            }
 
         rescoreElement = "{\n" +
                 "    \"window_size\" : 20,\n" +
                 "    \"query\" : [ ]\n" +
                 "}\n";
-        {
-            XContentParser parser = createParser(rescoreElement);
-            Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
-            assertEquals("unexpected token [START_ARRAY] after [query]", e.getMessage());
-        }
+            try (XContentParser parser = createParser(rescoreElement)) {
+                Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
+                assertEquals("unexpected token [START_ARRAY] after [query]", e.getMessage());
+            }
 
         rescoreElement = "{ }";
-        {
-            XContentParser parser = createParser(rescoreElement);
-            Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
-            assertEquals("missing rescore type", e.getMessage());
-        }
+            try (XContentParser parser = createParser(rescoreElement)) {
+                Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
+                assertEquals("missing rescore type", e.getMessage());
+            }
 
         rescoreElement = "{\n" +
                 "    \"window_size\" : 20,\n" +
                 "    \"query\" : { \"bad_fieldname\" : 1.0  } \n" +
                 "}\n";
-        {
-            XContentParser parser = createParser(rescoreElement);
-            XContentParseException e = expectThrows(XContentParseException.class, () -> RescorerBuilder.parseFromXContent(parser));
-            assertEquals("[3:17] [query] unknown field [bad_fieldname], parser not found", e.getMessage());
-        }
+            try (XContentParser parser = createParser(rescoreElement)) {
+                XContentParseException e = expectThrows(XContentParseException.class, () -> RescorerBuilder.parseFromXContent(parser));
+                assertEquals("[3:17] [query] unknown field [bad_fieldname], parser not found", e.getMessage());
+            }
 
         rescoreElement = "{\n" +
                 "    \"window_size\" : 20,\n" +
                 "    \"query\" : { \"rescore_query\" : { \"unknown_queryname\" : { } } } \n" +
                 "}\n";
-        {
-            XContentParser parser = createParser(rescoreElement);
-            Exception e = expectThrows(XContentParseException.class, () -> RescorerBuilder.parseFromXContent(parser));
-            assertThat(e.getMessage(), containsString("[query] failed to parse field [rescore_query]"));
-        }
+            try (XContentParser parser = createParser(rescoreElement)) {
+                Exception e = expectThrows(XContentParseException.class, () -> RescorerBuilder.parseFromXContent(parser));
+                assertThat(e.getMessage(), containsString("[query] failed to parse field [rescore_query]"));
+            }
 
         rescoreElement = "{\n" +
                 "    \"window_size\" : 20,\n" +
                 "    \"query\" : { \"rescore_query\" : { \"match_all\" : { } } } \n"
                 + "}\n";
-        XContentParser parser = createParser(rescoreElement);
-        RescorerBuilder.parseFromXContent(parser);
+        try (XContentParser parser = createParser(rescoreElement)) {
+            RescorerBuilder.parseFromXContent(parser);
+        }
     }
 
     /**
      * create a new parser from the rescorer string representation and reset context with it
      */
     private XContentParser createParser(String rescoreElement) throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent, rescoreElement);
-        // move to first token, this is where the internal fromXContent
-        assertTrue(parser.nextToken() == XContentParser.Token.START_OBJECT);
-        return parser;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, rescoreElement)) {
+            // move to first token, this is where the internal fromXContent
+            assertTrue(parser.nextToken() == XContentParser.Token.START_OBJECT);
+            return parser;
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
@@ -215,58 +215,58 @@ public class QueryRescorerBuilderTests extends ESTestCase {
     public void testUnknownFieldsExpection() throws IOException {
 
         String rescoreElement = "{\n" +
-                "    \"window_size\" : 20,\n" +
-                "    \"bad_rescorer_name\" : { }\n" +
-                "}\n";
-            try (XContentParser parser = createParser(rescoreElement)) {
-                Exception e = expectThrows(NamedObjectNotFoundException.class, () -> RescorerBuilder.parseFromXContent(parser));
-                assertEquals("[3:27] unable to parse RescorerBuilder with name [bad_rescorer_name]: parser not found", e.getMessage());
-            }
+            "    \"window_size\" : 20,\n" +
+            "    \"bad_rescorer_name\" : { }\n" +
+            "}\n";
+        try (XContentParser parser = createParser(rescoreElement)) {
+            Exception e = expectThrows(NamedObjectNotFoundException.class, () -> RescorerBuilder.parseFromXContent(parser));
+            assertEquals("[3:27] unable to parse RescorerBuilder with name [bad_rescorer_name]: parser not found", e.getMessage());
+        }
         rescoreElement = "{\n" +
-                "    \"bad_fieldName\" : 20\n" +
-                "}\n";
-            try (XContentParser parser = createParser(rescoreElement)) {
-                Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
-                assertEquals("rescore doesn't support [bad_fieldName]", e.getMessage());
-            }
+            "    \"bad_fieldName\" : 20\n" +
+            "}\n";
+        try (XContentParser parser = createParser(rescoreElement)) {
+            Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
+            assertEquals("rescore doesn't support [bad_fieldName]", e.getMessage());
+        }
 
         rescoreElement = "{\n" +
-                "    \"window_size\" : 20,\n" +
-                "    \"query\" : [ ]\n" +
-                "}\n";
-            try (XContentParser parser = createParser(rescoreElement)) {
-                Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
-                assertEquals("unexpected token [START_ARRAY] after [query]", e.getMessage());
-            }
+            "    \"window_size\" : 20,\n" +
+            "    \"query\" : [ ]\n" +
+            "}\n";
+        try (XContentParser parser = createParser(rescoreElement)) {
+            Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
+            assertEquals("unexpected token [START_ARRAY] after [query]", e.getMessage());
+        }
 
         rescoreElement = "{ }";
-            try (XContentParser parser = createParser(rescoreElement)) {
-                Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
-                assertEquals("missing rescore type", e.getMessage());
-            }
+        try (XContentParser parser = createParser(rescoreElement)) {
+            Exception e = expectThrows(ParsingException.class, () -> RescorerBuilder.parseFromXContent(parser));
+            assertEquals("missing rescore type", e.getMessage());
+        }
 
         rescoreElement = "{\n" +
-                "    \"window_size\" : 20,\n" +
-                "    \"query\" : { \"bad_fieldname\" : 1.0  } \n" +
-                "}\n";
-            try (XContentParser parser = createParser(rescoreElement)) {
-                XContentParseException e = expectThrows(XContentParseException.class, () -> RescorerBuilder.parseFromXContent(parser));
-                assertEquals("[3:17] [query] unknown field [bad_fieldname], parser not found", e.getMessage());
-            }
+            "    \"window_size\" : 20,\n" +
+            "    \"query\" : { \"bad_fieldname\" : 1.0  } \n" +
+            "}\n";
+        try (XContentParser parser = createParser(rescoreElement)) {
+            XContentParseException e = expectThrows(XContentParseException.class, () -> RescorerBuilder.parseFromXContent(parser));
+            assertEquals("[3:17] [query] unknown field [bad_fieldname], parser not found", e.getMessage());
+        }
 
         rescoreElement = "{\n" +
-                "    \"window_size\" : 20,\n" +
-                "    \"query\" : { \"rescore_query\" : { \"unknown_queryname\" : { } } } \n" +
-                "}\n";
-            try (XContentParser parser = createParser(rescoreElement)) {
-                Exception e = expectThrows(XContentParseException.class, () -> RescorerBuilder.parseFromXContent(parser));
-                assertThat(e.getMessage(), containsString("[query] failed to parse field [rescore_query]"));
-            }
+            "    \"window_size\" : 20,\n" +
+            "    \"query\" : { \"rescore_query\" : { \"unknown_queryname\" : { } } } \n" +
+            "}\n";
+        try (XContentParser parser = createParser(rescoreElement)) {
+            Exception e = expectThrows(XContentParseException.class, () -> RescorerBuilder.parseFromXContent(parser));
+            assertThat(e.getMessage(), containsString("[query] failed to parse field [rescore_query]"));
+        }
 
         rescoreElement = "{\n" +
-                "    \"window_size\" : 20,\n" +
-                "    \"query\" : { \"rescore_query\" : { \"match_all\" : { } } } \n"
-                + "}\n";
+            "    \"window_size\" : 20,\n" +
+            "    \"query\" : { \"rescore_query\" : { \"match_all\" : { } } } \n"
+            + "}\n";
         try (XContentParser parser = createParser(rescoreElement)) {
             RescorerBuilder.parseFromXContent(parser);
         }

--- a/server/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/searchafter/SearchAfterBuilderTests.java
@@ -136,11 +136,12 @@ public class SearchAfterBuilderTests extends ESTestCase {
         }
         jsonBuilder.endArray();
         jsonBuilder.endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(jsonBuilder));
-        parser.nextToken();
-        parser.nextToken();
-        parser.nextToken();
-        return SearchAfterBuilder.fromXContent(parser);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(jsonBuilder))) {
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
+            return SearchAfterBuilder.fromXContent(parser);
+        }
     }
 
     private static SearchAfterBuilder serializedCopy(SearchAfterBuilder original) throws IOException {
@@ -174,14 +175,15 @@ public class SearchAfterBuilderTests extends ESTestCase {
             builder.startObject();
             searchAfterBuilder.innerToXContent(builder);
             builder.endObject();
-            XContentParser parser = createParser(shuffleXContent(builder));
-            parser.nextToken();
-            parser.nextToken();
-            parser.nextToken();
-            SearchAfterBuilder secondSearchAfterBuilder = SearchAfterBuilder.fromXContent(parser);
-            assertNotSame(searchAfterBuilder, secondSearchAfterBuilder);
-            assertEquals(searchAfterBuilder, secondSearchAfterBuilder);
-            assertEquals(searchAfterBuilder.hashCode(), secondSearchAfterBuilder.hashCode());
+            try (XContentParser parser = createParser(shuffleXContent(builder))) {
+                parser.nextToken();
+                parser.nextToken();
+                parser.nextToken();
+                SearchAfterBuilder secondSearchAfterBuilder = SearchAfterBuilder.fromXContent(parser);
+                assertNotSame(searchAfterBuilder, secondSearchAfterBuilder);
+                assertEquals(searchAfterBuilder, secondSearchAfterBuilder);
+                assertEquals(searchAfterBuilder.hashCode(), secondSearchAfterBuilder.hashCode());
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
@@ -306,11 +306,12 @@ public class SliceBuilderTests extends ESTestCase {
         builder.startObject();
         sliceBuilder.innerToXContent(builder);
         builder.endObject();
-        XContentParser parser = createParser(shuffleXContent(builder));
-        SliceBuilder secondSliceBuilder = SliceBuilder.fromXContent(parser);
-        assertNotSame(sliceBuilder, secondSliceBuilder);
-        assertEquals(sliceBuilder, secondSliceBuilder);
-        assertEquals(sliceBuilder.hashCode(), secondSliceBuilder.hashCode());
+        try (XContentParser parser = createParser(shuffleXContent(builder))) {
+            SliceBuilder secondSliceBuilder = SliceBuilder.fromXContent(parser);
+            assertNotSame(sliceBuilder, secondSliceBuilder);
+            assertEquals(sliceBuilder, secondSliceBuilder);
+            assertEquals(sliceBuilder.hashCode(), secondSliceBuilder.hashCode());
+        }
     }
 
     public void testInvalidArguments() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -121,21 +121,22 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
             }
             testItem.toXContent(builder, ToXContent.EMPTY_PARAMS);
             XContentBuilder shuffled = shuffleXContent(builder);
-            XContentParser itemParser = createParser(shuffled);
-            itemParser.nextToken();
+            try (XContentParser itemParser = createParser(shuffled)) {
+                itemParser.nextToken();
 
-            /*
-             * filter out name of sort, or field name to sort on for element fieldSort
-             */
-            itemParser.nextToken();
-            String elementName = itemParser.currentName();
-            itemParser.nextToken();
+                /*
+                 * filter out name of sort, or field name to sort on for element fieldSort
+                 */
+                itemParser.nextToken();
+                String elementName = itemParser.currentName();
+                itemParser.nextToken();
 
-            T parsedItem = fromXContent(itemParser, elementName);
-            assertNotSame(testItem, parsedItem);
-            assertEquals(testItem, parsedItem);
-            assertEquals(testItem.hashCode(), parsedItem.hashCode());
-            assertWarnings(testItem);
+                T parsedItem = fromXContent(itemParser, elementName);
+                assertNotSame(testItem, parsedItem);
+                assertEquals(testItem, parsedItem);
+                assertEquals(testItem.hashCode(), parsedItem.hashCode());
+                assertWarnings(testItem);
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -304,14 +304,15 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
     public void testUnknownOptionFails() throws IOException {
         String json = "{ \"post_date\" : {\"reverse\" : true} },\n";
 
-        XContentParser parser = createParser(JsonXContent.jsonXContent, json);
-        // need to skip until parser is located on second START_OBJECT
-        parser.nextToken();
-        parser.nextToken();
-        parser.nextToken();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            // need to skip until parser is located on second START_OBJECT
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
 
-        XContentParseException e = expectThrows(XContentParseException.class, () -> FieldSortBuilder.fromXContent(parser, ""));
-        assertEquals("[1:18] [field_sort] unknown field [reverse], parser not found", e.getMessage());
+            XContentParseException e = expectThrows(XContentParseException.class, () -> FieldSortBuilder.fromXContent(parser, ""));
+            assertEquals("[1:18] [field_sort] unknown field [reverse], parser not found", e.getMessage());
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/GeoDistanceSortBuilderTests.java
@@ -232,12 +232,13 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "  \"distance_type\" : \"arc\",\n" +
                 "  \"mode\" : \"SUM\"\n" +
                 "}";
-        XContentParser itemParser = createParser(JsonXContent.jsonXContent, json);
-        itemParser.nextToken();
+        try (XContentParser itemParser = createParser(JsonXContent.jsonXContent, json)) {
+            itemParser.nextToken();
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
                 () -> GeoDistanceSortBuilder.fromXContent(itemParser, ""));
-        assertEquals("sort_mode [sum] isn't supported for sorting by geo distance", e.getMessage());
+            assertEquals("sort_mode [sum] isn't supported for sorting by geo distance", e.getMessage());
+        }
     }
 
     public void testGeoDistanceSortCanBeParsedFromGeoHash() throws IOException {
@@ -258,16 +259,17 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
                 "    },\n" +
                 "    \"validation_method\" : \"STRICT\"\n" +
                 "  }";
-        XContentParser itemParser = createParser(JsonXContent.jsonXContent, json);
-        itemParser.nextToken();
+        try (XContentParser itemParser = createParser(JsonXContent.jsonXContent, json)) {
+            itemParser.nextToken();
 
-        GeoDistanceSortBuilder result = GeoDistanceSortBuilder.fromXContent(itemParser, json);
-        assertEquals("[-19.700583312660456, -2.8225036337971687, "
+            GeoDistanceSortBuilder result = GeoDistanceSortBuilder.fromXContent(itemParser, json);
+            assertEquals("[-19.700583312660456, -2.8225036337971687, "
                 + "31.537466906011105, -74.63590376079082, "
                 + "43.71844606474042, -5.548660643398762, "
                 + "-37.20467280596495, 38.71751043945551, "
                 + "-69.44606635719538, 84.25200328230858, "
                 + "-39.03717711567879, 44.74099852144718]", Arrays.toString(result.points()));
+        }
     }
 
     public void testGeoDistanceSortParserManyPointsNoException() throws Exception {
@@ -380,9 +382,10 @@ public class GeoDistanceSortBuilderTests extends AbstractSortTestCase<GeoDistanc
     }
 
     private GeoDistanceSortBuilder parse(XContentBuilder sortBuilder) throws Exception {
-        XContentParser parser = createParser(sortBuilder);
-        parser.nextToken();
-        return GeoDistanceSortBuilder.fromXContent(parser, null);
+        try (XContentParser parser = createParser(sortBuilder)) {
+            parser.nextToken();
+            return GeoDistanceSortBuilder.fromXContent(parser, null);
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/sort/NestedSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/NestedSortBuilderTests.java
@@ -73,12 +73,13 @@ public class NestedSortBuilderTests extends ESTestCase {
             XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
             testItem.toXContent(builder, ToXContent.EMPTY_PARAMS);
             XContentBuilder shuffled = shuffleXContent(builder);
-            XContentParser parser = createParser(shuffled);
-            parser.nextToken();
-            NestedSortBuilder parsedItem = NestedSortBuilder.fromXContent(parser);
-            assertNotSame(testItem, parsedItem);
-            assertEquals(testItem, parsedItem);
-            assertEquals(testItem.hashCode(), parsedItem.hashCode());
+            try (XContentParser parser = createParser(shuffled)) {
+                parser.nextToken();
+                NestedSortBuilder parsedItem = NestedSortBuilder.fromXContent(parser);
+                assertNotSame(testItem, parsedItem);
+                assertEquals(testItem, parsedItem);
+                assertEquals(testItem.hashCode(), parsedItem.hashCode());
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/ScriptSortBuilderTests.java
@@ -177,20 +177,21 @@ public class ScriptSortBuilderTests extends AbstractSortTestCase<ScriptSortBuild
                     "\"mode\" : \"max\",\n" +
                     "\"order\" : \"asc\"\n" +
                 "} }\n";
-        XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort);
-        parser.nextToken();
-        parser.nextToken();
-        parser.nextToken();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort)) {
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
 
-        ScriptSortBuilder builder = ScriptSortBuilder.fromXContent(parser, null);
-        assertEquals("doc['field_name'].value * factor", builder.script().getIdOrCode());
-        assertEquals(Script.DEFAULT_SCRIPT_LANG, builder.script().getLang());
-        assertEquals(1.1, builder.script().getParams().get("factor"));
-        assertEquals(ScriptType.INLINE, builder.script().getType());
-        assertEquals(ScriptSortType.NUMBER, builder.type());
-        assertEquals(SortOrder.ASC, builder.order());
-        assertEquals(SortMode.MAX, builder.sortMode());
-        assertNull(builder.getNestedSort());
+            ScriptSortBuilder builder = ScriptSortBuilder.fromXContent(parser, null);
+            assertEquals("doc['field_name'].value * factor", builder.script().getIdOrCode());
+            assertEquals(Script.DEFAULT_SCRIPT_LANG, builder.script().getLang());
+            assertEquals(1.1, builder.script().getParams().get("factor"));
+            assertEquals(ScriptType.INLINE, builder.script().getType());
+            assertEquals(ScriptSortType.NUMBER, builder.type());
+            assertEquals(SortOrder.ASC, builder.order());
+            assertEquals(SortMode.MAX, builder.sortMode());
+            assertNull(builder.getNestedSort());
+        }
     }
 
     public void testParseJson_simple() throws IOException {
@@ -201,54 +202,58 @@ public class ScriptSortBuilderTests extends AbstractSortTestCase<ScriptSortBuild
                 "\"mode\" : \"max\",\n" +
                 "\"order\" : \"asc\"\n" +
                 "} }\n";
-        XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort);
-        parser.nextToken();
-        parser.nextToken();
-        parser.nextToken();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort)) {
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
 
-        ScriptSortBuilder builder = ScriptSortBuilder.fromXContent(parser, null);
-        assertEquals("doc['field_name'].value", builder.script().getIdOrCode());
-        assertEquals(Script.DEFAULT_SCRIPT_LANG, builder.script().getLang());
-        assertEquals(builder.script().getParams(), Collections.emptyMap());
-        assertEquals(ScriptType.INLINE, builder.script().getType());
-        assertEquals(ScriptSortType.NUMBER, builder.type());
-        assertEquals(SortOrder.ASC, builder.order());
-        assertEquals(SortMode.MAX, builder.sortMode());
-        assertNull(builder.getNestedSort());
+            ScriptSortBuilder builder = ScriptSortBuilder.fromXContent(parser, null);
+            assertEquals("doc['field_name'].value", builder.script().getIdOrCode());
+            assertEquals(Script.DEFAULT_SCRIPT_LANG, builder.script().getLang());
+            assertEquals(builder.script().getParams(), Collections.emptyMap());
+            assertEquals(ScriptType.INLINE, builder.script().getType());
+            assertEquals(ScriptSortType.NUMBER, builder.type());
+            assertEquals(SortOrder.ASC, builder.order());
+            assertEquals(SortMode.MAX, builder.sortMode());
+            assertNull(builder.getNestedSort());
+        }
     }
 
     public void testParseBadFieldNameExceptions() throws IOException {
         String scriptSort = "{\"_script\" : {" + "\"bad_field\" : \"number\"" + "} }";
-        XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort);
-        parser.nextToken();
-        parser.nextToken();
-        parser.nextToken();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort)) {
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
 
-        XContentParseException e = expectThrows(XContentParseException.class, () -> ScriptSortBuilder.fromXContent(parser, null));
-        assertEquals("[1:15] [_script] unknown field [bad_field], parser not found", e.getMessage());
+            XContentParseException e = expectThrows(XContentParseException.class, () -> ScriptSortBuilder.fromXContent(parser, null));
+            assertEquals("[1:15] [_script] unknown field [bad_field], parser not found", e.getMessage());
+        }
     }
 
     public void testParseBadFieldNameExceptionsOnStartObject() throws IOException {
 
         String scriptSort = "{\"_script\" : {" + "\"bad_field\" : { \"order\" : \"asc\" } } }";
-        XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort);
-        parser.nextToken();
-        parser.nextToken();
-        parser.nextToken();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort)) {
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
 
-        XContentParseException e = expectThrows(XContentParseException.class, () -> ScriptSortBuilder.fromXContent(parser, null));
-        assertEquals("[1:15] [_script] unknown field [bad_field], parser not found", e.getMessage());
+            XContentParseException e = expectThrows(XContentParseException.class, () -> ScriptSortBuilder.fromXContent(parser, null));
+            assertEquals("[1:15] [_script] unknown field [bad_field], parser not found", e.getMessage());
+        }
     }
 
     public void testParseUnexpectedToken() throws IOException {
         String scriptSort = "{\"_script\" : {" + "\"script\" : [ \"order\" : \"asc\" ] } }";
-        XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort);
-        parser.nextToken();
-        parser.nextToken();
-        parser.nextToken();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, scriptSort)) {
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
 
-        Exception e = expectThrows(XContentParseException.class, () -> ScriptSortBuilder.fromXContent(parser, null));
-        assertThat(e.getMessage(), containsString("[_script] script doesn't support values of type: START_ARRAY"));
+            Exception e = expectThrows(XContentParseException.class, () -> ScriptSortBuilder.fromXContent(parser, null));
+            assertThat(e.getMessage(), containsString("[_script] script doesn't support values of type: START_ARRAY"));
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/SortBuilderTests.java
@@ -252,12 +252,13 @@ public class SortBuilderTests extends ESTestCase {
     }
 
     private List<SortBuilder<?>> parseSort(String jsonString) throws IOException {
-        XContentParser itemParser = createParser(JsonXContent.jsonXContent, jsonString);
+        try (XContentParser itemParser = createParser(JsonXContent.jsonXContent, jsonString)) {
 
-        assertEquals(XContentParser.Token.START_OBJECT, itemParser.nextToken());
-        assertEquals(XContentParser.Token.FIELD_NAME, itemParser.nextToken());
-        assertEquals("sort", itemParser.currentName());
-        itemParser.nextToken();
-        return SortBuilder.fromXContent(itemParser);
+            assertEquals(XContentParser.Token.START_OBJECT, itemParser.nextToken());
+            assertEquals(XContentParser.Token.FIELD_NAME, itemParser.nextToken());
+            assertEquals("sort", itemParser.currentName());
+            itemParser.nextToken();
+            return SortBuilder.fromXContent(itemParser);
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -140,14 +140,15 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             xContentBuilder.endObject();
 
             XContentBuilder shuffled = shuffleXContent(xContentBuilder, shuffleProtectedFields());
-            XContentParser parser = createParser(shuffled);
-            // we need to skip the start object and the name, those will be parsed by outer SuggestBuilder
-            parser.nextToken();
+            try (XContentParser parser = createParser(shuffled)) {
+                // we need to skip the start object and the name, those will be parsed by outer SuggestBuilder
+                parser.nextToken();
 
-            SuggestionBuilder<?> secondSuggestionBuilder = SuggestionBuilder.fromXContent(parser);
-            assertNotSame(suggestionBuilder, secondSuggestionBuilder);
-            assertEquals(suggestionBuilder, secondSuggestionBuilder);
-            assertEquals(suggestionBuilder.hashCode(), secondSuggestionBuilder.hashCode());
+                SuggestionBuilder<?> secondSuggestionBuilder = SuggestionBuilder.fromXContent(parser);
+                assertNotSame(suggestionBuilder, secondSuggestionBuilder);
+                assertEquals(suggestionBuilder, secondSuggestionBuilder);
+                assertEquals(suggestionBuilder.hashCode(), secondSuggestionBuilder.hashCode());
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestBuilderTests.java
@@ -74,11 +74,12 @@ public class SuggestBuilderTests extends ESTestCase {
                 xContentBuilder.prettyPrint();
             }
             suggestBuilder.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
-            XContentParser parser = createParser(xContentBuilder);
-            SuggestBuilder secondSuggestBuilder = SuggestBuilder.fromXContent(parser);
-            assertNotSame(suggestBuilder, secondSuggestBuilder);
-            assertEquals(suggestBuilder, secondSuggestBuilder);
-            assertEquals(suggestBuilder.hashCode(), secondSuggestBuilder.hashCode());
+            try (XContentParser parser = createParser(xContentBuilder)) {
+                SuggestBuilder secondSuggestBuilder = SuggestBuilder.fromXContent(parser);
+                assertNotSame(suggestBuilder, secondSuggestBuilder);
+                assertEquals(suggestBuilder, secondSuggestBuilder);
+                assertEquals(suggestBuilder.hashCode(), secondSuggestBuilder.hashCode());
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -368,44 +368,48 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
 
     public void testQueryContextParsingBasic() throws Exception {
         XContentBuilder builder = jsonBuilder().value("context1");
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(1));
-        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(1));
+            assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
+        }
     }
 
     public void testBooleanQueryContextParsingBasic() throws Exception {
         XContentBuilder builder = jsonBuilder().value(true);
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(1));
-        assertThat(internalQueryContexts.get(0).context, equalTo("true"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(1));
+            assertThat(internalQueryContexts.get(0).context, equalTo("true"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
+        }
     }
 
     public void testNumberQueryContextParsingBasic() throws Exception {
         XContentBuilder builder = jsonBuilder().value(10);
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(1));
-        assertThat(internalQueryContexts.get(0).context, equalTo("10"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(1));
+            assertThat(internalQueryContexts.get(0).context, equalTo("10"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
+        }
     }
 
     public void testNULLQueryContextParsingBasic() throws Exception {
         XContentBuilder builder = jsonBuilder().nullValue();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
-        assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be an object, string, number or boolean"));
+            XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+            assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be an object, string, number or boolean"));
+        }
     }
 
     public void testQueryContextParsingArray() throws Exception {
@@ -413,16 +417,17 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                     .value("context1")
                     .value("context2")
                 .endArray();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(2));
-        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
-        assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
-        assertThat(internalQueryContexts.get(1).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(2));
+            assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
+            assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
+            assertThat(internalQueryContexts.get(1).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
+        }
     }
 
     public void testQueryContextParsingMixedTypeValuesArray() throws Exception {
@@ -432,22 +437,23 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                     .value(true)
                     .value(10)
                 .endArray();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(4));
-        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
-        assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
-        assertThat(internalQueryContexts.get(1).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
-        assertThat(internalQueryContexts.get(2).context, equalTo("true"));
-        assertThat(internalQueryContexts.get(2).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(2).isPrefix, equalTo(false));
-        assertThat(internalQueryContexts.get(3).context, equalTo("10"));
-        assertThat(internalQueryContexts.get(3).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(3).isPrefix, equalTo(false));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(4));
+            assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(false));
+            assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
+            assertThat(internalQueryContexts.get(1).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
+            assertThat(internalQueryContexts.get(2).context, equalTo("true"));
+            assertThat(internalQueryContexts.get(2).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(2).isPrefix, equalTo(false));
+            assertThat(internalQueryContexts.get(3).context, equalTo("10"));
+            assertThat(internalQueryContexts.get(3).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(3).isPrefix, equalTo(false));
+        }
     }
 
     public void testQueryContextParsingMixedTypeValuesArrayHavingNULL() throws Exception {
@@ -458,11 +464,12 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                     .value(10)
                     .nullValue()
                 .endArray();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
-        assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be an object, string, number or boolean"));
+            XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+            assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be an object, string, number or boolean"));
+        }
     }
 
     public void testQueryContextParsingObject() throws Exception {
@@ -471,13 +478,14 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .field("boost", 10)
                 .field("prefix", true)
                 .endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(1));
-        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(10));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(1));
+            assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(10));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+        }
     }
 
     public void testQueryContextParsingObjectHavingBoolean() throws Exception {
@@ -486,13 +494,14 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .field("boost", 10)
                 .field("prefix", true)
                 .endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(1));
-        assertThat(internalQueryContexts.get(0).context, equalTo("false"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(10));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(1));
+            assertThat(internalQueryContexts.get(0).context, equalTo("false"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(10));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+        }
     }
 
     public void testQueryContextParsingObjectHavingNumber() throws Exception {
@@ -501,13 +510,14 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .field("boost", 10)
                 .field("prefix", true)
                 .endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(1));
-        assertThat(internalQueryContexts.get(0).context, equalTo("333"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(10));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(1));
+            assertThat(internalQueryContexts.get(0).context, equalTo("333"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(10));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+        }
     }
 
     public void testQueryContextParsingObjectHavingNULL() throws Exception {
@@ -516,11 +526,12 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .field("boost", 10)
                 .field("prefix", true)
                 .endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        Exception e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
-        assertThat(e.getMessage(), containsString("category context must be a string, number or boolean"));
+            Exception e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+            assertThat(e.getMessage(), containsString("category context must be a string, number or boolean"));
+        }
     }
 
     public void testQueryContextParsingObjectArray() throws Exception {
@@ -536,16 +547,17 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .field("prefix", false)
                 .endObject()
                 .endArray();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(2));
-        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(2));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
-        assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
-        assertThat(internalQueryContexts.get(1).boost, equalTo(3));
-        assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(2));
+            assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(2));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+            assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
+            assertThat(internalQueryContexts.get(1).boost, equalTo(3));
+            assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
+        }
     }
 
     public void testQueryContextParsingMixedTypeObjectArray() throws Exception {
@@ -571,22 +583,23 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .field("prefix", false)
                 .endObject()
                 .endArray();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(4));
-        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(2));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
-        assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
-        assertThat(internalQueryContexts.get(1).boost, equalTo(3));
-        assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
-        assertThat(internalQueryContexts.get(2).context, equalTo("true"));
-        assertThat(internalQueryContexts.get(2).boost, equalTo(3));
-        assertThat(internalQueryContexts.get(2).isPrefix, equalTo(false));
-        assertThat(internalQueryContexts.get(3).context, equalTo("333"));
-        assertThat(internalQueryContexts.get(3).boost, equalTo(3));
-        assertThat(internalQueryContexts.get(3).isPrefix, equalTo(false));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(4));
+            assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(2));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+            assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
+            assertThat(internalQueryContexts.get(1).boost, equalTo(3));
+            assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
+            assertThat(internalQueryContexts.get(2).context, equalTo("true"));
+            assertThat(internalQueryContexts.get(2).boost, equalTo(3));
+            assertThat(internalQueryContexts.get(2).isPrefix, equalTo(false));
+            assertThat(internalQueryContexts.get(3).context, equalTo("333"));
+            assertThat(internalQueryContexts.get(3).boost, equalTo(3));
+            assertThat(internalQueryContexts.get(3).isPrefix, equalTo(false));
+        }
     }
 
     public void testQueryContextParsingMixedTypeObjectArrayHavingNULL() throws Exception {
@@ -617,11 +630,12 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .field("prefix", false)
                 .endObject()
                 .endArray();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
-        assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be a string, number or boolean"));
+            XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+            assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be a string, number or boolean"));
+        }
     }
 
 
@@ -640,22 +654,23 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .field("prefix", true)
                 .endObject()
                 .endArray();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
-        List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
-        assertThat(internalQueryContexts.size(), equalTo(4));
-        assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
-        assertThat(internalQueryContexts.get(0).boost, equalTo(2));
-        assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
-        assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
-        assertThat(internalQueryContexts.get(1).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
-        assertThat(internalQueryContexts.get(2).context, equalTo("false"));
-        assertThat(internalQueryContexts.get(2).boost, equalTo(1));
-        assertThat(internalQueryContexts.get(2).isPrefix, equalTo(false));
-        assertThat(internalQueryContexts.get(3).context, equalTo("333"));
-        assertThat(internalQueryContexts.get(3).boost, equalTo(2));
-        assertThat(internalQueryContexts.get(3).isPrefix, equalTo(true));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+            List<ContextMapping.InternalQueryContext> internalQueryContexts = mapping.parseQueryContext(parser);
+            assertThat(internalQueryContexts.size(), equalTo(4));
+            assertThat(internalQueryContexts.get(0).context, equalTo("context1"));
+            assertThat(internalQueryContexts.get(0).boost, equalTo(2));
+            assertThat(internalQueryContexts.get(0).isPrefix, equalTo(true));
+            assertThat(internalQueryContexts.get(1).context, equalTo("context2"));
+            assertThat(internalQueryContexts.get(1).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(1).isPrefix, equalTo(false));
+            assertThat(internalQueryContexts.get(2).context, equalTo("false"));
+            assertThat(internalQueryContexts.get(2).boost, equalTo(1));
+            assertThat(internalQueryContexts.get(2).isPrefix, equalTo(false));
+            assertThat(internalQueryContexts.get(3).context, equalTo("333"));
+            assertThat(internalQueryContexts.get(3).boost, equalTo(2));
+            assertThat(internalQueryContexts.get(3).isPrefix, equalTo(true));
+        }
     }
 
     public void testQueryContextParsingMixedHavingNULL() throws Exception {
@@ -674,11 +689,12 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject()
                 .nullValue()
                 .endArray();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        CategoryContextMapping mapping = ContextBuilder.category("cat").build();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            CategoryContextMapping mapping = ContextBuilder.category("cat").build();
 
-        XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
-        assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be an object, string, number or boolean"));
+            XContentParseException e = expectThrows(XContentParseException.class, () -> mapping.parseQueryContext(parser));
+            assertThat(ExceptionsHelper.detailedMessage(e), containsString("category context must be an object, string, number or boolean"));
+        }
     }
 
     public void testUnknownQueryContextParsing() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGeneratorTests.java
@@ -124,12 +124,13 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
                 builder.prettyPrint();
             }
             generator.toXContent(builder, ToXContent.EMPTY_PARAMS);
-            XContentParser parser = createParser(shuffleXContent(builder));
-            parser.nextToken();
-            DirectCandidateGeneratorBuilder secondGenerator = DirectCandidateGeneratorBuilder.PARSER.apply(parser, null);
-            assertNotSame(generator, secondGenerator);
-            assertEquals(generator, secondGenerator);
-            assertEquals(generator.hashCode(), secondGenerator.hashCode());
+            try (XContentParser parser = createParser(shuffleXContent(builder))) {
+                parser.nextToken();
+                DirectCandidateGeneratorBuilder secondGenerator = DirectCandidateGeneratorBuilder.PARSER.apply(parser, null);
+                assertNotSame(generator, secondGenerator);
+                assertEquals(generator, secondGenerator);
+                assertEquals(generator.hashCode(), secondGenerator.hashCode());
+            }
         }
     }
 
@@ -187,9 +188,10 @@ public class DirectCandidateGeneratorTests extends ESTestCase {
 
     private void assertIllegalXContent(String directGenerator, Class<? extends Exception> exceptionClass, String exceptionMsg)
             throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent, directGenerator);
-        Exception e = expectThrows(exceptionClass, () -> DirectCandidateGeneratorBuilder.PARSER.apply(parser, null));
-        assertThat(e.getMessage(), containsString(exceptionMsg));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, directGenerator)) {
+            Exception e = expectThrows(exceptionClass, () -> DirectCandidateGeneratorBuilder.PARSER.apply(parser, null));
+            assertThat(e.getMessage(), containsString(exceptionMsg));
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/SmoothingModelTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/SmoothingModelTestCase.java
@@ -95,12 +95,13 @@ public abstract class SmoothingModelTestCase extends ESTestCase {
         contentBuilder.startObject();
         testModel.innerToXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
         contentBuilder.endObject();
-        XContentParser parser = createParser(shuffleXContent(contentBuilder));
-        parser.nextToken();  // go to start token, real parsing would do that in the outer element parser
-        SmoothingModel parsedModel = fromXContent(parser);
-        assertNotSame(testModel, parsedModel);
-        assertEquals(testModel, parsedModel);
-        assertEquals(testModel.hashCode(), parsedModel.hashCode());
+        try (XContentParser parser = createParser(shuffleXContent(contentBuilder))) {
+            parser.nextToken();  // go to start token, real parsing would do that in the outer element parser
+            SmoothingModel parsedModel = fromXContent(parser);
+            assertNotSame(testModel, parsedModel);
+            assertEquals(testModel, parsedModel);
+            assertEquals(testModel.hashCode(), parsedModel.hashCode());
+        }
     }
 
     /**


### PR DESCRIPTION
I'm working through the codebase trying to close every instance where we leave an XContentParser open... there are a lot of them.  I will follow with separate PR's that enforce that we close XContentParsers.  

I recommend viewing this PR with &w=1.

If there's too much here, I'm happy to break it up into multiple different PRs.

Relates #30692