### PR TITLE
[DOCS] Add missing get mappings docs to HLRC

### DIFF
--- a/docs/java-rest/high-level/supported-apis.asciidoc
+++ b/docs/java-rest/high-level/supported-apis.asciidoc
@@ -81,6 +81,7 @@ Index Management::
 
 Mapping Management::
 * <<java-rest-high-put-mapping>>
+* <<java-rest-high-get-mappings>>
 * <<java-rest-high-get-field-mappings>>
 
 Alias Management::


### PR DESCRIPTION
This commit adds the high-level rest client docs for the get mappings API that
was added in #30889
