### PR TITLE
[DOCS] Starting Elasticsearch

### DIFF
--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -55,4 +55,6 @@ include::setup/sysconfig.asciidoc[]
 
 include::setup/bootstrap-checks.asciidoc[]
 
+include::setup/starting.asciidoc[]
+
 include::setup/stopping.asciidoc[]

--- a/docs/reference/setup/install/deb-init.asciidoc
+++ b/docs/reference/setup/install/deb-init.asciidoc
@@ -1,0 +1,20 @@
+==== Running Elasticsearch with SysV `init`
+
+Use the `update-rc.d` command to configure Elasticsearch to start automatically
+when the system boots up:
+
+[source,sh]
+--------------------------------------------------
+sudo update-rc.d elasticsearch defaults 95 10
+--------------------------------------------------
+
+Elasticsearch can be started and stopped using the `service` command:
+
+[source,sh]
+--------------------------------------------
+sudo -i service elasticsearch start
+sudo -i service elasticsearch stop
+--------------------------------------------
+
+If Elasticsearch fails to start for any reason, it will print the reason for
+failure to STDOUT. Log files can be found in `/var/log/elasticsearch/`.

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -146,26 +146,7 @@ endif::include-xpack[]
 include::init-systemd.asciidoc[]
 
 [[deb-running-init]]
-==== Running Elasticsearch with SysV `init`
-
-Use the `update-rc.d` command to configure Elasticsearch to start automatically
-when the system boots up:
-
-[source,sh]
---------------------------------------------------
-sudo update-rc.d elasticsearch defaults 95 10
---------------------------------------------------
-
-Elasticsearch can be started and stopped using the `service` command:
-
-[source,sh]
---------------------------------------------
-sudo -i service elasticsearch start
-sudo -i service elasticsearch stop
---------------------------------------------
-
-If Elasticsearch fails to start for any reason, it will print the reason for
-failure to STDOUT. Log files can be found in `/var/log/elasticsearch/`.
+include::deb-init.asciidoc[]
 
 [[deb-running-systemd]]
 include::systemd.asciidoc[]

--- a/docs/reference/setup/install/deb.asciidoc
+++ b/docs/reference/setup/install/deb.asciidoc
@@ -143,6 +143,8 @@ include::xpack-indices.asciidoc[]
 
 endif::include-xpack[]
 
+==== SysV `init` vs `systemd`
+
 include::init-systemd.asciidoc[]
 
 [[deb-running-init]]

--- a/docs/reference/setup/install/init-systemd.asciidoc
+++ b/docs/reference/setup/install/init-systemd.asciidoc
@@ -1,5 +1,3 @@
-==== SysV `init` vs `systemd`
-
 Elasticsearch is not started automatically after installation. How to start
 and stop Elasticsearch depends on whether your system uses SysV `init` or
 `systemd` (used by newer distributions).  You can tell which is being used by

--- a/docs/reference/setup/install/msi-windows-start.asciidoc
+++ b/docs/reference/setup/install/msi-windows-start.asciidoc
@@ -1,0 +1,16 @@
+==== Running Elasticsearch from the command line
+
+Once installed, Elasticsearch can be started from the command line, if not installed as a service
+and configured to start when installation completes, as follows:
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------
+.\bin\elasticsearch.exe
+--------------------------------------------
+
+The command line terminal will display output similar to the following:
+
+image::images/msi_installer/elasticsearch_exe.png[]
+
+By default, Elasticsearch runs in the foreground, prints its logs to `STDOUT` in addition
+to the `<cluster name>.log` file within `LOGSDIRECTORY`, and can be stopped by pressing `Ctrl-C`.

