### PR TITLE
Painless: Move Struct, Method, Field, and Cast

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/AnalyzerCaster.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/AnalyzerCaster.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Definition.def;
 
 import java.util.Objects;
@@ -30,7 +29,7 @@ import java.util.Objects;
  */
 public final class AnalyzerCaster {
 
-    public static Cast getLegalCast(Location location, Class<?> actual, Class<?> expected, boolean explicit, boolean internal) {
+    public static Painless.Cast getLegalCast(Location location, Class<?> actual, Class<?> expected, boolean explicit, boolean internal) {
         Objects.requireNonNull(actual);
         Objects.requireNonNull(expected);
 
@@ -40,421 +39,421 @@ public final class AnalyzerCaster {
 
         if (actual == def.class) {
             if (expected == boolean.class) {
-                return Cast.unboxTo(def.class, Boolean.class, explicit, boolean.class);
+                return Painless.Cast.unboxTo(def.class, Boolean.class, explicit, boolean.class);
             } else if (expected == byte.class) {
-                return Cast.unboxTo(def.class, Byte.class, explicit, byte.class);
+                return Painless.Cast.unboxTo(def.class, Byte.class, explicit, byte.class);
             } else if (expected == short.class) {
-                return Cast.unboxTo(def.class, Short.class, explicit, short.class);
+                return Painless.Cast.unboxTo(def.class, Short.class, explicit, short.class);
             } else if (expected == char.class) {
-                return Cast.unboxTo(def.class, Character.class, explicit, char.class);
+                return Painless.Cast.unboxTo(def.class, Character.class, explicit, char.class);
             } else if (expected == int.class) {
-                return Cast.unboxTo(def.class, Integer.class, explicit, int.class);
+                return Painless.Cast.unboxTo(def.class, Integer.class, explicit, int.class);
             } else if (expected == long.class) {
-                return Cast.unboxTo(def.class, Long.class, explicit, long.class);
+                return Painless.Cast.unboxTo(def.class, Long.class, explicit, long.class);
             } else if (expected == float.class) {
-                return Cast.unboxTo(def.class, Float.class, explicit, float.class);
+                return Painless.Cast.unboxTo(def.class, Float.class, explicit, float.class);
             } else if (expected == double.class) {
-                return Cast.unboxTo(def.class, Double.class, explicit, double.class);
+                return Painless.Cast.unboxTo(def.class, Double.class, explicit, double.class);
             }
         } else if (actual == Object.class) {
             if (expected == byte.class && explicit && internal) {
-                return Cast.unboxTo(Object.class, Byte.class, true, byte.class);
+                return Painless.Cast.unboxTo(Object.class, Byte.class, true, byte.class);
             } else if (expected == short.class && explicit && internal) {
-                return Cast.unboxTo(Object.class, Short.class, true, short.class);
+                return Painless.Cast.unboxTo(Object.class, Short.class, true, short.class);
             } else if (expected == char.class && explicit && internal) {
-                return Cast.unboxTo(Object.class, Character.class, true, char.class);
+                return Painless.Cast.unboxTo(Object.class, Character.class, true, char.class);
             } else if (expected == int.class && explicit && internal) {
-                return Cast.unboxTo(Object.class, Integer.class, true, int.class);
+                return Painless.Cast.unboxTo(Object.class, Integer.class, true, int.class);
             } else if (expected == long.class && explicit && internal) {
-                return Cast.unboxTo(Object.class, Long.class, true, long.class);
+                return Painless.Cast.unboxTo(Object.class, Long.class, true, long.class);
             } else if (expected == float.class && explicit && internal) {
-                return Cast.unboxTo(Object.class, Float.class, true, float.class);
+                return Painless.Cast.unboxTo(Object.class, Float.class, true, float.class);
             } else if (expected == double.class && explicit && internal) {
-                return Cast.unboxTo(Object.class, Double.class, true, double.class);
+                return Painless.Cast.unboxTo(Object.class, Double.class, true, double.class);
             }
         } else if (actual == Number.class) {
             if (expected == byte.class && explicit && internal) {
-                return Cast.unboxTo(Number.class, Byte.class, true, byte.class);
+                return Painless.Cast.unboxTo(Number.class, Byte.class, true, byte.class);
             } else if (expected == short.class && explicit && internal) {
-                return Cast.unboxTo(Number.class, Short.class, true, short.class);
+                return Painless.Cast.unboxTo(Number.class, Short.class, true, short.class);
             } else if (expected == char.class && explicit && internal) {
-                return Cast.unboxTo(Number.class, Character.class, true, char.class);
+                return Painless.Cast.unboxTo(Number.class, Character.class, true, char.class);
             } else if (expected == int.class && explicit && internal) {
-                return Cast.unboxTo(Number.class, Integer.class, true, int.class);
+                return Painless.Cast.unboxTo(Number.class, Integer.class, true, int.class);
             } else if (expected == long.class && explicit && internal) {
-                return Cast.unboxTo(Number.class, Long.class, true, long.class);
+                return Painless.Cast.unboxTo(Number.class, Long.class, true, long.class);
             } else if (expected == float.class && explicit && internal) {
-                return Cast.unboxTo(Number.class, Float.class, true, float.class);
+                return Painless.Cast.unboxTo(Number.class, Float.class, true, float.class);
             } else if (expected == double.class && explicit && internal) {
-                return Cast.unboxTo(Number.class, Double.class, true, double.class);
+                return Painless.Cast.unboxTo(Number.class, Double.class, true, double.class);
             }
         } else if (actual == String.class) {
             if (expected == char.class && explicit) {
-                return Cast.standard(String.class, char.class, true);
+                return Painless.Cast.standard(String.class, char.class, true);
             }
         } else if (actual == boolean.class) {
             if (expected == def.class) {
-                return Cast.boxFrom(Boolean.class, def.class, explicit, boolean.class);
+                return Painless.Cast.boxFrom(Boolean.class, def.class, explicit, boolean.class);
             } else if (expected == Object.class && internal) {
-                return Cast.boxFrom(Boolean.class, Object.class, explicit, boolean.class);
+                return Painless.Cast.boxFrom(Boolean.class, Object.class, explicit, boolean.class);
             } else if (expected == Boolean.class && internal) {
-                return Cast.boxTo(boolean.class, boolean.class, explicit, boolean.class);
+                return Painless.Cast.boxTo(boolean.class, boolean.class, explicit, boolean.class);
             }
         } else if (actual == byte.class) {
             if (expected == def.class) {
-                return Cast.boxFrom(Byte.class, def.class, explicit, byte.class);
+                return Painless.Cast.boxFrom(Byte.class, def.class, explicit, byte.class);
             } else if (expected == Object.class && internal) {
-                return Cast.boxFrom(Byte.class, Object.class, explicit, byte.class);
+                return Painless.Cast.boxFrom(Byte.class, Object.class, explicit, byte.class);
             } else if (expected == Number.class && internal) {
-                return Cast.boxFrom(Byte.class, Number.class, explicit, byte.class);
+                return Painless.Cast.boxFrom(Byte.class, Number.class, explicit, byte.class);
             } else if (expected == short.class) {
-                return Cast.standard(byte.class, short.class, explicit);
+                return Painless.Cast.standard(byte.class, short.class, explicit);
             } else if (expected == char.class && explicit) {
-                return Cast.standard(byte.class, char.class, true);
+                return Painless.Cast.standard(byte.class, char.class, true);
             } else if (expected == int.class) {
-                return Cast.standard(byte.class, int.class, explicit);
+                return Painless.Cast.standard(byte.class, int.class, explicit);
             } else if (expected == long.class) {
-                return Cast.standard(byte.class, long.class, explicit);
+                return Painless.Cast.standard(byte.class, long.class, explicit);
             } else if (expected == float.class) {
-                return Cast.standard(byte.class, float.class, explicit);
+                return Painless.Cast.standard(byte.class, float.class, explicit);
             } else if (expected == double.class) {
-                return Cast.standard(byte.class, double.class, explicit);
+                return Painless.Cast.standard(byte.class, double.class, explicit);
             } else if (expected == Byte.class && internal) {
-                return Cast.boxTo(byte.class, byte.class, explicit, byte.class);
+                return Painless.Cast.boxTo(byte.class, byte.class, explicit, byte.class);
             } else if (expected == Short.class && internal) {
-                return Cast.boxTo(byte.class, short.class, explicit, short.class);
+                return Painless.Cast.boxTo(byte.class, short.class, explicit, short.class);
             } else if (expected == Character.class && explicit && internal) {
-                return Cast.boxTo(byte.class, char.class, true, char.class);
+                return Painless.Cast.boxTo(byte.class, char.class, true, char.class);
             } else if (expected == Integer.class && internal) {
-                return Cast.boxTo(byte.class, int.class, explicit, int.class);
+                return Painless.Cast.boxTo(byte.class, int.class, explicit, int.class);
             } else if (expected == Long.class && internal) {
-                return Cast.boxTo(byte.class, long.class, explicit, long.class);
+                return Painless.Cast.boxTo(byte.class, long.class, explicit, long.class);
             } else if (expected == Float.class && internal) {
-                return Cast.boxTo(byte.class, float.class, explicit, float.class);
+                return Painless.Cast.boxTo(byte.class, float.class, explicit, float.class);
             } else if (expected == Double.class && internal) {
-                return Cast.boxTo(byte.class, double.class, explicit, double.class);
+                return Painless.Cast.boxTo(byte.class, double.class, explicit, double.class);
             }
         } else if (actual == short.class) {
             if (expected == def.class) {
-                return Cast.boxFrom(Short.class, def.class, explicit, short.class);
+                return Painless.Cast.boxFrom(Short.class, def.class, explicit, short.class);
             } else if (expected == Object.class && internal) {
-                return Cast.boxFrom(Short.class, Object.class, explicit, short.class);
+                return Painless.Cast.boxFrom(Short.class, Object.class, explicit, short.class);
             } else if (expected == Number.class && internal) {
-                return Cast.boxFrom(Short.class, Number.class, explicit, short.class);
+                return Painless.Cast.boxFrom(Short.class, Number.class, explicit, short.class);
             } else if (expected == byte.class && explicit) {
-                return Cast.standard(short.class, byte.class, true);
+                return Painless.Cast.standard(short.class, byte.class, true);
             } else if (expected == char.class && explicit) {
-                return Cast.standard(short.class, char.class, true);
+                return Painless.Cast.standard(short.class, char.class, true);
             } else if (expected == int.class) {
-                return Cast.standard(short.class, int.class, explicit);
+                return Painless.Cast.standard(short.class, int.class, explicit);
             } else if (expected == long.class) {
-                return Cast.standard(short.class, long.class, explicit);
+                return Painless.Cast.standard(short.class, long.class, explicit);
             } else if (expected == float.class) {
-                return Cast.standard(short.class, float.class, explicit);
+                return Painless.Cast.standard(short.class, float.class, explicit);
             } else if (expected == double.class) {
-                return Cast.standard(short.class, double.class, explicit);
+                return Painless.Cast.standard(short.class, double.class, explicit);
             } else if (expected == Byte.class && explicit && internal) {
-                return Cast.boxTo(short.class, byte.class, true, byte.class);
+                return Painless.Cast.boxTo(short.class, byte.class, true, byte.class);
             } else if (expected == Short.class && internal) {
-                return Cast.boxTo(short.class, short.class, explicit, short.class);
+                return Painless.Cast.boxTo(short.class, short.class, explicit, short.class);
             } else if (expected == Character.class && explicit && internal) {
-                return Cast.boxTo(short.class, char.class, true, char.class);
+                return Painless.Cast.boxTo(short.class, char.class, true, char.class);
             } else if (expected == Integer.class && internal) {
-                return Cast.boxTo(short.class, int.class, explicit, int.class);
+                return Painless.Cast.boxTo(short.class, int.class, explicit, int.class);
             } else if (expected == Long.class && internal) {
-                return Cast.boxTo(short.class, long.class, explicit, long.class);
+                return Painless.Cast.boxTo(short.class, long.class, explicit, long.class);
             } else if (expected == Float.class && internal) {
-                return Cast.boxTo(short.class, float.class, explicit, float.class);
+                return Painless.Cast.boxTo(short.class, float.class, explicit, float.class);
             } else if (expected == Double.class && internal) {
-                return Cast.boxTo(short.class, double.class, explicit, double.class);
+                return Painless.Cast.boxTo(short.class, double.class, explicit, double.class);
             }
         } else if (actual == char.class) {
             if (expected == def.class) {
-                return Cast.boxFrom(Character.class, def.class, explicit, char.class);
+                return Painless.Cast.boxFrom(Character.class, def.class, explicit, char.class);
             } else if (expected == Object.class && internal) {
-                return Cast.boxFrom(Character.class, Object.class, explicit, char.class);
+                return Painless.Cast.boxFrom(Character.class, Object.class, explicit, char.class);
             } else if (expected == Number.class && internal) {
-                return Cast.boxFrom(Character.class, Number.class, explicit, char.class);
+                return Painless.Cast.boxFrom(Character.class, Number.class, explicit, char.class);
             } else if (expected == String.class) {
-                return Cast.standard(char.class, String.class, explicit);
+                return Painless.Cast.standard(char.class, String.class, explicit);
             } else if (expected == byte.class && explicit) {
-                return Cast.standard(char.class, byte.class, true);
+                return Painless.Cast.standard(char.class, byte.class, true);
             } else if (expected == short.class && explicit) {
-                return Cast.standard(char.class, short.class, true);
+                return Painless.Cast.standard(char.class, short.class, true);
             } else if (expected == int.class) {
-                return Cast.standard(char.class, int.class, explicit);
+                return Painless.Cast.standard(char.class, int.class, explicit);
             } else if (expected == long.class) {
-                return Cast.standard(char.class, long.class, explicit);
+                return Painless.Cast.standard(char.class, long.class, explicit);
             } else if (expected == float.class) {
-                return Cast.standard(char.class, float.class, explicit);
+                return Painless.Cast.standard(char.class, float.class, explicit);
             } else if (expected == double.class) {
-                return Cast.standard(char.class, double.class, explicit);
+                return Painless.Cast.standard(char.class, double.class, explicit);
             } else if (expected == Byte.class && explicit && internal) {
-                return Cast.boxTo(char.class, byte.class, true, byte.class);
+                return Painless.Cast.boxTo(char.class, byte.class, true, byte.class);
             } else if (expected == Short.class && internal) {
-                return Cast.boxTo(char.class, short.class, explicit, short.class);
+                return Painless.Cast.boxTo(char.class, short.class, explicit, short.class);
             } else if (expected == Character.class && internal) {
-                return Cast.boxTo(char.class, char.class, true, char.class);
+                return Painless.Cast.boxTo(char.class, char.class, true, char.class);
             } else if (expected == Integer.class && internal) {
-                return Cast.boxTo(char.class, int.class, explicit, int.class);
+                return Painless.Cast.boxTo(char.class, int.class, explicit, int.class);
             } else if (expected == Long.class && internal) {
-                return Cast.boxTo(char.class, long.class, explicit, long.class);
+                return Painless.Cast.boxTo(char.class, long.class, explicit, long.class);
             } else if (expected == Float.class && internal) {
-                return Cast.boxTo(char.class, float.class, explicit, float.class);
+                return Painless.Cast.boxTo(char.class, float.class, explicit, float.class);
             } else if (expected == Double.class && internal) {
-                return Cast.boxTo(char.class, double.class, explicit, double.class);
+                return Painless.Cast.boxTo(char.class, double.class, explicit, double.class);
             }
         } else if (actual == int.class) {
             if (expected == def.class) {
-                return Cast.boxFrom(Integer.class, def.class, explicit, int.class);
+                return Painless.Cast.boxFrom(Integer.class, def.class, explicit, int.class);
             } else if (expected == Object.class && internal) {
-                return Cast.boxFrom(Integer.class, Object.class, explicit, int.class);
+                return Painless.Cast.boxFrom(Integer.class, Object.class, explicit, int.class);
             } else if (expected == Number.class && internal) {
-                return Cast.boxFrom(Integer.class, Number.class, explicit, int.class);
+                return Painless.Cast.boxFrom(Integer.class, Number.class, explicit, int.class);
             } else if (expected == byte.class && explicit) {
-                return Cast.standard(int.class, byte.class, true);
+                return Painless.Cast.standard(int.class, byte.class, true);
             } else if (expected == char.class && explicit) {
-                return Cast.standard(int.class, char.class, true);
+                return Painless.Cast.standard(int.class, char.class, true);
             } else if (expected == short.class && explicit) {
-                return Cast.standard(int.class, short.class, true);
+                return Painless.Cast.standard(int.class, short.class, true);
             } else if (expected == long.class) {
-                return Cast.standard(int.class, long.class, explicit);
+                return Painless.Cast.standard(int.class, long.class, explicit);
             } else if (expected == float.class) {
-                return Cast.standard(int.class, float.class, explicit);
+                return Painless.Cast.standard(int.class, float.class, explicit);
             } else if (expected == double.class) {
-                return Cast.standard(int.class, double.class, explicit);
+                return Painless.Cast.standard(int.class, double.class, explicit);
             } else if (expected == Byte.class && explicit && internal) {
-                return Cast.boxTo(int.class, byte.class, true, byte.class);
+                return Painless.Cast.boxTo(int.class, byte.class, true, byte.class);
             } else if (expected == Short.class && explicit && internal) {
-                return Cast.boxTo(int.class, short.class, true, short.class);
+                return Painless.Cast.boxTo(int.class, short.class, true, short.class);
             } else if (expected == Character.class && explicit && internal) {
-                return Cast.boxTo(int.class, char.class, true, char.class);
+                return Painless.Cast.boxTo(int.class, char.class, true, char.class);
             } else if (expected == Integer.class && internal) {
-                return Cast.boxTo(int.class, int.class, explicit, int.class);
+                return Painless.Cast.boxTo(int.class, int.class, explicit, int.class);
             } else if (expected == Long.class && internal) {
-                return Cast.boxTo(int.class, long.class, explicit, long.class);
+                return Painless.Cast.boxTo(int.class, long.class, explicit, long.class);
             } else if (expected == Float.class && internal) {
-                return Cast.boxTo(int.class, float.class, explicit, float.class);
+                return Painless.Cast.boxTo(int.class, float.class, explicit, float.class);
             } else if (expected == Double.class && internal) {
-                return Cast.boxTo(int.class, double.class, explicit, double.class);
+                return Painless.Cast.boxTo(int.class, double.class, explicit, double.class);
             }
         } else if (actual == long.class) {
             if (expected == def.class) {
-                return Cast.boxFrom(Long.class, def.class, explicit, long.class);
+                return Painless.Cast.boxFrom(Long.class, def.class, explicit, long.class);
             } else if (expected == Object.class && internal) {
-                return Cast.boxFrom(Long.class, Object.class, explicit, long.class);
+                return Painless.Cast.boxFrom(Long.class, Object.class, explicit, long.class);
             } else if (expected == Number.class && internal) {
-                return Cast.boxFrom(Long.class, Number.class, explicit, long.class);
+                return Painless.Cast.boxFrom(Long.class, Number.class, explicit, long.class);
             } else if (expected == byte.class && explicit) {
-                return Cast.standard(long.class, byte.class, true);
+                return Painless.Cast.standard(long.class, byte.class, true);
             } else if (expected == char.class && explicit) {
-                return Cast.standard(long.class, char.class, true);
+                return Painless.Cast.standard(long.class, char.class, true);
             } else if (expected == short.class && explicit) {
-                return Cast.standard(long.class, short.class, true);
+                return Painless.Cast.standard(long.class, short.class, true);
             } else if (expected == int.class && explicit) {
-                return Cast.standard(long.class, int.class, true);
+                return Painless.Cast.standard(long.class, int.class, true);
             } else if (expected == float.class) {
-                return Cast.standard(long.class, float.class, explicit);
+                return Painless.Cast.standard(long.class, float.class, explicit);
             } else if (expected == double.class) {
-                return Cast.standard(long.class, double.class, explicit);
+                return Painless.Cast.standard(long.class, double.class, explicit);
             } else if (expected == Byte.class && explicit && internal) {
-                return Cast.boxTo(long.class, byte.class, true, byte.class);
+                return Painless.Cast.boxTo(long.class, byte.class, true, byte.class);
             } else if (expected == Short.class && explicit && internal) {
-                return Cast.boxTo(long.class, short.class, true, short.class);
+                return Painless.Cast.boxTo(long.class, short.class, true, short.class);
             } else if (expected == Character.class && explicit && internal) {
-                return Cast.boxTo(long.class, char.class, true, char.class);
+                return Painless.Cast.boxTo(long.class, char.class, true, char.class);
             } else if (expected == Integer.class && explicit && internal) {
-                return Cast.boxTo(long.class, int.class, true, int.class);
+                return Painless.Cast.boxTo(long.class, int.class, true, int.class);
             } else if (expected == Long.class && internal) {
-                return Cast.boxTo(long.class, long.class, explicit, long.class);
+                return Painless.Cast.boxTo(long.class, long.class, explicit, long.class);
             } else if (expected == Float.class && internal) {
-                return Cast.boxTo(long.class, float.class, explicit, float.class);
+                return Painless.Cast.boxTo(long.class, float.class, explicit, float.class);
             } else if (expected == Double.class && internal) {
-                return Cast.boxTo(long.class, double.class, explicit, double.class);
+                return Painless.Cast.boxTo(long.class, double.class, explicit, double.class);
             }
         } else if (actual == float.class) {
             if (expected == def.class) {
-                return Cast.boxFrom(Float.class, def.class, explicit, float.class);
+                return Painless.Cast.boxFrom(Float.class, def.class, explicit, float.class);
             } else if (expected == Object.class && internal) {
-                return Cast.boxFrom(Float.class, Object.class, explicit, float.class);
+                return Painless.Cast.boxFrom(Float.class, Object.class, explicit, float.class);
             } else if (expected == Number.class && internal) {
-                return Cast.boxFrom(Float.class, Number.class, explicit, float.class);
+                return Painless.Cast.boxFrom(Float.class, Number.class, explicit, float.class);
             } else if (expected == byte.class && explicit) {
-                return Cast.standard(float.class, byte.class, true);
+                return Painless.Cast.standard(float.class, byte.class, true);
             } else if (expected == char.class && explicit) {
-                return Cast.standard(float.class, char.class, true);
+                return Painless.Cast.standard(float.class, char.class, true);
             } else if (expected == short.class && explicit) {
-                return Cast.standard(float.class, short.class, true);
+                return Painless.Cast.standard(float.class, short.class, true);
             } else if (expected == int.class && explicit) {
-                return Cast.standard(float.class, int.class, true);
+                return Painless.Cast.standard(float.class, int.class, true);
             } else if (expected == long.class && explicit) {
-                return Cast.standard(float.class, long.class, true);
+                return Painless.Cast.standard(float.class, long.class, true);
             } else if (expected == double.class) {
-                return Cast.standard(float.class, double.class, explicit);
+                return Painless.Cast.standard(float.class, double.class, explicit);
             } else if (expected == Byte.class && explicit && internal) {
-                return Cast.boxTo(float.class, byte.class, true, byte.class);
+                return Painless.Cast.boxTo(float.class, byte.class, true, byte.class);
             } else if (expected == Short.class && explicit && internal) {
-                return Cast.boxTo(float.class, short.class, true, short.class);
+                return Painless.Cast.boxTo(float.class, short.class, true, short.class);
             } else if (expected == Character.class && explicit && internal) {
-                return Cast.boxTo(float.class, char.class, true, char.class);
+                return Painless.Cast.boxTo(float.class, char.class, true, char.class);
             } else if (expected == Integer.class && explicit && internal) {
-                return Cast.boxTo(float.class, int.class, true, int.class);
+                return Painless.Cast.boxTo(float.class, int.class, true, int.class);
             } else if (expected == Long.class && explicit && internal) {
-                return Cast.boxTo(float.class, long.class, true, long.class);
+                return Painless.Cast.boxTo(float.class, long.class, true, long.class);
             } else if (expected == Float.class && internal) {
-                return Cast.boxTo(float.class, float.class, explicit, float.class);
+                return Painless.Cast.boxTo(float.class, float.class, explicit, float.class);
             } else if (expected == Double.class && internal) {
-                return Cast.boxTo(float.class, double.class, explicit, double.class);
+                return Painless.Cast.boxTo(float.class, double.class, explicit, double.class);
             }
         } else if (actual == double.class) {
             if (expected == def.class) {
-                return Cast.boxFrom(Double.class, def.class, explicit, double.class);
+                return Painless.Cast.boxFrom(Double.class, def.class, explicit, double.class);
             } else if (expected == Object.class && internal) {
-                return Cast.boxFrom(Double.class, Object.class, explicit, double.class);
+                return Painless.Cast.boxFrom(Double.class, Object.class, explicit, double.class);
             } else if (expected == Number.class && internal) {
-                return Cast.boxFrom(Double.class, Number.class, explicit, double.class);
+                return Painless.Cast.boxFrom(Double.class, Number.class, explicit, double.class);
             } else if (expected == byte.class && explicit) {
-                return Cast.standard(double.class, byte.class, true);
+                return Painless.Cast.standard(double.class, byte.class, true);
             } else if (expected == char.class && explicit) {
-                return Cast.standard(double.class, char.class, true);
+                return Painless.Cast.standard(double.class, char.class, true);
             } else if (expected == short.class && explicit) {
-                return Cast.standard(double.class, short.class, true);
+                return Painless.Cast.standard(double.class, short.class, true);
             } else if (expected == int.class && explicit) {
-                return Cast.standard(double.class, int.class, true);
+                return Painless.Cast.standard(double.class, int.class, true);
             } else if (expected == long.class && explicit) {
-                return Cast.standard(double.class, long.class, true);
+                return Painless.Cast.standard(double.class, long.class, true);
             } else if (expected == float.class && explicit) {
-                return Cast.standard(double.class, float.class, true);
+                return Painless.Cast.standard(double.class, float.class, true);
             } else if (expected == Byte.class && explicit && internal) {
-                return Cast.boxTo(double.class, byte.class, true, byte.class);
+                return Painless.Cast.boxTo(double.class, byte.class, true, byte.class);
             } else if (expected == Short.class && explicit && internal) {
-                return Cast.boxTo(double.class, short.class, true, short.class);
+                return Painless.Cast.boxTo(double.class, short.class, true, short.class);
             } else if (expected == Character.class && explicit && internal) {
-                return Cast.boxTo(double.class, char.class, true, char.class);
+                return Painless.Cast.boxTo(double.class, char.class, true, char.class);
             } else if (expected == Integer.class && explicit && internal) {
-                return Cast.boxTo(double.class, int.class, true, int.class);
+                return Painless.Cast.boxTo(double.class, int.class, true, int.class);
             } else if (expected == Long.class && explicit && internal) {
-                return Cast.boxTo(double.class, long.class, true, long.class);
+                return Painless.Cast.boxTo(double.class, long.class, true, long.class);
             } else if (expected == Float.class && explicit && internal) {
-                return Cast.boxTo(double.class, float.class, true, float.class);
+                return Painless.Cast.boxTo(double.class, float.class, true, float.class);
             } else if (expected == Double.class && internal) {
-                return Cast.boxTo(double.class, double.class, explicit, double.class);
+                return Painless.Cast.boxTo(double.class, double.class, explicit, double.class);
             }
         } else if (actual == Boolean.class) {
             if (expected == boolean.class && internal) {
-                return Cast.unboxFrom(boolean.class, boolean.class, explicit, boolean.class);
+                return Painless.Cast.unboxFrom(boolean.class, boolean.class, explicit, boolean.class);
             }
         } else if (actual == Byte.class) {
             if (expected == byte.class && internal) {
-                return Cast.unboxFrom(byte.class, byte.class, explicit, byte.class);
+                return Painless.Cast.unboxFrom(byte.class, byte.class, explicit, byte.class);
             } else if (expected == short.class && internal) {
-                return Cast.unboxFrom(byte.class, short.class, explicit, byte.class);
+                return Painless.Cast.unboxFrom(byte.class, short.class, explicit, byte.class);
             } else if (expected == char.class && explicit && internal) {
-                return Cast.unboxFrom(byte.class, char.class, true, byte.class);
+                return Painless.Cast.unboxFrom(byte.class, char.class, true, byte.class);
             } else if (expected == int.class && internal) {
-                return Cast.unboxFrom(byte.class, int.class, explicit, byte.class);
+                return Painless.Cast.unboxFrom(byte.class, int.class, explicit, byte.class);
             } else if (expected == long.class && internal) {
-                return Cast.unboxFrom(byte.class, long.class, explicit, byte.class);
+                return Painless.Cast.unboxFrom(byte.class, long.class, explicit, byte.class);
             } else if (expected == float.class && internal) {
-                return Cast.unboxFrom(byte.class, float.class, explicit, byte.class);
+                return Painless.Cast.unboxFrom(byte.class, float.class, explicit, byte.class);
             } else if (expected == double.class && internal) {
-                return Cast.unboxFrom(byte.class, double.class, explicit, byte.class);
+                return Painless.Cast.unboxFrom(byte.class, double.class, explicit, byte.class);
             }
         } else if (actual == Short.class) {
             if (expected == byte.class && explicit && internal) {
-                return Cast.unboxFrom(short.class, byte.class, true, short.class);
+                return Painless.Cast.unboxFrom(short.class, byte.class, true, short.class);
             } else if (expected == short.class && internal) {
-                return Cast.unboxFrom(short.class, short.class, explicit, short.class);
+                return Painless.Cast.unboxFrom(short.class, short.class, explicit, short.class);
             } else if (expected == char.class && explicit && internal) {
-                return Cast.unboxFrom(short.class, char.class, true, short.class);
+                return Painless.Cast.unboxFrom(short.class, char.class, true, short.class);
             } else if (expected == int.class && internal) {
-                return Cast.unboxFrom(short.class, int.class, explicit, short.class);
+                return Painless.Cast.unboxFrom(short.class, int.class, explicit, short.class);
             } else if (expected == long.class && internal) {
-                return Cast.unboxFrom(short.class, long.class, explicit, short.class);
+                return Painless.Cast.unboxFrom(short.class, long.class, explicit, short.class);
             } else if (expected == float.class && internal) {
-                return Cast.unboxFrom(short.class, float.class, explicit, short.class);
+                return Painless.Cast.unboxFrom(short.class, float.class, explicit, short.class);
             } else if (expected == double.class && internal) {
-                return Cast.unboxFrom(short.class, double.class, explicit, short.class);
+                return Painless.Cast.unboxFrom(short.class, double.class, explicit, short.class);
             }
         } else if (actual == Character.class) {
             if (expected == byte.class && explicit && internal) {
-                return Cast.unboxFrom(char.class, byte.class, true, char.class);
+                return Painless.Cast.unboxFrom(char.class, byte.class, true, char.class);
             } else if (expected == short.class && explicit && internal) {
-                return Cast.unboxFrom(char.class, short.class, true, char.class);
+                return Painless.Cast.unboxFrom(char.class, short.class, true, char.class);
             } else if (expected == char.class && internal) {
-                return Cast.unboxFrom(char.class, char.class, explicit, char.class);
+                return Painless.Cast.unboxFrom(char.class, char.class, explicit, char.class);
             } else if (expected == int.class && internal) {
-                return Cast.unboxFrom(char.class, int.class, explicit, char.class);
+                return Painless.Cast.unboxFrom(char.class, int.class, explicit, char.class);
             } else if (expected == long.class && internal) {
-                return Cast.unboxFrom(char.class, long.class, explicit, char.class);
+                return Painless.Cast.unboxFrom(char.class, long.class, explicit, char.class);
             } else if (expected == float.class && internal) {
-                return Cast.unboxFrom(char.class, float.class, explicit, char.class);
+                return Painless.Cast.unboxFrom(char.class, float.class, explicit, char.class);
             } else if (expected == double.class && internal) {
-                return Cast.unboxFrom(char.class, double.class, explicit, char.class);
+                return Painless.Cast.unboxFrom(char.class, double.class, explicit, char.class);
             }
         } else if (actual == Integer.class) {
             if (expected == byte.class && explicit && internal) {
-                return Cast.unboxFrom(int.class, byte.class, true, int.class);
+                return Painless.Cast.unboxFrom(int.class, byte.class, true, int.class);
             } else if (expected == short.class && explicit && internal) {
-                return Cast.unboxFrom(int.class, short.class, true, int.class);
+                return Painless.Cast.unboxFrom(int.class, short.class, true, int.class);
             } else if (expected == char.class && explicit && internal) {
-                return Cast.unboxFrom(int.class, char.class, true, int.class);
+                return Painless.Cast.unboxFrom(int.class, char.class, true, int.class);
             } else if (expected == int.class && internal) {
-                return Cast.unboxFrom(int.class, int.class, explicit, int.class);
+                return Painless.Cast.unboxFrom(int.class, int.class, explicit, int.class);
             } else if (expected == long.class && internal) {
-                return Cast.unboxFrom(int.class, long.class, explicit, int.class);
+                return Painless.Cast.unboxFrom(int.class, long.class, explicit, int.class);
             } else if (expected == float.class && internal) {
-                return Cast.unboxFrom(int.class, float.class, explicit, int.class);
+                return Painless.Cast.unboxFrom(int.class, float.class, explicit, int.class);
             } else if (expected == double.class && internal) {
-                return Cast.unboxFrom(int.class, double.class, explicit, int.class);
+                return Painless.Cast.unboxFrom(int.class, double.class, explicit, int.class);
             }
         } else if (actual == Long.class) {
             if (expected == byte.class && explicit && internal) {
-                return Cast.unboxFrom(long.class, byte.class, true, long.class);
+                return Painless.Cast.unboxFrom(long.class, byte.class, true, long.class);
             } else if (expected == short.class && explicit && internal) {
-                return Cast.unboxFrom(long.class, short.class, true, long.class);
+                return Painless.Cast.unboxFrom(long.class, short.class, true, long.class);
             } else if (expected == char.class && explicit && internal) {
-                return Cast.unboxFrom(long.class, char.class, true, long.class);
+                return Painless.Cast.unboxFrom(long.class, char.class, true, long.class);
             } else if (expected == int.class && explicit && internal) {
-                return Cast.unboxFrom(long.class, int.class, true, long.class);
+                return Painless.Cast.unboxFrom(long.class, int.class, true, long.class);
             } else if (expected == long.class && internal) {
-                return Cast.unboxFrom(long.class, long.class, explicit, long.class);
+                return Painless.Cast.unboxFrom(long.class, long.class, explicit, long.class);
             } else if (expected == float.class && internal) {
-                return Cast.unboxFrom(long.class, float.class, explicit, long.class);
+                return Painless.Cast.unboxFrom(long.class, float.class, explicit, long.class);
             } else if (expected == double.class && internal) {
-                return Cast.unboxFrom(long.class, double.class, explicit, long.class);
+                return Painless.Cast.unboxFrom(long.class, double.class, explicit, long.class);
             }
         } else if (actual == Float.class) {
             if (expected == byte.class && explicit && internal) {
-                return Cast.unboxFrom(float.class, byte.class, true, float.class);
+                return Painless.Cast.unboxFrom(float.class, byte.class, true, float.class);
             } else if (expected == short.class && explicit && internal) {
-                return Cast.unboxFrom(float.class, short.class, true, float.class);
+                return Painless.Cast.unboxFrom(float.class, short.class, true, float.class);
             } else if (expected == char.class && explicit && internal) {
-                return Cast.unboxFrom(float.class, char.class, true, float.class);
+                return Painless.Cast.unboxFrom(float.class, char.class, true, float.class);
             } else if (expected == int.class && explicit && internal) {
-                return Cast.unboxFrom(float.class, int.class, true, float.class);
+                return Painless.Cast.unboxFrom(float.class, int.class, true, float.class);
             } else if (expected == long.class && explicit && internal) {
-                return Cast.unboxFrom(float.class, long.class, true, float.class);
+                return Painless.Cast.unboxFrom(float.class, long.class, true, float.class);
             } else if (expected == float.class && internal) {
-                return Cast.unboxFrom(float.class, float.class, explicit, float.class);
+                return Painless.Cast.unboxFrom(float.class, float.class, explicit, float.class);
             } else if (expected == double.class && internal) {
-                return Cast.unboxFrom(float.class, double.class, explicit, float.class);
+                return Painless.Cast.unboxFrom(float.class, double.class, explicit, float.class);
             }
         } else if (actual == Double.class) {
             if (expected == byte.class && explicit && internal) {
-                return Cast.unboxFrom(double.class, byte.class, true, double.class);
+                return Painless.Cast.unboxFrom(double.class, byte.class, true, double.class);
             } else if (expected == short.class && explicit && internal) {
-                return Cast.unboxFrom(double.class, short.class, true, double.class);
+                return Painless.Cast.unboxFrom(double.class, short.class, true, double.class);
             } else if (expected == char.class && explicit && internal) {
-                return Cast.unboxFrom(double.class, char.class, true, double.class);
+                return Painless.Cast.unboxFrom(double.class, char.class, true, double.class);
             } else if (expected == int.class && explicit && internal) {
-                return Cast.unboxFrom(double.class, int.class, true, double.class);
+                return Painless.Cast.unboxFrom(double.class, int.class, true, double.class);
             } else if (expected == long.class && explicit && internal) {
-                return Cast.unboxFrom(double.class, long.class, true, double.class);
+                return Painless.Cast.unboxFrom(double.class, long.class, true, double.class);
             } else if (expected == float.class && explicit && internal) {
-                return Cast.unboxFrom(double.class, float.class, true, double.class);
+                return Painless.Cast.unboxFrom(double.class, float.class, true, double.class);
             } else if (expected == double.class && internal) {
-                return Cast.unboxFrom(double.class, double.class, explicit, double.class);
+                return Painless.Cast.unboxFrom(double.class, double.class, explicit, double.class);
             }
         }
 
@@ -462,14 +461,14 @@ public final class AnalyzerCaster {
                 (actual != void.class && expected == def.class) ||
                 expected.isAssignableFrom(actual)    ||
                 (actual.isAssignableFrom(expected) && explicit)) {
-            return Cast.standard(actual, expected, explicit);
+            return Painless.Cast.standard(actual, expected, explicit);
         } else {
             throw location.createError(new ClassCastException(
                     "Cannot cast from [" + Definition.ClassToName(actual) + "] to [" + Definition.ClassToName(expected) + "]."));
         }
     }
 
-    public static Object constCast(Location location, Object constant, Cast cast) {
+    public static Object constCast(Location location, Object constant, Painless.Cast cast) {
         Class<?> fsort = cast.from;
         Class<?> tsort = cast.to;
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -181,7 +181,7 @@ public final class Def {
      * @throws IllegalArgumentException if no matching whitelisted method was found.
      */
     static Painless.Method lookupMethodInternal(Definition definition, Class<?> receiverClass, String name, int arity) {
-        Definition.MethodKey key = new Definition.MethodKey(name, arity);
+        Painless.MethodKey key = new Painless.MethodKey(name, arity);
         // check whitelist for matching method
         for (Class<?> clazz = receiverClass; clazz != null; clazz = clazz.getSuperclass()) {
             Struct struct = definition.getPainlessStructFromJavaClass(clazz);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.painless.Definition.Struct;
+import org.elasticsearch.painless.Painless.Struct;
 
 import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandle;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.painless.Definition.Method;
 import org.elasticsearch.painless.Definition.Struct;
 
 import java.lang.invoke.CallSite;
@@ -181,14 +180,14 @@ public final class Def {
      * @return matching method to invoke. never returns null.
      * @throws IllegalArgumentException if no matching whitelisted method was found.
      */
-    static Method lookupMethodInternal(Definition definition, Class<?> receiverClass, String name, int arity) {
+    static Painless.Method lookupMethodInternal(Definition definition, Class<?> receiverClass, String name, int arity) {
         Definition.MethodKey key = new Definition.MethodKey(name, arity);
         // check whitelist for matching method
         for (Class<?> clazz = receiverClass; clazz != null; clazz = clazz.getSuperclass()) {
             Struct struct = definition.getPainlessStructFromJavaClass(clazz);
 
             if (struct != null) {
-                Method method = struct.methods.get(key);
+                Painless.Method method = struct.methods.get(key);
                 if (method != null) {
                     return method;
                 }
@@ -198,7 +197,7 @@ public final class Def {
                 struct = definition.getPainlessStructFromJavaClass(iface);
 
                 if (struct != null) {
-                    Method method = struct.methods.get(key);
+                    Painless.Method method = struct.methods.get(key);
                     if (method != null) {
                         return method;
                     }
@@ -259,7 +258,7 @@ public final class Def {
 
          // lookup the method with the proper arity, then we know everything (e.g. interface types of parameters).
          // based on these we can finally link any remaining lambdas that were deferred.
-         Method method = lookupMethodInternal(definition, receiverClass, name, arity);
+         Painless.Method method = lookupMethodInternal(definition, receiverClass, name, arity);
          MethodHandle handle = method.handle;
 
          int replaced = 0;
@@ -325,12 +324,12 @@ public final class Def {
     static MethodHandle lookupReference(Definition definition, Lookup lookup, String interfaceClass,
             Class<?> receiverClass, String name) throws Throwable {
          Class<?> interfaceType = definition.getJavaClassFromPainlessType(interfaceClass);
-         Method interfaceMethod = definition.getPainlessStructFromJavaClass(interfaceType).functionalMethod;
+         Painless.Method interfaceMethod = definition.getPainlessStructFromJavaClass(interfaceType).functionalMethod;
          if (interfaceMethod == null) {
              throw new IllegalArgumentException("Class [" + interfaceClass + "] is not a functional interface");
          }
          int arity = interfaceMethod.arguments.size();
-         Method implMethod = lookupMethodInternal(definition, receiverClass, name, arity);
+         Painless.Method implMethod = lookupMethodInternal(definition, receiverClass, name, arity);
         return lookupReferenceInternal(definition, lookup, interfaceType, implMethod.owner.name,
                 implMethod.name, receiverClass);
      }
@@ -342,7 +341,7 @@ public final class Def {
          final FunctionRef ref;
          if ("this".equals(type)) {
              // user written method
-             Method interfaceMethod = definition.getPainlessStructFromJavaClass(clazz).functionalMethod;
+             Painless.Method interfaceMethod = definition.getPainlessStructFromJavaClass(clazz).functionalMethod;
              if (interfaceMethod == null) {
                  throw new IllegalArgumentException("Cannot convert function reference [" + type + "::" + call + "] " +
                                                     "to [" + Definition.ClassToName(clazz) + "], not a functional interface");

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -47,56 +47,9 @@ public final class Definition {
     private static final Pattern TYPE_NAME_PATTERN = Pattern.compile("^[_a-zA-Z][._a-zA-Z0-9]*$");
 
     /** Marker class for def type to be used during type analysis. */
-    /** Marker class for def type to be used during type analysis. */
     public static final class def {
         private def() {
 
-        }
-    }
-
-    public static class Cast {
-
-        /** Create a standard cast with no boxing/unboxing. */
-        public static Cast standard(Class<?> from, Class<?> to, boolean explicit) {
-            return new Cast(from, to, explicit, null, null, null, null);
-        }
-
-        /** Create a cast where the from type will be unboxed, and then the cast will be performed. */
-        public static Cast unboxFrom(Class<?> from, Class<?> to, boolean explicit, Class<?> unboxFrom) {
-            return new Cast(from, to, explicit, unboxFrom, null, null, null);
-        }
-
-        /** Create a cast where the to type will be unboxed, and then the cast will be performed. */
-        public static Cast unboxTo(Class<?> from, Class<?> to, boolean explicit, Class<?> unboxTo) {
-            return new Cast(from, to, explicit, null, unboxTo, null, null);
-        }
-
-        /** Create a cast where the from type will be boxed, and then the cast will be performed. */
-        public static Cast boxFrom(Class<?> from, Class<?> to, boolean explicit, Class<?> boxFrom) {
-            return new Cast(from, to, explicit, null, null, boxFrom, null);
-        }
-
-        /** Create a cast where the to type will be boxed, and then the cast will be performed. */
-        public static Cast boxTo(Class<?> from, Class<?> to, boolean explicit, Class<?> boxTo) {
-            return new Cast(from, to, explicit, null, null, null, boxTo);
-        }
-
-        public final Class<?> from;
-        public final Class<?> to;
-        public final boolean explicit;
-        public final Class<?> unboxFrom;
-        public final Class<?> unboxTo;
-        public final Class<?> boxFrom;
-        public final Class<?> boxTo;
-
-        private Cast(Class<?> from, Class<?> to, boolean explicit, Class<?> unboxFrom, Class<?> unboxTo, Class<?> boxFrom, Class<?> boxTo) {
-            this.from = from;
-            this.to = to;
-            this.explicit = explicit;
-            this.unboxFrom = unboxFrom;
-            this.unboxTo = unboxTo;
-            this.boxFrom = boxFrom;
-            this.boxTo = boxTo;
         }
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Definition.java
@@ -54,87 +54,6 @@ public final class Definition {
         }
     }
 
-    // TODO: instead of hashing on this, we could have a 'next' pointer in Method itself, but it would make code more complex
-    // please do *NOT* under any circumstances change this to be the crappy Tuple from elasticsearch!
-
-    public static final class Struct {
-        public final String name;
-        public final Class<?> clazz;
-        public final org.objectweb.asm.Type type;
-
-        public final Map<Painless.MethodKey, Painless.Method> constructors;
-        public final Map<Painless.MethodKey, Painless.Method> staticMethods;
-        public final Map<Painless.MethodKey, Painless.Method> methods;
-
-        public final Map<String, Painless.Field> staticMembers;
-        public final Map<String, Painless.Field> members;
-
-        public final Map<String, MethodHandle> getters;
-        public final Map<String, MethodHandle> setters;
-
-        public final Painless.Method functionalMethod;
-
-        private Struct(String name, Class<?> clazz, org.objectweb.asm.Type type) {
-            this.name = name;
-            this.clazz = clazz;
-            this.type = type;
-
-            constructors = new HashMap<>();
-            staticMethods = new HashMap<>();
-            methods = new HashMap<>();
-
-            staticMembers = new HashMap<>();
-            members = new HashMap<>();
-
-            getters = new HashMap<>();
-            setters = new HashMap<>();
-
-            functionalMethod = null;
-        }
-
-        private Struct(Struct struct, Painless.Method functionalMethod) {
-            name = struct.name;
-            clazz = struct.clazz;
-            type = struct.type;
-
-            constructors = Collections.unmodifiableMap(struct.constructors);
-            staticMethods = Collections.unmodifiableMap(struct.staticMethods);
-            methods = Collections.unmodifiableMap(struct.methods);
-
-            staticMembers = Collections.unmodifiableMap(struct.staticMembers);
-            members = Collections.unmodifiableMap(struct.members);
-
-            getters = Collections.unmodifiableMap(struct.getters);
-            setters = Collections.unmodifiableMap(struct.setters);
-
-            this.functionalMethod = functionalMethod;
-        }
-
-        private Struct freeze(Painless.Method functionalMethod) {
-            return new Struct(this, functionalMethod);
-        }
-
-        @Override
-        public boolean equals(Object object) {
-            if (this == object) {
-                return true;
-            }
-
-            if (object == null || getClass() != object.getClass()) {
-                return false;
-            }
-
-            Struct struct = (Struct)object;
-
-            return name.equals(struct.name);
-        }
-
-        @Override
-        public int hashCode() {
-            return name.hashCode();
-        }
-    }
-
     public static class Cast {
 
         /** Create a standard cast with no boxing/unboxing. */
@@ -345,12 +264,12 @@ public final class Definition {
         return structName + fieldName + typeName;
     }
 
-    public Collection<Struct> getStructs() {
+    public Collection<Painless.Struct> getStructs() {
         return javaClassesToPainlessStructs.values();
     }
 
     private final Map<String, Class<?>> painlessTypesToJavaClasses;
-    private final Map<Class<?>, Struct> javaClassesToPainlessStructs;
+    private final Map<Class<?>, Painless.Struct> javaClassesToPainlessStructs;
 
     public Definition(List<Whitelist> whitelists) {
         painlessTypesToJavaClasses = new HashMap<>();
@@ -359,7 +278,7 @@ public final class Definition {
         String origin = null;
 
         painlessTypesToJavaClasses.put("def", def.class);
-        javaClassesToPainlessStructs.put(def.class, new Struct("def", Object.class, Type.getType(Object.class)));
+        javaClassesToPainlessStructs.put(def.class, new Painless.Struct("def", Object.class, Type.getType(Object.class)));
 
         try {
             // first iteration collects all the Painless type names that
@@ -367,7 +286,7 @@ public final class Definition {
             for (Whitelist whitelist : whitelists) {
                 for (Whitelist.Struct whitelistStruct : whitelist.whitelistStructs) {
                     String painlessTypeName = whitelistStruct.javaClassName.replace('$', '.');
-                    Struct painlessStruct = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(painlessTypeName));
+                    Painless.Struct painlessStruct = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(painlessTypeName));
 
                     if (painlessStruct != null && painlessStruct.clazz.getName().equals(whitelistStruct.javaClassName) == false) {
                         throw new IllegalArgumentException("struct [" + painlessStruct.name + "] cannot represent multiple classes " +
@@ -412,7 +331,7 @@ public final class Definition {
         // goes through each Painless struct and determines the inheritance list,
         // and then adds all inherited types to the Painless struct's whitelist
         for (Class<?> javaClass : javaClassesToPainlessStructs.keySet()) {
-            Struct painlessStruct = javaClassesToPainlessStructs.get(javaClass);
+            Painless.Struct painlessStruct = javaClassesToPainlessStructs.get(javaClass);
 
             List<String> painlessSuperStructs = new ArrayList<>();
             Class<?> javaSuperClass = painlessStruct.clazz.getSuperclass();
@@ -423,7 +342,7 @@ public final class Definition {
             // adds super classes to the inheritance list
             if (javaSuperClass != null && javaSuperClass.isInterface() == false) {
                 while (javaSuperClass != null) {
-                    Struct painlessSuperStruct = javaClassesToPainlessStructs.get(javaSuperClass);
+                    Painless.Struct painlessSuperStruct = javaClassesToPainlessStructs.get(javaSuperClass);
 
                     if (painlessSuperStruct != null) {
                         painlessSuperStructs.add(painlessSuperStruct.name);
@@ -439,7 +358,7 @@ public final class Definition {
                 Class<?> javaInterfaceLookup = javaInteraceLookups.pop();
 
                 for (Class<?> javaSuperInterface : javaInterfaceLookup.getInterfaces()) {
-                    Struct painlessInterfaceStruct = javaClassesToPainlessStructs.get(javaSuperInterface);
+                    Painless.Struct painlessInterfaceStruct = javaClassesToPainlessStructs.get(javaSuperInterface);
 
                     if (painlessInterfaceStruct != null) {
                         String painlessInterfaceStructName = painlessInterfaceStruct.name;
@@ -460,7 +379,7 @@ public final class Definition {
 
             // copies methods and fields from Object into interface types
             if (painlessStruct.clazz.isInterface() || (def.class.getSimpleName()).equals(painlessStruct.name)) {
-                Struct painlessObjectStruct = javaClassesToPainlessStructs.get(Object.class);
+                Painless.Struct painlessObjectStruct = javaClassesToPainlessStructs.get(Object.class);
 
                 if (painlessObjectStruct != null) {
                     copyStruct(painlessStruct.name, Collections.singletonList(painlessObjectStruct.name));
@@ -469,12 +388,12 @@ public final class Definition {
         }
 
         // precompute runtime classes
-        for (Struct painlessStruct : javaClassesToPainlessStructs.values()) {
+        for (Painless.Struct painlessStruct : javaClassesToPainlessStructs.values()) {
             addRuntimeClass(painlessStruct);
         }
 
         // copy all structs to make them unmodifiable for outside users:
-        for (Map.Entry<Class<?>,Struct> entry : javaClassesToPainlessStructs.entrySet()) {
+        for (Map.Entry<Class<?>,Painless.Struct> entry : javaClassesToPainlessStructs.entrySet()) {
             entry.setValue(entry.getValue().freeze(computeFunctionalInterfaceMethod(entry.getValue())));
         }
     }
@@ -513,10 +432,10 @@ public final class Definition {
             }
         }
 
-        Struct existingStruct = javaClassesToPainlessStructs.get(javaClass);
+        Painless.Struct existingStruct = javaClassesToPainlessStructs.get(javaClass);
 
         if (existingStruct == null) {
-            Struct struct = new Struct(painlessTypeName, javaClass, org.objectweb.asm.Type.getType(javaClass));
+            Painless.Struct struct = new Painless.Struct(painlessTypeName, javaClass, org.objectweb.asm.Type.getType(javaClass));
             painlessTypesToJavaClasses.put(painlessTypeName, javaClass);
             javaClassesToPainlessStructs.put(javaClass, struct);
         } else if (existingStruct.clazz.equals(javaClass) == false) {
@@ -551,7 +470,7 @@ public final class Definition {
     }
 
     private void addConstructor(String ownerStructName, Whitelist.Constructor whitelistConstructor) {
-        Struct ownerStruct = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(ownerStructName));
+        Painless.Struct ownerStruct = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(ownerStructName));
 
         if (ownerStruct == null) {
             throw new IllegalArgumentException("owner struct [" + ownerStructName + "] not defined for constructor with " +
@@ -611,7 +530,7 @@ public final class Definition {
     }
 
     private void addMethod(ClassLoader whitelistClassLoader, String ownerStructName, Whitelist.Method whitelistMethod) {
-        Struct ownerStruct = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(ownerStructName));
+        Painless.Struct ownerStruct = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(ownerStructName));
 
         if (ownerStruct == null) {
             throw new IllegalArgumentException("owner struct [" + ownerStructName + "] not defined for method with " +
@@ -748,7 +667,7 @@ public final class Definition {
     }
 
     private void addField(String ownerStructName, Whitelist.Field whitelistField) {
-        Struct ownerStruct = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(ownerStructName));
+        Painless.Struct ownerStruct = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(ownerStructName));
 
         if (ownerStruct == null) {
             throw new IllegalArgumentException("owner struct [" + ownerStructName + "] not defined for method with " +
@@ -829,14 +748,14 @@ public final class Definition {
     }
 
     private void copyStruct(String struct, List<String> children) {
-        final Struct owner = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(struct));
+        final Painless.Struct owner = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(struct));
 
         if (owner == null) {
             throw new IllegalArgumentException("Owner struct [" + struct + "] not defined for copy.");
         }
 
         for (int count = 0; count < children.size(); ++count) {
-            final Struct child = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(children.get(count)));
+            final Painless.Struct child = javaClassesToPainlessStructs.get(painlessTypesToJavaClasses.get(children.get(count)));
 
             if (child == null) {
                 throw new IllegalArgumentException("Child struct [" + children.get(count) + "]" +
@@ -914,7 +833,7 @@ public final class Definition {
     /**
      * Precomputes a more efficient structure for dynamic method/field access.
      */
-    private void addRuntimeClass(final Struct struct) {
+    private void addRuntimeClass(final Painless.Struct struct) {
         // add all getters/setters
         for (Map.Entry<Painless.MethodKey, Painless.Method> method : struct.methods.entrySet()) {
             String name = method.getKey().name;
@@ -957,7 +876,7 @@ public final class Definition {
     }
 
     /** computes the functional interface method for a class, or returns null */
-    private Painless.Method computeFunctionalInterfaceMethod(Struct clazz) {
+    private Painless.Method computeFunctionalInterfaceMethod(Painless.Struct clazz) {
         if (!clazz.clazz.isInterface()) {
             return null;
         }
@@ -1004,7 +923,7 @@ public final class Definition {
         return painlessTypesToJavaClasses.containsKey(painlessType);
     }
 
-    public Struct getPainlessStructFromJavaClass(Class<?> clazz) {
+    public Painless.Struct getPainlessStructFromJavaClass(Class<?> clazz) {
         return javaClassesToPainlessStructs.get(clazz);
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.painless.Definition.Method;
 import org.objectweb.asm.Type;
 
 import java.lang.invoke.MethodType;
@@ -55,9 +54,9 @@ public class FunctionRef {
     public final MethodType delegateMethodType;
 
     /** interface method */
-    public final Method interfaceMethod;
+    public final Painless.Method interfaceMethod;
     /** delegate method */
-    public final Method delegateMethod;
+    public final Painless.Method delegateMethod;
 
     /** factory method type descriptor */
     public final String factoryDescriptor;
@@ -89,7 +88,7 @@ public class FunctionRef {
      * @param delegateMethod implementation method
      * @param numCaptures number of captured arguments
      */
-    public FunctionRef(Class<?> expected, Method interfaceMethod, Method delegateMethod, int numCaptures) {
+    public FunctionRef(Class<?> expected, Painless.Method interfaceMethod, Painless.Method delegateMethod, int numCaptures) {
         MethodType delegateMethodType = delegateMethod.getMethodType();
 
         interfaceMethodName = interfaceMethod.name;
@@ -135,7 +134,7 @@ public class FunctionRef {
      * It is for runtime use only.
      */
     public FunctionRef(Class<?> expected,
-                       Method interfaceMethod, String delegateMethodName, MethodType delegateMethodType, int numCaptures) {
+                       Painless.Method interfaceMethod, String delegateMethodName, MethodType delegateMethodType, int numCaptures) {
         interfaceMethodName = interfaceMethod.name;
         factoryMethodType = MethodType.methodType(expected,
             delegateMethodType.dropParameterTypes(numCaptures, delegateMethodType.parameterCount()));
@@ -158,11 +157,11 @@ public class FunctionRef {
     /**
      * Looks up {@code type::call} from the whitelist, and returns a matching method.
      */
-    private static Definition.Method lookup(Definition definition, Class<?> expected,
-                                            String type, String call, boolean receiverCaptured) {
+    private static Painless.Method lookup(Definition definition, Class<?> expected,
+                                 String type, String call, boolean receiverCaptured) {
         // check its really a functional interface
         // for e.g. Comparable
-        Method method = definition.getPainlessStructFromJavaClass(expected).functionalMethod;
+        Painless.Method method = definition.getPainlessStructFromJavaClass(expected).functionalMethod;
         if (method == null) {
             throw new IllegalArgumentException("Cannot convert function reference [" + type + "::" + call + "] " +
                                                "to [" + Definition.ClassToName(expected) + "], not a functional interface");
@@ -170,13 +169,13 @@ public class FunctionRef {
 
         // lookup requested method
         Definition.Struct struct = definition.getPainlessStructFromJavaClass(definition.getJavaClassFromPainlessType(type));
-        final Definition.Method impl;
+        final Painless.Method impl;
         // ctor ref
         if ("new".equals(call)) {
             impl = struct.constructors.get(new Definition.MethodKey("<init>", method.arguments.size()));
         } else {
             // look for a static impl first
-            Definition.Method staticImpl = struct.staticMethods.get(new Definition.MethodKey(call, method.arguments.size()));
+            Painless.Method staticImpl = struct.staticMethods.get(new Definition.MethodKey(call, method.arguments.size()));
             if (staticImpl == null) {
                 // otherwise a virtual impl
                 final int arity;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
@@ -168,7 +168,7 @@ public class FunctionRef {
         }
 
         // lookup requested method
-        Definition.Struct struct = definition.getPainlessStructFromJavaClass(definition.getJavaClassFromPainlessType(type));
+        Painless.Struct struct = definition.getPainlessStructFromJavaClass(definition.getJavaClassFromPainlessType(type));
         final Painless.Method impl;
         // ctor ref
         if ("new".equals(call)) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/FunctionRef.java
@@ -172,10 +172,10 @@ public class FunctionRef {
         final Painless.Method impl;
         // ctor ref
         if ("new".equals(call)) {
-            impl = struct.constructors.get(new Definition.MethodKey("<init>", method.arguments.size()));
+            impl = struct.constructors.get(new Painless.MethodKey("<init>", method.arguments.size()));
         } else {
             // look for a static impl first
-            Painless.Method staticImpl = struct.staticMethods.get(new Definition.MethodKey(call, method.arguments.size()));
+            Painless.Method staticImpl = struct.staticMethods.get(new Painless.MethodKey(call, method.arguments.size()));
             if (staticImpl == null) {
                 // otherwise a virtual impl
                 final int arity;
@@ -186,7 +186,7 @@ public class FunctionRef {
                     // receiver passed
                     arity = method.arguments.size() - 1;
                 }
-                impl = struct.methods.get(new Definition.MethodKey(call, arity));
+                impl = struct.methods.get(new Painless.MethodKey(call, arity));
             } else {
                 impl = staticImpl;
             }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.painless.Definition.Method;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.ScriptClassInfo.MethodArgument;
 
@@ -109,9 +108,9 @@ public final class Locals {
     }
 
     /** Creates a new program scope: the list of methods. It is the parent for all methods */
-    public static Locals newProgramScope(Definition definition, Collection<Method> methods) {
+    public static Locals newProgramScope(Definition definition, Collection<Painless.Method> methods) {
         Locals locals = new Locals(null, definition, null, null);
-        for (Method method : methods) {
+        for (Painless.Method method : methods) {
             locals.addMethod(method);
         }
         return locals;
@@ -142,8 +141,8 @@ public final class Locals {
     }
 
     /** Looks up a method. Returns null if the method does not exist. */
-    public Method getMethod(MethodKey key) {
-        Method method = lookupMethod(key);
+    public Painless.Method getMethod(MethodKey key) {
+        Painless.Method method = lookupMethod(key);
         if (method != null) {
             return method;
         }
@@ -198,7 +197,7 @@ public final class Locals {
     // variable name -> variable
     private Map<String,Variable> variables;
     // method name+arity -> methods
-    private Map<MethodKey,Method> methods;
+    private Map<MethodKey, Painless.Method> methods;
 
     /**
      * Create a new Locals
@@ -236,7 +235,7 @@ public final class Locals {
     }
 
     /** Looks up a method at this scope only. Returns null if the method does not exist. */
-    private Method lookupMethod(MethodKey key) {
+    private Painless.Method lookupMethod(MethodKey key) {
         if (methods == null) {
             return null;
         }
@@ -255,7 +254,7 @@ public final class Locals {
         return variable;
     }
 
-    private void addMethod(Method method) {
+    private void addMethod(Painless.Method method) {
         if (methods == null) {
             methods = new HashMap<>();
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Locals.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.ScriptClassInfo.MethodArgument;
 
 import java.util.Arrays;
@@ -141,7 +140,7 @@ public final class Locals {
     }
 
     /** Looks up a method. Returns null if the method does not exist. */
-    public Painless.Method getMethod(MethodKey key) {
+    public Painless.Method getMethod(Painless.MethodKey key) {
         Painless.Method method = lookupMethod(key);
         if (method != null) {
             return method;
@@ -197,7 +196,7 @@ public final class Locals {
     // variable name -> variable
     private Map<String,Variable> variables;
     // method name+arity -> methods
-    private Map<MethodKey, Painless.Method> methods;
+    private Map<Painless.MethodKey, Painless.Method> methods;
 
     /**
      * Create a new Locals
@@ -235,7 +234,7 @@ public final class Locals {
     }
 
     /** Looks up a method at this scope only. Returns null if the method does not exist. */
-    private Painless.Method lookupMethod(MethodKey key) {
+    private Painless.Method lookupMethod(Painless.MethodKey key) {
         if (methods == null) {
             return null;
         }
@@ -258,7 +257,7 @@ public final class Locals {
         if (methods == null) {
             methods = new HashMap<>();
         }
-        methods.put(new MethodKey(method.name, method.arguments.size()), method);
+        methods.put(new Painless.MethodKey(method.name, method.arguments.size()), method);
         // TODO: check result
     }
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Definition.def;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
@@ -130,7 +129,7 @@ public final class MethodWriter extends GeneratorAdapter {
         mark(end);
     }
 
-    public void writeCast(Cast cast) {
+    public void writeCast(Painless.Cast cast) {
         if (cast != null) {
             if (cast.from == char.class && cast.to == String.class) {
                 invokeStatic(UTILITY_TYPE, CHAR_TO_STRING);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
@@ -283,4 +283,50 @@ public class Painless {
             return name.hashCode();
         }
     }
+
+    public static class Cast {
+
+        /** Create a standard cast with no boxing/unboxing. */
+        public static Cast standard(Class<?> from, Class<?> to, boolean explicit) {
+            return new Cast(from, to, explicit, null, null, null, null);
+        }
+
+        /** Create a cast where the from type will be unboxed, and then the cast will be performed. */
+        public static Cast unboxFrom(Class<?> from, Class<?> to, boolean explicit, Class<?> unboxFrom) {
+            return new Cast(from, to, explicit, unboxFrom, null, null, null);
+        }
+
+        /** Create a cast where the to type will be unboxed, and then the cast will be performed. */
+        public static Cast unboxTo(Class<?> from, Class<?> to, boolean explicit, Class<?> unboxTo) {
+            return new Cast(from, to, explicit, null, unboxTo, null, null);
+        }
+
+        /** Create a cast where the from type will be boxed, and then the cast will be performed. */
+        public static Cast boxFrom(Class<?> from, Class<?> to, boolean explicit, Class<?> boxFrom) {
+            return new Cast(from, to, explicit, null, null, boxFrom, null);
+        }
+
+        /** Create a cast where the to type will be boxed, and then the cast will be performed. */
+        public static Cast boxTo(Class<?> from, Class<?> to, boolean explicit, Class<?> boxTo) {
+            return new Cast(from, to, explicit, null, null, null, boxTo);
+        }
+
+        public final Class<?> from;
+        public final Class<?> to;
+        public final boolean explicit;
+        public final Class<?> unboxFrom;
+        public final Class<?> unboxTo;
+        public final Class<?> boxFrom;
+        public final Class<?> boxTo;
+
+        private Cast(Class<?> from, Class<?> to, boolean explicit, Class<?> unboxFrom, Class<?> unboxTo, Class<?> boxFrom, Class<?> boxTo) {
+            this.from = from;
+            this.to = to;
+            this.explicit = explicit;
+            this.unboxFrom = unboxFrom;
+            this.unboxTo = unboxTo;
+            this.boxFrom = boxFrom;
+            this.boxTo = boxTo;
+        }
+    }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
@@ -19,14 +19,15 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.painless.Definition.Struct;
 import org.objectweb.asm.Opcodes;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class Painless {
@@ -202,6 +203,84 @@ public class Painless {
             this.modifiers = modifiers;
             this.getter = getter;
             this.setter = setter;
+        }
+    }
+
+    public static final class Struct {
+        public final String name;
+        public final Class<?> clazz;
+        public final org.objectweb.asm.Type type;
+
+        public final Map<MethodKey, Method> constructors;
+        public final Map<MethodKey, Method> staticMethods;
+        public final Map<MethodKey, Method> methods;
+
+        public final Map<String, Field> staticMembers;
+        public final Map<String, Field> members;
+
+        public final Map<String, MethodHandle> getters;
+        public final Map<String, MethodHandle> setters;
+
+        public final Method functionalMethod;
+
+        public Struct(String name, Class<?> clazz, org.objectweb.asm.Type type) {
+            this.name = name;
+            this.clazz = clazz;
+            this.type = type;
+
+            constructors = new HashMap<>();
+            staticMethods = new HashMap<>();
+            methods = new HashMap<>();
+
+            staticMembers = new HashMap<>();
+            members = new HashMap<>();
+
+            getters = new HashMap<>();
+            setters = new HashMap<>();
+
+            functionalMethod = null;
+        }
+
+        private Struct(Struct struct, Method functionalMethod) {
+            name = struct.name;
+            clazz = struct.clazz;
+            type = struct.type;
+
+            constructors = Collections.unmodifiableMap(struct.constructors);
+            staticMethods = Collections.unmodifiableMap(struct.staticMethods);
+            methods = Collections.unmodifiableMap(struct.methods);
+
+            staticMembers = Collections.unmodifiableMap(struct.staticMembers);
+            members = Collections.unmodifiableMap(struct.members);
+
+            getters = Collections.unmodifiableMap(struct.getters);
+            setters = Collections.unmodifiableMap(struct.setters);
+
+            this.functionalMethod = functionalMethod;
+        }
+
+        public Struct freeze(Method functionalMethod) {
+            return new Struct(this, functionalMethod);
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+
+            if (object == null || getClass() != object.getClass()) {
+                return false;
+            }
+
+            Struct struct = (Struct)object;
+
+            return name.equals(struct.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
         }
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.painless;
+
+import org.elasticsearch.painless.Definition.Struct;
+import org.objectweb.asm.Opcodes;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.List;
+
+public class Painless {
+
+    public static class Method {
+        public final String name;
+        public final Struct owner;
+        public final Class<?> augmentation;
+        public final Class<?> rtn;
+        public final List<Class<?>> arguments;
+        public final org.objectweb.asm.commons.Method method;
+        public final int modifiers;
+        public final MethodHandle handle;
+
+        public Method(String name, Struct owner, Class<?> augmentation, Class<?> rtn, List<Class<?>> arguments,
+                      org.objectweb.asm.commons.Method method, int modifiers, MethodHandle handle) {
+            this.name = name;
+            this.augmentation = augmentation;
+            this.owner = owner;
+            this.rtn = rtn;
+            this.arguments = Collections.unmodifiableList(arguments);
+            this.method = method;
+            this.modifiers = modifiers;
+            this.handle = handle;
+        }
+
+        /**
+         * Returns MethodType for this method.
+         * <p>
+         * This works even for user-defined Methods (where the MethodHandle is null).
+         */
+        public MethodType getMethodType() {
+            // we have a methodhandle already (e.g. whitelisted class)
+            // just return its type
+            if (handle != null) {
+                return handle.type();
+            }
+            // otherwise compute it
+            final Class<?> params[];
+            final Class<?> returnValue;
+            if (augmentation != null) {
+                // static method disguised as virtual/interface method
+                params = new Class<?>[1 + arguments.size()];
+                params[0] = augmentation;
+                for (int i = 0; i < arguments.size(); i++) {
+                    params[i + 1] = Definition.defClassToObjectClass(arguments.get(i));
+                }
+                returnValue = Definition.defClassToObjectClass(rtn);
+            } else if (Modifier.isStatic(modifiers)) {
+                // static method: straightforward copy
+                params = new Class<?>[arguments.size()];
+                for (int i = 0; i < arguments.size(); i++) {
+                    params[i] = Definition.defClassToObjectClass(arguments.get(i));
+                }
+                returnValue = Definition.defClassToObjectClass(rtn);
+            } else if ("<init>".equals(name)) {
+                // constructor: returns the owner class
+                params = new Class<?>[arguments.size()];
+                for (int i = 0; i < arguments.size(); i++) {
+                    params[i] = Definition.defClassToObjectClass(arguments.get(i));
+                }
+                returnValue = owner.clazz;
+            } else {
+                // virtual/interface method: add receiver class
+                params = new Class<?>[1 + arguments.size()];
+                params[0] = owner.clazz;
+                for (int i = 0; i < arguments.size(); i++) {
+                    params[i + 1] = Definition.defClassToObjectClass(arguments.get(i));
+                }
+                returnValue = Definition.defClassToObjectClass(rtn);
+            }
+            return MethodType.methodType(returnValue, params);
+        }
+
+        public void write(MethodWriter writer) {
+            final org.objectweb.asm.Type type;
+            final Class<?> clazz;
+            if (augmentation != null) {
+                assert Modifier.isStatic(modifiers);
+                clazz = augmentation;
+                type = org.objectweb.asm.Type.getType(augmentation);
+            } else {
+                clazz = owner.clazz;
+                type = owner.type;
+            }
+
+            if (Modifier.isStatic(modifiers)) {
+                // invokeStatic assumes that the owner class is not an interface, so this is a
+                // special case for interfaces where the interface method boolean needs to be set to
+                // true to reference the appropriate class constant when calling a static interface
+                // method since java 8 did not check, but java 9 and 10 do
+                if (Modifier.isInterface(clazz.getModifiers())) {
+                    writer.visitMethodInsn(Opcodes.INVOKESTATIC,
+                            type.getInternalName(), name, getMethodType().toMethodDescriptorString(), true);
+                } else {
+                    writer.invokeStatic(type, method);
+                }
+            } else if (Modifier.isInterface(clazz.getModifiers())) {
+                writer.invokeInterface(type, method);
+            } else {
+                writer.invokeVirtual(type, method);
+            }
+        }
+    }
+}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
@@ -185,4 +185,23 @@ public class Painless {
         }
     }
 
+    public static final class Field {
+        public final String name;
+        public final Struct owner;
+        public final Class<?> clazz;
+        public final String javaName;
+        public final int modifiers;
+        public final MethodHandle getter;
+        public final MethodHandle setter;
+
+        public Field(String name, String javaName, Struct owner, Class<?> clazz, int modifiers, MethodHandle getter, MethodHandle setter) {
+            this.name = name;
+            this.javaName = javaName;
+            this.owner = owner;
+            this.clazz = clazz;
+            this.modifiers = modifiers;
+            this.getter = getter;
+            this.setter = setter;
+        }
+    }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Painless.java
@@ -27,8 +27,62 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class Painless {
+
+    /**
+     * Key for looking up a method.
+     * <p>
+     * Methods are keyed on both name and arity, and can be overloaded once per arity.
+     * This allows signatures such as {@code String.indexOf(String) vs String.indexOf(String, int)}.
+     * <p>
+     * It is less flexible than full signature overloading where types can differ too, but
+     * better than just the name, and overloading types adds complexity to users, too.
+     */
+    public static final class MethodKey {
+        public final String name;
+        public final int arity;
+
+        /**
+         * Create a new lookup key
+         * @param name name of the method
+         * @param arity number of parameters
+         */
+        public MethodKey(String name, int arity) {
+            this.name = Objects.requireNonNull(name);
+            this.arity = arity;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + arity;
+            result = prime * result + name.hashCode();
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null) return false;
+            if (getClass() != obj.getClass()) return false;
+            MethodKey other = (MethodKey) obj;
+            if (arity != other.arity) return false;
+            if (!name.equals(other.name)) return false;
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(name);
+            sb.append('/');
+            sb.append(arity);
+            return sb.toString();
+        }
+    }
 
     public static class Method {
         public final String name;
@@ -130,4 +184,5 @@ public class Painless {
             }
         }
     }
+
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessExplainError.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessExplainError.java
@@ -54,7 +54,7 @@ public class PainlessExplainError extends Error {
         if (objectToExplain != null) {
             toString = objectToExplain.toString();
             javaClassName = objectToExplain.getClass().getName();
-            Definition.Struct struct = definition.getPainlessStructFromJavaClass(objectToExplain.getClass());
+            Painless.Struct struct = definition.getPainlessStructFromJavaClass(objectToExplain.getClass());
             if (struct != null) {
                 painlessClassName = struct.name;
             }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/AExpression.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/AExpression.java
@@ -21,7 +21,7 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Cast;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
 
@@ -118,7 +118,7 @@ public abstract class AExpression extends ANode {
      * @return The new child node for the parent node calling this method.
      */
     AExpression cast(Locals locals) {
-        Cast cast = AnalyzerCaster.getLegalCast(location, actual, expected, explicit, internal);
+        Painless.Cast cast = AnalyzerCaster.getLegalCast(location, actual, expected, explicit, internal);
 
         if (cast == null) {
             if (constant == null || this instanceof EConstant) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EAssignment.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EAssignment.java
@@ -22,13 +22,13 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.DefBootstrap;
-import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
 import org.elasticsearch.painless.MethodWriter;
 import org.elasticsearch.painless.Operation;
+import org.elasticsearch.painless.Painless;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,8 +49,8 @@ public final class EAssignment extends AExpression {
     private boolean cat = false;
     private Class<?> promote = null;
     private Class<?> shiftDistance; // for shifts, the RHS is promoted independently
-    private Cast there = null;
-    private Cast back = null;
+    private Painless.Cast there = null;
+    private Painless.Cast back = null;
 
     public EAssignment(Location location, AExpression lhs, AExpression rhs, boolean pre, boolean post, Operation operation) {
         super(location);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECallLocal.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECallLocal.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -40,7 +40,7 @@ public final class ECallLocal extends AExpression {
     private final String name;
     private final List<AExpression> arguments;
 
-    private Method method = null;
+    private Painless.Method method = null;
 
     public ECallLocal(Location location, String name, List<AExpression> arguments) {
         super(location);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECallLocal.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECallLocal.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -58,7 +57,7 @@ public final class ECallLocal extends AExpression {
 
     @Override
     void analyze(Locals locals) {
-        MethodKey methodKey = new MethodKey(name, arguments.size());
+        Painless.MethodKey methodKey = new Painless.MethodKey(name, arguments.size());
         method = locals.getMethod(methodKey);
 
         if (method == null) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECast.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ECast.java
@@ -20,11 +20,11 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
 import org.elasticsearch.painless.MethodWriter;
+import org.elasticsearch.painless.Painless;
 
 import java.util.Objects;
 import java.util.Set;
@@ -35,9 +35,9 @@ import java.util.Set;
 final class ECast extends AExpression {
 
     private AExpression child;
-    private final Cast cast;
+    private final Painless.Cast cast;
 
-    ECast(Location location, AExpression child, Cast cast) {
+    ECast(Location location, AExpression child, Painless.Cast cast) {
         super(location);
 
         this.child = Objects.requireNonNull(child);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EFunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EFunctionRef.java
@@ -21,7 +21,7 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.Globals;
@@ -66,12 +66,12 @@ public final class EFunctionRef extends AExpression implements ILambda {
             try {
                 if ("this".equals(type)) {
                     // user's own function
-                    Method interfaceMethod = locals.getDefinition().getPainlessStructFromJavaClass(expected).functionalMethod;
+                    Painless.Method interfaceMethod = locals.getDefinition().getPainlessStructFromJavaClass(expected).functionalMethod;
                     if (interfaceMethod == null) {
                         throw new IllegalArgumentException("Cannot convert function reference [" + type + "::" + call + "] " +
                                                            "to [" + Definition.ClassToName(expected) + "], not a functional interface");
                     }
-                    Method delegateMethod = locals.getMethod(new MethodKey(call, interfaceMethod.arguments.size()));
+                    Painless.Method delegateMethod = locals.getMethod(new MethodKey(call, interfaceMethod.arguments.size()));
                     if (delegateMethod == null) {
                         throw new IllegalArgumentException("Cannot convert function reference [" + type + "::" + call + "] " +
                                                            "to [" + Definition.ClassToName(expected) + "], function not found");

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EFunctionRef.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EFunctionRef.java
@@ -22,7 +22,6 @@ package org.elasticsearch.painless.node;
 import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -71,7 +70,7 @@ public final class EFunctionRef extends AExpression implements ILambda {
                         throw new IllegalArgumentException("Cannot convert function reference [" + type + "::" + call + "] " +
                                                            "to [" + Definition.ClassToName(expected) + "], not a functional interface");
                     }
-                    Painless.Method delegateMethod = locals.getMethod(new MethodKey(call, interfaceMethod.arguments.size()));
+                    Painless.Method delegateMethod = locals.getMethod(new Painless.MethodKey(call, interfaceMethod.arguments.size()));
                     if (delegateMethod == null) {
                         throw new IllegalArgumentException("Cannot convert function reference [" + type + "::" + call + "] " +
                                                            "to [" + Definition.ClassToName(expected) + "], function not found");

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ELambda.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ELambda.java
@@ -21,7 +21,7 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.FunctionRef;
 import org.elasticsearch.painless.Globals;
@@ -103,7 +103,7 @@ public final class ELambda extends AExpression implements ILambda {
     void analyze(Locals locals) {
         Class<?> returnType;
         List<String> actualParamTypeStrs;
-        Method interfaceMethod;
+        Painless.Method interfaceMethod;
         // inspect the target first, set interface method if we know it.
         if (expected == null) {
             interfaceMethod = null;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EListInit.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EListInit.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
@@ -37,8 +37,8 @@ import java.util.Set;
 public final class EListInit extends AExpression {
     private final List<AExpression> values;
 
-    private Method constructor = null;
-    private Method method = null;
+    private Painless.Method constructor = null;
+    private Painless.Method method = null;
 
     public EListInit(Location location, List<AExpression> values) {
         super(location);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EListInit.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EListInit.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -61,13 +60,13 @@ public final class EListInit extends AExpression {
 
         actual = ArrayList.class;
 
-        constructor = locals.getDefinition().getPainlessStructFromJavaClass(actual).constructors.get(new MethodKey("<init>", 0));
+        constructor = locals.getDefinition().getPainlessStructFromJavaClass(actual).constructors.get(new Painless.MethodKey("<init>", 0));
 
         if (constructor == null) {
             throw createError(new IllegalStateException("Illegal tree structure."));
         }
 
-        method = locals.getDefinition().getPainlessStructFromJavaClass(actual).methods.get(new MethodKey("add", 1));
+        method = locals.getDefinition().getPainlessStructFromJavaClass(actual).methods.get(new Painless.MethodKey("add", 1));
 
         if (method == null) {
             throw createError(new IllegalStateException("Illegal tree structure."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EMapInit.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EMapInit.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
@@ -38,8 +38,8 @@ public final class EMapInit extends AExpression {
     private final List<AExpression> keys;
     private final List<AExpression> values;
 
-    private Method constructor = null;
-    private Method method = null;
+    private Painless.Method constructor = null;
+    private Painless.Method method = null;
 
     public EMapInit(Location location, List<AExpression> keys, List<AExpression> values) {
         super(location);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EMapInit.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/EMapInit.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -67,13 +66,13 @@ public final class EMapInit extends AExpression {
 
         actual = HashMap.class;
 
-        constructor = locals.getDefinition().getPainlessStructFromJavaClass(actual).constructors.get(new MethodKey("<init>", 0));
+        constructor = locals.getDefinition().getPainlessStructFromJavaClass(actual).constructors.get(new Painless.MethodKey("<init>", 0));
 
         if (constructor == null) {
             throw createError(new IllegalStateException("Illegal tree structure."));
         }
 
-        method = locals.getDefinition().getPainlessStructFromJavaClass(actual).methods.get(new MethodKey("put", 2));
+        method = locals.getDefinition().getPainlessStructFromJavaClass(actual).methods.get(new Painless.MethodKey("put", 2));
 
         if (method == null) {
             throw createError(new IllegalStateException("Illegal tree structure."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -62,7 +61,7 @@ public final class ENewObj extends AExpression {
             throw createError(new IllegalArgumentException("Not a type [" + this.type + "]."));
         }
 
-        Struct struct = locals.getDefinition().getPainlessStructFromJavaClass(actual);
+        Painless.Struct struct = locals.getDefinition().getPainlessStructFromJavaClass(actual);
         constructor = struct.constructors.get(new Painless.MethodKey("<init>", arguments.size()));
 
         if (constructor != null) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
@@ -64,7 +63,7 @@ public final class ENewObj extends AExpression {
         }
 
         Struct struct = locals.getDefinition().getPainlessStructFromJavaClass(actual);
-        constructor = struct.constructors.get(new Definition.MethodKey("<init>", arguments.size()));
+        constructor = struct.constructors.get(new Painless.MethodKey("<init>", arguments.size()));
 
         if (constructor != null) {
             Class<?>[] types = new Class<?>[constructor.arguments.size()];

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/ENewObj.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -39,7 +39,7 @@ public final class ENewObj extends AExpression {
     private final String type;
     private final List<AExpression> arguments;
 
-    private Method constructor;
+    private Painless.Method constructor;
 
     public ENewObj(Location location, String type, List<AExpression> arguments) {
         super(location);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.def;
@@ -78,7 +78,7 @@ public final class PCallInvoke extends AExpression {
         }
 
         MethodKey methodKey = new MethodKey(name, arguments.size());
-        Method method = prefix instanceof EStatic ? struct.staticMethods.get(methodKey) : struct.methods.get(methodKey);
+        Painless.Method method = prefix instanceof EStatic ? struct.staticMethods.get(methodKey) : struct.methods.get(methodKey);
 
         if (method != null) {
             sub = new PSubCallInvoke(location, method, prefix.actual, arguments);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
@@ -77,7 +76,7 @@ public final class PCallInvoke extends AExpression {
             struct = locals.getDefinition().getPainlessStructFromJavaClass(Definition.getBoxedType(prefix.actual));
         }
 
-        MethodKey methodKey = new MethodKey(name, arguments.size());
+        Painless.MethodKey methodKey = new Painless.MethodKey(name, arguments.size());
         Painless.Method method = prefix instanceof EStatic ? struct.staticMethods.get(methodKey) : struct.methods.get(methodKey);
 
         if (method != null) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PCallInvoke.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -70,7 +69,7 @@ public final class PCallInvoke extends AExpression {
             throw createError(new IllegalArgumentException("Illegal call [" + name + "] on array type."));
         }
 
-        Struct struct = locals.getDefinition().getPainlessStructFromJavaClass(prefix.actual);
+        Painless.Struct struct = locals.getDefinition().getPainlessStructFromJavaClass(prefix.actual);
 
         if (prefix.actual.isPrimitive()) {
             struct = locals.getDefinition().getPainlessStructFromJavaClass(Definition.getBoxedType(prefix.actual));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
@@ -21,7 +21,7 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Field;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
@@ -73,7 +73,7 @@ public final class PField extends AStoreable {
             if (field != null) {
                 sub = new PSubField(location, field);
             } else {
-                Method getter = struct.methods.get(
+                Painless.Method getter = struct.methods.get(
                     new Definition.MethodKey("get" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0));
 
                 if (getter == null) {
@@ -81,7 +81,7 @@ public final class PField extends AStoreable {
                         new Definition.MethodKey("is" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0));
                 }
 
-                Method setter = struct.methods.get(
+                Painless.Method setter = struct.methods.get(
                     new Definition.MethodKey("set" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 1));
 
                 if (getter != null || setter != null) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -66,7 +65,7 @@ public final class PField extends AStoreable {
         } else if (prefix.actual == def.class) {
             sub = new PSubDefField(location, value);
         } else {
-            Struct struct = locals.getDefinition().getPainlessStructFromJavaClass(prefix.actual);
+            Painless.Struct struct = locals.getDefinition().getPainlessStructFromJavaClass(prefix.actual);
             Painless.Field field = prefix instanceof EStatic ? struct.staticMembers.get(value) : struct.members.get(value);
 
             if (field != null) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Field;
 import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Definition.def;
@@ -68,7 +67,7 @@ public final class PField extends AStoreable {
             sub = new PSubDefField(location, value);
         } else {
             Struct struct = locals.getDefinition().getPainlessStructFromJavaClass(prefix.actual);
-            Field field = prefix instanceof EStatic ? struct.staticMembers.get(value) : struct.members.get(value);
+            Painless.Field field = prefix instanceof EStatic ? struct.staticMembers.get(value) : struct.members.get(value);
 
             if (field != null) {
                 sub = new PSubField(location, field);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PField.java
@@ -74,15 +74,15 @@ public final class PField extends AStoreable {
                 sub = new PSubField(location, field);
             } else {
                 Painless.Method getter = struct.methods.get(
-                    new Definition.MethodKey("get" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0));
+                    new Painless.MethodKey("get" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0));
 
                 if (getter == null) {
                     getter = struct.methods.get(
-                        new Definition.MethodKey("is" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0));
+                        new Painless.MethodKey("is" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 0));
                 }
 
                 Painless.Method setter = struct.methods.get(
-                    new Definition.MethodKey("set" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 1));
+                    new Painless.MethodKey("set" + Character.toUpperCase(value.charAt(0)) + value.substring(1), 1));
 
                 if (getter != null || setter != null) {
                     sub = new PSubShortcut(location, value, Definition.ClassToName(prefix.actual), getter, setter);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubCallInvoke.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -34,11 +34,11 @@ import java.util.Set;
  */
 final class PSubCallInvoke extends AExpression {
 
-    private final Method method;
+    private final Painless.Method method;
     private final Class<?> box;
     private final List<AExpression> arguments;
 
-    PSubCallInvoke(Location location, Method method, Class<?> box, List<AExpression> arguments) {
+    PSubCallInvoke(Location location, Painless.Method method, Class<?> box, List<AExpression> arguments) {
         super(location);
 
         this.method = Objects.requireNonNull(method);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubField.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubField.java
@@ -20,11 +20,11 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Field;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
 import org.elasticsearch.painless.MethodWriter;
+import org.elasticsearch.painless.Painless;
 
 import java.lang.reflect.Modifier;
 import java.util.Objects;
@@ -35,9 +35,9 @@ import java.util.Set;
  */
 final class PSubField extends AStoreable {
 
-    private final Field field;
+    private final Painless.Field field;
 
-    PSubField(Location location, Field field) {
+    PSubField(Location location, Painless.Field field) {
         super(location);
 
         this.field = Objects.requireNonNull(field);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -39,8 +39,8 @@ final class PSubListShortcut extends AStoreable {
     private final Struct struct;
     private AExpression index;
 
-    private Method getter;
-    private Method setter;
+    private Painless.Method getter;
+    private Painless.Method setter;
 
     PSubListShortcut(Location location, Struct struct, AExpression index) {
         super(location);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -35,13 +34,13 @@ import java.util.Set;
  */
 final class PSubListShortcut extends AStoreable {
 
-    private final Struct struct;
+    private final Painless.Struct struct;
     private AExpression index;
 
     private Painless.Method getter;
     private Painless.Method setter;
 
-    PSubListShortcut(Location location, Struct struct, AExpression index) {
+    PSubListShortcut(Location location, Painless.Struct struct, AExpression index) {
         super(location);
 
         this.struct = Objects.requireNonNull(struct);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubListShortcut.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
@@ -56,8 +55,8 @@ final class PSubListShortcut extends AStoreable {
 
     @Override
     void analyze(Locals locals) {
-        getter = struct.methods.get(new Definition.MethodKey("get", 1));
-        setter = struct.methods.get(new Definition.MethodKey("set", 2));
+        getter = struct.methods.get(new Painless.MethodKey("get", 1));
+        setter = struct.methods.get(new Painless.MethodKey("set", 2));
 
         if (getter != null && (getter.rtn == void.class || getter.arguments.size() != 1 ||
             getter.arguments.get(0) != int.class)) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -34,13 +33,13 @@ import java.util.Set;
  */
 final class PSubMapShortcut extends AStoreable {
 
-    private final Struct struct;
+    private final Painless.Struct struct;
     private AExpression index;
 
     private Painless.Method getter;
     private Painless.Method setter;
 
-    PSubMapShortcut(Location location, Struct struct, AExpression index) {
+    PSubMapShortcut(Location location, Painless.Struct struct, AExpression index) {
         super(location);
 
         this.struct = Objects.requireNonNull(struct);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -38,8 +38,8 @@ final class PSubMapShortcut extends AStoreable {
     private final Struct struct;
     private AExpression index;
 
-    private Method getter;
-    private Method setter;
+    private Painless.Method getter;
+    private Painless.Method setter;
 
     PSubMapShortcut(Location location, Struct struct, AExpression index) {
         super(location);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubMapShortcut.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.Globals;
@@ -55,8 +54,8 @@ final class PSubMapShortcut extends AStoreable {
 
     @Override
     void analyze(Locals locals) {
-        getter = struct.methods.get(new Definition.MethodKey("get", 1));
-        setter = struct.methods.get(new Definition.MethodKey("put", 2));
+        getter = struct.methods.get(new Painless.MethodKey("get", 1));
+        setter = struct.methods.get(new Painless.MethodKey("put", 2));
 
         if (getter != null && (getter.rtn == void.class || getter.arguments.size() != 1)) {
             throw createError(new IllegalArgumentException("Illegal map get shortcut for type [" + struct.name + "]."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubShortcut.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/PSubShortcut.java
@@ -19,7 +19,7 @@
 
 package org.elasticsearch.painless.node;
 
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Location;
@@ -34,10 +34,10 @@ final class PSubShortcut extends AStoreable {
 
     private final String value;
     private final String type;
-    private final Method getter;
-    private final Method setter;
+    private final Painless.Method getter;
+    private final Painless.Method setter;
 
-    PSubShortcut(Location location, String value, String type, Method getter, Method setter) {
+    PSubShortcut(Location location, String value, String type, Painless.Method getter, Painless.Method setter) {
         super(location);
 
         this.value = value;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFunction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SFunction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Constant;
 import org.elasticsearch.painless.Def;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Parameter;
@@ -93,7 +93,7 @@ public final class SFunction extends AStatement {
 
     Class<?> rtnType = null;
     List<Parameter> parameters = new ArrayList<>();
-    Method method = null;
+    Painless.Method method = null;
 
     private Variable loop = null;
 
@@ -146,7 +146,7 @@ public final class SFunction extends AStatement {
 
         org.objectweb.asm.commons.Method method = new org.objectweb.asm.commons.Method(
             name, MethodType.methodType(Definition.defClassToObjectClass(rtnType), paramClasses).toMethodDescriptorString());
-        this.method = new Method(name, null, null, rtnType, paramTypes, method, Modifier.STATIC | Modifier.PRIVATE, null);
+        this.method = new Painless.Method(name, null, null, rtnType, paramTypes, method, Modifier.STATIC | Modifier.PRIVATE, null);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
@@ -23,7 +23,6 @@ import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Constant;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Variable;
@@ -168,12 +167,12 @@ public final class SSource extends AStatement {
     }
 
     public void analyze(Definition definition) {
-        Map<MethodKey, Painless.Method> methods = new HashMap<>();
+        Map<Painless.MethodKey, Painless.Method> methods = new HashMap<>();
 
         for (SFunction function : functions) {
             function.generateSignature(definition);
 
-            MethodKey key = new MethodKey(function.name, function.parameters.size());
+            Painless.MethodKey key = new Painless.MethodKey(function.name, function.parameters.size());
 
             if (methods.put(key, function.method) != null) {
                 throw createError(new IllegalArgumentException("Duplicate functions with name [" + function.name + "]."));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSource.java
@@ -22,7 +22,7 @@ package org.elasticsearch.painless.node;
 import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Constant;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -168,7 +168,7 @@ public final class SSource extends AStatement {
     }
 
     public void analyze(Definition definition) {
-        Map<MethodKey, Method> methods = new HashMap<>();
+        Map<MethodKey, Painless.Method> methods = new HashMap<>();
 
         for (SFunction function : functions) {
             function.generateSignature(definition);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachArray.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachArray.java
@@ -21,12 +21,12 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
 import org.elasticsearch.painless.Locals.Variable;
 import org.elasticsearch.painless.Location;
 import org.elasticsearch.painless.MethodWriter;
+import org.elasticsearch.painless.Painless;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 
@@ -41,7 +41,7 @@ final class SSubEachArray extends AStatement {
     private AExpression expression;
     private final SBlock block;
 
-    private Cast cast = null;
+    private Painless.Cast cast = null;
     private Variable array = null;
     private Variable index = null;
     private Class<?> indexed = null;

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
@@ -24,7 +24,6 @@ import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
 import org.elasticsearch.painless.Locals;
@@ -77,7 +76,8 @@ final class SSubEachIterable extends AStatement {
         if (expression.actual == def.class) {
             method = null;
         } else {
-            method = locals.getDefinition().getPainlessStructFromJavaClass(expression.actual).methods.get(new MethodKey("iterator", 0));
+            method = locals.getDefinition().getPainlessStructFromJavaClass(expression.actual).methods.get(
+                    new Painless.MethodKey("iterator", 0));
 
             if (method == null) {
                 throw createError(new IllegalArgumentException(

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
@@ -23,7 +23,7 @@ import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
@@ -53,7 +53,7 @@ final class SSubEachIterable extends AStatement {
 
     private Cast cast = null;
     private Variable iterator = null;
-    private Method method = null;
+    private Painless.Method method = null;
 
     SSubEachIterable(Location location, Variable variable, AExpression expression, SBlock block) {
         super(location);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/node/SSubEachIterable.java
@@ -22,7 +22,6 @@ package org.elasticsearch.painless.node;
 import org.elasticsearch.painless.AnalyzerCaster;
 import org.elasticsearch.painless.DefBootstrap;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.def;
 import org.elasticsearch.painless.Globals;
@@ -50,7 +49,7 @@ final class SSubEachIterable extends AStatement {
     private final SBlock block;
     private final Variable variable;
 
-    private Cast cast = null;
+    private Painless.Cast cast = null;
     private Variable iterator = null;
     private Painless.Method method = null;
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/AnalyzerCasterTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/AnalyzerCasterTests.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.painless;
 
-import org.elasticsearch.painless.Definition.Cast;
-
 import org.elasticsearch.test.ESTestCase;
 
 public class AnalyzerCasterTests extends ESTestCase {
@@ -35,7 +33,7 @@ public class AnalyzerCasterTests extends ESTestCase {
             return;
         }
 
-        Cast cast = AnalyzerCaster.getLegalCast(location, actual, expected, true, false);
+        Painless.Cast cast = AnalyzerCaster.getLegalCast(location, actual, expected, true, false);
         assertEquals(actual, cast.from);
         assertEquals(expected, cast.to);
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessDocGenerator.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessDocGenerator.java
@@ -24,7 +24,7 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.painless.Definition.Field;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -51,8 +51,8 @@ public class PainlessDocGenerator {
     private static final Definition definition = new Definition(BASE_WHITELISTS);
     private static final Logger logger = ESLoggerFactory.getLogger(PainlessDocGenerator.class);
     private static final Comparator<Field> FIELD_NAME = comparing(f -> f.name);
-    private static final Comparator<Method> METHOD_NAME = comparing(m -> m.name);
-    private static final Comparator<Method> NUMBER_OF_ARGS = comparing(m -> m.arguments.size());
+    private static final Comparator<Painless.Method> METHOD_NAME = comparing(m -> m.name);
+    private static final Comparator<Painless.Method> NUMBER_OF_ARGS = comparing(m -> m.arguments.size());
 
     public static void main(String[] args) throws IOException {
         Path apiRootPath = PathUtils.get(args[0]);
@@ -94,7 +94,7 @@ public class PainlessDocGenerator {
                     typeStream.println("++::");
 
                     Consumer<Field> documentField = field -> PainlessDocGenerator.documentField(typeStream, field);
-                    Consumer<Method> documentMethod = method -> PainlessDocGenerator.documentMethod(typeStream, method);
+                    Consumer<Painless.Method> documentMethod = method -> PainlessDocGenerator.documentMethod(typeStream, method);
                     struct.staticMembers.values().stream().sorted(FIELD_NAME).forEach(documentField);
                     struct.members.values().stream().sorted(FIELD_NAME).forEach(documentField);
                     struct.staticMethods.values().stream().sorted(METHOD_NAME.thenComparing(NUMBER_OF_ARGS)).forEach(documentMethod);
@@ -159,7 +159,7 @@ public class PainlessDocGenerator {
     /**
      * Document a method.
      */
-    private static void documentMethod(PrintStream stream, Method method) {
+    private static void documentMethod(PrintStream stream, Painless.Method method) {
         stream.print("* ++[[");
         emitAnchor(stream, method);
         stream.print("]]");
@@ -209,9 +209,9 @@ public class PainlessDocGenerator {
     }
 
     /**
-     * Anchor text for a {@link Method}.
+     * Anchor text for a {@link Painless.Method}.
      */
-    private static void emitAnchor(PrintStream stream, Method method) {
+    private static void emitAnchor(PrintStream stream, Painless.Method method) {
         emitAnchor(stream, method.owner);
         stream.print('-');
         stream.print(methodName(method));
@@ -228,7 +228,7 @@ public class PainlessDocGenerator {
         stream.print(field.name);
     }
 
-    private static String methodName(Method method) {
+    private static String methodName(Painless.Method method) {
         return method.name.equals("<init>") ? method.owner.name : method.name;
     }
 
@@ -260,11 +260,11 @@ public class PainlessDocGenerator {
     }
 
     /**
-     * Emit an external link to Javadoc for a {@link Method}.
+     * Emit an external link to Javadoc for a {@link Painless.Method}.
      *
      * @param root name of the root uri variable
      */
-    private static void emitJavadocLink(PrintStream stream, String root, Method method) {
+    private static void emitJavadocLink(PrintStream stream, String root, Painless.Method method) {
         stream.print("link:{");
         stream.print(root);
         stream.print("-javadoc}/");
@@ -306,9 +306,9 @@ public class PainlessDocGenerator {
     }
 
     /**
-     * Pick the javadoc root for a {@link Method}.
+     * Pick the javadoc root for a {@link Painless.Method}.
      */
-    private static String javadocRoot(Method method) {
+    private static String javadocRoot(Painless.Method method) {
         if (method.augmentation != null) {
             return "painless";
         }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessDocGenerator.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessDocGenerator.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.logging.ESLoggerFactory;
-import org.elasticsearch.painless.Definition.Struct;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Modifier;
@@ -65,8 +64,8 @@ public class PainlessDocGenerator {
                 Files.newOutputStream(indexPath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE),
                 false, StandardCharsets.UTF_8.name())) {
             emitGeneratedWarning(indexStream);
-            List<Struct> structs = definition.getStructs().stream().sorted(comparing(t -> t.name)).collect(toList());
-            for (Struct struct : structs) {
+            List<Painless.Struct> structs = definition.getStructs().stream().sorted(comparing(t -> t.name)).collect(toList());
+            for (Painless.Struct struct : structs) {
                 if (struct.clazz.isPrimitive()) {
                     // Primitives don't have methods to reference
                     continue;
@@ -97,7 +96,7 @@ public class PainlessDocGenerator {
                     struct.members.values().stream().sorted(FIELD_NAME).forEach(documentField);
                     struct.staticMethods.values().stream().sorted(METHOD_NAME.thenComparing(NUMBER_OF_ARGS)).forEach(documentMethod);
                     struct.constructors.values().stream().sorted(NUMBER_OF_ARGS).forEach(documentMethod);
-                    Map<String, Struct> inherited = new TreeMap<>();
+                    Map<String, Painless.Struct> inherited = new TreeMap<>();
                     struct.methods.values().stream().sorted(METHOD_NAME.thenComparing(NUMBER_OF_ARGS)).forEach(method -> {
                         if (method.owner == struct) {
                             documentMethod(typeStream, method);
@@ -109,7 +108,7 @@ public class PainlessDocGenerator {
                     if (false == inherited.isEmpty()) {
                         typeStream.print("* Inherits methods from ");
                         boolean first = true;
-                        for (Struct inheritsFrom : inherited.values()) {
+                        for (Painless.Struct inheritsFrom : inherited.values()) {
                             if (first) {
                                 first = false;
                             } else {
@@ -199,9 +198,9 @@ public class PainlessDocGenerator {
     }
 
     /**
-     * Anchor text for a {@link Struct}.
+     * Anchor text for a {@link Painless.Struct}.
      */
-    private static void emitAnchor(PrintStream stream, Struct struct) {
+    private static void emitAnchor(PrintStream stream, Painless.Struct struct) {
         stream.print("painless-api-reference-");
         stream.print(struct.name.replace('.', '-'));
     }
@@ -242,10 +241,10 @@ public class PainlessDocGenerator {
     }
 
     /**
-     * Emit a {@link Struct}. If the {@linkplain Struct} is primitive or def this just emits the name of the struct. Otherwise this emits
-     * an internal link with the name.
+     * Emit a {@link Painless.Struct}. If the {@linkplain Painless.Struct} is primitive or def this just emits the name of the struct.
+     * Otherwise this emits an internal link with the name.
      */
-    private static void emitStruct(PrintStream stream, Struct struct) {
+    private static void emitStruct(PrintStream stream, Painless.Struct struct) {
         if (false == struct.clazz.isPrimitive() && false == struct.name.equals("def")) {
             stream.print("<<");
             emitAnchor(stream, struct);
@@ -321,9 +320,9 @@ public class PainlessDocGenerator {
     }
 
     /**
-     * Pick the javadoc root for a {@link Struct}.
+     * Pick the javadoc root for a {@link Painless.Struct}.
      */
-    private static String javadocRoot(Struct struct) {
+    private static String javadocRoot(Painless.Struct struct) {
         String classPackage = struct.clazz.getPackage().getName();
         if (classPackage.startsWith("java")) {
             return "java8";

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessDocGenerator.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessDocGenerator.java
@@ -23,8 +23,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.logging.ESLoggerFactory;
-import org.elasticsearch.painless.Definition.Field;
-import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -50,7 +48,7 @@ public class PainlessDocGenerator {
 
     private static final Definition definition = new Definition(BASE_WHITELISTS);
     private static final Logger logger = ESLoggerFactory.getLogger(PainlessDocGenerator.class);
-    private static final Comparator<Field> FIELD_NAME = comparing(f -> f.name);
+    private static final Comparator<Painless.Field> FIELD_NAME = comparing(f -> f.name);
     private static final Comparator<Painless.Method> METHOD_NAME = comparing(m -> m.name);
     private static final Comparator<Painless.Method> NUMBER_OF_ARGS = comparing(m -> m.arguments.size());
 
@@ -93,7 +91,7 @@ public class PainlessDocGenerator {
                     typeStream.print(struct.name);
                     typeStream.println("++::");
 
-                    Consumer<Field> documentField = field -> PainlessDocGenerator.documentField(typeStream, field);
+                    Consumer<Painless.Field> documentField = field -> PainlessDocGenerator.documentField(typeStream, field);
                     Consumer<Painless.Method> documentMethod = method -> PainlessDocGenerator.documentMethod(typeStream, method);
                     struct.staticMembers.values().stream().sorted(FIELD_NAME).forEach(documentField);
                     struct.members.values().stream().sorted(FIELD_NAME).forEach(documentField);
@@ -129,7 +127,7 @@ public class PainlessDocGenerator {
         logger.info("Done writing [index.asciidoc]");
     }
 
-    private static void documentField(PrintStream stream, Field field) {
+    private static void documentField(PrintStream stream, Painless.Field field) {
         stream.print("** [[");
         emitAnchor(stream, field);
         stream.print("]]");
@@ -220,9 +218,9 @@ public class PainlessDocGenerator {
     }
 
     /**
-     * Anchor text for a {@link Field}.
+     * Anchor text for a {@link Painless.Field}.
      */
-    private static void emitAnchor(PrintStream stream, Field field) {
+    private static void emitAnchor(PrintStream stream, Painless.Field field) {
         emitAnchor(stream, field.owner);
         stream.print('-');
         stream.print(field.name);
@@ -292,11 +290,11 @@ public class PainlessDocGenerator {
     }
 
     /**
-     * Emit an external link to Javadoc for a {@link Field}.
+     * Emit an external link to Javadoc for a {@link Painless.Field}.
      *
      * @param root name of the root uri variable
      */
-    private static void emitJavadocLink(PrintStream stream, String root, Field field) {
+    private static void emitJavadocLink(PrintStream stream, String root, Painless.Field field) {
         stream.print("link:{");
         stream.print(root);
         stream.print("-javadoc}/");
@@ -316,9 +314,9 @@ public class PainlessDocGenerator {
     }
 
     /**
-     * Pick the javadoc root for a {@link Field}.
+     * Pick the javadoc root for a {@link Painless.Field}.
      */
-    private static String javadocRoot(Field field) {
+    private static String javadocRoot(Painless.Field field) {
         return javadocRoot(field.owner);
     }
 

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Definition.Field;
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.FeatureTest;
 import org.elasticsearch.painless.GenericElasticsearchScript;
@@ -404,14 +403,14 @@ public class NodeToStringTests extends ESTestCase {
     public void testPSubCallInvoke() {
         Location l = new Location(getTestName(), 0);
         Struct c = definition.getPainlessStructFromJavaClass(Integer.class);
-        Painless.Method m = c.methods.get(new MethodKey("toString", 0));
+        Painless.Method m = c.methods.get(new Painless.MethodKey("toString", 0));
         PSubCallInvoke node = new PSubCallInvoke(l, m, null, emptyList());
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubCallInvoke (EVariable a) toString)", node.toString());
         assertEquals("(PSubNullSafeCallInvoke (PSubCallInvoke (EVariable a) toString))", new PSubNullSafeCallInvoke(l, node).toString());
 
         l = new Location(getTestName(), 1);
-        m = c.methods.get(new MethodKey("equals", 1));
+        m = c.methods.get(new Painless.MethodKey("equals", 1));
         node = new PSubCallInvoke(l, m, null, singletonList(new EVariable(l, "b")));
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubCallInvoke (EVariable a) equals (Args (EVariable b)))", node.toString());
@@ -501,8 +500,8 @@ public class NodeToStringTests extends ESTestCase {
     public void testPSubShortcut() {
         Location l = new Location(getTestName(), 0);
         Struct s = definition.getPainlessStructFromJavaClass(FeatureTest.class);
-        Painless.Method getter = s.methods.get(new MethodKey("getX", 0));
-        Painless.Method setter = s.methods.get(new MethodKey("setX", 1));
+        Painless.Method getter = s.methods.get(new Painless.MethodKey("getX", 0));
+        Painless.Method setter = s.methods.get(new Painless.MethodKey("setX", 1));
         PSubShortcut node = new PSubShortcut(l, "x", FeatureTest.class.getName(), getter, setter);
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubShortcut (EVariable a) x)", node.toString());

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Painless;
-import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.FeatureTest;
 import org.elasticsearch.painless.GenericElasticsearchScript;
 import org.elasticsearch.painless.Locals.Variable;
@@ -401,7 +400,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testPSubCallInvoke() {
         Location l = new Location(getTestName(), 0);
-        Struct c = definition.getPainlessStructFromJavaClass(Integer.class);
+        Painless.Struct c = definition.getPainlessStructFromJavaClass(Integer.class);
         Painless.Method m = c.methods.get(new Painless.MethodKey("toString", 0));
         PSubCallInvoke node = new PSubCallInvoke(l, m, null, emptyList());
         node.prefix = new EVariable(l, "a");
@@ -456,7 +455,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testPSubField() {
         Location l = new Location(getTestName(), 0);
-        Struct s = definition.getPainlessStructFromJavaClass(Boolean.class);
+        Painless.Struct s = definition.getPainlessStructFromJavaClass(Boolean.class);
         Painless.Field f = s.staticMembers.get("TRUE");
         PSubField node = new PSubField(l, f);
         node.prefix = new EStatic(l, "Boolean");
@@ -466,7 +465,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testPSubListShortcut() {
         Location l = new Location(getTestName(), 0);
-        Struct s = definition.getPainlessStructFromJavaClass(List.class);
+        Painless.Struct s = definition.getPainlessStructFromJavaClass(List.class);
         PSubListShortcut node = new PSubListShortcut(l, s, new EConstant(l, 1));
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubListShortcut (EVariable a) (EConstant Integer 1))", node.toString());
@@ -482,7 +481,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testPSubMapShortcut() {
         Location l = new Location(getTestName(), 0);
-        Struct s = definition.getPainlessStructFromJavaClass(Map.class);
+        Painless.Struct s = definition.getPainlessStructFromJavaClass(Map.class);
         PSubMapShortcut node = new PSubMapShortcut(l, s, new EConstant(l, "cat"));
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubMapShortcut (EVariable a) (EConstant String 'cat'))", node.toString());
@@ -498,7 +497,7 @@ public class NodeToStringTests extends ESTestCase {
 
     public void testPSubShortcut() {
         Location l = new Location(getTestName(), 0);
-        Struct s = definition.getPainlessStructFromJavaClass(FeatureTest.class);
+        Painless.Struct s = definition.getPainlessStructFromJavaClass(FeatureTest.class);
         Painless.Method getter = s.methods.get(new Painless.MethodKey("getX", 0));
         Painless.Method setter = s.methods.get(new Painless.MethodKey("setX", 1));
         PSubShortcut node = new PSubShortcut(l, "x", FeatureTest.class.getName(), getter, setter);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Definition.Field;
-import org.elasticsearch.painless.Definition.Method;
+import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.MethodKey;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.FeatureTest;
@@ -404,7 +404,7 @@ public class NodeToStringTests extends ESTestCase {
     public void testPSubCallInvoke() {
         Location l = new Location(getTestName(), 0);
         Struct c = definition.getPainlessStructFromJavaClass(Integer.class);
-        Method m = c.methods.get(new MethodKey("toString", 0));
+        Painless.Method m = c.methods.get(new MethodKey("toString", 0));
         PSubCallInvoke node = new PSubCallInvoke(l, m, null, emptyList());
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubCallInvoke (EVariable a) toString)", node.toString());
@@ -501,8 +501,8 @@ public class NodeToStringTests extends ESTestCase {
     public void testPSubShortcut() {
         Location l = new Location(getTestName(), 0);
         Struct s = definition.getPainlessStructFromJavaClass(FeatureTest.class);
-        Method getter = s.methods.get(new MethodKey("getX", 0));
-        Method setter = s.methods.get(new MethodKey("setX", 1));
+        Painless.Method getter = s.methods.get(new MethodKey("getX", 0));
+        Painless.Method setter = s.methods.get(new MethodKey("setX", 1));
         PSubShortcut node = new PSubShortcut(l, "x", FeatureTest.class.getName(), getter, setter);
         node.prefix = new EVariable(l, "a");
         assertEquals("(PSubShortcut (EVariable a) x)", node.toString());

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.painless.node;
 
 import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Definition;
-import org.elasticsearch.painless.Definition.Cast;
 import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.FeatureTest;
 import org.elasticsearch.painless.GenericElasticsearchScript;
@@ -158,12 +157,12 @@ public class NodeToStringTests extends ESTestCase {
     public void testECast() {
         Location l = new Location(getTestName(), 0);
         AExpression child = new EConstant(l, "test");
-        Cast cast = Cast.standard(String.class, Integer.class, true);
+        Painless.Cast cast = Painless.Cast.standard(String.class, Integer.class, true);
         assertEquals("(ECast java.lang.Integer (EConstant String 'test'))", new ECast(l, child, cast).toString());
 
         l = new Location(getTestName(), 1);
         child = new EBinary(l, Operation.ADD, new EConstant(l, "test"), new EConstant(l, 12));
-        cast = Cast.standard(Integer.class, Boolean.class, true);
+        cast = Painless.Cast.standard(Integer.class, Boolean.class, true);
         assertEquals("(ECast java.lang.Boolean (EBinary (EConstant String 'test') + (EConstant Integer 12)))",
             new ECast(l, child, cast).toString());
     }

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/node/NodeToStringTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.painless.node;
 import org.elasticsearch.painless.CompilerSettings;
 import org.elasticsearch.painless.Definition;
 import org.elasticsearch.painless.Definition.Cast;
-import org.elasticsearch.painless.Definition.Field;
 import org.elasticsearch.painless.Painless;
 import org.elasticsearch.painless.Definition.Struct;
 import org.elasticsearch.painless.FeatureTest;
@@ -458,7 +457,7 @@ public class NodeToStringTests extends ESTestCase {
     public void testPSubField() {
         Location l = new Location(getTestName(), 0);
         Struct s = definition.getPainlessStructFromJavaClass(Boolean.class);
-        Field f = s.staticMembers.get("TRUE");
+        Painless.Field f = s.staticMembers.get("TRUE");
         PSubField node = new PSubField(l, f);
         node.prefix = new EStatic(l, "Boolean");
         assertEquals("(PSubField (EStatic Boolean) TRUE)", node.toString());


### PR DESCRIPTION
This change moves the basic constructs of what's available in Painless from Definition to a Painless class.  This change helps with following which objects are used where as names such as Method are used in multiple places, so now it's easy to identify when a Painless.Method is being used versus a reflection Method or an asm Method.  This applies to all of the objects moved.  Also removed all static imports related to this sets of classes to ensure that all of them are now Painless.X for easy reading.