### PR TITLE
Remove obsolete parameters from analyze rest spec

### DIFF
--- a/docs/java-rest/high-level/indices/analyze.asciidoc
+++ b/docs/java-rest/high-level/indices/analyze.asciidoc
@@ -56,7 +56,7 @@ You can analyze text using the mappings for a particular field in an index:
 include-tagged::{doc-tests}/IndicesClientDocumentationIT.java[analyze-field-request]
 ---------------------------------------------------
 
-==== Optional arguemnts
+==== Optional arguments
 The following arguments can also optionally be provided:
 
 ["source","java",subs="attributes,callouts,macros"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
@@ -15,16 +15,6 @@
         "index": {
           "type" : "string",
           "description" : "The name of the index to scope the operation"
-        },
-        "prefer_local": {
-          "type" : "boolean",
-          "description" : "With `true`, specify that a local shard should be used if available, with `false`, use a random shard (default: true)"
-        },
-        "format": {
-          "type": "enum",
-          "options" : ["detailed","text"],
-          "default": "detailed",
-          "description": "Format of the output"
         }
       }
     },


### PR DESCRIPTION
This commit also fixes a typo in the analyze high-level client
documentation.