### PR TITLE
Fix broken backport of #31578 by adjusting constructor

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorTests.java
@@ -274,7 +274,7 @@ public class ForEachProcessorTests extends ESTestCase {
 
     public void testIgnoreMissing() throws Exception {
         IngestDocument originalIngestDocument = new IngestDocument(
-            "_index", "_type", "_id", null, null, null, Collections.emptyMap()
+            "_index", "_type", "_id", null, null, null, null, Collections.emptyMap()
         );
         IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
         TestProcessor testProcessor = new TestProcessor(doc -> {});


### PR DESCRIPTION
Fixes broken compilation introduced by #31578 backport to `6.x`
