### PR TITLE
Do not check for Azure container existence everytime an Azure object is accessed or modified

### DIFF
--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -100,14 +100,14 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     public void deleteBlob(String blobName) throws IOException {
         logger.trace("deleteBlob({})", blobName);
 
-        if (!blobExists(blobName)) {
-            throw new NoSuchFileException("Blob [" + blobName + "] does not exist");
-        }
-
         try {
             blobStore.deleteBlob(buildKey(blobName));
-        } catch (URISyntaxException | StorageException e) {
-            logger.warn("can not access [{}] in container {{}}: {}", blobName, blobStore, e.getMessage());
+        } catch (StorageException e) {
+            if (e.getHttpStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+                throw new NoSuchFileException(e.getMessage());
+            }
+            throw new IOException(e);
+        } catch (URISyntaxException e) {
             throw new IOException(e);
         }
     }

--- a/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
+++ b/plugins/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
@@ -22,7 +22,6 @@ package org.elasticsearch.repositories.azure;
 import com.microsoft.azure.storage.OperationContext;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
-
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
 import org.elasticsearch.common.collect.MapBuilder;
@@ -72,9 +71,11 @@ public class AzureStorageServiceMock extends AbstractComponent implements AzureS
     }
 
     @Override
-    public void deleteFiles(String account, String container, String path) {
+    public void deleteFiles(String account, String container, String path) throws URISyntaxException, StorageException {
         final Map<String, BlobMetaData> blobs = listBlobsByPrefix(account, container, path, null);
-        blobs.keySet().forEach(key -> deleteBlob(account, container, key));
+        for (String key : blobs.keySet()) {
+            deleteBlob(account, container, key);
+        }
     }
 
     @Override
@@ -83,8 +84,10 @@ public class AzureStorageServiceMock extends AbstractComponent implements AzureS
     }
 
     @Override
-    public void deleteBlob(String account, String container, String blob) {
-        blobs.remove(blob);
+    public void deleteBlob(String account, String container, String blob) throws URISyntaxException, StorageException {
+        if (blobs.remove(blob) == null) {
+            throw new StorageException("BlobNotFound", "[" + blob + "] does not exist.", 404, null, null);
+        }
     }
 
     @Override


### PR DESCRIPTION
The current AzureStorageServiceImpl always checks if the Azure container exists before reading or writing an object to the Azure container. This pull request removes this behavior, reducing the number of overhall requests executed for all snapshots operations.

It also removes a check for blob existence when deleting an object. Third party test for Azure now executes in 30% less time.