### PR TITLE
Watcher: Ensure correct method is used to read secure settings

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/hipchat/HipChatService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/hipchat/HipChatService.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.watcher.notification.hipchat;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
@@ -35,10 +36,9 @@ public class HipChatService extends NotificationService<HipChatAccount> {
                     (key) -> Setting.simpleString(key, Setting.Property.Dynamic, Setting.Property.NodeScope, Setting.Property.Filtered,
                             Setting.Property.Deprecated));
 
-    private static final Setting.AffixSetting<String> SETTING_AUTH_TOKEN_SECURE =
+    private static final Setting.AffixSetting<SecureString> SETTING_AUTH_TOKEN_SECURE =
             Setting.affixKeySetting("xpack.notification.hipchat.account.", "secure_auth_token",
-                    (key) -> SecureSetting.simpleString(key, Setting.Property.Dynamic, Setting.Property.NodeScope,
-                            Setting.Property.Filtered));
+                    (key) -> SecureSetting.secureString(key, null));
 
     private static final Setting.AffixSetting<String> SETTING_PROFILE =
             Setting.affixKeySetting("xpack.notification.hipchat.account.", "profile",

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraService.java
@@ -6,6 +6,8 @@
 package org.elasticsearch.xpack.watcher.notification.jira;
 
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -41,17 +43,17 @@ public class JiraService extends NotificationService<JiraAccount> {
             Setting.affixKeySetting("xpack.notification.jira.account.", "password",
                     (key) -> Setting.simpleString(key, Property.Dynamic, Property.NodeScope, Property.Filtered, Property.Deprecated));
 
-    private static final Setting.AffixSetting<String> SETTING_SECURE_USER =
+    private static final Setting.AffixSetting<SecureString> SETTING_SECURE_USER =
             Setting.affixKeySetting("xpack.notification.jira.account.", "secure_user",
-                    (key) -> Setting.simpleString(key, Property.Dynamic, Property.NodeScope, Property.Filtered));
+                    (key) -> SecureSetting.secureString(key, null));
 
-    private static final Setting.AffixSetting<String> SETTING_SECURE_URL =
+    private static final Setting.AffixSetting<SecureString> SETTING_SECURE_URL =
             Setting.affixKeySetting("xpack.notification.jira.account.", "secure_url",
-                    (key) -> Setting.simpleString(key, Property.Dynamic, Property.NodeScope, Property.Filtered));
+                    (key) -> SecureSetting.secureString(key, null));
 
-    private static final Setting.AffixSetting<String> SETTING_SECURE_PASSWORD =
+    private static final Setting.AffixSetting<SecureString> SETTING_SECURE_PASSWORD =
             Setting.affixKeySetting("xpack.notification.jira.account.", "secure_password",
-                    (key) -> Setting.simpleString(key, Property.Dynamic, Property.NodeScope, Property.Filtered));
+                    (key) -> SecureSetting.secureString(key, null));
 
     private static final Setting.AffixSetting<Settings> SETTING_DEFAULTS =
             Setting.affixKeySetting("xpack.notification.jira.account.", "issue_defaults",

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/pagerduty/PagerDutyService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/pagerduty/PagerDutyService.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.watcher.notification.pagerduty;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -28,9 +29,9 @@ public class PagerDutyService extends NotificationService<PagerDutyAccount> {
             Setting.affixKeySetting("xpack.notification.pagerduty.account.", "service_api_key",
                     (key) -> Setting.simpleString(key, Property.Dynamic, Property.NodeScope, Property.Filtered, Property.Deprecated));
 
-    private static final Setting.AffixSetting<String> SETTING_SECURE_SERVICE_API_KEY =
+    private static final Setting.AffixSetting<SecureString> SETTING_SECURE_SERVICE_API_KEY =
             Setting.affixKeySetting("xpack.notification.pagerduty.account.", "secure_service_api_key",
-                    (key) -> SecureSetting.simpleString(key, Property.Dynamic, Property.NodeScope, Property.Filtered));
+                    (key) -> SecureSetting.secureString(key, null));
 
     private static final Setting.AffixSetting<Settings> SETTING_DEFAULTS =
             Setting.affixKeySetting("xpack.notification.pagerduty.account.", "event_defaults",

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/SlackService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/SlackService.java
@@ -7,6 +7,7 @@ package org.elasticsearch.xpack.watcher.notification.slack;
 
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.SecureSetting;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -28,9 +29,9 @@ public class SlackService extends NotificationService<SlackAccount> {
             Setting.affixKeySetting("xpack.notification.slack.account.", "url",
                     (key) -> Setting.simpleString(key, Property.Dynamic, Property.NodeScope, Property.Filtered, Property.Deprecated));
 
-    private static final Setting.AffixSetting<String> SETTING_URL_SECURE =
+    private static final Setting.AffixSetting<SecureString> SETTING_URL_SECURE =
             Setting.affixKeySetting("xpack.notification.slack.account.", "secure_url",
-                    (key) -> SecureSetting.simpleString(key, Property.Dynamic, Property.NodeScope, Property.Filtered));
+                    (key) -> SecureSetting.secureString(key, null));
 
     private static final Setting.AffixSetting<Settings> SETTING_DEFAULTS =
             Setting.affixKeySetting("xpack.notification.slack.account.", "message_defaults",


### PR DESCRIPTION
As SecureSetting is extended from Setting, you can easily accidentally
use `SecureSetting.simpleString()` to read a secure setting instead of
`SecureSetting.secureString()`. This commit changes this behaviour in
some watcher notification services.
