### PR TITLE
Fix CreateSnapshotRequestTests Failure

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -325,6 +325,9 @@ public class IndicesOptions implements ToXContentFragment {
         builder.endArray();
         builder.field("ignore_unavailable", ignoreUnavailable());
         builder.field("allow_no_indices", allowNoIndices());
+        builder.field("forbid_aliases_to_multiple_indices", allowAliasesToMultipleIndices() == false);
+        builder.field("forbid_closed_indices", forbidClosedIndices());
+        builder.field("ignore_aliases", ignoreAliases());
         return builder;
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
@@ -20,6 +20,8 @@
 package org.elasticsearch.action.admin.cluster.snapshots.create;
 
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.IndicesOptions.Option;
+import org.elasticsearch.action.support.IndicesOptions.WildcardStates;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -30,6 +32,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +40,6 @@ import java.util.Map;
 public class CreateSnapshotRequestTests extends ESTestCase {
 
     // tests creating XContent and parsing with source(Map) equivalency
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/31625")
     public void testToXContent() throws IOException {
         String repo = randomAlphaOfLength(5);
         String snap = randomAlphaOfLength(10);
@@ -55,11 +57,11 @@ public class CreateSnapshotRequestTests extends ESTestCase {
             original.indices(indices);
         }
 
-        if (randomBoolean()) { // replace
+        if (randomBoolean()) {
             original.partial(randomBoolean());
         }
 
-        if (randomBoolean()) { // replace
+        if (randomBoolean()) {
             Map<String, Object> settings = new HashMap<>();
             int count = randomInt(3) + 1;
 
@@ -69,26 +71,43 @@ public class CreateSnapshotRequestTests extends ESTestCase {
 
         }
 
-        if (randomBoolean()) { // replace
+        if (randomBoolean()) {
             original.includeGlobalState(randomBoolean());
         }
 
-        if (randomBoolean()) { // replace
-            IndicesOptions[] indicesOptions = new IndicesOptions[] {
-                    IndicesOptions.STRICT_EXPAND_OPEN,
-                    IndicesOptions.STRICT_EXPAND_OPEN_CLOSED,
-                    IndicesOptions.LENIENT_EXPAND_OPEN,
-                    IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED,
-                    IndicesOptions.STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED};
+        if (randomBoolean()) {
+            List<WildcardStates> wildcardStates = new ArrayList<>();
 
-            original.indicesOptions(randomFrom(indicesOptions));
+            if (randomBoolean()) {
+                if (randomBoolean()) {
+                    wildcardStates.add(WildcardStates.OPEN);
+                }
+
+                if (randomBoolean()) {
+                    wildcardStates.add(WildcardStates.CLOSED);
+                }
+            }
+
+            List<Option> options = new ArrayList<>();
+
+            if (randomBoolean()) {
+                options.add(Option.ALLOW_NO_INDICES);
+            }
+
+            if (randomBoolean()) {
+                options.add(Option.IGNORE_UNAVAILABLE);
+            }
+
+            original.indicesOptions(new IndicesOptions(
+                    options.isEmpty() ? Option.NONE : EnumSet.copyOf(options),
+                    wildcardStates.isEmpty() ? WildcardStates.NONE : EnumSet.copyOf(wildcardStates)));
         }
 
-        if (randomBoolean()) { // replace
+        if (randomBoolean()) {
             original.waitForCompletion(randomBoolean());
         }
 
-        if (randomBoolean()) { // replace
+        if (randomBoolean()) {
             original.masterNodeTimeout("60s");
         }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
@@ -24,6 +24,8 @@ import org.elasticsearch.action.support.IndicesOptions.Option;
 import org.elasticsearch.action.support.IndicesOptions.WildcardStates;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent.MapParams;
+import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -32,6 +34,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -69,6 +72,7 @@ public class CreateSnapshotRequestTests extends ESTestCase {
                 settings.put(randomAlphaOfLength(randomInt(3) + 2), randomAlphaOfLength(randomInt(3) + 2));
             }
 
+            original.settings(settings);
         }
 
         if (randomBoolean()) {
@@ -111,7 +115,7 @@ public class CreateSnapshotRequestTests extends ESTestCase {
             original.masterNodeTimeout("60s");
         }
 
-        XContentBuilder builder = original.toXContent(XContentFactory.jsonBuilder(), null);
+        XContentBuilder builder = original.toXContent(XContentFactory.jsonBuilder(), new MapParams(Collections.emptyMap()));
         XContentParser parser = XContentType.JSON.xContent().createParser(
                 NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput());
         Map<String, Object> map = parser.mapOrdered();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
@@ -33,6 +33,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -79,27 +81,8 @@ public class CreateSnapshotRequestTests extends ESTestCase {
         }
 
         if (randomBoolean()) {
-            List<WildcardStates> wildcardStates = new ArrayList<>();
-
-            if (randomBoolean()) {
-                if (randomBoolean()) {
-                    wildcardStates.add(WildcardStates.OPEN);
-                }
-
-                if (randomBoolean()) {
-                    wildcardStates.add(WildcardStates.CLOSED);
-                }
-            }
-
-            List<Option> options = new ArrayList<>();
-
-            if (randomBoolean()) {
-                options.add(Option.ALLOW_NO_INDICES);
-            }
-
-            if (randomBoolean()) {
-                options.add(Option.IGNORE_UNAVAILABLE);
-            }
+            Collection<WildcardStates> wildcardStates = randomSubsetOf(Arrays.asList(WildcardStates.values()));
+            Collection<Option> options = randomSubsetOf(Arrays.asList(Option.ALLOW_NO_INDICES, Option.IGNORE_UNAVAILABLE));
 
             original.indicesOptions(new IndicesOptions(
                     options.isEmpty() ? Option.NONE : EnumSet.copyOf(options),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
@@ -46,7 +46,7 @@ public class CreateSnapshotRequestTests extends ESTestCase {
 
         CreateSnapshotRequest original = new CreateSnapshotRequest(repo, snap);
 
-        if (randomBoolean()) { // replace
+        if (randomBoolean()) {
             List<String> indices = new ArrayList<>();
             int count = randomInt(3) + 1;
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.action.support.IndicesOptions.WildcardStates;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent.MapParams;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -20,12 +20,27 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.support.IndicesOptions.Option;
+import org.elasticsearch.action.support.IndicesOptions.WildcardStates;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent.MapParams;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
@@ -241,5 +256,72 @@ public class IndicesOptionsTests extends ESTestCase {
             return IndicesOptions.fromOptions(ignoreUnavailable, allowNoIndices, expandOpen, expandClosed,
                 allowAliasesToMulti, forbidClosed, ignoreAliases);
         });
+    }
+
+    public void testFromMap() {
+        IndicesOptions defaults = IndicesOptions.strictExpandOpen();
+        Collection<String> wildcardStates = randomBoolean() ?
+                null : randomSubsetOf(Arrays.asList("open", "closed"));
+        Boolean ignoreUnavailable = randomBoolean() ? null : randomBoolean();
+        Boolean allowNoIndices = randomBoolean() ? null : randomBoolean();
+
+        Map<String, Object> settings = new HashMap<>();
+
+        if (wildcardStates != null) {
+            settings.put("expand_wildcards", wildcardStates);
+        }
+
+        if (ignoreUnavailable != null) {
+            settings.put("ignore_unavailable", ignoreUnavailable);
+        }
+
+        if (allowNoIndices != null) {
+            settings.put("allow_no_indices", allowNoIndices);
+        }
+
+        IndicesOptions fromMap = IndicesOptions.fromMap(settings, defaults);
+
+        boolean open = wildcardStates != null ? wildcardStates.contains("open") : defaults.expandWildcardsOpen();
+        assertEquals(fromMap.expandWildcardsOpen(), open);
+        boolean closed = wildcardStates != null ? wildcardStates.contains("closed") : defaults.expandWildcardsClosed();
+        assertEquals(fromMap.expandWildcardsClosed(), closed);
+
+        assertEquals(fromMap.ignoreUnavailable(), ignoreUnavailable == null ? defaults.ignoreUnavailable() : ignoreUnavailable);
+        assertEquals(fromMap.allowNoIndices(), allowNoIndices == null ? defaults.allowNoIndices() : allowNoIndices);
+    }
+
+    public void testToXContent() throws IOException {
+        Collection<WildcardStates> wildcardStates = randomSubsetOf(Arrays.asList(WildcardStates.values()));
+        Collection<Option> options = randomSubsetOf(Arrays.asList(Option.values()));
+
+        IndicesOptions indicesOptions = new IndicesOptions(
+                options.isEmpty() ? Option.NONE : EnumSet.copyOf(options),
+                wildcardStates.isEmpty() ? WildcardStates.NONE : EnumSet.copyOf(wildcardStates));
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        indicesOptions.toXContent(builder, new MapParams(Collections.emptyMap()));
+        builder.endObject();
+        XContentParser parser = XContentType.JSON.xContent().createParser(
+            NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput());
+        Map<String, Object> map = parser.mapOrdered();
+
+        boolean open = wildcardStates.contains(WildcardStates.OPEN);
+        if (open) {
+            assertTrue(((List)map.get("expand_wildcards")).contains("open"));
+        } else {
+            assertFalse(((List)map.get("expand_wildcards")).contains("open"));
+        }
+        boolean closed = wildcardStates.contains(WildcardStates.CLOSED);
+        if (closed) {
+            assertTrue(((List)map.get("expand_wildcards")).contains("closed"));
+        } else {
+            assertFalse(((List)map.get("expand_wildcards")).contains("closed"));
+        }
+        assertEquals(map.get("ignore_unavailable"), options.contains(Option.IGNORE_UNAVAILABLE));
+        assertEquals(map.get("allow_no_indices"), options.contains(Option.ALLOW_NO_INDICES));
+        assertEquals(map.get("forbid_aliases_to_multiple_indices"), options.contains(Option.FORBID_ALIASES_TO_MULTIPLE_INDICES));
+        assertEquals(map.get("forbid_closed_indices"), options.contains(Option.FORBID_CLOSED_INDICES));
+        assertEquals(map.get("ignore_aliases"), options.contains(Option.IGNORE_ALIASES));
     }
 }


### PR DESCRIPTION
Original test failure found here: (https://github.com/elastic/elasticsearch/issues/31625) Had to rework the tests to only include options available externally for create snapshot requests.