### PR TITLE
Match the examples in the description

### DIFF
--- a/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/percentile-aggregation.asciidoc
@@ -69,8 +69,8 @@ percentiles: `[ 1, 5, 25, 50, 75, 95, 99 ]`.  The response will look like this:
 
 As you can see, the aggregation will return a calculated value for each percentile
 in the default range.  If we assume response times are in milliseconds, it is
-immediately obvious that the webpage normally loads in 10-723ms, but occasionally
-spikes to 941-980ms.
+immediately obvious that the webpage normally loads in 10-725ms, but occasionally
+spikes to 945-985ms.
 
 Often, administrators are only interested in outliers -- the extreme percentiles.
 We can specify just the percents we are interested in (requested percentiles


### PR DESCRIPTION
The example deviated a little bit from the description since they changed in [this](https://github.com/elastic/elasticsearch/commit/fc406c9a5ac900d3d63f22623b84ed885342c2d8) commit