### PR TITLE
Fix Mockito trying to mock IOException that isn't thrown by method (#31433)

### DIFF
--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
@@ -460,7 +460,6 @@ public class HttpExporterTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix (bugUrl = "https://github.com/elastic/elasticsearch/issues/31433" )
     public void testHttpExporterShutdown() throws Exception {
         final Config config = createConfig(Settings.EMPTY);
         final RestClient client = mock(RestClient.class);
@@ -469,7 +468,7 @@ public class HttpExporterTests extends ESTestCase {
         final MultiHttpResource resource = mock(MultiHttpResource.class);
 
         if (sniffer != null && rarely()) {
-            doThrow(randomFrom(new IOException("expected"), new RuntimeException("expected"))).when(sniffer).close();
+            doThrow(new RuntimeException("expected")).when(sniffer).close();
         }
 
         if (rarely()) {


### PR DESCRIPTION
Fixes #31433 by removing trying to mock an `IOException` that isn't thrown by the sniffer anymore ever since 63f3a6113462525f8c882b0cbb7e364509f9566e