### PR TITLE
Fix typo in analysis doc.

### DIFF
--- a/docs/reference/analysis.asciidoc
+++ b/docs/reference/analysis.asciidoc
@@ -25,7 +25,7 @@ into these terms, which would be added to the inverted index.
 
 [source,text]
 ------
-[ quick, brown, fox, jump, over, lazi, dog ]
+[ quick, brown, fox, jump, over, lazy, dog ]
 ------
 
 [float]


### PR DESCRIPTION
The source text "lazy" would be converted into "lazy" within the inverted index, not "lazi".