### PR TITLE
[Docs] Correct default rescore `window_size`

### DIFF
--- a/docs/reference/search/request/rescore.asciidoc
+++ b/docs/reference/search/request/rescore.asciidoc
@@ -29,8 +29,7 @@ The query rescorer executes a second query only on the Top-K results
 returned by the <<search-request-query,`query`>> and
 <<search-request-post-filter,`post_filter`>> phases. The
 number of docs which will be examined on each shard can be controlled by
-the `window_size` parameter, which defaults to
-<<search-request-from-size,`from` and `size`>>.
+the `window_size` parameter, which defaults to 10.
 
 By default the scores from the original query and the rescore query are
 combined linearly to produce the final `_score` for each document. The


### PR DESCRIPTION
I was looking into some unrelated issue in the query rescorer and was suprised to see that the
default `window_size` parameter doesn't seem to be related to from/size any more. From looking
at the code and trying it out it seems to always default to 10.

This might be the wrong behaviour, but at least that seems to be the current one so I first want to 
suggest making the doc change. I'll do a bit of digging when this might have changed and if it was
a concious decision or somehow slipped in.