### PR TITLE
fix writeIndex evaluation for aliases

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
@@ -154,12 +154,18 @@ public interface AliasOrIndex {
         }
 
         public void computeAndValidateWriteIndex() {
-            List<IndexMetaData> writeIndices = referenceIndexMetaDatas.stream()
-                .filter(idxMeta -> Boolean.TRUE.equals(idxMeta.getAliases().get(aliasName).writeIndex()))
-                .collect(Collectors.toList());
-            if (referenceIndexMetaDatas.size() == 1) {
-                writeIndex.set(referenceIndexMetaDatas.get(0));
-            } else if (writeIndices.size() == 1) {
+            final List<IndexMetaData> writeIndices;
+            if (referenceIndexMetaDatas.size() > 1) {
+                writeIndices = referenceIndexMetaDatas.stream()
+                    .filter(idxMeta -> Boolean.TRUE.equals(idxMeta.getAliases().get(aliasName).writeIndex()))
+                    .collect(Collectors.toList());
+            } else if(Boolean.FALSE.equals(referenceIndexMetaDatas.get(0).getAliases().get(aliasName).writeIndex()) == false) {
+                writeIndices = Collections.singletonList(referenceIndexMetaDatas.get(0));
+            } else {
+                writeIndices = Collections.emptyList();
+            }
+
+            if (writeIndices.size() == 1) {
                 writeIndex.set(writeIndices.get(0));
             } else if (writeIndices.size() > 1) {
                 List<String> writeIndicesStrings = writeIndices.stream()

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AliasOrIndex.java
@@ -154,15 +154,13 @@ public interface AliasOrIndex {
         }
 
         public void computeAndValidateWriteIndex() {
-            final List<IndexMetaData> writeIndices;
-            if (referenceIndexMetaDatas.size() > 1) {
-                writeIndices = referenceIndexMetaDatas.stream()
-                    .filter(idxMeta -> Boolean.TRUE.equals(idxMeta.getAliases().get(aliasName).writeIndex()))
-                    .collect(Collectors.toList());
-            } else if(Boolean.FALSE.equals(referenceIndexMetaDatas.get(0).getAliases().get(aliasName).writeIndex()) == false) {
-                writeIndices = Collections.singletonList(referenceIndexMetaDatas.get(0));
-            } else {
-                writeIndices = Collections.emptyList();
+            List<IndexMetaData> writeIndices = referenceIndexMetaDatas.stream()
+                .filter(idxMeta -> Boolean.TRUE.equals(idxMeta.getAliases().get(aliasName).writeIndex()))
+                .collect(Collectors.toList());
+
+            if (writeIndices.isEmpty() && referenceIndexMetaDatas.size() == 1
+                    && referenceIndexMetaDatas.get(0).getAliases().get(aliasName).writeIndex() == null) {
+                writeIndices.add(referenceIndexMetaDatas.get(0));
             }
 
             if (writeIndices.size() == 1) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetaDataIndexAliasesServiceTests.java
@@ -136,8 +136,7 @@ public class MetaDataIndexAliasesServiceTests extends ESTestCase {
         ClusterState after = service.innerExecute(before, Arrays.asList(
             new AliasAction.Add("test", "alias", null, null, null, false)));
         assertFalse(after.metaData().index("test").getAliases().get("alias").writeIndex());
-        assertThat(((AliasOrIndex.Alias) after.metaData().getAliasAndIndexLookup().get("alias")).getWriteIndex(),
-            equalTo(after.metaData().index("test")));
+        assertNull(((AliasOrIndex.Alias) after.metaData().getAliasAndIndexLookup().get("alias")).getWriteIndex());
 
         after = service.innerExecute(before, Arrays.asList(
             new AliasAction.Add("test", "alias", null, null, null, null)));


### PR DESCRIPTION
AliasOrIndex.Alias#writeIndex was returning a write index when
an alias was pointing to only one index, regardless whether `is_write_index` was
set to `false`. This fixes that so that there is no write index in such a case
that an alias points to only one index with `is_write_index=false`.