### PR TITLE
Watcher: Reenable start/stop yaml tests

### DIFF
--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/watcher/stats/10_basic.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/watcher/stats/10_basic.yml
@@ -1,17 +1,11 @@
 ---
 "Test watcher stats output":
-  - skip:
-      version: "all"
-      reason: "@AwaitsFix: https://github.com/elastic/elasticsearch/issues/30298"
   - do: {xpack.watcher.stats: {}}
   - match: { "manually_stopped": false }
   - match: { "stats.0.watcher_state": "started" }
 
 ---
 "Test watcher stats supports emit_stacktraces parameter":
-  - skip:
-      version: "all"
-      reason: "@AwaitsFix: https://github.com/elastic/elasticsearch/issues/30298"
   - do:
       xpack.watcher.stats:
         metric: "all"


### PR DESCRIPTION
The underlying cause for this has been fixed, thus the tests can be
reenabled.

Closes #30298