### PR TITLE
Propagate mapping.single_type setting on shrinked index

### DIFF
--- a/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
+++ b/core/src/main/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexService.java
@@ -599,7 +599,7 @@ public class MetaDataCreateIndexService extends AbstractComponent {
         final List<String> nodesToAllocateOn = validateShrinkIndex(currentState, shrinkFromIndex.getName(),
             mappingKeys, shrinkIntoName, indexSettingsBuilder.build());
         final Predicate<String> analysisSimilarityPredicate = (s) -> s.startsWith("index.similarity.")
-            || s.startsWith("index.analysis.");
+            || s.startsWith("index.analysis.") || s.equals("index.mapping.single_type");
         indexSettingsBuilder
             // we use "i.r.a.initial_recovery" rather than "i.r.a.require|include" since we want the replica to allocate right away
             // once we are allocated.

--- a/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
+++ b/core/src/test/java/org/elasticsearch/cluster/metadata/MetaDataCreateIndexServiceTests.java
@@ -161,6 +161,7 @@ public class MetaDataCreateIndexServiceTests extends ESTestCase {
         Version minCompat = versions.get(1);
         Version upgraded = versions.get(2);
         // create one that won't fail
+        boolean singleType = randomBoolean();
         ClusterState clusterState = ClusterState.builder(createClusterState(indexName, randomIntBetween(2, 10), 0,
             Settings.builder()
                 .put("index.blocks.write", true)
@@ -169,6 +170,7 @@ public class MetaDataCreateIndexServiceTests extends ESTestCase {
                 .put("index.version.upgraded", upgraded)
                 .put("index.version.minimum_compatible", minCompat.luceneVersion)
                 .put("index.analysis.analyzer.my_analyzer.tokenizer", "keyword")
+                .put("index.mapping.single_type", singleType)
                 .build())).nodes(DiscoveryNodes.builder().add(newNode("node1")))
             .build();
         AllocationService service = new AllocationService(Settings.builder().build(), new AllocationDeciders(Settings.EMPTY,
@@ -188,6 +190,8 @@ public class MetaDataCreateIndexServiceTests extends ESTestCase {
         assertEquals("similarity settings must be copied", "BM25", builder.build().get("index.similarity.default.type"));
         assertEquals("analysis settings must be copied",
             "keyword", builder.build().get("index.analysis.analyzer.my_analyzer.tokenizer"));
+        assertEquals("mapping.single_type must be copied",
+            Boolean.toString(singleType), builder.build().get("index.mapping.single_type"));
         assertEquals("node1", builder.build().get("index.routing.allocation.initial_recovery._id"));
         assertEquals("1", builder.build().get("index.allocation.max_retries"));
         assertEquals(version, builder.build().getAsVersion("index.version.created", null));


### PR DESCRIPTION
The index.mapping.single_type setting is not propagated when shrinking an index created in 5.x.
This breaks search/get on the shrinked index because this setting is used to choose
whether _uid or _id field should be used as the primary key.
This commit fixes this bug by copying the setting in the shrinked index.

Closes #31787