### PR TITLE
Do not add multiple copies of stale docs to Lucene

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -929,7 +929,8 @@ public class InternalEngine extends Engine {
             } else {
                 final OpVsLuceneDocStatus opVsLucene = compareOpToLuceneDocBasedOnSeqNo(index);
                 if (opVsLucene == OpVsLuceneDocStatus.OP_STALE_OR_EQUAL) {
-                    plan = IndexingStrategy.processAsStaleOp(softDeleteEnabled, index.seqNo(), index.version());
+                    boolean addStaleOpToLucene = softDeleteEnabled && localCheckpointTracker.isProcessed(index.seqNo()) == false;
+                    plan = IndexingStrategy.processAsStaleOp(addStaleOpToLucene, index.seqNo(), index.version());
                 } else {
                     plan = IndexingStrategy.processNormally(opVsLucene == OpVsLuceneDocStatus.LUCENE_DOC_NOT_FOUND,
                         index.seqNo(), index.version());
@@ -1258,7 +1259,8 @@ public class InternalEngine extends Engine {
         } else {
             final OpVsLuceneDocStatus opVsLucene = compareOpToLuceneDocBasedOnSeqNo(delete);
             if (opVsLucene == OpVsLuceneDocStatus.OP_STALE_OR_EQUAL) {
-                plan = DeletionStrategy.processAsStaleOp(softDeleteEnabled, false, delete.seqNo(), delete.version());
+                boolean addStaleOpToLucene = softDeleteEnabled && localCheckpointTracker.isProcessed(delete.seqNo()) == false;
+                plan = DeletionStrategy.processAsStaleOp(addStaleOpToLucene, false, delete.seqNo(), delete.version());
             } else {
                 plan = DeletionStrategy.processNormally(opVsLucene == OpVsLuceneDocStatus.LUCENE_DOC_NOT_FOUND,
                     delete.seqNo(), delete.version());
@@ -1400,7 +1402,9 @@ public class InternalEngine extends Engine {
     @Override
     public NoOpResult noOp(final NoOp noOp) {
         NoOpResult noOpResult;
-        try (ReleasableLock ignored = readLock.acquire()) {
+        try (ReleasableLock ignored = readLock.acquire();
+             // prevent two noOps with same seqno get in at the same time
+             Releasable uidLock = versionMap.acquireLock(new BytesRef(Long.toString(noOp.seqNo())))) {
             noOpResult = innerNoOp(noOp);
         } catch (final Exception e) {
             noOpResult = new NoOpResult(noOp.seqNo(), e);
@@ -1414,7 +1418,7 @@ public class InternalEngine extends Engine {
         final long seqNo = noOp.seqNo();
         try {
             Exception failure = null;
-            if (softDeleteEnabled) {
+            if (softDeleteEnabled && localCheckpointTracker.isProcessed(noOp.seqNo()) == false) {
                 try {
                     final ParsedDocument tombstone = engineConfig.getTombstoneDocSupplier().newNoopTombstoneDoc(noOp.reason());
                     tombstone.updateSeqID(noOp.seqNo(), noOp.primaryTerm());

--- a/server/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
@@ -104,6 +104,21 @@ public class LocalCheckpointTracker {
     }
 
     /**
+     * Checks if the given sequence number has been processed (and tracked) in this tracker.
+     */
+    public synchronized boolean isProcessed(long seqNo) {
+        if (seqNo <= checkpoint) {
+            return true;
+        }
+        if (seqNo >= nextSeqNo) {
+            return false;
+        }
+        final long bitSetKey = getBitSetKey(seqNo);
+        final CountedBitSet bitSet = processedSeqNo.get(bitSetKey);
+        return bitSet != null && bitSet.get(seqNoToBitSetOffset(seqNo));
+    }
+
+    /**
      * Resets the checkpoint to the specified value.
      *
      * @param checkpoint the local checkpoint to reset this tracker to


### PR DESCRIPTION
Since #29679 we started adding stale operations to Lucene to have a complete history in Lucene. As the stale docs are rare, we accepted to have duplicate copies of them to keep an engine simple.

However, we now need to make sure that we have a single copy per stale operation in Lucene because the Lucene rollback requires a single document for each sequence number.

Relates #31637