--- a/docs/reference/setup/install/rpm-init.asciidoc
+++ b/docs/reference/setup/install/rpm-init.asciidoc
@@ -1,0 +1,20 @@
+==== Running Elasticsearch with SysV `init`
+
+Use the `chkconfig` command to configure Elasticsearch to start automatically
+when the system boots up:
+
+[source,sh]
+--------------------------------------------------
+sudo chkconfig --add elasticsearch
+--------------------------------------------------
+
+Elasticsearch can be started and stopped using the `service` command:
+
+[source,sh]
+--------------------------------------------
+sudo -i service elasticsearch start
+sudo -i service elasticsearch stop
+--------------------------------------------
+
+If Elasticsearch fails to start for any reason, it will print the reason for
+failure to STDOUT. Log files can be found in `/var/log/elasticsearch/`.

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -133,27 +133,7 @@ endif::include-xpack[]
 include::init-systemd.asciidoc[]
 
 [[rpm-running-init]]
-==== Running Elasticsearch with SysV `init`
-
-Use the `chkconfig` command to configure Elasticsearch to start automatically
-when the system boots up:
-
-[source,sh]
---------------------------------------------------
-sudo chkconfig --add elasticsearch
---------------------------------------------------
-
-Elasticsearch can be started and stopped using the `service` command:
-
-[source,sh]
---------------------------------------------
-sudo -i service elasticsearch start
-sudo -i service elasticsearch stop
---------------------------------------------
-
-If Elasticsearch fails to start for any reason, it will print the reason for
-failure to STDOUT. Log files can be found in `/var/log/elasticsearch/`.
-
+include::rpm-init.asciidoc[]
 
 [[rpm-running-systemd]]
 include::systemd.asciidoc[]

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -130,6 +130,8 @@ include::xpack-indices.asciidoc[]
 
 endif::include-xpack[]
 
+==== SysV `init` vs `systemd`
+
 include::init-systemd.asciidoc[]
 
 [[rpm-running-init]]

--- a/docs/reference/setup/install/windows.asciidoc
+++ b/docs/reference/setup/install/windows.asciidoc
@@ -342,23 +342,7 @@ include::xpack-indices.asciidoc[]
 endif::include-xpack[]
 
 [[msi-installer-command-line-running]]
-==== Running Elasticsearch from the command line
-
-Once installed, Elasticsearch can be started from the command line, if not installed as a service
-and configured to start when installation completes, as follows:
-
-["source","sh",subs="attributes,callouts"]
---------------------------------------------
-.\bin\elasticsearch.exe
---------------------------------------------
-
-The command line terminal will display output similar to the following:
-
-[[msi-installer-elasticsearch-exe]]
-image::images/msi_installer/elasticsearch_exe.png[]
-
-By default, Elasticsearch runs in the foreground, prints its logs to `STDOUT` in addition
-to the `<cluster name>.log` file within `LOGSDIRECTORY`, and can be stopped by pressing `Ctrl-C`.
+include::msi-windows-start.asciidoc[]
 
 [[msi-installer-command-line-configuration]]
 ==== Configuring Elasticsearch on the command line

--- a/docs/reference/setup/install/zip-targz-daemon.asciidoc
+++ b/docs/reference/setup/install/zip-targz-daemon.asciidoc
@@ -1,0 +1,21 @@
+==== Running as a daemon
+
+To run Elasticsearch as a daemon, specify `-d` on the command line, and record
+the process ID in a file using the `-p` option:
+
+[source,sh]
+--------------------------------------------
+./bin/elasticsearch -d -p pid
+--------------------------------------------
+
+Log messages can be found in the `$ES_HOME/logs/` directory.
+
+To shut down Elasticsearch, kill the process ID recorded in the `pid` file:
+
+[source,sh]
+--------------------------------------------
+kill `cat pid`
+--------------------------------------------
+
+NOTE: The startup scripts provided in the <<rpm,RPM>> and <<deb,Debian>>
+packages take care of starting and stopping the Elasticsearch process for you.

