### PR TITLE
Docs: Skip xpack snippet tests if no xpack

### DIFF
--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/RestTestsFromSnippetsTask.groovy
@@ -237,6 +237,18 @@ public class RestTestsFromSnippetsTask extends SnippetsTask {
                 current.println("        - stash_in_path")
                 current.println("        - stash_path_replace")
                 current.println("        - warnings")
+                if (test.testEnv != null) {
+                    switch (test.testEnv) {
+                    case 'basic':
+                    case 'gold':
+                    case 'platinum':
+                        current.println("        - xpack")
+                        break;
+                    default:
+                        throw new InvalidUserDataException('Unsupported testEnv: '
+                                + test.testEnv)
+                    }
+                }
             }
             if (test.skipTest) {
                 if (test.continued) {

--- a/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
+++ b/buildSrc/src/main/groovy/org/elasticsearch/gradle/doc/SnippetsTask.groovy
@@ -84,6 +84,7 @@ public class SnippetsTask extends DefaultTask {
             Snippet snippet = null
             StringBuilder contents = null
             List substitutions = null
+            String testEnv = null
             Closure emit = {
                 snippet.contents = contents.toString()
                 contents = null
@@ -143,10 +144,14 @@ public class SnippetsTask extends DefaultTask {
             }
             file.eachLine('UTF-8') { String line, int lineNumber ->
                 Matcher matcher
+                matcher = line =~ /\[testenv="([^"]+)"\]\s*/
+                if (matcher.matches()) {
+                    testEnv = matcher.group(1)
+                }
                 if (line ==~ /-{4,}\s*/) { // Four dashes looks like a snippet
                     if (snippet == null) {
                         Path path = docs.dir.toPath().relativize(file.toPath())
-                        snippet = new Snippet(path: path, start: lineNumber)
+                        snippet = new Snippet(path: path, start: lineNumber, testEnv: testEnv)
                         if (lastLanguageLine == lineNumber - 1) {
                             snippet.language = lastLanguage
                         }
@@ -297,6 +302,7 @@ public class SnippetsTask extends DefaultTask {
         int start
         int end = NOT_FINISHED
         String contents
+        String testEnv
 
         Boolean console = null
         boolean test = false
@@ -321,6 +327,9 @@ public class SnippetsTask extends DefaultTask {
             }
             if (test) {
                 result += '// TEST'
+                if (testEnv != null) {
+                    result += "[testenv=$testEnv]"
+                }
                 if (catchPart) {
                     result += "[catch: $catchPart]"
                 }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -63,6 +63,8 @@ buildRestTests.docs = fileTree(projectDir) {
   exclude 'README.asciidoc'
 }
 
+listSnippets.docs = buildRestTests.docs
+
 Closure setupTwitter = { String name, int count ->
   buildRestTests.setups[name] = '''
   - do:


### PR DESCRIPTION
Skips tests the require xpack if we run the doc build without xpack. So
this should work:
```
./gradlew -p docs check -Dtests.distribution=oss-zip
```

This is implemented by detecting parts of the doc that look like:
```
[testenv="basic"]
```

Relates to #30665
