### PR TITLE
TEST: Fix test task invocation

### DIFF
--- a/client/benchmark/build.gradle
+++ b/client/benchmark/build.gradle
@@ -46,8 +46,7 @@ mainClassName = 'org.elasticsearch.client.benchmark.BenchmarkMain'
 
 
 // never try to invoke tests on the benchmark project - there aren't any
-check.dependsOn.remove(test)
-tasks.remove(test)
+test.enabled = false
 
 dependencies {
   compile 'org.apache.commons:commons-math3:3.2'

--- a/client/benchmark/build.gradle
+++ b/client/benchmark/build.gradle
@@ -47,8 +47,7 @@ mainClassName = 'org.elasticsearch.client.benchmark.BenchmarkMain'
 
 // never try to invoke tests on the benchmark project - there aren't any
 check.dependsOn.remove(test)
-// explicitly override the test task too in case somebody invokes 'gradle test' so it won't trip
-task test(type: Test, overwrite: true)
+tasks.remove(test)
 
 dependencies {
   compile 'org.apache.commons:commons-math3:3.2'


### PR DESCRIPTION
`./gradlew test` was broken by 8557bbab28a52106536f4f47fbe3f36a7f3951be.

Fails with:
```sh

FAILURE: Build failed with an exception.

* What went wrong:
Found the 1 `test` tasks:
  :client:benchmark:test -> class org.gradle.api.tasks.testing.Test_Decorated

```
on master

I think simply removing the test task fixes things though (should be ok now since that commit made the test replace action hard against missing `test` tasks right?).