### PR TITLE
Removing redundant 'minimum_should_match'

### DIFF
--- a/docs/reference/query-dsl/common-terms-query.asciidoc
+++ b/docs/reference/query-dsl/common-terms-query.asciidoc
@@ -184,8 +184,6 @@ GET /_search
 --------------------------------------------------
 // CONSOLE
 
-minimum_should_match
-
 A different
 <<query-dsl-minimum-should-match,`minimum_should_match`>>
 can be applied for low and high frequency terms with the additional


### PR DESCRIPTION
In one place there is redundant 'minimum_should_match' phrase. Removing.