### PR TITLE
Extend allowed characters for grok field names (#21745)

### DIFF
--- a/libs/grok/src/main/java/org/elasticsearch/grok/Grok.java
+++ b/libs/grok/src/main/java/org/elasticsearch/grok/Grok.java
@@ -52,7 +52,7 @@ public final class Grok {
             "%\\{" +
             "(?<name>" +
             "(?<pattern>[A-z0-9]+)" +
-            "(?::(?<subname>[A-z0-9_:.-]+))?" +
+            "(?::(?<subname>[[:alnum:]@\\[\\]_:.-]+))?" +
             ")" +
             "(?:=(?<definition>" +
             "(?:" +
@@ -81,11 +81,11 @@ public final class Grok {
     public Grok(Map<String, String> patternBank, String grokPattern) {
         this(patternBank, grokPattern, true, ThreadWatchdog.noop());
     }
-    
+
     public Grok(Map<String, String> patternBank, String grokPattern, ThreadWatchdog threadWatchdog) {
         this(patternBank, grokPattern, true, threadWatchdog);
     }
-    
+
     Grok(Map<String, String> patternBank, String grokPattern, boolean namedCaptures) {
         this(patternBank, grokPattern, namedCaptures, ThreadWatchdog.noop());
     }

--- a/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
+++ b/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
@@ -412,10 +412,10 @@ public class GrokTests extends ESTestCase {
         expected.put("num", "1");
         assertThat(grok.captures("12"), equalTo(expected));
     }
-    
+
     public void testExponentialExpressions() {
         AtomicBoolean run = new AtomicBoolean(true); // to avoid a lingering thread when test has completed
-        
+
         String grokPattern = "Bonsuche mit folgender Anfrage: Belegart->\\[%{WORD:param2},(?<param5>(\\s*%{NOTSPACE})*)\\] " +
             "Zustand->ABGESCHLOSSEN Kassennummer->%{WORD:param9} Bonnummer->%{WORD:param10} Datum->%{DATESTAMP_OTHER:param11}";
         String logLine = "Bonsuche mit folgender Anfrage: Belegart->[EINGESCHRAENKTER_VERKAUF, VERKAUF, NACHERFASSUNG] " +
@@ -438,5 +438,14 @@ public class GrokTests extends ESTestCase {
         Exception e = expectThrows(RuntimeException.class, () -> grok.captures(logLine));
         run.set(false);
         assertThat(e.getMessage(), equalTo("grok pattern matching was interrupted after [200] ms"));
+    }
+
+    public void testUnicodeFieldnames() {
+        for(String fieldName : Arrays.asList("@metadata", "@metädata", "@metädat[a]")) {
+            String line = "foo";
+            Grok grok = new Grok(basePatterns, "%{WORD:" + fieldName + "}");
+            Map<String, Object> matches = grok.captures(line);
+            assertEquals("foo", matches.get(fieldName));
+        }
     }
 }

--- a/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
+++ b/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
@@ -440,14 +440,49 @@ public class GrokTests extends ESTestCase {
         assertThat(e.getMessage(), equalTo("grok pattern matching was interrupted after [200] ms"));
     }
 
-    public void testUnicodeFieldnames() {
-        for (String fieldName : Arrays.asList("@metadata", "@metädata", "@metädat[a]",
-            randomAlphaOfLengthBetween(1, 5), String.valueOf(randomIntBetween(0, 100)),
-            randomAlphaOfLengthBetween(1, 5) + randomIntBetween(0, 100))) {
-            String line = "foo";
-            Grok grok = new Grok(basePatterns, "%{WORD:" + fieldName + "}");
-            Map<String, Object> matches = grok.captures(line);
-            assertEquals("foo", matches.get(fieldName));
-        }
+    public void testAtInFieldName() {
+        assertGrokedField("@metadata");
+    }
+
+    public void assertNonAsciiLetterInFieldName() {
+        assertGrokedField("metädata");
+    }
+
+    public void assertSquareBracketInFieldName() {
+        assertGrokedField("metadat[a]");
+        assertGrokedField("metad[a]ta");
+        assertGrokedField("[m]etadata");
+    }
+
+    public void testUnderscoreInFieldName() {
+        assertGrokedField("meta_data");
+    }
+
+    public void testDotInFieldName() {
+        assertGrokedField("meta.data");
+    }
+
+    public void testMinusInFieldName() {
+        assertGrokedField("meta-data");
+    }
+
+    public void testAlphanumericFieldName() {
+        assertGrokedField(randomAlphaOfLengthBetween(1, 5));
+        assertGrokedField(randomAlphaOfLengthBetween(1, 5) + randomIntBetween(0, 100));
+        assertGrokedField(randomIntBetween(0, 100) + randomAlphaOfLengthBetween(1, 5));
+        assertGrokedField(String.valueOf(randomIntBetween(0, 100)));
+    }
+
+    public void testUnsupportedBracketsInFieldName() {
+        Grok grok = new Grok(basePatterns, "%{WORD:unsuppo(r)ted}");
+        Map<String, Object> matches = grok.captures("line");
+        assertNull(matches);
+    }
+
+    private void assertGrokedField(String fieldName) {
+        String line = "foo";
+        Grok grok = new Grok(basePatterns, "%{WORD:" + fieldName + "}");
+        Map<String, Object> matches = grok.captures(line);
+        assertEquals(line, matches.get(fieldName));
     }
 }

--- a/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
+++ b/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
@@ -441,7 +441,9 @@ public class GrokTests extends ESTestCase {
     }
 
     public void testUnicodeFieldnames() {
-        for(String fieldName : Arrays.asList("@metadata", "@metädata", "@metädat[a]")) {
+        for (String fieldName : Arrays.asList("@metadata", "@metädata", "@metädat[a]",
+            randomAlphaOfLengthBetween(1, 5), String.valueOf(randomIntBetween(0, 100)),
+            randomAlphaOfLengthBetween(1, 5) + randomIntBetween(0, 100))) {
             String line = "foo";
             Grok grok = new Grok(basePatterns, "%{WORD:" + fieldName + "}");
             Map<String, Object> matches = grok.captures(line);


### PR DESCRIPTION
Fixes #21745 
I couldn't make it as lenient as matching every visible char because whatever is matched by the `subname` group is itself used as the name of a matcher group (so things like `\` won't work without additional escaping).

So I left level of leniency out for now (I can look into making that work as well, but it's going to be a trickier change potentially) and used @clintongormley 's suggestion here (https://github.com/elastic/elasticsearch/issues/21745#issuecomment-262512055) of simply using unicode properties (`:alnum:` matches all letters and numbers here) + allowed punctuation (I defined allowed as exactly what LS grok allows so only `[\[\]@]` was added) for now.

let me know what you think :)