### PR TITLE
Renames endpoints for setting and deleting ILM policies

### DIFF
--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/RestRemovePolicyForIndexAction.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/RestRemovePolicyForIndexAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.indexlifecycle.action.RemovePolicyForIndexAction;
-import org.elasticsearch.xpack.indexlifecycle.IndexLifecycle;
 
 import java.io.IOException;
 
@@ -21,8 +20,8 @@ public class RestRemovePolicyForIndexAction extends BaseRestHandler {
 
     public RestRemovePolicyForIndexAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.PUT, "_" + IndexLifecycle.NAME + "/remove_policy", this);
-        controller.registerHandler(RestRequest.Method.PUT, "{index}/_" + IndexLifecycle.NAME + "/remove_policy", this);
+        controller.registerHandler(RestRequest.Method.DELETE, "_lifecycle", this);
+        controller.registerHandler(RestRequest.Method.DELETE, "{index}/_lifecycle", this);
     }
 
     @Override

--- a/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/RestSetPolicyForIndexAction.java
+++ b/x-pack/plugin/index-lifecycle/src/main/java/org/elasticsearch/xpack/indexlifecycle/action/RestSetPolicyForIndexAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.indexlifecycle.action.SetPolicyForIndexAction;
-import org.elasticsearch.xpack.indexlifecycle.IndexLifecycle;
 
 import java.io.IOException;
 
@@ -21,8 +20,8 @@ public class RestSetPolicyForIndexAction extends BaseRestHandler {
 
     public RestSetPolicyForIndexAction(Settings settings, RestController controller) {
         super(settings);
-        controller.registerHandler(RestRequest.Method.PUT, "_" + IndexLifecycle.NAME + "/set_policy/{new_policy}", this);
-        controller.registerHandler(RestRequest.Method.PUT, "{index}/_" + IndexLifecycle.NAME + "/set_policy/{new_policy}", this);
+        controller.registerHandler(RestRequest.Method.PUT, "_lifecycle/{new_policy}", this);
+        controller.registerHandler(RestRequest.Method.PUT, "{index}/_lifecycle/{new_policy}", this);
     }
 
     @Override

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.index_lifecycle.remove_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.index_lifecycle.remove_policy.json
@@ -1,10 +1,10 @@
 {
   "xpack.index_lifecycle.remove_policy": {
     "documentation": "http://www.elastic.co/guide/en/index_lifecycle/current/index_lifecycle.html",
-    "methods": [ "PUT" ],
+    "methods": [ "DELETE" ],
     "url": {
-      "path": "/{index}/_index_lifecycle/remove_policy",
-      "paths": ["/{index}/_index_lifecycle/remove_policy", "/_index_lifecycle/remove_policy"],
+      "path": "/{index}/_lifecycle",
+      "paths": ["/{index}/_lifecycle", "/_lifecycle"],
       "parts": {
         "index": {
           "type" : "string",

--- a/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.index_lifecycle.set_policy.json
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/api/xpack.index_lifecycle.set_policy.json
@@ -3,8 +3,8 @@
     "documentation": "http://www.elastic.co/guide/en/index_lifecycle/current/index_lifecycle.html",
     "methods": [ "PUT" ],
     "url": {
-      "path": "/{index}/_index_lifecycle/set_policy/{new_policy}",
-      "paths": ["/{index}/_index_lifecycle/set_policy/{new_policy}", "/_index_lifecycle/set_policy/{new_policy}"],
+      "path": "/{index}/_lifecycle/{new_policy}",
+      "paths": ["/{index}/_lifecycle/{new_policy}", "/_lifecycle/{new_policy}"],
       "parts": {
         "index": {
           "type" : "string",


### PR DESCRIPTION
`PUT {index}/_index_lifecycle/remove_policy` is now `DELETE {index}/_lifecycle`
`PUT {index}/_index_lifecycle/set_policy/{policy_name}` is now `PUT {index}/_lifecycle/{policy_name}`