### PR TITLE
S3 fixture should report 404 on unknown bucket

### DIFF
--- a/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AmazonS3Fixture.java
+++ b/plugins/repository-s3/src/test/java/org/elasticsearch/repositories/s3/AmazonS3Fixture.java
@@ -96,8 +96,13 @@ public class AmazonS3Fixture extends AbstractHttpFixture {
             if (handler != null) {
                 final String bucket = request.getParam("bucket");
                 if (bucket != null && permittedBucket.equals(bucket) == false) {
-                    // allow a null bucket to support bucket-free APIs
-                    return newError(request.getId(), RestStatus.FORBIDDEN, "AccessDenied", "Bad bucket", "");
+                    // allow a null bucket to support the multi-object-delete API which
+                    // passes the bucket name in the host header instead of the URL.
+                    if (buckets.containsKey(bucket)) {
+                        return newError(request.getId(), RestStatus.FORBIDDEN, "AccessDenied", "Bad bucket", "");
+                    } else {
+                        return newBucketNotFoundError(request.getId(), bucket);
+                    }
                 }
                 return handler.handle(request);
             } else {

--- a/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/20_repository_permanent_credentials.yml
+++ b/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/20_repository_permanent_credentials.yml
@@ -183,10 +183,6 @@ setup:
 ---
 "Register a repository with a non existing bucket":
 
-  - skip:
-      version: all
-      reason: to be fixed
-
   - do:
       catch: /repository_exception/
       snapshot.create_repository:

--- a/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/30_repository_temporary_credentials.yml
+++ b/plugins/repository-s3/src/test/resources/rest-api-spec/test/repository_s3/30_repository_temporary_credentials.yml
@@ -183,10 +183,6 @@ setup:
 ---
 "Register a repository with a non existing bucket":
 
-  - skip:
-      version: all
-      reason: to be fixed
-
   - do:
       catch: /repository_exception/
       snapshot.create_repository:


### PR DESCRIPTION
Today, `AmazonS3Fixture` returns 403 on attempts to access any inappropriate
bucket, whether known or otherwise. In fact, S3 reports 404 on nonexistent
buckets and 403 on inaccessible ones. This change enhances AmazonS3Fixture to
distinguish these cases.