--- a/docs/reference/setup/install/zip-targz-start.asciidoc
+++ b/docs/reference/setup/install/zip-targz-start.asciidoc
@@ -1,0 +1,17 @@
+==== Running Elasticsearch from the command line
+
+Elasticsearch can be started from the command line as follows:
+
+[source,sh]
+--------------------------------------------
+./bin/elasticsearch
+--------------------------------------------
+
+By default, Elasticsearch runs in the foreground, prints its logs to the
+standard output (`stdout`), and can be stopped by pressing `Ctrl-C`.
+
+NOTE: All scripts packaged with Elasticsearch require a version of Bash
+that supports arrays and assume that Bash is available at `/bin/bash`.
+As such, Bash should be available at this path either directly or via a
+symbolic link.
+

--- a/docs/reference/setup/install/zip-targz.asciidoc
+++ b/docs/reference/setup/install/zip-targz.asciidoc
@@ -98,7 +98,7 @@ Log printing to `stdout` can be disabled using the `-q` or `--quiet`
 option on the command line.
 
 [[setup-installation-daemon]]
-include::zip-targz-dameon.asciidoc[]
+include::zip-targz-daemon.asciidoc[]
 
 [[zip-targz-configuring]]
 ==== Configuring Elasticsearch on the command line

--- a/docs/reference/setup/install/zip-targz.asciidoc
+++ b/docs/reference/setup/install/zip-targz.asciidoc
@@ -90,22 +90,7 @@ include::xpack-indices.asciidoc[]
 endif::include-xpack[]
 
 [[zip-targz-running]]
-==== Running Elasticsearch from the command line
-
-Elasticsearch can be started from the command line as follows:
-
-[source,sh]
---------------------------------------------
-./bin/elasticsearch
---------------------------------------------
-
-By default, Elasticsearch runs in the foreground, prints its logs to the
-standard output (`stdout`), and can be stopped by pressing `Ctrl-C`.
-
-NOTE: All scripts packaged with Elasticsearch require a version of Bash
-that supports arrays and assume that Bash is available at `/bin/bash`.
-As such, Bash should be available at this path either directly or via a
-symbolic link.
+include::zip-targz-start.asciidoc[]
 
 include::check-running.asciidoc[]
 
@@ -113,27 +98,7 @@ Log printing to `stdout` can be disabled using the `-q` or `--quiet`
 option on the command line.
 
 [[setup-installation-daemon]]
-==== Running as a daemon
-
-To run Elasticsearch as a daemon, specify `-d` on the command line, and record
-the process ID in a file using the `-p` option:
-
-[source,sh]
---------------------------------------------
-./bin/elasticsearch -d -p pid
---------------------------------------------
-
-Log messages can be found in the `$ES_HOME/logs/` directory.
-
-To shut down Elasticsearch, kill the process ID recorded in the `pid` file:
-
-[source,sh]
---------------------------------------------
-kill `cat pid`
---------------------------------------------
-
-NOTE: The startup scripts provided in the <<rpm,RPM>> and <<deb,Debian>>
-packages take care of starting and stopping the Elasticsearch process for you.
+include::zip-targz-dameon.asciidoc[]
 
 [[zip-targz-configuring]]
 ==== Configuring Elasticsearch on the command line

--- a/docs/reference/setup/install/zip-windows-start.asciidoc
+++ b/docs/reference/setup/install/zip-windows-start.asciidoc
@@ -1,0 +1,11 @@
+==== Running Elasticsearch from the command line
+
+Elasticsearch can be started from the command line as follows:
+
+[source,sh]
+--------------------------------------------
+.\bin\elasticsearch.bat
+--------------------------------------------
+
+By default, Elasticsearch runs in the foreground, prints its logs to `STDOUT`,
+and can be stopped by pressing `Ctrl-C`.

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -58,17 +58,7 @@ include::xpack-indices.asciidoc[]
 endif::include-xpack[]
 
 [[windows-running]]
