### PR TITLE
[CCR] Add index setting to keep track of the index uuid of the leader index in the follow index

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrSettings.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrSettings.java
@@ -33,6 +33,12 @@ public final class CcrSettings {
             Setting.boolSetting("index.xpack.ccr.following_index", false, Setting.Property.IndexScope);
 
     /**
+     * An internal setting used to keep track to what leader index a follow index associated. Do not use externally!
+     */
+    public static final Setting<String> CCR_LEADER_INDEX_UUID_SETTING =
+            Setting.simpleString("index.xpack.ccr.leader_index_uuid", Setting.Property.IndexScope);
+
+    /**
      * The settings defined by CCR.
      *
      * @return the settings
@@ -40,7 +46,8 @@ public final class CcrSettings {
     static List<Setting<?>> getSettings() {
         return Arrays.asList(
                 CCR_ENABLED_SETTING,
-                CCR_FOLLOWING_INDEX_SETTING);
+                CCR_FOLLOWING_INDEX_SETTING,
+                CCR_LEADER_INDEX_UUID_SETTING);
     }
 
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CreateAndFollowIndexAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CreateAndFollowIndexAction.java
@@ -276,6 +276,7 @@ public class CreateAndFollowIndexAction extends Action<CreateAndFollowIndexActio
                     settingsBuilder.put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID());
                     settingsBuilder.put(IndexMetaData.SETTING_INDEX_PROVIDED_NAME, followIndex);
                     settingsBuilder.put(CcrSettings.CCR_FOLLOWING_INDEX_SETTING.getKey(), true);
+                    settingsBuilder.put(CcrSettings.CCR_LEADER_INDEX_UUID_SETTING.getKey(), leaderIndexMetaData.getIndexUUID());
                     imdBuilder.settings(settingsBuilder);
 
                     // Copy mappings from leader IMD to follow IMD


### PR DESCRIPTION
The follow index api checks if the uuid in the follow index matches
with uuid of the leader index and fails otherwise. This validation will
prevent a follow index from following an incompatible leader index.

The create_and_follow api will automatically add this index setting
when it creates the follow index.

Closes #31505