### PR TITLE
[Docs] Backport: Fix typo in elasticsearch.yml name (#31626)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -428,7 +428,7 @@ optional, and when they are present `_reindex` will connect to the remote
 Elasticsearch node using basic auth. Be sure to use `https` when using
 basic auth or the password will be sent in plain text.
 
-Remote hosts have to be explicitly whitelisted in elasticsearch.yaml using the
+Remote hosts have to be explicitly whitelisted in elasticsearch.yml using the
 `reindex.remote.whitelist` property. It can be set to a comma delimited list
 of allowed remote `host` and `port` combinations (e.g.
 `otherhost:9200, another:9200, 127.0.10.*:9200, localhost:*`). Scheme is


### PR DESCRIPTION
Backports #31626 to 6.3 branch