### PR TITLE
Return both concrete fields and aliases in DocumentFieldMappers#getMapper.

### DIFF
--- a/docs/reference/mapping/types/alias.asciidoc
+++ b/docs/reference/mapping/types/alias.asciidoc
@@ -74,7 +74,7 @@ field alias to query over multiple target fields in a single clause.
 ==== Unsupported APIs
 
 Writes to field aliases are not supported: attempting to use an alias in an index or update request
-will result in a failure.
+will result in a failure. This also precludes aliases from being the target of `copy_to`.
 
 Because alias names are not present in the document source, aliases cannot be used when performing
 source filtering. For example, the following request will return an empty result for `_source`:

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
@@ -79,9 +79,9 @@ public class TokenCountFieldMapperTests extends ESSingleNodeTestCase {
                 new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         // previous mapper has not been modified
-        assertThat(((TokenCountFieldMapper) stage1.mappers().getFieldMapper("tc")).analyzer(), equalTo("keyword"));
+        assertThat(((TokenCountFieldMapper) stage1.mappers().getMapper("tc")).analyzer(), equalTo("keyword"));
         // but the new one has the change
-        assertThat(((TokenCountFieldMapper) stage2.mappers().getFieldMapper("tc")).analyzer(), equalTo("standard"));
+        assertThat(((TokenCountFieldMapper) stage2.mappers().getMapper("tc")).analyzer(), equalTo("standard"));
     }
 
     /**

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/TokenCountFieldMapperTests.java
@@ -79,9 +79,9 @@ public class TokenCountFieldMapperTests extends ESSingleNodeTestCase {
                 new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         // previous mapper has not been modified
-        assertThat(((TokenCountFieldMapper) stage1.mappers().getMapper("tc")).analyzer(), equalTo("keyword"));
+        assertThat(((TokenCountFieldMapper) stage1.mappers().getFieldMapper("tc")).analyzer(), equalTo("keyword"));
         // but the new one has the change
-        assertThat(((TokenCountFieldMapper) stage2.mappers().getMapper("tc")).analyzer(), equalTo("standard"));
+        assertThat(((TokenCountFieldMapper) stage2.mappers().getFieldMapper("tc")).analyzer(), equalTo("standard"));
     }
 
     /**

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -60,7 +60,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
+        assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
 
         // Doc without join
         ParsedDocument doc = docMapper.parse(SourceToParse.source("test", "type", "0",
@@ -144,7 +144,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
+        assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
 
         // Doc without join
         ParsedDocument doc = docMapper.parse(SourceToParse.source("test", "type", "0",
@@ -224,7 +224,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("test");
         DocumentMapper docMapper = indexService.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
+        assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
 
         {
             final String updateMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
@@ -303,7 +303,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
             docMapper = indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
                 MapperService.MergeReason.MAPPING_UPDATE);
-            assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
+            assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
             ParentJoinFieldMapper mapper = ParentJoinFieldMapper.getMapper(indexService.mapperService());
             assertTrue(mapper.hasChild("child2"));
             assertFalse(mapper.hasParent("child2"));
@@ -324,7 +324,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
             docMapper = indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
                 MapperService.MergeReason.MAPPING_UPDATE);
-            assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
+            assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
             ParentJoinFieldMapper mapper = ParentJoinFieldMapper.getMapper(indexService.mapperService());
             assertTrue(mapper.hasParent("other"));
             assertFalse(mapper.hasChild("other"));
@@ -445,7 +445,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
+        assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
         assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
         assertNotNull(service.mapperService().fullName("join_field#parent"));
         assertTrue(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/mapper/ParentJoinFieldMapperTests.java
@@ -60,7 +60,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
+        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
 
         // Doc without join
         ParsedDocument doc = docMapper.parse(SourceToParse.source("test", "type", "0",
@@ -144,7 +144,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
+        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
 
         // Doc without join
         ParsedDocument doc = docMapper.parse(SourceToParse.source("test", "type", "0",
@@ -224,7 +224,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("test");
         DocumentMapper docMapper = indexService.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
+        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
 
         {
             final String updateMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("properties")
@@ -303,7 +303,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
             docMapper = indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
                 MapperService.MergeReason.MAPPING_UPDATE);
-            assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
+            assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
             ParentJoinFieldMapper mapper = ParentJoinFieldMapper.getMapper(indexService.mapperService());
             assertTrue(mapper.hasChild("child2"));
             assertFalse(mapper.hasParent("child2"));
@@ -324,7 +324,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
             docMapper = indexService.mapperService().merge("type", new CompressedXContent(updateMapping),
                 MapperService.MergeReason.MAPPING_UPDATE);
-            assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
+            assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(indexService.mapperService()));
             ParentJoinFieldMapper mapper = ParentJoinFieldMapper.getMapper(indexService.mapperService());
             assertTrue(mapper.hasParent("other"));
             assertFalse(mapper.hasChild("other"));
@@ -445,7 +445,7 @@ public class ParentJoinFieldMapperTests extends ESSingleNodeTestCase {
         IndexService service = createIndex("test");
         DocumentMapper docMapper = service.mapperService().merge("type", new CompressedXContent(mapping),
             MapperService.MergeReason.MAPPING_UPDATE);
-        assertTrue(docMapper.mappers().getFieldMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
+        assertTrue(docMapper.mappers().getMapper("join_field") == ParentJoinFieldMapper.getMapper(service.mapperService()));
         assertFalse(service.mapperService().fullName("join_field").eagerGlobalOrdinals());
         assertNotNull(service.mapperService().fullName("join_field#parent"));
         assertTrue(service.mapperService().fullName("join_field#parent").eagerGlobalOrdinals());

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQuery.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQuery.java
@@ -194,6 +194,10 @@ final class PercolateQuery extends Query implements Accountable {
         return candidateMatchesQuery;
     }
 
+    Query getVerifiedMatchesQuery() {
+        return verifiedMatchesQuery;
+    }
+
     // Comparing identity here to avoid being cached
     // Note that in theory if the same instance gets used multiple times it could still get cached,
     // however since we create a new query instance each time we this query this shouldn't happen and thus

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -618,7 +618,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
             docSearcher.setQueryCache(null);
         }
 
-        PercolatorFieldMapper percolatorFieldMapper = (PercolatorFieldMapper) docMapper.mappers().getMapper(field);
+        PercolatorFieldMapper percolatorFieldMapper = (PercolatorFieldMapper) docMapper.mappers().getFieldMapper(field);
         boolean mapUnmappedFieldsAsString = percolatorFieldMapper.isMapUnmappedFieldAsText();
         QueryShardContext percolateShardContext = wrap(context);
 

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -618,13 +618,13 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
             docSearcher.setQueryCache(null);
         }
 
-        PercolatorFieldMapper percolatorFieldMapper = (PercolatorFieldMapper) docMapper.mappers().getFieldMapper(field);
-        boolean mapUnmappedFieldsAsString = percolatorFieldMapper.isMapUnmappedFieldAsText();
-        QueryShardContext percolateShardContext = wrap(context);
-
-        String name = this.name != null ? this.name : field;
         PercolatorFieldMapper.FieldType pft = (PercolatorFieldMapper.FieldType) fieldType;
-        PercolateQuery.QueryStore queryStore = createStore(pft.queryBuilderField, percolateShardContext, mapUnmappedFieldsAsString);
+        String name = this.name != null ? this.name : pft.name();
+        QueryShardContext percolateShardContext = wrap(context);
+        PercolateQuery.QueryStore queryStore = createStore(pft.queryBuilderField,
+            percolateShardContext,
+            pft.mapUnmappedFieldsAsText);
+
         return pft.percolateQuery(name, queryStore, documents, docSearcher, context.indexVersionCreated());
     }
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -161,7 +161,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
                 .startObject("properties").startObject(queryField).field("type", "percolator").endObject().endObject()
                 .endObject().endObject());
         mapperService.merge("type", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
-        fieldMapper = (PercolatorFieldMapper) mapperService.documentMapper("type").mappers().getFieldMapper(queryField);
+        fieldMapper = (PercolatorFieldMapper) mapperService.documentMapper("type").mappers().getMapper(queryField);
         fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
 
         queries = new ArrayList<>();
@@ -194,8 +194,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         }
         Collections.sort(intValues);
 
-        MappedFieldType intFieldType = mapperService.documentMapper("type").mappers()
-            .getFieldMapper("int_field").fieldType();
+        MappedFieldType intFieldType = mapperService.fullName("int_field");
 
         List<Supplier<Query>> queryFunctions = new ArrayList<>();
         queryFunctions.add(MatchNoDocsQuery::new);
@@ -327,8 +326,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         stringValues.add("value2");
         stringValues.add("value3");
 
-        MappedFieldType intFieldType = mapperService.documentMapper("type").mappers()
-            .getFieldMapper("int_field").fieldType();
+        MappedFieldType intFieldType = mapperService.fullName("int_field");
         List<int[]> ranges = new ArrayList<>();
         ranges.add(new int[]{-5, 5});
         ranges.add(new int[]{0, 10});

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -161,7 +161,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
                 .startObject("properties").startObject(queryField).field("type", "percolator").endObject().endObject()
                 .endObject().endObject());
         mapperService.merge("type", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
-        fieldMapper = (PercolatorFieldMapper) mapperService.documentMapper("type").mappers().getMapper(queryField);
+        fieldMapper = (PercolatorFieldMapper) mapperService.documentMapper("type").mappers().getFieldMapper(queryField);
         fieldType = (PercolatorFieldMapper.FieldType) fieldMapper.fieldType();
 
         queries = new ArrayList<>();
@@ -195,7 +195,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         Collections.sort(intValues);
 
         MappedFieldType intFieldType = mapperService.documentMapper("type").mappers()
-            .getMapper("int_field").fieldType();
+            .getFieldMapper("int_field").fieldType();
 
         List<Supplier<Query>> queryFunctions = new ArrayList<>();
         queryFunctions.add(MatchNoDocsQuery::new);
@@ -328,7 +328,7 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         stringValues.add("value3");
 
         MappedFieldType intFieldType = mapperService.documentMapper("type").mappers()
-            .getMapper("int_field").fieldType();
+            .getFieldMapper("int_field").fieldType();
         List<int[]> ranges = new ArrayList<>();
         ranges.add(new int[]{-5, 5});
         ranges.add(new int[]{0, 10});

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -181,7 +181,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         bq.add(termQuery2, Occur.SHOULD);
 
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
-        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getFieldMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
                 mapperService.documentMapperParser(), documentMapper, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
@@ -224,15 +224,15 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     public void testExtractRanges() throws Exception {
         addQueryFieldMappings();
         BooleanQuery.Builder bq = new BooleanQuery.Builder();
-        Query rangeQuery1 = mapperService.documentMapper("doc").mappers().getMapper("number_field1").fieldType()
+        Query rangeQuery1 = mapperService.documentMapper("doc").mappers().getFieldMapper("number_field1").fieldType()
             .rangeQuery(10, 20, true, true, null, null, null, null);
         bq.add(rangeQuery1, Occur.MUST);
-        Query rangeQuery2 = mapperService.documentMapper("doc").mappers().getMapper("number_field1").fieldType()
+        Query rangeQuery2 = mapperService.documentMapper("doc").mappers().getFieldMapper("number_field1").fieldType()
             .rangeQuery(15, 20, true, true, null, null, null, null);
         bq.add(rangeQuery2, Occur.MUST);
 
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
-        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getFieldMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
             mapperService.documentMapperParser(), documentMapper, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
@@ -255,7 +255,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         // Range queries on different fields:
         bq = new BooleanQuery.Builder();
         bq.add(rangeQuery1, Occur.MUST);
-        rangeQuery2 = mapperService.documentMapper("doc").mappers().getMapper("number_field2").fieldType()
+        rangeQuery2 = mapperService.documentMapper("doc").mappers().getFieldMapper("number_field2").fieldType()
             .rangeQuery(15, 20, true, true, null, null, null, null);
         bq.add(rangeQuery2, Occur.MUST);
 
@@ -282,7 +282,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         addQueryFieldMappings();
         TermRangeQuery query = new TermRangeQuery("field1", new BytesRef("a"), new BytesRef("z"), true, true);
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
-        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getFieldMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
                 mapperService.documentMapperParser(), documentMapper, null, null);
         fieldMapper.processQuery(query, parseContext);
@@ -297,7 +297,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         addQueryFieldMappings();
         PhraseQuery phraseQuery = new PhraseQuery("field", "term");
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
-        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getFieldMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
                 mapperService.documentMapperParser(), documentMapper, null, null);
         fieldMapper.processQuery(phraseQuery, parseContext);

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -181,7 +181,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         bq.add(termQuery2, Occur.SHOULD);
 
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
-        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getFieldMapper(fieldName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
                 mapperService.documentMapperParser(), documentMapper, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
@@ -224,15 +224,15 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
     public void testExtractRanges() throws Exception {
         addQueryFieldMappings();
         BooleanQuery.Builder bq = new BooleanQuery.Builder();
-        Query rangeQuery1 = mapperService.documentMapper("doc").mappers().getFieldMapper("number_field1").fieldType()
+        Query rangeQuery1 = mapperService.fullName("number_field1")
             .rangeQuery(10, 20, true, true, null, null, null, null);
         bq.add(rangeQuery1, Occur.MUST);
-        Query rangeQuery2 = mapperService.documentMapper("doc").mappers().getFieldMapper("number_field1").fieldType()
+        Query rangeQuery2 = mapperService.fullName("number_field1")
             .rangeQuery(15, 20, true, true, null, null, null, null);
         bq.add(rangeQuery2, Occur.MUST);
 
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
-        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getFieldMapper(fieldName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
             mapperService.documentMapperParser(), documentMapper, null, null);
         fieldMapper.processQuery(bq.build(), parseContext);
@@ -255,7 +255,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         // Range queries on different fields:
         bq = new BooleanQuery.Builder();
         bq.add(rangeQuery1, Occur.MUST);
-        rangeQuery2 = mapperService.documentMapper("doc").mappers().getFieldMapper("number_field2").fieldType()
+        rangeQuery2 = mapperService.fullName("number_field2")
             .rangeQuery(15, 20, true, true, null, null, null, null);
         bq.add(rangeQuery2, Occur.MUST);
 
@@ -282,7 +282,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         addQueryFieldMappings();
         TermRangeQuery query = new TermRangeQuery("field1", new BytesRef("a"), new BytesRef("z"), true, true);
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
-        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getFieldMapper(fieldName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
                 mapperService.documentMapperParser(), documentMapper, null, null);
         fieldMapper.processQuery(query, parseContext);
@@ -297,7 +297,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         addQueryFieldMappings();
         PhraseQuery phraseQuery = new PhraseQuery("field", "term");
         DocumentMapper documentMapper = mapperService.documentMapper("doc");
-        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getFieldMapper(fieldName);
+        PercolatorFieldMapper fieldMapper = (PercolatorFieldMapper) documentMapper.mappers().getMapper(fieldName);
         ParseContext.InternalParseContext parseContext = new ParseContext.InternalParseContext(Settings.EMPTY,
                 mapperService.documentMapperParser(), documentMapper, null, null);
         fieldMapper.processQuery(phraseQuery, parseContext);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -39,7 +39,6 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentFieldMappers;
 import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
@@ -175,13 +174,13 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
         final DocumentFieldMappers allFieldMappers = documentMapper.mappers();
         for (String field : request.fields()) {
             if (Regex.isMatchAllPattern(field)) {
-                for (FieldMapper fieldMapper : allFieldMappers) {
-                    addFieldMapper(fieldPredicate, fieldMapper.fieldType().name(), fieldMapper, fieldMappings, request.includeDefaults());
+                for (Mapper fieldMapper : allFieldMappers) {
+                    addFieldMapper(fieldPredicate, fieldMapper.name(), fieldMapper, fieldMappings, request.includeDefaults());
                 }
             } else if (Regex.isSimpleMatchPattern(field)) {
-                for (FieldMapper fieldMapper : allFieldMappers) {
-                    if (Regex.simpleMatch(field, fieldMapper.fieldType().name())) {
-                        addFieldMapper(fieldPredicate,  fieldMapper.fieldType().name(),
+                for (Mapper fieldMapper : allFieldMappers) {
+                    if (Regex.simpleMatch(field, fieldMapper.name())) {
+                        addFieldMapper(fieldPredicate,  fieldMapper.name(),
                                 fieldMapper, fieldMappings, request.includeDefaults());
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -186,7 +186,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
                 }
             } else {
                 // not a pattern
-                FieldMapper fieldMapper = allFieldMappers.getMapper(field);
+                FieldMapper fieldMapper = allFieldMappers.getFieldMapper(field);
                 if (fieldMapper != null) {
                     addFieldMapper(fieldPredicate, field, fieldMapper, fieldMappings, request.includeDefaults());
                 } else if (request.probablySingleFieldRequest()) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetFieldMappingsIndexAction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentFieldMappers;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.TypeMissingException;
@@ -186,7 +187,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
                 }
             } else {
                 // not a pattern
-                FieldMapper fieldMapper = allFieldMappers.getFieldMapper(field);
+                Mapper fieldMapper = allFieldMappers.getMapper(field);
                 if (fieldMapper != null) {
                     addFieldMapper(fieldPredicate, field, fieldMapper, fieldMappings, request.includeDefaults());
                 } else if (request.probablySingleFieldRequest()) {
@@ -198,7 +199,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
     }
 
     private static void addFieldMapper(Predicate<String> fieldPredicate,
-                                       String field, FieldMapper fieldMapper, Map<String, FieldMappingMetaData> fieldMappings,
+                                       String field, Mapper fieldMapper, Map<String, FieldMappingMetaData> fieldMappings,
                                        boolean includeDefaults) {
         if (fieldMappings.containsKey(field)) {
             return;
@@ -207,7 +208,7 @@ public class TransportGetFieldMappingsIndexAction extends TransportSingleShardAc
             try {
                 BytesReference bytes = XContentHelper.toXContent(fieldMapper, XContentType.JSON,
                         includeDefaults ? includeDefaultsParams : ToXContent.EMPTY_PARAMS, false);
-                fieldMappings.put(field, new FieldMappingMetaData(fieldMapper.fieldType().name(), bytes));
+                fieldMappings.put(field, new FieldMappingMetaData(fieldMapper.name(), bytes));
             } catch (IOException e) {
                 throw new ElasticsearchException("failed to serialize XContent of field [" + field + "]", e);
             }

--- a/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexWarmer.java
@@ -27,8 +27,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.shard.IndexShard;
@@ -121,16 +119,12 @@ public final class IndexWarmer extends AbstractComponent {
         public TerminationHandle warmReader(final IndexShard indexShard, final Engine.Searcher searcher) {
             final MapperService mapperService = indexShard.mapperService();
             final Map<String, MappedFieldType> warmUpGlobalOrdinals = new HashMap<>();
-            DocumentMapper docMapper = mapperService.documentMapper();
-            if (docMapper != null) {
-                for (FieldMapper fieldMapper : docMapper.mappers()) {
-                    final MappedFieldType fieldType = fieldMapper.fieldType();
-                    final String indexName = fieldType.name();
-                    if (fieldType.eagerGlobalOrdinals() == false) {
-                        continue;
-                    }
-                    warmUpGlobalOrdinals.put(indexName, fieldType);
+            for (MappedFieldType fieldType : mapperService.fieldTypes()) {
+                final String indexName = fieldType.name();
+                if (fieldType.eagerGlobalOrdinals() == false) {
+                    continue;
                 }
+                warmUpGlobalOrdinals.put(indexName, fieldType);
             }
             final CountDownLatch latch = new CountDownLatch(warmUpGlobalOrdinals.size());
             for (final MappedFieldType fieldType : warmUpGlobalOrdinals.values()) {

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -39,7 +39,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fieldvisitor.CustomFieldsVisitor;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
@@ -202,7 +202,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
 
         if (gFields != null && gFields.length > 0) {
             for (String field : gFields) {
-                FieldMapper fieldMapper = docMapper.mappers().getFieldMapper(field);
+                Mapper fieldMapper = docMapper.mappers().getMapper(field);
                 if (fieldMapper == null) {
                     if (docMapper.objectMappers().get(field) != null) {
                         // Only fail if we know it is a object field, missing paths / fields shouldn't fail.

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -202,7 +202,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
 
         if (gFields != null && gFields.length > 0) {
             for (String field : gFields) {
-                FieldMapper fieldMapper = docMapper.mappers().getMapper(field);
+                FieldMapper fieldMapper = docMapper.mappers().getFieldMapper(field);
                 if (fieldMapper == null) {
                     if (docMapper.objectMappers().get(field) != null) {
                         // Only fail if we know it is a object field, missing paths / fields shouldn't fail.

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -61,9 +61,8 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper> {
         this.searchAnalyzer = new FieldNameAnalyzer(searchAnalyzers);
         this.searchQuoteAnalyzer = new FieldNameAnalyzer(searchQuoteAnalyzers);
     }
-
-    /** Returns the mapper for the given field */
-    public FieldMapper getMapper(String field) {
+    
+    public FieldMapper getFieldMapper(String field) {
         return fieldMappers.get(field);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -28,10 +28,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-public final class DocumentFieldMappers implements Iterable<FieldMapper> {
+public final class DocumentFieldMappers implements Iterable<Mapper> {
 
     /** Full field name to mapper */
-    private final Map<String, FieldMapper> fieldMappers;
+    private final Map<String, Mapper> fieldMappers;
 
     private final FieldNameAnalyzer indexAnalyzer;
     private final FieldNameAnalyzer searchAnalyzer;
@@ -44,8 +44,12 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper> {
         analyzers.put(key, value);
     }
 
-    public DocumentFieldMappers(Collection<FieldMapper> mappers, Analyzer defaultIndex, Analyzer defaultSearch, Analyzer defaultSearchQuote) {
-        Map<String, FieldMapper> fieldMappers = new HashMap<>();
+    public DocumentFieldMappers(Collection<FieldMapper> mappers,
+                                Collection<FieldAliasMapper> aliasMappers,
+                                Analyzer defaultIndex,
+                                Analyzer defaultSearch,
+                                Analyzer defaultSearchQuote) {
+        Map<String, Mapper> fieldMappers = new HashMap<>();
         Map<String, Analyzer> indexAnalyzers = new HashMap<>();
         Map<String, Analyzer> searchAnalyzers = new HashMap<>();
         Map<String, Analyzer> searchQuoteAnalyzers = new HashMap<>();
@@ -56,6 +60,11 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper> {
             put(searchAnalyzers, fieldType.name(), fieldType.searchAnalyzer(), defaultSearch);
             put(searchQuoteAnalyzers, fieldType.name(), fieldType.searchQuoteAnalyzer(), defaultSearchQuote);
         }
+
+        for (FieldAliasMapper aliasMapper : aliasMappers) {
+            fieldMappers.put(aliasMapper.name(), aliasMapper);
+        }
+
         this.fieldMappers = Collections.unmodifiableMap(fieldMappers);
         this.indexAnalyzer = new FieldNameAnalyzer(indexAnalyzers);
         this.searchAnalyzer = new FieldNameAnalyzer(searchAnalyzers);
@@ -68,9 +77,14 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper> {
      */
     @Deprecated
     public FieldMapper getFieldMapper(String field) {
-        return fieldMappers.get(field);
+        Mapper mapper = getMapper(field);
+        return (mapper instanceof FieldMapper) ? (FieldMapper) mapper : null;
     }
 
+    /**
+     * Returns the leaf mapper associated with this field name. Note that the returned mapper
+     * could be either a concrete {@link FieldMapper}, or a {@link FieldAliasMapper}.
+     */
     public Mapper getMapper(String field) {
         return fieldMappers.get(field);
     }
@@ -95,7 +109,7 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper> {
         return this.searchQuoteAnalyzer;
     }
 
-    public Iterator<FieldMapper> iterator() {
+    public Iterator<Mapper> iterator() {
         return fieldMappers.values().iterator();
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -61,8 +61,17 @@ public final class DocumentFieldMappers implements Iterable<FieldMapper> {
         this.searchAnalyzer = new FieldNameAnalyzer(searchAnalyzers);
         this.searchQuoteAnalyzer = new FieldNameAnalyzer(searchQuoteAnalyzers);
     }
-    
+
+    /**
+     * @deprecated Use {@link DocumentFieldMappers#getMapper} instead. To access a field's
+     * type information, instead use {@link MapperService#fullName}.
+     */
+    @Deprecated
     public FieldMapper getFieldMapper(String field) {
+        return fieldMappers.get(field);
+    }
+
+    public Mapper getMapper(String field) {
         return fieldMappers.get(field);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -133,16 +133,18 @@ public class DocumentMapper implements ToXContentFragment {
         // collect all the mappers for this type
         List<ObjectMapper> newObjectMappers = new ArrayList<>();
         List<FieldMapper> newFieldMappers = new ArrayList<>();
+        List<FieldAliasMapper> newFieldAliasMappers = new ArrayList<>();
         for (MetadataFieldMapper metadataMapper : this.mapping.metadataMappers) {
             if (metadataMapper instanceof FieldMapper) {
                 newFieldMappers.add(metadataMapper);
             }
         }
         MapperUtils.collect(this.mapping.root,
-            newObjectMappers, newFieldMappers, new ArrayList<>());
+            newObjectMappers, newFieldMappers, newFieldAliasMappers);
 
         final IndexAnalyzers indexAnalyzers = mapperService.getIndexAnalyzers();
         this.fieldMappers = new DocumentFieldMappers(newFieldMappers,
+                newFieldAliasMappers,
                 indexAnalyzers.getDefaultIndexAnalyzer(),
                 indexAnalyzers.getDefaultSearchAnalyzer(),
                 indexAnalyzers.getDefaultSearchQuoteAnalyzer());

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -70,7 +70,7 @@ public class DocumentMapper implements ToXContentFragment {
                 final String name = entry.getKey();
                 final MetadataFieldMapper existingMetadataMapper = existingMapper == null
                         ? null
-                        : (MetadataFieldMapper) existingMapper.mappers().getFieldMapper(name);
+                        : (MetadataFieldMapper) existingMapper.mappers().getMapper(name);
                 final MetadataFieldMapper metadataMapper;
                 if (existingMetadataMapper == null) {
                     final TypeParser parser = entry.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -70,7 +70,7 @@ public class DocumentMapper implements ToXContentFragment {
                 final String name = entry.getKey();
                 final MetadataFieldMapper existingMetadataMapper = existingMapper == null
                         ? null
-                        : (MetadataFieldMapper) existingMapper.mappers().getMapper(name);
+                        : (MetadataFieldMapper) existingMapper.mappers().getFieldMapper(name);
                 final MetadataFieldMapper metadataMapper;
                 if (existingMetadataMapper == null) {
                     final TypeParser parser = entry.getValue();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -854,46 +854,46 @@ final class DocumentParser {
             ObjectMapper currentParent) {
         ObjectMapper mapper = currentParent == null ? context.root() : currentParent;
         int pathsAdded = 0;
-            ObjectMapper parent = mapper;
-            for (int i = 0; i < paths.length-1; i++) {
-            String currentPath = context.path().pathAsText(paths[i]);
-            FieldMapper existingFieldMapper = context.docMapper().mappers().getFieldMapper(currentPath);
-            if (existingFieldMapper != null) {
-                throw new MapperParsingException(
-                        "Could not dynamically add mapping for field [{}]. Existing mapping for [{}] must be of type object but found [{}].",
-                        null, String.join(".", paths), currentPath, existingFieldMapper.fieldType.typeName());
-            }
-            mapper = context.docMapper().objectMappers().get(currentPath);
-                if (mapper == null) {
-                    // One mapping is missing, check if we are allowed to create a dynamic one.
-                    ObjectMapper.Dynamic dynamic = dynamicOrDefault(parent, context);
+        ObjectMapper parent = mapper;
+        for (int i = 0; i < paths.length-1; i++) {
+        String currentPath = context.path().pathAsText(paths[i]);
+        Mapper existingFieldMapper = context.docMapper().mappers().getMapper(currentPath);
+        if (existingFieldMapper != null) {
+            throw new MapperParsingException(
+                    "Could not dynamically add mapping for field [{}]. Existing mapping for [{}] must be of type object but found [{}].",
+                    null, String.join(".", paths), currentPath, existingFieldMapper.typeName());
+        }
+        mapper = context.docMapper().objectMappers().get(currentPath);
+            if (mapper == null) {
+                // One mapping is missing, check if we are allowed to create a dynamic one.
+                ObjectMapper.Dynamic dynamic = dynamicOrDefault(parent, context);
 
-                    switch (dynamic) {
-                        case STRICT:
-                            throw new StrictDynamicMappingException(parent.fullPath(), paths[i]);
-                        case TRUE:
-                            Mapper.Builder builder = context.root().findTemplateBuilder(context, paths[i], XContentFieldType.OBJECT);
-                            if (builder == null) {
-                                builder = new ObjectMapper.Builder(paths[i]).enabled(true);
-                            }
-                            Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings(), context.path());
-                            mapper = (ObjectMapper) builder.build(builderContext);
-                            if (mapper.nested() != ObjectMapper.Nested.NO) {
-                                throw new MapperParsingException("It is forbidden to create dynamic nested objects ([" + context.path().pathAsText(paths[i])
-                                        + "]) through `copy_to` or dots in field names");
-                            }
-                            context.addDynamicMapper(mapper);
-                            break;
-                        case FALSE:
-                           // Should not dynamically create any more mappers so return the last mapper
-                        return new Tuple<>(pathsAdded, parent);
+                switch (dynamic) {
+                    case STRICT:
+                        throw new StrictDynamicMappingException(parent.fullPath(), paths[i]);
+                    case TRUE:
+                        Mapper.Builder builder = context.root().findTemplateBuilder(context, paths[i], XContentFieldType.OBJECT);
+                        if (builder == null) {
+                            builder = new ObjectMapper.Builder(paths[i]).enabled(true);
+                        }
+                        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings(), context.path());
+                        mapper = (ObjectMapper) builder.build(builderContext);
+                        if (mapper.nested() != ObjectMapper.Nested.NO) {
+                            throw new MapperParsingException("It is forbidden to create dynamic nested objects ([" + context.path().pathAsText(paths[i])
+                                    + "]) through `copy_to` or dots in field names");
+                        }
+                        context.addDynamicMapper(mapper);
+                        break;
+                    case FALSE:
+                       // Should not dynamically create any more mappers so return the last mapper
+                    return new Tuple<>(pathsAdded, parent);
 
-                    }
                 }
-                context.path().add(paths[i]);
-                pathsAdded++;
-                parent = mapper;
             }
+            context.path().add(paths[i]);
+            pathsAdded++;
+            parent = mapper;
+        }
         return new Tuple<>(pathsAdded, mapper);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -832,7 +832,7 @@ final class DocumentParser {
 
     /** Creates an copy of the current field with given field name and boost */
     private static void parseCopy(String field, ParseContext context) throws IOException {
-        FieldMapper fieldMapper = context.docMapper().mappers().getMapper(field);
+        FieldMapper fieldMapper = context.docMapper().mappers().getFieldMapper(field);
         if (fieldMapper != null) {
             fieldMapper.parse(context);
         } else {
@@ -857,7 +857,7 @@ final class DocumentParser {
             ObjectMapper parent = mapper;
             for (int i = 0; i < paths.length-1; i++) {
             String currentPath = context.path().pathAsText(paths[i]);
-            FieldMapper existingFieldMapper = context.docMapper().mappers().getMapper(currentPath);
+            FieldMapper existingFieldMapper = context.docMapper().mappers().getFieldMapper(currentPath);
             if (existingFieldMapper != null) {
                 throw new MapperParsingException(
                         "Could not dynamically add mapping for field [{}]. Existing mapping for [{}] must be of type object but found [{}].",

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
@@ -56,6 +56,11 @@ public final class FieldAliasMapper extends Mapper {
         return name;
     }
 
+    @Override
+    public String typeName() {
+        return CONTENT_TYPE;
+    }
+
     public String path() {
         return path;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -247,6 +247,11 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         return fieldType().name();
     }
 
+    @Override
+    public String typeName() {
+        return fieldType.typeName();
+    }
+
     public MappedFieldType fieldType() {
         return fieldType;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -173,6 +173,11 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
     /** Returns the canonical name which uniquely identifies the mapper against other mappers in a type. */
     public abstract String name();
 
+    /**
+     * Returns a name representing the the type of this mapper.
+     */
+    public abstract String typeName();
+
     /** Return the merge of {@code mergeWith} into this.
      *  Both {@code this} and {@code mergeWith} will be left unmodified. */
     public abstract Mapper merge(Mapper mergeWith);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -621,6 +621,13 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return fieldTypes.simpleMatchToFullName(pattern);
     }
 
+    /**
+     * Returns all mapped field types.
+     */
+    public Iterable<MappedFieldType> fieldTypes() {
+        return fieldTypes;
+    }
+
     public ObjectMapper getObjectMapper(String name) {
         return fullPathObjectMappers.get(name);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -359,6 +359,11 @@ public class ObjectMapper extends Mapper implements Cloneable {
         return this.fullPath;
     }
 
+    @Override
+    public String typeName() {
+        return CONTENT_TYPE;
+    }
+
     public boolean isEnabled() {
         return this.enabled;
     }

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -89,10 +90,10 @@ public final class QueryParserHelper {
      * @param mapperService The mapper service where to find the mapping.
      * @param field The field name to search.
      */
-    public static FieldMapper getFieldMapper(MapperService mapperService, String field) {
+    public static Mapper getFieldMapper(MapperService mapperService, String field) {
         DocumentMapper mapper = mapperService.documentMapper();
         if (mapper != null) {
-            FieldMapper fieldMapper = mapper.mappers().getFieldMapper(field);
+            Mapper fieldMapper = mapper.mappers().getMapper(field);
             if (fieldMapper != null) {
                 return fieldMapper;
             }
@@ -185,7 +186,7 @@ public final class QueryParserHelper {
             }
 
             // Ignore metadata fields.
-            FieldMapper mapper = getFieldMapper(context.getMapperService(), fieldName);
+            Mapper mapper = getFieldMapper(context.getMapperService(), fieldName);
             if (acceptMetadataField == false && mapper instanceof MetadataFieldMapper) {
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -92,7 +92,7 @@ public final class QueryParserHelper {
     public static FieldMapper getFieldMapper(MapperService mapperService, String field) {
         DocumentMapper mapper = mapperService.documentMapper();
         if (mapper != null) {
-            FieldMapper fieldMapper = mapper.mappers().getMapper(field);
+            FieldMapper fieldMapper = mapper.mappers().getFieldMapper(field);
             if (fieldMapper != null) {
                 return fieldMapper;
             }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -29,8 +29,8 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ParseContext;
 import org.elasticsearch.index.mapper.ParseContext.Document;
 
@@ -138,8 +138,8 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
     @Override
     public Set<CharSequence> parseContext(ParseContext parseContext, XContentParser parser) throws IOException, ElasticsearchParseException {
         if (fieldName != null) {
-            FieldMapper mapper = parseContext.docMapper().mappers().getFieldMapper(fieldName);
-            if (!(mapper instanceof GeoPointFieldMapper)) {
+            MappedFieldType fieldType = parseContext.mapperService().fullName(fieldName);
+            if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
                 throw new ElasticsearchParseException("referenced field must be mapped to geo_point");
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -138,7 +138,7 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
     @Override
     public Set<CharSequence> parseContext(ParseContext parseContext, XContentParser parser) throws IOException, ElasticsearchParseException {
         if (fieldName != null) {
-            FieldMapper mapper = parseContext.docMapper().mappers().getMapper(fieldName);
+            FieldMapper mapper = parseContext.docMapper().mappers().getFieldMapper(fieldName);
             if (!(mapper instanceof GeoPointFieldMapper)) {
                 throw new ElasticsearchParseException("referenced field must be mapped to geo_point");
             }

--- a/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/analysis/PreBuiltAnalyzerTests.java
@@ -89,7 +89,7 @@ public class PreBuiltAnalyzerTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
         DocumentMapper docMapper = createIndex("test", indexSettings).mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
 
-        FieldMapper fieldMapper = docMapper.mappers().getMapper("field");
+        FieldMapper fieldMapper = docMapper.mappers().getFieldMapper("field");
         assertThat(fieldMapper.fieldType().searchAnalyzer(), instanceOf(NamedAnalyzer.class));
         NamedAnalyzer fieldMapperNamedAnalyzer = fieldMapper.fieldType().searchAnalyzer();
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -59,7 +59,7 @@ public class BinaryFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper mapper = createIndex("test").mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
 
-        FieldMapper fieldMapper = mapper.mappers().getMapper("field");
+        FieldMapper fieldMapper = mapper.mappers().getFieldMapper("field");
         assertThat(fieldMapper, instanceOf(BinaryFieldMapper.class));
         assertThat(fieldMapper.fieldType().stored(), equalTo(false));
     }
@@ -94,7 +94,7 @@ public class BinaryFieldMapperTests extends ESSingleNodeTestCase {
                     XContentType.JSON));
             BytesRef indexedValue = doc.rootDoc().getBinaryValue("field");
             assertEquals(new BytesRef(value), indexedValue);
-            FieldMapper fieldMapper = mapper.mappers().getMapper("field");
+            FieldMapper fieldMapper = mapper.mappers().getFieldMapper("field");
             Object originalValue = fieldMapper.fieldType().valueForDisplay(indexedValue);
             assertEquals(new BytesArray(value), originalValue);
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -101,7 +101,7 @@ public class BooleanFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = parser.parse("type", new CompressedXContent(mapping));
-        FieldMapper mapper = defaultMapper.mappers().getMapper("field");
+        FieldMapper mapper = defaultMapper.mappers().getFieldMapper("field");
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
         mapper.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
@@ -117,7 +117,7 @@ public class BooleanFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         defaultMapper = parser.parse("type", new CompressedXContent(mapping));
-        mapper = defaultMapper.mappers().getMapper("field");
+        mapper = defaultMapper.mappers().getFieldMapper("field");
         builder = XContentFactory.jsonBuilder().startObject();
         mapper.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();

--- a/server/src/test/java/org/elasticsearch/index/mapper/CamelCaseFieldNameTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CamelCaseFieldNameTests.java
@@ -46,12 +46,12 @@ public class CamelCaseFieldNameTests extends ESSingleNodeTestCase {
             .setSource(doc.dynamicMappingsUpdate().toString(), XContentType.JSON).get();
 
         documentMapper = index.mapperService().documentMapper("type");
-        assertNotNull(documentMapper.mappers().getMapper("thisIsCamelCase"));
-        assertNull(documentMapper.mappers().getMapper("this_is_camel_case"));
+        assertNotNull(documentMapper.mappers().getFieldMapper("thisIsCamelCase"));
+        assertNull(documentMapper.mappers().getFieldMapper("this_is_camel_case"));
 
         documentMapper = index.mapperService().documentMapperParser().parse("type", documentMapper.mappingSource());
 
-        assertNotNull(documentMapper.mappers().getMapper("thisIsCamelCase"));
-        assertNull(documentMapper.mappers().getMapper("this_is_camel_case"));
+        assertNotNull(documentMapper.mappers().getFieldMapper("thisIsCamelCase"));
+        assertNull(documentMapper.mappers().getFieldMapper("this_is_camel_case"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -61,7 +61,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
 
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         assertThat(fieldMapper, instanceOf(CompletionFieldMapper.class));
 
         MappedFieldType completionFieldType = fieldMapper.fieldType();
@@ -94,7 +94,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
 
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         assertThat(fieldMapper, instanceOf(CompletionFieldMapper.class));
 
         MappedFieldType completionFieldType = fieldMapper.fieldType();
@@ -129,7 +129,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
 
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         assertThat(fieldMapper, instanceOf(CompletionFieldMapper.class));
 
         CompletionFieldMapper completionFieldMapper = (CompletionFieldMapper) fieldMapper;
@@ -153,7 +153,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(XContentFactory.jsonBuilder()
@@ -192,7 +192,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(XContentFactory.jsonBuilder()
@@ -212,7 +212,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(XContentFactory.jsonBuilder()
@@ -235,7 +235,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(XContentFactory.jsonBuilder()
@@ -258,7 +258,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(XContentFactory.jsonBuilder()
@@ -291,7 +291,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(XContentFactory.jsonBuilder()
@@ -420,7 +420,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         CompletionFieldMapper completionFieldMapper = (CompletionFieldMapper) fieldMapper;
         Query prefixQuery = completionFieldMapper.fieldType().prefixQuery(new BytesRef("co"));
         assertThat(prefixQuery, instanceOf(PrefixCompletionQuery.class));
@@ -434,7 +434,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         CompletionFieldMapper completionFieldMapper = (CompletionFieldMapper) fieldMapper;
         Query prefixQuery = completionFieldMapper.fieldType().fuzzyQuery("co",
                 Fuzziness.fromEdits(FuzzyCompletionQuery.DEFAULT_MAX_EDITS), FuzzyCompletionQuery.DEFAULT_NON_FUZZY_PREFIX,
@@ -451,7 +451,7 @@ public class CompletionFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         CompletionFieldMapper completionFieldMapper = (CompletionFieldMapper) fieldMapper;
         Query prefixQuery = completionFieldMapper.fieldType()
                 .regexpQuery(new BytesRef("co"), RegExp.ALL, Operations.DEFAULT_MAX_DETERMINIZED_STATES);

--- a/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
@@ -72,7 +72,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
         IndexService index = createIndex("test");
         client().admin().indices().preparePutMapping("test").setType("type1").setSource(mapping, XContentType.JSON).get();
         DocumentMapper docMapper = index.mapperService().documentMapper("type1");
-        FieldMapper fieldMapper = docMapper.mappers().getMapper("copy_test");
+        FieldMapper fieldMapper = docMapper.mappers().getFieldMapper("copy_test");
 
         // Check json serialization
         TextFieldMapper stringFieldMapper = (TextFieldMapper) fieldMapper;
@@ -122,7 +122,7 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
             .setSource(parsedDoc.dynamicMappingsUpdate().toString(), XContentType.JSON).get();
 
         docMapper = index.mapperService().documentMapper("type1");
-        fieldMapper = docMapper.mappers().getMapper("new_field");
+        fieldMapper = docMapper.mappers().getFieldMapper("new_field");
         assertThat(fieldMapper.fieldType().typeName(), equalTo("long"));
     }
 
@@ -309,12 +309,12 @@ public class CopyToMapperTests extends ESSingleNodeTestCase {
         MapperService mapperService = createIndex("test").mapperService();
         DocumentMapper docMapperBefore = mapperService.merge("type1", new CompressedXContent(mappingBefore), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertEquals(Arrays.asList("foo", "bar"), docMapperBefore.mappers().getMapper("copy_test").copyTo().copyToFields());
+        assertEquals(Arrays.asList("foo", "bar"), docMapperBefore.mappers().getFieldMapper("copy_test").copyTo().copyToFields());
 
         DocumentMapper docMapperAfter = mapperService.merge("type1", new CompressedXContent(mappingAfter), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertEquals(Arrays.asList("baz", "bar"), docMapperAfter.mappers().getMapper("copy_test").copyTo().copyToFields());
-        assertEquals(Arrays.asList("foo", "bar"), docMapperBefore.mappers().getMapper("copy_test").copyTo().copyToFields());
+        assertEquals(Arrays.asList("baz", "bar"), docMapperAfter.mappers().getFieldMapper("copy_test").copyTo().copyToFields());
+        assertEquals(Arrays.asList("foo", "bar"), docMapperBefore.mappers().getFieldMapper("copy_test").copyTo().copyToFields());
     }
 
     public void testCopyToNestedField() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -385,8 +385,8 @@ public class DateFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper initMapper = indexService.mapperService().merge("movie", new CompressedXContent(initMapping),
             MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertThat(initMapper.mappers().getMapper("release_date"), notNullValue());
-        assertFalse(initMapper.mappers().getMapper("release_date").fieldType().stored());
+        assertThat(initMapper.mappers().getFieldMapper("release_date"), notNullValue());
+        assertFalse(initMapper.mappers().getFieldMapper("release_date").fieldType().stored());
 
         String updateFormatMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("movie")
             .startObject("properties")

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentFieldMapperTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.query.QueryShardContext;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class DocumentFieldMapperTests extends LuceneTestCase {
@@ -138,7 +139,12 @@ public class DocumentFieldMapperTests extends LuceneTestCase {
         Analyzer defaultSearch = new FakeAnalyzer("default_search");
         Analyzer defaultSearchQuote = new FakeAnalyzer("default_search_quote");
 
-        DocumentFieldMappers documentFieldMappers = new DocumentFieldMappers(Arrays.asList(fieldMapper1, fieldMapper2), defaultIndex, defaultSearch, defaultSearchQuote);
+        DocumentFieldMappers documentFieldMappers = new DocumentFieldMappers(
+            Arrays.asList(fieldMapper1, fieldMapper2),
+            Collections.emptyList(),
+            defaultIndex,
+            defaultSearch,
+            defaultSearchQuote);
 
         assertAnalyzes(documentFieldMappers.indexAnalyzer(), "field1", "index");
         assertAnalyzes(documentFieldMappers.searchAnalyzer(), "field1", "search");

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperMergeTests.java
@@ -56,11 +56,11 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
 
         DocumentMapper merged = stage1.merge(stage2.mapping());
         // stage1 mapping should not have been modified
-        assertThat(stage1.mappers().getMapper("age"), nullValue());
-        assertThat(stage1.mappers().getMapper("obj1.prop1"), nullValue());
+        assertThat(stage1.mappers().getFieldMapper("age"), nullValue());
+        assertThat(stage1.mappers().getFieldMapper("obj1.prop1"), nullValue());
         // but merged should
-        assertThat(merged.mappers().getMapper("age"), notNullValue());
-        assertThat(merged.mappers().getMapper("obj1.prop1"), notNullValue());
+        assertThat(merged.mappers().getFieldMapper("age"), notNullValue());
+        assertThat(merged.mappers().getFieldMapper("obj1.prop1"), notNullValue());
     }
 
     public void testMergeObjectDynamic() throws Exception {
@@ -115,10 +115,10 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
         DocumentMapper existing = parser.parse("type", new CompressedXContent(mapping1));
         DocumentMapper changed = parser.parse("type", new CompressedXContent(mapping2));
 
-        assertThat(((NamedAnalyzer) existing.mappers().getMapper("field").fieldType().searchAnalyzer()).name(), equalTo("whitespace"));
+        assertThat(((NamedAnalyzer) existing.mappers().getFieldMapper("field").fieldType().searchAnalyzer()).name(), equalTo("whitespace"));
         DocumentMapper merged = existing.merge(changed.mapping());
 
-        assertThat(((NamedAnalyzer) merged.mappers().getMapper("field").fieldType().searchAnalyzer()).name(), equalTo("keyword"));
+        assertThat(((NamedAnalyzer) merged.mappers().getFieldMapper("field").fieldType().searchAnalyzer()).name(), equalTo("keyword"));
     }
 
     public void testChangeSearchAnalyzerToDefault() throws Exception {
@@ -133,9 +133,9 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
         DocumentMapper existing = mapperService.merge("type", new CompressedXContent(mapping1), MapperService.MergeReason.MAPPING_UPDATE);
         DocumentMapper merged = mapperService.merge("type", new CompressedXContent(mapping2), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertThat(((NamedAnalyzer) existing.mappers().getMapper("field").fieldType().searchAnalyzer()).name(), equalTo("whitespace"));
+        assertThat(((NamedAnalyzer) existing.mappers().getFieldMapper("field").fieldType().searchAnalyzer()).name(), equalTo("whitespace"));
 
-        assertThat(((NamedAnalyzer) merged.mappers().getMapper("field").fieldType().searchAnalyzer()).name(), equalTo("standard"));
+        assertThat(((NamedAnalyzer) merged.mappers().getFieldMapper("field").fieldType().searchAnalyzer()).name(), equalTo("standard"));
     }
 
     public void testConcurrentMergeTest() throws Throwable {
@@ -226,7 +226,7 @@ public class DocumentMapperMergeTests extends ESSingleNodeTestCase {
                 .endObject().endObject()));
         DocumentMapper mapper = mapperService.merge("type", update, MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotNull(mapper.mappers().getMapper("foo"));
+        assertNotNull(mapper.mappers().getFieldMapper("foo"));
         assertFalse(mapper.sourceMapper().enabled());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
@@ -46,8 +46,8 @@ public class DocumentMapperParserTests extends ESSingleNodeTestCase {
             .startObject("foo.baz").field("type", "keyword").endObject()
             .endObject().endObject().endObject());
         DocumentMapper docMapper = mapperParser.parse("type", new CompressedXContent(mapping));
-        assertNotNull(docMapper.mappers().getMapper("foo.bar"));
-        assertNotNull(docMapper.mappers().getMapper("foo.baz"));
+        assertNotNull(docMapper.mappers().getFieldMapper("foo.bar"));
+        assertNotNull(docMapper.mappers().getFieldMapper("foo.baz"));
         assertNotNull(docMapper.objectMappers().get("foo"));
     }
 
@@ -60,8 +60,8 @@ public class DocumentMapperParserTests extends ESSingleNodeTestCase {
             .startObject("deep.field").field("type", "keyword").endObject().endObject()
             .endObject().endObject().endObject().endObject());
         DocumentMapper docMapper = mapperParser.parse("type", new CompressedXContent(mapping));
-        assertNotNull(docMapper.mappers().getMapper("foo.bar"));
-        assertNotNull(docMapper.mappers().getMapper("foo.baz.deep.field"));
+        assertNotNull(docMapper.mappers().getFieldMapper("foo.bar"));
+        assertNotNull(docMapper.mappers().getFieldMapper("foo.baz.deep.field"));
         assertNotNull(docMapper.objectMappers().get("foo"));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1390,7 +1390,7 @@ public class DocumentParserTests extends ESSingleNodeTestCase {
         assertThat(ExceptionsHelper.detailedMessage(err), containsString("field name cannot be an empty string"));
     }
 
-    public void testFieldAlias() throws Exception {
+    public void testWriteToFieldAlias() throws Exception {
         String mapping = Strings.toString(XContentFactory.jsonBuilder()
             .startObject()
                 .startObject("type")
@@ -1417,6 +1417,39 @@ public class DocumentParserTests extends ESSingleNodeTestCase {
             () -> mapper.parse(SourceToParse.source("test", "type", "1", bytes, XContentType.JSON)));
 
         assertEquals("Cannot write to a field alias [alias-field].", exception.getCause().getMessage());
+    }
+
+     public void testCopyToFieldAlias() throws Exception {
+        String mapping = Strings.toString(XContentFactory.jsonBuilder()
+            .startObject()
+                .startObject("type")
+                    .startObject("properties")
+                        .startObject("alias-field")
+                            .field("type", "alias")
+                            .field("path", "concrete-field")
+                        .endObject()
+                        .startObject("concrete-field")
+                            .field("type", "keyword")
+                        .endObject()
+                        .startObject("text-field")
+                            .field("type", "text")
+                            .field("copy_to", "alias-field")
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .endObject());
+
+        DocumentMapperParser mapperParser = createIndex("test").mapperService().documentMapperParser();
+        DocumentMapper mapper = mapperParser.parse("type", new CompressedXContent(mapping));
+
+        BytesReference bytes = BytesReference.bytes(XContentFactory.jsonBuilder()
+            .startObject()
+                .field("text-field", "value")
+            .endObject());
+        MapperParsingException exception = expectThrows(MapperParsingException.class,
+            () -> mapper.parse(SourceToParse.source("test", "type", "1", bytes, XContentType.JSON)));
+
+        assertEquals("Cannot copy to a field alias [alias-field].", exception.getCause().getMessage());
     }
 
     public void testDynamicDottedFieldNameWithFieldAlias() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1001,7 +1001,7 @@ public class DocumentParserTests extends ESSingleNodeTestCase {
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
         Document doc = docMapper.parse(SourceToParse.source("test", "person", "1", json, XContentType.JSON)).rootDoc();
 
-        assertThat(doc.get(docMapper.mappers().getMapper("name.first").fieldType().name()), equalTo("shay"));
+        assertThat(doc.get(docMapper.mappers().getFieldMapper("name.first").fieldType().name()), equalTo("shay"));
         doc = docMapper.parse(SourceToParse.source("test", "person", "1", json, XContentType.JSON)).rootDoc();
     }
 
@@ -1015,7 +1015,7 @@ public class DocumentParserTests extends ESSingleNodeTestCase {
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
         Document doc = builtDocMapper.parse(SourceToParse.source("test", "person", "1", json, XContentType.JSON)).rootDoc();
         assertThat(doc.getBinaryValue(docMapper.idFieldMapper().fieldType().name()), equalTo(Uid.encodeId("1")));
-        assertThat(doc.get(docMapper.mappers().getMapper("name.first").fieldType().name()), equalTo("shay"));
+        assertThat(doc.get(docMapper.mappers().getFieldMapper("name.first").fieldType().name()), equalTo("shay"));
     }
 
     public void testSimpleParser() throws Exception {
@@ -1027,7 +1027,7 @@ public class DocumentParserTests extends ESSingleNodeTestCase {
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1.json"));
         Document doc = docMapper.parse(SourceToParse.source("test", "person", "1", json, XContentType.JSON)).rootDoc();
         assertThat(doc.getBinaryValue(docMapper.idFieldMapper().fieldType().name()), equalTo(Uid.encodeId("1")));
-        assertThat(doc.get(docMapper.mappers().getMapper("name.first").fieldType().name()), equalTo("shay"));
+        assertThat(doc.get(docMapper.mappers().getFieldMapper("name.first").fieldType().name()), equalTo("shay"));
     }
 
     public void testSimpleParserNoTypeNoId() throws Exception {
@@ -1036,7 +1036,7 @@ public class DocumentParserTests extends ESSingleNodeTestCase {
         BytesReference json = new BytesArray(copyToBytesFromClasspath("/org/elasticsearch/index/mapper/simple/test1-notype-noid.json"));
         Document doc = docMapper.parse(SourceToParse.source("test", "person", "1", json, XContentType.JSON)).rootDoc();
         assertThat(doc.getBinaryValue(docMapper.idFieldMapper().fieldType().name()), equalTo(Uid.encodeId("1")));
-        assertThat(doc.get(docMapper.mappers().getMapper("name.first").fieldType().name()), equalTo("shay"));
+        assertThat(doc.get(docMapper.mappers().getFieldMapper("name.first").fieldType().name()), equalTo("shay"));
     }
 
     public void testAttributes() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleIndexingDocTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleIndexingDocTests.java
@@ -69,25 +69,25 @@ public class DoubleIndexingDocTests extends ESSingleNodeTestCase {
         IndexReader reader = DirectoryReader.open(writer);
         IndexSearcher searcher = new IndexSearcher(reader);
 
-        TopDocs topDocs = searcher.search(mapper.mappers().getMapper("field1").fieldType().termQuery("value1", context), 10);
+        TopDocs topDocs = searcher.search(mapper.mappers().getFieldMapper("field1").fieldType().termQuery("value1", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().getMapper("field2").fieldType().termQuery("1", context), 10);
+        topDocs = searcher.search(mapper.mappers().getFieldMapper("field2").fieldType().termQuery("1", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().getMapper("field3").fieldType().termQuery("1.1", context), 10);
+        topDocs = searcher.search(mapper.mappers().getFieldMapper("field3").fieldType().termQuery("1.1", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().getMapper("field4").fieldType().termQuery("2010-01-01", context), 10);
+        topDocs = searcher.search(mapper.mappers().getFieldMapper("field4").fieldType().termQuery("2010-01-01", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().getMapper("field5").fieldType().termQuery("1", context), 10);
+        topDocs = searcher.search(mapper.mappers().getFieldMapper("field5").fieldType().termQuery("1", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().getMapper("field5").fieldType().termQuery("2", context), 10);
+        topDocs = searcher.search(mapper.mappers().getFieldMapper("field5").fieldType().termQuery("2", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
 
-        topDocs = searcher.search(mapper.mappers().getMapper("field5").fieldType().termQuery("3", context), 10);
+        topDocs = searcher.search(mapper.mappers().getFieldMapper("field5").fieldType().termQuery("3", context), 10);
         assertThat(topDocs.totalHits, equalTo(2L));
         writer.close();
         reader.close();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -562,14 +562,14 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
                 .endObject();
         SourceToParse source = SourceToParse.source("test", "_doc", "1", BytesReference.bytes(json), json.contentType());
         DocumentMapper mapper = indexService.mapperService().documentMapper("_doc");
-        assertNull(mapper.mappers().getMapper("field.raw"));
+        assertNull(mapper.mappers().getFieldMapper("field.raw"));
         ParsedDocument parsed = mapper.parse(source);
         assertNotNull(parsed.dynamicMappingsUpdate());
 
         indexService.mapperService().merge("_doc", new CompressedXContent(parsed.dynamicMappingsUpdate().toString()),
             MapperService.MergeReason.MAPPING_UPDATE);
         mapper = indexService.mapperService().documentMapper("_doc");
-        assertNotNull(mapper.mappers().getMapper("field.raw"));
+        assertNotNull(mapper.mappers().getFieldMapper("field.raw"));
         parsed = mapper.parse(source);
         assertNull(parsed.dynamicMappingsUpdate());
     }
@@ -625,10 +625,10 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
             .setSource(doc.dynamicMappingsUpdate().toString(), XContentType.JSON).get();
 
         defaultMapper = index.mapperService().documentMapper("type");
-        FieldMapper mapper = defaultMapper.mappers().getMapper("s_long");
+        FieldMapper mapper = defaultMapper.mappers().getFieldMapper("s_long");
         assertThat(mapper.fieldType().typeName(), equalTo("long"));
 
-        mapper = defaultMapper.mappers().getMapper("s_double");
+        mapper = defaultMapper.mappers().getFieldMapper("s_double");
         assertThat(mapper.fieldType().typeName(), equalTo("float"));
     }
 
@@ -652,10 +652,10 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
             .setSource(doc.dynamicMappingsUpdate().toString(), XContentType.JSON).get());
 
         defaultMapper = index.mapperService().documentMapper("type");
-        FieldMapper mapper = defaultMapper.mappers().getMapper("s_long");
+        FieldMapper mapper = defaultMapper.mappers().getFieldMapper("s_long");
         assertThat(mapper, instanceOf(TextFieldMapper.class));
 
-        mapper = defaultMapper.mappers().getMapper("s_double");
+        mapper = defaultMapper.mappers().getFieldMapper("s_double");
         assertThat(mapper, instanceOf(TextFieldMapper.class));
     }
 
@@ -703,9 +703,9 @@ public class DynamicMappingTests extends ESSingleNodeTestCase {
 
         defaultMapper = index.mapperService().documentMapper("type");
 
-        DateFieldMapper dateMapper1 = (DateFieldMapper) defaultMapper.mappers().getMapper("date1");
-        DateFieldMapper dateMapper2 = (DateFieldMapper) defaultMapper.mappers().getMapper("date2");
-        DateFieldMapper dateMapper3 = (DateFieldMapper) defaultMapper.mappers().getMapper("date3");
+        DateFieldMapper dateMapper1 = (DateFieldMapper) defaultMapper.mappers().getFieldMapper("date1");
+        DateFieldMapper dateMapper2 = (DateFieldMapper) defaultMapper.mappers().getFieldMapper("date2");
+        DateFieldMapper dateMapper3 = (DateFieldMapper) defaultMapper.mappers().getFieldMapper("date3");
         // inherited from dynamic date format
         assertEquals("yyyy-MM-dd", dateMapper1.fieldType().dateTimeFormatter().format());
         // inherited from dynamic date format since the mapping in the template did not specify a format

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
@@ -56,11 +56,11 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         docMapper = index.mapperService().documentMapper("person");
         DocumentFieldMappers mappers = docMapper.mappers();
 
-        assertThat(mappers.getMapper("s"), Matchers.notNullValue());
-        assertEquals(IndexOptions.NONE, mappers.getMapper("s").fieldType().indexOptions());
+        assertThat(mappers.getFieldMapper("s"), Matchers.notNullValue());
+        assertEquals(IndexOptions.NONE, mappers.getFieldMapper("s").fieldType().indexOptions());
 
-        assertThat(mappers.getMapper("l"), Matchers.notNullValue());
-        assertNotSame(IndexOptions.NONE, mappers.getMapper("l").fieldType().indexOptions());
+        assertThat(mappers.getFieldMapper("l"), Matchers.notNullValue());
+        assertNotSame(IndexOptions.NONE, mappers.getFieldMapper("l").fieldType().indexOptions());
 
 
     }
@@ -84,7 +84,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        FieldMapper fieldMapper = docMapper.mappers().getMapper("name");
+        FieldMapper fieldMapper = docMapper.mappers().getFieldMapper("name");
         assertNotNull(fieldMapper);
 
         f = doc.getField("multi1");
@@ -93,7 +93,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(true));
 
-        fieldMapper = docMapper.mappers().getMapper("multi1");
+        fieldMapper = docMapper.mappers().getFieldMapper("multi1");
         assertNotNull(fieldMapper);
 
         f = doc.getField("multi1.org");
@@ -102,7 +102,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        fieldMapper = docMapper.mappers().getMapper("multi1.org");
+        fieldMapper = docMapper.mappers().getFieldMapper("multi1.org");
         assertNotNull(fieldMapper);
 
         f = doc.getField("multi2");
@@ -111,7 +111,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(true));
 
-        fieldMapper = docMapper.mappers().getMapper("multi2");
+        fieldMapper = docMapper.mappers().getFieldMapper("multi2");
         assertNotNull(fieldMapper);
 
         f = doc.getField("multi2.org");
@@ -120,7 +120,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        fieldMapper = docMapper.mappers().getMapper("multi2.org");
+        fieldMapper = docMapper.mappers().getFieldMapper("multi2.org");
         assertNotNull(fieldMapper);
     }
 
@@ -143,7 +143,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        FieldMapper fieldMapper = docMapper.mappers().getMapper("name");
+        FieldMapper fieldMapper = docMapper.mappers().getFieldMapper("name");
         assertNotNull(fieldMapper);
 
         f = doc.getField("multi1");
@@ -152,7 +152,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(true));
 
-        fieldMapper = docMapper.mappers().getMapper("multi1");
+        fieldMapper = docMapper.mappers().getFieldMapper("multi1");
         assertNotNull(fieldMapper);
 
         f = doc.getField("multi1.org");
@@ -161,7 +161,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        fieldMapper = docMapper.mappers().getMapper("multi1.org");
+        fieldMapper = docMapper.mappers().getFieldMapper("multi1.org");
         assertNotNull(fieldMapper);
 
         f = doc.getField("multi2");
@@ -170,7 +170,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(true));
 
-        fieldMapper = docMapper.mappers().getMapper("multi2");
+        fieldMapper = docMapper.mappers().getFieldMapper("multi2");
         assertNotNull(fieldMapper);
 
         f = doc.getField("multi2.org");
@@ -179,7 +179,7 @@ public class DynamicTemplatesTests extends ESSingleNodeTestCase {
         assertNotSame(IndexOptions.NONE, f.fieldType().indexOptions());
         assertThat(f.fieldType().tokenized(), equalTo(false));
 
-        fieldMapper = docMapper.mappers().getMapper("multi2.org");
+        fieldMapper = docMapper.mappers().getFieldMapper("multi2.org");
         assertNotNull(fieldMapper);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GenericStoreDynamicTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GenericStoreDynamicTemplateTests.java
@@ -23,10 +23,7 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.ParseContext.Document;
-import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import static org.elasticsearch.test.StreamsUtils.copyToBytesFromClasspath;
@@ -52,7 +49,7 @@ public class GenericStoreDynamicTemplateTests extends ESSingleNodeTestCase {
         assertThat(f.stringValue(), equalTo("some name"));
         assertThat(f.fieldType().stored(), equalTo(true));
 
-        FieldMapper fieldMapper = docMapper.mappers().getMapper("name");
+        FieldMapper fieldMapper = docMapper.mappers().getFieldMapper("name");
         assertThat(fieldMapper.fieldType().stored(), equalTo(true));
 
         boolean stored = false;
@@ -61,7 +58,7 @@ public class GenericStoreDynamicTemplateTests extends ESSingleNodeTestCase {
         }
         assertTrue(stored);
 
-        fieldMapper = docMapper.mappers().getMapper("age");
+        fieldMapper = docMapper.mappers().getFieldMapper("age");
         assertThat(fieldMapper.fieldType().stored(), equalTo(true));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -287,7 +287,7 @@ public class GeoPointFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
             .parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoPointFieldMapper.class));
 
         boolean ignoreZValue = ((GeoPointFieldMapper)fieldMapper).ignoreZValue().value();
@@ -302,7 +302,7 @@ public class GeoPointFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject());
 
         defaultMapper = createIndex("test2").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        fieldMapper = defaultMapper.mappers().getMapper("location");
+        fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoPointFieldMapper.class));
 
         ignoreZValue = ((GeoPointFieldMapper)fieldMapper).ignoreZValue().value();
@@ -364,7 +364,7 @@ public class GeoPointFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
             .parse("type", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoPointFieldMapper.class));
 
         Object nullValue = fieldMapper.fieldType().nullValue();

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
@@ -58,7 +58,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -82,7 +82,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         ShapeBuilder.Orientation orientation = ((GeoShapeFieldMapper)fieldMapper).fieldType().orientation();
@@ -99,7 +99,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         defaultMapper = createIndex("test2").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        fieldMapper = defaultMapper.mappers().getMapper("location");
+        fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         orientation = ((GeoShapeFieldMapper)fieldMapper).fieldType().orientation();
@@ -120,7 +120,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         boolean coerce = ((GeoShapeFieldMapper)fieldMapper).coerce().value();
@@ -135,7 +135,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         defaultMapper = createIndex("test2").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        fieldMapper = defaultMapper.mappers().getMapper("location");
+        fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         coerce = ((GeoShapeFieldMapper)fieldMapper).coerce().value();
@@ -156,7 +156,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser()
             .parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         boolean ignoreZValue = ((GeoShapeFieldMapper)fieldMapper).ignoreZValue().value();
@@ -171,7 +171,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject());
 
         defaultMapper = createIndex("test2").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        fieldMapper = defaultMapper.mappers().getMapper("location");
+        fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         ignoreZValue = ((GeoShapeFieldMapper)fieldMapper).ignoreZValue().value();
@@ -190,7 +190,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         Explicit<Boolean> ignoreMalformed = ((GeoShapeFieldMapper)fieldMapper).ignoreMalformed();
@@ -205,7 +205,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
             .endObject().endObject());
 
         defaultMapper = createIndex("test2").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        fieldMapper = defaultMapper.mappers().getMapper("location");
+        fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         ignoreMalformed = ((GeoShapeFieldMapper)fieldMapper).ignoreMalformed();
@@ -224,7 +224,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -247,7 +247,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -275,7 +275,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
 
 
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -299,7 +299,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
 
 
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -325,7 +325,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                     .endObject().endObject());
 
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -349,7 +349,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                     .endObject().endObject());
 
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -372,7 +372,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                     .endObject().endObject());
 
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -394,7 +394,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -417,7 +417,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
 
 
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -439,7 +439,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                     .endObject().endObject());
 
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            FieldMapper fieldMapper = defaultMapper.mappers().getMapper("location");
+            FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("location");
             assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
             GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -474,7 +474,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
         }
 
         // verify nothing changed
-        FieldMapper fieldMapper = docMapper.mappers().getMapper("shape");
+        FieldMapper fieldMapper = docMapper.mappers().getFieldMapper("shape");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         GeoShapeFieldMapper geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -492,7 +492,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .field("tree_levels", 8).field("distance_error_pct", 0.001).field("orientation", "cw").endObject().endObject().endObject().endObject());
         docMapper = mapperService.merge("type", new CompressedXContent(stage2Mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        fieldMapper = docMapper.mappers().getMapper("shape");
+        fieldMapper = docMapper.mappers().getFieldMapper("shape");
         assertThat(fieldMapper, instanceOf(GeoShapeFieldMapper.class));
 
         geoShapeFieldMapper = (GeoShapeFieldMapper) fieldMapper;
@@ -530,7 +530,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject()
                 .endObject().endObject());
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getFieldMapper("location"));
             assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
             assertTrue(serialized, serialized.contains("\"tree_levels\":21"));
         }
@@ -542,7 +542,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject()
                 .endObject().endObject());
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getFieldMapper("location"));
             assertTrue(serialized, serialized.contains("\"precision\":\"50.0m\""));
             assertTrue(serialized, serialized.contains("\"tree_levels\":9"));
         }
@@ -555,7 +555,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject()
                 .endObject().endObject());
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getFieldMapper("location"));
             assertFalse(serialized, serialized.contains("\"precision\":"));
             assertTrue(serialized, serialized.contains("\"tree_levels\":6"));
         }
@@ -568,7 +568,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject()
                 .endObject().endObject());
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getFieldMapper("location"));
             assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
             assertFalse(serialized, serialized.contains("\"tree_levels\":"));
         }
@@ -582,7 +582,7 @@ public class GeoShapeFieldMapperTests extends ESSingleNodeTestCase {
                 .endObject().endObject()
                 .endObject().endObject());
             DocumentMapper defaultMapper = parser.parse("type1", new CompressedXContent(mapping));
-            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getMapper("location"));
+            String serialized = toXContentString((GeoShapeFieldMapper) defaultMapper.mappers().getFieldMapper("location"));
             assertTrue(serialized, serialized.contains("\"precision\":\"6.0m\""));
             assertTrue(serialized, serialized.contains("\"tree_levels\":5"));
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/JavaMultiFieldMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JavaMultiFieldMergeTests.java
@@ -40,8 +40,8 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
 
         DocumentMapper docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.indexed"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), nullValue());
 
         BytesReference json = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("name", "some name").endObject());
         Document doc = docMapper.parse(SourceToParse.source("test", "person", "1", json, XContentType.JSON)).rootDoc();
@@ -53,13 +53,13 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping2.json");
         docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), nullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed2"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed3"), nullValue());
 
         doc = docMapper.parse(SourceToParse.source("test", "person", "1", json, XContentType.JSON)).rootDoc();
         f = doc.getField("name");
@@ -70,24 +70,24 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping3.json");
         docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed2"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed3"), nullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping4.json");
         docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), notNullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed2"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed3"), notNullValue());
     }
 
     public void testUpgradeFromMultiFieldTypeToMultiFields() throws Exception {
@@ -96,8 +96,8 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
 
         DocumentMapper docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.indexed"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), nullValue());
 
         BytesReference json = BytesReference.bytes(XContentFactory.jsonBuilder().startObject().field("name", "some name").endObject());
         Document doc = docMapper.parse(SourceToParse.source("test", "person", "1", json, XContentType.JSON)).rootDoc();
@@ -110,13 +110,13 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade1.json");
         docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), nullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed2"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed3"), nullValue());
 
         doc = docMapper.parse(SourceToParse.source("test", "person", "1", json, XContentType.JSON)).rootDoc();
         f = doc.getField("name");
@@ -127,13 +127,13 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade2.json");
         docMapper = mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
 
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed2"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed3"), nullValue());
 
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade3.json");
@@ -146,10 +146,10 @@ public class JavaMultiFieldMergeTests extends ESSingleNodeTestCase {
         }
 
         // There are conflicts, so the `name.not_indexed3` has not been added
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed2"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed3"), nullValue());
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed2"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed3"), nullValue());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MultiFieldTests.java
@@ -84,37 +84,37 @@ public class MultiFieldTests extends ESSingleNodeTestCase {
         assertThat(f.name(), equalTo("object1.multi1.string"));
         assertThat(f.binaryValue(), equalTo(new BytesRef("2010-01-01")));
 
-        assertThat(docMapper.mappers().getMapper("name"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name"), instanceOf(TextFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name").fieldType().stored(), equalTo(true));
-        assertThat(docMapper.mappers().getMapper("name").fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getFieldMapper("name"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name"), instanceOf(TextFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name").fieldType().stored(), equalTo(true));
+        assertThat(docMapper.mappers().getFieldMapper("name").fieldType().tokenized(), equalTo(true));
 
-        assertThat(docMapper.mappers().getMapper("name.indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.indexed"), instanceOf(TextFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name.indexed").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.indexed").fieldType().stored(), equalTo(false));
-        assertThat(docMapper.mappers().getMapper("name.indexed").fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed"), instanceOf(TextFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name.indexed").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed").fieldType().stored(), equalTo(false));
+        assertThat(docMapper.mappers().getFieldMapper("name.indexed").fieldType().tokenized(), equalTo(true));
 
-        assertThat(docMapper.mappers().getMapper("name.not_indexed"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed"), instanceOf(TextFieldMapper.class));
-        assertEquals(IndexOptions.NONE, docMapper.mappers().getMapper("name.not_indexed").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.not_indexed").fieldType().stored(), equalTo(true));
-        assertThat(docMapper.mappers().getMapper("name.not_indexed").fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed"), instanceOf(TextFieldMapper.class));
+        assertEquals(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name.not_indexed").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed").fieldType().stored(), equalTo(true));
+        assertThat(docMapper.mappers().getFieldMapper("name.not_indexed").fieldType().tokenized(), equalTo(true));
 
-        assertThat(docMapper.mappers().getMapper("name.test1"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name.test1"), instanceOf(TextFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("name.test1").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("name.test1").fieldType().stored(), equalTo(true));
-        assertThat(docMapper.mappers().getMapper("name.test1").fieldType().tokenized(), equalTo(true));
-        assertThat(docMapper.mappers().getMapper("name.test1").fieldType().eagerGlobalOrdinals(), equalTo(true));
+        assertThat(docMapper.mappers().getFieldMapper("name.test1"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name.test1"), instanceOf(TextFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("name.test1").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("name.test1").fieldType().stored(), equalTo(true));
+        assertThat(docMapper.mappers().getFieldMapper("name.test1").fieldType().tokenized(), equalTo(true));
+        assertThat(docMapper.mappers().getFieldMapper("name.test1").fieldType().eagerGlobalOrdinals(), equalTo(true));
 
-        assertThat(docMapper.mappers().getMapper("object1.multi1"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("object1.multi1"), instanceOf(DateFieldMapper.class));
-        assertThat(docMapper.mappers().getMapper("object1.multi1.string"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("object1.multi1.string"), instanceOf(KeywordFieldMapper.class));
-        assertNotSame(IndexOptions.NONE, docMapper.mappers().getMapper("object1.multi1.string").fieldType().indexOptions());
-        assertThat(docMapper.mappers().getMapper("object1.multi1.string").fieldType().tokenized(), equalTo(false));
+        assertThat(docMapper.mappers().getFieldMapper("object1.multi1"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("object1.multi1"), instanceOf(DateFieldMapper.class));
+        assertThat(docMapper.mappers().getFieldMapper("object1.multi1.string"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("object1.multi1.string"), instanceOf(KeywordFieldMapper.class));
+        assertNotSame(IndexOptions.NONE, docMapper.mappers().getFieldMapper("object1.multi1.string").fieldType().indexOptions());
+        assertThat(docMapper.mappers().getFieldMapper("object1.multi1.string").fieldType().tokenized(), equalTo(false));
     }
 
     public void testBuildThenParse() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/PathMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/PathMapperTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import java.io.IOException;
@@ -35,18 +34,18 @@ public class PathMapperTests extends ESSingleNodeTestCase {
         DocumentMapper docMapper = createIndex("test").mapperService().documentMapperParser().parse("person", new CompressedXContent(mapping));
 
         // test full name
-        assertThat(docMapper.mappers().getMapper("first1"), nullValue());
-        assertThat(docMapper.mappers().getMapper("name1.first1"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("last1"), nullValue());
-        assertThat(docMapper.mappers().getMapper("i_last_1"), nullValue());
-        assertThat(docMapper.mappers().getMapper("name1.last1"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("name1.i_last_1"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("first1"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name1.first1"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("last1"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("i_last_1"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name1.last1"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name1.i_last_1"), nullValue());
 
-        assertThat(docMapper.mappers().getMapper("first2"), nullValue());
-        assertThat(docMapper.mappers().getMapper("name2.first2"), notNullValue());
-        assertThat(docMapper.mappers().getMapper("last2"), nullValue());
-        assertThat(docMapper.mappers().getMapper("i_last_2"), nullValue());
-        assertThat(docMapper.mappers().getMapper("name2.i_last_2"), nullValue());
-        assertThat(docMapper.mappers().getMapper("name2.last2"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("first2"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name2.first2"), notNullValue());
+        assertThat(docMapper.mappers().getFieldMapper("last2"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("i_last_2"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name2.i_last_2"), nullValue());
+        assertThat(docMapper.mappers().getFieldMapper("name2.last2"), notNullValue());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/PathMatchDynamicTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/PathMatchDynamicTemplateTests.java
@@ -23,10 +23,7 @@ import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.ParseContext.Document;
-import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 
 import static org.elasticsearch.test.StreamsUtils.copyToBytesFromClasspath;
@@ -52,26 +49,26 @@ public class PathMatchDynamicTemplateTests extends ESSingleNodeTestCase {
         assertThat(f.stringValue(), equalTo("top_level"));
         assertThat(f.fieldType().stored(), equalTo(false));
 
-        FieldMapper fieldMapper = docMapper.mappers().getMapper("name");
+        FieldMapper fieldMapper = docMapper.mappers().getFieldMapper("name");
         assertThat(fieldMapper.fieldType().stored(), equalTo(false));
 
         f = doc.getField("obj1.name");
         assertThat(f.name(), equalTo("obj1.name"));
         assertThat(f.fieldType().stored(), equalTo(true));
 
-        fieldMapper = docMapper.mappers().getMapper("obj1.name");
+        fieldMapper = docMapper.mappers().getFieldMapper("obj1.name");
         assertThat(fieldMapper.fieldType().stored(), equalTo(true));
 
         f = doc.getField("obj1.obj2.name");
         assertThat(f.name(), equalTo("obj1.obj2.name"));
         assertThat(f.fieldType().stored(), equalTo(false));
 
-        fieldMapper = docMapper.mappers().getMapper("obj1.obj2.name");
+        fieldMapper = docMapper.mappers().getFieldMapper("obj1.obj2.name");
         assertThat(fieldMapper.fieldType().stored(), equalTo(false));
 
         // verify more complex path_match expressions
 
-        fieldMapper = docMapper.mappers().getMapper("obj3.obj4.prop1");
+        fieldMapper = docMapper.mappers().getFieldMapper("obj3.obj4.prop1");
         assertNotNull(fieldMapper);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -492,7 +492,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
 
         assertEquals(mapping, mapper.mappingSource().toString());
-        assertTrue(mapper.mappers().getMapper("field").fieldType().eagerGlobalOrdinals());
+        assertTrue(mapper.mappers().getFieldMapper("field").fieldType().eagerGlobalOrdinals());
     }
 
     public void testFielddata() throws IOException {
@@ -505,7 +505,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper disabledMapper = parser.parse("type", new CompressedXContent(mapping));
         assertEquals(mapping, disabledMapper.mappingSource().toString());
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> disabledMapper.mappers().getMapper("field").fieldType().fielddataBuilder("test"));
+                () -> disabledMapper.mappers().getFieldMapper("field").fieldType().fielddataBuilder("test"));
         assertThat(e.getMessage(), containsString("Fielddata is disabled"));
 
         mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
@@ -518,7 +518,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper enabledMapper = parser.parse("type", new CompressedXContent(mapping));
 
         assertEquals(mapping, enabledMapper.mappingSource().toString());
-        enabledMapper.mappers().getMapper("field").fieldType().fielddataBuilder("test"); // no exception this time
+        enabledMapper.mappers().getFieldMapper("field").fieldType().fielddataBuilder("test"); // no exception this time
 
         String illegalMapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("type")
                 .startObject("properties").startObject("field")
@@ -547,7 +547,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
         DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
 
         assertEquals(mapping, mapper.mappingSource().toString());
-        TextFieldType fieldType = (TextFieldType) mapper.mappers().getMapper("field").fieldType();
+        TextFieldType fieldType = (TextFieldType) mapper.mappers().getFieldMapper("field").fieldType();
         assertThat(fieldType.fielddataMinFrequency(), equalTo(2d));
         assertThat(fieldType.fielddataMaxFrequency(), equalTo((double) Integer.MAX_VALUE));
         assertThat(fieldType.fielddataMinSegmentSize(), equalTo(1000));
@@ -630,7 +630,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
 
             DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
 
-            FieldMapper prefix = mapper.mappers().getMapper("field._index_prefix");
+            FieldMapper prefix = mapper.mappers().getFieldMapper("field._index_prefix");
             FieldType ft = prefix.fieldType;
             assertEquals(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS, ft.indexOptions());
         }
@@ -646,7 +646,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
 
             DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
 
-            FieldMapper prefix = mapper.mappers().getMapper("field._index_prefix");
+            FieldMapper prefix = mapper.mappers().getFieldMapper("field._index_prefix");
             FieldType ft = prefix.fieldType;
             assertEquals(IndexOptions.DOCS, ft.indexOptions());
             assertFalse(ft.storeTermVectors());
@@ -663,7 +663,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
 
             DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
 
-            FieldMapper prefix = mapper.mappers().getMapper("field._index_prefix");
+            FieldMapper prefix = mapper.mappers().getFieldMapper("field._index_prefix");
             FieldType ft = prefix.fieldType;
             if (indexService.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_4_0)) {
                 assertEquals(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS, ft.indexOptions());
@@ -684,7 +684,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
 
             DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
 
-            FieldMapper prefix = mapper.mappers().getMapper("field._index_prefix");
+            FieldMapper prefix = mapper.mappers().getFieldMapper("field._index_prefix");
             FieldType ft = prefix.fieldType;
             if (indexService.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_4_0)) {
                 assertEquals(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS, ft.indexOptions());
@@ -705,7 +705,7 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
 
             DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
 
-            FieldMapper prefix = mapper.mappers().getMapper("field._index_prefix");
+            FieldMapper prefix = mapper.mappers().getFieldMapper("field._index_prefix");
             FieldType ft = prefix.fieldType;
             if (indexService.getIndexSettings().getIndexVersionCreated().onOrAfter(Version.V_6_4_0)) {
                 assertEquals(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS, ft.indexOptions());
@@ -834,11 +834,11 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
             DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
             assertEquals(mapping, mapper.mappingSource().toString());
 
-            assertThat(mapper.mappers().getMapper("field._index_prefix").toString(), containsString("prefixChars=1:10"));
+            assertThat(mapper.mappers().getFieldMapper("field._index_prefix").toString(), containsString("prefixChars=1:10"));
 
-            Query q = mapper.mappers().getMapper("field").fieldType().prefixQuery("goin", CONSTANT_SCORE_REWRITE, queryShardContext);
+            Query q = mapper.mappers().getFieldMapper("field").fieldType().prefixQuery("goin", CONSTANT_SCORE_REWRITE, queryShardContext);
             assertEquals(new ConstantScoreQuery(new TermQuery(new Term("field._index_prefix", "goin"))), q);
-            q = mapper.mappers().getMapper("field").fieldType().prefixQuery("internationalisatio",
+            q = mapper.mappers().getFieldMapper("field").fieldType().prefixQuery("internationalisatio",
                 CONSTANT_SCORE_REWRITE, queryShardContext);
             assertEquals(new PrefixQuery(new Term("field", "internationalisatio")), q);
 
@@ -864,16 +864,16 @@ public class TextFieldMapperTests extends ESSingleNodeTestCase {
             CompressedXContent json = new CompressedXContent(mapping);
             DocumentMapper mapper = parser.parse("type", json);
 
-            Query q1 = mapper.mappers().getMapper("field").fieldType().prefixQuery("g",
+            Query q1 = mapper.mappers().getFieldMapper("field").fieldType().prefixQuery("g",
                 CONSTANT_SCORE_REWRITE, queryShardContext);
             assertThat(q1, instanceOf(PrefixQuery.class));
-            Query q2 = mapper.mappers().getMapper("field").fieldType().prefixQuery("go",
+            Query q2 = mapper.mappers().getFieldMapper("field").fieldType().prefixQuery("go",
                 CONSTANT_SCORE_REWRITE, queryShardContext);
             assertThat(q2, instanceOf(ConstantScoreQuery.class));
-            Query q5 = mapper.mappers().getMapper("field").fieldType().prefixQuery("going",
+            Query q5 = mapper.mappers().getFieldMapper("field").fieldType().prefixQuery("going",
                 CONSTANT_SCORE_REWRITE, queryShardContext);
             assertThat(q5, instanceOf(ConstantScoreQuery.class));
-            Query q6 = mapper.mappers().getMapper("field").fieldType().prefixQuery("goings",
+            Query q6 = mapper.mappers().getFieldMapper("field").fieldType().prefixQuery("goings",
                 CONSTANT_SCORE_REWRITE, queryShardContext);
             assertThat(q6, instanceOf(PrefixQuery.class));
         }

--- a/server/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
@@ -99,9 +99,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().get(), instanceOf(ClassicSimilarity.class));
+        assertThat(documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get(), instanceOf(ClassicSimilarity.class));
 
-        ClassicSimilarity similarity = (ClassicSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        ClassicSimilarity similarity = (ClassicSimilarity) documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getDiscountOverlaps(), equalTo(false));
     }
 
@@ -131,9 +131,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().get(), instanceOf(BM25Similarity.class));
+        assertThat(documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get(), instanceOf(BM25Similarity.class));
 
-        BM25Similarity similarity = (BM25Similarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        BM25Similarity similarity = (BM25Similarity) documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getK1(), equalTo(2.0f));
         assertThat(similarity.getB(), equalTo(0.5f));
         assertThat(similarity.getDiscountOverlaps(), equalTo(false));
@@ -150,7 +150,7 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         DocumentMapper documentMapper = indexService.mapperService()
             .documentMapperParser()
             .parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().get(),
+        assertThat(documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get(),
             instanceOf(BooleanSimilarity.class));
     }
 
@@ -170,9 +170,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().get(), instanceOf(DFRSimilarity.class));
+        assertThat(documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get(), instanceOf(DFRSimilarity.class));
 
-        DFRSimilarity similarity = (DFRSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        DFRSimilarity similarity = (DFRSimilarity) documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getBasicModel(), instanceOf(BasicModelG.class));
         assertThat(similarity.getAfterEffect(), instanceOf(AfterEffectL.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -195,9 +195,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().get(), instanceOf(IBSimilarity.class));
+        assertThat(documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get(), instanceOf(IBSimilarity.class));
 
-        IBSimilarity similarity = (IBSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        IBSimilarity similarity = (IBSimilarity) documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getDistribution(), instanceOf(DistributionSPL.class));
         assertThat(similarity.getLambda(), instanceOf(LambdaTTF.class));
         assertThat(similarity.getNormalization(), instanceOf(NormalizationH2.class));
@@ -217,7 +217,7 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        MappedFieldType fieldType = documentMapper.mappers().getMapper("field1").fieldType();
+        MappedFieldType fieldType = documentMapper.mappers().getFieldMapper("field1").fieldType();
         assertThat(fieldType.similarity().get(), instanceOf(DFISimilarity.class));
         DFISimilarity similarity = (DFISimilarity) fieldType.similarity().get();
         assertThat(similarity.getIndependence(), instanceOf(IndependenceChiSquared.class));
@@ -236,9 +236,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().get(), instanceOf(LMDirichletSimilarity.class));
+        assertThat(documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get(), instanceOf(LMDirichletSimilarity.class));
 
-        LMDirichletSimilarity similarity = (LMDirichletSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        LMDirichletSimilarity similarity = (LMDirichletSimilarity) documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getMu(), equalTo(3000f));
     }
 
@@ -255,9 +255,9 @@ public class SimilarityTests extends ESSingleNodeTestCase {
             .build();
         IndexService indexService = createIndex("foo", indexSettings);
         DocumentMapper documentMapper = indexService.mapperService().documentMapperParser().parse("type", new CompressedXContent(mapping));
-        assertThat(documentMapper.mappers().getMapper("field1").fieldType().similarity().get(), instanceOf(LMJelinekMercerSimilarity.class));
+        assertThat(documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get(), instanceOf(LMJelinekMercerSimilarity.class));
 
-        LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) documentMapper.mappers().getMapper("field1").fieldType().similarity().get();
+        LMJelinekMercerSimilarity similarity = (LMJelinekMercerSimilarity) documentMapper.mappers().getFieldMapper("field1").fieldType().similarity().get();
         assertThat(similarity.getLambda(), equalTo(0.7f));
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/state/RareClusterStateIT.java
@@ -369,7 +369,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
             final MapperService mapperService = indexService.mapperService();
             DocumentMapper mapper = mapperService.documentMapper("type");
             assertNotNull(mapper);
-            assertNotNull(mapper.mappers().getMapper("field"));
+            assertNotNull(mapper.mappers().getFieldMapper("field"));
         });
 
         final AtomicReference<Object> docIndexResponse = new AtomicReference<>();

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -74,7 +74,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(jsonBuilder()
@@ -113,7 +113,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(jsonBuilder()
@@ -147,7 +147,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(jsonBuilder()
@@ -181,7 +181,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(jsonBuilder()
@@ -247,7 +247,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(jsonBuilder()
@@ -279,7 +279,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(jsonBuilder()
@@ -345,7 +345,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         XContentBuilder builder = jsonBuilder()
                 .startObject()
@@ -715,7 +715,7 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         CompletionFieldType completionFieldType = (CompletionFieldType) fieldMapper.fieldType();
 
         Exception e = expectThrows(IllegalArgumentException.class, () -> completionFieldType.getContextMappings().get("brand"));

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
@@ -63,7 +63,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(jsonBuilder()
@@ -103,7 +103,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(jsonBuilder()
@@ -140,7 +140,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         ParsedDocument parsedDocument = defaultMapper.parse(SourceToParse.source("test", "type1", "1", BytesReference
                 .bytes(jsonBuilder()
@@ -185,7 +185,7 @@ public class GeoContextMappingTests extends ESSingleNodeTestCase {
                 .endObject().endObject());
 
         DocumentMapper defaultMapper = createIndex("test").mapperService().documentMapperParser().parse("type1", new CompressedXContent(mapping));
-        FieldMapper fieldMapper = defaultMapper.mappers().getMapper("completion");
+        FieldMapper fieldMapper = defaultMapper.mappers().getFieldMapper("completion");
         MappedFieldType completionFieldType = fieldMapper.fieldType();
         XContentBuilder builder = jsonBuilder()
                 .startObject()


### PR DESCRIPTION
This PR updates `DocumentFieldMappers#getMapper` to return both concrete fields and field aliases. Its method signature now has a top-level `Mapper` as its return type as opposed to a `FieldMapper`.

To support incremental changes, there is still a `getFieldMapper` method that returns a `FieldMapper` as before. Almost all callers were migrated to use the method that returns a `Mapper`, except the ~250 instances in `server_test` that require a `FieldMapper`. The `getFieldMapper` method has been marked as deprecated.

Updating `DocumentFieldMappers#getMappers` in this way has a few advantages:
- **There is now only one recommended way to retrieve a field's type information**, and this pathway will correctly resolve field aliases. By switching callers over to use the new method signature, I found a few bugs that would've been difficult to anticipate otherwise (see the fixes below around percolate queries and geo suggestion contexts). This also helps avoid future bugs from being introduced by a developer accessing `MappedFieldType` in the wrong way.
- By returning a `Mapper`, we force consumers to consider how field aliases should be handled. This also caught a few bugs (see the fixes below around dynamic object mappers and copy_to).
- Because we return both concrete fields and aliases, **the 'get field mappings' API now supports aliases** without any additional work.

Open questions:
- Are we okay with ~250 deprecated method calls in tests? I briefly looked into removing them, and it is a very large amount of manual work.
- A natural option would be to introduce a parent class for `FieldMapper` and `FieldAliasMapper`, instead of just using the top-level `Mapper`. I quickly tried this out and didn't think it made things much cleaner, and also adds complexity to an (already complex) mapper hierarchy. I would be happy to take a more detailed look at it though.