### PR TITLE
field collapsing on multiple fields

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestConvertersTests.java
@@ -1207,7 +1207,7 @@ public class RequestConvertersTests extends ESTestCase {
                             new TermQueryBuilder(randomAlphaOfLengthBetween(3, 10), randomAlphaOfLengthBetween(3, 10))));
                 }
                 if (randomBoolean()) {
-                    searchSourceBuilder.collapse(new CollapseBuilder(randomAlphaOfLengthBetween(3, 10)));
+                    searchSourceBuilder.collapse(new CollapseBuilder(new String[] {randomAlphaOfLengthBetween(3, 10)}));
                 }
             }
             searchRequest.source(searchSourceBuilder);

--- a/docs/reference/search/request/collapse.asciidoc
+++ b/docs/reference/search/request/collapse.asciidoc
@@ -32,6 +32,88 @@ The total number of distinct group is unknown.
 
 The field used for collapsing must be a single valued <<keyword, `keyword`>> or <<number, `numeric`>> field with <<doc-values, `doc_values`>> activated
 
+Collapsing on multiple fields is also supported as long all the fields
+in the field collapsing request are of the same type, either all are of
+the <<keyword, `keyword`>> or <<number, `numeric`>> type.
+
+For example, the query below retrieves the most relevant tweet for each group,
+and outputs the top 3 groups. A group here is a
+combination of a country and a user.
+
+[source,js]
+--------------------------------------------------
+GET /twitter/_search
+{
+    "query": {
+        "match": {
+            "message": "elasticsearch"
+        }
+    },
+    "collapse" : {
+        "field" : ["country", "user"]
+    },
+    "size" : 3
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+
+Response:
+[source,js]
+--------------------------------------------------
+{
+    ...
+    "hits": [
+        {
+            "_index": "twitter",
+            "_type": "_doc",
+            "_id": "9",
+            "_score": ...,
+            "_source": {...},
+            "fields": {
+                "country": [
+                    "UK"
+                ],
+                "user": [
+                    "user25"
+                ]
+            }
+        },
+        {
+            "_index": "twitter",
+            "_type": "_doc",
+            "_id": "8",
+            "_score": ...,
+            "_source": { ...},
+            "fields": {
+                "country": [
+                    "UK"
+                ],
+                "user": [
+                    "user256"
+                ]
+            }
+        },
+        {
+            "_index": "twitter",
+            "_type": "_doc",
+            "_id": "1",
+            "_score": ..,
+            "_source": {...},
+            "fields": {
+                "country": [
+                    "Canada"
+                ],
+                "user": [
+                    "user3"
+                ]
+            }
+        }
+    ]
+}
+--------------------------------------------------
+// NOTCONSOLE
+
 NOTE: The collapsing is applied to the top hits only and does not affect aggregations.
 
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/test/search/115_multiple_field_collapsing.yml
+++ b/rest-api-spec/src/main/resources/rest-api-spec/test/search/115_multiple_field_collapsing.yml
@@ -1,0 +1,185 @@
+---
+"multiple keyword fields collapsing":
+    - skip:
+        version: " - 6.99.99"
+        reason: using multiple field collapsing from 7.0 on
+    - do:
+        indices.create:
+          index: addresses
+          body:
+            settings:
+              number_of_shards: 1
+              number_of_replicas: 1
+            mappings:
+              _doc:
+                properties:
+                  country: {"type": "keyword"}
+                  city: {"type": "keyword"}
+                  address: {"type": "text"}
+
+    - do:
+        bulk:
+          refresh: true
+          body:
+            - '{ "index" : { "_index" : "addresses", "_type" : "_doc", "_id" : "1" } }'
+            - '{"country" : "Canada", "city" : "Saskatoon", "address" : "701 Victoria Avenue" }'
+            - '{ "index" : { "_index" : "addresses", "_type" : "_doc", "_id" : "2" } }'
+            - '{"country" : "Canada", "city" : "Toronto", "address" : "74 Victoria Street, Suite, 74 Victoria Street, Suite 300" }'
+            - '{ "index" : { "_index" : "addresses", "_type" : "_doc", "_id" : "3" } }'
+            - '{"country" : "Canada", "city" : "Toronto", "address" : "350 Victoria St" }'
+            - '{ "index" : { "_index" : "addresses", "_type" : "_doc", "_id" : "4" } }'
+            - '{"country" : "Canada", "city" : "Toronto", "address" : "20 Victoria Street" }'
+            - '{ "index" : { "_index" : "addresses", "_type" : "_doc", "_id" : "5" } }'
+            - '{"country" : "UK", "city" : "London", "address" : "58 Victoria Street" }'
+            - '{ "index" : { "_index" : "addresses", "_type" : "_doc", "_id" : "6" } }'
+            - '{"country" : "UK", "city" : "London", "address" : "Victoria Street Victoria Palace Theatre" }'
+            - '{ "index" : { "_index" : "addresses", "_type" : "_doc", "_id" : "7" } }'
+            - '{"country" : "UK", "city" : "London", "address" : "75 Victoria street Westminster" }'
+            - '{ "index" : { "_index" : "addresses", "_type" : "_doc", "_id" : "8" } }'
+            - '{"country" : "UK", "city" : "London", "address" : "Victoria Station Victoria Arcade" }'
+            - '{ "index" : { "_index" : "addresses", "_type" : "_doc", "_id" : "9" } }'
+            - '{"city" : "Unknown", "address" : "address without country and unknown city" }'
+
+
+  # collapsing - top scored
+    - do:
+        search:
+          index: addresses
+          body:
+            query: { "match" : { "address" : "victoria" }}
+            collapse: { field: ["country", "city"] }
+
+    - match: { hits.total: 8 }
+    - length: { hits.hits: 3 }
+    - match: { hits.hits.0.fields.country: ["UK"] }
+    - match: { hits.hits.0.fields.city : ["London"] }
+
+    - match: { hits.hits.1.fields.country: ["Canada"] }
+    - match: { hits.hits.1.fields.city : ["Saskatoon"] }
+
+    - match: { hits.hits.2.fields.country: ["Canada"] }
+    - match: { hits.hits.2.fields.city : ["Toronto"] }
+
+    # collapsing - top sorted
+    - do:
+        search:
+          index: addresses
+          body:
+            query: { "match_all" : {}}
+            collapse: { field: ["country", "city"] }
+            sort: [{ country: asc, city: asc }]
+
+    - match: { hits.total: 9 }
+    - length: { hits.hits: 4 }
+    - match: { hits.hits.0.fields.country: ["Canada"] }
+    - match: { hits.hits.0.fields.city: ["Saskatoon"] }
+
+    - match: { hits.hits.1.fields.country : ["Canada"] }
+    - match: { hits.hits.1.fields.city: ["Toronto"] }
+
+    - match: { hits.hits.2.fields.country : ["UK"] }
+    - match: { hits.hits.2.fields.city: ["London"] }
+
+    - match: { hits.hits.3.fields.city : ["Unknown"] }
+
+    # collapsing - top sorted and inner hits
+    - do:
+        search:
+          index: addresses
+          body:
+            query: { "match_all" : {}}
+            collapse: { field: ["country", "city"], inner_hits: { name: by_location, size: 2 } }
+            sort: [{ country: asc, city: asc }]
+
+    - match: { hits.total: 9 }
+    - length: { hits.hits: 4 }
+    - match: { hits.hits.0.fields.country: ["Canada"] }
+    - match: { hits.hits.0.fields.city: ["Saskatoon"] }
+    - match: { hits.hits.0.inner_hits.by_location.hits.total: 1 }
+    - match: { hits.hits.0.inner_hits.by_location.hits.hits.0._id: "1" }
+
+    - match: { hits.hits.1.fields.country : ["Canada"] }
+    - match: { hits.hits.1.fields.city: ["Toronto"] }
+    - match: { hits.hits.1.inner_hits.by_location.hits.total: 3 }
+    - match: { hits.hits.1.inner_hits.by_location.hits.hits.0._id: "2" }
+    - match: { hits.hits.1.inner_hits.by_location.hits.hits.1._id: "3" }
+
+    - match: { hits.hits.2.fields.country : ["UK"] }
+    - match: { hits.hits.2.fields.city: ["London"] }
+    - match: { hits.hits.2.inner_hits.by_location.hits.total: 4 }
+    - match: { hits.hits.2.inner_hits.by_location.hits.hits.0._id: "5" }
+    - match: { hits.hits.2.inner_hits.by_location.hits.hits.1._id: "6" }
+
+    - match: { hits.hits.3.fields.city : ["Unknown"] }
+    - match: { hits.hits.3.inner_hits.by_location.hits.total: 1 }
+    - match: { hits.hits.3.inner_hits.by_location.hits.hits.0._id: "9" }
+
+
+---
+"multiple numeric fields collapsing":
+    - skip:
+        version: " - 6.99.99"
+        reason: using multiple field collapsing from 7.0 on
+    - do:
+        indices.create:
+          index: events
+          body:
+            settings:
+              number_of_shards: 1
+              number_of_replicas: 1
+            mappings:
+              _doc:
+                properties:
+                  year : {"type" : "integer"}
+                  month : {"type" : "integer"}
+                  day : {"type" : "integer"}
+                  event: {"type": "text"}
+
+    - do:
+        bulk:
+          refresh: true
+          body:
+            - '{ "index" : { "_index" : "events", "_type" : "_doc", "_id" : "1" } }'
+            - '{ "year" : 2018, "month": 1, "day": 1, "event" : "New Year Day" }'
+            - '{ "index" : { "_index" : "events", "_type" : "_doc", "_id" : "2" } }'
+            - '{ "year" : 2018, "month": 1, "day": 14, "event" : "Old New Year" }'
+            - '{  "index" : { "_index" : "events", "_type" : "_doc", "_id" : "3" } }'
+            - '{ "year" : 2018, "month": 1, "day": 14, "event" : "Carrie birthday" }'
+            - '{  "index" : { "_index" : "events", "_type" : "_doc", "_id" : "4" } }'
+            - '{ "year" : 2018, "month": 2, "day": 14, "event" : "Valentine day" }'
+            - '{  "index" : { "_index" : "events", "_type" : "_doc", "_id" : "5" } }'
+            - '{ "year" : 2018, "month": 2, "day": 19, "event" : "Island day" }'
+            - '{  "index" : { "_index" : "events", "_type" : "_doc", "_id" : "6" } }'
+            - '{ "year" : 2018, "month": 2, "day": 19, "event" : "Louis Riel day" }'
+            - '{  "index" : { "_index" : "events", "_type" : "_doc", "_id" : "7" } }'
+            - '{ "year" : 2018, "month": 2, "day": 19, "event" : "Heritage day" }'
+            - '{  "index" : { "_index" : "events", "_type" : "_doc", "_id" : "8" } }'
+            - '{ "year" : 2018, "month": 2, "day": 19, "event" : "Family day" }'
+            - '{  "index" : { "_index" : "events", "_type" : "_doc", "_id" : "9" } }'
+            - '{ "year" : 2018, "month": 3, "day": 25, "event" : "Lisa birthday" }'
+
+
+    # collapsing - collapse on 3 fields and inner hits and from parameter
+    - do:
+        search:
+          index: events
+          body:
+            query: { "match_all" : {}}
+            collapse: { field: ["year", "month", "day"], inner_hits: { name: by_date, size: 2, sort: [{ day: asc }] } }
+            from : 3
+
+    - match: { hits.total: 9 }
+    - length: { hits.hits: 2 }
+
+    - match: { hits.hits.0.fields.year: [2018] }
+    - match: { hits.hits.0.fields.month: [2] }
+    - match: { hits.hits.0.fields.day: [19] }
+    - match: { hits.hits.0.inner_hits.by_date.hits.total: 4 }
+    - match: { hits.hits.0.inner_hits.by_date.hits.hits.0._id: "5" }
+    - match: { hits.hits.0.inner_hits.by_date.hits.hits.1._id: "6" }
+
+    - match: { hits.hits.1.fields.year: [2018] }
+    - match: { hits.hits.1.fields.month: [3] }
+    - match: { hits.hits.1.fields.day: [25] }
+    - match: { hits.hits.1.inner_hits.by_date.hits.total: 1 }
+    - match: { hits.hits.1.inner_hits.by_date.hits.hits.0._id: "9" }

--- a/server/src/main/java/org/apache/lucene/search/grouping/CollapsingDocValuesSource.java
+++ b/server/src/main/java/org/apache/lucene/search/grouping/CollapsingDocValuesSource.java
@@ -32,145 +32,63 @@ import org.elasticsearch.index.fielddata.AbstractNumericDocValues;
 import org.elasticsearch.index.fielddata.AbstractSortedDocValues;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Utility class that ensures that a single collapse key is extracted per document.
  */
 abstract class CollapsingDocValuesSource<T> extends GroupSelector<T> {
-    protected final String field;
-
-    CollapsingDocValuesSource(String field) {
-        this.field = field;
-    }
-
     @Override
     public void setGroups(Collection<SearchGroup<T>> groups) {
         throw new UnsupportedOperationException();
     }
 
     /**
-     * Implementation for {@link NumericDocValues} and {@link SortedNumericDocValues}.
-     * Fails with an {@link IllegalStateException} if a document contains multiple values for the specified field.
-     */
-    static class Numeric extends CollapsingDocValuesSource<Long> {
-        private NumericDocValues values;
-        private long value;
-        private boolean hasValue;
-
-        Numeric(String field) {
-            super(field);
-        }
-
-        @Override
-        public State advanceTo(int doc) throws IOException {
-            if (values.advanceExact(doc)) {
-                hasValue = true;
-                value = values.longValue();
-                return State.ACCEPT;
-            } else {
-                hasValue = false;
-                return State.SKIP;
-            }
-        }
-
-        @Override
-        public Long currentValue() {
-            return hasValue ? value : null;
-        }
-
-        @Override
-        public Long copyValue() {
-            return currentValue();
-        }
-
-        @Override
-        public void setNextReader(LeafReaderContext readerContext) throws IOException {
-            LeafReader reader = readerContext.reader();
-            DocValuesType type = getDocValuesType(reader, field);
-            if (type == null || type == DocValuesType.NONE) {
-                values = DocValues.emptyNumeric();
-                return ;
-            }
-            switch (type) {
-                case NUMERIC:
-                    values = DocValues.getNumeric(reader, field);
-                    break;
-
-                case SORTED_NUMERIC:
-                    final SortedNumericDocValues sorted = DocValues.getSortedNumeric(reader, field);
-                    values = DocValues.unwrapSingleton(sorted);
-                    if (values == null) {
-                        values = new AbstractNumericDocValues() {
-
-                            private long value;
-
-                            @Override
-                            public boolean advanceExact(int target) throws IOException {
-                                if (sorted.advanceExact(target)) {
-                                    if (sorted.docValueCount() > 1) {
-                                        throw new IllegalStateException("failed to collapse " + target +
-                                                ", the collapse field must be single valued");
-                                    }
-                                    value = sorted.nextValue();
-                                    return true;
-                                } else {
-                                    return false;
-                                }
-                            }
-
-                            @Override
-                            public int docID() {
-                                return sorted.docID();
-                            }
-
-                            @Override
-                            public long longValue() throws IOException {
-                                return value;
-                            }
-
-                        };
-                    }
-                    break;
-
-                default:
-                    throw new IllegalStateException("unexpected doc values type " +
-                        type + "` for field `" + field + "`");
-            }
-        }
-    }
-
-    /**
      * Implementation for {@link SortedDocValues} and {@link SortedSetDocValues}.
-     * Fails with an {@link IllegalStateException} if a document contains multiple values for the specified field.
+     * Fails with an {@link IllegalStateException} if a document contains multiple values for of the collapsed fields.
      */
-    static class Keyword extends CollapsingDocValuesSource<BytesRef> {
-        private SortedDocValues values;
-        private int ord;
+    static class MultipleKeyword extends CollapsingDocValuesSource<List<BytesRef>> {
+        private final String[] fields;
+        private final int fieldsCount;
+        private SortedDocValues[] values;
+        private int[] ord;
+        private boolean valuesExist;
 
-        Keyword(String field) {
-            super(field);
+        MultipleKeyword(String[] fields) {
+            this.fields = fields;
+            this.fieldsCount = fields.length;
+            this.values = new SortedDocValues[fieldsCount];
+            this.ord = new int[fieldsCount];
         }
 
         @Override
         public org.apache.lucene.search.grouping.GroupSelector.State advanceTo(int doc)
-                throws IOException {
-            if (values.advanceExact(doc)) {
-                ord = values.ordValue();
-                return State.ACCEPT;
-            } else {
-                ord = -1;
-                return State.SKIP;
+            throws IOException {
+            valuesExist = true;
+            for (int i = 0;  i < fieldsCount; i++) {
+                if (values[i].advanceExact(doc)) {
+                    ord[i] = values[i].ordValue();
+                } else {
+                    valuesExist = false;
+                    return State.SKIP;
+                }
             }
+            return State.ACCEPT;
         }
 
         @Override
-        public BytesRef currentValue() {
-            if (ord == -1) {
+        public List<BytesRef> currentValue() {
+            if (valuesExist == false) {
                 return null;
             } else {
                 try {
-                    return values.lookupOrd(ord);
+                    ArrayList<BytesRef> result = new ArrayList<>();
+                    for (int i = 0;  i < fieldsCount; i++) {
+                        result.add(values[i].lookupOrd(ord[i]));
+                    }
+                    return result;
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -178,79 +96,179 @@ abstract class CollapsingDocValuesSource<T> extends GroupSelector<T> {
         }
 
         @Override
-        public BytesRef copyValue() {
-            BytesRef value = currentValue();
-            if (value == null) {
+        public List<BytesRef> copyValue() {
+            if (valuesExist == false) {
                 return null;
             } else {
-                return BytesRef.deepCopyOf(value);
+                try {
+                    ArrayList<BytesRef> result = new ArrayList<>();
+                    for (int i = 0;  i < fieldsCount; i++) {
+                        BytesRef value = values[i].lookupOrd(ord[i]);
+                        result.add(BytesRef.deepCopyOf(value));
+                    }
+                    return result;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         }
 
         @Override
         public void setNextReader(LeafReaderContext readerContext) throws IOException {
             LeafReader reader = readerContext.reader();
-            DocValuesType type = getDocValuesType(reader, field);
-            if (type == null || type == DocValuesType.NONE) {
-                values = DocValues.emptySorted();
-                return ;
-            }
-            switch (type) {
-                case SORTED:
-                    values = DocValues.getSorted(reader, field);
-                    break;
-
-                case SORTED_SET:
-                    final SortedSetDocValues sorted = DocValues.getSortedSet(reader, field);
-                    values = DocValues.unwrapSingleton(sorted);
-                    if (values == null) {
-                        values = new AbstractSortedDocValues() {
-
-                            private int ord;
-
-                            @Override
-                            public boolean advanceExact(int target) throws IOException {
-                                if (sorted.advanceExact(target)) {
-                                    ord = (int) sorted.nextOrd();
-                                    if (sorted.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
-                                        throw new IllegalStateException("failed to collapse " + target +
-                                            ", the collapse field must be single valued");
+            for (int i = 0;  i < fieldsCount; i++) {
+                DocValuesType type = getDocValuesType(reader, fields[i]);
+                if (type == null || type == DocValuesType.NONE) {
+                    values[i] = DocValues.emptySorted();
+                    continue;
+                }
+                switch (type) {
+                    case SORTED:
+                        values[i] = DocValues.getSorted(reader, fields[i]);
+                        break;
+                    case SORTED_SET:
+                        final SortedSetDocValues sorted = DocValues.getSortedSet(reader, fields[i]);
+                        values[i] = DocValues.unwrapSingleton(sorted);
+                        if (values[i] == null) {
+                            values[i] = new AbstractSortedDocValues() {
+                                private int ord;
+                                @Override
+                                public boolean advanceExact(int target) throws IOException {
+                                    if (sorted.advanceExact(target)) {
+                                        ord = (int) sorted.nextOrd();
+                                        if (sorted.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
+                                            throw new IllegalStateException("failed to collapse " + target +
+                                                ", the collapse field must be single valued");
+                                        }
+                                        return true;
+                                    } else {
+                                        return false;
                                     }
-                                    return true;
-                                } else {
-                                    return false;
                                 }
-                            }
-
-                            @Override
-                            public int docID() {
-                                return sorted.docID();
-                            }
-
-                            @Override
-                            public int ordValue() {
-                                return ord;
-                            }
-
-                            @Override
-                            public BytesRef lookupOrd(int ord) throws IOException {
-                                return sorted.lookupOrd(ord);
-                            }
-
-                            @Override
-                            public int getValueCount() {
-                                return (int) sorted.getValueCount();
-                            }
-                        };
-                    }
-                    break;
-
-                default:
-                    throw new IllegalStateException("unexpected doc values type "
-                        + type + "` for field `" + field + "`");
+                                @Override
+                                public int docID() {
+                                    return sorted.docID();
+                                }
+                                @Override
+                                public int ordValue() {
+                                    return ord;
+                                }
+                                @Override
+                                public BytesRef lookupOrd(int ord) throws IOException {
+                                    return sorted.lookupOrd(ord);
+                                }
+                                @Override
+                                public int getValueCount() {
+                                    return (int) sorted.getValueCount();
+                                }
+                            };
+                        }
+                        break;
+                    default:
+                        throw new IllegalStateException("unexpected doc values type [" + type + "] for field ]" + fields[i] + "]");
+                }
             }
         }
     }
+
+
+    /**
+     * Implementation for {@link NumericDocValues} and {@link SortedNumericDocValues}.
+     * Fails with an {@link IllegalStateException} if a document contains multiple values for one of the collapsed fields.
+     */
+    static class MultipleNumeric extends CollapsingDocValuesSource<List<Long>> {
+        private final String[] fields;
+        private final int fieldsCount;
+        private NumericDocValues[] docValues;
+        private boolean valuesExist;
+        private List<Long> values;
+
+        MultipleNumeric(String[] fields) {
+            this.fields = fields;
+            this.fieldsCount = fields.length;
+            this.docValues = new NumericDocValues[fieldsCount];
+        }
+
+        @Override
+        public org.apache.lucene.search.grouping.GroupSelector.State advanceTo(int doc)
+            throws IOException {
+            valuesExist = true;
+            values = new ArrayList<>(fieldsCount);
+            for (int i = 0;  i < fieldsCount; i++) {
+                if (docValues[i].advanceExact(doc)) {
+                    values.add(docValues[i].longValue());
+                } else {
+                    valuesExist = false;
+                    return State.SKIP;
+                }
+            }
+            return State.ACCEPT;
+        }
+
+        @Override
+        public List<Long> currentValue() {
+            if (valuesExist == false) {
+                return null;
+            } else {
+               return values;
+            }
+        }
+
+        @Override
+        public List<Long> copyValue() {
+            return currentValue();
+        }
+
+        @Override
+        public void setNextReader(LeafReaderContext readerContext) throws IOException {
+            LeafReader reader = readerContext.reader();
+            for (int i = 0;  i < fieldsCount; i++) {
+                DocValuesType type = getDocValuesType(reader, fields[i]);
+                if (type == null || type == DocValuesType.NONE) {
+                    docValues[i] = DocValues.emptyNumeric();
+                    continue;
+                }
+                switch (type) {
+                    case NUMERIC:
+                        docValues[i] = DocValues.getNumeric(reader, fields[i]);
+                        break;
+                    case SORTED_NUMERIC:
+                        final SortedNumericDocValues sorted = DocValues.getSortedNumeric(reader, fields[i]);
+                        docValues[i] = DocValues.unwrapSingleton(sorted);
+                        if (docValues[i] == null) {
+                            docValues[i] = new AbstractNumericDocValues() {
+                                private long value;
+                                @Override
+                                public boolean advanceExact(int target) throws IOException {
+                                    if (sorted.advanceExact(target)) {
+                                        if (sorted.docValueCount() > 1) {
+                                            throw new IllegalStateException("failed to collapse " + target +
+                                                ", the collapse field must be single valued");
+                                        }
+                                        value = sorted.nextValue();
+                                        return true;
+                                    } else {
+                                        return false;
+                                    }
+                                }
+                                @Override
+                                public int docID() {
+                                    return sorted.docID();
+                                }
+                                @Override
+                                public long longValue() throws IOException {
+                                    return value;
+                                }
+                            };
+                        }
+                        break;
+                    default:
+                        throw new IllegalStateException("unexpected doc values type [" + type + "] for field [" + fields[i] + "]");
+                }
+            }
+        }
+    }
+
 
     private static DocValuesType getDocValuesType(LeafReader in, String field) {
         FieldInfo fi = in.getFieldInfos().fieldInfo(field);

--- a/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -76,11 +76,14 @@ final class ExpandSearchPhase extends SearchPhase {
             }
             for (SearchHit hit : searchResponse.hits().getHits()) {
                 BoolQueryBuilder groupQuery = new BoolQueryBuilder();
-                Object collapseValue = hit.field(collapseBuilder.getField()).getValue();
-                if (collapseValue != null) {
-                    groupQuery.filter(QueryBuilders.matchQuery(collapseBuilder.getField(), collapseValue));
-                } else {
-                    groupQuery.mustNot(QueryBuilders.existsQuery(collapseBuilder.getField()));
+                String[] collapseFields = collapseBuilder.getFields();
+                for (int i = 0; i<collapseFields.length; i++) {
+                    Object collapseValue = hit.field(collapseFields[i]).getValue();
+                    if (collapseValue != null) {
+                        groupQuery.filter(QueryBuilders.matchQuery(collapseFields[i], collapseValue));
+                    } else {
+                        groupQuery.mustNot(QueryBuilders.existsQuery(collapseFields[i]));
+                    }
                 }
                 QueryBuilder origQuery = searchRequest.source().query();
                 if (origQuery != null) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/DocValueFieldsFetchSubPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/DocValueFieldsFetchSubPhase.java
@@ -41,7 +41,6 @@ import org.elasticsearch.search.internal.SearchContext;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -61,12 +60,21 @@ public final class DocValueFieldsFetchSubPhase implements FetchSubPhase {
 
         if (context.collapse() != null) {
             // retrieve the `doc_value` associated with the collapse field
-            String name = context.collapse().getFieldType().name();
+            //String name = context.collapse().getFieldType().name();
+            String[] fieldNames = context.collapse().getFieldNames();
             if (context.docValueFieldsContext() == null) {
-                context.docValueFieldsContext(new DocValueFieldsContext(
-                        Collections.singletonList(new FieldAndFormat(name, DocValueFieldsContext.USE_DEFAULT_FORMAT))));
-            } else if (context.docValueFieldsContext().fields().stream().map(ff -> ff.field).anyMatch(name::equals) == false) {
-                context.docValueFieldsContext().fields().add(new FieldAndFormat(name, DocValueFieldsContext.USE_DEFAULT_FORMAT));
+                List<FieldAndFormat> ff = new ArrayList<>(fieldNames.length);
+                for(int i=0; i<fieldNames.length; i++) {
+                    ff.add(new FieldAndFormat(fieldNames[i], DocValueFieldsContext.USE_DEFAULT_FORMAT));
+                }
+                context.docValueFieldsContext(new DocValueFieldsContext(ff));
+            } else  {
+                for(int i=0; i<fieldNames.length; i++) {
+                    if (context.docValueFieldsContext().fields().stream().map(ff -> ff.field).anyMatch(fieldNames[i]::equals) == false) {
+                        context.docValueFieldsContext().fields().add(
+                            new FieldAndFormat(fieldNames[i], DocValueFieldsContext.USE_DEFAULT_FORMAT));
+                    }
+                }
             }
         }
 

--- a/server/src/test/java/org/apache/lucene/grouping/CollapsingTopDocsCollectorTests.java
+++ b/server/src/test/java/org/apache/lucene/grouping/CollapsingTopDocsCollectorTests.java
@@ -123,10 +123,12 @@ public class CollapsingTopDocsCollectorTests extends ESTestCase {
         final CollapsingTopDocsCollector<?> collapsingCollector;
         if (numeric) {
             collapsingCollector =
-                CollapsingTopDocsCollector.createNumeric(collapseField.getField(), sort, expectedNumGroups, trackMaxScores);
+                CollapsingTopDocsCollector.createMultipleNumeric(new String[]{collapseField.getField()},
+                    sort, expectedNumGroups, trackMaxScores);
         } else {
             collapsingCollector =
-                CollapsingTopDocsCollector.createKeyword(collapseField.getField(), sort, expectedNumGroups, trackMaxScores);
+                CollapsingTopDocsCollector.createMultipleKeyword(new String[] {collapseField.getField()},
+                    sort, expectedNumGroups, trackMaxScores);
         }
 
         TopFieldCollector topFieldCollector =
@@ -136,7 +138,7 @@ public class CollapsingTopDocsCollectorTests extends ESTestCase {
         searcher.search(new MatchAllDocsQuery(), topFieldCollector);
         CollapseTopFieldDocs collapseTopFieldDocs = collapsingCollector.getTopDocs();
         TopFieldDocs topDocs = topFieldCollector.topDocs();
-        assertEquals(collapseField.getField(), collapseTopFieldDocs.field);
+        assertEquals(collapseField.getField(), collapseTopFieldDocs.collapseFields[0]);
         assertEquals(expectedNumGroups, collapseTopFieldDocs.scoreDocs.length);
         assertEquals(totalHits, collapseTopFieldDocs.totalHits);
         assertEquals(totalHits, topDocs.scoreDocs.length);
@@ -201,9 +203,11 @@ public class CollapsingTopDocsCollectorTests extends ESTestCase {
             final SegmentSearcher subSearcher = subSearchers[shardIDX];
             final CollapsingTopDocsCollector<?> c;
             if (numeric) {
-                c = CollapsingTopDocsCollector.createNumeric(collapseField.getField(), sort, expectedNumGroups, trackMaxScores);
+                c = CollapsingTopDocsCollector.createMultipleNumeric(new String[] {collapseField.getField()},
+                    sort, expectedNumGroups, trackMaxScores);
             } else {
-                c = CollapsingTopDocsCollector.createKeyword(collapseField.getField(), sort, expectedNumGroups, trackMaxScores);
+                c = CollapsingTopDocsCollector.createMultipleKeyword(new String[] {collapseField.getField()},
+                    sort, expectedNumGroups, trackMaxScores);
             }
             subSearcher.search(weight, c);
             shardHits[shardIDX] = c.getTopDocs();
@@ -384,14 +388,14 @@ public class CollapsingTopDocsCollectorTests extends ESTestCase {
         sortField.setMissingValue(Long.MAX_VALUE);
         Sort sort = new Sort(sortField);
         final CollapsingTopDocsCollector<?> collapsingCollector =
-                CollapsingTopDocsCollector.createNumeric("group", sort, 10, false);
+                CollapsingTopDocsCollector.createMultipleNumeric(new String[] {"group"}, sort, 10, false);
         searcher.search(new MatchAllDocsQuery(), collapsingCollector);
         CollapseTopFieldDocs collapseTopFieldDocs = collapsingCollector.getTopDocs();
         assertEquals(4, collapseTopFieldDocs.scoreDocs.length);
         assertEquals(4, collapseTopFieldDocs.collapseValues.length);
-        assertEquals(0L, collapseTopFieldDocs.collapseValues[0]);
-        assertEquals(1L, collapseTopFieldDocs.collapseValues[1]);
-        assertEquals(10L, collapseTopFieldDocs.collapseValues[2]);
+        assertEquals(0L, ((ArrayList) collapseTopFieldDocs.collapseValues[0]).get(0));
+        assertEquals(1L, ((ArrayList) collapseTopFieldDocs.collapseValues[1]).get(0));
+        assertEquals(10L, ((ArrayList) collapseTopFieldDocs.collapseValues[2]).get(0));
         assertNull(collapseTopFieldDocs.collapseValues[3]);
         w.close();
         reader.close();
@@ -419,16 +423,16 @@ public class CollapsingTopDocsCollectorTests extends ESTestCase {
         final IndexReader reader = w.getReader();
         final IndexSearcher searcher = newSearcher(reader);
         Sort sort = new Sort(new SortField("group", SortField.Type.STRING_VAL));
-        final CollapsingTopDocsCollector<?> collapsingCollector =
-            CollapsingTopDocsCollector.createKeyword("group", sort, 10, false);
+        final CollapsingTopDocsCollector<?>  collapsingCollector =
+            CollapsingTopDocsCollector.createMultipleKeyword(new String[] {"group"}, sort, 10, false);
         searcher.search(new MatchAllDocsQuery(), collapsingCollector);
         CollapseTopFieldDocs collapseTopFieldDocs = collapsingCollector.getTopDocs();
         assertEquals(4, collapseTopFieldDocs.scoreDocs.length);
         assertEquals(4, collapseTopFieldDocs.collapseValues.length);
         assertNull(collapseTopFieldDocs.collapseValues[0]);
-        assertEquals(new BytesRef("0"), collapseTopFieldDocs.collapseValues[1]);
-        assertEquals(new BytesRef("1"), collapseTopFieldDocs.collapseValues[2]);
-        assertEquals(new BytesRef("10"), collapseTopFieldDocs.collapseValues[3]);
+        assertEquals(new BytesRef("0"), ((ArrayList) collapseTopFieldDocs.collapseValues[1]).get(0));
+        assertEquals(new BytesRef("1"), ((ArrayList) collapseTopFieldDocs.collapseValues[2]).get(0));
+        assertEquals(new BytesRef("10"), ((ArrayList) collapseTopFieldDocs.collapseValues[3]).get(0));
         w.close();
         reader.close();
         dir.close();

--- a/server/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
@@ -65,7 +65,7 @@ public class ExpandSearchPhaseTests extends ESTestCase {
             String collapseValue = randomBoolean() ? null : "boom";
 
             mockSearchPhaseContext.getRequest().source(new SearchSourceBuilder()
-                .collapse(new CollapseBuilder("someField")
+                .collapse(new CollapseBuilder(new String[] {"someField"})
                     .setInnerHits(IntStream.range(0, numInnerHits).mapToObj(hitNum -> new InnerHitBuilder().setName("innerHit" + hitNum))
                         .collect(Collectors.toList()))));
             mockSearchPhaseContext.getRequest().source().query(originalQuery);
@@ -143,7 +143,7 @@ public class ExpandSearchPhaseTests extends ESTestCase {
         MockSearchPhaseContext mockSearchPhaseContext = new MockSearchPhaseContext(1);
         String collapseValue = randomBoolean() ? null : "boom";
         mockSearchPhaseContext.getRequest().source(new SearchSourceBuilder()
-            .collapse(new CollapseBuilder("someField").setInnerHits(new InnerHitBuilder().setName("foobarbaz"))));
+            .collapse(new CollapseBuilder(new String[] {"someField"}).setInnerHits(new InnerHitBuilder().setName("foobarbaz"))));
         mockSearchPhaseContext.searchTransport = new SearchTransportService(
             Settings.builder().put("search.remote.connect", false).build(), null, null) {
 
@@ -226,7 +226,7 @@ public class ExpandSearchPhaseTests extends ESTestCase {
             }
         };
         mockSearchPhaseContext.getRequest().source(new SearchSourceBuilder()
-            .collapse(new CollapseBuilder("someField").setInnerHits(new InnerHitBuilder().setName("foobarbaz"))));
+            .collapse(new CollapseBuilder(new String[] {"someField"}).setInnerHits(new InnerHitBuilder().setName("foobarbaz"))));
 
         SearchHits hits = new SearchHits(new SearchHit[0], 1, 1.0f);
         InternalSearchResponse internalSearchResponse = new InternalSearchResponse(hits, null, null, null, false, null, 1);
@@ -263,7 +263,7 @@ public class ExpandSearchPhaseTests extends ESTestCase {
         };
         mockSearchPhaseContext.getRequest().source(new SearchSourceBuilder()
             .collapse(
-                new CollapseBuilder("someField")
+                new CollapseBuilder(new String[] {"someField"})
                     .setInnerHits(new InnerHitBuilder().setName("foobarbaz").setVersion(version))
             )
             .postFilter(QueryBuilders.existsQuery("foo")))

--- a/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -74,7 +74,7 @@ public class CollapseBuilderTests extends AbstractSerializingTestCase<CollapseBu
     }
 
     public static CollapseBuilder randomCollapseBuilder(boolean multiInnerHits) {
-        CollapseBuilder builder = new CollapseBuilder(randomAlphaOfLength(10));
+        CollapseBuilder builder = new CollapseBuilder(new String[] {randomAlphaOfLength(10)});
         builder.setMaxConcurrentGroupRequests(randomIntBetween(1, 48));
         int numInnerHits = randomIntBetween(0, multiInnerHits ? 5 : 1);
         if (numInnerHits == 1) {
@@ -107,7 +107,7 @@ public class CollapseBuilderTests extends AbstractSerializingTestCase<CollapseBu
         CollapseBuilder newBuilder;
         switch (between(0, 2)) {
         case 0:
-            newBuilder = new CollapseBuilder(instance.getField() + randomAlphaOfLength(10));
+            newBuilder = new CollapseBuilder(new String[] {instance.getFields()[0] + randomAlphaOfLength(10)});
             newBuilder.setMaxConcurrentGroupRequests(instance.getMaxConcurrentGroupRequests());
             newBuilder.setInnerHits(instance.getInnerHits());
             break;
@@ -164,13 +164,13 @@ public class CollapseBuilderTests extends AbstractSerializingTestCase<CollapseBu
                 fieldType.setName("field");
                 fieldType.setHasDocValues(true);
                 when(searchContext.getQueryShardContext().fieldMapper("field")).thenReturn(fieldType);
-                CollapseBuilder builder = new CollapseBuilder("field");
+                CollapseBuilder builder = new CollapseBuilder(new String[] {"field"});
                 CollapseContext collapseContext = builder.build(searchContext);
-                assertEquals(collapseContext.getFieldType(), fieldType);
+                assertEquals(collapseContext.getFieldTypes()[0], fieldType);
 
                 fieldType.setIndexOptions(IndexOptions.NONE);
                 collapseContext = builder.build(searchContext);
-                assertEquals(collapseContext.getFieldType(), fieldType);
+                assertEquals(collapseContext.getFieldTypes()[0], fieldType);
 
                 fieldType.setHasDocValues(false);
                 SearchContextException exc = expectThrows(SearchContextException.class, () -> builder.build(searchContext));
@@ -189,7 +189,7 @@ public class CollapseBuilderTests extends AbstractSerializingTestCase<CollapseBu
     public void testBuildWithSearchContextExceptions() {
         SearchContext context = mockSearchContext();
         {
-            CollapseBuilder builder = new CollapseBuilder("unknown_field");
+            CollapseBuilder builder = new CollapseBuilder(new String[] {"unknown_field"});
             SearchContextException exc = expectThrows(SearchContextException.class, () -> builder.build(context));
             assertEquals(exc.getMessage(), "no mapping found for `unknown_field` in order to collapse on");
         }
@@ -218,7 +218,7 @@ public class CollapseBuilderTests extends AbstractSerializingTestCase<CollapseBu
             fieldType.setName("field");
             fieldType.setHasDocValues(true);
             when(context.getQueryShardContext().fieldMapper("field")).thenReturn(fieldType);
-            CollapseBuilder builder = new CollapseBuilder("field");
+            CollapseBuilder builder = new CollapseBuilder(new String[] {"field"});
             SearchContextException exc = expectThrows(SearchContextException.class, () -> builder.build(context));
             assertEquals(exc.getMessage(), "unknown type for collapse field `field`, only keywords and numbers are accepted");
         }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -206,7 +206,7 @@ public class MonitoringIT extends ESSingleNodeTestCase {
             assertBusy(() -> {
                 final SearchResponse response =
                         client().prepareSearch(".monitoring-es-*")
-                                .setCollapse(new CollapseBuilder("type"))
+                                .setCollapse(new CollapseBuilder(new String[]{"type"}))
                                 .addSort("timestamp", SortOrder.DESC)
                                 .get();
 


### PR DESCRIPTION
Introduce collapsingo on multiple fields

`field` field in  the `collapse` request in addition of taking a string,
can take an array - fields on which to collapse.

Limitation:  all fields in the field collapsing request must be
of the same type, either all are of keyword or numeric type.

Example request:
```json
{
    "query": {
        "match": {
            "address": "victoria"
        }
    },
    "collapse" : {
        "field" : ["country", "city"]
    }
}
```

Example response:
```json
{
    ...
    "hits": [
        {
            ...
            "fields": {
                "country": [
                    "Canda"
                ],
                "city": [
                    "Saskatoon"
                ]
            }
        },
        {
            ...,
            "fields": {
                "country": [
                    "Canada"
                ],
                "city": [
                    "Toronto"
                ]
            }
        },
        {
            ...,
            "fields": {
                "country": [
                    "UK"
                ],
                "city": [
                    "London"
                ]
            }
        }
    ]
}
```
TODO:
1. Limit the number of fields for multiple collapsing
2. Return 400x instead of 500x for field types on which collapsing
    can't be done (all types except keyword or numeric)

Closes #24855
