### PR TITLE
Change GeoHashGrid.Bucket#getKey() to return String

### DIFF
--- a/docs/reference/migration/migrate_7_0/aggregations.asciidoc
+++ b/docs/reference/migration/migrate_7_0/aggregations.asciidoc
@@ -23,3 +23,10 @@ Aggregation is now a variable called `state` available in the script context, ra
 being provided via the `params` object as `params._agg`.
 
 The old `params._agg` variable is still available as well.
+
+==== Change GeoHashGrid.Bucket#getKey() to return a String instead of a GeoPoint
+
+The aggregation bucket used to return a GeoPoint representing the bucket keys hash
+value. This was not consistent with the Rest API output that represents the key simply
+as the string value of the geohash. The Java API now also returns a String here which
+can be converted to a point as needed by the client.

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoHashUtils.java
@@ -77,7 +77,7 @@ public class GeoHashUtils {
         long b;
         long l = 0L;
         for(char c : hash.toCharArray()) {
-            b = (long)(BASE_32_STRING.indexOf(c));
+            b = BASE_32_STRING.indexOf(c);
             l |= (b<<(level--*5));
             if (level < 0) {
                 // We cannot handle more than 12 levels
@@ -178,7 +178,7 @@ public class GeoHashUtils {
         long b;
         long l = 0L;
         for(char c : hash.toCharArray()) {
-            b = (long)(BASE_32_STRING.indexOf(c));
+            b = BASE_32_STRING.indexOf(c);
             if (b < 0) {
                 throw new IllegalArgumentException("unsupported symbol [" + c + "] in geohash [" + hash + "]");
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
@@ -20,7 +20,6 @@ package org.elasticsearch.search.aggregations.bucket.geogrid;
 
 import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.common.geo.GeoHashUtils;
-import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
@@ -77,12 +76,12 @@ public class InternalGeoHashGrid extends InternalMultiBucketAggregation<Internal
 
         @Override
         public String getKeyAsString() {
-            return GeoHashUtils.stringEncode(geohashAsLong);
+            return getKey();
         }
 
         @Override
-        public GeoPoint getKey() {
-            return GeoPoint.fromGeohash(geohashAsLong);
+        public String getKey() {
+            return GeoHashUtils.stringEncode(geohashAsLong);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/ParsedGeoHashGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/ParsedGeoHashGrid.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.search.aggregations.bucket.geogrid;
 
-import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -57,8 +56,8 @@ public class ParsedGeoHashGrid extends ParsedMultiBucketAggregation<ParsedGeoHas
         private String geohashAsString;
 
         @Override
-        public GeoPoint getKey() {
-            return GeoPoint.fromGeohash(geohashAsString);
+        public String getKey() {
+            return geohashAsString;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GeoHashGridIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.GeoBoundingBoxQueryBuilder;
@@ -171,8 +170,8 @@ public class GeoHashGridIT extends ESIntegTestCase {
                 assertNotSame(bucketCount, 0);
                 assertEquals("Geohash " + geohash + " has wrong doc count ",
                         expectedBucketCount, bucketCount);
-                GeoPoint geoPoint = (GeoPoint) propertiesKeys[i];
-                assertThat(stringEncode(geoPoint.lon(), geoPoint.lat(), precision), equalTo(geohash));
+                String parsedGeoHash = (String) propertiesKeys[i];
+                assertThat(parsedGeoHash, equalTo(geohash));
                 assertThat((long) propertiesDocCounts[i], equalTo(bucketCount));
             }
         }


### PR DESCRIPTION
The GeoHashGrid bucket class currently returns a GeoPoint with its getKey()
method. The REST API returns geohash as a String in the key field of the bucket.
This changes the getKey() method to also return a String. Having the ability to
get a GeoPoint from a bucket that represents a geohash cell is misleading
because the cell does not represent a point but an area. Instead, it should be
the clients responsibility to make the decision on how to represent the bucket
key in its application. This also simplifies implementing the high level rest
client aspects of #30320, as the client will not need to know about the
GeoHashType being used and will only care that there is some string key for the
buckets.

Relates to #30320