### PR TITLE
[ML] add duration statistics to forecast stats

### DIFF
--- a/x-pack/docs/en/rest-api/ml/jobcounts.asciidoc
+++ b/x-pack/docs/en/rest-api/ml/jobcounts.asciidoc
@@ -202,6 +202,9 @@ The `forecasts_stats` object shows statistics about forecasts. It has the follow
 `processing_time_ms`::
   (object) Statistics about the forecast runtime in milliseconds: minimum, maximum, average and total.
 
+`duration_ms`::
+  (object) Statistics about the forecast duration in milliseconds: minimum, maximum, average and total.
+
 `status`::
   (object) Counts per forecast status, for example: {"finished" : 2}. 
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/stats/ForecastStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/stats/ForecastStats.java
@@ -28,6 +28,7 @@ public class ForecastStats implements ToXContentObject, Writeable {
         public static final String MEMORY = "memory_bytes";
         public static final String RUNTIME = "processing_time_ms";
         public static final String RECORDS = "records";
+        public static final String DURATION = "duration_ms";
         public static final String STATUSES = "status";
     }
 
@@ -36,6 +37,7 @@ public class ForecastStats implements ToXContentObject, Writeable {
     private StatsAccumulator memoryStats;
     private StatsAccumulator recordStats;
     private StatsAccumulator runtimeStats;
+    private StatsAccumulator durationStats;
     private CountAccumulator statusCounts;
 
     public ForecastStats() {
@@ -44,6 +46,7 @@ public class ForecastStats implements ToXContentObject, Writeable {
         this.memoryStats = new StatsAccumulator();
         this.recordStats = new StatsAccumulator();
         this.runtimeStats = new StatsAccumulator();
+        this.durationStats = new StatsAccumulator();
         this.statusCounts = new CountAccumulator();
     }
 
@@ -51,12 +54,13 @@ public class ForecastStats implements ToXContentObject, Writeable {
      * Construct ForecastStats for 1 job. Additional statistics can be added by merging other ForecastStats into it.
      */
     public ForecastStats(long total, StatsAccumulator memoryStats, StatsAccumulator recordStats, StatsAccumulator runtimeStats,
-            CountAccumulator statusCounts) {
+            StatsAccumulator durationStats, CountAccumulator statusCounts) {
         this.total = total;
         this.forecastedJobs = total > 0 ? 1 : 0;
         this.memoryStats = Objects.requireNonNull(memoryStats);
         this.recordStats = Objects.requireNonNull(recordStats);
         this.runtimeStats = Objects.requireNonNull(runtimeStats);
+        this.durationStats = Objects.requireNonNull(durationStats);
         this.statusCounts = Objects.requireNonNull(statusCounts);
     }
 
@@ -66,6 +70,7 @@ public class ForecastStats implements ToXContentObject, Writeable {
         this.memoryStats = new StatsAccumulator(in);
         this.recordStats = new StatsAccumulator(in);
         this.runtimeStats = new StatsAccumulator(in);
+        this.durationStats = new StatsAccumulator(in);
         this.statusCounts = new CountAccumulator(in);
     }
 
@@ -78,6 +83,7 @@ public class ForecastStats implements ToXContentObject, Writeable {
         memoryStats.merge(other.memoryStats);
         recordStats.merge(other.recordStats);
         runtimeStats.merge(other.runtimeStats);
+        durationStats.merge(other.durationStats);
         statusCounts.merge(other.statusCounts);
 
         return this;
@@ -98,6 +104,7 @@ public class ForecastStats implements ToXContentObject, Writeable {
             builder.field(Fields.MEMORY, memoryStats.asMap());
             builder.field(Fields.RECORDS, recordStats.asMap());
             builder.field(Fields.RUNTIME, runtimeStats.asMap());
+            builder.field(Fields.DURATION, durationStats.asMap());
             builder.field(Fields.STATUSES, statusCounts.asMap());
         }
 
@@ -113,6 +120,7 @@ public class ForecastStats implements ToXContentObject, Writeable {
             map.put(Fields.MEMORY, memoryStats.asMap());
             map.put(Fields.RECORDS, recordStats.asMap());
             map.put(Fields.RUNTIME, runtimeStats.asMap());
+            map.put(Fields.DURATION, durationStats.asMap());
             map.put(Fields.STATUSES, statusCounts.asMap());
         }
 
@@ -126,12 +134,13 @@ public class ForecastStats implements ToXContentObject, Writeable {
         memoryStats.writeTo(out);
         recordStats.writeTo(out);
         runtimeStats.writeTo(out);
+        durationStats.writeTo(out);
         statusCounts.writeTo(out);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(total, forecastedJobs, memoryStats, recordStats, runtimeStats, statusCounts);
+        return Objects.hash(total, forecastedJobs, memoryStats, recordStats, runtimeStats, durationStats, statusCounts);
     }
 
     @Override
@@ -147,6 +156,7 @@ public class ForecastStats implements ToXContentObject, Writeable {
         ForecastStats other = (ForecastStats) obj;
         return Objects.equals(total, other.total) && Objects.equals(forecastedJobs, other.forecastedJobs)
                 && Objects.equals(memoryStats, other.memoryStats) && Objects.equals(recordStats, other.recordStats)
-                && Objects.equals(runtimeStats, other.runtimeStats) && Objects.equals(statusCounts, other.statusCounts);
+                && Objects.equals(runtimeStats, other.runtimeStats) && Objects.equals(durationStats, other.durationStats)
+                && Objects.equals(statusCounts, other.statusCounts);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/stats/ForecastStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/stats/ForecastStatsTests.java
@@ -36,6 +36,7 @@ public class ForecastStatsTests extends AbstractWireSerializingTestCase<Forecast
         assertFalse(properties.containsKey(Fields.RECORDS));
         assertFalse(properties.containsKey(Fields.RUNTIME));
         assertFalse(properties.containsKey(Fields.STATUSES));
+        assertFalse(properties.containsKey(Fields.DURATION));
     }
 
     public void testMerge() {
@@ -58,7 +59,12 @@ public class ForecastStatsTests extends AbstractWireSerializingTestCase<Forecast
         statusStats.add("finished", 2L);
         statusStats.add("failed", 5L);
 
-        ForecastStats forecastStats = new ForecastStats(3, memoryStats, recordStats, runtimeStats, statusStats);
+        StatsAccumulator durationStats = new StatsAccumulator();
+        durationStats.add(96);
+        durationStats.add(192);
+        durationStats.add(96);
+
+        ForecastStats forecastStats = new ForecastStats(3, memoryStats, recordStats, runtimeStats, durationStats, statusStats);
 
         StatsAccumulator memoryStats2 = new StatsAccumulator();
         memoryStats2.add(10);
@@ -76,7 +82,11 @@ public class ForecastStatsTests extends AbstractWireSerializingTestCase<Forecast
         statusStats2.add("finished", 2L);
         statusStats2.add("scheduled", 1L);
 
-        ForecastStats forecastStats2 = new ForecastStats(2, memoryStats2, recordStats2, runtimeStats2, statusStats2);
+        StatsAccumulator durationStats2 = new StatsAccumulator();
+        durationStats2.add(192);
+        durationStats2.add(192);
+
+        ForecastStats forecastStats2 = new ForecastStats(2, memoryStats2, recordStats2, runtimeStats2, durationStats2, statusStats2);
 
         forecastStats.merge(forecastStats2);
 
@@ -117,6 +127,14 @@ public class ForecastStatsTests extends AbstractWireSerializingTestCase<Forecast
         assertEquals(4, mergedCountStats.get("finished").longValue());
         assertEquals(5, mergedCountStats.get("failed").longValue());
         assertEquals(1, mergedCountStats.get("scheduled").longValue());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Double> mergedDurationStats = (Map<String, Double>) mergedStats.get(Fields.DURATION);
+
+        assertTrue(mergedDurationStats != null);
+        assertThat(mergedDurationStats.get(StatsAccumulator.Fields.AVG), equalTo(153.6));
+        assertThat(mergedDurationStats.get(StatsAccumulator.Fields.MAX), equalTo(192.0));
+        assertThat(mergedDurationStats.get(StatsAccumulator.Fields.MIN), equalTo(96.0));
     }
 
     public void testChainedMerge() {
@@ -135,7 +153,12 @@ public class ForecastStatsTests extends AbstractWireSerializingTestCase<Forecast
         CountAccumulator statusStats = new CountAccumulator();
         statusStats.add("finished", 2L);
         statusStats.add("failed", 5L);
-        ForecastStats forecastStats = new ForecastStats(3, memoryStats, recordStats, runtimeStats, statusStats);
+        StatsAccumulator durationStats = new StatsAccumulator();
+        durationStats.add(96);
+        durationStats.add(192);
+        durationStats.add(96);
+
+        ForecastStats forecastStats = new ForecastStats(3, memoryStats, recordStats, runtimeStats, durationStats, statusStats);
 
         StatsAccumulator memoryStats2 = new StatsAccumulator();
         memoryStats2.add(10);
@@ -149,7 +172,10 @@ public class ForecastStatsTests extends AbstractWireSerializingTestCase<Forecast
         CountAccumulator statusStats2 = new CountAccumulator();
         statusStats2.add("finished", 2L);
         statusStats2.add("scheduled", 1L);
-        ForecastStats forecastStats2 = new ForecastStats(2, memoryStats2, recordStats2, runtimeStats2, statusStats2);
+        StatsAccumulator durationStats2 = new StatsAccumulator();
+        durationStats2.add(192);
+        durationStats2.add(192);
+        ForecastStats forecastStats2 = new ForecastStats(2, memoryStats2, recordStats2, runtimeStats2, durationStats2, statusStats2);
 
         StatsAccumulator memoryStats3 = new StatsAccumulator();
         memoryStats3.add(500);
@@ -159,7 +185,9 @@ public class ForecastStatsTests extends AbstractWireSerializingTestCase<Forecast
         runtimeStats3.add(32);
         CountAccumulator statusStats3 = new CountAccumulator();
         statusStats3.add("finished", 1L);
-        ForecastStats forecastStats3 = new ForecastStats(1, memoryStats3, recordStats3, runtimeStats3, statusStats3);
+        StatsAccumulator durationStats3 = new StatsAccumulator();
+        durationStats3.add(282);
+        ForecastStats forecastStats3 = new ForecastStats(1, memoryStats3, recordStats3, runtimeStats3, durationStats3, statusStats3);
 
         ForecastStats forecastStats4 = new ForecastStats();
 
@@ -209,6 +237,14 @@ public class ForecastStatsTests extends AbstractWireSerializingTestCase<Forecast
         assertEquals(5, mergedCountStats.get("finished").longValue());
         assertEquals(5, mergedCountStats.get("failed").longValue());
         assertEquals(1, mergedCountStats.get("scheduled").longValue());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Double> mergedDurationStats = (Map<String, Double>) mergedStats.get(Fields.DURATION);
+
+        assertTrue(mergedDurationStats != null);
+        assertThat(mergedDurationStats.get(StatsAccumulator.Fields.AVG), equalTo(175.0));
+        assertThat(mergedDurationStats.get(StatsAccumulator.Fields.MAX), equalTo(282.0));
+        assertThat(mergedDurationStats.get(StatsAccumulator.Fields.MIN), equalTo(96.0));
     }
 
     public void testUniqueCountOfJobs() {
@@ -238,7 +274,7 @@ public class ForecastStatsTests extends AbstractWireSerializingTestCase<Forecast
 
     public ForecastStats createForecastStats(long minTotal, long maxTotal) {
         ForecastStats forecastStats = new ForecastStats(randomLongBetween(minTotal, maxTotal), createStatsAccumulator(),
-                createStatsAccumulator(), createStatsAccumulator(), createCountAccumulator());
+                createStatsAccumulator(), createStatsAccumulator(), createStatsAccumulator(), createCountAccumulator());
 
         return forecastStats;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobProvider.java
@@ -1137,8 +1137,8 @@ public class JobProvider {
                 .field(ForecastRequestStats.PROCESSED_RECORD_COUNT.getPreferredName()));
         sourceBuilder.aggregation(
                 AggregationBuilders.stats(ForecastStats.Fields.RUNTIME).field(ForecastRequestStats.PROCESSING_TIME_MS.getPreferredName()));
-        Script durationScript = new Script(
-                "doc['forecast_end_timestamp'].value.getMillis() - doc['forecast_start_timestamp'].value.getMillis()");
+        Script durationScript = new Script("doc['" + ForecastRequestStats.END_TIME + "'].value.getMillis() - doc['"
+                + ForecastRequestStats.START_TIME + "'].value.getMillis()");
         sourceBuilder.aggregation(AggregationBuilders.stats(Fields.DURATION).script(durationScript));
         sourceBuilder.aggregation(
                 AggregationBuilders.terms(ForecastStats.Fields.STATUSES).field(ForecastRequestStats.STATUS.getPreferredName()));


### PR DESCRIPTION
This change is an extension to #31647 adding duration to the statistics.

Notes: 

- BWC isn't required as #31647 hasn't been released yet and I target the same versions.
- `duration_ms` ignores the status of the forecasts, so includes failed ones as well. So it is rather statistics about the durations that have been requested