### PR TITLE
WIP Add a pointer to our hosted ES service

### DIFF
--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -14,6 +14,9 @@ Here are a few sample use-cases that Elasticsearch could be used for:
 * You have analytics/business-intelligence needs and want to quickly investigate, analyze, visualize, and ask ad-hoc questions on a lot of data (think millions or billions of records). In this case, you can use Elasticsearch to store your data and then use Kibana (part of the Elasticsearch/Logstash/Kibana stack) to build custom dashboards that can visualize aspects of your data that are important to you. Additionally, you can use the Elasticsearch aggregations functionality to perform complex business intelligence queries against your data.
 
 For the rest of this tutorial, you will be guided through the process of getting Elasticsearch up and running, taking a peek inside it, and performing basic operations like indexing, searching, and modifying your data. At the end of this tutorial, you should have a good idea of what Elasticsearch is, how it works, and hopefully be inspired to see how you can use it to either build sophisticated search applications or to mine intelligence from your data.
+
+TIP: Want to get Elasticsearch up and running quickly? Sign up for a free trial of our hosted https://www.elastic.co/cloud/elasticsearch-service[Elasticsearch Service] to use with this tutorial.
+
 --
 
 == Basic Concepts

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -15,7 +15,7 @@ Here are a few sample use-cases that Elasticsearch could be used for:
 
 For the rest of this tutorial, you will be guided through the process of getting Elasticsearch up and running, taking a peek inside it, and performing basic operations like indexing, searching, and modifying your data. At the end of this tutorial, you should have a good idea of what Elasticsearch is, how it works, and hopefully be inspired to see how you can use it to either build sophisticated search applications or to mine intelligence from your data.
 
-TIP: Want to get Elasticsearch up and running quickly? Sign up for a free trial of our hosted https://www.elastic.co/cloud/elasticsearch-service[Elasticsearch Service] to use with this tutorial.
+TIP: Want to get Elasticsearch up and running quickly? Try our hosted https://www.elastic.co/cloud/elasticsearch-service[Elasticsearch Service] for free. 
 
 --
 


### PR DESCRIPTION
This PR adds a pointer to our hosted Elasticsearch service from the [ES getting started steps](https://www.elastic.co/guide/en/elasticsearch/reference/current/_create_an_index.html), as per an email thread with @sfingerhut and @emorales1:

![image](https://user-images.githubusercontent.com/15148011/42115472-d50c2618-7ba7-11e8-9a8c-729842a3627a.png)

There is a problem with this plan: The  **COPY AS CURL** button used in the getting started section doesn't work against our hosted Elasticsearch Service as is, with no way to change that. To make our hosted Elasticsearch Service a viable alternative for people trying out these getting started steps, we would need:

* A way to configure the  **COPY AS CURL** button to use ES endpoints on Cloud (e.g. `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.us-east-1.aws.found.io` instead of `localhost`).
* Support for HTTPS endpoints. We strong recommend HTTPS and some regions don't support HTTP (e.g. Frankfurt).
* A way to tell people that they also need to authenticate with -u elastic:<password> when running these curl commands. (I don't think we want to let people save their elastic superuser PW in the docs console to do it for them, so this adds a manual step for every example command.) 

On the upside, the current configuration modal lets you set the Kibana endpoint, which works just fine against Cloud when I tested it just now:
![image](https://user-images.githubusercontent.com/15148011/42114855-7d84feda-7ba5-11e8-8007-8141cd673164.png)

