### PR TITLE
[ML][TEST] Use java 11 valid time format in DataDescriptionTests

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/DataDescriptionTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.AbstractSerializingTestCase;
-import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription.DataFormat;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 
@@ -255,7 +254,7 @@ public class DataDescriptionTests extends AbstractSerializingTestCase<DataDescri
             } else if (randomBoolean()) {
                 format = DataDescription.EPOCH_MS;
             } else {
-                format = "yyy.MM.dd G 'at' HH:mm:ss z";
+                format = "yyyy-MM-dd HH:mm:ss.SSS";
             }
             dataDescription.setTimeFormat(format);
         }


### PR DESCRIPTION
It seems that java 11 tightened some validations with regard to
time formats. The random instance creator was setting an odd
time format to the data description which is invalid when run
with java 11. This commit changes it to a valid format.