-==== Running Elasticsearch from the command line
-
-Elasticsearch can be started from the command line as follows:
-
-[source,sh]
---------------------------------------------
-.\bin\elasticsearch.bat
---------------------------------------------
-
-By default, Elasticsearch runs in the foreground, prints its logs to `STDOUT`,
-and can be stopped by pressing `Ctrl-C`.
+include::zip-windows-start.asciidoc[]
 
 [[windows-configuring]]
 ==== Configuring Elasticsearch on the command line

--- a/docs/reference/setup/starting.asciidoc
+++ b/docs/reference/setup/starting.asciidoc
@@ -11,7 +11,7 @@ If you installed {es} with a `.tar.gz` package, you can start {es} from the
 command line.  
 
 [float]
-include::install/targz-running.asciidoc[]
+include::install/zip-targz-start.asciidoc[]
 
 [float]
 include::install/zip-targz-daemon.asciidoc[]
@@ -56,6 +56,7 @@ from the command line. If you want it to start automatically at boot time
 without any user interaction, 
 <<msi-installer-windows-service,install {es} as a Windows service>>.
 
+[float]
 include::install/msi-windows-start.asciidoc[]
 
 [float]
@@ -68,5 +69,4 @@ include::install/init-systemd.asciidoc[]
 include::install/rpm-init.asciidoc[]
 
 [float]
-[[rpm-running-systemd]]
 include::install/systemd.asciidoc[]

--- a/docs/reference/setup/starting.asciidoc
+++ b/docs/reference/setup/starting.asciidoc
@@ -1,0 +1,72 @@
+[[starting-elasticsearch]]
+== Starting Elasticsearch
+
+The method for starting {es} varies depending on how you installed it. 
+
+[float]
+[[start-targz]]
+=== Archive packages (`.tar.gz`)
+
+If you installed {es} with a `.tar.gz` package, you can start {es} from the 
+command line.  
+
+[float]
+include::install/targz-running.asciidoc[]
+
+[float]
+include::install/zip-targz-daemon.asciidoc[]
+
+[float]
+[[start-zip]]
+=== Archive packages (`.zip`)
+
+If you installed {es} on Windows with a `.zip` package, you can start {es} from 
+the command line. If you want {es} to start automatically at boot time without 
+any user interaction, <<windows-service,install {es} as a service>>.
+
+[float]
+include::install/zip-windows-start.asciidoc[]
+
+[float]
+[[start-deb]]
+=== Debian packages
+
+include::install/init-systemd.asciidoc[]
+
+[float]
+include::install/deb-init.asciidoc[]
+
+[float]
+include::install/systemd.asciidoc[]
+
+[float]
+[[start-docker]]
+=== Docker images
+
+If you installed a Docker image, you can start {es} from the command line. There 
+are different methods depending on whether you're using development mode or 
+production mode. See <<docker-cli-run>>. 
+
+[float]
+[[start-msi]]
+=== MSI packages
+
+If you installed {es} on Windows using the `.msi` package, you can start {es} 
+from the command line. If you want it to start automatically at boot time 
+without any user interaction, 
+<<msi-installer-windows-service,install {es} as a Windows service>>.
+
+include::install/msi-windows-start.asciidoc[]
+
+[float]
+[[start-rpm]]
+=== RPM packages
+
+include::install/init-systemd.asciidoc[]
+
+[float]
+include::install/rpm-init.asciidoc[]
+
+[float]
+[[rpm-running-systemd]]
+include::install/systemd.asciidoc[]


### PR DESCRIPTION
This PR creates a "Starting Elasticsearch" page, similar to the "Stopping Elasticsearch" page here: https://www.elastic.co/guide/en/elasticsearch/reference/current/stopping-elasticsearch.html

The goal is to put this information in a separate page so that it can be referenced from getting started tutorials where we advise users to stop and start Elasticsearch several times and don't want to repeat all the various commands every time.

This new page re-uses the existing info about starting Elasticsearch on various distributions, which was buried in the installation pages.