### PR TITLE
[DOCS] Replace CONFIG_DIR with ES_PATH_CONF

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -328,7 +328,7 @@ role mappings are not considered. Defaults to `false`.
 `files.role_mapping`::
 The {xpack-ref}/security-files.html[location] for the {xpack-ref}/mapping-roles.html#mapping-roles[
 YAML role mapping configuration file]. Defaults to
-`CONFIG_DIR/role_mapping.yml`.
+`ES_PATH_CONF/role_mapping.yml`.
 
 `follow_referrals`::
 Specifies whether {security} should follow referrals returned
@@ -494,7 +494,7 @@ considered. Defaults to `false`.
 
 `files.role_mapping`::
 The {xpack-ref}/security-files.html[location] for the YAML
-role mapping configuration file. Defaults to `CONFIG_DIR/role_mapping.yml`.
+role mapping configuration file. Defaults to `ES_PATH_CONF/role_mapping.yml`.
 
 `user_search.base_dn`::
 The context to search for a user. Defaults to the root
@@ -719,7 +719,7 @@ for SSL. This setting cannot be used with `certificate_authorities`.
 `files.role_mapping`::
 Specifies the {xpack-ref}/security-files.html[location] of the
 {xpack-ref}/mapping-roles.html[YAML role  mapping configuration file].
-Defaults to `CONFIG_DIR/role_mapping.yml`.
+Defaults to `ES_PATH_CONF/role_mapping.yml`.
 
 `cache.ttl`::
 Specifies the time-to-live for cached user entries. A user and a hash of its 

--- a/x-pack/docs/en/security/auditing/output-logfile.asciidoc
+++ b/x-pack/docs/en/security/auditing/output-logfile.asciidoc
@@ -47,7 +47,7 @@ audited in plain text when including the request body in audit events.
 
 [[logging-file]]
 You can also configure how the logfile is written in the `log4j2.properties`
-file located in `CONFIG_DIR`. By default, audit information is appended to the
+file located in `ES_PATH_CONF`. By default, audit information is appended to the
 `<clustername>_access.log` file located in the standard Elasticsearch `logs` directory
 (typically located at `$ES_HOME/logs`). The file rolls over on a daily basis.
 

--- a/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
@@ -5,7 +5,7 @@
 You can manage and authenticate users with the built-in `file` internal realm. 
 All the data about the users for the `file` realm is stored in two files on each 
 node in the cluster: `users` and `users_roles`. Both files are located in 
-`CONFIG_DIR/` and are read on startup.
+`ES_PATH_CONF` and are read on startup.
 
 [IMPORTANT]
 ==============================
@@ -50,7 +50,7 @@ xpack:
 
 . Restart {es}.
 
-. Add user information to the `CONFIG_DIR/users` file on each node in the 
+. Add user information to the `ES_PATH_CONF/users` file on each node in the 
 cluster. 
 +
 --
@@ -76,7 +76,7 @@ IMPORTANT:  As the administrator of the cluster, it is your responsibility to
             
 --
 
-. Add role information to the `CONFIG_DIR/users_roles` file on each node 
+. Add role information to the `ES_PATH_CONF/users_roles` file on each node 
 in the cluster. 
 +
 --

--- a/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-ldap-realm.asciidoc
@@ -56,7 +56,7 @@ xpack:
           group_search:
             base_dn: "dc=example,dc=com"
           files:
-            role_mapping: "CONFIG_DIR/role_mapping.yml"
+            role_mapping: "ES_PATH_CONF/role_mapping.yml"
           unmapped_groups_as_roles: false
 ------------------------------------------------------------
 

--- a/x-pack/docs/en/security/authorization/managing-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/managing-roles.asciidoc
@@ -137,7 +137,7 @@ see {ref}/security-api-roles.html[Role Management APIs].
 === File-based role management
 
 Apart from the _Role Management APIs_, roles can also be defined in local
-`roles.yml` file located in `CONFIG_DIR`. This is a YAML file where each
+`roles.yml` file located in `ES_PATH_CONF`. This is a YAML file where each
 role definition is keyed by its name.
 
 [IMPORTANT]

--- a/x-pack/docs/en/security/reference/files.asciidoc
+++ b/x-pack/docs/en/security/reference/files.asciidoc
@@ -1,23 +1,23 @@
 [[security-files]]
 === Security Files
 
-The {security} uses the following files:
+{security} uses the following files:
 
-* `CONFIG_DIR/roles.yml` defines the roles in use on the cluster
+* `ES_PATH_CONF/roles.yml` defines the roles in use on the cluster
   (read more <<roles-management-file, here>>).
 
-* `CONFIG_DIR/elasticsearch-users` defines the users and their hashed passwords for
+* `ES_PATH_CONF/elasticsearch-users` defines the users and their hashed passwords for
   the <<file-realm,`file` realm>>.
 
-* `CONFIG_DIR/elasticsearch-users_roles` defines the user roles assignment for the
+* `ES_PATH_CONF/elasticsearch-users_roles` defines the user roles assignment for the
   the <<file-realm, `file` realm>>.
 
-* `CONFIG_DIR/role_mapping.yml` defines the role assignments for a
+* `ES_PATH_CONF/role_mapping.yml` defines the role assignments for a
   Distinguished Name (DN) to a role. This allows for LDAP and Active Directory
   groups and users and PKI users to be mapped to roles (read more
   <<mapping-roles, here>>).
 
-* `CONFIG_DIR/log4j2.properties` contains audit information (read more
+* `ES_PATH_CONF/log4j2.properties` contains audit information (read more
   <<logging-file, here>>).
 
 [[security-files-location]]

--- a/x-pack/docs/en/security/securing-communications/tls-ad.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-ad.asciidoc
@@ -37,7 +37,7 @@ xpack:
           domain_name: ad.example.com
           url: ldaps://ad.example.com:636
           ssl:
-            certificate_authorities: [ "CONFIG_DIR/cacert.pem" ]
+            certificate_authorities: [ "ES_PATH_CONF/cacert.pem" ]
 --------------------------------------------------
 
 The CA cert must be a PEM encoded certificate.

--- a/x-pack/docs/en/security/securing-communications/tls-ldap.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/tls-ldap.asciidoc
@@ -29,7 +29,7 @@ xpack:
           order: 0
           url: "ldaps://ldap.example.com:636"
           ssl:
-            certificate_authorities: [ "CONFIG_DIR/cacert.pem" ]
+            certificate_authorities: [ "ES_PATH_CONF/cacert.pem" ]
 --------------------------------------------------
 
 The CA certificate must be a PEM encoded.

--- a/x-pack/docs/en/security/troubleshooting.asciidoc
+++ b/x-pack/docs/en/security/troubleshooting.asciidoc
@@ -101,7 +101,7 @@ The role definition might be missing or invalid.
 |======================
 
 To help track down these possibilities, add the following lines to the end of
-the `log4j2.properties` configuration file in the `CONFIG_DIR`:
+the `log4j2.properties` configuration file in the `ES_PATH_CONF`:
 
 [source,properties]
 ----------------


### PR DESCRIPTION
Several security pages used a "CONFIG_DIR" environment variable, which I've changed to ES_PATH_CONF to match what was done for the "CONF_DIR" occurrences. 

Related to https://www.elastic.co/guide/en/elasticsearch/reference/6.3/breaking_60_packaging_changes.html#_literal_conf_dir_literal_is_no_longer_supported