### PR TITLE
Improve test times for tests using `RandomObjects::addFields`

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulateDocumentVerboseResultTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulateDocumentVerboseResultTests.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 public class SimulateDocumentVerboseResultTests extends AbstractXContentTestCase<SimulateDocumentVerboseResult> {
 
     static SimulateDocumentVerboseResult createTestInstance(boolean withFailures) {
-        int numDocs = randomIntBetween(0, 10);
+        int numDocs = randomIntBetween(0, 5);
         List<SimulateProcessorResult> results = new ArrayList<>();
         for (int i = 0; i<numDocs; i++) {
             boolean isSuccessful = !(withFailures && randomBoolean());

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineResponseTests.java
@@ -94,7 +94,7 @@ public class SimulatePipelineResponseTests extends AbstractXContentTestCase<Simu
     }
 
     static SimulatePipelineResponse createInstance(String pipelineId, boolean isVerbose, boolean withFailure) {
-        int numResults = randomIntBetween(1, 10);
+        int numResults = randomIntBetween(1, 5);
         List<SimulateDocumentResult> results = new ArrayList<>(numResults);
         for (int i = 0; i < numResults; i++) {
             if (isVerbose) {

--- a/test/framework/src/main/java/org/elasticsearch/test/RandomObjects.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/RandomObjects.java
@@ -175,7 +175,7 @@ public final class RandomObjects {
     public static BytesReference randomSource(Random random, XContentType xContentType, int minNumFields) {
         try (XContentBuilder builder = XContentFactory.contentBuilder(xContentType)) {
             builder.startObject();
-            addFields(random, builder, minNumFields, 0, 0);
+            addFields(random, builder, minNumFields, 0);
             builder.endObject();
             return BytesReference.bytes(builder);
         } catch(IOException e) {
@@ -185,21 +185,14 @@ public final class RandomObjects {
 
     /**
      * Randomly adds fields, objects, or arrays to the provided builder. The maximum depth is 5.
-     * @return Returns the number of fields in the document
      */
-    private static int addFields(Random random, XContentBuilder builder, int minNumFields, int currentDepth,
-                                 int currentFields) throws IOException {
-        int maxTotalFields = 200;
-        int maxFields = Math.max(minNumFields, 10 - (currentFields * 10)/maxTotalFields); // Map to range 0-10
-        int numFields = randomIntBetween(random, minNumFields, maxFields);
-        int maxDepth = 5 - (currentFields * 5)/maxTotalFields; // Map to range 0-5
-        currentFields += numFields;
+    private static void addFields(Random random, XContentBuilder builder, int minNumFields, int currentDepth) throws IOException {
+        int numFields = randomIntBetween(random, minNumFields, 5);
         for (int i = 0; i < numFields; i++) {
-            if (currentDepth < maxDepth && random.nextBoolean()) {
+            if (currentDepth < 5 && random.nextInt(100) >= 70) {
                 if (random.nextBoolean()) {
                     builder.startObject(RandomStrings.randomAsciiOfLengthBetween(random, 6, 10));
-                    currentFields =
-                        addFields(random, builder, minNumFields, currentDepth + 1, currentFields);
+                    addFields(random, builder, minNumFields, currentDepth + 1);
                     builder.endObject();
                 } else {
                     builder.startArray(RandomStrings.randomAsciiOfLengthBetween(random, 6, 10));
@@ -212,8 +205,7 @@ public final class RandomObjects {
                     for (int j = 0; j < numElements; j++) {
                         if (object) {
                             builder.startObject();
-                            currentFields =
-                                addFields(random, builder, minNumFields, 5, currentFields);
+                            addFields(random, builder, minNumFields, 5);
                             builder.endObject();
                         } else {
                             builder.value(randomFieldValue(random, dataType));
@@ -223,10 +215,9 @@ public final class RandomObjects {
                 }
             } else {
                 builder.field(RandomStrings.randomAsciiOfLengthBetween(random, 6, 10),
-                    randomFieldValue(random, randomDataType(random)));
+                        randomFieldValue(random, randomDataType(random)));
             }
         }
-        return currentFields;
     }
 
     private static int randomDataType(Random random) {


### PR DESCRIPTION
Currently RandomObjects::addFields can potentially generate a large number of fields. This commit decreases the chances that a new object or array is added as a new branch of an object, which lowers the probability of ending up with very big documents generated.

It also reduces the number of documents generated for the SimulatePipelineResponseTests from 10 to 5 to reduce the testing time required for parsing.