### PR TITLE
Remove _all example

### DIFF
--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -485,32 +485,6 @@ GET /_search
 // CONSOLE
 // TEST[setup:twitter]
 
-
-[[highlight-all]]
-[float]
-=== Highlight in all fields
-
-By default, only fields that contains a query match are highlighted. Set
-`require_field_match` to `false` to highlight all fields.
-
-[source,js]
---------------------------------------------------
-GET /_search
-{
-    "query" : {
-        "match": { "user": "kimchy" }
-    },
-    "highlight" : {
-        "require_field_match": false,
-        "fields": {
-                "_all" : { "pre_tags" : ["<em>"], "post_tags" : ["</em>"] }
-        }
-    }
-}
---------------------------------------------------
-// CONSOLE
-// TEST[setup:twitter]
-
 [[matched-fields]]
 [float]
 === Combine matches on multiple fields


### PR DESCRIPTION
Since the `_all` is now deprecated and removed, this example in the highlight docs is irrelevant and confusing.

Note, there are many references to the `_all` field in this doc, some will require a rewrite of the examples so I didn't go into doing that.