### PR TITLE
Only connect to new nodes on new cluster state

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
@@ -83,8 +83,7 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         for (final DiscoveryNode node : discoveryNodes) {
             final boolean connected;
             try (Releasable ignored = nodeLocks.acquire(node)) {
-                nodes.putIfAbsent(node, 0);
-                connected = transportService.nodeConnected(node);
+                connected = (nodes.putIfAbsent(node, 0) != null);
             }
             if (connected) {
                 latch.countDown();

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -462,7 +462,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
             }
         }
 
-        nodeConnectionsService.connectToNodes(newClusterState.nodes());
+        nodeConnectionsService.connectToNodes(newClusterState.nodes(), false);
 
         logger.debug("applying cluster state version {}", newClusterState.version());
         try {

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -91,8 +91,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
             "ClusterApplierServiceTests").build(), new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             threadPool);
         timedClusterApplierService.setNodeConnectionsService(new NodeConnectionsService(Settings.EMPTY, null, null) {
+
             @Override
-            public void connectToNodes(DiscoveryNodes discoveryNodes) {
+            public void connectToNodes(DiscoveryNodes discoveryNodes, boolean reconnectToKnownNodes) {
                 // skip
             }
 

--- a/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/test/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -47,6 +47,7 @@ import org.elasticsearch.test.disruption.NetworkDisruption.NetworkLinkDisruption
 import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.transport.NodeNotConnectedException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -207,7 +208,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                                 assertTrue("doc [" + id + "] indexed via node [" + ackedDocs.get(id) + "] not found",
                                     client(node).prepareGet("test", "type", id).setPreference("_local").get().isExists());
                             }
-                        } catch (AssertionError | NoShardAvailableActionException e) {
+                        } catch (AssertionError | NoShardAvailableActionException | NodeNotConnectedException e) {
                             throw new AssertionError(e.getMessage() + " (checked via node [" + node + "]", e);
                         }
                     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -135,7 +135,7 @@ public class ClusterServiceUtils {
             clusterSettings, threadPool, Collections.emptyMap());
         clusterService.setNodeConnectionsService(new NodeConnectionsService(Settings.EMPTY, null, null) {
             @Override
-            public void connectToNodes(DiscoveryNodes discoveryNodes) {
+            public void connectToNodes(DiscoveryNodes discoveryNodes, boolean reconnectToKnownNodes) {
                 // skip
             }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/NetworkDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/NetworkDisruption.java
@@ -104,7 +104,7 @@ public class NetworkDisruption implements ServiceDisruptionScheme {
     public static void ensureFullyConnectedCluster(InternalTestCluster cluster) {
         for (String node: cluster.getNodeNames()) {
             ClusterState stateOnNode = cluster.getInstance(ClusterService.class, node).state();
-            cluster.getInstance(NodeConnectionsService.class, node).connectToNodes(stateOnNode.nodes());
+            cluster.getInstance(NodeConnectionsService.class, node).connectToNodes(stateOnNode.nodes(), true);
         }
     }
 


### PR DESCRIPTION
Today, when a new cluster state is committed we attempt to connect to all of
its nodes as part of the application process. This is the right thing to do
with new nodes, and is a no-op on any already-connected nodes, but is
questionable on known nodes from which we are currently disconnected: there is
a risk that we are partitioned from these nodes so that any attempt to connect
to them will hang until it times out. This can dramatically slow down the
application of new cluster states which hinders the recovery of the cluster
during certain kinds of partition.

If nodes are disconnected from the master then it is likely that they are to be
removed as part of a subsequent cluster state update, so there's no need to try
and reconnect to them like this. Moreover there is no need to attempt to
reconnect to disconnected nodes as part of the cluster state application
process, because we periodically try and reconnect to any disconnected nodes,
and handle their disconnectedness gracefully in the meantime.

This commit alters this behaviour to avoid reconnecting to known nodes during
cluster state application.

Resolves #29025.
