### PR TITLE
[DOCS] Secure settings specified per node

### DIFF
--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -1,5 +1,5 @@
 [[secure-settings]]
-=== Secure Settings
+=== Secure settings
 
 Some settings are sensitive, and relying on filesystem permissions to protect
 their values is not sufficient. For this use case, Elasticsearch provides a
@@ -16,9 +16,9 @@ Elasticsearch.
 NOTE: The elasticsearch keystore currently only provides obfuscation. In the future,
 password protection will be added.
 
-These settings, just like the ones in the regular `elasticsearch.yml` config file,
-need to be specified for each cluster node. These are node-specific settings,
-although they usually have the same value on every node.
+These settings, just like the regular ones in the `elasticsearch.yml` config file,
+need to be specified on each node in the cluster. Currently, all secure settings
+are node-specific settings that must have the same value on every node.
 
 [float]
 [[creating-keystore]]

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -16,6 +16,10 @@ Elasticsearch.
 NOTE: The elasticsearch keystore currently only provides obfuscation. In the future,
 password protection will be added.
 
+These settings, just like the ones in the regular `elasticsearch.yml` config file,
+need to be specified for each cluster node. These are node-specific settings,
+although they usually have the same value on every node.
+
 [float]
 [[creating-keystore]]
 === Creating the keystore


### PR DESCRIPTION
It might not be obvious that `SecureSettings` need to be specified per node. If there's a mistake, and a node misses a setting, then the exception should be informative in most cases. It is not informative in the case of the S3 plugin. This might cause frustration, as per: https://discuss.elastic.co/t/is-repository-s3-plugin-fixed-in-6-3/135997/3

Even if this arguably does not mend the source of frustration (S3 plugin should not quietly default to using instance credentials), I think the proposed doc mention is not superfluous.