### PR TITLE
Correct integTest enable logic

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -192,7 +192,7 @@ integTestCluster {
       return tmpFile.exists()
   }
 }
-if (integTestCluster.distribution.startsWith("oss-") == false) {
+if (integTestCluster.distribution.startsWith("oss-")) {
   integTest.enabled = false
 }
 


### PR DESCRIPTION
Run xPack plugin integration tests when not on oss distro
