### PR TITLE
Remove extra check for object existence in repository-gcs read object

### DIFF
--- a/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockStorage.java
+++ b/plugins/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockStorage.java
@@ -167,7 +167,27 @@ class MockStorage implements Storage {
     public ReadChannel reader(BlobId blob, BlobSourceOption... options) {
         if (bucketName.equals(blob.getBucket())) {
             final byte[] bytes = blobs.get(blob.getName());
-            final ReadableByteChannel readableByteChannel = Channels.newChannel(new ByteArrayInputStream(bytes));
+
+            final ReadableByteChannel readableByteChannel;
+            if (bytes != null) {
+                readableByteChannel = Channels.newChannel(new ByteArrayInputStream(bytes));
+            } else {
+                readableByteChannel = new ReadableByteChannel() {
+                    @Override
+                    public int read(ByteBuffer dst) throws IOException {
+                        throw new StorageException(404, "Object not found");
+                    }
+
+                    @Override
+                    public boolean isOpen() {
+                        return false;
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                    }
+                };
+            }
             return new ReadChannel() {
                 @Override
                 public void close() {

--- a/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/ESBlobStoreContainerTestCase.java
@@ -49,7 +49,11 @@ public abstract class ESBlobStoreContainerTestCase extends ESTestCase {
     public void testReadNonExistingPath() throws IOException {
         try(BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(new BlobPath());
-            expectThrows(NoSuchFileException.class, () -> container.readBlob("non-existing"));
+            expectThrows(NoSuchFileException.class, () -> {
+                try (InputStream is = container.readBlob("non-existing")) {
+                    is.read();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
This pull request removes another extra blob exist check when reading an object from Google Cloud Storage.