### PR TITLE
[DOCS] Check for Windows and *nix file paths

### DIFF
--- a/x-pack/docs/src/test/java/org/elasticsearch/smoketest/XDocsClientYamlTestSuiteIT.java
+++ b/x-pack/docs/src/test/java/org/elasticsearch/smoketest/XDocsClientYamlTestSuiteIT.java
@@ -107,7 +107,7 @@ public class XDocsClientYamlTestSuiteIT extends XPackRestIT {
     @Override
     protected boolean isWatcherTest() {
         String testName = getTestName();
-        return testName != null && testName.contains("watcher/");
+        return testName != null && (testName.contains("watcher/") || testName.contains("watcher\\"));
     }
 
     @Override
@@ -118,13 +118,13 @@ public class XDocsClientYamlTestSuiteIT extends XPackRestIT {
     @Override
     protected boolean isMachineLearningTest() {
         String testName = getTestName();
-        return testName != null && testName.contains("ml/");
+        return testName != null && (testName.contains("ml/") || testName.contains("ml\\"));
     }
 
     @Override
     protected boolean isRollupTest() {
         String testName = getTestName();
-        return testName != null && testName.contains("rollup/");
+        return testName != null && (testName.contains("rollup/") || testName.contains("rollup\\"));
     }
 
     /**


### PR DESCRIPTION
Occasional failures of the Docs snippet tests have happened on Windows recently where the error is a ML job cannot be created because one with the same name already exists. ML jobs are supposed to be cleaned up after if the tests is an ML test based on the condition `testName.contains("ml/")`

See https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-windows-compatibility/1724/console
https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+master+multijob-windows-compatibility/1721/console

Looking at the test output:
```
  1> [2018-06-27T20:58:22,546][INFO ][o.e.s.XDocsClientYamlTestSuiteIT] [test {yaml=en\ml\functions/geo/line_78}]: after test
...
... some other none ML tests
1> [2018-06-27T20:58:24,079][INFO ][o.e.s.XDocsClientYamlTestSuiteIT] [test {yaml=en\ml/aggregations/line_26}]: before test   <-- this test fails because the last ML test was not cleaned up properly 
```

The difference is `ml\` vs `ml/` and the jobs are not cleaned up after the first test.

`XPackRestIT` already contains the same check for Windows and *nix path separators.  