### PR TITLE
Fix syntax errors in get-snapshots docs

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SnapshotClientDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SnapshotClientDocumentationIT.java
@@ -470,7 +470,7 @@ public class SnapshotClientDocumentationIT extends ESRestHighLevelClientTestCase
         // end::get-snapshots-request
 
         // tag::get-snapshots-request-repositoryName
-        request.repository(repositoryName);
+        request.repository(repositoryName); // <1>
         // end::get-snapshots-request-repositoryName
 
         // tag::get-snapshots-request-snapshots

--- a/docs/java-rest/high-level/snapshot/get_snapshots.asciidoc
+++ b/docs/java-rest/high-level/snapshot/get_snapshots.asciidoc
@@ -83,7 +83,7 @@ A typical listener for `GetSnapshotsResponse` looks like:
 
 ["source","java",subs="attributes,callouts,macros"]
 --------------------------------------------------
-include-tagged::{doc-tests}/SnapshotClientDocumentationIT.java[get-snapshots-execute-listener
+include-tagged::{doc-tests}/SnapshotClientDocumentationIT.java[get-snapshots-execute-listener]
 --------------------------------------------------
 <1> Called when the execution is successfully completed. The response is
 provided as an argument.


### PR DESCRIPTION
This is related to #31537. It fixes two syntax errors that are breaking
the docs build.