### PR TITLE
Watcher: Fix chain input toXcontent serialization

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/watcher/get_watch/30_with_chain_input.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/watcher/get_watch/30_with_chain_input.yml
@@ -1,0 +1,51 @@
+---
+"Test get watch api with chained input and basic auth":
+  - do:
+      cluster.health:
+          wait_for_status: yellow
+
+  - do:
+      xpack.watcher.put_watch:
+        id: "my_watch"
+        body:  >
+          {
+            "trigger": {
+              "schedule": {
+                "cron": "0 0 0 1 * ? 2099"
+              }
+            },
+            "input": {
+              "chain": {
+                "inputs": [
+                  {
+                    "http": {
+                      "http": {
+                        "request": {
+                          "url" : "http://localhost/",
+                          "auth": {
+                            "basic": {
+                              "username": "Username123",
+                              "password": "Password123"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "actions": {
+              "logging": {
+                "logging": {
+                  "text": "logging statement here"
+                }
+              }
+            }
+          }
+
+  - do:
+      xpack.watcher.get_watch:
+        id: "my_watch"
+  - match: { found : true}
+  - match: { _id: "my_watch" }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/chain/ChainInput.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/chain/ChainInput.java
@@ -41,7 +41,7 @@ public class ChainInput implements Input {
         builder.startArray(INPUTS.getPreferredName());
         for (Tuple<String, Input> tuple : inputs) {
             builder.startObject().startObject(tuple.v1());
-            builder.field(tuple.v2().type(), tuple.v2());
+            builder.field(tuple.v2().type(), tuple.v2(), params);
             builder.endObject().endObject();
         }
         builder.endArray();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/chain/ChainInputTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/chain/ChainInputTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.xpack.watcher.input.simple.SimpleInput;
 import org.elasticsearch.xpack.watcher.input.simple.SimpleInputFactory;
 import org.elasticsearch.xpack.watcher.test.WatcherTestUtils;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -228,14 +227,14 @@ public class ChainInputTests extends ESTestCase {
 
     public void testThatXContentParametersArePassedToInputs() throws Exception {
         ToXContent.Params randomParams = new ToXContent.MapParams(Collections.singletonMap(randomAlphaOfLength(5), randomAlphaOfLength(5)));
-        ChainInput chainInput = new ChainInput(Collections.singletonList(Tuple.tuple("second", new Input() {
+        ChainInput chainInput = new ChainInput(Collections.singletonList(Tuple.tuple("whatever", new Input() {
             @Override
             public String type() {
                 return "test";
             }
 
             @Override
-            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) {
                 assertThat(params, sameInstance(randomParams));
                 return builder;
             }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/chain/ChainInputTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/chain/ChainInputTests.java
@@ -9,6 +9,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -18,6 +19,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
+import org.elasticsearch.xpack.core.watcher.input.Input;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
 import org.elasticsearch.xpack.watcher.common.http.HttpRequestTemplate;
 import org.elasticsearch.xpack.watcher.common.http.auth.basic.BasicAuth;
@@ -29,6 +31,8 @@ import org.elasticsearch.xpack.watcher.input.simple.SimpleInput;
 import org.elasticsearch.xpack.watcher.input.simple.SimpleInputFactory;
 import org.elasticsearch.xpack.watcher.test.WatcherTestUtils;
 
+import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,6 +50,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class ChainInputTests extends ESTestCase {
 
@@ -219,5 +224,35 @@ public class ChainInputTests extends ESTestCase {
         ElasticsearchParseException e =
                 expectThrows(ElasticsearchParseException.class, () -> chainInputFactory.parseInput("test", parser));
         assertThat(e.getMessage(), containsString("Expected starting JSON object after [first] in watch [test]"));
+    }
+
+    public void testThatXContentParametersArePassedToInputs() throws Exception {
+        ToXContent.Params params = new ToXContent.MapParams(Collections.singletonMap(randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        ChainInput chainInput = new ChainInput(Collections.singletonList(Tuple.tuple("second", new TestInput(params))));
+
+        try (XContentBuilder builder = jsonBuilder()) {
+            chainInput.toXContent(builder, params);
+        }
+    }
+
+    // a test input that checks the xcontent parameters to ensure the correct params have been passed
+    private static final class TestInput implements Input {
+
+        private ToXContent.Params expectedParams;
+
+        TestInput(ToXContent.Params expectedParams) {
+            this.expectedParams = expectedParams;
+        }
+
+        @Override
+        public String type() {
+            return "test";
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            assertThat(params, sameInstance(expectedParams));
+            return builder;
+        }
     }
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/chain/ChainInputTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/input/chain/ChainInputTests.java
@@ -227,32 +227,22 @@ public class ChainInputTests extends ESTestCase {
     }
 
     public void testThatXContentParametersArePassedToInputs() throws Exception {
-        ToXContent.Params params = new ToXContent.MapParams(Collections.singletonMap(randomAlphaOfLength(5), randomAlphaOfLength(5)));
-        ChainInput chainInput = new ChainInput(Collections.singletonList(Tuple.tuple("second", new TestInput(params))));
+        ToXContent.Params randomParams = new ToXContent.MapParams(Collections.singletonMap(randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        ChainInput chainInput = new ChainInput(Collections.singletonList(Tuple.tuple("second", new Input() {
+            @Override
+            public String type() {
+                return "test";
+            }
+
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                assertThat(params, sameInstance(randomParams));
+                return builder;
+            }
+        })));
 
         try (XContentBuilder builder = jsonBuilder()) {
-            chainInput.toXContent(builder, params);
-        }
-    }
-
-    // a test input that checks the xcontent parameters to ensure the correct params have been passed
-    private static final class TestInput implements Input {
-
-        private ToXContent.Params expectedParams;
-
-        TestInput(ToXContent.Params expectedParams) {
-            this.expectedParams = expectedParams;
-        }
-
-        @Override
-        public String type() {
-            return "test";
-        }
-
-        @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            assertThat(params, sameInstance(expectedParams));
-            return builder;
+            chainInput.toXContent(builder, randomParams);
         }
     }
 }


### PR DESCRIPTION
The xcontent parameters were not passed to the xcontent serialization
of the chain input. This could lead to wrongly stored watches, which did
not contain passwords but only their redacted counterparts.