### PR TITLE
SQL: Fix incorrect message for aliases

### DIFF
--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolver.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolver.java
@@ -253,7 +253,7 @@ public class IndexResolver {
             // need the same mapping across all resolutions
             if (!merged.get().mapping().equals(resolution.get().mapping())) {
                 return IndexResolution.invalid(
-                        "[" + indexWildcard + "] points to indices [" + resolution.get().name() + "] "
+                        "[" + indexWildcard + "] points to indices [" + merged.get().name() + "] "
                                 + "and [" + resolution.get().name() + "] which have different mappings. "
                                 + "When using multiple indices, the mappings must be identical.");
             }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -56,7 +56,8 @@ public class IndexResolverTests extends ESTestCase {
 
         MappingException ex = expectThrows(MappingException.class, () -> resolution.get());
         assertEquals(
-                "[*] points to indices [a] and [diff] which have different mappings. When using multiple indices, the mappings must be identical.",
+                "[*] points to indices [a] and [diff] which have different mappings. "
+                        + "When using multiple indices, the mappings must be identical.",
                 ex.getMessage());
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+package org.elasticsearch.xpack.sql.analysis.index;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.sql.type.EsField;
+import org.elasticsearch.xpack.sql.type.TypesTests;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class IndexResolverTests extends ESTestCase {
+
+    @Test
+    public void testMergeSameMapping() throws Exception {
+        Map<String, EsField> oneMapping = TypesTests.loadMapping("mapping-basic.json", true);
+        Map<String, EsField> sameMapping = TypesTests.loadMapping("mapping-basic.json", true);
+        assertNotSame(oneMapping, sameMapping);
+        assertEquals(oneMapping, sameMapping);
+
+        String wildcard = "*";
+        IndexResolution resolution = IndexResolver.merge(
+                Arrays.asList(IndexResolution.valid(new EsIndex("a", oneMapping)), IndexResolution.valid(new EsIndex("b", sameMapping))),
+                wildcard);
+
+        assertTrue(resolution.isValid());
+
+        EsIndex esIndex = resolution.get();
+
+        assertEquals(wildcard, esIndex.name());
+        assertEquals(sameMapping, esIndex.mapping());
+    }
+
+    @Test
+    public void testMergeDifferentMapping() throws Exception {
+        Map<String, EsField> oneMapping = TypesTests.loadMapping("mapping-basic.json", true);
+        Map<String, EsField> sameMapping = TypesTests.loadMapping("mapping-basic.json", true);
+        Map<String, EsField> differentMapping = TypesTests.loadMapping("mapping-numeric.json", true);
+
+        assertNotSame(oneMapping, sameMapping);
+        assertEquals(oneMapping, sameMapping);
+        assertNotEquals(oneMapping, differentMapping);
+
+        String wildcard = "*";
+        IndexResolution resolution = IndexResolver.merge(
+                Arrays.asList(IndexResolution.valid(new EsIndex("a", oneMapping)),
+                        IndexResolution.valid(new EsIndex("b", sameMapping)),
+                        IndexResolution.valid(new EsIndex("diff", differentMapping))),
+                wildcard);
+
+        assertFalse(resolution.isValid());
+
+        MappingException ex = expectThrows(MappingException.class, () -> resolution.get());
+        assertEquals(
+                "[*] points to indices [a] and [diff] which have different mappings. When using multiple indices, the mappings must be identical.",
+                ex.getMessage());
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -8,14 +8,12 @@ package org.elasticsearch.xpack.sql.analysis.index;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.type.EsField;
 import org.elasticsearch.xpack.sql.type.TypesTests;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Map;
 
 public class IndexResolverTests extends ESTestCase {
 
-    @Test
     public void testMergeSameMapping() throws Exception {
         Map<String, EsField> oneMapping = TypesTests.loadMapping("mapping-basic.json", true);
         Map<String, EsField> sameMapping = TypesTests.loadMapping("mapping-basic.json", true);
@@ -35,7 +33,6 @@ public class IndexResolverTests extends ESTestCase {
         assertEquals(sameMapping, esIndex.mapping());
     }
 
-    @Test
     public void testMergeDifferentMapping() throws Exception {
         Map<String, EsField> oneMapping = TypesTests.loadMapping("mapping-basic.json", true);
         Map<String, EsField> sameMapping = TypesTests.loadMapping("mapping-basic.json", true);

--- a/x-pack/plugin/sql/src/test/resources/mapping-numeric.json
+++ b/x-pack/plugin/sql/src/test/resources/mapping-numeric.json
@@ -1,0 +1,16 @@
+{
+    "properties" : {
+        "byte" : {
+            "type" : "byte"
+        },
+        "short" : {
+            "type" : "short"
+        },
+        "integer" : {
+            "type" : "integer"
+        },
+        "long" : {
+            "type" : "long"
+        }
+    }
+}


### PR DESCRIPTION
Fix the naming in the verification message thrown for aliases over
multiple indices with different mappings.

Closes #31611 
Closes #31784