### PR TITLE
Docs: Clarify sensitive fields watcher encryption

### DIFF
--- a/x-pack/docs/en/watcher/encrypting-data.asciidoc
+++ b/x-pack/docs/en/watcher/encrypting-data.asciidoc
@@ -6,6 +6,12 @@ information or details about your SMTP email service. You can encrypt this
 data by generating a key and adding some secure settings on each node in your
 cluster.
 
+Every `password` field that is used in your watch within a HTTP basic
+authentication block - for example within a webhook, a HTTP input or when using
+the reporting email attachment - will not be stored as plain text anymore. Also
+be aware, that there is no way to configure your own fields in a watch to be
+encrypted.
+
 To encrypt sensitive data in {watcher}:
 
 . Use the {ref}/syskeygen.html[elasticsearch-syskeygen] command to create a system key file.


### PR DESCRIPTION
In order to clarify the scope of the encrypting sensitive settings in
watcher based on community questions.
