### PR TITLE
[Docs] Clarify accepted `sort` usage with `rescore`

### DIFF
--- a/docs/reference/search/request/rescore.asciidoc
+++ b/docs/reference/search/request/rescore.asciidoc
@@ -15,8 +15,8 @@ Currently the rescore API has only one implementation: the query
 rescorer, which uses a query to tweak the scoring. In the future,
 alternative rescorers may be made available, for example, a pair-wise rescorer.
 
-NOTE: An error will be thrown if an explicit <<search-request-sort,`sort`>> (other than `_score`)
-is provided with a `rescore` query.
+NOTE: An error will be thrown if an explicit <<search-request-sort,`sort`>> 
+(other than `_score` in descending order) is provided with a `rescore` query.
 
 NOTE: when exposing pagination to your users, you should not change
 `window_size` as you step through each page (by passing different


### PR DESCRIPTION
Rescore only works with an explicite "sort" element if it is on descending
"_score". Even using "order" : "asc" will throw an error.